### PR TITLE
fix another flaky tail test

### DIFF
--- a/sdk/go/common/tail/tail_test.go
+++ b/sdk/go/common/tail/tail_test.go
@@ -640,6 +640,9 @@ func TestIncompleteLongLines(t *testing.T) {
 func TestIncompleteLinesWithReopens(t *testing.T) {
 	t.Parallel()
 
+	// TODO[pulumi/pulumi#19888]: Skipping flaky test
+	t.Skip("Skipping because the tail library is flaky.  See pulumi/pulumi#19888")
+
 	tailTest, cleanup := NewTailTest("incomplete-lines-reopens", t)
 	defer cleanup()
 	filename := "test.txt"


### PR DESCRIPTION
This library is notoriously flaky, and we've mostly moved off of it, other than for backwards compatibility purposes.  As with other tests for this library, just skip the offender, as we're not going to spend time fixing this.