### PR TITLE
Test output values in ReplacementTrigger

### DIFF
--- a/pkg/engine/lifecycletest/replacement_trigger_test.go
+++ b/pkg/engine/lifecycletest/replacement_trigger_test.go
@@ -323,7 +323,8 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 
 	// Unknown output values during non-preview runs should trigger an error.
 	expectedError = errors.New("replacement trigger contains unknowns")
-	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.ErrorContains(t, err, expectedError.Error())
 
 	assert.Equal(t, 2, len(snap.Resources))
@@ -394,7 +395,8 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 
 	// Unknown values during non-preview runs should trigger an error.
 	expectedError = errors.New("replacement trigger contains unknowns")
-	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
 	require.ErrorContains(t, err, expectedError.Error())
 
 	assert.Equal(t, 2, len(snap.Resources))

--- a/pkg/engine/lifecycletest/replacement_trigger_test.go
+++ b/pkg/engine/lifecycletest/replacement_trigger_test.go
@@ -16,7 +16,7 @@ package lifecycletest
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 
 	"github.com/blang/semver"
@@ -258,13 +258,18 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 	})
 	initialValue := value
 
+	var expectedError error
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs:             resource.NewPropertyMapFromMap(map[string]any{"foo": "bar"}),
 			ReplacementTrigger: value,
 		})
-		require.NoError(t, err)
-		return nil
+		if expectedError != nil {
+			require.ErrorContains(t, err, expectedError.Error())
+		} else {
+			require.NoError(t, err)
+		}
+		return err
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -317,22 +322,9 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// Unknown output values during non-preview runs should trigger an error.
-	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient,
-		func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
-			for _, e := range events {
-				if e.Type == DiagEvent {
-					diag := e.Payload().(DiagEventPayload).Message
-
-					if strings.Contains(diag, "replacement trigger contains unknowns for urn:pulumi:test::test::pkgA:m:typA::resA") {
-						return nil
-					}
-				}
-			}
-
-			assert.Fail(t, "expected matching diag event")
-			return nil
-		}, "2")
-	require.NoError(t, err)
+	expectedError = errors.New("replacement trigger contains unknowns")
+	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.ErrorContains(t, err, expectedError.Error())
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
@@ -356,14 +348,19 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 		}),
 	}
 
-	value := resource.MakeComputed(resource.NewPropertyValue("first"))
+	value := resource.NewPropertyValue("first")
+	var expectedError error
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
 			Inputs:             resource.NewPropertyMapFromMap(map[string]any{"foo": "bar"}),
 			ReplacementTrigger: value,
 		})
-		require.NoError(t, err)
-		return nil
+		if expectedError != nil {
+			require.ErrorContains(t, err, expectedError.Error())
+		} else {
+			require.NoError(t, err)
+		}
+		return err
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
@@ -375,9 +372,10 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
-	assert.Equal(t, resource.MakeComputed(resource.NewPropertyValue("")), snap.Resources[1].ReplacementTrigger)
+	assert.Equal(t, resource.NewPropertyValue("first"), snap.Resources[1].ReplacementTrigger)
 
 	// Unknown values during preview runs should trigger a replace.
+	value = resource.MakeComputed(resource.NewPropertyValue("first"))
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
 			operations := []display.StepOp{}
@@ -394,27 +392,12 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 
 	require.NoError(t, err)
 
-	value = resource.MakeComputed(resource.NewPropertyValue("first"))
-
 	// Unknown values during non-preview runs should trigger an error.
-	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient,
-		func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
-			for _, e := range events {
-				if e.Type == DiagEvent {
-					diag := e.Payload().(DiagEventPayload).Message
-
-					if strings.Contains(diag, "replacement trigger contains unknowns for urn:pulumi:test::test::pkgA:m:typA::resA") {
-						return nil
-					}
-				}
-			}
-
-			assert.Fail(t, "expected matching diag event")
-			return nil
-		}, "2")
-	require.NoError(t, err)
+	expectedError = errors.New("replacement trigger contains unknowns")
+	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.ErrorContains(t, err, expectedError.Error())
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
-	assert.Equal(t, resource.MakeComputed(resource.NewPropertyValue("")), snap.Resources[1].ReplacementTrigger)
+	assert.Equal(t, resource.NewPropertyValue("first"), snap.Resources[1].ReplacementTrigger)
 }

