### PR TITLE
Require protobuf 5+ for Python 3.14 compatibility

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -21,8 +21,9 @@ classifiers = [
 dependencies = [
     # We deliberately allow older versions of protobuf and grpcio (3.20.3 and 1.68.1 respectively)
     # to support users who require older versions of these dependencies.
-    # grpcio 1.75.1 is needed for Python 3.14.
-    'protobuf>=3.20.3,<7',
+    # protobuf 5+ and grpcio 1.75.1 are needed for Python 3.14.
+    'protobuf>=3.20.3,<7; python_version < "3.14"',
+    'protobuf>=5,<7; python_version >= "3.14"',
     'grpcio>=1.68.1,<2; python_version < "3.14"',
     'grpcio>=1.75.1,<2; python_version >= "3.14"',
     'dill~=0.4',


### PR DESCRIPTION
Fixes #21828

## Summary
Python 3.14 removed support for metaclasses with custom `tp_new`, which older protobuf versions (4.x and earlier) use. This causes a `TypeError: Metaclasses with custom tp_new are not supported` when importing Pulumi with protobuf 4.x on Python 3.14.

This change adds version constraints to the protobuf dependency to require protobuf 5+ for Python 3.14+, matching the existing pattern used for grpcio version requirements.

## Changes
- Updated `sdk/python/pyproject.toml` to require `protobuf>=5,<7` for Python 3.14+
- Kept the existing `protobuf>=3.20.3,<7` constraint for Python < 3.14
- Updated the comment to reflect both protobuf and grpcio requirements for Python 3.14

## Testing
Verified that the TOML syntax is valid. The protobuf 5.x series contains the fix for Python 3.14 compatibility (metaclasses with custom tp_new were removed in Python 3.14, and protobuf 5+ addresses this).

```
 sdk/python/pyproject.toml | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```