### PR TITLE
[sdk/python] Use asyncio-based gRPC monitor client

### DIFF
--- a/changelog/pending/20260228--sdk-python--add-support-for-asyncio-based-monitor-clients.yaml
+++ b/changelog/pending/20260228--sdk-python--add-support-for-asyncio-based-monitor-clients.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add support for asyncio-based monitor clients

--- a/sdk/python/lib/pulumi/runtime/_monitor.py
+++ b/sdk/python/lib/pulumi/runtime/_monitor.py
@@ -1,0 +1,190 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import TYPE_CHECKING, Optional, Protocol, cast, runtime_checkable
+from collections.abc import Callable
+
+import grpc
+
+from ._grpc_settings import _GRPC_CHANNEL_OPTIONS
+from .proto.resource_pb2_grpc import ResourceMonitorStub
+from .sync_await import _sync_await
+
+if TYPE_CHECKING:
+    from .proto.resource_pb2_grpc import ResourceMonitorAsyncStub
+else:
+    ResourceMonitorAsyncStub = object  # make cast work at runtime
+
+
+@runtime_checkable
+class _ProvidesAsyncMonitor(Protocol):
+    """
+    A protocol for monitors that and provide an async monitor interface, either directly or via a wrapper.
+    """
+
+    def async_monitor(self) -> ResourceMonitorAsyncStub:
+        """
+        Returns the async monitor interface provided by this monitor, if any.
+        This may be the monitor itself, an underlying async monitor if this is a sync wrapper,
+        or an async wrapper around this monitor if this is a sync monitor without its own async
+        interface.
+        """
+        ...
+
+
+def _get_async_monitor_method(
+    monitor,
+) -> Optional[Callable[[], ResourceMonitorAsyncStub]]:
+    """
+    Returns the monitor's async_monitor method if it exists and is callable, otherwise returns None.
+    This is used to check if the monitor provides an async_monitor method without triggering
+    __getattr__/dynamic resolution, which a user-specified test mock monitor may do.
+    """
+    name = _ProvidesAsyncMonitor.async_monitor.__name__
+
+    try:
+        raw = inspect.getattr_static(monitor, name)
+    except AttributeError:
+        return None
+
+    # raw may be function/descriptor/property/etc. Check callability of the descriptor object itself:
+    if not callable(raw):
+        return None
+
+    # Now bind it the normal way (so you call the bound method):
+    bound = getattr(monitor, name)
+    if not callable(bound):
+        return None
+
+    return cast(Callable[[], ResourceMonitorAsyncStub], bound)
+
+
+def _async_to_sync_monitor(monitor: ResourceMonitorAsyncStub) -> ResourceMonitorStub:
+    """
+    Factory for wrapping an async monitor in a sync interface.
+    The returned monitor will implement the ResourceMonitorStub interface by synchronously waiting on the async
+    monitor's methods, and also provide access to the async monitor via the _ProvidesAsyncMonitor protocol.
+    """
+
+    class AsyncToSyncMonitorProxy:
+        def __init__(self, monitor: ResourceMonitorAsyncStub):
+            assert isinstance(self, _ProvidesAsyncMonitor)
+            self._monitor = monitor
+
+        def async_monitor(self) -> ResourceMonitorAsyncStub:
+            return self._monitor
+
+        def __getattr__(self, name):
+            attr = getattr(self._monitor, name)
+            if not callable(attr):
+                return attr
+
+            def sync_call(*args, **kwargs):
+                return _sync_await(attr(*args, **kwargs))  # type: ignore
+
+            return sync_call
+
+    proxy = AsyncToSyncMonitorProxy(monitor)
+    return cast(ResourceMonitorStub, proxy)
+
+
+def _sync_to_async_monitor(monitor: ResourceMonitorStub) -> ResourceMonitorAsyncStub:
+    """
+    Factory for wrapping a sync monitor in an async interface.
+    The returned monitor will implement the ResourceMonitorAsyncStub interface by asynchronously
+    executing the sync monitor's methods in a separate thread, and also provide access to the
+    async monitor (itself) via the _ProvidesAsyncMonitor protocol.
+    """
+
+    class SyncToAsyncMonitorProxy:
+        def __init__(self, monitor: ResourceMonitorStub):
+            assert isinstance(self, _ProvidesAsyncMonitor)
+            self._monitor = monitor
+
+        def async_monitor(self) -> ResourceMonitorAsyncStub:
+            return cast(ResourceMonitorAsyncStub, self)
+
+        def __getattr__(self, name):
+            attr = getattr(self._monitor, name)
+            if not callable(attr):
+                return attr
+
+            async def async_call(*args, **kwargs):
+                return await asyncio.to_thread(attr, *args, **kwargs)
+
+            return async_call
+
+    proxy = SyncToAsyncMonitorProxy(monitor)
+    return cast(ResourceMonitorAsyncStub, proxy)
+
+
+def _lazy_async_monitor(
+    target: str, factory: Callable[[str], ResourceMonitorAsyncStub]
+) -> ResourceMonitorAsyncStub:
+    """
+    Factory for creating a lazy async monitor from a factory that creates async monitors.
+    This is used to lazily create the async monitor for the gRPC case, since it needs to be created
+    in the context of a running event loop.
+    """
+
+    _monitor: Optional[ResourceMonitorAsyncStub] = None
+
+    def _get_monitor() -> ResourceMonitorAsyncStub:
+        nonlocal _monitor
+        if _monitor is None:
+            _monitor = factory(target)
+        return _monitor
+
+    class LazyAsyncMonitorProxy:
+        def async_monitor(self) -> ResourceMonitorAsyncStub:
+            return _get_monitor()
+
+        def __getattr__(self, name: str):
+            return getattr(_get_monitor(), name)
+
+    return cast(ResourceMonitorAsyncStub, LazyAsyncMonitorProxy())
+
+
+def _grpc_monitor(target: str) -> ResourceMonitorStub:
+    """
+    Factory for creating a gRPC monitor.
+    """
+
+    # Lazily create an async gRPC monitor using grpc.aio upon first attr access to ensure it binds
+    # to the correct running event loop, otherwise it can result in "Future attached to a
+    # different loop" errors when the monitor is first used.
+    # Then wrap it in a proxy that provides a synchronous interface, with a way to access the
+    # underlying async monitor for use in async contexts.
+    #
+    # The result of this function is what will be stored in SETTINGS.monitor and return from get_monitor,
+    # so it needs to be a sync monitor that existing callers expect.
+    # Inside this library _get_async_monitor should be used over get_monitor, which returns the underlying
+    # async monitor.
+
+    def factory(target: str):
+        # The actual class is ResourceMonitorStub, but we know we're using an grpc.aio channel,
+        # so cast it to ResourceMonitorAsyncStub so we get the correct type hints.
+        return cast(
+            ResourceMonitorAsyncStub,
+            ResourceMonitorStub(
+                grpc.aio.insecure_channel(target, options=_GRPC_CHANNEL_OPTIONS)
+            ),
+        )
+
+    monitor = _lazy_async_monitor(target, factory)
+    return _async_to_sync_monitor(monitor)

