### PR TITLE
Fix invalid URNs in state move tests

### DIFF
--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -224,7 +224,7 @@ func TestMoveResourceWithDependencies(t *testing.T) {
 	depsURN := resource.NewURN("sourceStack", "test", "", "a:b:c", "deps")
 	deletedWithURN := resource.NewURN("sourceStack", "test", "", "a:b:c", "deletedWith")
 	propDepsURN := resource.NewURN("sourceStack", "test", "", "a:b:c", "propDeps")
-	movedChildURN := resource.NewURN("sourceStack", "test", "", "a:b:c", "movedChildURN")
+	movedChildURN := resource.NewURN("sourceStack", "test", "a:b:c", "a:b:c", "movedChildURN")
 	dependsOnMovedChildURN := resource.NewURN("sourceStack", "test", "a:b:c", "a:b:c", "dependsOnMovedChildURN")
 	sourceResources := []*resource.State{
 		{
@@ -285,7 +285,7 @@ func TestMoveResourceWithDependencies(t *testing.T) {
 	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
 
   - urn:pulumi:sourceStack::test::a:b:c::resToMove
-  - urn:pulumi:sourceStack::test::a:b:c::movedChildURN
+  - urn:pulumi:sourceStack::test::a:b:c$a:b:c::movedChildURN
   - urn:pulumi:sourceStack::test::a:b:c$a:b:c::dependsOnMovedChildURN
 
 The following resources remaining in organization/test/sourceStack have dependencies on resources moved to organization/test/destStack:
@@ -333,7 +333,7 @@ Successfully moved resources from organization/test/sourceStack to organization/
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::a:b:c::resToMove"),
 		destSnapshot.Resources[2].URN)
 	assert.Empty(t, destSnapshot.Resources[2].Dependencies)
-	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::a:b:c::movedChildURN"),
+	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::a:b:c$a:b:c::movedChildURN"),
 		destSnapshot.Resources[3].URN)
 	assert.Empty(t, destSnapshot.Resources[3].Dependencies)
 	assert.Equal(t, urn.URN("urn:pulumi:destStack::test::a:b:c$a:b:c::dependsOnMovedChildURN"),


### PR DESCRIPTION
The state move tests manually constructed URNs and state files to work with. Unfortunately a lot of those URNs weren't valid, they had qualified types that did not match the resources parent.
e.g. a URN like "urn:pulumi:sourceStack::test::d:e:f$a:b:c::name" but no parent resource set with a type of "d:e:f".

I've gone through and removed all the spurious "d:e:f" qualified types, and fixed up the resources that do have parents set to have their qualified type match the type of the parent resource.

Tests still pass, no logic code changes needed.