### PR TITLE
Add VS Code Python project for `sdk/python`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,13 @@
         // Uses https://github.com/mvdan/gofumpt for formatting.
         "formatting.gofumpt": true,
     },
+    "python-envs.pythonProjects": [
+        {
+            "path": "sdk/python",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ],
     "python.testing.pytestArgs": [
         "sdk/python/lib/test"
     ],


### PR DESCRIPTION
This specifies a [Python project](https://code.visualstudio.com/docs/python/environments#_python-projects) for `sdk/python` in `.vscode/settings.json` to make VS Code use the virtual environment from uv when editing files in the Python SDK dir.

<img width="558" height="244" alt="Screenshot 2026-02-23 at 7 38 01 AM" src="https://github.com/user-attachments/assets/2d4bdf65-250b-4a6b-b815-d86c88ebc521" />
