### PR TITLE
add tracing for nodejs language host

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -202,7 +202,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		if rootSpan != nil {
 			rootSpan.End()
 		}
-		cmdutil.CloseOTelReceiver()
+		cmdutil.CloseOtelTracing()
 
 		if logging.Verbose > 0 && !logging.LogToStderr {
 			logFile, err := logging.GetLogfilePath()

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -452,11 +452,15 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 		verbose:         logging.Verbose,
 	})
 
-	var environment []string
+	environment := os.Environ()
 	if e != nil && e.GetStore() != nil {
 		for k, v := range e.GetStore().Values() {
 			environment = append(environment, k+"="+v)
 		}
+	}
+
+	if otelEndpoint := cmdutil.OTelEndpoint(); otelEndpoint != "" {
+		environment = append(environment, "OTEL_EXPORTER_OTLP_ENDPOINT="+otelEndpoint)
 	}
 
 	// Check to see if we have a binary we can invoke directly

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/pulumi/pulumi/pkg/v3 v3.156.0
 	github.com/pulumi/pulumi/sdk/v3 v3.223.0
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.11
@@ -111,12 +113,10 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.51.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.51.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -131,7 +131,7 @@ func testLanguage(t *testing.T, forceTsc bool) {
 			// Run the language plugin
 			handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 				Init: func(srv *grpc.Server) error {
-					host := newLanguageHost(engineAddress, "", forceTsc)
+					host := newLanguageHost(engineAddress, "", "", forceTsc)
 					pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 					return nil
 				},


### PR DESCRIPTION
This sets up the infrastructure for plugins to get all the information to send traces back to the CLI, and implements it for the NodeJS language host.  Note that this does not include the SDK yet, though we already pass the necessary information via env variables when starting the pulumi program.

Adding the tracing to the SDK will come in a subsequent PR, to avoid getting this PR too large.

/xref https://github.com/pulumi/pulumi/issues/21858