### PR TITLE
Ensure that `projectDir` is an absolute path

### DIFF
--- a/changelog/pending/20260211--cli-install-package--dont-panic-when-a-non-absolute-path-is-passed-to-pulumi-package-get-schema-where-the-pulumiplugin-yaml-has-a-packages-section.yaml
+++ b/changelog/pending/20260211--cli-install-package--dont-panic-when-a-non-absolute-path-is-passed-to-pulumi-package-get-schema-where-the-pulumiplugin-yaml-has-a-packages-section.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install,package
+  description: Don't panic when a non-absolute path is passed to `pulumi package get-schema` where the PulumiPlugin.yaml has a packages section

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -272,6 +272,14 @@ func (w Workspace) LinkIntoProject(
 	delete(w.unlinkedProjects, projectDir)
 	w.unlinkedProjectsM.Unlock()
 
+	if !filepath.IsAbs(projectDir) {
+		var err error
+		projectDir, err = filepath.Abs(projectDir)
+		if err != nil {
+			return err
+		}
+	}
+
 	servers, err := w.servers(ctx, runtimeInfo.Name(), projectDir, refs...)
 	if err != nil {
 		return fmt.Errorf("running servers for linking: %w", err)


### PR DESCRIPTION
When it is not, the CLI panics. You can reproduce this issue now by running:

	pulumi package get-schema .

Where the current `PulumiPlugin.yaml` has a non-empty `packages` section.