### PR TITLE
Fix flaky TestPolicyProxy_Attach_ConfigureStackError

### DIFF
--- a/sdk/policy_proxy_test.go
+++ b/sdk/policy_proxy_test.go
@@ -207,10 +207,7 @@ func TestPolicyProxy_Attach_ConfigureStackError(t *testing.T) {
 	_, err = proxy.ConfigureStack(ctx, &pulumirpc.AnalyzerStackConfigureRequest{})
 	require.NoError(t, err)
 
-	// We don't need a long-running cmd here: Attach returns early on ConfigureStack error before
-	// waiting for the process to exit. Use a no-op process so cmd.Wait() is valid.
-	cmd := exec.Command("true")
-	require.NoError(t, cmd.Start())
+	cmd := startLongRunningCmd(t)
 	attachDone := runAttach(ctx, proxy, cmd)
 
 	// Write port after starting Attach goroutine so the synchronous pipe write doesn't block.


### PR DESCRIPTION
This test would occasionally fail with:

> Error "could not read policy pack port: io: read/write on closed pipe" does not contain "policy pack configuration failed"

The problem is with the use of `exec.Command("true")`, which exits almost immediately, which could result in the pipe being closed before the port is read, and thus getting the wrong error. The fix is to use `startLongRunningCmd(t)` like the other tests, to avoid the process exiting prematurely, so it fails with the expected error.

Fixes #21868