### PR TITLE
Pin Node.js to 25.6

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -145,7 +145,8 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
     "go": ["1.25.x", "1.26.x"],
-    "nodejs": ["20.x", "22.x", "24.x", "25.x"],
+    # TODO: https://github.com/pulumi/pulumi/issues/21945 revert to Node.js 25.x
+    "nodejs": ["20.x", "22.x", "24.x", "25.6"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.
     "python": ["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"],


### PR DESCRIPTION
25.7 was just released and broke `yargs`, which we use via `mocha`. Pinning to 25.6 temporarily.

https://github.com/pulumi/pulumi/issues/21945