--- a/sdk/python/lib/test/runtime/test_mocks.py
+++ b/sdk/python/lib/test/runtime/test_mocks.py
@@ -1,0 +1,172 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from pulumi.runtime._monitor import _sync_to_async_monitor
+from pulumi.runtime.mocks import AsyncMockMonitor, MockMonitor, Mocks, set_mocks
+from pulumi.runtime.settings import ROOT, SETTINGS, _get_async_monitor, get_monitor
+from pulumi.runtime.sync_await import _ensure_event_loop
+
+
+class _SimpleMocks(Mocks):
+    def call(self, args):
+        return {}, None
+
+    def new_resource(self, args):
+        return args.name + "_id", {}
+
+
+# SyncToAsyncMonitorProxy is defined *inside* _sync_to_async_monitor, so each call
+# produces a distinct class object.  All of them share the same __qualname__, though,
+# so we capture it once from a known-good reference instance.
+_SYNC_TO_ASYNC_PROXY_QUALNAME: str = type(
+    _sync_to_async_monitor(cast(object, object()))  # type: ignore[arg-type]
+).__qualname__
+
+
+def _is_sync_to_async_wrapper(obj) -> bool:
+    """Returns True when obj is a _sync_to_async_monitor proxy."""
+    return type(obj).__qualname__ == _SYNC_TO_ASYNC_PROXY_QUALNAME
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings():
+    """Isolate every test: restore the monitor and root-resource context vars."""
+    _ensure_event_loop()
+    old_monitor = SETTINGS.monitor
+    old_root = ROOT.get()
+    yield
+    SETTINGS.monitor = old_monitor
+    ROOT.set(old_root)
+
+
+# Test arbitrary (non-MockMonitor / non-AsyncMockMonitor) object.
+class TestArbitraryMonitor:
+    class _ArbitraryMonitor:
+        """A plain monitor object that doesn't subclass MockMonitor or AsyncMockMonitor."""
+
+    def setup_method(self):
+        self.arb = self._ArbitraryMonitor()
+        set_mocks(_SimpleMocks(), monitor=self.arb)  # type: ignore[arg-type]
+
+    def test_get_monitor_returns_the_object(self):
+        assert get_monitor() is self.arb
+
+    def test_get_async_monitor_returns_sync_to_async_wrapper(self):
+        async_mon = _get_async_monitor()
+        assert _is_sync_to_async_wrapper(async_mon)
+
+    def test_async_wrapper_wraps_the_arbitrary_object(self):
+        # The proxy's __getattr__ delegates to the wrapped sync object.
+        # We can confirm by checking that the proxy's async_monitor() is itself
+        # (self-referential, distinguishing it from the raw arbitrary object).
+        async_mon = _get_async_monitor()
+        assert async_mon is not self.arb
+
+
+# Test MockMonitor subclass with an overridden method.
+class TestMockMonitorSubclass:
+    class _SubMockMonitor(MockMonitor):
+        def __init__(self, mocks):
+            super().__init__(mocks)
+            self.feature_calls = 0
+
+        def SupportsFeature(self, request):
+            self.feature_calls += 1
+            return type("R", (), {"hasSupport": True})()
+
+    def setup_method(self):
+        self.sub_mon = self._SubMockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=self.sub_mon)
+
+    def test_get_monitor_returns_same_instance(self):
+        assert get_monitor() is self.sub_mon
+
+    def test_get_async_monitor_returns_sync_to_async_wrapper(self):
+        async_mon = _get_async_monitor()
+        # For a subclass, MockMonitor.async_monitor() wraps self in _sync_to_async_monitor.
+        assert _is_sync_to_async_wrapper(async_mon)
+
+    def test_async_wrapper_is_not_the_async_mock_monitor(self):
+        async_mon = _get_async_monitor()
+        assert not isinstance(async_mon, AsyncMockMonitor)
+
+    @pytest.mark.asyncio
+    async def test_overridden_method_is_called_through_async_wrapper(self):
+        """Awaiting a method through the async wrapper invokes the subclass override."""
+        async_mon = _get_async_monitor()
+        request = type("Req", (), {"id": "test"})()
+        await async_mon.SupportsFeature(request)  # type: ignore[attr-defined]
+        assert self.sub_mon.feature_calls == 1
+
+
+# Test plain MockMonitor (not a subclass).
+class TestPlainMockMonitor:
+    def setup_method(self):
+        self.mock_mon = MockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=self.mock_mon)
+
+    def test_get_monitor_returns_same_instance(self):
+        assert get_monitor() is self.mock_mon
+
+    def test_get_async_monitor_returns_async_mock_monitor(self):
+        async_mon = _get_async_monitor()
+        assert isinstance(async_mon, AsyncMockMonitor)
+
+    def test_get_async_monitor_matches_mock_monitor_async_monitor(self):
+        # mock_mon.async_monitor() should return the same object as _get_async_monitor().
+        assert self.mock_mon.async_monitor() is _get_async_monitor()
+
+    def test_async_monitor_is_not_the_mock_monitor_itself(self):
+        assert _get_async_monitor() is not self.mock_mon
+
+
+# Test AsyncMockMonitor passed directly.
+class TestAsyncMockMonitorPassedDirectly:
+    def setup_method(self):
+        self.async_mon = AsyncMockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=self.async_mon)
+
+    def test_get_monitor_returns_mock_monitor_wrapper(self):
+        mon = get_monitor()
+        assert isinstance(mon, MockMonitor)
+        assert mon is not self.async_mon
+
+    def test_mock_monitor_async_monitor_returns_the_passed_instance(self):
+        mon = get_monitor()
+        assert mon.async_monitor() is self.async_mon  # type: ignore[attr-defined]
+
+    def test_get_async_monitor_returns_the_passed_instance(self):
+        assert _get_async_monitor() is self.async_mon
+
+
+# Test default monitor (no monitor passed).
+class TestDefaultMonitor:
+    def setup_method(self):
+        set_mocks(_SimpleMocks())
+
+    def test_get_monitor_returns_mock_monitor(self):
+        assert isinstance(get_monitor(), MockMonitor)
+
+    def test_get_async_monitor_returns_async_mock_monitor(self):
+        assert isinstance(_get_async_monitor(), AsyncMockMonitor)
+
+    def test_mock_monitor_async_monitor_matches_get_async_monitor(self):
+        mon = get_monitor()
+        assert mon.async_monitor() is _get_async_monitor()  # type: ignore[attr-defined]

