### PR TITLE
Add pulumi config edit command

### DIFF
--- a/changelog/pending/20260225--cli-config--add-pulumi-config-edit-command.yaml
+++ b/changelog/pending/20260225--cli-config--add-pulumi-config-edit-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/config
+  description: Add `pulumi config edit` for interactive JSON editing of stack config

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -67,8 +67,9 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 		Use:   "config",
 		Short: "Manage configuration",
 		Long: "Lists all configuration values for a specific stack. To add a new configuration value, run\n" +
-			"`pulumi config set`. To remove an existing value run `pulumi config rm`. To get the value of\n" +
-			"for a specific configuration key, use `pulumi config get <key-name>`.",
+			"`pulumi config set`. To remove an existing value run `pulumi config rm`. To get the value for\n" +
+			"a specific configuration key, use `pulumi config get <key-name>`. To edit the full\n" +
+			"configuration document in your editor, use `pulumi config edit`.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			opts := display.Options{
@@ -149,6 +150,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.AddCommand(newConfigSetCmd(ws, &stack))
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager, &ssml))
+	cmd.AddCommand(newConfigEditCmd(ws, &stack))
 	cmd.AddCommand(newConfigRefreshCmd(ws, &stack))
 	cmd.AddCommand(newConfigCopyCmd(ws, &stack))
 	cmd.AddCommand(newConfigEnvCmd(ws, &stack))

