### PR TITLE
double number of macos acceptance test partitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
               --version-set current \
               --partition-module pkg 1 \
               --partition-module sdk 1 \
-              --partition-module tests 2 \
+              --partition-module tests 4 \
               --partition-package github.com/pulumi/pulumi/tests/smoke tests/smoke 4 \
               --partition-package github.com/pulumi/pulumi/tests/integration tests/integration 8
             )


### PR DESCRIPTION
This is similar to https://github.com/pulumi/pulumi/pull/21706, but for MacOS.  Anecdotally these are the slowest tests in the merge queue now (I haven't tried to run the script tbh), but we wouldn't notice these on PR because we don't run MacOS tests on PR.