### PR TITLE
Skip hyphen-url for dotnet

### DIFF
--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -194,7 +194,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 		Directory:        "hyphen-url",
 		Description:      "A resource url with a hyphen in its path",
 		Skip:             codegen.NewStringSet("go/any"),
-		SkipCompileCheck: codegen.NewStringSet(TestNodeJS, TestPython),
+		SkipCompileCheck: codegen.NewStringSet(TestNodeJS, TestPython, TestDotnet),
 	},
 	{
 		Directory:   "output-funcs",


### PR DESCRIPTION
This test doesn't work in dotnet and is blocking the pulumi/pkg upgrade at https://github.com/pulumi/pulumi-dotnet/pull/871

```
hyphen-url/Pulumi.Registrygeoreplication.csproj : error NU1101: Unable to find package Pulumi.UsingDashes. No packages exist with this id in source(s): nuget.org, pulumi-awsx
```