--- a/pkg/engine/lifecycletest/replacement_trigger_test.go
+++ b/pkg/engine/lifecycletest/replacement_trigger_test.go
@@ -71,6 +71,7 @@ func TestReplacementTrigger(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	snap, err = lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
@@ -87,6 +88,7 @@ func TestReplacementTrigger(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	value = resource.NewPropertyValue("second")
 
@@ -109,6 +111,7 @@ func TestReplacementTrigger(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 }
 
 func TestReplacementTriggerWithSecret(t *testing.T) {
@@ -148,6 +151,7 @@ func TestReplacementTriggerWithSecret(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	// Making this value secret should not trigger a replace, as the underlying value is still the same.
 	value = resource.MakeSecret(value)
@@ -167,6 +171,7 @@ func TestReplacementTriggerWithSecret(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 }
 
 func TestReplacementTriggerWithDeepSecret(t *testing.T) {
@@ -206,6 +211,7 @@ func TestReplacementTriggerWithDeepSecret(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	// Making the inner value secret should not trigger a replace, as the underlying value is still the same.
 	value = resource.NewPropertyValue([]resource.PropertyValue{resource.MakeSecret(resource.NewPropertyValue("first"))})
@@ -225,6 +231,7 @@ func TestReplacementTriggerWithDeepSecret(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 }
 
 func TestReplacementTriggerWithOutput(t *testing.T) {
@@ -246,11 +253,10 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 
 	// A known output should not trigger a replace.
 	value := resource.NewProperty(resource.Output{
-		Element:      resource.NewPropertyValue("first"),
-		Known:        true,
-		Secret:       false,
-		Dependencies: []resource.URN{},
+		Element: resource.NewPropertyValue("first"),
+		Known:   true,
 	})
+	initialValue := value
 
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
@@ -270,6 +276,7 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
@@ -285,13 +292,12 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, value, snap.Resources[1].ReplacementTrigger)
 
 	// Now we make it unknown...
 	value = resource.NewProperty(resource.Output{
-		Element:      resource.NewPropertyValue("first"),
-		Known:        false,
-		Secret:       false,
-		Dependencies: []resource.URN{},
+		Element: resource.NewPropertyValue("first"),
+		Known:   false,
 	})
 
 	// Unknown output values during preview runs should trigger a replace.
@@ -330,6 +336,7 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, initialValue, snap.Resources[1].ReplacementTrigger)
 }
 
 func TestReplacementTriggerWithComputed(t *testing.T) {
@@ -368,6 +375,7 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 
 	require.Len(t, snap.Resources, 2)
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, resource.MakeComputed(resource.NewPropertyValue("")), snap.Resources[1].ReplacementTrigger)
 
 	// Unknown values during preview runs should trigger a replace.
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), p.Options, true, p.BackendClient,
@@ -408,4 +416,5 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 
 	assert.Equal(t, 2, len(snap.Resources))
 	assert.Equal(t, snap.Resources[1].URN.Name(), "resA")
+	assert.Equal(t, resource.MakeComputed(resource.NewPropertyValue("")), snap.Resources[1].ReplacementTrigger)
 }

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -476,9 +476,10 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 	}
 
 	trigger, err := plugin.MarshalPropertyValue("replacementTrigger", opts.ReplacementTrigger, plugin.MarshalOptions{
-		KeepUnknowns:  true,
-		KeepSecrets:   rm.supportsSecrets,
-		KeepResources: rm.supportsResourceReferences,
+		KeepUnknowns:     true,
+		KeepSecrets:      rm.supportsSecrets,
+		KeepResources:    rm.supportsResourceReferences,
+		KeepOutputValues: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshaling replacement trigger: %w", err)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2600,6 +2600,12 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			return nil, fmt.Errorf("unmarshaling replacement trigger: %w", err)
 		}
 		replacementTrigger = *t
+
+		// Unknowns in replacement triggers are fine during preview, but they should raise an error during the actual
+		// operation.
+		if !rm.opts.DryRun && replacementTrigger.ContainsUnknowns() {
+			return nil, fmt.Errorf("replacement trigger contains unknowns")
+		}
 	}
 
 	retainOnDelete := opts.RetainOnDelete

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2604,7 +2604,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		// Unknowns in replacement triggers are fine during preview, but they should raise an error during the actual
 		// operation.
 		if !rm.opts.DryRun && replacementTrigger.ContainsUnknowns() {
-			return nil, fmt.Errorf("replacement trigger contains unknowns")
+			return nil, errors.New("replacement trigger contains unknowns")
 		}
 	}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1623,16 +1623,6 @@ func (sg *stepGenerator) generateStepsFromDiff(
 	prov plugin.Provider, goal *resource.Goal, randomSeed []byte,
 	autonaming *plugin.AutonamingOptions,
 ) ([]Step, bool, error) {
-	// Unknowns in replacement triggers are fine during preview, but they should raise an error during the actual
-	// operation. This check only applies when we have an old resource (i.e., during updates/replaces), since a
-	// replacement trigger only makes sense when there's something to replace.
-	if !sg.deployment.opts.DryRun && new.ReplacementTrigger.ContainsUnknowns() {
-		message := fmt.Sprintf("replacement trigger contains unknowns for %s", urn)
-		sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
-		sg.sawError = true
-		return nil, false, result.BailErrorf("%s", message)
-	}
-
 	triggerReplace := shouldTriggerReplace(new.ReplacementTrigger, old.ReplacementTrigger)
 
 	var diff plugin.DiffResult


### PR DESCRIPTION
This adds some checks in the ReplacementTrigger tests as to what value is actually written to the snapshot. It also fixes that we shouldn't be able to send `computed` on any update, even for new resources.