### PR TITLE
drop unnecessary CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,6 @@ on:
         required: true
         description: "Version to produce"
         type: string
-      test-codegen:
-        required: false
-        default: true
-        description: "Whether to run per-language codegen tests."
-        type: boolean
       lint:
         required: false
         default: true
@@ -122,7 +117,6 @@ jobs:
       - name: build matrix
         id: matrix
         env:
-          TEST_CODEGEN: ${{ inputs.test-codegen }}
           TEST_VERSION_SETS: ${{ inputs.test-version-sets }}
           INPUT_INTEGRATION_TEST_PLATFORMS: ${{ inputs.integration-test-platforms }}
           INPUT_ACCEPTANCE_TEST_PLATFORMS: ${{ inputs.acceptance-test-platforms }}
@@ -153,10 +147,6 @@ jobs:
 
           CODEGEN_TESTS_FLAG=--codegen-tests
           PKG_UNIT_TEST_PARTITIONS=7
-          if [ "${TEST_CODEGEN}" = "false" ]; then
-            CODEGEN_TESTS_FLAG=--no-codegen-tests
-            PKG_UNIT_TEST_PARTITIONS=3
-          fi
 
           UNIT_TEST_MATRIX=$(
             ./scripts/get-job-matrix.py \

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -31,9 +31,6 @@ jobs:
       ref: ${{ github.ref }}
       version: ${{ needs.info.outputs.version }}
       lint: true
-      # codegen tests are not the fastest, but we want to run all
-      # tests daily
-      test-codegen: true
       test-version-sets: 'all'
       integration-test-platforms: ubuntu-latest
       acceptance-test-platforms: 'macos-latest windows-latest'

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -32,35 +32,10 @@ jobs:
       is-snapshot: true
     secrets: inherit
 
-  # Determines which files have changed so we can avoid running expensive tests
-  # if they're not necessary.
-  inspect:
-    name: Inspect changed files
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
-        id: changes
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          filters: |
-            # If files matching any of these patterns change,
-            # we will run codegen tests for pull requests.
-            test-codegen:
-              - 'pkg/codegen/docs/**'
-              - 'pkg/codegen/dotnet/**'
-              - 'pkg/codegen/go/**'
-              - 'pkg/codegen/nodejs/**'
-              - 'pkg/codegen/python/**'
-    outputs:
-      # Add an entry here for every named pattern
-      # defined in filters.
-      test-codegen: ${{ steps.changes.outputs.test-codegen }}
-
   ci:
     name: CI
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, inspect]
+    needs: [info]
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
@@ -72,7 +47,6 @@ jobs:
       lint: true
       # codegen tests are not the fastest, but we want to run them
       # on PR to get correct coverage numbers.
-      test-codegen: true
       test-version-sets: >- # No newlines or trailing newline.
         ${{
           contains(github.event.pull_request.labels.*.name, 'ci/test')
@@ -92,7 +66,7 @@ jobs:
   performance-gate:
     name: Performance Gate
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, inspect]
+    needs: [info]
     uses: ./.github/workflows/ci-performance-gate.yml
     permissions:
       contents: read


### PR DESCRIPTION
We have a CI step to check whether we should test codegen in a PR, but then always test it in the end (iirc the reason for that was code coverage, which would be inaccurate if we only run part of the tests).

Remove the step as it is no longer needed, and just counts against our API rate limit.