### PR TITLE
Improve error message when importing an already-existing resource

### DIFF
--- a/pkg/engine/lifecycletest/testdata/output/TestImportPlanExistingImport/1/diff.stderr.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestImportPlanExistingImport/1/diff.stderr.txt
@@ -1,2 +1,2 @@
-<{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists<{%reset%}>
+<{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists; to import this existing resource into your stack, run: pulumi import pkgA:m:typA resA <resource-id><{%reset%}>
 <{%fg 1%}>error: <{%reset%}><{%reset%}>update failed<{%reset%}>

--- a/pkg/engine/lifecycletest/testdata/output/TestImportPlanExistingImport/1/progress.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestImportPlanExistingImport/1/progress.stdout.txt
@@ -5,13 +5,13 @@
  <{%bold%}><{%reset%}>  <{%reset%}> pulumi:providers:pkgA default <{%bold%}><{%reset%}><{%reset%}> 
  <{%bold%}><{%reset%}>  <{%reset%}> pkgA:m:typA resA <{%bold%}><{%reset%}><{%reset%}> 
  <{%bold%}><{%fg 2%}>= <{%reset%}> pkgA:m:typA resA <{%bold%}><{%fg 2%}>importing<{%reset%}> 
- <{%bold%}><{%fg 2%}>= <{%reset%}> pkgA:m:typA resA <{%bold%}><{%fg 2%}>importing<{%reset%}> <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists<{%reset%}>
- <{%fg 2%}>= <{%reset%}> pkgA:m:typA resA <{%fg 1%}>**importing failed**<{%reset%}> <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists<{%reset%}>
+ <{%bold%}><{%fg 2%}>= <{%reset%}> pkgA:m:typA resA <{%bold%}><{%fg 2%}>importing<{%reset%}> <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists; to import this existing resource into your stack, run: pulumi import pkgA:m:typA resA <resource-id><{%reset%}>
+ <{%fg 2%}>= <{%reset%}> pkgA:m:typA resA <{%fg 1%}>**importing failed**<{%reset%}> <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists; to import this existing resource into your stack, run: pulumi import pkgA:m:typA resA <resource-id><{%reset%}>
  <{%bold%}><{%reset%}>  <{%reset%}> pulumi:pulumi:Stack test running <{%fg 1%}>error: <{%reset%}><{%reset%}>update failed<{%reset%}>
  <{%reset%}>  <{%reset%}> pulumi:pulumi:Stack test <{%fg 1%}>**failed**<{%reset%}> 1 <{%fg 1%}>error<{%reset%}>
 <{%fg 13%}><{%bold%}>Diagnostics:<{%reset%}>
   <{%fg 12%}>pkgA:m:typA (resA):<{%reset%}>
-    <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists<{%reset%}>
+    <{%fg 1%}>error: <{%reset%}><{%reset%}>resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists; to import this existing resource into your stack, run: pulumi import pkgA:m:typA resA <resource-id><{%reset%}>
 
   <{%fg 12%}>pulumi:pulumi:Stack (test):<{%reset%}>
     <{%fg 1%}>error: <{%reset%}><{%reset%}>update failed<{%reset%}>

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1779,7 +1779,11 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		contract.Assertf(s.cts == nil, "planned import should not have a completion source")
 
 		if _, ok := s.deployment.olds[s.new.URN]; ok {
-			return resource.StatusOK, nil, fmt.Errorf("resource '%v' already exists", s.new.URN)
+			return resource.StatusOK, nil, fmt.Errorf(
+				"resource '%v' already exists; "+
+					"to import this existing resource into your stack, run: "+
+					"pulumi import %v %v <resource-id>",
+				s.new.URN, s.new.URN.Type(), s.new.URN.Name())
 		}
 		if s.new.Parent.QualifiedType() != resource.RootStackType {
 			_, ok := s.deployment.news.Load(s.new.Parent)


### PR DESCRIPTION
## What

When running `pulumi import` for a resource that already exists in the stack state, the error message was not actionable:

```
error: resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists
```

This PR improves it to:

```
error: resource 'urn:pulumi:test::test::pkgA:m:typA::resA' already exists; to import this existing resource into your stack, run: pulumi import pkgA:m:typA resA <resource-id>
```

## Why

Fixes #10313. Users hitting this error often don't know the correct next step. The new message tells them exactly which command to run (with the type and name pre-filled from the URN).

## Changes

- `pkg/resource/deploy/step.go`: Enhanced error message in `ImportStep.Apply` to include the `pulumi import` command hint
- Updated golden test output files to match the new message

## Testing

The existing `TestImportPlanExistingImport` test continues to pass — the `ErrorContains` assertion only checks for the `already exists` substring which is preserved.

Golden files were updated manually to match the new error text. Maintainers can verify by running:
```
PULUMI_ACCEPT=1 go test ./pkg/engine/lifecycletest/... -run TestImportPlanExistingImport
```