### PR TITLE
Don't mark successful stream close as error

### DIFF
--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -17,6 +17,7 @@ package rpcutil
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -389,7 +390,7 @@ type trackedClientStream struct {
 
 func (s *trackedClientStream) RecvMsg(m any) error {
 	err := s.ClientStream.RecvMsg(m)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		setSpanStatus(s.span, err)
 		s.span.End()
 	}


### PR DESCRIPTION
https://pkg.go.dev/google.golang.org/grpc@v1.79.1#ClientStream.RecvMsg

> It returns io.EOF when the stream completes successfully. 