### PR TITLE
Rename `pulumiVersionRange` to `requiredPulumiVersion` in `PulumiPlugin.yaml`

### DIFF
--- a/changelog/pending/20260212--engine--breaking-rename-pulumiversionrange-to-requiredpulumiversion-in-pulumiplugin-yaml.yaml
+++ b/changelog/pending/20260212--engine--breaking-rename-pulumiversionrange-to-requiredpulumiversion-in-pulumiplugin-yaml.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: "BREAKING: Rename `pulumiVersionRange` to `requiredPulumiVersion` in `PulumiPlugin.yaml`"

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -477,14 +477,14 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 				return nil, fmt.Errorf("loading PulumiPlugin.yaml: %w", err)
 			}
 			runtimeInfo = proj.Runtime
-			pulumiVersionRange = proj.PulumiVersionRange
+			pulumiVersionRange = proj.RequiredPulumiVersion
 		case apitype.AnalyzerPlugin:
 			proj, err := workspace.LoadPluginProject(filepath.Join(pluginDir, "PulumiPolicy.yaml"))
 			if err != nil {
 				return nil, fmt.Errorf("loading PulumiPolicy.yaml: %w", err)
 			}
 			runtimeInfo = proj.Runtime
-			pulumiVersionRange = proj.PulumiVersionRange
+			pulumiVersionRange = proj.RequiredPulumiVersion
 		default:
 			return nil, errors.New("language plugins must be executable binaries")
 		}

--- a/sdk/go/common/resource/plugin/testdata/test-plugin-cli-version/PulumiPlugin.yaml
+++ b/sdk/go/common/resource/plugin/testdata/test-plugin-cli-version/PulumiPlugin.yaml
@@ -1,2 +1,2 @@
 runtime: test
-pulumiVersionRange: ">=100.0.0"
+requiredPulumiVersion: ">=100.0.0"

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -949,7 +949,7 @@ type PluginProject struct {
 	// https://pkg.go.dev/github.com/blang/semver#ParseRange. For example ">=3.0.0", or "!3.1.2". Ranges can be AND-ed
 	// together by concatenating with spaces ">=3.5.0 !3.7.7", meaning greater-or-equal to 3.5.0 and not exactly 3.7.7.
 	// Ranges can be OR-ed with the `||` operator: "<3.4.0 || >3.8.0", meaning less-than 3.4.0 or greater-than 3.8.0.
-	PulumiVersionRange string `json:"pulumiVersionRange" yaml:"pulumiVersionRange"`
+	RequiredPulumiVersion string `json:"requiredPulumiVersion" yaml:"requiredPulumiVersion"`
 }
 
 var _ BaseProject = (*PluginProject)(nil)


### PR DESCRIPTION
# This is a breaking change.

This is called `requiredPulumiVersion` in `Pulumi.yaml`. The SDK methods to check this from languages are called `requirePulumiVersion(...)` (`require`, not `required`, because this is a function call ie an action).

Rename this to `requiredPulumiVersion` in `PulumiPlugin.yaml`. This was not documented yet for `PulumiPlugin.yaml`.