### PR TITLE
Fix `sdk/go/common/workspace.IsExternalURL`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,5 +294,5 @@ work:
 		sdk/nodejs/cmd/pulumi-language-nodejs \
 		sdk/nodejs/cmd/pulumi-language-bun \
 		sdk/python/cmd/pulumi-language-python \
-		sdk/pcl/cmd/pulumi-language-pcl \
+		sdk/pcl \
 		tests

--- a/changelog/pending/20260310--cli-package--correctly-parse-package-urls-with-git-in-them.yaml
+++ b/changelog/pending/20260310--cli-package--correctly-parse-package-urls-with-git-in-them.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Correctly parse package URLs with .git in them

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1080,11 +1080,14 @@ type PluginDescriptor struct {
 type PluginVersionNotFoundError error
 
 var urlRegex = sync.OnceValue(func() *regexp.Regexp {
-	return regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-_/]*[a-zA-Z0-9/](@.*)?$`)
+	return regexp.MustCompile(`^[^\./].*\.[a-z]+/[a-zA-Z0-9-_\./]*[a-zA-Z0-9/](@.*)?$`)
 })
 
 func IsExternalURL(source string) bool {
-	return strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "git://") || urlRegex().MatchString(source)
+	return strings.HasPrefix(source, "https://") ||
+		strings.HasPrefix(source, "http://") ||
+		strings.HasPrefix(source, "git://") ||
+		urlRegex().MatchString(source)
 }
 
 // Allow sha1 and sha256 hashes.

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -2239,3 +2239,37 @@ func TestLocalName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExternalURL(t *testing.T) {
+	t.Parallel()
+
+	is := func(source string) { t.Helper(); assert.Truef(t, IsExternalURL(source), "source = %q", source) }
+	isnot := func(source string) { t.Helper(); assert.Falsef(t, IsExternalURL(source), "source = %q", source) }
+
+	is("git://anything")
+	is("https://anything")
+	is("gitlab.com/project/subgroup/component-test")
+	is("gitlab.com/project/subgroup/component-test.git")
+	is("gitlab.com/project/subgroup/component-test@v4.0.0")
+	is("gitlab.com/project/subgroup/component-test.git@v4.0.0")
+	is("github.com/pulumi/pulumi-aws")
+	is("github.com/org/repo@deadbeef")
+	is("example.com/a")
+	is("registry.io/org/plugin/")
+	is("my-registry.com/org/repo")
+	is("https://example.com/path")
+	is("git://example.com/repo")
+	is("a.co/x")
+	is("http://example.com")
+
+	isnot("word")
+	isnot("")
+	isnot("./relative/path")
+	isnot("/absolute/path")
+	isnot("../parent/path")
+	isnot("just-a-name")
+	isnot("pulumi-aws")
+	isnot("name@v1.0.0")
+	isnot(".hidden")
+	isnot("local.exe")
+}


### PR DESCRIPTION
This PR changes
`github.com/pulumi/pulumi/sdk/v3/go/common/workspace.IsExternalURL` to correctly identify `gitlab.com/lichtie-group/subgroup/component-test-2.git@v4.0.0` as an external URL.

The problem was a missing `\.` in the path recognizer, causing `urlRegex` to reject `gitlab.com/lichtie-group/subgroup/component-test-2.git` due to the `.git`.

Including a `http://` check on `IsExternalURL` is defensive, but it seems correct.

Fixes #22024

---

The `Makefile` fix is unrelated. `go work init` needs to point to the module root.