### PR TITLE
Track required flags and executable menus in `constrictor`

### DIFF
--- a/sdk/nodejs/tools/automation/src/index.ts
+++ b/sdk/nodejs/tools/automation/src/index.ts
@@ -62,6 +62,7 @@ function generateOptionsTypes(
         isExported: true,
         properties: Object.entries(flags).map(([name, flag]) => ({
             name: camelCase(flag.name),
+            hasQuestionToken: flag.required === true ? false : true,
             type: convertType(flag.type, flag.repeatable ?? false),
             docs: flag.description ? [flag.description] : undefined,
         })),

--- a/sdk/nodejs/tools/automation/src/types.ts
+++ b/sdk/nodejs/tools/automation/src/types.ts
@@ -17,6 +17,9 @@ export interface Flag {
     /** The canonical flag name (for example, "stack"). */
     name: string;
 
+    /** True if this flag is required. */
+    required?: boolean;
+
     /** A primitive logical type: "string", "boolean", "int", etc. */
     type: string;
 
@@ -69,6 +72,9 @@ interface NodeBase {
 // A menu is a command that groups other commands.
 export interface Menu extends NodeBase {
     type: "menu";
+
+    /** True if this menu can also be executed directly as a command. */
+    executable?: boolean;
 
     /** Subcommands in this menu. */
     commands?: Record<string, Structure>;


### PR DESCRIPTION
Missed this earlier, and @julienp caught it in a review.

* Commands can be menus _and_ executable. For example, `pulumi about`: you can run the `env` subcommand, or the menu itself as a command. We track these exceptions with the `executable` menu flag so that we can generate commands for them too.
* Some flags are required, so they should be required properties in the options object too. For example:

```js
/** Options for the `pulumi template publish` command. */
export interface PulumiTemplatePublishOptions {
    /** The name of the template (required) */
    name: string;
    /** The publisher of the template (e.g., 'pulumi'). Defaults to the default organization in your pulumi config. */
    publisher?: string;
    /** The version of the template (required, semver format) */
    version: string;
}
```