### PR TITLE
Support the Partial<T> utility type in component schema inference

### DIFF
--- a/changelog/pending/20260212--sdk-nodejs--support-the-partial-t-utility-type-in-component-schema-inference.yaml
+++ b/changelog/pending/20260212--sdk-nodejs--support-the-partial-t-utility-type-in-component-schema-inference.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Support the Partial<T> utility type in component schema inference

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -132,6 +132,178 @@ describe("Analyzer", function () {
         });
     });
 
+    it("infers Partial<T> utility type", async function () {
+        const dir = path.join(__dirname, "testdata", "partial-type");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components, typeDefinitions } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    regularType: {
+                        $ref: "#/types/provider:index:SomeType",
+                        optional: true,
+                        description: "The regular type with required fields",
+                    },
+                    partialType: {
+                        $ref: "#/types/provider:index:PartialSomeType",
+                        optional: true,
+                        description: "A partial type where all fields are optional",
+                    },
+                },
+                outputs: {
+                    regularType: {
+                        $ref: "#/types/provider:index:SomeType",
+                        description: "The regular type output",
+                    },
+                    partialType: {
+                        $ref: "#/types/provider:index:PartialSomeType",
+                        description: "The partial type output",
+                    },
+                },
+            },
+        });
+        assert.deepStrictEqual(typeDefinitions, {
+            SomeType: {
+                name: "SomeType",
+                description: "A type with required fields",
+                properties: {
+                    a: {
+                        type: "string",
+                        plain: true,
+                        description: "A required string field",
+                    },
+                    b: {
+                        type: "number",
+                        plain: true,
+                        description: "A required number field",
+                    },
+                    c: {
+                        type: "boolean",
+                        plain: true,
+                        description: "A required boolean field",
+                    },
+                },
+                type: "object",
+            },
+            PartialSomeType: {
+                name: "PartialSomeType",
+                description: "A type with required fields",
+                properties: {
+                    a: {
+                        type: "string",
+                        plain: true,
+                        optional: true,
+                        description: "A required string field",
+                    },
+                    b: {
+                        type: "number",
+                        plain: true,
+                        optional: true,
+                        description: "A required number field",
+                    },
+                    c: {
+                        type: "boolean",
+                        plain: true,
+                        optional: true,
+                        description: "A required boolean field",
+                    },
+                },
+                type: "object",
+            },
+        });
+    });
+
+    it("infers Partial<T> with nested types", async function () {
+        const dir = path.join(__dirname, "testdata", "partial-nested");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components, typeDefinitions } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    partialOuter: {
+                        $ref: "#/types/provider:index:PartialOuterType",
+                        optional: true,
+                        description: "A partial outer type with nested inner type",
+                    },
+                    partialInner: {
+                        $ref: "#/types/provider:index:PartialInnerType",
+                        optional: true,
+                        description: "A nested partial of the inner type",
+                    },
+                },
+                outputs: {
+                    partialOuter: {
+                        $ref: "#/types/provider:index:PartialOuterType",
+                        description: "The partial outer type output",
+                    },
+                    partialInner: {
+                        $ref: "#/types/provider:index:PartialInnerType",
+                        description: "The partial inner type output",
+                    },
+                },
+            },
+        });
+        assert.deepStrictEqual(typeDefinitions, {
+            InnerType: {
+                name: "InnerType",
+                description: "An inner type",
+                properties: {
+                    x: {
+                        type: "number",
+                        plain: true,
+                        description: "Inner field x",
+                    },
+                    y: {
+                        type: "string",
+                        plain: true,
+                        description: "Inner field y",
+                    },
+                },
+                type: "object",
+            },
+            PartialOuterType: {
+                name: "PartialOuterType",
+                description: "An outer type that contains another type",
+                properties: {
+                    inner: {
+                        $ref: "#/types/provider:index:InnerType",
+                        plain: true,
+                        optional: true,
+                        description: "An inner object",
+                    },
+                    outerField: {
+                        type: "boolean",
+                        plain: true,
+                        optional: true,
+                        description: "An outer field",
+                    },
+                },
+                type: "object",
+            },
+            PartialInnerType: {
+                name: "PartialInnerType",
+                description: "An inner type",
+                properties: {
+                    x: {
+                        type: "number",
+                        plain: true,
+                        optional: true,
+                        description: "Inner field x",
+                    },
+                    y: {
+                        type: "string",
+                        plain: true,
+                        optional: true,
+                        description: "Inner field y",
+                    },
+                },
+                type: "object",
+            },
+        });
+    });
+
     it("infers self recursive complex types", async function () {
         const dir = path.join(__dirname, "testdata", "recursive-complex-types");
         const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));

--- a/sdk/nodejs/tests/provider/experimental/testdata/partial-nested/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/partial-nested/index.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/** An inner type */
+interface InnerType {
+    /** Inner field x */
+    x: number;
+    /** Inner field y */
+    y: string;
+}
+
+/** An outer type that contains another type */
+interface OuterType {
+    /** An inner object */
+    inner: InnerType;
+    /** An outer field */
+    outerField: boolean;
+}
+
+export interface MyComponentArgs {
+    /** A partial outer type with nested inner type */
+    partialOuter?: pulumi.Input<Partial<OuterType>>;
+    /** A nested partial of the inner type */
+    partialInner?: pulumi.Input<Partial<InnerType>>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    /** The partial outer type output */
+    partialOuter: pulumi.Output<Partial<OuterType>>;
+    /** The partial inner type output */
+    partialInner: pulumi.Output<Partial<InnerType>>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+        this.partialOuter = pulumi.output(args.partialOuter || {});
+        this.partialInner = pulumi.output(args.partialInner || {});
+        this.registerOutputs({
+            partialOuter: this.partialOuter,
+            partialInner: this.partialInner,
+        });
+    }
+}

--- a/sdk/nodejs/tests/provider/experimental/testdata/partial-type/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/partial-type/index.ts
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/** A type with required fields */
+interface SomeType {
+    /** A required string field */
+    a: string;
+    /** A required number field */
+    b: number;
+    /** A required boolean field */
+    c: boolean;
+}
+
+export interface MyComponentArgs {
+    /** The regular type with required fields */
+    regularType?: pulumi.Input<SomeType>;
+    /** A partial type where all fields are optional */
+    partialType?: pulumi.Input<Partial<SomeType>>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    /** The regular type output */
+    regularType: pulumi.Output<SomeType>;
+    /** The partial type output */
+    partialType: pulumi.Output<Partial<SomeType>>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+        this.regularType = pulumi.output(args.regularType || { a: "", b: 0, c: false });
+        this.partialType = pulumi.output(args.partialType || {});
+        this.registerOutputs({
+            regularType: this.regularType,
+            partialType: this.partialType,
+        });
+    }
+}


### PR DESCRIPTION
When the type `T` of a property is wrapped with `Partial`, generate a
type definition for `PartialT` that has all the options set to optional.

```typescript
interface SomeType {
    a: string;
}

export interface MyComponentArgs {
    regularType?: pulumi.Input<SomeType>;
    partialType?: pulumi.Input<Partial<SomeType>>;
}
```

The above will create two type definitions, one for `SometType` with a
required property `a`, and one for `PartialSomeType` with an optional
property `a`.

Ref https://github.com/pulumi/pulumi/issues/21637