### PR TITLE
increase timeout for fuzz tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ test_lifecycle_fuzz:
 	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzz$$' \
 		-tags all \
+		-timeout 1h \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 test_lifecycle_fuzz_from_state_file: GO_TEST_RACE = false
@@ -188,6 +189,7 @@ test_lifecycle_fuzz_from_state_file:
 	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzzFromStateFile$$' \
 		-tags all \
+		-timeout 1h \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 lang=$(subst test_codegen_,,$(word 1,$(subst !, ,$@)))


### PR DESCRIPTION
Fuzz tests currently have a default 10 minute timeout. This seems to be mostly fine in CI, but sometimes we go over.  I'm not sure if that is because the fuzz tests actually take a bit longer in some cases, or if they genuinely just hang (they shouldn't because the test specifies a timeout after which we give up).

Increase the timeout to see if we can catch any actual failures, or if they still time out occasionally with the increase.

Closes https://github.com/pulumi/pulumi/issues/21935