### PR TITLE
document `provider-<name>` language conformance tests

### DIFF
--- a/cmd/pulumi-test-language/README.md
+++ b/cmd/pulumi-test-language/README.md
@@ -192,7 +192,7 @@ as follows:
   such as custom resources, function invocations, and so on.
 * *L3 tests* exercise features that require more advanced language support such
   as first-class functions -- `apply` is a good example of this.
-  * *Provider tests* exercise language code that acts as a provider, iow calls `Construct`.
+* *Provider tests* exercise language code that acts as a provider, that is `Construct` and `Call` implementations.
 
 Each language defines a test function (the *language test host*) responsible for
 running its conformance test suite, if it implements one. For core languages


### PR DESCRIPTION
We have a few of these now, but they were so far undocumented as far as I could see.  Document these in the README for the provider tests, which will also show up in our developer docs at https://pulumi-developer-docs.readthedocs.io/latest/cmd/pulumi-test-language/README.html