### PR TITLE
Always surface errors from uv, poetry or pip during dependency installation

### DIFF
--- a/changelog/pending/20260213--sdk-python--always-surface-errors-from-uv-poetry-or-pip-during-dependency-installation.yaml
+++ b/changelog/pending/20260213--sdk-python--always-surface-errors-from-uv-poetry-or-pip-during-dependency-installation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Always surface errors from uv, poetry or pip during dependency installation

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -161,9 +161,14 @@ func (p *poetry) InstallDependencies(ctx context.Context,
 		}
 	}
 	poetryCmd.Dir = p.directory
-	poetryCmd.Stdout = infoWriter
-	poetryCmd.Stderr = errorWriter
-	return errutil.ErrorWithStderr(poetryCmd.Run(), "poetry install failed")
+	if showOutput {
+		poetryCmd.Stdout = infoWriter
+		poetryCmd.Stderr = errorWriter
+		return poetryCmd.Run()
+	} else {
+		_, err := poetryCmd.Output()
+		return errutil.ErrorWithStderr(err, "poetry install failed")
+	}
 }
 
 func (p *poetry) PrepareProject(

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -158,7 +158,12 @@ func (u *uv) InstallDependencies(ctx context.Context, cwd string, useLanguageVer
 	// We now have either a uv.lock or at least a pyproject.toml file, and we can use uv
 	// install the dependencies.
 	syncCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "sync")
-	return errutil.ErrorWithStderr(syncCmd.Run(), "error installing dependencies")
+	if !showOutput {
+		_, err := syncCmd.Output()
+		return errutil.ErrorWithStderr(err, "error installing dependencies")
+	} else {
+		return syncCmd.Run()
+	}
 }
 
 // PrepareProject prepares a project for use with uv. It will create a suitable pyproject.toml project file. If a


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/21770 but for dependency installation instead of linking.

Fixes https://github.com/pulumi/pulumi/issues/21622
