### PR TITLE
Add import hint for "already exists" create errors

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -406,6 +406,19 @@ func (s *CreateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 		}
 
 		if err != nil && resp.Status != resource.StatusPartialFailure {
+			// If the error indicates the resource already exists externally,
+			// add a helpful hint about how to resolve it (issue #10313).
+			if strings.Contains(strings.ToLower(err.Error()), "already exists") {
+				err = fmt.Errorf("%w\n\n"+
+					"This error typically means the resource already exists in your cloud provider "+
+					"but is not tracked in your Pulumi state. To resolve this, you can:\n"+
+					"  1. Import the existing resource into your Pulumi state:\n"+
+					"     pulumi import '%s' '%s' <id>\n"+
+					"     Replace <id> with the actual ID of the existing resource in your cloud provider.\n"+
+					"  2. Delete the existing resource from your cloud provider and rerun the update.\n"+
+					"  3. Rename the resource in your Pulumi program to avoid the conflict.",
+					err, s.URN().Type(), s.URN().Name())
+			}
 			return resp.Status, nil, err
 		}
 

--- a/pkg/resource/deploy/step_test.go
+++ b/pkg/resource/deploy/step_test.go
@@ -185,6 +185,56 @@ func TestCreateStep(t *testing.T) {
 				assert.True(t, createCalled)
 				assert.Equal(t, resource.StatusOK, status)
 			})
+			t.Run("already exists error includes import hint", func(t *testing.T) {
+				t.Parallel()
+				alreadyExistsErr := errors.New("resource my-bucket already exists")
+				s := &CreateStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::my-bucket",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						opts: &Options{
+							DryRun: true,
+						},
+					},
+					provider: &deploytest.Provider{
+						CreateF: func(context.Context, plugin.CreateRequest) (plugin.CreateResponse, error) {
+							return plugin.CreateResponse{}, alreadyExistsErr
+						},
+					},
+				}
+				status, _, err := s.Apply()
+				assert.ErrorContains(t, err, "already exists")
+				assert.ErrorContains(t, err, "pulumi import")
+				assert.ErrorContains(t, err, "aws:s3/bucket:Bucket")
+				assert.ErrorContains(t, err, "my-bucket")
+				assert.Equal(t, resource.StatusOK, status)
+			})
+			t.Run("non-already-exists error has no import hint", func(t *testing.T) {
+				t.Parallel()
+				otherErr := errors.New("some other provider error")
+				s := &CreateStep{
+					new: &resource.State{
+						URN:    "urn:pulumi:stack::project::aws:s3/bucket:Bucket::my-bucket",
+						Custom: true,
+					},
+					deployment: &Deployment{
+						opts: &Options{
+							DryRun: true,
+						},
+					},
+					provider: &deploytest.Provider{
+						CreateF: func(context.Context, plugin.CreateRequest) (plugin.CreateResponse, error) {
+							return plugin.CreateResponse{}, otherErr
+						},
+					},
+				}
+				status, _, err := s.Apply()
+				assert.ErrorIs(t, err, otherErr)
+				assert.NotContains(t, err.Error(), "pulumi import")
+				assert.Equal(t, resource.StatusOK, status)
+			})
 			t.Run("handle InitError", func(t *testing.T) {
 				t.Parallel()
 				s := &CreateStep{


### PR DESCRIPTION
## Summary

When `pulumi up` fails with an "already exists" error from the cloud provider during resource creation, the error message now includes actionable instructions for resolving the issue:

1. **Import** the existing resource: `pulumi import '<type>' '<name>' <id>`
2. **Delete** the existing resource from the provider and retry
3. **Rename** the resource in the Pulumi program

The type and name are pre-filled from the resource URN. The user only needs to supply the cloud provider resource ID.

## Changes

- `pkg/resource/deploy/step.go`: In `CreateStep.Apply()`, detect "already exists" in provider error messages and wrap with helpful instructions
- `pkg/resource/deploy/step_test.go`: Added two tests — one verifying the hint is added for "already exists" errors, another verifying non-matching errors are unchanged

## Example output

Before:
```
error: resource my-bucket already exists
```

After:
```
error: resource my-bucket already exists

This error typically means the resource already exists in your cloud provider but is not tracked in your Pulumi state. To resolve this, you can:
  1. Import the existing resource into your Pulumi state:
     pulumi import 'aws:s3/bucket:Bucket' 'my-bucket' <id>
     Replace <id> with the actual ID of the existing resource in your cloud provider.
  2. Delete the existing resource from your cloud provider and rerun the update.
  3. Rename the resource in your Pulumi program to avoid the conflict.
```

## Test plan

- [x] Added unit test for "already exists" error → hint is appended with correct type/name
- [x] Added unit test for other errors → no hint is appended
- [ ] CI should run existing test suite

Fixes #10313