### PR TITLE
 Allow underscores in the path of plugin URLs

### DIFF
--- a/changelog/pending/20260210--cli-package--allow-underscores-in-the-path-of-plugin-urls.yaml
+++ b/changelog/pending/20260210--cli-package--allow-underscores-in-the-path-of-plugin-urls.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Allow underscores in the path of plugin URLs

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -137,6 +137,16 @@ func TestIsLocalPluginPath(t *testing.T) {
 			path:     "example.com/no-repo-exists/here",
 			expected: false,
 		},
+		{
+			name:     "git URL with a path",
+			path:     "github.com/example/component.git/path-here",
+			expected: false,
+		},
+		{
+			name:     "git URL with a path with underscores",
+			path:     "github.com/example/component.git/path_here",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1046,7 +1046,7 @@ type PluginDescriptor struct {
 type PluginVersionNotFoundError error
 
 var urlRegex = sync.OnceValue(func() *regexp.Regexp {
-	return regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-/]*[a-zA-Z0-9/](@.*)?$`)
+	return regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-_/]*[a-zA-Z0-9/](@.*)?$`)
 })
 
 func IsExternalURL(source string) bool {


### PR DESCRIPTION
The presence of an `_` in a git URL for a plugin caused us to enter an if branch for local plugins introduced in https://github.com/pulumi/pulumi/pull/21350/, even though this is not a local plugin.

Fixes https://github.com/pulumi/pulumi/issues/21668
