### PR TITLE
Prepare for patch release (#22104)

### DIFF
--- a/changelog/pending/20260303--sdk-python--normalize-python-package-names-per-pep-503.yaml
+++ b/changelog/pending/20260303--sdk-python--normalize-python-package-names-per-pep-503.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Normalize Python package names per PEP 503

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -525,16 +525,13 @@ func (w *logWriter) Write(p []byte) (n int, err error) {
 // TODO[pulumi/pulumi#5863]: Remove this once the `pulumi-policy` package includes a `pulumi-plugin.json`
 // file that indicates the package does not have an associated plugin, and enough time has passed.
 // TODO[pulumi/pulumi#18023]: Can only remove after this issue with `uv` is fixed
+// These packages are known not to have any plugins.
+// TODO[pulumi/pulumi#5863]: Remove this once the `pulumi-policy` package includes a `pulumi-plugin.json`
+// file that indicates the package does not have an associated plugin, and enough time has passed.
+// TODO[pulumi/pulumi#18023]: Can only remove after this issue with `uv` is fixed
 var packagesWithoutPlugins = map[string]struct{}{
-	// We include both the hyphen and underscore variants of the package name
-	// to account for the fact that later versions of the package will come
-	// back from `python -m pip list` as the underscore variant due to a
-	// behavior change in setuptools where it keeps underscores rather than
-	// replacing them with hyphens.
 	"pulumi-policy":  {},
-	"pulumi_policy":  {},
 	"pulumi-esc-sdk": {},
-	"pulumi_esc_sdk": {},
 }
 
 // Returns if pkg is a pulumi package.
@@ -548,7 +545,7 @@ func isPulumiPackage(pkg toolchain.PythonPackage) bool {
 		return true
 	}
 
-	return strings.HasPrefix(pkg.Name, "pulumi_") || strings.HasPrefix(pkg.Name, "pulumi-")
+	return strings.HasPrefix(pkg.Name, "pulumi-")
 }
 
 func readPulumiPluginJSON(pkg toolchain.PythonPackage) (*plugin.PulumiPluginJSON, error) {

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -277,7 +277,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			require.NotEmpty(t, packages)
 			require.Len(t, packages, 1)
 			random := packages[0]
-			require.Equal(t, "pulumi_random", random.Name)
+			require.Equal(t, "pulumi-random", random.Name)
 			require.NotEmpty(t, random.Location)
 		})
 
@@ -350,7 +350,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			packages, err := determinePulumiPackages(t.Context(), opts)
 			require.NoError(t, err)
 			require.Len(t, packages, 1)
-			assert.Equal(t, "pulumi_foo", packages[0].Name)
+			assert.Equal(t, "pulumi-foo", packages[0].Name)
 			assert.NotEmpty(t, packages[0].Location)
 
 			// There should be no associated plugin since its `resource` field is set to `false`.
@@ -377,7 +377,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			assert.NotEmpty(t, packages)
 			require.Len(t, packages, 1)
 			old := packages[0]
