### PR TITLE
Add pulumi skills sync command

### DIFF
--- a/changelog/pending/20260213--cli--add-pulumi-skills-sync-command.yaml
+++ b/changelog/pending/20260213--cli--add-pulumi-skills-sync-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi skills sync` command for syncing agent skills to AI assistant config directories

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -70,6 +70,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/policy"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/schema"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/skills"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/state"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templatecmd"
@@ -428,6 +429,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				schema.NewSchemaCmd(),
 				packagecmd.NewPackageCmd(),
 				templatecmd.NewTemplateCmd(),
+				skills.NewSkillsCmd(),
 			},
 		},
 		{

--- a/pkg/cmd/pulumi/skills/skills.go
+++ b/pkg/cmd/pulumi/skills/skills.go
@@ -1,0 +1,41 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func NewSkillsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skills",
+		Short: "Manage Pulumi agent skills",
+		Long: "Manage Pulumi agent skills for AI assistants.\n" +
+			"\n" +
+			"Agent skills are packages of procedural knowledge that teach AI assistants\n" +
+			"how to write Pulumi code, migrate from other tools, and follow best practices.\n" +
+			"Skills work across platforms including Claude Code, Cursor, VS Code, and more.\n" +
+			"\n" +
+			"The skills family of commands provides a way to install and manage these skills\n" +
+			"in your project's AI assistant configuration directories.",
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	cmd.AddCommand(newSyncCmd())
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/skills/skills_sync.go
+++ b/pkg/cmd/pulumi/skills/skills_sync.go
@@ -1,0 +1,410 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/blang/semver"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+)
+
+const (
+	skillsRepoURL = "https://github.com/pulumi/agent-skills.git"
+	skillsBranch  = "main"
+
+	metadataPath = ".claude-plugin/plugin.json"
+)
+
+// TargetLocation represents a detected AI assistant config directory.
+type TargetLocation struct {
+	Type string
+	Path string
+}
+
+// SkillMetadata holds the name and version read from a skill package's metadata file.
+type SkillMetadata struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// SyncResult is the JSON output structure.
+type SyncResult struct {
+	Targets        []TargetResult `json:"targets"`
+	SkillsSynced   int            `json:"skillsSynced"`
+	SkillsUpToDate int            `json:"skillsUpToDate"`
+	Errors         []string       `json:"errors,omitempty"`
+}
+
+// TargetResult represents the sync outcome for a single target/skill pair.
+type TargetResult struct {
+	Path      string `json:"path"`
+	Type      string `json:"type"`
+	SkillName string `json:"skillName"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
+}
+
+type skillsSyncCmd struct {
+	jsonOutput bool
+	force      bool
+
+	cloneFunc func(ctx context.Context) (string, error)
+}
+
+func newSyncCmd() *cobra.Command {
+	var cmd skillsSyncCmd
+	cobraCmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Sync Pulumi agent skills to AI assistant config directories",
+		Long: "Sync Pulumi agent skills from github.com/pulumi/agent-skills to AI assistant\n" +
+			"configuration directories in the current working directory.\n" +
+			"\n" +
+			"This command detects AI assistant configuration directories (.claude/, .cursor/,\n" +
+			".windsurf/, .github/, .agents/) and installs Pulumi skills into each one.\n" +
+			"Skills are only updated when a newer version is available unless --force is used.\n" +
+			"\n" +
+			"Supported AI assistants:\n" +
+			"  - Claude Code (.claude/)\n" +
+			"  - Cursor (.cursor/)\n" +
+			"  - Windsurf (.windsurf/)\n" +
+			"  - GitHub Copilot (.github/skills/)\n" +
+			"  - Codex (.agents/)",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cobraCmd, constrictor.NoArgs)
+
+	cobraCmd.PersistentFlags().BoolVarP(&cmd.force, "force", "f", false,
+		"Force sync even if skills are up to date")
+	cobraCmd.PersistentFlags().BoolVar(&cmd.jsonOutput, "json", false,
+		"Emit output as JSON")
+
+	return cobraCmd
+}
+
+// Run executes the sync command using the current working directory.
+func (cmd *skillsSyncCmd) Run(ctx context.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+	return cmd.runInDir(ctx, cwd)
+}
+
+func (cmd *skillsSyncCmd) getCloneFunc() func(ctx context.Context) (string, error) {
+	if cmd.cloneFunc != nil {
+		return cmd.cloneFunc
+	}
+	return cloneSkillsRepo
+}
+
+func (cmd *skillsSyncCmd) runInDir(ctx context.Context, dir string) error {
+	targets, err := detectTargetLocations(dir)
+	if err != nil {
+		return fmt.Errorf("detecting target locations: %w", err)
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("no AI assistant configuration directories found in %s\n\n"+
+			"Supported configurations:\n"+
+			"  - .claude/                           (Claude Code)\n"+
+			"  - .cursor/                           (Cursor)\n"+
+			"  - .windsurf/                         (Windsurf)\n"+
+			"  - .github/skills/                    (GitHub Copilot)\n"+
+			"  - .agents/                           (Codex)\n\n"+
+			"Create one of these directories and try again.", dir)
+	}
+
+	if !cmd.jsonOutput {
+		fmt.Fprintf(os.Stdout, "Detected %d AI assistant configuration(s):\n", len(targets))
+		for _, t := range targets {
+			fmt.Fprintf(os.Stdout, "  - %s (%s)\n", t.Type, t.Path)
+		}
+		fmt.Fprintln(os.Stdout)
+		fmt.Fprintln(os.Stdout, "Fetching skills from github.com/pulumi/agent-skills...")
+	}
+
+	repoDir, err := cmd.getCloneFunc()(ctx)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(repoDir)
+
+	skillDirs, err := discoverSkillPackages(repoDir)
+	if err != nil {
+		return fmt.Errorf("discovering skills: %w", err)
+	}
+	if len(skillDirs) == 0 {
+		return errors.New("no skills found in repository")
+	}
+
+	result := SyncResult{}
+	for _, skillDirName := range skillDirs {
+		skillPath := filepath.Join(repoDir, skillDirName)
+
+		remoteMeta, err := parseSkillMetadata(skillPath)
+		if err != nil {
+			errMsg := fmt.Sprintf("reading metadata for %s: %s", skillDirName, err.Error())
+			result.Errors = append(result.Errors, errMsg)
+			if !cmd.jsonOutput {
+				fmt.Fprintf(os.Stderr, "Warning: %s\n", errMsg)
+			}
+			continue
+		}
+
+		for _, target := range targets {
+			targetResult := TargetResult{
+				Path:      target.Path,
+				Type:      target.Type,
+				SkillName: remoteMeta.Name,
+			}
+
+			destDir := filepath.Join(target.Path, remoteMeta.Name)
+			localMeta, _ := parseSkillMetadata(destDir)
+
+			if !shouldUpdate(localMeta, remoteMeta, cmd.force) {
+				targetResult.Status = "up-to-date"
+				result.SkillsUpToDate++
+				result.Targets = append(result.Targets, targetResult)
+				if !cmd.jsonOutput {
+					fmt.Fprintf(os.Stdout, "  %s/%s: up to date (v%s)\n",
+						target.Type, remoteMeta.Name, remoteMeta.Version)
+				}
+				continue
+			}
+
+			if localMeta != nil {
+				if err := os.RemoveAll(destDir); err != nil {
+					targetResult.Status = "error"
+					targetResult.Error = err.Error()
+					result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", destDir, err.Error()))
+					result.Targets = append(result.Targets, targetResult)
+					continue
+				}
+			}
+			if err := os.MkdirAll(destDir, 0o755); err != nil {
+				targetResult.Status = "error"
+				targetResult.Error = err.Error()
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", destDir, err.Error()))
+				result.Targets = append(result.Targets, targetResult)
+				continue
+			}
+
+			if err := copyDirectory(skillPath, destDir); err != nil {
+				targetResult.Status = "error"
+				targetResult.Error = err.Error()
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", destDir, err.Error()))
+				result.Targets = append(result.Targets, targetResult)
+				continue
+			}
+
+			targetResult.Status = "synced"
+			result.SkillsSynced++
+			result.Targets = append(result.Targets, targetResult)
+			if !cmd.jsonOutput {
+				action := "installed"
+				if localMeta != nil {
+					action = "updated from v" + localMeta.Version
+				}
+				fmt.Fprintf(os.Stdout, "  %s/%s: %s (v%s)\n",
+					target.Type, remoteMeta.Name, action, remoteMeta.Version)
+			}
+		}
+	}
+
+	if cmd.jsonOutput {
+		return ui.PrintJSON(result)
+	}
+
+	fmt.Fprintln(os.Stdout)
+	if result.SkillsSynced > 0 {
+		fmt.Fprintf(os.Stdout, "Synced %d skill(s).\n", result.SkillsSynced)
+	}
+	if result.SkillsUpToDate > 0 {
+		fmt.Fprintf(os.Stdout, "%d skill(s) already up to date.\n", result.SkillsUpToDate)
+	}
+	if len(result.Errors) > 0 {
+		return fmt.Errorf("completed with %d error(s)", len(result.Errors))
+	}
+
+	return nil
+}
+
+func detectTargetLocations(cwd string) ([]TargetLocation, error) {
+	var targets []TargetLocation
+
+	if info, err := os.Stat(filepath.Join(cwd, ".claude")); err == nil && info.IsDir() {
+		targets = append(targets, TargetLocation{
+			Type: "claude",
+			Path: filepath.Join(cwd, ".claude", "skills"),
+		})
+	}
+
+	if info, err := os.Stat(filepath.Join(cwd, ".cursor")); err == nil && info.IsDir() {
+		targets = append(targets, TargetLocation{
+			Type: "cursor",
+			Path: filepath.Join(cwd, ".cursor", "skills"),
+		})
+	}
+
+	if info, err := os.Stat(filepath.Join(cwd, ".windsurf")); err == nil && info.IsDir() {
+		targets = append(targets, TargetLocation{
+			Type: "windsurf",
+			Path: filepath.Join(cwd, ".windsurf", "skills"),
+		})
+	}
+
+	if info, err := os.Stat(filepath.Join(cwd, ".github", "skills")); err == nil && info.IsDir() {
+		targets = append(targets, TargetLocation{
+			Type: "copilot",
+			Path: filepath.Join(cwd, ".github", "skills"),
+		})
+	}
+
+	if info, err := os.Stat(filepath.Join(cwd, ".agents")); err == nil && info.IsDir() {
+		targets = append(targets, TargetLocation{
+			Type: "codex",
+			Path: filepath.Join(cwd, ".agents", "skills"),
+		})
+	}
+
+	return targets, nil
+}
+
+func discoverSkillPackages(repoDir string) ([]string, error) {
+	entries, err := os.ReadDir(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	var skills []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(repoDir, entry.Name(), metadataPath)); err == nil {
+			skills = append(skills, entry.Name())
+		}
+	}
+	return skills, nil
+}
+
+func cloneSkillsRepo(ctx context.Context) (string, error) {
+	tempDir, err := os.MkdirTemp("", "pulumi-skills-")
+	if err != nil {
+		return "", fmt.Errorf("creating temp directory: %w", err)
+	}
+
+	branch := plumbing.NewBranchReferenceName(skillsBranch)
+
+	if err := gitutil.GitCloneOrPull(ctx, skillsRepoURL, branch, tempDir, true); err != nil {
+		os.RemoveAll(tempDir)
+		return "", fmt.Errorf("cloning skills repository: %w", err)
+	}
+
+	return tempDir, nil
+}
+
+func parseSkillMetadata(skillDir string) (*SkillMetadata, error) {
+	path := filepath.Join(skillDir, metadataPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading skill metadata: %w", err)
+	}
+
+	var meta SkillMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parsing skill metadata: %w", err)
+	}
+
+	if meta.Version == "" {
+		return nil, errors.New("skill metadata missing version field")
+	}
+	if meta.Name == "" {
+		return nil, errors.New("skill metadata missing name field")
+	}
+
+	return &meta, nil
+}
+
+func shouldUpdate(local, remote *SkillMetadata, force bool) bool {
+	if force {
+		return true
+	}
+	if local == nil {
+		return true
+	}
+	if remote == nil {
+		return false
+	}
+
+	localVer, err := semver.ParseTolerant(local.Version)
+	if err != nil {
+		return true
+	}
+
+	remoteVer, err := semver.ParseTolerant(remote.Version)
+	if err != nil {
+		return false
+	}
+
+	return remoteVer.GT(localVer)
+}
+
+func copyDirectory(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() && d.Name() == ".git" {
+			return filepath.SkipDir
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755)
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(dstPath, content, info.Mode().Perm()|0o644)
+	})
+}

