### PR TITLE
add otel equivalent for remaining opentracing spans

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -225,6 +225,16 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 	)
 	defer requestSpan.Finish()
 
+	tracer := otel.Tracer("pulumi-cli")
+	ctx, otelSpan := cmdutil.StartSpan(ctx, tracer, "HTTP request",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("http.method", req.Method),
+			attribute.String("http.url", req.URL.String()),
+			attribute.String("http.retry", policy.String()),
+		))
+	defer otelSpan.End()
+
 	req = req.WithContext(ctx)
 
 	// Add a User-Agent header to distinguish the pulumi CLI from other clients.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/util/validation"
@@ -43,6 +44,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -759,6 +761,10 @@ func (pc *Client) ExportStackDeployment(
 ) (apitype.UntypedDeployment, error) {
 	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "ExportStackDeployment")
 	defer tracingSpan.Finish()
+
+	tracer := otel.Tracer("pulumi-cli")
+	childCtx, otelSpan := cmdutil.StartSpan(childCtx, tracer, "ExportStackDeployment")
+	defer otelSpan.End()
 
 	path := getStackPath(stack, "export")
 

--- a/pkg/backend/httpstate/diffs.go
+++ b/pkg/backend/httpstate/diffs.go
@@ -28,9 +28,13 @@ import (
 	"github.com/hexops/gotextdiff/span"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pgavlin/diff/lcs"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	segmentio_json "github.com/segmentio/encoding/json"
 )
 
@@ -85,6 +89,10 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment)
 	tracingSpan, childCtx := opentracing.StartSpanFromContext(ctx, "Diff")
 	defer tracingSpan.Finish()
 
+	tracer := otel.Tracer("pulumi-cli")
+	childCtx, otelSpan := cmdutil.StartSpan(childCtx, tracer, "Diff")
+	defer otelSpan.End()
+
 	before := dds.lastSavedDeployment.raw
 	after := deployment.raw
 
@@ -107,6 +115,14 @@ func (dds *deploymentDiffState) Diff(ctx context.Context, deployment deployment)
 	tracingSpan.SetTag("diff", len(delta))
 	tracingSpan.SetTag("compression", 100.0*float64(len(delta))/float64(len(after)))
 	tracingSpan.SetTag("hash", checkpointHash)
