### PR TITLE
Normalize Python package names per PEP 503

### DIFF
--- a/changelog/pending/20260303--sdk-python--normalize-python-package-names-per-pep-503.yaml
+++ b/changelog/pending/20260303--sdk-python--normalize-python-package-names-per-pep-503.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/python
+  description: Normalize Python package names per PEP 503

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -524,17 +524,9 @@ func (w *logWriter) Write(p []byte) (n int, err error) {
 // These packages are known not to have any plugins.
 // TODO[pulumi/pulumi#5863]: Remove this once the `pulumi-policy` package includes a `pulumi-plugin.json`
 // file that indicates the package does not have an associated plugin, and enough time has passed.
-// TODO[pulumi/pulumi#18023]: Can only remove after this issue with `uv` is fixed
 var packagesWithoutPlugins = map[string]struct{}{
-	// We include both the hyphen and underscore variants of the package name
-	// to account for the fact that later versions of the package will come
-	// back from `python -m pip list` as the underscore variant due to a
-	// behavior change in setuptools where it keeps underscores rather than
-	// replacing them with hyphens.
 	"pulumi-policy":  {},
-	"pulumi_policy":  {},
 	"pulumi-esc-sdk": {},
-	"pulumi_esc_sdk": {},
 }
 
 // Returns if pkg is a pulumi package.
@@ -548,7 +540,7 @@ func isPulumiPackage(pkg toolchain.PythonPackage) bool {
 		return true
 	}
 
-	return strings.HasPrefix(pkg.Name, "pulumi_") || strings.HasPrefix(pkg.Name, "pulumi-")
+	return strings.HasPrefix(pkg.Name, "pulumi-")
 }
 
 func readPulumiPluginJSON(pkg toolchain.PythonPackage) (*plugin.PulumiPluginJSON, error) {

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -277,7 +277,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			require.NotEmpty(t, packages)
 			require.Len(t, packages, 1)
 			random := packages[0]
-			require.Equal(t, "pulumi_random", random.Name)
+			require.Equal(t, "pulumi-random", random.Name)
 			require.NotEmpty(t, random.Location)
 		})
 
@@ -350,7 +350,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			packages, err := determinePulumiPackages(t.Context(), opts)
 			require.NoError(t, err)
 			require.Len(t, packages, 1)
-			assert.Equal(t, "pulumi_foo", packages[0].Name)
+			assert.Equal(t, "pulumi-foo", packages[0].Name)
 			assert.NotEmpty(t, packages[0].Location)
 
 			// There should be no associated plugin since its `resource` field is set to `false`.
@@ -377,7 +377,7 @@ func TestDeterminePulumiPackages(t *testing.T) {
 			assert.NotEmpty(t, packages)
 			require.Len(t, packages, 1)
 			old := packages[0]
-			assert.Equal(t, "pulumi_old", old.Name)
+			assert.Equal(t, "pulumi-old", old.Name)
 			assert.NotEmpty(t, old.Location)
 		})
 

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -165,6 +165,9 @@ func (p *pip) ListPackages(ctx context.Context, transitive bool) ([]PythonPackag
 		return nil, fmt.Errorf("parsing `python %s` output: %w", strings.Join(cmd.Args, " "), err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/sdk/python/toolchain/poetry.go
+++ b/sdk/python/toolchain/poetry.go
@@ -272,6 +272,9 @@ func (p *poetry) ListPackages(ctx context.Context, transitive bool) ([]PythonPac
 		return nil, fmt.Errorf("parsing `python %s` output: %w", strings.Join(cmd.Args, " "), err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -338,3 +338,13 @@ func getPythonVersion(ctx context.Context,
 	}
 	return pythonVersion, nil
 }
+
+// pythonNormRe matches runs of PEP 503 separator characters.
+var pythonNormRe = regexp.MustCompile(`[-_.]+`)
+
+// normalizePythonPackageName normalizes a Python package name to its canonical form per PEP 503:
+// lowercase, with runs of '-', '_', and '.' replaced by a single '-'.
+// https://peps.python.org/pep-0503/
+func normalizePythonPackageName(name string) string {
+	return pythonNormRe.ReplaceAllString(strings.ToLower(name), "-")
+}

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -217,7 +217,7 @@ func TestListPackages(t *testing.T) {
 			for i, pkg := range packages {
 				packageNames[i] = pkg.Name
 			}
-			expectedPackages := append([]string{"pulumi_test_package"}, test.expectedPackages...)
+			expectedPackages := append([]string{"pulumi-test-package"}, test.expectedPackages...)
 			for _, pkg := range expectedPackages {
 				require.Contains(t, packageNames, pkg)
 			}
@@ -238,7 +238,7 @@ func TestListPackages(t *testing.T) {
 			for i, pkg := range packages {
 				packageNames[i] = pkg.Name
 			}
-			expectedPackages := append([]string{"pulumi_test_package"}, test.expectedPackages...)
+			expectedPackages := append([]string{"pulumi-test-package"}, test.expectedPackages...)
 			for _, pkg := range expectedPackages {
 				require.Contains(t, packageNames, pkg)
 			}

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -331,6 +331,9 @@ func (u *uv) ListPackages(ctx context.Context, transitive bool) ([]PythonPackage
 		return nil, fmt.Errorf("parsing package list: %w", err)
 	}
 
+	for i := range packages {
+		packages[i].Name = normalizePythonPackageName(packages[i].Name)
+	}
 	return packages, nil
 }
 

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1330,7 +1330,7 @@ func TestAboutPython(t *testing.T) {
 	e.RunCommand("pulumi", "install")
 	stdout, _ := e.RunCommand("pulumi", "about")
 	// Assert we parsed the dependencies
-	assert.Contains(t, stdout, "pulumi_kubernetes")
+	assert.Contains(t, stdout, "pulumi-kubernetes")
 	// Assert we parsed the language plugin, we don't assert against the minor version number
 	assert.Regexp(t, regexp.MustCompile(`language\W+python\W+3\.`), stdout)
 }
@@ -1580,13 +1580,13 @@ func TestConvertTerraformProviderPython(t *testing.T) {
 	found := false
 	depList := []string{}
 	for _, dep := range a.Dependencies {
-		if dep.Name == "pulumi_supabase" {
+		if dep.Name == "pulumi-supabase" {
 			found = true
 			break
 		}
 		depList = append(depList, dep.Name)
 	}
-	require.True(t, found, fmt.Sprintf("pulumi_supabase not found in dependencies.  Full list: %v", depList))
+	require.True(t, found, fmt.Sprintf("pulumi-supabase not found in dependencies.  Full list: %v", depList))
 }
 
 func TestConfigGetterOverloads(t *testing.T) {


### PR DESCRIPTION
Package names returned by `pip list` vary between hyphenated and underscore forms depending on the setuptools version. Normalize all names to their canonical [PEP 503](https://peps.python.org/pep-0503/) form (lowercase, hyphens) so callers don't need to handle both variants.