### PR TITLE
`l2-resource-secret`: Tolerate the correct input

### DIFF
--- a/pkg/testing/pulumi-test-language/providers/secret_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/secret_provider.go
@@ -227,7 +227,11 @@ func (p *SecretProvider) Check(
 	}
 
 	publicData := req.News["publicData"].ObjectValue()
-	check = assertField(publicData, "private", "secret string", resource.PropertyValue.IsString)
+	check = assertField(publicData, "private", "string or secret string", func(v resource.PropertyValue) bool {
+		// TODO[https://github.com/pulumi/pulumi/issues/10319] publicData.private should be a secret string, but
+		// we tolerate a plain string here. Most SDKs do not correctly send a secret string on nested inputs.
+		return v.IsString() || (v.IsSecret() && v.SecretValue().Element.IsString())
+	})
 	if check != nil {
 		return *check, nil
 	}

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_secret.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_secret.go
@@ -42,7 +42,20 @@ func init() {
 					RequireSingleResource(l, snap.Resources, "pulumi:providers:secret")
 					secret := RequireSingleResource(l, snap.Resources, "secret:index:Resource")
 
-					want := resource.NewPropertyMapFromMap(map[string]any{
+					wantCorrect := resource.NewPropertyMapFromMap(map[string]any{
+						"public":  "open",
+						"private": resource.MakeSecret(resource.NewProperty("closed")),
+						"publicData": map[string]any{
+							"public":  "open",
+							"private": resource.MakeSecret(resource.NewProperty("closed")),
+						},
+						"privateData": resource.MakeSecret(resource.NewProperty(resource.NewPropertyMapFromMap(map[string]any{
+							"public":  "open",
+							"private": "closed",
+						}))),
+					})
+
+					wantExpected := resource.NewPropertyMapFromMap(map[string]any{
 						"public":  "open",
 						"private": resource.MakeSecret(resource.NewProperty("closed")),
 						"publicData": map[string]any{
@@ -57,7 +70,12 @@ func init() {
 							"private": "closed",
 						}))),
 					})
-					assert.Equal(l, want, secret.Inputs, "expected inputs to be %v", want)
+
+					if !wantCorrect.DeepEquals(secret.Inputs) {
+						assert.Equal(l, wantExpected, secret.Inputs,
+							"expected inputs to be %v, will accept %v", wantCorrect, wantExpected)
+					}
+
 					assert.Equal(l, secret.Inputs, secret.Outputs, "expected inputs and outputs to match")
 				},
 			},


### PR DESCRIPTION
This was really confusing to figure out.