### PR TITLE
Report policy pack installation errors

### DIFF
--- a/changelog/pending/20260219--engine--report-policy-pack-installation-errors.yaml
+++ b/changelog/pending/20260219--engine--report-policy-pack-installation-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Report policy pack installation errors

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -488,11 +488,11 @@ func newUpdateSource(ctx context.Context,
 	client deploy.BackendClient, opts *deploymentOptions, proj *workspace.Project, pwd, main, projectRoot string,
 	target *deploy.Target, plugctx *plugin.Context, resourceHooks *deploy.ResourceHooks, panicErrs chan<- error,
 ) (deploy.Source, error) {
-	manager := newInstallManager(false /*returnPluginErrors*/)
-
 	//
 	// Step 1: Install policy packs and plugins.
 	//
+
+	manager := newInstallManager(false /*returnPluginErrors*/)
 
 	ensurePoliciesAreInstalled(ctx, plugctx, opts, opts.RequiredPolicies, manager)
 
@@ -512,7 +512,7 @@ func newUpdateSource(ctx context.Context,
 	}
 
 	if err := manager.Wait(); err != nil {
-		logging.V(7).Infof("newUpdateSource(): failed to install policy packs and plugins: %v", err)
+		return nil, err
 	}
 
 	//


### PR DESCRIPTION
v3.219.0 included a [change](https://github.com/pulumi/pulumi/pull/21651) to download/install required policy packs in parallel with plugins before a pulumi operation begins. That change mistakenly only logged policy pack installation errors rather than returning the error and stopping the operation. We then subsequently proceed to try to load the policy packs, but this can lead to errors like "Cannot find module" (in the case of nodejs policy packs) because the policy pack wasn't fully installed.

This change fixes the regression by returning any download/installation errors and ending the operation before we try to load the policy packs.

Fixes #21864