### PR TITLE
Revert "Pin Node.js to 25.6"

### DIFF
--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -145,8 +145,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
     "go": ["1.25.x", "1.26.x"],
-    # TODO: https://github.com/pulumi/pulumi/issues/21945 revert to Node.js 25.x
-    "nodejs": ["20.x", "22.x", "24.x", "25.6"],
+    "nodejs": ["20.x", "22.x", "24.x", "25.x"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.
     "python": ["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"],


### PR DESCRIPTION
Reverts pulumi/pulumi#21946

Fixed in 25.8.1 https://github.com/nodejs/node/issues/61971#issuecomment-4037602546

Fixes https://github.com/pulumi/pulumi/issues/21945