### PR TITLE
Add lock file detection for picking the Python toolchain

### DIFF
--- a/changelog/pending/20260314--sdk-python--add-lock-file-detection-for-picking-the-python-toolchain.yaml
+++ b/changelog/pending/20260314--sdk-python--add-lock-file-detection-for-picking-the-python-toolchain.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: Add lock file detection for picking the Python toolchain

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -227,7 +227,9 @@ type pythonLanguageHost struct {
 	toolchain string
 }
 
-func parseOptions(root string, programDir string, options map[string]any) (toolchain.PythonOptions, error) {
+func parseOptions(
+	root string, programDir string, options map[string]any, isPlugin bool,
+) (toolchain.PythonOptions, error) {
 	pythonOptions := toolchain.PythonOptions{
 		Root:       root,
 		ProgramDir: programDir,
@@ -273,6 +275,15 @@ func parseOptions(root string, programDir string, options map[string]any) (toolc
 		}
 	}
 
+	// Default the `virtualenv` option to `venv` for plugins if not provided. We don't support running plugins using the
+	// global or ambient Python environment, but we do for programs for backwards compatibility. Auto is included
+	// because it is the zero value of the toolchain type: a plugin with no explicit toolchain set will have Toolchain
+	// == Auto, and should still get the venv default.
+	if isPlugin && (pythonOptions.Toolchain == toolchain.Pip || pythonOptions.Toolchain == toolchain.Auto) &&
+		pythonOptions.Virtualenv == "" {
+		pythonOptions.Virtualenv = "venv"
+	}
+
 	return pythonOptions, nil
 }
 
@@ -309,7 +320,7 @@ func (host *pythonLanguageHost) connectToEngine() (pulumirpc.EngineClient, io.Cl
 func (host *pythonLanguageHost) GetRequiredPackages(ctx context.Context,
 	req *pulumirpc.GetRequiredPackagesRequest,
 ) (*pulumirpc.GetRequiredPackagesResponse, error) {
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -974,7 +985,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 	}
 	defer contract.IgnoreClose(closer)
 
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -1274,15 +1285,9 @@ func validateVersion(ctx context.Context, options toolchain.PythonOptions) {
 func (host *pythonLanguageHost) InstallDependencies(
 	req *pulumirpc.InstallDependenciesRequest, server pulumirpc.LanguageRuntime_InstallDependenciesServer,
 ) error {
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), req.IsPlugin)
 	if err != nil {
 		return err
-	}
-
-	// Default the `virtualenv` option to `venv` for plugins if not provided. We don't support running plugins using the
-	// global or ambient Python environment, but we do for programs for backwards compatibility.
-	if req.IsPlugin && opts.Toolchain == toolchain.Pip && opts.Virtualenv == "" {
-		opts.Virtualenv = "venv"
 	}
 
 	closer, stdout, stderr, err := rpcutil.MakeInstallDependenciesStreams(server, req.IsTerminal)
@@ -1396,7 +1401,7 @@ func (host *pythonLanguageHost) Template(
 ) (*pulumirpc.TemplateResponse, error) {
 	logging.V(5).Infof("Template(%+v)", req)
 
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -1420,7 +1425,7 @@ func (host *pythonLanguageHost) About(ctx context.Context,
 	// Previously we did not pass any arguments to About and we always used the default python command.
 	opts := toolchain.PythonOptions{Toolchain: toolchain.Pip}
 	if req != nil && req.Info != nil {
-		aboutOpts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+		aboutOpts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 		if err != nil {
 			return nil, err
 		}
@@ -1451,7 +1456,7 @@ func (host *pythonLanguageHost) About(ctx context.Context,
 func (host *pythonLanguageHost) GetProgramDependencies(
 	ctx context.Context, req *pulumirpc.GetProgramDependenciesRequest,
 ) (*pulumirpc.GetProgramDependenciesResponse, error) {
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -1501,16 +1506,10 @@ func (host *pythonLanguageHost) RunPlugin(
 	}
 	defer contract.IgnoreClose(closer)
 
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	isPlugin := req.Kind != string(apitype.AnalyzerPlugin)
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), isPlugin)
 	if err != nil {
 		return err
-	}
-
-	// Default the `virtualenv` option to `venv` if not provided. We don't support running plugins using the global or
-	// ambient Python environment. Except for policy packs that still need to support the old behavior of defaulting to
-	// the global environment.
-	if opts.Toolchain == toolchain.Pip && opts.Virtualenv == "" && req.Kind != string(apitype.AnalyzerPlugin) {
-		opts.Virtualenv = "venv"
 	}
 	tc, err := toolchain.ResolveToolchain(opts)
 	if err != nil {
@@ -1887,7 +1886,7 @@ func (host *pythonLanguageHost) Link(
 	ctx context.Context, req *pulumirpc.LinkRequest,
 ) (*pulumirpc.LinkResponse, error) {
 	logging.V(5).Infof("Linking %+v in %s", req.Packages, req.Info.RootDirectory)
-	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap())
+	opts, err := parseOptions(req.Info.RootDirectory, req.Info.ProgramDirectory, req.Info.Options.AsMap(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/python/cmd/pulumi-language-python/main_test.go
+++ b/sdk/python/cmd/pulumi-language-python/main_test.go
@@ -26,6 +26,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{}, false)
+		require.NoError(t, err)
+		assert.Equal(t, "root", opts.Root)
+		assert.Equal(t, "programDir", opts.ProgramDir)
+		assert.Equal(t, toolchain.Auto, opts.Toolchain)
+		assert.Equal(t, toolchain.TypeCheckerNone, opts.Typechecker)
+		assert.Equal(t, "", opts.Virtualenv)
+	})
+
+	t.Run("virtualenv", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{
+			"virtualenv":  "myvenv",
+			"toolchain":   "uv",
+			"typechecker": "mypy",
+		}, false)
+		require.NoError(t, err)
+		assert.Equal(t, "myvenv", opts.Virtualenv)
+		assert.Equal(t, toolchain.Uv, opts.Toolchain)
+		assert.Equal(t, toolchain.TypeCheckerMypy, opts.Typechecker)
+	})
+
+	t.Run("toolchain unknown", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseOptions("root", "programDir", map[string]any{"toolchain": "npm"}, false)
+		require.ErrorContains(t, err, "unsupported toolchain option: npm")
+	})
+
+	t.Run("plugin auto toolchain defaults virtualenv to `venv`", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "venv", opts.Virtualenv)
+		assert.Equal(t, toolchain.Auto, opts.Toolchain)
+	})
+
+	t.Run("plugin pip toolchain defaults virtualenv to `venv`", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{"toolchain": "pip"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "venv", opts.Virtualenv)
+	})
+
+	t.Run("plugin explicit virtualenv is not overridden", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{"virtualenv": "myvenv"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "myvenv", opts.Virtualenv)
+	})
+
+	t.Run("plugin poetry toolchain does not default virtualenv", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{"toolchain": "poetry"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "", opts.Virtualenv)
+	})
+
+	t.Run("plugin uv toolchain does not default virtualenv", func(t *testing.T) {
+		t.Parallel()
+		opts, err := parseOptions("root", "programDir", map[string]any{"toolchain": "uv"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "", opts.Virtualenv)
+	})
+}
+
 func TestRemoveReleaseCandidateSuffix(t *testing.T) {
 	t.Parallel()
 
@@ -158,7 +228,7 @@ func getOptions(t *testing.T, name, cwd string) toolchain.PythonOptions {
 func addPackage(t *testing.T, opts toolchain.PythonOptions, name string) {
 	t.Helper()
 	switch opts.Toolchain {
-	case toolchain.Pip:
+	case toolchain.Pip, toolchain.Auto:
 		tc, err := toolchain.ResolveToolchain(opts)
 		require.NoError(t, err)
 		cmd, err := tc.ModuleCommand(t.Context(), "pip", "install", name)

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -157,7 +157,7 @@ func (p *pip) ListPackages(ctx context.Context, transitive bool) ([]plugin.Depen
 
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("calling `python %s`: %w", strings.Join(cmd.Args, " "), err)
+		return nil, fmt.Errorf("calling `%s`: %w", strings.Join(cmd.Args, " "), err)
 	}
 
 	var raw []struct {

--- a/sdk/python/toolchain/toolchain.go
+++ b/sdk/python/toolchain/toolchain.go
@@ -48,7 +48,10 @@ const (
 type toolchain int
 
 const (
-	Pip toolchain = iota
+	// Auto is the default toolchain value. When set, ResolveToolchain will detect the toolchain to use by looking for
+	// lockfiles in the project directory, falling back to pip if none are found.
+	Auto toolchain = iota
+	Pip
 	Poetry
 	Uv
 )
@@ -108,6 +111,8 @@ type Toolchain interface {
 
 func Name(tc toolchain) string {
 	switch tc {
+	case Auto:
+		return "Auto"
 	case Pip:
 		return "Pip"
 	case Poetry:
@@ -133,7 +138,22 @@ func TypeCheckerName(tc typeChecker) string {
 }
 
 func ResolveToolchain(options PythonOptions) (Toolchain, error) {
-	switch options.Toolchain { //nolint:exhaustive // golangci-lint v2 upgrade
+	switch options.Toolchain {
+	case Auto:
+		if _, err := searchup(options.ProgramDir, "uv.lock"); err == nil {
+			logging.V(9).Infof("Python toolchain: detected uv (found uv.lock)")
+			virtualenv := options.Virtualenv
+			if virtualenv != "" && !filepath.IsAbs(virtualenv) {
+				virtualenv = filepath.Join(options.Root, virtualenv)
+			}
+			return newUv(options.ProgramDir, virtualenv)
+		}
+		if _, err := searchup(options.ProgramDir, "poetry.lock"); err == nil {
+			logging.V(9).Infof("Python toolchain: detected poetry (found poetry.lock)")
+			return newPoetry(options.ProgramDir)
+		}
+		logging.V(9).Infof("Python toolchain: defaulting to pip")
+		return newPip(options.Root, options.Virtualenv)
 	case Poetry:
 		return newPoetry(options.ProgramDir)
 	case Uv:
@@ -142,8 +162,11 @@ func ResolveToolchain(options PythonOptions) (Toolchain, error) {
 			virtualenv = filepath.Join(options.Root, virtualenv)
 		}
 		return newUv(options.ProgramDir, virtualenv)
+	case Pip:
+		return newPip(options.Root, options.Virtualenv)
+	default:
+		return nil, fmt.Errorf("unknown toolchain: %d", options.Toolchain)
 	}
-	return newPip(options.Root, options.Virtualenv)
 }
 
 // ActivateVirtualEnv takes an array of environment variables (same format as os.Environ()) and path to

--- a/sdk/python/toolchain/toolchain_test.go
+++ b/sdk/python/toolchain/toolchain_test.go
@@ -474,7 +474,7 @@ func createVenv(t *testing.T, opts PythonOptions, packages ...string) {
 	t.Helper()
 
 	switch opts.Toolchain {
-	case Pip:
+	case Auto, Pip:
 		tc, err := ResolveToolchain(opts)
 		require.NoError(t, err)
 		err = tc.InstallDependencies(context.Background(), opts.Root, false, /*useLanguageVersionTools*/
@@ -608,6 +608,54 @@ func (p *ProcessState) Pid() int {
 
 func (p *ProcessState) String() string {
 	return "exit status 139 "
+}
+
+func TestResolveToolchainAuto(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		tc        toolchain
+		lockFiles []string
+		expected  string
+	}{
+		{"Auto defaults to pip", Auto, []string{}, "Pip"},
+		{"Auto picks pip with requirements.txt only", Auto, []string{"requirements.txt"}, "Pip"},
+		{"Auto detects uv from uv.lock", Auto, []string{"uv.lock"}, "Uv"},
+		{"Auto detects poetry from poetry.lock", Auto, []string{"poetry.lock"}, "Poetry"},
+		{"Auto uv takes priority over poetry", Auto, []string{"uv.lock", "poetry.lock"}, "Uv"},
+		{"Auto uv takes priority over requirements.txt", Auto, []string{"uv.lock", "requirements.txt"}, "Uv"},
+		{"Auto poetry takes priority over requirements.txt", Auto, []string{"poetry.lock", "requirements.txt"}, "Poetry"},
+		{"explicit Pip ignores lockfiles", Pip, []string{"uv.lock", "poetry.lock"}, "Pip"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			for _, lockFile := range tt.lockFiles {
+				f, err := os.Create(filepath.Join(dir, lockFile))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+			}
+			tc, err := ResolveToolchain(PythonOptions{
+				Toolchain:  tt.tc,
+				Root:       dir,
+				ProgramDir: dir,
+			})
+			require.NoError(t, err)
+			var got string
+			switch tc.(type) {
+			case *pip:
+				got = "Pip"
+			case *poetry:
+				got = "Poetry"
+			case *uv:
+				got = "Uv"
+			default:
+				require.Fail(t, "unexpected toolchain type: %T", tc)
+			}
+			require.Equal(t, tt.expected, got)
+		})
+	}
 }
 
 func TestErrorWithStderr(t *testing.T) {


### PR DESCRIPTION
Similar to how the Node.js language host behaves, we can look for uv and poetry lockfiles to determine the Python toolchain if it is not explicitly set in the runtime options.

Fixes https://github.com/pulumi/pulumi/issues/22231