### PR TITLE
Skip l2-failed-create-continue-on-error for now

### DIFF
--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -94,6 +94,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
+	"l2-failed-create-continue-on-error": "not yet supported: continue on error",
 	"l2-component-property-deps":         "unexpected property dependency on custom1 where dependency set should be empty",
 	"l2-parameterized-resource-twice":    "dependency loading reports duplicate package definition for hipackage",
 	"l2-parameterized-invoke":            "dependency loading reports duplicate package definition for subpackage",


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/22145

This was intermittently passing so I didn't realise we hadn't actually hooked up support for `--continue-on-error`.