### PR TITLE
pass through context to HTTP calls

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -265,7 +265,7 @@ type Backend interface {
 	//
 	// When a stack has been instantiated, you should favor using the Stack.DefaultSecretManager method to get a default
 	// secrets manager for that stack.
-	DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManager(ctx context.Context, ps *workspace.ProjectStack) (secrets.Manager, error)
 
 	// SupportsTemplates checks if the backend supports listing and downloading templates.
 	SupportsTemplates() bool

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1564,7 +1564,7 @@ func (b *diyBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend.S
 	return nil
 }
 
-func (b *diyBackend) DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error) {
+func (b *diyBackend) DefaultSecretManager(_ context.Context, ps *workspace.ProjectStack) (secrets.Manager, error) {
 	// The default secrets manager for stacks against a DIY backend is a
 	// passphrase-based manager.
 	return passphrase.NewPromptingPassphraseSecretsManager(ps, false /* rotateSecretsProvider */)

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -121,7 +121,7 @@ func (s *diyStack) Tags() map[apitype.StackTagName]string {
 	return tags
 }
 
-func (s *diyStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
+func (s *diyStack) DefaultSecretManager(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 	return passphrase.NewPromptingPassphraseSecretsManager(info, false /* rotatePassphraseSecretsProvider */)
 }
 

--- a/pkg/backend/diy/stack_tags_test.go
+++ b/pkg/backend/diy/stack_tags_test.go
@@ -441,7 +441,7 @@ func (m *mockStackForTesting) SnapshotStackOutputs(context.Context, secrets.Prov
 }
 func (m *mockStackForTesting) Backend() backend.Backend              { return nil }
 func (m *mockStackForTesting) Tags() map[apitype.StackTagName]string { return nil }
-func (m *mockStackForTesting) DefaultSecretManager(*workspace.ProjectStack) (secrets.Manager, error) {
+func (m *mockStackForTesting) DefaultSecretManager(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
 	return nil, nil
 }
 

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -254,8 +254,8 @@ func (s *cloudStack) SnapshotStackOutputs(
 	return *s.snapshotStackOutputs.Load(), nil
 }
 
-func (s *cloudStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
-	return service.NewServiceSecretsManager(s.b.Client(), s.StackIdentifier(), info)
+func (s *cloudStack) DefaultSecretManager(ctx context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
+	return service.NewServiceSecretsManager(ctx, s.b.Client(), s.StackIdentifier(), info)
 }
 
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -102,7 +102,7 @@ type MockBackend struct {
 
 	CancelCurrentUpdateF func(ctx context.Context, stackRef StackReference) error
 
-	DefaultSecretManagerF func(ps *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManagerF func(ctx context.Context, ps *workspace.ProjectStack) (secrets.Manager, error)
 
 	SupportsTemplatesF        func() bool
 	ListTemplatesF            func(_ context.Context, orgName string) (apitype.ListOrgTemplatesResponse, error)
@@ -471,9 +471,9 @@ func (be *MockBackend) GetGHAppIntegration(ctx context.Context, stack Stack) (*a
 	panic("not implemented")
 }
 
-func (be *MockBackend) DefaultSecretManager(ps *workspace.ProjectStack) (secrets.Manager, error) {
+func (be *MockBackend) DefaultSecretManager(ctx context.Context, ps *workspace.ProjectStack) (secrets.Manager, error) {
 	if be.DefaultSecretManagerF != nil {
-		return be.DefaultSecretManagerF(ps)
+		return be.DefaultSecretManagerF(ctx, ps)
 	}
 	panic("not implemented")
 }
@@ -590,7 +590,7 @@ type MockStack struct {
 	SnapshotF             func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
 	TagsF                 func() map[apitype.StackTagName]string
 	BackendF              func() Backend
-	DefaultSecretManagerF func(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManagerF func(ctx context.Context, info *workspace.ProjectStack) (secrets.Manager, error)
 }
 
 var _ Stack = (*MockStack)(nil)
@@ -676,9 +676,9 @@ func (ms *MockStack) Backend() Backend {
 	panic("not implemented: MockStack.Backend")
 }
 
-func (ms *MockStack) DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error) {
+func (ms *MockStack) DefaultSecretManager(ctx context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 	if ms.DefaultSecretManagerF != nil {
-		return ms.DefaultSecretManagerF(info)
+		return ms.DefaultSecretManagerF(ctx, info)
 	}
 	panic("not implemented: MockStack.DefaultSecretManager")
 }

--- a/pkg/backend/secrets.go
+++ b/pkg/backend/secrets.go
@@ -53,8 +53,12 @@ func newErrorCatchingSecretsProvider(
 	}
 }
 
-func (p *errorCatchingSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
-	delegateManager, err := p.delegateProvider.OfType(ty, state)
+func (p *errorCatchingSecretsProvider) OfType(
+	ctx context.Context,
+	ty string,
+	state json.RawMessage,
+) (secrets.Manager, error) {
+	delegateManager, err := p.delegateProvider.OfType(ctx, ty, state)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/secrets/providers.go
+++ b/pkg/backend/secrets/providers.go
@@ -15,6 +15,7 @@
 package secrets
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -35,14 +36,14 @@ type secretsProvider struct{}
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
 // if the type is unknown or the state is invalid.
-func (secretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+func (secretsProvider) OfType(ctx context.Context, ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error
 	switch ty {
 	case passphrase.Type:
 		sm, err = passphrase.NewPromptingPassphraseSecretsManagerFromState(state)
 	case service.Type:
-		sm, err = service.NewServiceSecretsManagerFromState(state)
+		sm, err = service.NewServiceSecretsManagerFromState(ctx, state)
 	case cloud.Type:
 		sm, err = cloud.NewCloudSecretsManagerFromState(state)
 	default:
@@ -65,14 +66,14 @@ type NamedStackProvider struct {
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
 // if the type is unknown or the state is invalid.
-func (s NamedStackProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+func (s NamedStackProvider) OfType(ctx context.Context, ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error
 	switch ty {
 	case passphrase.Type:
 		sm, err = passphrase.NewStackPromptingPassphraseSecretsManagerFromState(state, s.StackName)
 	case service.Type:
-		sm, err = service.NewServiceSecretsManagerFromState(state)
+		sm, err = service.NewServiceSecretsManagerFromState(ctx, state)
 	case cloud.Type:
 		sm, err = cloud.NewCloudSecretsManagerFromState(state)
 	default:

--- a/pkg/backend/secrets_test.go
+++ b/pkg/backend/secrets_test.go
@@ -37,7 +37,7 @@ func TestErrorCatchingSecretsProvider_OfType_Success(t *testing.T) {
 	provider := newErrorCatchingSecretsProvider(delegate, func(err error) error { return err })
 
 	// Act
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 
 	// Assert
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestErrorCatchingSecretsProvider_Batching_OfType_Success(t *testing.T) {
 	provider := newErrorCatchingSecretsProvider(delegate, func(err error) error { return err })
 
 	// Act
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 
 	// Assert
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestErrorCatchingSecretsProvider_OfType_Error(t *testing.T) {
 	provider := newErrorCatchingSecretsProvider(delegate, func(err error) error { return err })
 
 	// Act
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 
 	// Assert
 	assert.Error(t, err)
@@ -341,7 +341,7 @@ func TestErrorCatchingSecretsManager_Batching_Enqueue_Success(t *testing.T) {
 	delegateManager := &MockProviderManager{batching: true, encrypterDecrypter: encDecrypter}
 
 	provider := newErrorCatchingSecretsProvider(delegateManager, func(err error) error { return err })
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 	require.NoError(t, err)
 
 	batchingManager, ok := manager.(stack.BatchingSecretsManager)
@@ -411,7 +411,7 @@ func TestErrorCatchingSecretsManager_Batching_ErrorPropagated(t *testing.T) {
 		onDecryptErrorCalled = true
 		return err
 	})
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 	require.NoError(t, err)
 
 	batchingManager, ok := manager.(stack.BatchingSecretsManager)
@@ -478,7 +478,7 @@ func TestErrorCatchingSecretsManager_Batching_ErrorIgnored(t *testing.T) {
 		onDecryptErrorCalled = true
 		return nil
 	})
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 	require.NoError(t, err)
 
 	batchingManager, ok := manager.(stack.BatchingSecretsManager)
@@ -532,7 +532,7 @@ func TestErrorCatchingSecretsManager_Batching_NilDecrypter(t *testing.T) {
 	delegateManager := &MockProviderManager{batching: true, encrypterDecrypter: nil}
 
 	provider := newErrorCatchingSecretsProvider(delegateManager, func(err error) error { return err })
-	manager, err := provider.OfType("test", nil)
+	manager, err := provider.OfType(t.Context(), "test", nil)
 	require.NoError(t, err)
 
 	batchingManager, ok := manager.(stack.BatchingSecretsManager)
@@ -602,7 +602,7 @@ func (m *MockProviderManager) Decrypter() config.Decrypter {
 	return nil
 }
 
-func (m *MockProviderManager) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+func (m *MockProviderManager) OfType(_ context.Context, ty string, state json.RawMessage) (secrets.Manager, error) {
 	m.ofTypeCalled = true
 	if m.ofTypeErr != nil {
 		return nil, m.ofTypeErr

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -61,7 +61,7 @@ type Stack interface {
 
 	// DefaultSecretManager returns the default secrets manager to use for this stack. This may be more specific than
 	// Backend.DefaultSecretManager.
-	DefaultSecretManager(info *workspace.ProjectStack) (secrets.Manager, error)
+	DefaultSecretManager(ctx context.Context, info *workspace.ProjectStack) (secrets.Manager, error)
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -125,7 +125,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 						CheckYAMLEnvironmentF: checkYAMLEnvironment,
 					}
 				},
-				DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+				DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 					return b64.NewBase64SecretsManager(), nil
 				},
 				ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -1267,7 +1267,7 @@ func TestConfigPathOperations(t *testing.T) {
 				ConfigLocationF: func() backend.StackConfigLocation {
 					return backend.StackConfigLocation{}
 				},
-				DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+				DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 					return &secrets.MockSecretsManager{
 						TypeF: func() string { return "mock" },
 						EncrypterF: func() config.Encrypter {
@@ -1346,7 +1346,7 @@ func TestConfigPathOperations(t *testing.T) {
 				// Decrypt if needed
 				var actualValue string
 				if v.Secure() {
-					secretsManager, err := s.DefaultSecretManager(ps)
+					secretsManager, err := s.DefaultSecretManager(t.Context(), ps)
 					require.NoError(t, err)
 					decrypter := secretsManager.Decrypter()
 					actualValue, err = v.Value(decrypter)

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -78,7 +78,7 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 			LoadRemoteF: func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error) {
 				return workspace.LoadProjectStack(cmdutil.Diag(), project, "Pulumi.name.yaml")
 			},
-			DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+			DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 				return nil, nil
 			},
 			BackendF: func() backend.Backend {
@@ -114,7 +114,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 			LoadRemoteF: func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error) {
 				return nil, workspace.ErrProjectNotFound
 			},
-			DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+			DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 				return nil, nil
 			},
 			BackendF: func() backend.Backend {
@@ -335,7 +335,7 @@ func TestStackEnvConfig(t *testing.T) {
 				FullyQualifiedNameV: tokens.QName("org/project/" + name),
 			}
 		}
-		stack.DefaultSecretManagerF = func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		stack.DefaultSecretManagerF = func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return mockSecretsManager, nil
 		}
 
@@ -420,7 +420,7 @@ func TestCopyConfig(t *testing.T) {
 				FullyQualifiedNameV: tokens.QName("org/project/" + name),
 			}
 		}
-		stack.DefaultSecretManagerF = func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		stack.DefaultSecretManagerF = func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return mockSecretsManager, nil
 		}
 

--- a/pkg/cmd/pulumi/stack/io_test.go
+++ b/pkg/cmd/pulumi/stack/io_test.go
@@ -90,7 +90,7 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 			require.NoError(t, err)
 			return nil, nil
 		},
-		DefaultSecretManagerF: func(*workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
 			return expectedSm, nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -68,7 +68,7 @@ func CreateSecretsManagerForExistingStack(
 
 	oldConfig := deepcopy.Copy(ps).(*workspace.ProjectStack)
 	if isDefaultSecretsProvider {
-		_, err = stack.DefaultSecretManager(ps)
+		_, err = stack.DefaultSecretManager(ctx, ps)
 	} else if secretsProvider == passphrase.Type {
 		_, err = passphrase.NewPromptingPassphraseSecretsManager(ps, rotateSecretsProvider)
 	} else {
@@ -112,7 +112,7 @@ func createSecretsManagerForNewStack(
 
 	isDefaultSecretsProvider := secretsProvider == "" || secretsProvider == "default"
 	if isDefaultSecretsProvider {
-		sm, err = b.DefaultSecretManager(ps)
+		sm, err = b.DefaultSecretManager(ctx, ps)
 	} else if secretsProvider == passphrase.Type {
 		sm, err = passphrase.NewPromptingPassphraseSecretsManager(ps, false /*rotateSecretsProvider*/)
 	} else {
@@ -283,7 +283,7 @@ func (l *SecretsManagerLoader) GetSecretsManager(
 				ps.EncryptedKey = ""
 			}
 		} else {
-			sm, err = s.DefaultSecretManager(ps)
+			sm, err = s.DefaultSecretManager(ctx, ps)
 		}
 	}
 	if err != nil {

--- a/pkg/cmd/pulumi/stack/secrets_test.go
+++ b/pkg/cmd/pulumi/stack/secrets_test.go
@@ -139,7 +139,7 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 	}
 
 	s := &backend.MockStack{
-		DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return sm, nil
 		},
 		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
@@ -247,7 +247,7 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 	}
 
 	s := &backend.MockStack{
-		DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return sm, nil
 		},
 		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -224,7 +224,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
 			return snapshot, nil
 		},
-		DefaultSecretManagerF: func(_ *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
 			return secretsManager, nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -97,7 +97,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 				// Pass a dummy ProjectStack here since DefaultSecretManger will want to write to it to say no
 				// encryption is in use, but for import purposes we don't care about that.
 				ps := workspace.ProjectStack{}
-				sm, err := s.DefaultSecretManager(&ps)
+				sm, err := s.DefaultSecretManager(ctx, &ps)
 				if err != nil {
 					return fmt.Errorf("could not create service secrets manager for stack %q: %w",
 						s.Ref().String(), err)

--- a/pkg/cmd/pulumi/stack/stack_import_test.go
+++ b/pkg/cmd/pulumi/stack/stack_import_test.go
@@ -72,7 +72,7 @@ func TestStackImport_ChangeServiceSecrets(t *testing.T) {
 			}
 		},
 		BackendF: func() backend.Backend { return be },
-		DefaultSecretManagerF: func(info *workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return newSm, nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_init_test.go
+++ b/pkg/cmd/pulumi/stack/stack_init_test.go
@@ -54,7 +54,7 @@ func TestStackInit_teamsUnsupportedByBackend(t *testing.T) {
 			assert.NotEmpty(t, opts.Teams, "expected teams to be set")
 			return nil, backend.ErrTeamsNotSupported
 		},
-		DefaultSecretManagerF: func(*workspace.ProjectStack) (secrets.Manager, error) {
+		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
 			return nil, nil
 		},
 	}

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -213,7 +213,7 @@ func (cmd *stateMoveCmd) Run(
 			return err
 		}
 
-		destSecretManager, err := dest.DefaultSecretManager(ps)
+		destSecretManager, err := dest.DefaultSecretManager(ctx, ps)
 		if err != nil {
 			return err
 		}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -390,7 +390,7 @@ func DeserializeStackOutputs(
 		return nil, nil
 	}
 
-	secretsManager, err := initializeSecretsManager(deployment, secretsProv)
+	secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
 	if err != nil {
 		return nil, err
 	}
@@ -415,7 +415,7 @@ func DeserializeDeploymentV3(
 		return nil, err
 	}
 
-	secretsManager, err := initializeSecretsManager(deployment, secretsProv)
+	secretsManager, err := initializeSecretsManager(ctx, deployment, secretsProv)
 	if err != nil {
 		return nil, err
 	}
@@ -468,6 +468,7 @@ func DeserializeDeploymentV3(
 
 // initializeSecretsManager initializes the secrets manager for a deployment.
 func initializeSecretsManager(
+	ctx context.Context,
 	deployment apitype.DeploymentV3,
 	secretsProv secrets.Provider,
 ) (secrets.Manager, error) {
@@ -477,7 +478,7 @@ func initializeSecretsManager(
 			return nil, errors.New("deployment uses a SecretsProvider but no SecretsProvider was provided")
 		}
 
-		sm, err := secretsProv.OfType(deployment.SecretsProviders.Type, deployment.SecretsProviders.State)
+		sm, err := secretsProv.OfType(ctx, deployment.SecretsProviders.Type, deployment.SecretsProviders.State)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -1067,7 +1067,7 @@ func TestDeserializeStackOutputs_SecretsInSnapshotButNotInStackOutputs_NoDecrypt
 func TestDeserializeStackOutputs_SecretsInStackOutputs_Decrypted(t *testing.T) {
 	t.Parallel()
 
-	manager, err := b64.Base64SecretsProvider.OfType("b64", nil)
+	manager, err := b64.Base64SecretsProvider.OfType(t.Context(), "b64", nil)
 	require.NoError(t, err)
 	ciphertext, err := manager.Encrypter().EncryptValue(t.Context(), "\"super secret\"")
 	require.NoError(t, err)

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -33,7 +33,7 @@ import (
 
 type Base64SecretsProvider struct{}
 
-func (Base64SecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+func (Base64SecretsProvider) OfType(_ context.Context, ty string, state json.RawMessage) (secrets.Manager, error) {
 	if ty != "b64" {
 		return nil, fmt.Errorf("no known secrets provider for type %q", ty)
 	}

--- a/pkg/secrets/mock.go
+++ b/pkg/secrets/mock.go
@@ -109,7 +109,7 @@ type MockProvider struct {
 	managers map[string]func(json.RawMessage) (Manager, error)
 }
 
-func (mp *MockProvider) OfType(ty string, state json.RawMessage) (Manager, error) {
+func (mp *MockProvider) OfType(_ context.Context, ty string, state json.RawMessage) (Manager, error) {
 	if f, ok := mp.managers[ty]; ok {
 		return f(state)
 	}

--- a/pkg/secrets/provider.go
+++ b/pkg/secrets/provider.go
@@ -15,11 +15,12 @@
 package secrets
 
 import (
+	"context"
 	"encoding/json"
 )
 
 // Provider allows for the creation of secrets managers based on a well-known type name.
 type Provider interface {
 	// OfType returns a secrets manager for the given type, initialized with its previous state.
-	OfType(ty string, state json.RawMessage) (Manager, error)
+	OfType(ctx context.Context, ty string, state json.RawMessage) (Manager, error)
 }

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -273,13 +273,13 @@ func TestPostgresBackend(t *testing.T) {
 
 	// Test default secrets manager
 	projectStack := &workspace.ProjectStack{}
-	secretsManager, err := b.DefaultSecretManager(projectStack)
+	secretsManager, err := b.DefaultSecretManager(ctx, projectStack)
 	if err == nil {
 		require.NotNil(t, secretsManager, "Default secrets manager should not be nil")
 	}
 
 	// Test stack-level secrets manager
-	stackSecretsManager, err := stack1.DefaultSecretManager(projectStack)
+	stackSecretsManager, err := stack1.DefaultSecretManager(ctx, projectStack)
 	if err == nil {
 		require.NotNil(t, stackSecretsManager, "Stack secrets manager should not be nil")
 	}


### PR DESCRIPTION
There's still a few HTTP calls that do not take a context.  Unlike engine operations (see https://github.com/pulumi/pulumi/pull/20561), these should always be safe to abort if the main context is closed.

This will help pass the context correctly for OTEL tracing.