### PR TITLE
cli: improve SAML SSO reauthorization error message with login URL

### DIFF
--- a/pkg/backend/backenderr/backenderr.go
+++ b/pkg/backend/backenderr/backenderr.go
@@ -17,6 +17,8 @@ package backenderr
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
@@ -124,6 +126,45 @@ func (ForbiddenError) Is(other error) bool {
 	default:
 		return false
 	}
+}
+
+// SAMLReauthorizationError is returned when a SAML SSO session has expired
+// and the user must re-authenticate via the Pulumi Cloud console.
+type SAMLReauthorizationError struct {
+	Err    error
+	APIURL string // The Pulumi Cloud API URL (e.g., https://api.pulumi.com)
+}
+
+func (err SAMLReauthorizationError) Error() string {
+	return err.Err.Error()
+}
+
+func (err SAMLReauthorizationError) Unwrap() error { return err.Err }
+
+// ConsoleURL returns the Pulumi Cloud console URL where the user can re-authenticate.
+// Returns "" if the console URL cannot be determined from the API URL.
+func (err SAMLReauthorizationError) ConsoleURL() string {
+	u, parseErr := url.Parse(err.APIURL)
+	if parseErr != nil {
+		return ""
+	}
+
+	const defaultAPIDomainPrefix = "api."
+	const defaultConsoleDomainPrefix = "app."
+
+	switch {
+	case os.Getenv("PULUMI_CONSOLE_DOMAIN") != "":
+		u.Host = os.Getenv("PULUMI_CONSOLE_DOMAIN")
+	case strings.HasPrefix(u.Host, defaultAPIDomainPrefix):
+		u.Host = defaultConsoleDomainPrefix + u.Host[len(defaultAPIDomainPrefix):]
+	case u.Host == "localhost:8080":
+		u.Host = "localhost:3000"
+	default:
+		return ""
+	}
+
+	u.Path = ""
+	return u.String()
 }
 
 type LoginRequiredError struct{}

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -365,6 +365,25 @@ func pulumiAPICall(ctx context.Context,
 		return "", nil, backenderr.ErrLoginRequired
 	}
 
+	// Detect SAML SSO reauthorization errors and wrap them with actionable context.
+	if resp.StatusCode == 401 && creds != "" {
+		respBody, readErr := readBody(resp)
+		if readErr == nil {
+			var errResp apitype.ErrorResponse
+			if jsonErr := json.Unmarshal(respBody, &errResp); jsonErr == nil {
+				lowMsg := strings.ToLower(errResp.Message)
+				if strings.Contains(lowMsg, "saml") && strings.Contains(lowMsg, "reauthorization") {
+					return "", nil, backenderr.SAMLReauthorizationError{
+						Err:    &errResp,
+						APIURL: cloudAPI,
+					}
+				}
+			}
+			// Re-wrap body back in the response for later processing.
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		}
+	}
+
 	// Provide a better error if rate-limit is exceeded(429: Too Many Requests)
 	if resp.StatusCode == 429 {
 		return "", nil, errors.New("pulumi service: request rate-limit exceeded")

--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -17,11 +17,13 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
 	"strings"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -63,6 +65,12 @@ func processCmdErrors(err error) error {
 	}
 
 	// Other type-specific error handling.
+	var samlErr backenderr.SAMLReauthorizationError
+	if errors.As(err, &samlErr) {
+		printSAMLReauthorizationError(samlErr)
+		return result.BailError(err)
+	}
+
 	if de, ok := engine.AsDecryptError(err); ok {
 		printDecryptError(*de)
 		return nil
@@ -77,6 +85,20 @@ func processCmdErrors(err error) error {
 
 	// In all other cases, return the unexpected error as-is for generic handling.
 	return err
+}
+
+// printSAMLReauthorizationError prints a helpful error message when SAML SSO
+// reauthorization is required, including a link to the Pulumi Cloud console.
+func printSAMLReauthorizationError(e backenderr.SAMLReauthorizationError) {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	ui.Fprintf(writer, "SAML SSO reauthorization is required.\n")
+	if consoleURL := e.ConsoleURL(); consoleURL != "" {
+		ui.Fprintf(writer, "\nTo re-authenticate, visit: %s\n", consoleURL)
+	}
+	ui.Fprintf(writer, "\nAlternatively, run `pulumi login` to log in again.\n")
+	contract.IgnoreError(writer.Flush())
+	cmdutil.Diag().Errorf(diag.RawMessage("" /*urn*/, buf.String()))
 }
 
 // A type-specific handler for engine.DecryptErrors that prints out help text


### PR DESCRIPTION
When a SAML SSO session expires, users previously saw a bare error message with no actionable guidance:

  error: [401] SAML SSO reauthorization is required.

This change detects the SAML reauthorization 401 response in the HTTP API client, wraps it in a new SAMLReauthorizationError type, and renders a helpful error message that includes the Pulumi Cloud console URL where the user can re-authenticate, plus a reminder to use `pulumi login`.

After this change users see:

  error: SAML SSO reauthorization is required.

         To re-authenticate, visit: https://app.pulumi.com

         Alternatively, run `pulumi login` to log in again.

Fixes #21534