### PR TITLE
Use defaultErrorMessage in run-plugin and run-policy-pack

### DIFF
--- a/changelog/pending/20260312--sdk-bun-nodejs--use-defaulterrormessage-in-run-plugin-and-run-policy-pack.yaml
+++ b/changelog/pending/20260312--sdk-bun-nodejs--use-defaulterrormessage-in-run-plugin-and-run-policy-pack.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs,bun
+  description: Use defaultErrorMessage in run-plugin and run-policy-pack

--- a/sdk/nodejs/cmd/run-plugin/run.ts
+++ b/sdk/nodejs/cmd/run-plugin/run.ts
@@ -15,7 +15,6 @@
 // The tsnode import is used for type-checking only. Do not reference it in the emitted code.
 import * as tsnode from "ts-node";
 import * as fs from "fs";
-import * as util from "util";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as tsutils from "../../tsutils";
@@ -23,6 +22,7 @@ import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import * as settings from "../../runtime/settings";
 import { componentProviderHost, getPulumiComponents } from "../../provider/experimental/provider";
+import { defaultErrorMessage } from "../run/error";
 
 // Keep track if we already logged the information about an unhandled error to the user..  If
 // so, we end with a different exit code.  The language host recognizes this and will not print
@@ -210,15 +210,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
 
         errorSet.add(err);
 
-        // colorize stack trace if exists
-        const stackMessage = err.stack && util.inspect(err, { colors: true });
-
-        // Default message should be to include the full stack (which includes the message), or
-        // fallback to just the message if we can't get the stack.
-        //
-        // If both the stack and message are empty, then just stringify the err object itself. This
-        // is also necessary as users can throw arbitrary things in JS (including non-Errors).
-        const defaultMessage = stackMessage || err.message || "" + err;
+        const defaultMessage = defaultErrorMessage(err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -15,11 +15,11 @@
 // The tsnode import is used for type-checking only. Do not reference it in the emitted code.
 import * as tsnode from "ts-node";
 import * as fs from "fs";
-import * as util from "util";
 import * as minimist from "minimist";
 import * as path from "path";
 import * as tsutils from "../../tsutils";
 import { ResourceError, RunError } from "../../errors";
+import { defaultErrorMessage } from "../run/error";
 import * as log from "../../log";
 import * as settings from "../../runtime/settings";
 import * as stack from "../../runtime/stack";
@@ -207,15 +207,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
 
         errorSet.add(err);
 
-        // colorize stack trace if exists
-        const stackMessage = err.stack && util.inspect(err, { colors: true });
-
-        // Default message should be to include the full stack (which includes the message), or
-        // fallback to just the message if we can't get the stack.
-        //
-        // If both the stack and message are empty, then just stringify the err object itself. This
-        // is also necessary as users can throw arbitrary things in JS (including non-Errors).
-        const defaultMessage = stackMessage || err.message || "" + err;
+        const defaultMessage = defaultErrorMessage(err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {


### PR DESCRIPTION
Use the helper function we already use in `run` to get the error message
when handling an error in run-plugin or run-policy-pack. This function
knows how to print the stack trace and gracefully handles weird objects
being thrown. See https://github.com/pulumi/pulumi/pull/18080.