### PR TITLE
Correctly generate `for` expressions in TypeScript

### DIFF
--- a/changelog/pending/20260313--programgen-nodejs--correctly-generate-for-expressions.yaml
+++ b/changelog/pending/20260313--programgen-nodejs--correctly-generate-for-expressions.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Correctly generate `for` expressions

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -184,15 +184,24 @@ func (g *generator) GenConditionalExpression(w io.Writer, expr *model.Conditiona
 }
 
 func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
+	// Check if the key variable is actually accessed in any sub-expression.
+	// If not, we can skip the intermediate tuple creation for lists, which
+	// avoids TypeScript type inference issues where [k, v] becomes (number | T)[]
+	// instead of a properly typed tuple.
+	keyUsed := expr.KeyVariable != nil &&
+		(pcl.VariableAccessed(expr.KeyVariable.Name, expr.Value) ||
+			pcl.VariableAccessed(expr.KeyVariable.Name, expr.Key) ||
+			pcl.VariableAccessed(expr.KeyVariable.Name, expr.Condition))
+
 	switch expr.Collection.Type().(type) {
 	case *model.ListType, *model.TupleType:
-		if expr.KeyVariable == nil {
-			g.Fgenf(w, "%.20v", expr.Collection)
+		if keyUsed {
+			g.Fgenf(w, "%.20v.map((v, k) => [k, v] as const)", expr.Collection)
 		} else {
-			g.Fgenf(w, "%.20v.map((v, k) => [k, v])", expr.Collection)
+			g.Fgenf(w, "%.20v", expr.Collection)
 		}
 	case *model.MapType, *model.ObjectType:
-		if expr.KeyVariable == nil {
+		if !keyUsed {
 			g.Fgenf(w, "Object.values(%.v)", expr.Collection)
 		} else {
 			g.Fgenf(w, "Object.entries(%.v)", expr.Collection)
@@ -200,7 +209,7 @@ func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 	}
 
 	fnParams, reduceParams := expr.ValueVariable.Name, expr.ValueVariable.Name
-	if expr.KeyVariable != nil {
+	if keyUsed {
 		reduceParams = fmt.Sprintf("[%s, %s]", expr.KeyVariable.Name, expr.ValueVariable.Name)
 		fnParams = fmt.Sprintf("(%s)", reduceParams)
 	}
@@ -211,7 +220,7 @@ func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 
 	if expr.Key != nil {
 		// TODO(pdg): grouping
-		g.Fgenf(w, ".reduce((__obj, %s) => ({ ...__obj, [%.v]: %.v }))", reduceParams, expr.Key, expr.Value)
+		g.Fgenf(w, ".reduce((__obj, %s) => ({ ...__obj, [%.v]: %.v }), {})", reduceParams, expr.Key, expr.Value)
 	} else {
 		g.Fgenf(w, ".map(%s => (%.v))", fnParams, expr.Value)
 	}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -99,8 +99,6 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l2-invoke-options-depends-on": "not implemented yet",
-	"l3-for":                       "reduce() missing initial value causes first element to be used as accumulator",
-	"l3-for-resource":              "Property 'value' does not exist on type 'number | Detail'. Did you mean 'valueOf'",
 	"l3-deferred-outputs":          "Cannot find name '_arg0_'.",
 }
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-for-resource
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as nestedobject from "@pulumi/nestedobject";
+
+const source = new nestedobject.Container("source", {inputs: [
+    "a",
+    "b",
+    "c",
+]});
+// for over list<object> output
+const receiver = new nestedobject.Receiver("receiver", {details: source.details.apply(details => details.map(detail => ({
+    key: detail.key,
+    value: detail.value,
+})))});
+// for over list<string> output
+const fromSimple = new nestedobject.Container("fromSimple", {inputs: source.details.apply(details => details.map(detail => (detail.value)))});
+// for producing a map
+const mapped = new nestedobject.MapContainer("mapped", {tags: source.details.apply(details => details.reduce((__obj, detail) => ({ ...__obj, [detail.key]: detail.value }), {}))});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "l3-for-resource",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/nestedobject": "ROOT/artifacts/pulumi-nestedobject-1.42.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for-resource/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-for
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const names = config.requireObject<Array<string>>("names");
+const tags = config.requireObject<Record<string, string>>("tags");
+export const greetings = names.map(name => (`Hello, ${name}!`));
+export const numbered = names.map((v, k) => [k, v] as const).map(([i, name]) => (`${i}-${name}`));
+export const tagList = Object.entries(tags).map(([k, v]) => (`${k}=${v}`));
+export const greetingMap = names.reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});
+export const filteredList = names.filter(name => name != "b").map(name => (name));
+export const filteredMap = names.filter(name => name != "b").reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "l3-for",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-for/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l3-for-resource
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as nestedobject from "@pulumi/nestedobject";
+
+const source = new nestedobject.Container("source", {inputs: [
+    "a",
+    "b",
+    "c",
+]});
+// for over list<object> output
+const receiver = new nestedobject.Receiver("receiver", {details: source.details.apply(details => details.map(detail => ({
+    key: detail.key,
+    value: detail.value,
+})))});
+// for over list<string> output
+const fromSimple = new nestedobject.Container("fromSimple", {inputs: source.details.apply(details => details.map(detail => (detail.value)))});
+// for producing a map
+const mapped = new nestedobject.MapContainer("mapped", {tags: source.details.apply(details => details.reduce((__obj, detail) => ({ ...__obj, [detail.key]: detail.value }), {}))});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-for-resource",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/nestedobject": "ROOT/artifacts/pulumi-nestedobject-1.42.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for-resource/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l3-for
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const names = config.requireObject<Array<string>>("names");
+const tags = config.requireObject<Record<string, string>>("tags");
+export const greetings = names.map(name => (`Hello, ${name}!`));
+export const numbered = names.map((v, k) => [k, v] as const).map(([i, name]) => (`${i}-${name}`));
+export const tagList = Object.entries(tags).map(([k, v]) => (`${k}=${v}`));
+export const greetingMap = names.reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});
+export const filteredList = names.filter(name => name != "b").map(name => (name));
+export const filteredMap = names.filter(name => name != "b").reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "l3-for",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-for/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-for-resource
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/index.ts
@@ -1,0 +1,17 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as nestedobject from "@pulumi/nestedobject";
+
+const source = new nestedobject.Container("source", {inputs: [
+    "a",
+    "b",
+    "c",
+]});
+// for over list<object> output
+const receiver = new nestedobject.Receiver("receiver", {details: source.details.apply(details => details.map(detail => ({
+    key: detail.key,
+    value: detail.value,
+})))});
+// for over list<string> output
+const fromSimple = new nestedobject.Container("fromSimple", {inputs: source.details.apply(details => details.map(detail => (detail.value)))});
+// for producing a map
+const mapped = new nestedobject.MapContainer("mapped", {tags: source.details.apply(details => details.reduce((__obj, detail) => ({ ...__obj, [detail.key]: detail.value }), {}))});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-for-resource",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/nestedobject": "ROOT/artifacts/pulumi-nestedobject-1.42.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for-resource/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-for
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const names = config.requireObject<Array<string>>("names");
+const tags = config.requireObject<Record<string, string>>("tags");
+export const greetings = names.map(name => (`Hello, ${name}!`));
+export const numbered = names.map((v, k) => [k, v] as const).map(([i, name]) => (`${i}-${name}`));
+export const tagList = Object.entries(tags).map(([k, v]) => (`${k}=${v}`));
+export const greetingMap = names.reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});
+export const filteredList = names.filter(name => name != "b").map(name => (name));
+export const filteredMap = names.filter(name => name != "b").reduce((__obj, name) => ({ ...__obj, [name]: `Hello, ${name}!` }), {});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "l3-for",
+	"devDependencies": {
+		"@types/node": "^18"
+	},
+	"dependencies": {
+		"typescript": "^4.0.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-for/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"outDir": "bin",
+		"target": "es2016",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"experimentalDecorators": true,
+		"pretty": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"forceConsistentCasingInFileNames": true
+	},
+	"files": [
+		"index.ts",
+	]
+}


### PR DESCRIPTION
Fix how `for` expressions are generated in TypeScript. This PR fixes `reduce` (adding the accumulator) and fixes `.map` tuples loosing type information. This allows us to enable `l3-for` & `l3-for-resource` for TypeScript.