### PR TITLE
_utilities.py: remove outdated comment

### DIFF
--- a/pkg/codegen/python/utilities.py
+++ b/pkg/codegen/python/utilities.py
@@ -67,9 +67,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -85,7 +82,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/conformance-component-22.0.0/pulumi_conformance_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/alpha-3.0.0-alpha.1.internal+exp.sha.12345678/pulumi_alpha/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/any-type-function-15.0.0/pulumi_any_type_function/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/asset-archive-5.0.0/pulumi_asset_archive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/camelNames-19.0.0/pulumi_camelNames/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pulumi_config/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-9.0.0/pulumi_config/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/config-grpc-1.0.0/pulumi_config_grpc/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/fail_on_create-4.0.0/pulumi_fail_on_create/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/keywords-20.0.0/pulumi_keywords/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pulumi_large/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/large-4.3.2/pulumi_large/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/module-format-29.0.0/pulumi_module_format/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pulumi_names/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/names-6.0.0/pulumi_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/namespaced-16.0.0/a_namespace_namespaced/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/nestedobject-1.42.0/pulumi_nestedobject/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pulumi_output/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-23.0.0/pulumi_output/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/output-only-invoke-24.0.0/pulumi_output_only_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/plain-13.0.0/pulumi_plain/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-7.0.0/pulumi_primitive/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/primitive-ref-11.0.0/pulumi_primitive_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/replaceonchanges-25.0.0/pulumi_replaceonchanges/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/scalar-returns-21.0.0/pulumi_scalar_returns/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/secret-14.0.0/pulumi_secret/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-2.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-26.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-27.0.0/pulumi_simple/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-10.0.0/pulumi_simple_invoke/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/simple-invoke-with-scalar-return-17.0.0/pulumi_simple_invoke_with_scalar_return/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/sync-3.0.0-alpha.1.internal+exp.sha.2143768/pulumi_sync/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/union-18.0.0/pulumi_union/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/assets-and-archives/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
+++ b/tests/testdata/codegen/azure-native-nested-types/python/pulumi_azure_native/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/config-variables/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/cyclic-types/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/tests/testdata/codegen/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/different-enum/python/pulumi_plant/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/embedded-crd-types/python/pulumi_foo/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference-python/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/enum-reference/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-enum/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-python-same-module-name/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/external-resource-schema/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/functions-secrets/python/pulumi_mypkg/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/tests/testdata/codegen/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
+++ b/tests/testdata/codegen/hyphenated-symbols/python/pulumi_repro/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
+++ b/tests/testdata/codegen/legacy-names/python/pulumi_legacy_names/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
+++ b/tests/testdata/codegen/methods-return-plain-resource/python/pulumi_metaprovider/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/naming-collisions/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/tests/testdata/codegen/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/nested-module/python/pulumi_foo/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/tests/testdata/codegen/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/tests/testdata/codegen/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
+++ b/tests/testdata/codegen/provider-type-schema/python/pulumi_providerType/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-disabled-setuppy/python/pulumi_typedDictDisabledExample/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-pyproject/python/pulumi_typedDictExample/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
+++ b/tests/testdata/codegen/python-typed-dict-setuppy/python/pulumi_typedDictExample/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
+++ b/tests/testdata/codegen/regress-8403/python/pulumi_mongodbatlas/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/tests/testdata/codegen/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12546/python/pulumi_plant/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
+++ b/tests/testdata/codegen/regress-py-12980/python/pulumi_myPkg/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14012/python/pulumi_foo/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
+++ b/tests/testdata/codegen/regress-py-17219/python/pulumi_cloudinit/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
+++ b/tests/testdata/codegen/regress-py-tfbridge-611/python/pulumi_aws/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-args-python/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
+++ b/tests/testdata/codegen/secrets/python/pulumi_mypkg/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/tests/testdata/codegen/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-resource-with-aliases/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-schema-pyproject/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inline/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
+++ b/tests/testdata/codegen/unions-inside-arrays/python/pulumi_example/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"

--- a/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
+++ b/tests/testdata/codegen/using-shared-types-in-config/python/pulumi_credentials/_utilities.py
@@ -71,9 +71,6 @@ def _get_semver_version():
     # <some module>._utilities. <some module> is the module we want to query the version for.
     root_package, *rest = __name__.split('.')
 
-    # pkg_resources uses setuptools to inspect the set of installed packages. We use it here to ask
-    # for the currently installed version of the root package (i.e. us) and get its version.
-
     # Unfortunately, PEP440 and semver differ slightly in incompatible ways. The Pulumi engine expects
     # to receive a valid semver string when receiving requests from the language host, so it's our
     # responsibility as the library to convert our own PEP440 version into a valid semver string.
@@ -89,7 +86,7 @@ def _get_semver_version():
     elif pep440_version.pre_tag == 'rc':
         prerelease = f"rc.{pep440_version.pre}"
     elif pep440_version.dev is not None:
-        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge 
+        # PEP440 has explicit support for dev builds, while semver encodes them as "prerelease" versions. To bridge
         # between the two, we convert our dev build version into a prerelease tag. This matches what all of our other
         # packages do when constructing their own semver string.
         prerelease = f"dev.{pep440_version.dev}"


### PR DESCRIPTION
We don't use `pkg_resources` since https://github.com/pulumi/pulumi/pull/15266, but still mention it in this comment.  Remove the outdated comment, and re-generate testdata.