### PR TITLE
Add Name and Type to resource reference values

### DIFF
--- a/changelog/pending/20260312--engine--the-engine-will-fill-in-name-and-type-for-resourcereference-values-on-the-wire-protocol.yaml
+++ b/changelog/pending/20260312--engine--the-engine-will-fill-in-name-and-type-for-resourcereference-values-on-the-wire-protocol.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: engine
+  description: The engine will fill in Name and Type for ResourceReference values on the wire protocol

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -835,6 +835,8 @@ func filterPropertyValue(v resource.PropertyValue, debug bool, showSecrets bool)
 		ref := v.ResourceReferenceValue()
 		return resource.NewProperty(resource.ResourceReference{
 			URN:            resource.URN(logging.FilterString(string(ref.URN))),
+			Name:           logging.FilterString(ref.Name),
+			Type:           logging.FilterString(ref.Type),
 			ID:             filterPropertyValue(ref.ID, debug, showSecrets),
 			PackageVersion: logging.FilterString(ref.PackageVersion),
 		})

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -354,3 +354,114 @@ func TestResourceReferences_GetResource(t *testing.T) {
 	}
 	p.Run(t, nil)
 }
+
+// TestResourceReferences_NameAndTypeFilledByEngine tests that Name and Type are filled in by the engine before
+// passing resource references to Construct calls and program code, even when the originating side omitted them.
+func TestResourceReferences_NameAndTypeFilledByEngine(t *testing.T) {
+	t.Parallel()
+
+	var sourceURN resource.URN
+	var sourceID resource.ID
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					id := "created-id"
+					if req.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{
+						ID:         resource.ID(id),
+						Properties: req.Properties,
+						Status:     resource.StatusOK,
+					}, nil
+				},
+				ConstructF: func(
+					_ context.Context,
+					req plugin.ConstructRequest,
+					monitor *deploytest.ResourceMonitor,
+				) (plugin.ConstructResponse, error) {
+					ref := req.Inputs["ref"].ResourceReferenceValue()
+					assert.Equal(t, sourceURN, ref.URN)
+					assert.Equal(t, sourceURN.Name(), ref.Name)
+					assert.Equal(t, string(sourceURN.Type()), ref.Type)
+
+					component, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{
+						Parent: req.Parent,
+					})
+					require.NoError(t, err)
+
+					// Echo the reference back while intentionally omitting Name/Type to validate
+					// the engine fills them before they reach the program.
+					outputs := resource.PropertyMap{
+						"echo": resource.NewProperty(resource.ResourceReference{
+							URN: ref.URN,
+							ID:  ref.ID,
+						}),
+					}
+					err = monitor.RegisterResourceOutputs(component.URN, outputs)
+					require.NoError(t, err)
+
+					return plugin.ConstructResponse{
+						URN:     component.URN,
+						Outputs: outputs,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		sourceResp, err := monitor.RegisterResource("pkgA:m:source", "source", true)
+		require.NoError(t, err)
+		sourceURN, sourceID = sourceResp.URN, sourceResp.ID
+
+		refID := resource.NewProperty(string(sourceID))
+		if sourceID == "" {
+			refID = resource.MakeComputed(resource.NewProperty(""))
+		}
+		inputRef := resource.NewProperty(resource.ResourceReference{
+			URN: sourceURN,
+			ID:  refID,
+		})
+		assert.Empty(t, inputRef.ResourceReferenceValue().Name)
+		assert.Empty(t, inputRef.ResourceReferenceValue().Type)
+
+		componentResp, err := monitor.RegisterResource("pkgA:m:component", "component", false, deploytest.ResourceOptions{
+			Remote: true,
+			Inputs: resource.PropertyMap{
+				"ref": inputRef,
+			},
+		})
+		require.NoError(t, err)
+
+		echo := componentResp.Outputs["echo"].ResourceReferenceValue()
+		assert.Equal(t, sourceURN, echo.URN)
+		assert.Equal(t, sourceURN.Name(), echo.Name)
+		assert.Equal(t, string(sourceURN.Type()), echo.Type)
+		assert.True(t, echo.ID.DeepEquals(refID))
+
+		return nil
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+	snap, err := lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, nil),
+		p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	var componentState *resource.State
+	for _, res := range snap.Resources {
+		if res.URN.Name() == "component" && res.Type == "pkgA:m:component" {
+			componentState = res
+			break
+		}
+	}
+	require.NotNil(t, componentState)
+
+	echo := componentState.Outputs["echo"]
+	assert.True(t, echo.IsResourceReference())
+}

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -628,7 +628,8 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 func (rm *ResourceMonitor) RegisterResourceOutputs(urn resource.URN, outputs resource.PropertyMap) error {
 	// marshal outputs
 	outs, err := plugin.MarshalProperties(outputs, plugin.MarshalOptions{
-		KeepUnknowns: true,
+		KeepUnknowns:  true,
+		KeepResources: rm.supportsResourceReferences,
 	})
 	if err != nil {
 		return err

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -3226,6 +3226,8 @@ func downgradeOutputValues(v resource.PropertyMap) resource.PropertyMap {
 			return resource.NewProperty(
 				resource.ResourceReference{
 					URN:            ref.URN,
+					Name:           ref.Name,
+					Type:           ref.Type,
 					ID:             downgradeOutputPropertyValue(ref.ID),
 					PackageVersion: ref.PackageVersion,
 				})

--- a/pkg/testing/pulumi-test-language/providers/component_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/component_provider.go
@@ -399,10 +399,8 @@ func (p *ComponentProvider) constructComponentCustomRefOutput(
 
 	// Create a resource reference to the child, that we'll register as an output of the component and return as part of
 	// our ConstructResponse.
-	refPropVal := resource.NewProperty(resource.ResourceReference{
-		URN: resource.URN(child.Urn),
-		ID:  resource.NewProperty(child.Id),
-	})
+
+	refPropVal := resource.MakeCustomResourceReference(resource.URN(child.Urn), resource.ID(child.Id), "")
 	refStruct, err := plugin.MarshalPropertyValue("ref", refPropVal, plugin.MarshalOptions{
 		KeepResources: true,
 		KeepSecrets:   true,
@@ -508,10 +506,7 @@ func (p *ComponentProvider) constructComponentCustomRefInputOutput(
 		return plugin.ConstructResponse{}, fmt.Errorf("marshal input ref: %w", err)
 	}
 
-	outputRefPropVal := resource.NewProperty(resource.ResourceReference{
-		URN: resource.URN(child.Urn),
-		ID:  resource.NewProperty(child.Id),
-	})
+	outputRefPropVal := resource.MakeCustomResourceReference(resource.URN(child.Urn), resource.ID(child.Id), "")
 	outputRefStruct, err := plugin.MarshalPropertyValue("outputRef", outputRefPropVal, plugin.MarshalOptions{
 		KeepResources: true,
 		KeepSecrets:   true,

--- a/pkg/testing/pulumi-test-language/tests/l2_namespaced_provider.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_namespaced_provider.go
@@ -50,8 +50,10 @@ func init() {
 					want := resource.NewPropertyMapFromMap(map[string]any{
 						"value": true,
 						"resourceRef": resource.NewProperty(resource.ResourceReference{
-							URN: "urn:pulumi:test::l2-namespaced-provider::component:index:ComponentCustomRefOutput$component:index:Custom::componentRes-child",
-							ID:  resource.NewProperty("id-foo-bar-baz"),
+							URN:  "urn:pulumi:test::l2-namespaced-provider::component:index:ComponentCustomRefOutput$component:index:Custom::componentRes-child",
+							Name: "componentRes-child",
+							Type: "component:index:Custom",
+							ID:   resource.NewProperty("id-foo-bar-baz"),
 						}),
 					})
 					require.Equal(l, want, namespaced.Inputs)

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -228,6 +228,12 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			resource.SigKey: resource.NewProperty(resource.ResourceReferenceSig),
 			"urn":           resource.NewProperty(string(ref.URN)),
 		}
+		if ref.Name != "" {
+			m["name"] = resource.NewProperty(ref.Name)
+		}
+		if ref.Type != "" {
+			m["type"] = resource.NewProperty(ref.Type)
+		}
 		if id, hasID := ref.IDString(); hasID {
 			m["id"] = resource.NewProperty(id)
 		}
@@ -438,6 +444,22 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				return nil, fmt.Errorf("malformed resource reference for %q: urn not a string", key)
 			}
 
+			name := ""
+			if nameProp, ok := obj["name"]; ok {
+				if !nameProp.IsString() {
+					return nil, fmt.Errorf("malformed resource reference for %q: name not a string", key)
+				}
+				name = nameProp.StringValue()
+			}
+
+			typ := ""
+			if typeProp, ok := obj["type"]; ok {
+				if !typeProp.IsString() {
+					return nil, fmt.Errorf("malformed resource reference for %q: type not a string", key)
+				}
+				typ = typeProp.StringValue()
+			}
+
 			id, hasID := "", false
 			if idProp, ok := obj["id"]; ok {
 				hasID = true
@@ -482,12 +504,28 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				return &r, nil
 			}
 
-			var ref resource.PropertyValue
-			if hasID {
-				ref = resource.MakeCustomResourceReference(resource.URN(urn.StringValue()), resource.ID(id), packageVersion)
-			} else {
-				ref = resource.MakeComponentResourceReference(resource.URN(urn.StringValue()), packageVersion)
+			urnValue := resource.URN(urn.StringValue())
+			if name == "" && urnValue.IsValid() {
+				name = urnValue.Name()
 			}
+			if typ == "" && urnValue.IsValid() {
+				typ = string(urnValue.Type())
+			}
+
+			refID := resource.PropertyValue{}
+			if hasID {
+				refID = resource.NewProperty(id)
+				if id == "" {
+					refID = resource.MakeComputed(resource.NewProperty(""))
+				}
+			}
+			ref := resource.NewProperty(resource.ResourceReference{
+				URN:            urnValue,
+				Name:           name,
+				Type:           typ,
+				ID:             refID,
+				PackageVersion: packageVersion,
+			})
 			return &ref, nil
 		case resource.OutputValueSig:
 			value, known := obj["value"]

--- a/sdk/go/common/resource/plugin/rpc_rapid_test.go
+++ b/sdk/go/common/resource/plugin/rpc_rapid_test.go
@@ -182,10 +182,13 @@ func ArchiveValueGenerator(maxDepth int) *rapid.Generator[*structpb.Value] {
 // ResourceReferenceValueGenerator generates resource reference *structpb.Values.
 func ResourceReferenceValueGenerator() *rapid.Generator[*structpb.Value] {
 	return rapid.Custom(func(t *rapid.T) *structpb.Value {
+		referencedURN := resource_testing.URNGenerator().Draw(t, "referenced URN")
 		fields := map[string]*structpb.Value{
 			resource.SigKey: stringValue(resource.ResourceReferenceSig),
-			"urn":           stringValue(string(resource_testing.URNGenerator().Draw(t, "referenced URN"))),
+			"urn":           stringValue(string(referencedURN)),
 		}
+		fields["name"] = stringValue(referencedURN.Name())
+		fields["type"] = stringValue(string(referencedURN.Type()))
 
 		id := rapid.OneOf(UnknownValueGenerator(), StringValueGenerator()).Draw(t, "referenced ID")
 		if idstr := id.Kind.(*structpb.Value_StringValue).StringValue; idstr != "" && idstr != UnknownStringValue {

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -114,6 +114,8 @@ type Secret struct {
 //nolint:revive
 type ResourceReference struct {
 	URN            URN
+	Name           string
+	Type           string
 	ID             PropertyValue
 	PackageVersion string
 }
@@ -263,8 +265,16 @@ func MakeSecret(v PropertyValue) PropertyValue {
 
 // MakeComponentResourceReference creates a reference to a component resource.
 func MakeComponentResourceReference(urn URN, packageVersion string) PropertyValue {
+	name, typ := "", ""
+	if urn.IsValid() {
+		name = urn.Name()
+		typ = string(urn.Type())
+	}
+
 	return NewProperty(ResourceReference{
 		URN:            urn,
+		Name:           name,
+		Type:           typ,
 		PackageVersion: packageVersion,
 	})
 }
@@ -276,10 +286,17 @@ func MakeCustomResourceReference(urn URN, id ID, packageVersion string) Property
 	if id == "" {
 		idProp = MakeComputed(NewProperty(""))
 	}
+	name, typ := "", ""
+	if urn.IsValid() {
+		name = urn.Name()
+		typ = string(urn.Type())
+	}
 
 	return NewProperty(ResourceReference{
 		ID:             idProp,
 		URN:            urn,
+		Name:           name,
+		Type:           typ,
 		PackageVersion: packageVersion,
 	})
 }

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -64,6 +64,8 @@ func ToResourcePropertyValue(v property.Value) PropertyValue {
 		ref := v.AsResourceReference()
 		r = NewProperty(ResourceReference{
 			URN:            ref.URN,
+			Name:           ref.Name,
+			Type:           ref.Type,
 			ID:             ToResourcePropertyValue(ref.ID),
 			PackageVersion: ref.PackageVersion,
 		})
@@ -135,6 +137,8 @@ func FromResourcePropertyValue(v PropertyValue) property.Value {
 
 		return property.New(property.ResourceReference{
 			URN:            r.URN,
+			Name:           r.Name,
+			Type:           r.Type,
 			ID:             FromResourcePropertyValue(r.ID),
 			PackageVersion: r.PackageVersion,
 		})

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -295,6 +295,8 @@ func resourceReferenceGenerator(ctx *StackContext) *rapid.Generator[resource.Res
 
 		return resource.ResourceReference{
 			URN:            r.URN,
+			Name:           r.URN.Name(),
+			Type:           string(r.URN.Type()),
 			ID:             id,
 			PackageVersion: SemverStringGenerator().Draw(t, "package version"),
 		}

--- a/sdk/go/property/reference.go
+++ b/sdk/go/property/reference.go
@@ -26,6 +26,8 @@ import "github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 //   - Otherwise, the ID must be a string.
 type ResourceReference struct {
 	URN            urn.URN
+	Name           string
+	Type           string
 	ID             Value
 	PackageVersion string
 }

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -522,8 +522,16 @@ func unmarshalResourceReference(ctx *Context, ref resource.ResourceReference) (R
 		}
 	}
 
-	resName := ref.URN.Name()
-	resType := ref.URN.Type()
+	resName := ref.Name
+	if resName == "" && ref.URN.IsValid() {
+		resName = ref.URN.Name()
+	}
+
+	resTypeString := ref.Type
+	if resTypeString == "" && ref.URN.IsValid() {
+		resTypeString = string(ref.URN.Type())
+	}
+	resType := tokens.Type(resTypeString)
 
 	isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"
 	if isProvider {


### PR DESCRIPTION
Currently ResourceReferences only carry their URN, they don't have separate fields for Name and Type. This means in SDKs if we want to construct a `Resource` class we have to parse the URN to get the name and type out of it. We don't want anything but the engine parsing URNs so that we can edit their format without breaking things, so we need these resource reference values to carry separate name and type fields that the SDKs can just pick off instead of URN parsing.

This updates the resource reference structs to have those and fills them in whenever serializing/deserializing, ensuring that whatever the engine sees and sends has these values filled in.

Note that these _don't_ show up in state files. We don't need the data duplication and it's only the engine that reads state files.