### PR TITLE
Revert "increase timeout for fuzz tests"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,6 @@ test_lifecycle_fuzz:
 	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzz$$' \
 		-tags all \
-		-timeout 1h \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 test_lifecycle_fuzz_from_state_file: GO_TEST_RACE = false
@@ -189,7 +188,6 @@ test_lifecycle_fuzz_from_state_file:
 	@cd pkg && go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
 		-run '^TestFuzzFromStateFile$$' \
 		-tags all \
-		-timeout 1h \
 		-rapid.checks=$(LIFECYCLE_TEST_FUZZ_CHECKS)
 
 lang=$(subst test_codegen_,,$(word 1,$(subst !, ,$@)))


### PR DESCRIPTION
Reverts pulumi/pulumi#21949.  This didn't seem to help fuzz tests, as they still time out, but it's way more annoying to have a test time out after an hour, than having it time out after a minute, given they both fail anyway. I don't have any smart ideas what's happening yet, but at least we can make this a little less annoying.