-			assert.Equal(t, "pulumi_old", old.Name)
+			assert.Equal(t, "pulumi-old", old.Name)
 			assert.NotEmpty(t, old.Location)
 		})
 

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -165,6 +165,9 @@ func (p *pip) ListPackages(ctx context.Context, transitive bool) ([]PythonPackag
 		return nil, fmt.Errorf("parsing `python %s` output: %w", strings.Join(cmd.Args, " "), err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -272,6 +272,9 @@ func (p *poetry) ListPackages(ctx context.Context, transitive bool) ([]PythonPac
 		return nil, fmt.Errorf("parsing `python %s` output: %w", strings.Join(cmd.Args, " "), err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -338,3 +338,13 @@ func getPythonVersion(ctx context.Context,
 	}
 	return pythonVersion, nil
 }
+
+// pythonNormRe matches runs of PEP 503 separator characters.
+var pythonNormRe = regexp.MustCompile(`[-_.]+`)
+
+// normalizePythonPackageName normalizes a Python package name to its canonical form per PEP 503:
+// lowercase, with runs of '-', '_', and '.' replaced by a single '-'.
+// https://peps.python.org/pep-0503/
+func normalizePythonPackageName(name string) string {
+	return pythonNormRe.ReplaceAllString(strings.ToLower(name), "-")
+}

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -217,7 +217,7 @@ func TestListPackages(t *testing.T) {
 			for i, pkg := range packages {
 				packageNames[i] = pkg.Name
 			}
-			expectedPackages := append([]string{"pulumi_test_package"}, test.expectedPackages...)
+			expectedPackages := append([]string{"pulumi-test-package"}, test.expectedPackages...)
 			for _, pkg := range expectedPackages {
 				require.Contains(t, packageNames, pkg)
 			}
@@ -238,7 +238,7 @@ func TestListPackages(t *testing.T) {
 			for i, pkg := range packages {
 				packageNames[i] = pkg.Name
 			}
-			expectedPackages := append([]string{"pulumi_test_package"}, test.expectedPackages...)
+			expectedPackages := append([]string{"pulumi-test-package"}, test.expectedPackages...)
 			for _, pkg := range expectedPackages {
 				require.Contains(t, packageNames, pkg)
 			}

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -331,6 +331,9 @@ func (u *uv) ListPackages(ctx context.Context, transitive bool) ([]PythonPackage
 		return nil, fmt.Errorf("parsing package list: %w", err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1330,7 +1330,7 @@ func TestAboutPython(t *testing.T) {
 	e.RunCommand("pulumi", "install")
 	stdout, _ := e.RunCommand("pulumi", "about")
 	// Assert we parsed the dependencies
-	assert.Contains(t, stdout, "pulumi_kubernetes")
+	assert.Contains(t, stdout, "pulumi-kubernetes")
 	// Assert we parsed the language plugin, we don't assert against the minor version number
 	assert.Regexp(t, regexp.MustCompile(`language\W+python\W+3\.`), stdout)
 }
@@ -1580,13 +1580,13 @@ func TestConvertTerraformProviderPython(t *testing.T) {
 	found := false
 	depList := []string{}
 	for _, dep := range a.Dependencies {
-		if dep.Name == "pulumi_supabase" {
+		if dep.Name == "pulumi-supabase" {
 			found = true
 			break
 		}
 		depList = append(depList, dep.Name)
 	}
-	require.True(t, found, fmt.Sprintf("pulumi_supabase not found in dependencies.  Full list: %v", depList))
+	require.True(t, found, fmt.Sprintf("pulumi-supabase not found in dependencies.  Full list: %v", depList))
 }
 
 func TestConfigGetterOverloads(t *testing.T) {


### PR DESCRIPTION
Prepare for patch release (#22104)

Fix Go program generation lifting plains to input values (#22084)

This fixes Go program generation to lift plain values like `string` to
input/output values like `pulumi.String` in locations that is needed.
Most directly this fixes the generation of the l1-builtin-secret test
for Go as we now correctly lift the `notSecret` value to be a
`pulumi.String`.

As part of this I had to fix the `readFile` helper function to match
what PCL binding expected it to be, a plain string, not an output
string. This is so PCL binding added the correct `__convert` calls,
rather than it thinking `readFile` returned a string, trying to cast it
to an input and then failing because the Go helper was already an
output.

---------

Co-authored-by: Ian Wahbe <me@iwahbe.com>

Fix provider inheritence (#22101)

Fixes https://github.com/pulumi/pulumi/issues/22096

In https://github.com/pulumi/pulumi/pull/21999 we changed the engine to
handle the inheritance of providers, rather than having SDKs needing to
do it. This was to help bringing online two new language runtimes.

Unfortunately we got the logic wrong when dealing with default
providers. The language SDKs never see default providers so would never
inherit them, but the engine _does_ see them and so would flow them down
the parent chain. This is fine for resources in the same package but
breaks if you have a resource from say packageA as a parent and a
resource from packageB as it's child.

Previously that would work as long as the resource from packageA didn't
set an explicit provider as the language runtime would see "provider" as
empty and so the resource from packageB would send an empty provider ref
and both would get filled in by the engine with the default providers.
But when doing this inheritance engine side the engine always sees the
provider value set, either the explicit value set by the program, or the
default set by the engine. So we started flowing default providers down
the parent chain.

The logic was also wrong for providers from different packages. Again
the language SDKs check the provider package and only send it if it
matches.

We can fix both of these problems by just fixing the latter one. That is
don't inherit the provider if its for the wrong package.

Freeze 3.225.1 (#22112)

Changelog and go.mod updates for v3.225.1 (#22116)

Co-authored-by: github-actions <github-actions@github.com>

Move call __self__ provider inheritence logic to the engine (#22114)

Currently language SDKs have logic that if they're sending a resource
object as the special `__self__` argument to a call they'll use the
provider reference & package version from that resource to build the
CallRequest.

We don't need that in each language SDK, the engine can handle this by
checking to see if there's a `__self__` argument, and if there is
looking up the goal state for it's URN and pulling the provider from
that.

This also covers the case of getting the right package version because
the engine will also see provider references for default providers,
unlike language sdks. So we _only_ have to worry about the provider
field here.

If the `CallRequest` has an explicitly specified provider (which most
language SDKs will continue to do for now) the engine respects that.
Likewise if there's no `__self__` argument the engine leaves the
provider field blank.

Fix ReplacementTrigger firing because of new output dependencies (#22119)

If a language runtime sent the replacement trigger value wrapped as an
output, it could result in the replacement trigger firing even if the
actual value hadn't changed.

This adds a test for this scenario, first sending the trigger as a plain
string, then an output string but with the same value.

And fixes this by unwrapping secrets, but also outputs, before comparing
replacement trigger values in the engine.

Normalize Python package names per PEP 503

Package names returned by `pip list` vary between hyphenated and
underscore forms depending on setuptools version. Normalize all package
names to their canonical PEP 503 form (lowercase, hyphens) so callers
don't need to handle both variants.