### PR TITLE
Fix Azure DevOps URL support in git operations

### DIFF
--- a/changelog/pending/20260312--sdk-go--added-support-for-azure-devops-git-urls-in-pulumi-package-publish-code-paths.yaml
+++ b/changelog/pending/20260312--sdk-go--added-support-for-azure-devops-git-urls-in-pulumi-package-publish-code-paths.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Add support for Azure DevOps git URLs in pulumi package publish code paths

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"go.opentelemetry.io/otel"
@@ -461,6 +462,12 @@ func expandHomeDir(path string) (string, error) {
 func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.Hash, path string) error {
 	logging.V(10).Infof("Attempting to clone from %s at commit %v and path %s", url, commit, path)
 
+	// go-git v5 has limited ADO support and cannot perform this operation.
+	// TODO(https://github.com/go-git/go-git/pull/1204): Remove once go-git v6 is released.
+	if u, err := parseGitRepoURLParts(url); err == nil && u.Hostname == AzureDevOpsHostName {
+		return gitCloneAndCheckoutRevisionSystemGit(ctx, url, plumbing.Revision(commit.String()), path)
+	}
+
 	u, auth, err := getAuthForURL(url)
 	if err != nil {
 		return err
@@ -487,6 +494,12 @@ func GitCloneAndCheckoutCommit(ctx context.Context, url string, commit plumbing.
 // GitCloneAndCheckoutRevision clones a Git repository, resolves the revision and checks it out.
 func GitCloneAndCheckoutRevision(ctx context.Context, url string, revision plumbing.Revision, path string) error {
 	logging.V(10).Infof("Attempting to clone from %s at commit %v and path %s", url, revision, path)
+
+	// go-git v5 has limited ADO support and cannot perform this operation.
+	// TODO(https://github.com/go-git/go-git/pull/1204): Remove once go-git v6 is released.
+	if u, err := parseGitRepoURLParts(url); err == nil && u.Hostname == AzureDevOpsHostName {
+		return gitCloneAndCheckoutRevisionSystemGit(ctx, url, revision, path)
+	}
 
 	u, auth, err := getAuthForURL(url)
 	if err != nil {
@@ -532,10 +545,9 @@ func GitCloneOrPull(
 
 	logging.V(10).Infof("Attempting to clone from %s at ref %s", rawurl, referenceName)
 
-	// TODO: https://github.com/go-git/go-git/pull/613 should have resolved the issue preventing this from cloning.
+	// go-git v5 has limited ADO support and cannot perform this operation.
+	// TODO(https://github.com/go-git/go-git/pull/1204): Remove once go-git v6 is released.
 	if u, err := parseGitRepoURLParts(rawurl); err == nil && u.Hostname == AzureDevOpsHostName {
-		// system-installed git is used to clone Azure DevOps repositories
-		// due to https://github.com/go-git/go-git/issues/64
 		return gitCloneOrPullSystemGit(ctx, rawurl, referenceName, path, shallow)
 	}
 	return gitCloneOrPull(ctx, rawurl, referenceName, path, shallow)
@@ -664,6 +676,59 @@ func gitCloneOrPullSystemGit(
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to run `git %v`", strings.Join(gitArgs, " "))
+	}
+	return nil
+}
+
+// gitListRefsSystemGit uses the system `git ls-remote` command to list refs.
+// This is used for Azure DevOps repositories where go-git v5 has limited support.
+func gitListRefsSystemGit(ctx context.Context, url string) ([]*plumbing.Reference, error) {
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", url)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, errutil.ErrorWithStderr(err, fmt.Sprintf("failed to run `git ls-remote %s`", url))
+	}
+	return parseGitLsRemoteOutput(string(out)), nil
+}
+
+// parseGitLsRemoteOutput parses the output of `git ls-remote` into plumbing.Reference values.
+// Each line has the format: <hash>\t<refname>
+// This is used for Azure DevOps repositories where go-git v5 has limited support.
+func parseGitLsRemoteOutput(output string) []*plumbing.Reference {
+	lines := strings.Split(output, "\n")
+	refs := make([]*plumbing.Reference, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			// git ls-remote may include non-ref lines such as "From <url>".
+			continue
+		}
+		hash := plumbing.NewHash(parts[0])
+		refName := plumbing.ReferenceName(parts[1])
+		refs = append(refs, plumbing.NewHashReference(refName, hash))
+	}
+	return refs
+}
+
+// gitCloneAndCheckoutRevisionSystemGit uses system git to clone and checkout a revision.
+// This is used for Azure DevOps repositories where go-git v5 has limited support.
+func gitCloneAndCheckoutRevisionSystemGit(
+	ctx context.Context, url string, revision plumbing.Revision, path string,
+) error {
+	cloneCmd := exec.CommandContext(ctx, "git", "clone", url, path)
+	if _, err := cloneCmd.Output(); err != nil {
+		return errutil.ErrorWithStderr(err, fmt.Sprintf("failed to run `git clone %s %s`", url, path))
+	}
+
+	//nolint:gosec // revision is from trusted internal callers
+	checkoutCmd := exec.CommandContext(ctx, "git", "checkout", string(revision))
+	checkoutCmd.Dir = path
+	if _, err := checkoutCmd.Output(); err != nil {
+		return errutil.ErrorWithStderr(err, fmt.Sprintf("failed to run `git checkout %s`", string(revision)))
 	}
 	return nil
 }
@@ -884,6 +949,12 @@ func GetGitReferenceNameOrHashAndSubDirectory(url string, urlPath string) (
 }
 
 func gitListRefs(ctx context.Context, url string) ([]*plumbing.Reference, error) {
+	// go-git v5 has limited ADO support and cannot perform this operation.
+	// TODO(https://github.com/go-git/go-git/pull/1204): Remove once go-git v6 is released.
+	if u, err := parseGitRepoURLParts(url); err == nil && u.Hostname == AzureDevOpsHostName {
+		return gitListRefsSystemGit(ctx, url)
+	}
+
 	// We're only listing the references, so just use in-memory storage.
 	repo, err := git.Init(memory.NewStorage(), nil)
 	if err != nil {

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -664,6 +664,80 @@ func TestGitCloneAndCheckoutRevision(t *testing.T) {
 	}
 }
 
+func TestParseGitLsRemoteOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("typical output", func(t *testing.T) {
+		t.Parallel()
+		output := "abc123def456abc123def456abc123def456abc1\tHEAD\n" +
+			"abc123def456abc123def456abc123def456abc1\trefs/heads/main\n" +
+			"def456abc123def456abc123def456abc123def4\trefs/tags/v1.0.0\n"
+
+		refs := parseGitLsRemoteOutput(output)
+		require.Len(t, refs, 3)
+
+		assert.Equal(t, plumbing.HEAD, refs[0].Name())
+		assert.Equal(t, plumbing.NewHash("abc123def456abc123def456abc123def456abc1"), refs[0].Hash())
+
+		assert.Equal(t, plumbing.ReferenceName("refs/heads/main"), refs[1].Name())
+		assert.Equal(t, plumbing.NewHash("abc123def456abc123def456abc123def456abc1"), refs[1].Hash())
+
+		assert.Equal(t, plumbing.ReferenceName("refs/tags/v1.0.0"), refs[2].Name())
+		assert.Equal(t, plumbing.NewHash("def456abc123def456abc123def456abc123def4"), refs[2].Hash())
+	})
+
+	t.Run("empty output", func(t *testing.T) {
+		t.Parallel()
+		refs := parseGitLsRemoteOutput("")
+		assert.Empty(t, refs)
+	})
+
+	t.Run("trailing newline", func(t *testing.T) {
+		t.Parallel()
+		output := "abc123def456abc123def456abc123def456abc1\trefs/heads/main\n\n"
+		refs := parseGitLsRemoteOutput(output)
+		require.Len(t, refs, 1)
+		assert.Equal(t, plumbing.ReferenceName("refs/heads/main"), refs[0].Name())
+	})
+
+	t.Run("with peeled tags", func(t *testing.T) {
+		t.Parallel()
+		output := "abc123def456abc123def456abc123def456abc1\trefs/tags/v1.0.0\n" +
+			"def456abc123def456abc123def456abc123def4\trefs/tags/v1.0.0^{}\n"
+		refs := parseGitLsRemoteOutput(output)
+		require.Len(t, refs, 2)
+		assert.Equal(t, plumbing.ReferenceName("refs/tags/v1.0.0"), refs[0].Name())
+		assert.Equal(t, plumbing.ReferenceName("refs/tags/v1.0.0^{}"), refs[1].Name())
+	})
+
+	t.Run("skips non-ref lines", func(t *testing.T) {
+		t.Parallel()
+		output := "From git@github.com:pulumi/pulumi.git\n" +
+			"abc123def456abc123def456abc123def456abc1\tHEAD\n"
+		refs := parseGitLsRemoteOutput(output)
+		require.Len(t, refs, 1)
+		assert.Equal(t, plumbing.HEAD, refs[0].Name())
+	})
+}
+
+func TestGitListRefsADODetection(t *testing.T) {
+	t.Parallel()
+
+	// Verify that ADO URLs are detected for system git routing.
+	// We can't easily test the actual system git call without network access,
+	// but we can verify the detection logic works.
+	adoURL := "https://dev.azure.com/org/project/_git/repo"
+	u, err := parseGitRepoURLParts(adoURL)
+	require.NoError(t, err)
+	assert.Equal(t, AzureDevOpsHostName, u.Hostname)
+
+	// Non-ADO URL should not match.
+	githubURL := "https://github.com/pulumi/pulumi.git"
+	u, err = parseGitRepoURLParts(githubURL)
+	require.NoError(t, err)
+	assert.NotEqual(t, AzureDevOpsHostName, u.Hostname)
+}
+
 func TestGetLatestTagOrHash(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Fix `pulumi package publish` and `pulumi package add` failing with Azure DevOps repository URLs (`invalid pkt-len found` error)
- Add system git fallbacks for `gitListRefs`, `GitCloneAndCheckoutRevision`, and `GitCloneAndCheckoutCommit` when the target is an ADO repository, matching the existing pattern in `GitCloneOrPull`

## Background

go-git is incompatible with Azure DevOps due to unsupported protocol capabilities ([go-git/go-git#64](https://github.com/go-git/go-git/issues/64)). `GitCloneOrPull` already had a fallback to system git for ADO URLs, but the other git operations did not. This caused commands like:

```
pulumi package publish dev.azure.com/org/project/_git/repo
pulumi package add https://dev.azure.com/org/project/_git/repo
```

to fail because `gitListRefs` (used for version resolution) and `GitCloneAndCheckoutRevision`/`GitCloneAndCheckoutCommit` (used for cloning) both hit the go-git incompatibility.

## Test plan

- [x] `go test ./util/gitutil/...` — all tests pass
- [x] New unit tests for `parseGitLsRemoteOutput` (typical output, empty, trailing newline, peeled tags)
- [x] New unit test for ADO URL detection routing
- [x] Manual: `pulumi package publish dev.azure.com/fallimic000/neo-testing/_git/component-test` succeeds
- [x] Manual: `pulumi package add https://dev.azure.com/fallimic000/neo-testing/_git/component-test` succeeds

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format_fix` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
