### PR TITLE
close listeners to free up ports

### DIFF
--- a/pkg/resource/deploy/deploytest/callbacks.go
+++ b/pkg/resource/deploy/deploytest/callbacks.go
@@ -57,6 +57,7 @@ type CallbackServer struct {
 
 func (s *CallbackServer) Close() error {
 	s.stop <- true
+	_ = s.handle.Close()
 	return <-s.handle.Done
 }
 

--- a/pkg/resource/deploy/resource_status.go
+++ b/pkg/resource/deploy/resource_status.go
@@ -147,6 +147,7 @@ func resourceStatusServeOptions(ctx *plugin.Context, logFile string) []grpc.Serv
 func (rs *resourceStatusServer) Close() error {
 	if rs != nil && rs.cancel != nil {
 		rs.cancel <- true
+		_ = rs.handle.Close()
 		err := <-rs.handle.Done
 		rs.cancel = nil
 		return err


### PR DESCRIPTION
During fuzz testing, we run out of ports before we get to the maximum number of iterations. Fix this by closing the listeners properly, and doing a hard stop of the grpc server, when we're running in the fuzz tester.