### PR TITLE
Language tests: `simple-invoke:secretInvoke` handles secrets

### DIFF
--- a/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_invoke_provider.go
@@ -288,8 +288,13 @@ func (p *SimpleInvokeProvider) Invoke(
 			}, nil
 		}
 
+		valueIsSecret := value.IsSecret()
+		if valueIsSecret {
+			value = value.SecretValue().Element
+		}
+
 		if !value.IsString() {
-			reason := fmt.Sprintf("value is not a string: %v", value)
+			reason := fmt.Sprintf("value is not a string: %#v", value)
 			return plugin.InvokeResponse{
 				Failures: makeCheckFailure("value", reason),
 			}, nil
@@ -309,7 +314,7 @@ func (p *SimpleInvokeProvider) Invoke(
 
 		// if the secretResponse is true, wrap the response as a secret
 		response := resource.NewProperty(value.StringValue() + " world")
-		if secretResponse.BoolValue() {
+		if secretResponse.BoolValue() || valueIsSecret {
 			response = resource.MakeSecret(response)
 		}
 		return plugin.InvokeResponse{


### PR DESCRIPTION
This PR relaxes how `simple-invoke:secretInvoke` handles secrets.

Before: `simple-invoke:secretInvoke` would error whenever it received a secret value. It would not make it's output a secret when it's input was a secret.

After: `simple-invoke:secretInvoke` allows it's `value` field to be secret, and it marks `result` as secret if `value` is secret.

The new behavior reflects a better behaved provider. This allows language implementations to do the "obvious" thing - pass secrets into functions and then respect the secrets from functions.


Depends on https://github.com/pulumi/pulumi/pull/21959 for correctness.