--- a/pkg/cmd/pulumi/skills/skills_sync_test.go
+++ b/pkg/cmd/pulumi/skills/skills_sync_test.go
@@ -1,0 +1,641 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createFakeRepo(t *testing.T, skills map[string]SkillMetadata) string {
+	t.Helper()
+	repoDir := t.TempDir()
+	for dirName, meta := range skills {
+		skillDir := filepath.Join(repoDir, dirName)
+		require.NoError(t, os.MkdirAll(filepath.Join(skillDir, ".claude-plugin"), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(skillDir, "skills", "example-skill"), 0o755))
+
+		metaJSON := `{"name": "` + meta.Name + `", "version": "` + meta.Version + `"}`
+		require.NoError(t, os.WriteFile(
+			filepath.Join(skillDir, ".claude-plugin", "plugin.json"),
+			[]byte(metaJSON), 0o600))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(skillDir, "skills", "example-skill", "SKILL.md"),
+			[]byte("# "+meta.Name+"\nversion "+meta.Version), 0o600))
+	}
+	return repoDir
+}
+
+func fakeCloneFunc(t *testing.T, repoDir string) func(ctx context.Context) (string, error) {
+	t.Helper()
+	return func(ctx context.Context) (string, error) {
+		tmpDir := t.TempDir()
+		require.NoError(t, copyDirectory(repoDir, tmpDir))
+		return tmpDir, nil
+	}
+}
+
+func TestDetectTargetLocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, dir string)
+		expected []TargetLocation
+	}{
+		{
+			name: "claude directory",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "claude", Path: ".claude/skills"},
+			},
+		},
+		{
+			name: "cursor directory",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".cursor"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "cursor", Path: ".cursor/skills"},
+			},
+		},
+		{
+			name: "windsurf directory",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".windsurf"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "windsurf", Path: ".windsurf/skills"},
+			},
+		},
+		{
+			name: "copilot skills directory",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "skills"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "copilot", Path: ".github/skills"},
+			},
+		},
+		{
+			name: "codex agents directory",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".agents"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "codex", Path: ".agents/skills"},
+			},
+		},
+		{
+			name: "multiple targets",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".cursor"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "claude", Path: ".claude/skills"},
+				{Type: "cursor", Path: ".cursor/skills"},
+			},
+		},
+		{
+			name: "all targets",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".cursor"), 0o755))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".windsurf"), 0o755))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, ".github", "skills"), 0o755))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, ".agents"), 0o755))
+			},
+			expected: []TargetLocation{
+				{Type: "claude", Path: ".claude/skills"},
+				{Type: "cursor", Path: ".cursor/skills"},
+				{Type: "windsurf", Path: ".windsurf/skills"},
+				{Type: "copilot", Path: ".github/skills"},
+				{Type: "codex", Path: ".agents/skills"},
+			},
+		},
+		{
+			name:     "empty directory",
+			setup:    func(t *testing.T, dir string) {},
+			expected: nil,
+		},
+		{
+			name: "unrelated files only",
+			setup: func(t *testing.T, dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte{}, 0o600))
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			targets, err := detectTargetLocations(dir)
+			require.NoError(t, err)
+
+			if tt.expected == nil {
+				assert.Empty(t, targets)
+				return
+			}
+
+			require.Len(t, targets, len(tt.expected))
+			for i, expected := range tt.expected {
+				assert.Equal(t, expected.Type, targets[i].Type)
+				relPath, err := filepath.Rel(dir, targets[i].Path)
+				require.NoError(t, err)
+				assert.Equal(t, expected.Path, relPath)
+			}
+		})
+	}
+}
+
+func TestShouldUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		local    *SkillMetadata
+		remote   *SkillMetadata
+		force    bool
+		expected bool
+	}{
+		{
+			name:     "remote newer",
+			local:    &SkillMetadata{Version: "1.0.0"},
+			remote:   &SkillMetadata{Version: "1.0.1"},
+			expected: true,
+		},
+		{
+			name:     "local newer",
+			local:    &SkillMetadata{Version: "1.0.1"},
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			expected: false,
+		},
+		{
+			name:     "same version",
+			local:    &SkillMetadata{Version: "1.0.0"},
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			expected: false,
+		},
+		{
+			name:     "major version bump",
+			local:    &SkillMetadata{Version: "1.9.9"},
+			remote:   &SkillMetadata{Version: "2.0.0"},
+			expected: true,
+		},
+		{
+			name:     "not installed",
+			local:    nil,
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			expected: true,
+		},
+		{
+			name:     "force flag",
+			local:    &SkillMetadata{Version: "1.0.0"},
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			force:    true,
+			expected: true,
+		},
+		{
+			name:     "force with local newer",
+			local:    &SkillMetadata{Version: "2.0.0"},
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			force:    true,
+			expected: true,
+		},
+		{
+			name:     "invalid local version",
+			local:    &SkillMetadata{Version: "invalid"},
+			remote:   &SkillMetadata{Version: "1.0.0"},
+			expected: true,
+		},
+		{
+			name:     "invalid remote version",
+			local:    &SkillMetadata{Version: "1.0.0"},
+			remote:   &SkillMetadata{Version: "invalid"},
+			expected: false,
+		},
+		{
+			name:     "nil remote",
+			local:    &SkillMetadata{Version: "1.0.0"},
+			remote:   nil,
+			expected: false,
+		},
+		{
+			name:     "both nil",
+			local:    nil,
+			remote:   nil,
+			expected: true, // nil local means not installed, should try to install
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := shouldUpdate(tt.local, tt.remote, tt.force)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseSkillMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		content     string
+		expected    *SkillMetadata
+		expectError bool
+	}{
+		{
+			name:     "valid metadata",
+			content:  `{"name": "pulumi-migration", "version": "1.0.0"}`,
+			expected: &SkillMetadata{Name: "pulumi-migration", Version: "1.0.0"},
+		},
+		{
+			name:     "valid metadata with extra fields",
+			content:  `{"name": "pulumi-authoring", "version": "2.1.0", "description": "test"}`,
+			expected: &SkillMetadata{Name: "pulumi-authoring", Version: "2.1.0"},
+		},
+		{
+			name:        "missing version",
+			content:     `{"name": "pulumi-migration"}`,
+			expectError: true,
+		},
+		{
+			name:        "missing name",
+			content:     `{"version": "1.0.0"}`,
+			expectError: true,
+		},
+		{
+			name:        "invalid json",
+			content:     `{invalid}`,
+			expectError: true,
+		},
+		{
+			name:        "empty file",
+			content:     ``,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			metaDir := filepath.Join(dir, ".claude-plugin")
+			require.NoError(t, os.MkdirAll(metaDir, 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(metaDir, "plugin.json"), []byte(tt.content), 0o600))
+
+			metadata, err := parseSkillMetadata(dir)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected.Name, metadata.Name)
+				assert.Equal(t, tt.expected.Version, metadata.Version)
+			}
+		})
+	}
+}
+
+func TestParseSkillMetadataNoFile(t *testing.T) {
+	t.Parallel()
+	_, err := parseSkillMetadata(t.TempDir())
+	assert.Error(t, err)
+}
+
+func TestDiscoverSkillPackages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finds skill packages with metadata", func(t *testing.T) {
+		t.Parallel()
+		repoDir := createFakeRepo(t, map[string]SkillMetadata{
+			"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+			"authoring": {Name: "pulumi-authoring", Version: "1.0.0"},
+		})
+
+		packages, err := discoverSkillPackages(repoDir)
+		require.NoError(t, err)
+		require.Len(t, packages, 2)
+		assert.Contains(t, packages, "migration")
+		assert.Contains(t, packages, "authoring")
+	})
+
+	t.Run("ignores directories without metadata", func(t *testing.T) {
+		t.Parallel()
+		repoDir := createFakeRepo(t, map[string]SkillMetadata{
+			"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+		})
+		require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "docs"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hi"), 0o600))
+
+		packages, err := discoverSkillPackages(repoDir)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"migration"}, packages)
+	})
+
+	t.Run("returns empty for repo with no skills", func(t *testing.T) {
+		t.Parallel()
+		repoDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(repoDir, "docs"), 0o755))
+
+		packages, err := discoverSkillPackages(repoDir)
+		require.NoError(t, err)
+		assert.Empty(t, packages)
+	})
+}
+
+func TestCopyDirectory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("copies all files preserving structure", func(t *testing.T) {
+		t.Parallel()
+
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		require.NoError(t, os.MkdirAll(filepath.Join(src, ".claude-plugin"), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(src, ".claude-plugin", "plugin.json"),
+			[]byte(`{"name": "test", "version": "1.0.0"}`), 0o600))
+		require.NoError(t, os.MkdirAll(filepath.Join(src, "skills", "test-skill"), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(src, "skills", "test-skill", "SKILL.md"),
+			[]byte("# Test Skill"), 0o600))
+
+		require.NoError(t, copyDirectory(src, dst))
+
+		content, err := os.ReadFile(filepath.Join(dst, ".claude-plugin", "plugin.json"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), `"test"`)
+
+		content, err = os.ReadFile(filepath.Join(dst, "skills", "test-skill", "SKILL.md"))
+		require.NoError(t, err)
+		assert.Equal(t, "# Test Skill", string(content))
+	})
+
+	t.Run("overwrites existing files", func(t *testing.T) {
+		t.Parallel()
+
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		require.NoError(t, os.WriteFile(filepath.Join(src, "file.txt"), []byte("new"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dst, "file.txt"), []byte("old"), 0o600))
+
+		require.NoError(t, copyDirectory(src, dst))
+
+		content, err := os.ReadFile(filepath.Join(dst, "file.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "new", string(content))
+	})
+
+	t.Run("skips .git directory", func(t *testing.T) {
+		t.Parallel()
+
+		src := t.TempDir()
+		dst := t.TempDir()
+
+		require.NoError(t, os.MkdirAll(filepath.Join(src, ".git"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(src, ".git", "config"), []byte("git"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(src, "file.txt"), []byte("content"), 0o600))
+
+		require.NoError(t, copyDirectory(src, dst))
+
+		_, err := os.Stat(filepath.Join(dst, ".git"))
+		assert.True(t, os.IsNotExist(err))
+
+		_, err = os.Stat(filepath.Join(dst, "file.txt"))
+		require.NoError(t, err)
+	})
+}
+
+func TestSyncNoTargets(t *testing.T) {
+	t.Parallel()
+
+	cmd := &skillsSyncCmd{}
+	err := cmd.runInDir(context.Background(), t.TempDir())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no AI assistant configuration directories found")
+}
+
+func TestSyncFreshInstall(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	repoDir := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+		"authoring": {Name: "pulumi-authoring", Version: "2.0.0"},
+	})
+
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoDir)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		".claude-plugin", "plugin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"version": "1.0.0"`)
+
+	data, err = os.ReadFile(filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		"skills", "example-skill", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "pulumi-migration")
+
+	data, err = os.ReadFile(filepath.Join(dir, ".claude", "skills", "pulumi-authoring",
+		".claude-plugin", "plugin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"version": "2.0.0"`)
+}
+
+func TestSyncMultipleTargets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".cursor"), 0o755))
+
+	repoDir := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+	})
+
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoDir)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	for _, target := range []string{".claude", ".cursor"} {
+		data, err := os.ReadFile(filepath.Join(dir, target, "skills", "pulumi-migration",
+			".claude-plugin", "plugin.json"))
+		require.NoError(t, err, "reading metadata from %s", target)
+		assert.Contains(t, string(data), `"pulumi-migration"`)
+	}
+}
+
+func TestSyncSkipsUpToDate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	repoDir := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+	})
+
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoDir)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	skillFile := filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		"skills", "example-skill", "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("TAMPERED"), 0o600))
+
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	data, err := os.ReadFile(skillFile)
+	require.NoError(t, err)
+	assert.Equal(t, "TAMPERED", string(data), "file should not be overwritten when up to date")
+}
+
+func TestSyncUpdatesWhenNewer(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	repoV1 := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+	})
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoV1)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	repoV2 := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "2.0.0"},
+	})
+	cmd = &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoV2)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		".claude-plugin", "plugin.json"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"version": "2.0.0"`)
+
+	data, err = os.ReadFile(filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		"skills", "example-skill", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "version 2.0.0")
+}
+
+func TestSyncRemovesStaleFilesOnUpdate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	repoV1 := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+	})
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoV1)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	staleDir := filepath.Join(dir, ".claude", "skills", "pulumi-migration", "skills", "old-skill")
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staleDir, "SKILL.md"), []byte("stale"), 0o600))
+
+	repoV2 := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "2.0.0"},
+	})
+	cmd = &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoV2)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	_, err := os.Stat(filepath.Join(staleDir, "SKILL.md"))
+	assert.True(t, os.IsNotExist(err), "stale file should be removed on update")
+}
+
+func TestSyncForce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	repoDir := createFakeRepo(t, map[string]SkillMetadata{
+		"migration": {Name: "pulumi-migration", Version: "1.0.0"},
+	})
+
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, repoDir)}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	skillFile := filepath.Join(dir, ".claude", "skills", "pulumi-migration",
+		"skills", "example-skill", "SKILL.md")
+	require.NoError(t, os.WriteFile(skillFile, []byte("TAMPERED"), 0o600))
+
+	cmd.force = true
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	data, err := os.ReadFile(skillFile)
+	require.NoError(t, err)
+	assert.NotEqual(t, "TAMPERED", string(data), "force should overwrite tampered file")
+	assert.Contains(t, string(data), "pulumi-migration")
+}
+
+func TestSyncNoSkillsInRepo(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	emptyRepo := t.TempDir()
+	cmd := &skillsSyncCmd{cloneFunc: fakeCloneFunc(t, emptyRepo)}
+	err := cmd.runInDir(context.Background(), dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no skills found")
+}
+
+func TestSyncIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".claude"), 0o755))
+
+	cmd := &skillsSyncCmd{}
+	require.NoError(t, cmd.runInDir(context.Background(), dir))
+
+	entries, err := os.ReadDir(filepath.Join(dir, ".claude", "skills"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, entries, "expected at least one skill installed")
+
+	for _, entry := range entries {
+		meta, err := parseSkillMetadata(filepath.Join(dir, ".claude", "skills", entry.Name()))
+		require.NoError(t, err, "each installed dir should have valid metadata")
+		assert.NotEmpty(t, meta.Name)
+		assert.NotEmpty(t, meta.Version)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pulumi skills sync` command that syncs Pulumi agent skills from github.com/pulumi/agent-skills to detected AI assistant configuration directories.

Closes #21822

- Detects AI assistant config directories: Claude Code (`.claude/`), Cursor (`.cursor/`), Windsurf (`.windsurf/`), GitHub Copilot (`.github/skills/`), Codex (`.agents/`)
- Compares skill versions and only updates when newer versions are available
- Supports `--force` flag to sync regardless of version
- Supports `--json` flag for machine-readable output