### PR TITLE
fix flaky TestTerminate_unhandledInterrupt

### DIFF
--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -282,7 +282,7 @@ func TestTerminate_unhandledInterrupt(t *testing.T) {
 			go func() {
 				defer close(done)
 
-				ok, err := TerminateProcessGroup(cmd.Process, 400*time.Millisecond)
+				ok, err := TerminateProcessGroup(cmd.Process, 1*time.Second)
 				assert.True(t, ok, "child process did not exit gracefully")
 				assert.Error(t, err, "child process should have exited with an error")
 			}()
@@ -291,7 +291,7 @@ func TestTerminate_unhandledInterrupt(t *testing.T) {
 			case <-done:
 				// continue
 
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(2 * time.Second):
 				// Took too long to kill the child process.
 				t.Fatal("Took too long to kill child process")
 			}


### PR DESCRIPTION
Give this process group a little longer to exit. It's kind of hard to know if this would have fixed the issue in https://github.com/pulumi/pulumi/actions/runs/21976251003/job/63488708156, but it's worth a try to hopefully make this less flaky.

Fixes https://github.com/pulumi/pulumi/issues/21811