### PR TITLE
rename env variable used for otel internal endpoint

### DIFF
--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -472,7 +472,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 	}
 
 	if otelEndpoint := cmdutil.OTelEndpoint(); otelEndpoint != "" {
-		environment = append(environment, "OTEL_EXPORTER_OTLP_ENDPOINT="+otelEndpoint)
+		environment = append(environment, "PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT="+otelEndpoint)
 	}
 
 	// Check to see if we have a binary we can invoke directly

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -195,7 +195,7 @@ func main() {
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid
 	// duplicate spans.
-	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otelEndpoint == "" {
 		cmdutil.InitTracing("pulumi-language-go", "pulumi-language-go", p.tracing)
 	} else {
@@ -1048,7 +1048,7 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 		env = append(env, "TRACEPARENT="+traceparent)
 	}
 	if host.otelEndpoint != "" {
-		env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
+		env = append(env, "PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
 	}
 
 	// the user can explicitly opt in to using a binary executable by specifying

--- a/sdk/go/pulumi/instrumentation.go
+++ b/sdk/go/pulumi/instrumentation.go
@@ -32,7 +32,7 @@ import (
 var tracerProvider *sdktrace.TracerProvider
 
 // initTracing initializes OpenTelemetry tracing when TRACEPARENT and
-// OTEL_EXPORTER_OTLP_ENDPOINT environment variables are present.
+// PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT environment variables are present.
 // Returns a context with the extracted trace parent.
 func initTracing(ctx context.Context) context.Context {
 	traceparent := os.Getenv("TRACEPARENT")
@@ -40,7 +40,7 @@ func initTracing(ctx context.Context) context.Context {
 		return ctx
 	}
 
-	otlpEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	otlpEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otlpEndpoint == "" {
 		return ctx
 	}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -134,7 +134,7 @@ func main() {
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid
 	// duplicate spans.
-	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otelEndpoint == "" {
 		cmdutil.InitTracing("pulumi-language-nodejs", "pulumi-language-nodejs", tracing)
 	} else {
@@ -893,7 +893,7 @@ func (host *nodeLanguageHost) execRuntime(ctx context.Context, req *pulumirpc.Ru
 	}
 
 	if host.otelEndpoint != "" {
-		env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
+		env = append(env, "PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
 	}
 
 	// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.

--- a/sdk/nodejs/cmd/run/instrumentation.ts
+++ b/sdk/nodejs/cmd/run/instrumentation.ts
@@ -38,7 +38,7 @@ if (process.env.TRACEPARENT) {
         }),
     });
 
-    const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const otlpEndpoint = process.env.PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT;
     if (otlpEndpoint) {
         const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-grpc");
         process.env.OTEL_EXPORTER_OTLP_INSECURE = "true";

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -134,7 +134,7 @@ func main() {
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid
 	// duplicate spans.
-	otelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
 	if otelEndpoint == "" {
 		cmdutil.InitTracing("pulumi-language-python", "pulumi-language-python", tracing)
 	} else {
@@ -1052,7 +1052,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 	}
 
 	if host.otelEndpoint != "" {
-		env = append(env, "OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
+		env = append(env, "PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT="+host.otelEndpoint)
 	}
 	cmd.Env = env
 

--- a/sdk/python/lib/pulumi/runtime/_instrumentation.py
+++ b/sdk/python/lib/pulumi/runtime/_instrumentation.py
@@ -53,7 +53,7 @@ def _initialize_tracing() -> None:
     global _root_context, _tracer_provider  # noqa: PLW0603
 
     traceparent = os.environ.get("TRACEPARENT")
-    otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    otlp_endpoint = os.environ.get("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
 
     if not traceparent:
         return


### PR DESCRIPTION
We're using this env variable to pass the addres of the internal otel receiver to plugins. However some users might already have set the env variable in their environment, which may lead to confusion, and wasn't intended.

Prefix the env variable with `PULUMI_`, so we don't accidentally enable this feature for users that didn't intend to do so.
