### PR TITLE
pass otel options to grpc clients

### DIFF
--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -59,7 +59,7 @@ func (host *clientLanguageRuntimeHost) LanguageRuntime(
 
 func langRuntimePluginDialOptions(ctx *plugin.Context, address string) []grpc.DialOption {
 	dialOpts := append(
-		rpcutil.OpenTracingInterceptorDialOptions(),
+		rpcutil.TracingInterceptorDialOptions(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		rpcutil.GrpcChannelOptions(),
 	)

--- a/pkg/resource/deploy/deploytest/callbacks.go
+++ b/pkg/resource/deploy/deploytest/callbacks.go
@@ -37,7 +37,7 @@ func NewCallbacksServer() (*CallbackServer, error) {
 			pulumirpc.RegisterCallbacksServer(srv, callbackServer)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource provider service: %w", err)

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -169,7 +169,7 @@ func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer,
 			pulumirpc.RegisterResourceProviderServer(srv, plugin.NewProviderServer(provider))
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not start resource provider service: %w", err)
@@ -198,7 +198,7 @@ func wrapAnalyzerWithGrpc(analyzer plugin.Analyzer) (plugin.Analyzer, io.Closer,
 			pulumirpc.RegisterAnalyzerServer(srv, plugin.NewAnalyzerServer(analyzer))
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not start policy analyzer service: %w", err)
@@ -321,7 +321,7 @@ func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 			pulumirpc.RegisterEngineServer(srv, engine)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		panic(fmt.Errorf("could not start engine service: %w", err))

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -883,7 +883,7 @@ func (rm *resmon) Cancel(ctx context.Context) error {
 }
 
 func sourceEvalServeOptions(ctx *plugin.Context, tracingSpan opentracing.Span, logFile string) []grpc.ServerOption {
-	serveOpts := rpcutil.OpenTracingServerInterceptorOptions(
+	serveOpts := rpcutil.TracingServerInterceptorOptions(
 		tracingSpan,
 		otgrpc.SpanDecorator(decorateResourceSpans),
 	)

--- a/pkg/resource/provider/main.go
+++ b/pkg/resource/provider/main.go
@@ -92,7 +92,7 @@ func MainContext(
 			pulumirpc.RegisterResourceProviderServer(srv, prov)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return fmt.Errorf("fatal: %w", err)

--- a/pkg/testing/pulumi-test-language/policy_simple_test.go
+++ b/pkg/testing/pulumi-test-language/policy_simple_test.go
@@ -360,7 +360,7 @@ func (h *PolicySimpleLanguageHost) RunPlugin(
 			pulumirpc.RegisterAnalyzerServer(srv, analyzer)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return fmt.Errorf("could not start analyzer plugin: %w", err)

--- a/pkg/testing/pulumi-test-language/test_host.go
+++ b/pkg/testing/pulumi-test-language/test_host.go
@@ -336,7 +336,7 @@ func wrapProviderWithGrpc(provider plugin.Provider) (plugin.Provider, io.Closer,
 			pulumirpc.RegisterResourceProviderServer(srv, newProviderServer(provider))
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not start resource provider service: %w", err)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1708,7 +1708,7 @@ func startLanguageRuntimeServer(fn pulumi.RunFunc) (*languageRuntimeServer, erro
 			pulumirpc.RegisterLanguageRuntimeServer(srv, s)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, err
@@ -1914,7 +1914,7 @@ func tailLogs(command string, receivers []chan<- events.EngineEvent, version sem
 				return nil
 			},
 			Cancel:  cancel,
-			Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+			Options: rpcutil.TracingServerInterceptorOptions(nil),
 		})
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -82,7 +82,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	}
 	contract.Assertf(path != "", "unexpected empty path for analyzer plugin %s", name)
 
-	dialOpts := rpcutil.OpenTracingInterceptorDialOptions()
+	dialOpts := rpcutil.TracingInterceptorDialOptions()
 
 	plug, _, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
 		apitype.AnalyzerPlugin, []string{host.ServerAddr(), ctx.Pwd}, nil, /*env*/
@@ -718,7 +718,7 @@ func (a *analyzer) getPolicySeverity(policyName string) apitype.PolicySeverity {
 
 func analyzerPluginDialOptions(ctx *Context, name string) []grpc.DialOption {
 	dialOpts := append(
-		rpcutil.OpenTracingInterceptorDialOptions(),
+		rpcutil.TracingInterceptorDialOptions(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		rpcutil.GrpcChannelOptions(),
 	)

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -76,7 +76,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 
 func converterPluginDialOptions(ctx *Context, name string, path string) []grpc.DialOption {
 	dialOpts := append(
-		rpcutil.OpenTracingInterceptorDialOptions(otgrpc.SpanDecorator(decorateProviderSpans)),
+		rpcutil.TracingInterceptorDialOptions(otgrpc.SpanDecorator(decorateProviderSpans)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		rpcutil.GrpcChannelOptions(),
 	)

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -63,7 +63,7 @@ func newHostServer(host Host, ctx *Context, newLoader NewLoaderFunc) (*hostServe
 			}
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(ctx.tracingSpan),
+		Options: rpcutil.TracingServerInterceptorOptions(ctx.tracingSpan),
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -187,7 +187,7 @@ func GetLanguageAttachPort(runtime string) (*int, error) {
 
 func langRuntimePluginDialOptions(ctx *Context, runtime string) []grpc.DialOption {
 	dialOpts := append(
-		rpcutil.OpenTracingInterceptorDialOptions(),
+		rpcutil.TracingInterceptorDialOptions(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		rpcutil.GrpcChannelOptions(),
 	)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -355,7 +355,7 @@ func handshake(
 
 func providerPluginDialOptions(ctx *Context, pkg tokens.Package, path string) []grpc.DialOption {
 	dialOpts := append(
-		rpcutil.OpenTracingInterceptorDialOptions(otgrpc.SpanDecorator(decorateProviderSpans)),
+		rpcutil.TracingInterceptorDialOptions(otgrpc.SpanDecorator(decorateProviderSpans)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		rpcutil.GrpcChannelOptions(),
 	)

--- a/sdk/go/common/resource/plugin/server.go
+++ b/sdk/go/common/resource/plugin/server.go
@@ -44,7 +44,7 @@ func NewServer(ctx *Context, registrations ...func(server *grpc.Server)) (*GrpcS
 			}
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(ctx.tracingSpan),
+		Options: rpcutil.TracingServerInterceptorOptions(ctx.tracingSpan),
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/util/rpcutil/health.go
+++ b/sdk/go/common/util/rpcutil/health.go
@@ -27,13 +27,12 @@ import (
 
 // Healthcheck will poll the address at duration intervals and then call cancel once it reports unhealthy
 func Healthcheck(context context.Context, addr string, duration time.Duration, cancel context.CancelFunc) error {
-	conn, err := grpc.NewClient(
-		addr,
+	dialOpts := append(
+		TracingInterceptorDialOptions(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithUnaryInterceptor(OpenTracingClientInterceptor()),
-		grpc.WithStreamInterceptor(OpenTracingStreamClientInterceptor()),
 		GrpcChannelOptions(),
 	)
+	conn, err := grpc.NewClient(addr, dialOpts...)
 	if err != nil {
 		return err
 	}

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -15,12 +15,24 @@
 package rpcutil
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"runtime"
+	"strings"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // Configures interceptors to propagate OpenTracing metadata through headers. If parentSpan is non-nil, it becomes the
@@ -29,6 +41,35 @@ func OpenTracingServerInterceptorOptions(parentSpan opentracing.Span, options ..
 	return []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(OpenTracingServerInterceptor(parentSpan, options...)),
 		grpc.ChainStreamInterceptor(OpenTracingStreamServerInterceptor(parentSpan, options...)),
+	}
+}
+
+// Configures interceptors to propagate OpenTracing and OpenTelemetry metadata through headers.
+// If parentSpan is non-nil, it becomes the default parent for orphan spans.
+func TracingServerInterceptorOptions(parentSpan opentracing.Span, options ...otgrpc.Option) []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(
+			OpenTracingServerInterceptor(parentSpan, options...),
+			stackTraceUnaryServerInterceptor(),
+		),
+		grpc.ChainStreamInterceptor(
+			OpenTracingStreamServerInterceptor(parentSpan, options...),
+			stackTraceStreamServerInterceptor(),
+		),
+	}
+}
+
+// Configures gRPC clients with OpenTracing and OpenTelemetry interceptors.
+func TracingInterceptorDialOptions(opts ...otgrpc.Option) []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(
+			OpenTracingClientInterceptor(opts...),
+			otelUnaryClientInterceptor(),
+		),
+		grpc.WithChainStreamInterceptor(
+			OpenTracingStreamClientInterceptor(opts...),
+			otelStreamClientInterceptor(),
+		),
 	}
 }
 
@@ -137,4 +178,168 @@ func logPayloads() []otgrpc.Option {
 		res = append(res, otgrpc.LogPayloads())
 	}
 	return res
+}
+
+func captureStackTrace(skip int) string {
+	const maxDepth = 32
+	var pcs [maxDepth]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+
+	var stackBuilder strings.Builder
+	more := true
+	for more {
+		var frame runtime.Frame
+		frame, more = frames.Next()
+		fmt.Fprintf(&stackBuilder, "%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
+	}
+
+	return stackBuilder.String()
+}
+
+func stackTraceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		span := trace.SpanFromContext(ctx)
+		if span.SpanContext().IsValid() && span.IsRecording() {
+			stackTrace := captureStackTrace(5)
+			span.SetAttributes(attribute.String("code.stacktrace", stackTrace))
+		}
+		return handler(ctx, req)
+	}
+}
+
+func stackTraceStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		span := trace.SpanFromContext(ss.Context())
+		if span.SpanContext().IsValid() && span.IsRecording() {
+			stackTrace := captureStackTrace(5)
+			span.SetAttributes(attribute.String("code.stacktrace", stackTrace))
+		}
+		return handler(srv, ss)
+	}
+}
+
+func otelUnaryClientInterceptor() grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx, span := startClientSpan(ctx, method, cc.Target())
+		defer span.End()
+
+		span.SetAttributes(attribute.String("code.stacktrace", captureStackTrace(4)))
+
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		setSpanStatus(span, err)
+		return err
+	}
+}
+
+func otelStreamClientInterceptor() grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx, span := startClientSpan(ctx, method, cc.Target())
+		span.SetAttributes(attribute.String("code.stacktrace", captureStackTrace(4)))
+
+		s, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			setSpanStatus(span, err)
+			span.End()
+			return s, err
+		}
+		return &trackedClientStream{ClientStream: s, span: span}, nil
+	}
+}
+
+func startClientSpan(ctx context.Context, method, target string) (context.Context, trace.Span) {
+	// Parse method name: "/package.Service/Method" -> "package.Service/Method"
+	name := strings.TrimPrefix(method, "/")
+
+	var attrs []attribute.KeyValue
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		attrs = []attribute.KeyValue{
+			semconv.RPCSystemGRPC,
+			semconv.RPCServiceKey.String(name[:idx]),
+			semconv.RPCMethodKey.String(name[idx+1:]),
+			attribute.String("net.peer.name", target),
+		}
+	}
+
+	tracer := otel.Tracer("pulumi-cli")
+	ctx, span := tracer.Start(ctx, name,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attrs...),
+	)
+
+	md, _ := metadata.FromOutgoingContext(ctx)
+	md = md.Copy()
+	otel.GetTextMapPropagator().Inject(ctx, propagationCarrier(md))
+	return metadata.NewOutgoingContext(ctx, md), span
+}
+
+func setSpanStatus(span trace.Span, err error) {
+	if err != nil {
+		s, _ := status.FromError(err)
+		span.SetStatus(codes.Error, s.Message())
+		span.SetAttributes(semconv.RPCGRPCStatusCodeKey.Int(int(s.Code())))
+	} else {
+		span.SetAttributes(semconv.RPCGRPCStatusCodeKey.Int(int(grpccodes.OK)))
+	}
+}
+
+// trackedClientStream wraps a grpc.ClientStream to end the span when the stream closes.
+type trackedClientStream struct {
+	grpc.ClientStream
+	span trace.Span
+}
+
+func (s *trackedClientStream) RecvMsg(m any) error {
+	err := s.ClientStream.RecvMsg(m)
+	if err != nil {
+		setSpanStatus(s.span, err)
+		s.span.End()
+	}
+	return err
+}
+
+// propagationCarrier adapts gRPC metadata for trace context propagation.
+type propagationCarrier metadata.MD
+
+func (c propagationCarrier) Get(key string) string {
+	if vals := metadata.MD(c).Get(key); len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
+}
+
+func (c propagationCarrier) Set(key, value string) {
+	metadata.MD(c).Set(key, value)
+}
+
+func (c propagationCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/sdk/go/common/util/rpcutil/serve.go
+++ b/sdk/go/common/util/rpcutil/serve.go
@@ -136,7 +136,7 @@ func serveWithOptions(opts ServeOptions) (ServeHandle, chan error, error) {
 	return ServeHandle{Port: port, Done: done}, done, nil
 }
 
-// Deprecated: Please use [ServeWithOptions] and [OpenTracingServerInterceptorOptions].
+// Deprecated: Please use [ServeWithOptions] and [TracingServerInterceptorOptions].
 func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 	parentSpan opentracing.Span, options ...otgrpc.Option,
 ) (int, chan error, error) {
@@ -151,7 +151,7 @@ func Serve(port int, cancel chan bool, registers []func(*grpc.Server) error,
 			}
 			return nil
 		},
-		Options: OpenTracingServerInterceptorOptions(parentSpan, options...),
+		Options: TracingServerInterceptorOptions(parentSpan, options...),
 	}
 
 	handle, done, err := serveWithOptions(opts)

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -241,7 +241,7 @@ func (cmd *mainCmd) Run(p *runParams) error {
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return fmt.Errorf("could not start language host RPC server: %w", err)

--- a/sdk/go/pulumi/callback.go
+++ b/sdk/go/pulumi/callback.go
@@ -51,7 +51,7 @@ func newCallbackServer() (*callbackServer, error) {
 			pulumirpc.RegisterCallbacksServer(srv, callbackServer)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource provider service: %w", err)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -100,11 +100,12 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 	var monitorConn *grpc.ClientConn
 	var monitor pulumirpc.ResourceMonitorClient
 	if addr := info.MonitorAddr; addr != "" {
-		conn, err := grpc.NewClient(
-			info.MonitorAddr,
+		dialOpts := append(
+			rpcutil.TracingInterceptorDialOptions(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			rpcutil.GrpcChannelOptions(),
 		)
+		conn, err := grpc.NewClient(info.MonitorAddr, dialOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("connecting to resource monitor over RPC: %w", err)
 		}
@@ -118,11 +119,12 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 		engineConn = info.engineConn
 		engine = pulumirpc.NewEngineClient(engineConn)
 	} else if addr := info.EngineAddr; addr != "" {
-		conn, err := grpc.NewClient(
-			info.EngineAddr,
+		dialOpts := append(
+			rpcutil.TracingInterceptorDialOptions(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			rpcutil.GrpcChannelOptions(),
 		)
+		conn, err := grpc.NewClient(info.EngineAddr, dialOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("connecting to engine over RPC: %w", err)
 		}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -155,7 +155,7 @@ func main() {
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		cmdutil.Exit(fmt.Errorf("could not start language host RPC server: %w", err))
@@ -678,7 +678,7 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 			pulumirpc.RegisterResourceMonitorServer(srv, &monitorProxy{target: target})
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(tracingSpan),
+		Options: rpcutil.TracingServerInterceptorOptions(tracingSpan),
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -180,7 +180,7 @@ func main() {
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: rpcutil.TracingServerInterceptorOptions(nil),
 	})
 	if err != nil {
 		cmdutil.Exit(fmt.Errorf("could not start language host RPC server: %w", err))


### PR DESCRIPTION
We want to make sure we can track all the grpc calls with otel, similar to how we do it with OpenTracing.  Pass the options through, so we get spans for grpc calls.

Note that some of these are not parented correctly yet under the root span (or under the plugin spans).  Fixing that will come in subsequent PRs.