### PR TITLE
Add support for running policy packs with bun

### DIFF
--- a/changelog/pending/20260312--sdk-bun--add-support-for-running-policy-packs-with-bun.yaml
+++ b/changelog/pending/20260312--sdk-bun--add-support-for-running-policy-packs-with-bun.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/bun
+  description: Add support for running policy packs with bun

--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -73,13 +73,6 @@ process.on("exit", (code: number) => {
     }
 });
 
-// As the second thing we do, ensure that we're connected to v8's inspector API.  We need to do
-// this as some information is only sent out as events, without any way to query for it after the
-// fact.  For example, we want to keep track of ScriptId->FileNames so that we can appropriately
-// report errors for Functions we cannot serialize.  This can only be done (up to Node11 at least)
-// by register to hear about scripts being parsed.
-import * as v8Hooks from "../../runtime/closure/v8Hooks";
-
 // This is the entrypoint for running a Node.js program with minimal scaffolding.
 import minimist from "minimist";
 
@@ -105,7 +98,19 @@ function main(args: string[]): void {
     argv._.shift();
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
-    v8Hooks.isInitializedAsync().then(() => {
+    const initializeHooks = async (): Promise<void> => {
+        if (process.versions.bun) {
+            return;
+        }
+        // Ensure that we're connected to v8's inspector API. We need to do this as some information is only sent out as
+        // events, without any way to query for it after the fact. For example, we want to keep track of
+        // ScriptId->FileNames so that we can appropriately report errors for Functions we cannot serialize. This can
+        // only be done (up to Node11 at least) by registering to hear about scripts being parsed.
+        const v8Hooks = require("../../runtime/closure/v8Hooks");
+        return v8Hooks.isInitializedAsync();
+    };
+
+    initializeHooks().then(() => {
         const promise: Promise<void> = require("./run").run({
             argv,
             programStarted: () => {
@@ -113,7 +118,7 @@ function main(args: string[]): void {
             },
             reportLoggedError: (err: Error) => loggedErrors.add(err),
             runInStack: false,
-            typeScript: true, // Should have no deleterious impact on JS codebases.
+            typeScript: !process.versions.bun, // bun handles TypeScript natively
         });
 
         // when the user's program completes successfully, set programRunning back to false.  That

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1184,6 +1184,34 @@ func TestMandatoryPolicyPack(t *testing.T) {
 	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: mandatory_policy_pack)")
 }
 
+func TestBunMandatoryPolicyPack(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("single_resource")
+	e.ImportDirectory("policy")
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+
+	stackName, err := resource.NewUniqueHex("bun-mandatory-policy-pack", 8, -1)
+	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
+
+	e.RunCommand("pulumi", "stack", "init", stackName)
+
+	_, _, err = e.GetCommandResultsIn(filepath.Join(e.CWD, "bun_mandatory_policy_pack"), "bun", "install")
+	require.NoError(t, err)
+
+	e.RunCommandWithRetry("yarn", "link", "@pulumi/pulumi")
+	e.RunCommandWithRetry("yarn", "install")
+
+	stdout, _, err := e.GetCommandResults(
+		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "bun_mandatory_policy_pack")
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "error: update failed")
+	assert.Contains(t, stdout, "❌ bun@v0.0.1 (local: bun_mandatory_policy_pack)")
+}
+
 func TestMultiplePolicyPacks(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration/policy/bun_mandatory_policy_pack/.gitignore
+++ b/tests/integration/policy/bun_mandatory_policy_pack/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/tests/integration/policy/bun_mandatory_policy_pack/PulumiPolicy.yaml
+++ b/tests/integration/policy/bun_mandatory_policy_pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+runtime: bun
+description: A minimal Policy Pack using bun.

--- a/tests/integration/policy/bun_mandatory_policy_pack/index.ts
+++ b/tests/integration/policy/bun_mandatory_policy_pack/index.ts
@@ -1,0 +1,12 @@
+import { PolicyPack } from "@pulumi/policy";
+
+new PolicyPack("bun", {
+    policies: [{
+        name: "mandatory-policy-pack",
+        description: "Failing mandatory policy pack for testing",
+        enforcementLevel: "mandatory",
+        validateStack: (stack, reportViolation) => {
+            reportViolation("mandatory-policy-pack");
+        },
+    }],
+});

--- a/tests/integration/policy/bun_mandatory_policy_pack/package.json
+++ b/tests/integration/policy/bun_mandatory_policy_pack/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "bun",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/policy": "^1.3.0"
+    },
+    "overrides": {
+        "@pulumi/pulumi": "link:@pulumi/pulumi"
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/22078

All we need here is to lazy import `v8hooks` to avoid bun tripping over that. Same as we do for programs and plugins.
