### PR TITLE
nodejs: enable incremental builds

### DIFF
--- a/sdk/nodejs/.gitignore
+++ b/sdk/nodejs/.gitignore
@@ -1,4 +1,5 @@
 **/bin
+/build/
 /coverage/
 /prebuilt/
 /node_modules/

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -4,6 +4,8 @@ VERSION          := $(if ${PULUMI_VERSION},${PULUMI_VERSION},$(shell ../../scrip
 
 LANGHOST_PKG    := github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
+_ := $(shell go build -o build/helpmakego github.com/iwahbe/helpmakego)
+
 TEST_FAST_TIMEOUT := 2m
 
 ifeq ($(DEBUG),"true")
@@ -35,7 +37,7 @@ lint_fix:: ensure
 	yarn biome format --write .
 
 build_package:: ensure
-	yarn run tsc
+	yarn run tsc -b
 	mkdir -p bin/tests/automation/data/
 	cp -R tests/automation/data/. bin/tests/automation/data/
 	cp -R tests/provider/experimental/testdata/ bin/tests/provider/experimental/testdata
@@ -51,8 +53,7 @@ build_package:: ensure
 build_plugin: ../../bin/pulumi-language-nodejs
 	cp ./dist/pulumi-resource-pulumi-nodejs ../../bin
 
-.PHONY: ../../bin/pulumi-language-nodejs
-../../bin/pulumi-language-nodejs:
+../../bin/pulumi-language-nodejs: $(shell build/helpmakego cmd/pulumi-language-nodejs)
 	go build -C cmd/pulumi-language-nodejs \
 	-o ../../$@ \
 		-ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" \

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "composite": true,
         "strict": true,
         "outDir": "bin",
         "target": "es2020",
@@ -26,6 +27,7 @@
         "output.ts",
         "resource.ts",
         "stackReference.ts",
+        "stash.ts",
         "tsutils.ts",
         "typescript-shim.ts",
         "utils.ts",
@@ -53,7 +55,10 @@
         "runtime/closure/serializeClosure.ts",
         "runtime/closure/utils.ts",
         "runtime/closure/v8.ts",
+        "runtime/closure/v8Hooks.ts",
+        "runtime/closure/package.ts",
         "runtime/asyncIterableUtil.ts",
+        "runtime/callbacks.ts",
         "runtime/config.ts",
         "runtime/debuggable.ts",
         "runtime/dependsOn.ts",
@@ -63,6 +68,7 @@
         "runtime/rpc.ts",
         "runtime/settings.ts",
         "runtime/stack.ts",
+        "runtime/state.ts",
         "cmd/dynamic-provider/index.ts",
         "cmd/dynamic-provider/config.ts",
         "cmd/run/index.ts",
@@ -77,6 +83,8 @@
         "automation/index.ts",
         "automation/cmd.ts",
         "automation/config.ts",
+        "automation/errors.ts",
+        "automation/events.ts",
         "automation/localWorkspace.ts",
         "automation/minimumVersion.ts",
         "automation/projectSettings.ts",
@@ -85,6 +93,7 @@
         "automation/stackSettings.ts",
         "automation/server.ts",
         "automation/stack.ts",
+        "automation/tag.ts",
         "automation/workspace.ts",
         "tests/cmd/dynamic/config.spec.ts",
         "tests/cmd/run/error.spec.ts",
@@ -123,7 +132,8 @@
         "tests_with_mocks/mocks.spec.ts",
         "npm/testdata/nested/project/index.ts",
         "types/arborist.d.ts",
-        "types/fdir.d.ts"
+        "types/fdir.d.ts",
+        "package.json"
     ],
     "ts-node": {
         "files": true


### PR DESCRIPTION
- Enable incremental `tsc` using the `composite` option in
  `tsconfig.json`
- Use `helpmakego` to skip builds of the language host when possible