+
+	otelSpan.SetAttributes(
+		attribute.Int("before", len(before)),
+		attribute.Int("after", len(after)),
+		attribute.Int("diff", len(delta)),
+		attribute.Float64("compression", 100.0*float64(len(delta))/float64(len(after))),
+		attribute.String("hash", checkpointHash),
+	)
 
 	diff := deploymentDiff{
 		checkpointHash:  checkpointHash,
@@ -132,6 +148,11 @@ func (dds *deploymentDiffState) Saved(ctx context.Context, deployment deployment
 func (*deploymentDiffState) computeHash(ctx context.Context, deployment json.RawMessage) string {
 	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "computeHash")
 	defer tracingSpan.Finish()
+
+	tracer := otel.Tracer("pulumi-cli")
+	_, otelSpan := cmdutil.StartSpan(ctx, tracer, "computeHash")
+	defer otelSpan.End()
+
 	hash := sha256.Sum256(deployment)
 	return hex.EncodeToString(hash[:])
 }
@@ -275,6 +296,10 @@ func (dds *deploymentDiffState) MarshalDeployment(
 func (*deploymentDiffState) computeEdits(ctx context.Context, before, after deployment) (json.RawMessage, error) {
 	tracingSpan, _ := opentracing.StartSpanFromContext(ctx, "computeEdits")
 	defer tracingSpan.Finish()
+
+	tracer := otel.Tracer("pulumi-cli")
+	_, otelSpan := cmdutil.StartSpan(ctx, tracer, "computeEdits")
+	defer otelSpan.End()
 
 	diffs := lcs.DiffLines(before.spans.spans, after.spans.spans)
 

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -21,6 +21,9 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -31,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -86,7 +90,12 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 
 // newDeploymentContext creates a context for a subsequent deployment. Callers must call Close on the context after the
 // associated deployment completes.
-func newDeploymentContext(u UpdateInfo, opName string, parentSpan opentracing.SpanContext) (*deploymentContext, error) {
+func newDeploymentContext(
+	ctx context.Context,
+	u UpdateInfo,
+	opName string,
+	parentSpan opentracing.SpanContext,
+) (*deploymentContext, error) {
 	// Create a root span for the operation
 	opts := []opentracing.StartSpanOption{}
 	if opName != "" {
@@ -97,19 +106,31 @@ func newDeploymentContext(u UpdateInfo, opName string, parentSpan opentracing.Sp
 	}
 	tracingSpan := opentracing.StartSpan("pulumi-plan", opts...)
 
+	tracer := otel.Tracer("pulumi-cli")
+	var otelOpts []trace.SpanStartOption
+	if opName != "" {
+		otelOpts = append(otelOpts, trace.WithAttributes(attribute.String("operation", opName)))
+	}
+	_, otelSpan := cmdutil.StartSpan(ctx, tracer, "pulumi-plan", otelOpts...)
+
 	return &deploymentContext{
 		Update:      u,
 		TracingSpan: tracingSpan,
+		otelSpan:    otelSpan,
 	}, nil
 }
 
 type deploymentContext struct {
 	Update      UpdateInfo       // The update being processed.
 	TracingSpan opentracing.Span // An OpenTracing span to parent deployment operations within.
+	otelSpan    trace.Span
 }
 
 func (ctx *deploymentContext) Close() {
 	ctx.TracingSpan.Finish()
+	if ctx.otelSpan != nil {
+		ctx.otelSpan.End()
+	}
 }
 
 // deploymentOptions includes a full suite of options for performing a deployment.

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -129,7 +129,7 @@ func TestSourceFuncCancellation(t *testing.T) {
 	ctx := makeTestContext(t, cancelCtx)
 	defer ctx.Close()
 
-	info, err := newDeploymentContext(makeUpdateInfo(), "test", nil)
+	info, err := newDeploymentContext(t.Context(), makeUpdateInfo(), "test", nil)
 	require.NoError(t, err)
 	defer info.Close()
 

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -41,7 +41,7 @@ func Destroy(
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "destroy", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "destroy", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -178,7 +178,7 @@ func DestroyV2(
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "destroy", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "destroy", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -27,7 +27,7 @@ func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Imp
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "import", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "import", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -38,7 +38,7 @@ func Refresh(
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "refresh", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "refresh", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,7 +140,7 @@ func RefreshV2(
 
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "refresh", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "refresh", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -237,7 +237,7 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
-	info, err := newDeploymentContext(u, "update", ctx.ParentSpan)
+	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "update", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -37,6 +37,9 @@ import (
 	"github.com/blang/semver"
 	multierror "github.com/hashicorp/go-multierror"
 	opentracing "github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -269,6 +272,15 @@ func newPlugin[T any](
 	}
 	tracingSpan := opentracing.StartSpan("newPlugin", opts...)
 	defer tracingSpan.Finish()
+
+	tracer := otel.Tracer("pulumi-cli")
+	_, otelSpan := cmdutil.StartSpan(context.Background(), tracer, "newPlugin",
+		trace.WithAttributes(
+			attribute.String("prefix", prefix),
+			attribute.String("bin", bin),
+			attribute.String("pulumi-decorator", prefix+":"+bin),
+		))
+	defer otelSpan.End()
 
 	// Try to execute the binary.
 	plug, err := ExecPlugin(ctx, bin, prefix, kind, args, pwd, env, attachDebugger)


### PR DESCRIPTION
We currently still have some more opentracing spans than we have otel spans, for various things.  Add otel spans for all the opentracing spans we have implemented.