### PR TITLE
fuzzing: fix URN rewriting with multiple changes

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/program.go
+++ b/pkg/engine/lifecycletest/fuzzing/program.go
@@ -294,13 +294,11 @@ func GeneratedProgramSpec(
 			if urn == "" {
 				return "", false
 			}
-			rewriteCount := 0
 			wasRewritten := false
 			for {
 				if newURN, has := rewritten[urn]; has {
 					urn = newURN
 					wasRewritten = true
-					rewriteCount++
 				} else {
 					return urn, wasRewritten
 				}


### PR DESCRIPTION
During fuzzing a URN can be rewritten multiple ways.  E.g. it is possible that a URN is changed during an update because of a parent change, but that parent could also have change, so we have an additional entry in the "rewritten" table.

Make sure to search this table transitively, so we update dependencies correctly.  Otherwise the fuzzer can fail in ways that can't be reproduced in a real program.