### PR TITLE
enable journaling by default

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -47,11 +47,6 @@ on:
         default: 0
         required: false
         type: number
-      enable-journaling:
-        description: "Whether journaling is enabled for running the tests"
-        required: false
-        default: true
-        type: boolean
 
       version-set:
         required: false
@@ -84,7 +79,6 @@ env:
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
   PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION: "true"
-  PULUMI_ENABLE_JOURNALING: "${{ inputs.enable-journaling }}"
   PYTHON: python
   GO_TEST_PARALLELISM: 8
   GO_TEST_PKG_PARALLELISM: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,6 @@ on:
         default: false
         required: false
         type: boolean
-      enable-journaling:
-        description: "Whether journaling is enabled in tests"
-        default: true
-        required: false
-        type: boolean
       fail-fast:
         required: false
         default: false
@@ -361,7 +356,6 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: false
       enable-coverage: ${{ inputs.enable-coverage }}
-      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -388,7 +382,6 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
-      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -416,7 +409,6 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
-      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -444,7 +436,6 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
-      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -463,7 +454,6 @@ jobs:
       test-command: make test_lifecycle_fuzz
       is-integration-test: false
       enable-coverage: false
-      enable-journaling: ${{ inputs.enable-journaling }}
       test-retries: ${{ inputs.test-retries }}
       version-set: ${{ needs.matrix.outputs.version-set }}
       continue-on-error: ${{ inputs.fuzz-test-optional }}

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -40,7 +40,6 @@ jobs:
       # data on every merge to main, so getting it in the daily cro
       # job is not important.
       enable-coverage: false
-      enable-journaling: false
     secrets: inherit
 
   performance-gate:

--- a/changelog/pending/20260302--engine--enable-journaling-by-default-it-can-still-be-turned-off-using-the-pulumi_disable_journaling-env-variable.yaml
+++ b/changelog/pending/20260302--engine--enable-journaling-by-default-it-can-still-be-turned-off-using-the-pulumi_disable_journaling-env-variable.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: Enable journaling by default. It can still be turned off using the PULUMI_DISABLE_JOURNALING env variable

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1745,7 +1745,7 @@ func (b *cloudBackend) runEngineAction(
 		// we can send a newer version than 1, and switch out the API completely on the server side, while the client
 		// will continue working with the non-journaling snapshotter. This will be slower but won't be a breaking change
 		// for older clients.
-		if journalVersion == 1 && env.EnableJournaling.Value() {
+		if journalVersion == 1 && !env.DisableJournaling.Value() {
 			snapshotJournaler := journal.NewJournaler(ctx, b.client, update, tokenSource, op.SecretsManager)
 			journalManager, err := engine.NewJournalSnapshotManager(snapshotJournaler, u.Target.Snapshot, op.SecretsManager)
 			if err != nil {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -899,7 +899,7 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 		Tags: tags,
 	}
 
-	if env.EnableJournaling.Value() {
+	if !env.DisableJournaling.Value() {
 		req.JournalVersion = 1
 	}
 

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -238,8 +238,8 @@ var (
 	PolicyTemplateBranch = env.String("POLICY_TEMPLATE_BRANCH", "Branch name for Pulumi Policy Pack templates repository.")
 )
 
-var EnableJournaling = env.Bool("ENABLE_JOURNALING",
-	"Enable journaling of engine operations to the backend (if the backend supports it)")
+var DisableJournaling = env.Bool("DISABLE_JOURNALING",
+	"Disable journaling of engine operations to the backend")
 
 var JournalingBatchSize = env.Int("JOURNALING_BATCH_SIZE", "Maximum batch size for journal entries")
 

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -165,15 +165,12 @@ func TestPerfManyResourcesWithJournaling(t *testing.T) {
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		NoParallel:     true,
-		Dir:            filepath.Join("typescript", "many_resources"),
-		Dependencies:   []string{"@pulumi/pulumi"},
-		RequireService: true,
-		ReportStats:    initialBenchmark,
-		SkipPreview:    true,
-		Env: []string{
-			"PULUMI_ENABLE_JOURNALING=true",
-		},
+		NoParallel:       true,
+		Dir:              filepath.Join("typescript", "many_resources"),
+		Dependencies:     []string{"@pulumi/pulumi"},
+		RequireService:   true,
+		ReportStats:      initialBenchmark,
+		SkipPreview:      true,
 		DestroyOnCleanup: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			require.Greater(t, len(stack.Deployment.Resources), 2000)


### PR DESCRIPTION
We've had the journaling feature flag turned on for everyone for a while, and have had enough updates use it be confident in flipping it and turning it on by default.

We still keep a `PULUMI_DISABLE_JOURNALING` env variable, so users can disable it if necessary.

Fixes https://github.com/pulumi/home/issues/4404