### PR TITLE
Run in the correct location when using `uv` to link in Python SDKs

### DIFF
--- a/changelog/pending/20260211--cli-install-package--run-in-the-correct-location-when-using-uv-to-link-python-packages.yaml
+++ b/changelog/pending/20260211--cli-install-package--run-in-the-correct-location-when-using-uv-to-link-python-packages.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/install,package
+  description: Run in the correct location when using `uv` to link python packages

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -254,7 +254,7 @@ func (u *uv) LinkPackages(ctx context.Context, packages map[string]string) error
 
 	paths := slices.Collect(maps.Values(packages))
 	args = append(args, paths...)
-	cmd := u.uvCommand(ctx, "", false, nil, nil, args...)
+	cmd := u.uvCommand(ctx, u.root, false, nil, nil, args...)
 	if _, err := cmd.Output(); err != nil {
 		return errutil.ErrorWithStderr(err, "linking packages")
 	}


### PR DESCRIPTION
This was causing `pulumi package get-schema github.com/<org>/<component>` to fail when the component used `uv` as it's package manager & when it depended on local packages.