### PR TITLE
Support the Required<T> utility type in component schema inference 

### DIFF
--- a/changelog/pending/20260212--sdk-nodejs--support-the-required-t-utility-type-in-component-schema-inference.yaml
+++ b/changelog/pending/20260212--sdk-nodejs--support-the-required-t-utility-type-in-component-schema-inference.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Support the Required<T> utility type in component schema inference

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -304,6 +304,176 @@ describe("Analyzer", function () {
         });
     });
 
+    it("infers Required<T> utility type", async function () {
+        const dir = path.join(__dirname, "testdata", "required-type");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components, typeDefinitions } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    regularType: {
+                        $ref: "#/types/provider:index:SomeType",
+                        optional: true,
+                        description: "The regular type with optional fields",
+                    },
+                    requiredType: {
+                        $ref: "#/types/provider:index:RequiredSomeType",
+                        optional: true,
+                        description: "A required type where all fields are required",
+                    },
+                },
+                outputs: {
+                    regularType: {
+                        $ref: "#/types/provider:index:SomeType",
+                        description: "The regular type output",
+                    },
+                    requiredType: {
+                        $ref: "#/types/provider:index:RequiredSomeType",
+                        description: "The required type output",
+                    },
+                },
+            },
+        });
+        assert.deepStrictEqual(typeDefinitions, {
+            SomeType: {
+                name: "SomeType",
+                description: "A type with optional fields",
+                properties: {
+                    a: {
+                        type: "string",
+                        plain: true,
+                        optional: true,
+                        description: "An optional string field",
+                    },
+                    b: {
+                        type: "number",
+                        plain: true,
+                        optional: true,
+                        description: "An optional number field",
+                    },
+                    c: {
+                        type: "boolean",
+                        plain: true,
+                        optional: true,
+                        description: "An optional boolean field",
+                    },
+                },
+                type: "object",
+            },
+            RequiredSomeType: {
+                name: "RequiredSomeType",
+                description: "A type with optional fields",
+                properties: {
+                    a: {
+                        type: "string",
+                        plain: true,
+                        description: "An optional string field",
+                    },
+                    b: {
+                        type: "number",
+                        plain: true,
+                        description: "An optional number field",
+                    },
+                    c: {
+                        type: "boolean",
+                        plain: true,
+                        description: "An optional boolean field",
+                    },
+                },
+                type: "object",
+            },
+        });
+    });
+
+    it("infers Required<T> with nested types", async function () {
+        const dir = path.join(__dirname, "testdata", "required-nested");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components, typeDefinitions } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    requiredOuter: {
+                        $ref: "#/types/provider:index:RequiredOuterType",
+                        optional: true,
+                        description: "A required outer type with nested inner type",
+                    },
+                    requiredInner: {
+                        $ref: "#/types/provider:index:RequiredInnerType",
+                        optional: true,
+                        description: "A nested required of the inner type",
+                    },
+                },
+                outputs: {
+                    requiredOuter: {
+                        $ref: "#/types/provider:index:RequiredOuterType",
+                        description: "The required outer type output",
+                    },
+                    requiredInner: {
+                        $ref: "#/types/provider:index:RequiredInnerType",
+                        description: "The required inner type output",
+                    },
+                },
+            },
+        });
+        assert.deepStrictEqual(typeDefinitions, {
+            InnerType: {
+                name: "InnerType",
+                description: "An inner type with optional fields",
+                properties: {
+                    x: {
+                        type: "number",
+                        plain: true,
+                        optional: true,
+                        description: "Inner field x",
+                    },
+                    y: {
+                        type: "string",
+                        plain: true,
+                        optional: true,
+                        description: "Inner field y",
+                    },
+                },
+                type: "object",
+            },
+            RequiredOuterType: {
+                name: "RequiredOuterType",
+                description: "An outer type with optional fields including a nested type",
+                properties: {
+                    inner: {
+                        $ref: "#/types/provider:index:InnerType",
+                        plain: true,
+                        description: "An inner object",
+                    },
+                    outerField: {
+                        type: "boolean",
+                        plain: true,
+                        description: "An outer field",
+                    },
+                },
+                type: "object",
+            },
+            RequiredInnerType: {
+                name: "RequiredInnerType",
+                description: "An inner type with optional fields",
+                properties: {
+                    x: {
+                        type: "number",
+                        plain: true,
+                        description: "Inner field x",
+                    },
+                    y: {
+                        type: "string",
+                        plain: true,
+                        description: "Inner field y",
+                    },
+                },
+                type: "object",
+            },
+        });
+    });
+
     it("infers self recursive complex types", async function () {
         const dir = path.join(__dirname, "testdata", "recursive-complex-types");
         const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));

--- a/sdk/nodejs/tests/provider/experimental/testdata/required-nested/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/required-nested/index.ts
@@ -1,0 +1,43 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/** An inner type with optional fields */
+interface InnerType {
+    /** Inner field x */
+    x?: number;
+    /** Inner field y */
+    y?: string;
+}
+
+/** An outer type with optional fields including a nested type */
+interface OuterType {
+    /** An inner object */
+    inner?: InnerType;
+    /** An outer field */
+    outerField?: boolean;
+}
+
+export interface MyComponentArgs {
+    /** A required outer type with nested inner type */
+    requiredOuter?: pulumi.Input<Required<OuterType>>;
+    /** A nested required of the inner type */
+    requiredInner?: pulumi.Input<Required<InnerType>>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    /** The required outer type output */
+    requiredOuter: pulumi.Output<Required<OuterType>>;
+    /** The required inner type output */
+    requiredInner: pulumi.Output<Required<InnerType>>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+        this.requiredOuter = pulumi.output(args.requiredOuter || { inner: { x: 0, y: "" }, outerField: false });
+        this.requiredInner = pulumi.output(args.requiredInner || { x: 0, y: "" });
+        this.registerOutputs({
+            requiredOuter: this.requiredOuter,
+            requiredInner: this.requiredInner,
+        });
+    }
+}

--- a/sdk/nodejs/tests/provider/experimental/testdata/required-type/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/required-type/index.ts
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/** A type with optional fields */
+interface SomeType {
+    /** An optional string field */
+    a?: string;
+    /** An optional number field */
+    b?: number;
+    /** An optional boolean field */
+    c?: boolean;
+}
+
+export interface MyComponentArgs {
+    /** The regular type with optional fields */
+    regularType?: pulumi.Input<SomeType>;
+    /** A required type where all fields are required */
+    requiredType?: pulumi.Input<Required<SomeType>>;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    /** The regular type output */
+    regularType: pulumi.Output<SomeType>;
+    /** The required type output */
+    requiredType: pulumi.Output<Required<SomeType>>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+        this.regularType = pulumi.output(args.regularType || {});
+        this.requiredType = pulumi.output(args.requiredType || { a: "", b: 0, c: false });
+        this.registerOutputs({
+            regularType: this.regularType,
+            requiredType: this.requiredType,
+        });
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/21802

When the type `T` of a property is wrapped with `Required`, generate a type definition for `RequiredT` that has all the options set to optional.

```typescript
interface SomeType {
    a?: string;
}

export interface MyComponentArgs {
    regularType?: pulumi.Input<SomeType>;
    requiredType?: pulumi.Input<Required<SomeType>>;
}
```

The above will create two type definitions, one for `SometType` with an optional property `a`, and one for `RequiredSomeType` with a required property `a`.

Ref https://github.com/pulumi/pulumi/issues/21637