### PR TITLE
Speed up windows tests with this one weird trick

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -116,11 +116,6 @@ jobs:
     timeout-minutes: 70
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
-      - name: Print RUNNER_TEMP
-        run: |
-          echo "RUNNER_TEMP: ${{ runner.temp }}"
-          echo "TMP: ${TMP}"
-          echo "TEMP: ${TEMP}"
       - if: contains(inputs.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be


### PR DESCRIPTION
Looking at some recent test runs for PRs, we see that on Windows there are many integration tests that take minutes to run.

Some recent examples for `tests/integration 2/8 windows`

<details>
<summary>
<a href="https://github.com/pulumi/pulumi/actions/runs/22109606029/job/63902760876"> job/63902760876 </a> - 30m 50s
</summary>
<pre>
TestPolicyPackPublish	github.com/pulumi/pulumi/tests/integration	11m50.87s	pass
TestUntaintResource	github.com/pulumi/pulumi/tests/integration	5m54.94s	pass
TestConfigFlag	github.com/pulumi/pulumi/tests/integration	5m54.43s	pass
TestNodePackageAddTypes	github.com/pulumi/pulumi/tests/integration	5m45.05s	pass
TestPythonComponentProviderRun/nodejs	github.com/pulumi/pulumi/tests/integration	5m14.96s	pass
TestPythonComponentProviderInComponentProvider	github.com/pulumi/pulumi/tests/integration	3m44.45s	pass
</pre>
</details>
<details>
<summary>
<a href="https://github.com/pulumi/pulumi/actions/runs/22121605474/job/63943391588">job/63943391588</a> -  27m 9s
</summary>
<pre>
TestPolicyPackPublish	github.com/pulumi/pulumi/tests/integration	5m29.13s	pass
TestUntaintResource	github.com/pulumi/pulumi/tests/integration	4m3.42s	pass
TestConfigFlag	github.com/pulumi/pulumi/tests/integration	3m57.06s	pass
TestPythonComponentProviderInComponentProvider	github.com/pulumi/pulumi/tests/integration	3m55.85s	pass
TestPythonComponentProviderRun/nodejs	github.com/pulumi/pulumi/tests/integration	3m16.39s	pass
TestNodePackageAddTypes	github.com/pulumi/pulumi/tests/integration	2m31.47s	pass
TestPackageAddNode/npm	github.com/pulumi/pulumi/tests/integration	2m15.28s	pass
TestPythonComponentProviderRun/python	github.com/pulumi/pulumi/tests/integration	2m1.16s	pass
</pre>
</details>

There is anecdotal evidence that using the D: drive is faster for tests on windows runners:
* https://github.com/actions/runner-images/issues/8755
* https://github.com/conda/conda/pull/15453

By setting `$TMP` to point to `runner.temp`, ie `D:\a\_temp` on Windows, we also see a significant speed up for tests that create a temporary pulumi test environment, with speed comparable to that of the `ubuntu` runners.

With this PR:

<details>
<summary>
<a href="https://github.com/pulumi/pulumi/actions/runs/22142112181/job/64009939001"> job/64009939001 </a> - 16m 39s
</summary>
<pre>
TestPythonComponentProviderInComponentProvider	github.com/pulumi/pulumi/tests/integration	2m56.95s	pass
TestConstructProviderPropagationPython	github.com/pulumi/pulumi/tests/integration	2m14.199999999s	pass
TestPythonComponentProviderRun/nodejs	github.com/pulumi/pulumi/tests/integration	1m41.81s	pass
TestPythonComponentProviderRun/python	github.com/pulumi/pulumi/tests/integration	1m41.09s	pass
TestGetResourcePython	github.com/pulumi/pulumi/tests/integration	1m38.58s	pass
TestConstructUnknownPython	github.com/pulumi/pulumi/tests/integration	1m7.91s	pass
TestPartialValuesPython	github.com/pulumi/pulumi/tests/integration	1m7.73s	pass
TestPolicyPackPublish	github.com/pulumi/pulumi/tests/integration	1m4.17s	pass</pre>
</details>
<details>
<summary>
<a href="https://github.com/pulumi/pulumi/actions/runs/22140762206/job/64005059024"> job/64005059024</a> - 18m 33s
</summary>
<pre>

</pre>
</details>