--- a/sdk/python/lib/test/runtime/test_monitor.py
+++ b/sdk/python/lib/test/runtime/test_monitor.py
@@ -1,0 +1,524 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from pulumi.runtime._grpc_settings import _GRPC_CHANNEL_OPTIONS
+from pulumi.runtime._monitor import (
+    _ProvidesAsyncMonitor,
+    _async_to_sync_monitor,
+    _get_async_monitor_method,
+    _grpc_monitor,
+    _lazy_async_monitor,
+    _sync_to_async_monitor,
+)
+
+if TYPE_CHECKING:
+    from pulumi.runtime.proto.resource_pb2_grpc import ResourceMonitorAsyncStub
+else:
+    ResourceMonitorAsyncStub = object  # make cast work at runtime
+
+
+class TestGetAsyncMonitorMethod:
+    def test_returns_none_when_no_async_monitor_attribute(self):
+        """Monitor with no async_monitor attribute returns None."""
+
+        class PlainMonitor:
+            pass
+
+        assert _get_async_monitor_method(PlainMonitor()) is None
+
+    def test_returns_bound_method_when_async_monitor_is_regular_method(self):
+        """Monitor with a normal async_monitor method returns the bound method."""
+        sentinel = object()
+
+        class MonitorWithMethod:
+            def async_monitor(self):
+                return sentinel
+
+        monitor = MonitorWithMethod()
+        result = _get_async_monitor_method(monitor)
+        assert result is not None
+        assert callable(result)
+        assert result() is sentinel
+
+    def test_returns_none_when_async_monitor_is_non_callable_attribute(self):
+        """Monitor where async_monitor is a plain (non-callable) attribute returns None."""
+
+        class MonitorWithNonCallable:
+            async_monitor = 42
+
+        assert _get_async_monitor_method(MonitorWithNonCallable()) is None
+
+    def test_does_not_trigger_getattr_for_dynamic_monitor(self):
+        """
+        Monitors that use __getattr__ for dynamic dispatch (e.g. test mocks) must NOT
+        have _get_async_monitor_method accidentally trigger that dynamic lookup and
+        return a truthy result when async_monitor is not actually defined.
+        """
+        getattr_calls = []
+
+        class DynamicMonitor:
+            def __getattr__(self, name):
+                getattr_calls.append(name)
+                # A test mock might return a callable for any attribute lookup —
+                # this should NOT cause _get_async_monitor_method to return non-None
+                # unless async_monitor is explicitly defined on the class/instance.
+                return lambda: None
+
+        result = _get_async_monitor_method(DynamicMonitor())
+        assert result is None
+        # Confirm __getattr__ was not consulted for the static inspection phase
+        assert "async_monitor" not in getattr_calls
+
+    def test_returns_none_when_async_monitor_is_property_returning_non_callable(self):
+        """Property that returns a non-callable value causes the bound check to return None."""
+
+        class MonitorWithProperty:
+            @property
+            def async_monitor(self):
+                return 99  # not callable
+
+        # inspect.getattr_static sees the property object itself (which is callable),
+        # but getattr returns the property's value (99), which is not callable.
+        assert _get_async_monitor_method(MonitorWithProperty()) is None
+
+    def test_returns_none_when_async_monitor_is_property(self):
+        """
+        A @property descriptor is not callable itself, so the static-inspection callable
+        check returns None even if the property getter returns a callable.
+        """
+        sentinel = object()
+
+        class MonitorWithCallableProperty:
+            @property
+            def async_monitor(self):
+                return lambda: sentinel
+
+        # The raw descriptor (property object) is not callable, so None is returned.
+        assert _get_async_monitor_method(MonitorWithCallableProperty()) is None
+
+    def test_returns_none_when_callable_descriptor_get_returns_non_callable(self):
+        """
+        A descriptor whose object is callable (has __call__) but whose __get__ returns
+        a non-callable value hits the second callable check and returns None.
+        """
+
+        class CallableDescriptorReturningInt:
+            """Callable as an object, but __get__ yields a plain int."""
+
+            def __call__(self):
+                pass
+
+            def __get__(self, obj, objtype=None):
+                return 99  # not callable
+
+        class MonitorWithCallableDescriptor:
+            async_monitor = CallableDescriptorReturningInt()
+
+        # inspect.getattr_static -> descriptor (callable) passes first check;
+        # getattr -> 99 (not callable) hits the second `return None`.
+        assert _get_async_monitor_method(MonitorWithCallableDescriptor()) is None
+
+    def test_returned_callable_is_bound_to_instance(self):
+        """The returned callable is the bound method of the specific instance."""
+
+        class MonitorWithMethod:
+            def __init__(self, value):
+                self.value = value
+
+            def async_monitor(self):
+                return self.value
+
+        m1 = MonitorWithMethod("first")
+        m2 = MonitorWithMethod("second")
+        assert _get_async_monitor_method(m1)() == "first"
+        assert _get_async_monitor_method(m2)() == "second"
+
+    def test_returns_none_for_classmethod(self):
+        """
+        A classmethod descriptor object is not callable itself in Python 3.11, so
+        the static-inspection callable check returns None.
+        """
+
+        class MonitorWithClassMethod:
+            @classmethod
+            def async_monitor(cls):
+                return cls
+
+        assert _get_async_monitor_method(MonitorWithClassMethod()) is None
+
+    def test_works_with_staticmethod(self):
+        """async_monitor defined as a staticmethod is callable and returned."""
+        sentinel = object()
+
+        class MonitorWithStaticMethod:
+            @staticmethod
+            def async_monitor():
+                return sentinel
+
+        result = _get_async_monitor_method(MonitorWithStaticMethod())
+        assert result is not None
+        assert result() is sentinel
+
+
+class _AsyncMonitorStub:
+    """Minimal async-monitor stand-in with a mix of callable and non-callable members."""
+
+    non_callable_attr = "hello"
+
+    async def get_value(self, x: int) -> int:
+        return x * 2
+
+    async def raises(self) -> None:
+        raise ValueError("boom")
+
+
+def _as_async_stub(obj) -> ResourceMonitorAsyncStub:
+    return cast(ResourceMonitorAsyncStub, obj)
+
+
+class TestAsyncToSyncMonitor:
+    def _make_proxy(self):
+        return _async_to_sync_monitor(_as_async_stub(_AsyncMonitorStub()))
+
+    def test_proxy_satisfies_provides_async_monitor_protocol(self):
+        """The returned proxy is recognised as a _ProvidesAsyncMonitor."""
+        proxy = self._make_proxy()
+        assert isinstance(proxy, _ProvidesAsyncMonitor)
+
+    def test_async_monitor_returns_wrapped_async_monitor(self):
+        """proxy.async_monitor() returns the original async monitor object."""
+        inner = _AsyncMonitorStub()
+        proxy = _async_to_sync_monitor(_as_async_stub(inner))
+        assert proxy.async_monitor() is inner  # type: ignore[attr-defined]
+
+    def test_async_monitor_method_visible_to_get_async_monitor_method(self):
+        """
+        _get_async_monitor_method should see async_monitor on the proxy and return a
+        bound callable, confirming the two helpers compose correctly.
+        """
+        inner = _AsyncMonitorStub()
+        proxy = _async_to_sync_monitor(_as_async_stub(inner))
+        bound = _get_async_monitor_method(proxy)
+        assert bound is not None
+        assert bound() is inner
+
+    def test_sync_call_returns_result_of_awaited_coroutine(self):
+        """Calling a proxied async method synchronously returns its awaited result."""
+        proxy = self._make_proxy()
+        result = proxy.get_value(21)  # type: ignore[attr-defined]
+        assert result == 42
+
+    def test_sync_call_passes_args_and_kwargs_to_async_method(self):
+        """Positional and keyword arguments are forwarded to the underlying async method."""
+
+        class ArgsMonitor:
+            async def echo(self, a, b, *, flag=False):
+                return (a, b, flag)
+
+        proxy = _async_to_sync_monitor(_as_async_stub(ArgsMonitor()))
+        result = proxy.echo(1, 2, flag=True)  # type: ignore[attr-defined]
+        assert result == (1, 2, True)
+
+    def test_sync_call_propagates_exception_from_coroutine(self):
+        """Exceptions raised inside the async method surface as-is to the sync caller."""
+        proxy = self._make_proxy()
+        with pytest.raises(ValueError, match="boom"):
+            proxy.raises()  # type: ignore[attr-defined]
+
+    def test_each_attribute_access_returns_same_sync_wrapper_behaviour(self):
+        """Repeated attribute lookups via __getattr__ each produce a working wrapper."""
+        proxy = self._make_proxy()
+        # Access the same method twice and verify both wrappers produce correct results.
+        assert proxy.get_value(3) == 6  # type: ignore[attr-defined]
+        assert proxy.get_value(5) == 10  # type: ignore[attr-defined]
+
+    def test_non_callable_attribute_is_returned_directly(self):
+        """Non-callable attributes on the async monitor are passed through unchanged."""
+        proxy = self._make_proxy()
+        assert proxy.non_callable_attr == "hello"  # type: ignore[attr-defined]
+
+    def test_each_proxy_wraps_its_own_inner_monitor(self):
+        """Two proxies created from different async monitors are independent."""
+        inner_a = _AsyncMonitorStub()
+        inner_b = _AsyncMonitorStub()
+        proxy_a = _async_to_sync_monitor(_as_async_stub(inner_a))
+        proxy_b = _async_to_sync_monitor(_as_async_stub(inner_b))
+        assert proxy_a.async_monitor() is inner_a  # type: ignore[attr-defined]
+        assert proxy_b.async_monitor() is inner_b  # type: ignore[attr-defined]
+        assert proxy_a.async_monitor() is not proxy_b.async_monitor()  # type: ignore[attr-defined]
+
+
+class _SyncMonitorStub:
+    """Minimal sync-monitor stand-in with a mix of callable and non-callable members."""
+
+    non_callable_attr = "world"
+
+    def get_value(self, x: int) -> int:
+        return x * 3
+
+    def raises(self) -> None:
+        raise RuntimeError("sync-boom")
+
+
+class TestSyncToAsyncMonitor:
+    def _make_proxy(self):
+        return _sync_to_async_monitor(cast(object, _SyncMonitorStub()))  # type: ignore[arg-type]
+
+    def test_proxy_satisfies_provides_async_monitor_protocol(self):
+        """The returned proxy is recognised as a _ProvidesAsyncMonitor."""
+        proxy = self._make_proxy()
+        assert isinstance(proxy, _ProvidesAsyncMonitor)
+
+    def test_async_monitor_returns_self(self):
+        """proxy.async_monitor() returns the proxy itself, not the inner sync monitor."""
+        inner = _SyncMonitorStub()
+        proxy = _sync_to_async_monitor(cast(object, inner))  # type: ignore[arg-type]
+        result = proxy.async_monitor()  # type: ignore[attr-defined]
+        assert result is proxy
+        assert result is not inner
+
+    def test_async_monitor_method_visible_to_get_async_monitor_method(self):
+        """
+        _get_async_monitor_method should see async_monitor on the proxy and return a
+        bound callable that returns the proxy itself.
+        """
+        proxy = self._make_proxy()
+        bound = _get_async_monitor_method(proxy)
+        assert bound is not None
+        assert bound() is proxy
+
+    @pytest.mark.asyncio
+    async def test_async_call_returns_result_of_sync_method(self):
+        """Awaiting a proxied sync method returns its result."""
+        proxy = self._make_proxy()
+        result = await proxy.get_value(14)  # type: ignore[attr-defined]
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_async_call_passes_args_and_kwargs_to_sync_method(self):
+        """Positional and keyword arguments are forwarded to the underlying sync method."""
+
+        class ArgsMonitor:
+            def echo(self, a, b, *, flag=False):
+                return (a, b, flag)
+
+        proxy = _sync_to_async_monitor(cast(object, ArgsMonitor()))  # type: ignore[arg-type]
+        result = await proxy.echo(1, 2, flag=True)  # type: ignore[attr-defined]
+        assert result == (1, 2, True)
+
+    @pytest.mark.asyncio
+    async def test_async_call_propagates_exception_from_sync_method(self):
+        """Exceptions raised inside the sync method surface when the coroutine is awaited."""
+        proxy = self._make_proxy()
+        with pytest.raises(RuntimeError, match="sync-boom"):
+            await proxy.raises()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_each_attribute_access_returns_awaitable(self):
+        """Repeated attribute lookups each produce a working async wrapper."""
+        proxy = self._make_proxy()
+        assert await proxy.get_value(4) == 12  # type: ignore[attr-defined]
+        assert await proxy.get_value(7) == 21  # type: ignore[attr-defined]
+
+    def test_non_callable_attribute_is_returned_directly(self):
+        """Non-callable attributes on the sync monitor are passed through unchanged."""
+        proxy = self._make_proxy()
+        assert proxy.non_callable_attr == "world"  # type: ignore[attr-defined]
+
+    def test_each_proxy_wraps_its_own_inner_monitor(self):
+        """Two proxies created from different sync monitors are independent."""
+        inner_a = _SyncMonitorStub()
+        inner_b = _SyncMonitorStub()
+        proxy_a = _sync_to_async_monitor(cast(object, inner_a))  # type: ignore[arg-type]
+        proxy_b = _sync_to_async_monitor(cast(object, inner_b))  # type: ignore[arg-type]
+        assert proxy_a.async_monitor() is proxy_a  # type: ignore[attr-defined]
+        assert proxy_b.async_monitor() is proxy_b  # type: ignore[attr-defined]
+        assert proxy_a is not proxy_b
+
+
+class _CountingFactory:
+    """A factory that records calls and returns a fixed inner monitor."""
+
+    def __init__(self, inner: ResourceMonitorAsyncStub):
+        self.calls: list[str] = []
+        self._inner = inner
+
+    def __call__(self, target: str) -> ResourceMonitorAsyncStub:
+        self.calls.append(target)
+        return self._inner
+
+
+class TestLazyAsyncMonitor:
+    def _make_factory(self) -> tuple[_CountingFactory, ResourceMonitorAsyncStub]:
+        inner = _as_async_stub(_AsyncMonitorStub())
+        return _CountingFactory(inner), inner
+
+    def test_factory_not_called_at_construction(self):
+        """The factory is NOT invoked when the proxy is created."""
+        factory, _ = self._make_factory()
+        _lazy_async_monitor("target", factory)
+        assert factory.calls == []
+
+    def test_factory_called_on_first_getattr(self):
+        """The factory is invoked on the first __getattr__ access."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        _ = proxy.get_value  # type: ignore[attr-defined]
+        assert len(factory.calls) == 1
+
+    def test_factory_called_with_target(self):
+        """The factory receives the target string that was passed to _lazy_async_monitor."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("my-target", factory)
+        _ = proxy.get_value  # type: ignore[attr-defined]
+        assert factory.calls == ["my-target"]
+
+    def test_factory_called_only_once(self):
+        """Multiple attribute accesses only trigger the factory once (memoised)."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        _ = proxy.get_value  # type: ignore[attr-defined]
+        _ = proxy.get_value  # type: ignore[attr-defined]
+        _ = proxy.raises  # type: ignore[attr-defined]
+        assert len(factory.calls) == 1
+
+    def test_async_monitor_triggers_factory(self):
+        """Calling async_monitor() also triggers the factory."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        proxy.async_monitor()  # type: ignore[attr-defined]
+        assert len(factory.calls) == 1
+
+    def test_async_monitor_returns_inner_monitor(self):
+        """async_monitor() returns the monitor produced by the factory."""
+        factory, inner = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        assert proxy.async_monitor() is inner  # type: ignore[attr-defined]
+
+    def test_attributes_delegated_to_inner_monitor(self):
+        """__getattr__ forwards attribute lookups to the underlying async monitor."""
+        factory, inner = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        # Bound method objects differ per-access, but the underlying function must be
+        # identical, confirming the proxy delegates directly without any wrapping.
+        assert proxy.get_value.__func__ is inner.get_value.__func__  # type: ignore[attr-defined]
+
+    def test_non_callable_attribute_delegated_to_inner_monitor(self):
+        """Non-callable attributes are also forwarded to the inner monitor."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        assert proxy.non_callable_attr == "hello"  # type: ignore[attr-defined]
+
+    def test_proxy_satisfies_provides_async_monitor_protocol(self):
+        """The returned proxy is recognised as a _ProvidesAsyncMonitor."""
+        factory, _ = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        assert isinstance(proxy, _ProvidesAsyncMonitor)
+
+    def test_get_async_monitor_method_sees_async_monitor(self):
+        """_get_async_monitor_method returns a bound callable for the proxy."""
+        factory, inner = self._make_factory()
+        proxy = _lazy_async_monitor("target", factory)
+        bound = _get_async_monitor_method(proxy)
+        assert bound is not None
+        assert bound() is inner
+
+    def test_each_proxy_has_independent_factory_and_inner_monitor(self):
+        """Two proxies backed by different factories/targets are fully independent."""
+        inner_a = _as_async_stub(_AsyncMonitorStub())
+        inner_b = _as_async_stub(_AsyncMonitorStub())
+        factory_a = _CountingFactory(inner_a)
+        factory_b = _CountingFactory(inner_b)
+        proxy_a = _lazy_async_monitor("target-a", factory_a)
+        proxy_b = _lazy_async_monitor("target-b", factory_b)
+
+        assert proxy_a.async_monitor() is inner_a  # type: ignore[attr-defined]
+        assert proxy_b.async_monitor() is inner_b  # type: ignore[attr-defined]
+        assert factory_a.calls == ["target-a"]
+        assert factory_b.calls == ["target-b"]
+
+
+_PATCH_CHANNEL = "grpc.aio.insecure_channel"
+
+
+def _trigger_factory(proxy) -> None:
+    """
+    Force the lazy gRPC factory to run by drilling through the two proxy layers:
+      AsyncToSyncProxy.async_monitor() -> LazyAsyncProxy
+      LazyAsyncProxy.async_monitor()   -> calls _get_monitor() -> factory
+    """
+    lazy = proxy.async_monitor()  # type: ignore[attr-defined]
+    lazy.async_monitor()  # type: ignore[attr-defined]
+
+
+class TestGrpcMonitor:
+    def test_returns_provides_async_monitor(self):
+        """The returned proxy satisfies the _ProvidesAsyncMonitor protocol."""
+        with patch(_PATCH_CHANNEL):
+            proxy = _grpc_monitor("host:1234")
+        assert isinstance(proxy, _ProvidesAsyncMonitor)
+
+    def test_get_async_monitor_method_works(self):
+        """_get_async_monitor_method sees async_monitor on the returned proxy."""
+        with patch(_PATCH_CHANNEL):
+            proxy = _grpc_monitor("host:1234")
+        bound = _get_async_monitor_method(proxy)
+        assert bound is not None
+        assert callable(bound)
+
+    def test_channel_not_created_at_construction(self):
+        """grpc.aio.insecure_channel is NOT called when _grpc_monitor is called."""
+        with patch(_PATCH_CHANNEL) as mock_channel:
+            _grpc_monitor("host:1234")
+            mock_channel.assert_not_called()
+
+    def test_channel_created_on_first_access(self):
+        """grpc.aio.insecure_channel is called on the first attribute access."""
+        with patch(_PATCH_CHANNEL) as mock_channel:
+            proxy = _grpc_monitor("host:1234")
+            mock_channel.assert_not_called()
+            _trigger_factory(proxy)
+            mock_channel.assert_called_once()
+
+    def test_channel_created_with_correct_target(self):
+        """The target string is forwarded to grpc.aio.insecure_channel."""
+        with patch(_PATCH_CHANNEL) as mock_channel:
+            proxy = _grpc_monitor("my-host:9090")
+            _trigger_factory(proxy)
+        assert mock_channel.call_args.args[0] == "my-host:9090"
+
+    def test_channel_created_with_correct_options(self):
+        """The standard _GRPC_CHANNEL_OPTIONS are forwarded to grpc.aio.insecure_channel."""
+        with patch(_PATCH_CHANNEL) as mock_channel:
+            proxy = _grpc_monitor("host:1234")
+            _trigger_factory(proxy)
+        _, kwargs = mock_channel.call_args
+        assert kwargs.get("options") == _GRPC_CHANNEL_OPTIONS
+
+    def test_channel_created_only_once(self):
+        """Multiple accesses only create the gRPC channel once."""
+        with patch(_PATCH_CHANNEL) as mock_channel:
+            proxy = _grpc_monitor("host:1234")
+            _trigger_factory(proxy)
+            _trigger_factory(proxy)
+            _trigger_factory(proxy)
+        mock_channel.assert_called_once()

--- a/sdk/python/lib/test/runtime/test_settings.py
+++ b/sdk/python/lib/test/runtime/test_settings.py
@@ -1,0 +1,199 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from pulumi.runtime._monitor import _sync_to_async_monitor
+from pulumi.runtime.mocks import AsyncMockMonitor, MockMonitor, Mocks, set_mocks
+from pulumi.runtime.proto import resource_pb2
+from pulumi.runtime.settings import ROOT, SETTINGS, _get_async_monitor, get_monitor
+
+
+class _SimpleMocks(Mocks):
+    def call(self, args):
+        return {}, None
+
+    def new_resource(self, args):
+        return args.name + "_id", {}
+
+
+# Capture the qualname of SyncToAsyncMonitorProxy once (each _sync_to_async_monitor
+# call creates a fresh class, but all share the same __qualname__).
+_SYNC_TO_ASYNC_PROXY_QUALNAME: str = type(
+    _sync_to_async_monitor(cast(object, object()))  # type: ignore[arg-type]
+).__qualname__
+
+
+def _is_sync_to_async_wrapper(obj) -> bool:
+    """Returns True when obj is a _sync_to_async_monitor proxy."""
+    return type(obj).__qualname__ == _SYNC_TO_ASYNC_PROXY_QUALNAME
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings():
+    """Restore monitor and root-resource state between tests."""
+    old_monitor = SETTINGS.monitor
+    old_root = ROOT.get()
+    yield
+    SETTINGS.monitor = old_monitor
+    ROOT.set(old_root)
+
+
+class TestGetMonitor:
+    def test_returns_none_when_no_monitor_configured(self):
+        SETTINGS.monitor = None
+        assert get_monitor() is None
+
+    def test_returns_settings_monitor_directly(self):
+        mock_mon = MockMonitor(_SimpleMocks())
+        SETTINGS.monitor = mock_mon
+        assert get_monitor() is mock_mon
+
+    def test_sync_register_package_on_mock_monitor(self):
+        """
+        Mirrors the real-world usage pattern we currently have in generated
+        provider SDKs, where _utilities.py calls get_monitor() and then calls
+        RegisterPackage synchronously:
+
+            monitor = get_monitor()
+            response = monitor.RegisterPackage(RegisterPackageRequest(...))
+
+        MockMonitor.RegisterPackage is synchronous; the response is the same
+        fake ref that AsyncMockMonitor returns.
+        """
+        set_mocks(_SimpleMocks())
+        monitor = get_monitor()
+        assert monitor is not None
+
+        request = resource_pb2.RegisterPackageRequest(
+            name="mypkg",
+            version="1.2.3",
+        )
+        response = monitor.RegisterPackage(request)  # type: ignore[attr-defined]
+
+        # AsyncMockMonitor always returns "mock-uuid" for RegisterPackage.
+        assert response.ref == "mock-uuid"
+
+    def test_sync_register_package_with_mock_monitor_subclass(self):
+        """A MockMonitor subclass passed explicitly also exposes sync RegisterPackage."""
+
+        class _SubMon(MockMonitor):
+            pass
+
+        set_mocks(_SimpleMocks(), monitor=_SubMon(_SimpleMocks()))
+        monitor = get_monitor()
+
+        response = monitor.RegisterPackage(  # type: ignore[attr-defined]
+            resource_pb2.RegisterPackageRequest(name="pkg", version="0.1.0")
+        )
+        assert response.ref == "mock-uuid"
+
+    def test_sync_register_package_with_async_mock_monitor_passed(self):
+        """AsyncMockMonitor wrapped by set_mocks; sync RegisterPackage still works."""
+        async_mon = AsyncMockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=async_mon)
+        monitor = get_monitor()
+        assert isinstance(monitor, MockMonitor)
+
+        response = monitor.RegisterPackage(  # type: ignore[attr-defined]
+            resource_pb2.RegisterPackageRequest(name="pkg", version="0.1.0")
+        )
+        assert response.ref == "mock-uuid"
+
+    def test_returns_arbitrary_monitor_unchanged(self):
+        """An object that is not MockMonitor/AsyncMockMonitor is stored and returned as-is."""
+
+        class _ArbitraryMonitor:
+            pass
+
+        arb = _ArbitraryMonitor()
+        SETTINGS.monitor = arb
+        assert get_monitor() is arb
+
+
+class TestGetAsyncMonitor:
+    def test_returns_none_when_no_monitor_configured(self):
+        SETTINGS.monitor = None
+        assert _get_async_monitor() is None
+
+    def test_returns_async_mock_monitor_for_plain_mock_monitor(self):
+        """MockMonitor.async_monitor() returns the inner AsyncMockMonitor."""
+        set_mocks(_SimpleMocks())
+        assert isinstance(_get_async_monitor(), AsyncMockMonitor)
+
+    def test_returns_inner_async_mock_monitor_for_explicit_mock_monitor(self):
+        mock_mon = MockMonitor(_SimpleMocks())
+        SETTINGS.monitor = mock_mon
+        async_mon = _get_async_monitor()
+        # Should be the same object that mock_mon.async_monitor() returns.
+        assert async_mon is mock_mon.async_monitor()
+        assert isinstance(async_mon, AsyncMockMonitor)
+
+    def test_returns_sync_to_async_wrapper_for_mock_monitor_subclass(self):
+        """
+        For a MockMonitor subclass, async_monitor() returns a _sync_to_async_monitor
+        wrapper (so that overridden sync methods are called through the async interface).
+        """
+
+        class _SubMon(MockMonitor):
+            pass
+
+        SETTINGS.monitor = _SubMon(_SimpleMocks())
+        assert _is_sync_to_async_wrapper(_get_async_monitor())
+
+    def test_returns_passed_async_mock_monitor_when_wrapped(self):
+        """When an AsyncMockMonitor is passed to set_mocks it is wrapped in a MockMonitor,
+        but _get_async_monitor() unwraps it and returns the original instance."""
+        async_mon = AsyncMockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=async_mon)
+        assert _get_async_monitor() is async_mon
+
+    def test_returns_sync_to_async_wrapper_for_arbitrary_monitor(self):
+        """An arbitrary object without async_monitor gets wrapped in _sync_to_async_monitor."""
+
+        class _ArbitraryMonitor:
+            pass
+
+        SETTINGS.monitor = _ArbitraryMonitor()
+        assert _is_sync_to_async_wrapper(_get_async_monitor())
+
+    @pytest.mark.asyncio
+    async def test_async_register_package_on_mock_monitor(self):
+        """Calling RegisterPackage through _get_async_monitor() works asynchronously."""
+        set_mocks(_SimpleMocks())
+        async_mon = _get_async_monitor()
+        assert async_mon is not None
+
+        response = await async_mon.RegisterPackage(  # type: ignore[attr-defined]
+            resource_pb2.RegisterPackageRequest(name="mypkg", version="1.2.3")
+        )
+        assert response.ref == "mock-uuid"
+
+    @pytest.mark.asyncio
+    async def test_async_register_package_on_async_mock_monitor_passed_directly(self):
+        """AsyncMockMonitor passed to set_mocks returns the right ref asynchronously."""
+        async_mon = AsyncMockMonitor(_SimpleMocks())
+        set_mocks(_SimpleMocks(), monitor=async_mon)
+
+        result_mon = _get_async_monitor()
+        assert result_mon is async_mon
+
+        response = await result_mon.RegisterPackage(  # type: ignore[attr-defined]
+            resource_pb2.RegisterPackageRequest(name="pkg", version="0.1.0")
+        )
+        assert response.ref == "mock-uuid"


### PR DESCRIPTION
This change switches to using an asyncio-based gRPC client for the monitor rather than using `asyncio.get_event_loop().run_in_executor()` to make non-blocking gRPC calls. This should contribute to improving the scalability and stability of the SDK as asyncio loops should be capable of cheaper context switches than jumping threads on every monitor call (e.g. `RegisterResource`, `Invoke`, etc.).

We have the following existing function in `sdk/python/lib/pulumi/runtime/settings.py` which gets the current configured monitor client:

```python
def get_monitor() -> Optional[Union[resource_pb2_grpc.ResourceMonitorStub, Any]]:
    return SETTINGS.monitor
```

Ideally this function would not have been used outside of the SDK, but external code relies on it. For [example](https://github.com/pulumi/pulumi/blob/05225cbea7344b925b074c121bc4fbe7b9685b13/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py#L330-L356), generated provider SDKs currently call this to get the monitor and then calls `monitor.RegisterPackage(...)` synchronously to get the package ref for parameterized SDKs.

The behavior of `get_monitor` needs to remain compatible: returning a monitor object that conforms to the synchronous interface.

However, we want to move internal callers to use the asynchronous asyncio-based monitor API. To enable this, a new internal function has been introduced (not intended for external callers):

```python
def _get_async_monitor() -> Optional[resource_pb2_grpc.ResourceMonitorAsyncStub]:
    ...
```

With this change, the internal monitor client that is created is the asyncio-based client. This is wrapped by a synchronous wrapper that allows synchronous blocking calls. `get_monitor()` returns the synchronous wrapper, allowing callers to continue making synchronous calls as expected. The new `_get_async_monitor()` function returns the async client, used internally throughout the implementation of the SDK. This is done by calling a standardized `def async_monitor(self) -> ResourceMonitorAsyncStub` method on the wrapper.

Mocks have also been updated to support asyncio. By default, if you call `set_mocks(MyMocks())`, internally `SETTINGS.monitor` will be set to an instance of the synchronous `MockMonitor`. But now `MockMonitor` is just a synchronous wrapper of an instance of a new `AsyncMockMonitor` class. Calling `MockMonitor`'s `async_monitor` method will return the inner `AsyncMockMonitor` instance. `set_mocks` also allows you to pass-in an explicit monitor. The type signature has been updated to accept both `MockMonitor` or `AsyncMockMonitor`. You can continue to pass a `MockMonitor` instance or subclass, or other object that implements the synchronous interface, and we do the right thing to make it work. If you want to stay purely async, you can now use `AsyncMockMonitor` or a subclass of it.

Note that this change only changes the monitor client; it doesn't fully remove threading from the SDK:

- The client for the engine remains synchronous as its usage is largely synchronous (for synchronous log calls).
- Existing gRPC servers that use `ThreadPoolExecutor` have not been switched over to asyncio.

⚠️ More downstream testing of this change with actual Pulumi programs should be done before this is merged.

Part of #7663