### PR TITLE
Remove construct code from ConformanceComponentProvider

### DIFF
--- a/pkg/testing/pulumi-test-language/providers/conformance_component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/conformance_component_provider.go
@@ -17,19 +17,11 @@ package providers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 type ConformanceComponentProvider struct {
@@ -84,72 +76,4 @@ func (p *ConformanceComponentProvider) GetSchema(
 	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
 }
 
-func (p *ConformanceComponentProvider) Construct(
-	ctx context.Context,
-	req plugin.ConstructRequest,
-) (plugin.ConstructResponse, error) {
-	conn, err := grpc.NewClient(
-		req.Info.MonitorAddress,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		rpcutil.GrpcChannelOptions(),
-	)
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("connect to resource monitor: %w", err)
-	}
-	defer conn.Close()
-
-	monitor := pulumirpc.NewResourceMonitorClient(conn)
-
-	if req.Type != "conformance-component:index:Simple" {
-		return plugin.ConstructResponse{}, fmt.Errorf("unknown type %v", req.Type)
-	}
-
-	// Register the parent component.
-	parent, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
-		Type:          "conformance-component:index:Simple",
-		Name:          req.Name,
-		Provider:      req.Options.Providers["conformance-component"],
-		IgnoreChanges: req.Options.IgnoreChanges,
-	})
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("register parent component: %w", err)
-	}
-
-	// Register a child resource, parented to the component we just created.
-	child, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
-		Type:     "simple:index:Resource",
-		Custom:   true,
-		Name:     "res-child",
-		Parent:   parent.Urn,
-		Provider: req.Options.Providers["simple"],
-		Object: &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"value": structpb.NewBoolValue(req.Inputs["value"].BoolValue()),
-			},
-		},
-	})
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("register child resource: %w", err)
-	}
-
-	// Register the component's outputs and finish up.
-	value := child.Object.Fields["value"].GetBoolValue()
-	_, err = monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
-		Urn: parent.Urn,
-		Outputs: &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"value": structpb.NewBoolValue(value),
-			},
-		},
-	})
-	if err != nil {
-		return plugin.ConstructResponse{}, fmt.Errorf("register resource outputs: %w", err)
-	}
-
-	return plugin.ConstructResponse{
-		URN: resource.URN(parent.Urn),
-		Outputs: resource.NewPropertyMapFromMap(map[string]any{
-			"value": value,
-		}),
-	}, nil
-}
+// N.B This provider should not implement any runtime code. It is just used for its schema for program binding.


### PR DESCRIPTION
This provider isn't actually executed against, we just need it to return a schema for binding. The actual runtime code must be implemented by the target language.