### PR TITLE
retry downloading releases

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -11,13 +11,36 @@ if command -v gh >/dev/null && gh auth status >/dev/null 2>&1; then
   USE_GH=true
 fi
 
+retry_with_backoff() {
+    local max_attempts=3
+    local attempt=1
+    local exitcode=0
+
+    while [ ${attempt} -le ${max_attempts} ]; do
+        if "$@"; then
+            return 0
+        fi
+
+        exitcode=$?
+
+        if [ ${attempt} -lt ${max_attempts} ]; then
+            local backoff=$((2 ** (attempt - 1)))
+            sleep ${backoff}
+        fi
+
+        attempt=$((attempt + 1))
+    done
+
+    return ${exitcode}
+}
+
 download_release() {
   local lang="$1"
   local tag="$2"
   local filename="$3"
 
   if "${USE_GH}"; then
-    gh release download "${tag}" --repo "pulumi/pulumi-${lang}" -p "${filename}"
+    retry_with_backoff gh release download "${tag}" --repo "pulumi/pulumi-${lang}" -p "${filename}"
   else
     curl -OL --fail --retry 3 "https://github.com/pulumi/pulumi-${lang}/releases/download/${tag}/${filename}"
   fi


### PR DESCRIPTION
With GitHub being as flaky as it is, building binaries sometimes fails because we fail to download language plugins from our other repos. Try to work around this by retrying this a few times with backoff, to hopefully reduce the chance of failure here.