### PR TITLE
Ensure `(*testHost).ResolvePlugin` does not panic

### DIFF
--- a/pkg/testing/pulumi-test-language/test_host.go
+++ b/pkg/testing/pulumi-test-language/test_host.go
@@ -251,7 +251,7 @@ func (h *testHost) ResolvePlugin(
 			if err != nil {
 				return nil, fmt.Errorf("get provider version %s: %w", pkg, err)
 			}
-			if spec.Name == string(pkg) && spec.Version == nil || spec.Version.EQ(providerVersion) {
+			if spec.Name == string(pkg) && (spec.Version == nil || spec.Version.EQ(providerVersion)) {
 				return &workspace.PluginInfo{
 					Name:    spec.Name,
 					Kind:    spec.Kind,


### PR DESCRIPTION
A missing version would previously panic. The expression in question (without parentheses) bound like this:

```go
if (spec.Name == string(pkg) && spec.Version == nil) || spec.Version.EQ(providerVersion) {
```

This change corrects the precedence:

```go
if spec.Name == string(pkg) && (spec.Version == nil || spec.Version.EQ(providerVersion)) {
```