--- a/pkg/cmd/pulumi/config/config_edit.go
+++ b/pkg/cmd/pulumi/config/config_edit.go
@@ -1,0 +1,388 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pulumiSecrets "github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+var errConfigEditNeedsEncrypter = errors.New("edited config contains secrets but no encrypter is available")
+
+type configEditCmd struct {
+	OpenInEditor       func(filename string) error
+	LoadProjectStack   func(context.Context, diag.Sink, *workspace.Project, backend.Stack) (*workspace.ProjectStack, error)
+	SaveProjectStack   func(context.Context, backend.Stack, *workspace.ProjectStack) error
+	SecretsManagerLoad cmdStack.SecretsManagerLoader
+}
+
+func newConfigEditCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+	edit := &configEditCmd{
+		OpenInEditor:       openInEditor,
+		LoadProjectStack:   cmdStack.LoadProjectStack,
+		SaveProjectStack:   cmdStack.SaveProjectStack,
+		SecretsManagerLoad: cmdStack.NewStackSecretsManagerLoaderFromEnv(),
+	}
+
+	editCmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Edit configuration in your EDITOR",
+		Long: "Edit the stack configuration in your configured editor (`EDITOR`).\n\n" +
+			"The edited document follows the same format used by `pulumi config --json` and `pulumi config set-all --json`.\n" +
+			"Set `secret: true` to store a value as secret. Use `objectValue` for object and array values.",
+		Example: "  pulumi config edit\n\n" +
+			"  # Example edited JSON for a secret string value:\n" +
+			"  # {\n" +
+			"  #   \"app:token\": {\n" +
+			"  #     \"value\": \"mytoken123\",\n" +
+			"  #     \"secret\": true\n" +
+			"  #   }\n" +
+			"  # }\n\n" +
+			"  # Example edited JSON for a secret object value:\n" +
+			"  # {\n" +
+			"  #   \"app:oauth\": {\n" +
+			"  #     \"value\": \"{\\\"clientId\\\":\\\"id\\\",\\\"clientSecret\\\":\\\"secret\\\"}\",\n" +
+			"  #     \"objectValue\": {\n" +
+			"  #       \"clientId\": \"id\",\n" +
+			"  #       \"clientSecret\": \"secret\"\n" +
+			"  #     },\n" +
+			"  #     \"secret\": true\n" +
+			"  #   }\n" +
+			"  # }",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmdutil.Interactive() {
+				return errors.New("pulumi config edit must be run in interactive mode")
+			}
+
+			ctx := cmd.Context()
+			opts := display.Options{
+				Color:         cmdutil.GetGlobalColorization(),
+				IsInteractive: true,
+			}
+
+			project, _, err := ws.ReadProject()
+			if err != nil {
+				return err
+			}
+
+			s, err := cmdStack.RequireStack(
+				ctx,
+				cmdutil.Diag(),
+				ws,
+				cmdBackend.DefaultLoginManager,
+				*stack,
+				cmdStack.OfferNew|cmdStack.SetCurrent,
+				opts,
+			)
+			if err != nil {
+				return err
+			}
+
+			return edit.Run(ctx, ws, project, s)
+		},
+	}
+
+	constrictor.AttachArguments(editCmd, constrictor.NoArgs)
+	return editCmd
+}
+
+func (c *configEditCmd) Run(
+	ctx context.Context,
+	ws pkgWorkspace.Context,
+	project *workspace.Project,
+	stack backend.Stack,
+) error {
+	projectStack, err := c.LoadProjectStack(ctx, cmdutil.Diag(), project, stack)
+	if err != nil {
+		return err
+	}
+
+	if configLocation := stack.ConfigLocation(); configLocation.IsRemote {
+		err := errors.New("config edit not supported for remote stack config")
+		if configLocation.EscEnv != nil {
+			return fmt.Errorf("%w: use `pulumi env set %s pulumiConfig.<key> <value>`",
+				err, *configLocation.EscEnv)
+		}
+		return err
+	}
+
+	var (
+		secretsManager   pulumiSecrets.Manager
+		secretsAvailable bool
+	)
+	ensureSecretsManager := func() (pulumiSecrets.Manager, error) {
+		if secretsAvailable {
+			return secretsManager, nil
+		}
+
+		sm, state, err := c.SecretsManagerLoad.GetSecretsManager(ctx, stack, projectStack)
+		if err != nil {
+			return nil, err
+		}
+		if state != cmdStack.SecretsManagerUnchanged {
+			if err = c.SaveProjectStack(ctx, stack, projectStack); err != nil {
+				return nil, fmt.Errorf("save stack config: %w", err)
+			}
+		}
+
+		secretsManager = sm
+		secretsAvailable = true
+		return sm, nil
+	}
+
+	var decrypter config.Decrypter = config.NewPanicCrypter()
+	if projectStack.Config.HasSecureValue() {
+		sm, err := ensureSecretsManager()
+		if err != nil {
+			return err
+		}
+		decrypter = sm.Decrypter()
+	}
+
+	initialConfig, err := encodeEditableConfig(projectStack.Config, decrypter)
+	if err != nil {
+		return err
+	}
+
+	tempFile, err := os.CreateTemp("", "pulumi-config-edit-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp file for config edit: %w", err)
+	}
+	filename := tempFile.Name()
+	defer os.Remove(filename)
+
+	if _, err = tempFile.Write(initialConfig); err != nil {
+		tempFile.Close()
+		return fmt.Errorf("writing editable config file: %w", err)
+	}
+	if err = tempFile.Close(); err != nil {
+		return fmt.Errorf("closing editable config file: %w", err)
+	}
+
+	if err = c.OpenInEditor(filename); err != nil {
+		return err
+	}
+
+	editedConfig, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("reading edited config file: %w", err)
+	}
+
+	if bytes.Equal(initialConfig, editedConfig) {
+		return nil
+	}
+
+	var encrypter config.Encrypter
+	if secretsAvailable {
+		encrypter = secretsManager.Encrypter()
+	}
+	updatedConfig, err := decodeEditableConfig(ctx, ws, editedConfig, encrypter)
+	if errors.Is(err, errConfigEditNeedsEncrypter) {
+		sm, serr := ensureSecretsManager()
+		if serr != nil {
+			return serr
+		}
+		updatedConfig, err = decodeEditableConfig(ctx, ws, editedConfig, sm.Encrypter())
+	}
+	if err != nil {
+		return err
+	}
+
+	projectStack.Config = updatedConfig
+	return c.SaveProjectStack(ctx, stack, projectStack)
+}
+
+func encodeEditableConfig(cfg config.Map, decrypter config.Decrypter) ([]byte, error) {
+	editable := make(map[string]configValueJSON, len(cfg))
+	for key, value := range cfg {
+		encodedValue, err := encodeEditableConfigValue(value, decrypter)
+		if err != nil {
+			return nil, fmt.Errorf("encoding value for %q: %w", key.String(), err)
+		}
+		editable[key.String()] = encodedValue
+	}
+
+	out, err := json.MarshalIndent(editable, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+func encodeEditableConfigValue(v config.Value, decrypter config.Decrypter) (configValueJSON, error) {
+	var d config.Decrypter = config.NewPanicCrypter()
+	if v.Secure() {
+		d = decrypter
+	}
+
+	raw, err := v.Value(d)
+	if err != nil {
+		return configValueJSON{}, err
+	}
+
+	entry := configValueJSON{
+		Value:  &raw,
+		Secret: v.Secure(),
+	}
+	if v.Object() {
+		var editable any
+		dec := json.NewDecoder(strings.NewReader(raw))
+		dec.UseNumber()
+		if err := dec.Decode(&editable); err != nil {
+			return configValueJSON{}, err
+		}
+		entry.ObjectValue = editable
+	}
+
+	return entry, nil
+}
+
+func decodeEditableConfig(
+	ctx context.Context,
+	ws pkgWorkspace.Context,
+	editableConfig []byte,
+	encrypter config.Encrypter,
+) (config.Map, error) {
+	dec := json.NewDecoder(bytes.NewReader(editableConfig))
+	dec.UseNumber()
+
+	var edited map[string]configValueJSON
+	if err := dec.Decode(&edited); err != nil {
+		return nil, fmt.Errorf("parsing edited config document: %w", err)
+	}
+	if err := ensureSingleJSONValue(dec); err != nil {
+		return nil, err
+	}
+
+	result := make(config.Map, len(edited))
+	for rawKey, rawValue := range edited {
+		key, err := ParseConfigKey(ws, rawKey, false /*path*/)
+		if err != nil {
+			return nil, fmt.Errorf("invalid edited config key %q: %w", rawKey, err)
+		}
+
+		value, err := decodeEditableConfigValue(ctx, rawValue, encrypter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid edited config value for key %q: %w", rawKey, err)
+		}
+		result[key] = value
+	}
+
+	return result, nil
+}
+
+func ensureSingleJSONValue(dec *json.Decoder) error {
+	var extra any
+	err := dec.Decode(&extra)
+	switch {
+	case errors.Is(err, io.EOF):
+		return nil
+	case err != nil:
+		return err
+	default:
+		return errors.New("edited config document must contain a single JSON object")
+	}
+}
+
+func decodeEditableConfigValue(
+	ctx context.Context,
+	rawValue configValueJSON,
+	encrypter config.Encrypter,
+) (config.Value, error) {
+	var valueText string
+	if rawValue.ObjectValue != nil {
+		encodedObject, err := json.Marshal(rawValue.ObjectValue)
+		if err != nil {
+			return config.Value{}, err
+		}
+		valueText = string(encodedObject)
+	} else if rawValue.Value != nil {
+		valueText = *rawValue.Value
+	} else {
+		return config.Value{}, errors.New("value is nil")
+	}
+
+	if !rawValue.Secret {
+		if rawValue.ObjectValue != nil {
+			return config.NewObjectValue(valueText), nil
+		}
+		return config.NewValue(valueText), nil
+	}
+
+	if encrypter == nil {
+		return config.Value{}, errConfigEditNeedsEncrypter
+	}
+
+	encrypted, err := encrypter.EncryptValue(ctx, valueText)
+	if err != nil {
+		return config.Value{}, err
+	}
+	if rawValue.ObjectValue != nil {
+		// Preserve object metadata while storing the object payload as a secret ciphertext.
+		secureObject, err := json.Marshal(map[string]string{"secure": encrypted})
+		if err != nil {
+			return config.Value{}, err
+		}
+		return config.NewSecureObjectValue(string(secureObject)), nil
+	}
+	return config.NewSecureValue(encrypted), nil
+}
+
+func openInEditor(filename string) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		return errors.New("no EDITOR environment variable set")
+	}
+	return openInEditorInternal(editor, filename)
+}
+
+func openInEditorInternal(editor, filename string) error {
+	args, err := shlex.Split(editor)
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return errors.New("configured editor is empty")
+	}
+
+	args = append(args, filename)
+	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/pkg/cmd/pulumi/config/config_edit_test.go
+++ b/pkg/cmd/pulumi/config/config_edit_test.go
@@ -1,0 +1,239 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditableConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	encryptedSecret, err := config.Base64Crypter.EncryptValue(ctx, "hunter2")
+	require.NoError(t, err)
+
+	initial := config.Map{
+		config.MustMakeKey("test", "plain"):  config.NewValue("value"),
+		config.MustMakeKey("test", "secret"): config.NewSecureValue(encryptedSecret),
+		config.MustMakeKey("test", "object"): config.NewObjectValue(`{"enabled":true,"retries":3}`),
+	}
+
+	editable, err := encodeEditableConfig(initial, config.Base64Crypter)
+	require.NoError(t, err)
+
+	var editableMap map[string]any
+	require.NoError(t, json.Unmarshal(editable, &editableMap))
+
+	secretJSON := editableMap["test:secret"].(map[string]any)
+	require.Equal(t, true, secretJSON["secret"])
+	require.Equal(t, "hunter2", secretJSON["value"])
+
+	objectJSON := editableMap["test:object"].(map[string]any)
+	require.Equal(t, false, objectJSON["secret"])
+	require.NotNil(t, objectJSON["objectValue"])
+
+	roundTripped, err := decodeEditableConfig(ctx, &pkgWorkspace.MockContext{}, editable, config.Base64Crypter)
+	require.NoError(t, err)
+
+	initialValues, err := initial.Decrypt(config.Base64Crypter)
+	require.NoError(t, err)
+
+	roundTripValues, err := roundTripped.Decrypt(config.Base64Crypter)
+	require.NoError(t, err)
+
+	require.Equal(t, initialValues, roundTripValues)
+	for key, initialValue := range initial {
+		require.Equal(t, initialValue.Secure(), roundTripped[key].Secure())
+		require.Equal(t, initialValue.Object(), roundTripped[key].Object())
+	}
+}
+
+func TestEncodeEditableConfigSecureObject(t *testing.T) {
+	t.Parallel()
+
+	secureObject := config.Map{
+		config.MustMakeKey("test", "obj"): config.NewSecureObjectValue(`{"inner":{"secure":"c2VjcmV0"}}`),
+	}
+
+	editable, err := encodeEditableConfig(secureObject, config.Base64Crypter)
+	require.NoError(t, err)
+
+	var editableMap map[string]any
+	require.NoError(t, json.Unmarshal(editable, &editableMap))
+
+	secretValue := editableMap["test:obj"].(map[string]any)
+	require.Equal(t, true, secretValue["secret"])
+	require.Equal(t, map[string]any{"inner": "secret"}, secretValue["objectValue"])
+}
+
+func TestDecodeEditableConfigNeedsEncrypter(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key":{"value":"plaintext","secret":true}}`),
+		nil,
+	)
+	require.ErrorIs(t, err, errConfigEditNeedsEncrypter)
+}
+
+func TestDecodeEditableConfigSecretString(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key":{"value":"plaintext","secret":true}}`),
+		config.Base64Crypter,
+	)
+	require.NoError(t, err)
+
+	value := cfg[config.MustMakeKey("test", "key")]
+	require.True(t, value.Secure())
+	require.False(t, value.Object())
+
+	decrypted, err := value.Value(config.Base64Crypter)
+	require.NoError(t, err)
+	require.Equal(t, "plaintext", decrypted)
+}
+
+func TestDecodeEditableConfigLiteralSecretPrefixString(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key":{"value":"secret:plaintext","secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.NoError(t, err)
+
+	key := config.MustMakeKey("test", "key")
+	value := cfg[key]
+	require.False(t, value.Secure())
+	require.False(t, value.Object())
+
+	decrypted, err := value.Value(config.NewPanicCrypter())
+	require.NoError(t, err)
+	require.Equal(t, "secret:plaintext", decrypted)
+}
+
+func TestDecodeEditableConfigRejectsInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key:invalid":{"value":"value","secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.ErrorContains(t, err, "invalid edited config key")
+}
+
+func TestDecodeEditableConfigSecretObject(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:obj":{"value":"{\"inner\":\"value\",\"arr\":[1,true]}","objectValue":{"inner":"value","arr":[1,true]},"secret":true}}`),
+		config.Base64Crypter,
+	)
+	require.NoError(t, err)
+
+	key := config.MustMakeKey("test", "obj")
+	value := cfg[key]
+	require.True(t, value.Secure())
+	require.True(t, value.Object())
+
+	decrypted, err := cfg.Decrypt(config.Base64Crypter)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"arr":[1,true],"inner":"value"}`, decrypted[key])
+}
+
+func TestDecodeEditableConfigLiteralSecretObject(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:obj":{"value":"{\"secret\":\"literal\"}","objectValue":{"secret":"literal"},"secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.NoError(t, err)
+
+	key := config.MustMakeKey("test", "obj")
+	value := cfg[key]
+	require.False(t, value.Secure())
+	require.True(t, value.Object())
+
+	decrypted, err := cfg.Decrypt(config.Base64Crypter)
+	require.NoError(t, err)
+	require.Equal(t, `{"secret":"literal"}`, decrypted[key])
+}
+
+func TestDecodeEditableConfigSingleDocument(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key":{"value":"value","secret":false}} {"test:other":{"value":"value","secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.ErrorContains(t, err, "single JSON object")
+}
+
+func TestDecodeEditableConfigValueRequired(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:key":{"secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.ErrorContains(t, err, "value is nil")
+}
+
+func TestDecodeEditableConfigObjectValueWins(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := decodeEditableConfig(
+		context.Background(),
+		&pkgWorkspace.MockContext{},
+		[]byte(`{"test:obj":{"value":"{\"stale\":true}","objectValue":{"fresh":true},"secret":false}}`),
+		config.Base64Crypter,
+	)
+	require.NoError(t, err)
+
+	key := config.MustMakeKey("test", "obj")
+	value := cfg[key]
+	require.False(t, value.Secure())
+	require.True(t, value.Object())
+
+	decrypted, err := cfg.Decrypt(config.Base64Crypter)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"fresh":true}`, decrypted[key])
+}


### PR DESCRIPTION
## What

Add a new `pulumi config edit` subcommand to edit stack config interactively in `$EDITOR`.

This command is now wired under `pulumi config` and supports round-tripping plaintext values, secret values, and object values.

Fixes #9624

## Why

Editing multiple config values one-by-one is slow, especially when changing several secrets/objects at once.

`pulumi config edit` provides a faster workflow while keeping compatibility with Pulumi’s existing JSON config schema.

## How

- Added `pulumi config edit` command.
- Opens a temp JSON file in `$EDITOR`.
- Uses the same JSON shape as `pulumi config --json` / `pulumi config set-all --json` (`value`, `objectValue`, `secret`).
- Supports decrypting existing secrets for edit and re-encrypting edited secret values on save.
- Rejects unsupported remote stack config locations.
- Keeps existing editor-launch behavior consistent with other Pulumi edit commands.

## Tests

Added focused unit tests covering:

- encode/decode roundtrip
- secret string handling
- secret object handling
- object precedence (`objectValue` over stale `value`)
- invalid keys
- nil/missing values
- single-document JSON validation
- literal `secret:` string and literal `{"secret": ...}` object cases

## User-facing docs

- Added command help/examples for `pulumi config edit`.
- Added pending changelog entry.
