### PR TITLE
Convert integer component inputs to `int`

### DIFF
--- a/changelog/pending/20260224--sdk-python--convert-integers-component-inputs-to-int.yaml
+++ b/changelog/pending/20260224--sdk-python--convert-integers-component-inputs-to-int.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Convert integer component inputs to `int`


### PR DESCRIPTION
Integers are sent over the wire as floats. Convert to `int` in the component provider.
