### PR TITLE
Surface errors from uv, poetry or pip during linking

### DIFF
--- a/changelog/pending/20260210--sdk-python--surface-errors-from-uv-poetry-or-pip-during-linking.yaml
+++ b/changelog/pending/20260210--sdk-python--surface-errors-from-uv-poetry-or-pip-during-linking.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Surface errors from uv, poetry or pip during linking

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -15,7 +15,6 @@
 package toolchain
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -255,9 +254,8 @@ func (u *uv) LinkPackages(ctx context.Context, packages map[string]string) error
 
 	paths := slices.Collect(maps.Values(packages))
 	args = append(args, paths...)
-	var stdout, stderr bytes.Buffer
-	cmd := u.uvCommand(ctx, "", true, &stdout, &stderr, args...)
-	if err := cmd.Run(); err != nil {
+	cmd := u.uvCommand(ctx, "", false, nil, nil, args...)
+	if _, err := cmd.Output(); err != nil {
 		return errutil.ErrorWithStderr(err, "linking packages")
 	}
 	return nil
@@ -353,7 +351,7 @@ func (u *uv) Command(ctx context.Context, args ...string) (*exec.Cmd, error) {
 		// uv run does an "inexact" sync, that is it leaves extraneous
 		// dependencies alone and does not remove them.
 		venvCmd := u.uvCommand(ctx, u.root, false, nil, nil, "sync", "--inexact")
-		if err := venvCmd.Run(); err != nil {
+		if _, err := venvCmd.Output(); err != nil {
 			return nil, errutil.ErrorWithStderr(err, "error creating virtual environment")
 		}
 	}


### PR DESCRIPTION
When there's an issue during dependency resolution in uv, for example because of incompatible versions, we get an unhelpful error message: `linking packages: exit status 1`.

We are using `errutil.ErrorWithStderr` to capture stderr in some places, but this requires using `cmd.Output`. `cmd.Run` will not capture stderr for us.

Fixes https://github.com/pulumi/pulumi/issues/21608
