### PR TITLE
Add AGENTS.md files for AI-assisted development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,33 @@ The core Pulumi SDK and CLI. Go monorepo with multiple Go modules (`pkg/`, `sdk/
 - `scripts/` — CI and development helper scripts
 - `changelog/` — Pending changelog entries
 
+### pkg/ in more detail
+```
+pkg/
+├── cmd/pulumi/          # CLI commands (Cobra). Entry: main.go → pulumi.go (NewPulumiCmd)
+│   ├── operations/      # pulumi up/destroy/preview/refresh
+│   ├── config/          # pulumi config
+│   ├── state/           # pulumi state
+│   └── stack/           # pulumi stack
+├── backend/             # Stack backends
+│   ├── httpstate/       # Pulumi Cloud backend
+│   ├── diy/             # Self-hosted (file, S3, GCS, Azure, Postgres)
+│   └── display/         # Event → CLI output rendering
+├── engine/              # Deployment orchestration
+│   └── lifecycletest/   # Lifecycle + fuzz tests
+├── resource/deploy/     # Step generation, execution, state management
+│   ├── providers/       # Provider registry
+│   └── deploytest/      # Mock providers/hosts for tests
+├── codegen/             # Code generation
+│   ├── go/, python/, nodejs/, dotnet/  # Language generators
+│   ├── schema/          # Type system and schema loading
+│   ├── hcl2/, pcl/      # PCL parsing and binding
+│   └── testing/test/testdata/  # Golden file tests
+├── secrets/             # Encryption: b64/, passphrase/, cloud/
+├── workspace/           # Pulumi.yaml loading, plugin management
+└── display/             # Terminal output formatting
+```
+
 ## Command canon
 All commands assume you're at the repo root.
 
@@ -37,6 +64,62 @@ All commands assume you're at the repo root.
 - `cd sdk/nodejs && make test_fast`
 - `cd sdk/python && make test_fast`
 - `cd sdk/go && make test_fast`
+
+## Code conventions
+
+### Style
+- **Formatter:** gofumpt (not gofmt)
+- **Linter:** golangci-lint v2, config in `.golangci.yml`
+- **License header required** on all files (Apache 2.0, enforced by `goheader` linter)
+- **Imports:** stdlib, then third-party, then internal Pulumi packages (enforced by linter)
+- **Import aliases:** `pulumirpc`, `testingrpc`, `mapset`, `ptesting` (see `.golangci.yml` `importas`)
+
+### Naming
+- Files: `[feature].go`, tests: `[feature]_test.go`
+- Types: PascalCase, no `I` prefix on interfaces
+- Constructors: `New[Type]()` pattern
+- Receivers: short (`d *Deployment`, `s *Stack`)
+
+### Error handling
+- Wrap with `fmt.Errorf("context: %w", err)` for `errors.Is`/`errors.As` support
+- **Bail errors:** `result.BailError(err)` / `result.IsBail(err)` for expected failures already reported to the user
+- **Decrypt errors:** `engine.AsDecryptError(err)` for config decryption failures
+- **Snapshot errors:** `snapshot.AsSnapshotIntegrityError(err)` for serious bugs that generate a diagnostic bundle
+- **Backend errors:** `backenderr.ErrNotFound`, `ErrLoginRequired`, `ErrForbidden`, all `errors.Is()` compatible
+- **Contract checks:** `util/contract` package, panics in debug builds
+
+### Testing
+- Always use `t.Parallel()` unless modifying global state (enforced by `paralleltest` linter)
+- Use `require` for critical assertions, `assert` for secondary checks
+- Table-driven tests with `t.Run()` subtests
+- Mocks: custom struct types implementing interfaces (no mock framework)
+- Suppress parallel requirement with `//nolint:paralleltest // reason`
+- Integration tests: `tests/integration/`, gated by `PULUMI_INTEGRATION_TESTS`
+- Lifecycle tests: `pkg/engine/lifecycletest/`, supports fuzzing via Rapid
+
+### Forbidden imports (enforced by `depguard`)
+- `github.com/golang/protobuf` — use `google.golang.org/protobuf`
+
+## Architecture
+
+**Data flow:** CLI → Backend → Engine → Resource Monitor → Step Generator → Step Executor → Plugin (gRPC)
+
+1. CLI parses command, loads workspace (`Pulumi.yaml`)
+2. Backend acquires stack (Cloud or DIY)
+3. Engine orchestrates deployment, emits events
+4. **Resource monitor** receives `RegisterResource` RPCs from language SDK, resolves default providers, dispatches `Construct` for multi-language components
+5. **Step generator** processes registration events **serially** (critical path!) and diffs desired vs current state, issues steps fire-and-forget to executor
+6. **Step executor** applies steps in parallel via chain/antichain model
+7. Snapshot manager persists state (journaling + atomic writes)
+
+**Key abstractions:**
+- `Backend` interface (`pkg/backend/backend.go`) for Cloud vs local
+- `Step` interface (`pkg/resource/deploy/step.go`) with 11 types: Create, Update, Delete, Same, Replace, Read, Refresh, Import, Diff, View, RemovePendingReplace
+- `StepExecutor` with chain (serial) / antichain (parallel) execution model
+- Resource Monitor as gRPC shim between language SDKs and engine, handling default providers
+- Plugin Host managing gRPC resource provider lifecycle
+
+See also: `developer-docs/architecture/` for detailed diagrams and algorithms.
 
 ## Key invariants
 - The repo has multiple Go modules (`pkg/go.mod`, `sdk/go.mod`, `tests/go.mod`, etc.). Changes to `go.mod` in one module may require updates in others. Run `make tidy` to verify.
@@ -78,3 +161,25 @@ All commands assume you're at the repo root.
 - Anything in `pkg/codegen/` → run codegen tests: `cd pkg && go test -count=1 -tags all ./codegen/...`
 - Anything in `pkg/backend/display/...` → add a test that uses pre-constructed, JSON-serialized engine events (ref. testProgressEvents)
 - Anything that adds or changes the engine, resource options, or the provider interface → add a test to `pkg/engine/lifecycletest/`
+
+## Adding new code
+
+| What | Where | Register in |
+|------|-------|-------------|
+| New CLI command | `pkg/cmd/pulumi/[cmd]/` | `pkg/cmd/pulumi/pulumi.go` (commandGroup) |
+| New subcommand | Existing command dir | Parent's `AddCommand()` |
+| New backend | `pkg/backend/[name]/` | Backend factory |
+| New secret provider | `pkg/secrets/[name]/` | Secrets factory |
+| New resource feature | `pkg/resource/deploy/` | Step types / executor |
+| New codegen language | `pkg/codegen/[lang]/` | `GeneratePackage()` + `schema.Language` |
+| New codegen test | `pkg/codegen/testing/test/testdata/[name]/` | Golden files per language |
+
+## Deeper documentation
+
+Each major subsystem has its own AGENTS.md with implementation details:
+
+- **`pkg/cmd/pulumi/AGENTS.md`** — Command patterns, registration, flag handling, constrictor args
+- **`pkg/backend/AGENTS.md`** — Backend interface, httpstate vs diy, state persistence, error types
+- **`pkg/engine/AGENTS.md`** — Deployment flow, event system, plugin management, cancellation, lifecycle tests
+- **`pkg/resource/deploy/AGENTS.md`** — Step types, generator algorithm, executor parallelism, race conditions, deploytest mocks
+- **`pkg/codegen/AGENTS.md`** — Generation pipeline, schema system, PCL, language generators, golden file testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/backend/AGENTS.md
+++ b/pkg/backend/AGENTS.md
@@ -1,0 +1,91 @@
+# Backend
+
+## Backend Interface
+
+`backend.go` defines the `Backend` interface (~40 methods):
+
+**Stack lifecycle:** `GetStack`, `CreateStack`, `RemoveStack`, `RenameStack`, `ListStacks`
+**Operations:** `Preview`, `Update`, `Refresh`, `Destroy`, `Import`, `Watch`
+**State:** `ExportDeployment`, `ImportDeployment`, `GetHistory`, `GetLogs`
+**Config:** `GetLatestConfiguration`, `UpdateStackTags`, `UpdateStackDeploymentSettings`
+
+**Related interfaces:**
+- `Stack` (`stack.go`) — snapshot access, tags, secrets management
+- `StackReference` — opaque stack identifier with `Name()`, `Project()`, `FullyQualifiedName()`
+- `EnvironmentsBackend` — optional ESC capability
+- `SpecificDeploymentExporter` — optional versioned export
+
+## Implementations
+
+### httpstate/ (Pulumi Cloud)
+
+- HTTP REST API via `client/client.go` → `NewClient(apiURL, apiToken, insecure, diag)`
+- Auth: bearer token from `~/.pulumi/credentials.json` via `workspace.GetAccount(cloudURL)`
+- OAuth browser login with nonce-based security (local webserver on random port)
+- Update tokens for in-progress operations (separate from auth token)
+- Journal-based persistence: batch entries sent via API, configurable via `PULUMI_JOURNALING_BATCH_SIZE` / `PULUMI_JOURNALING_BATCH_PERIOD`
+- Handles 413 (Too Large) by recursive batch splitting
+
+### diy/ (Self-Hosted)
+
+- Pluggable storage via `Bucket` abstraction:
+  - `file://` — local filesystem
+  - `s3://` — AWS S3
+  - `gs://` — Google Cloud Storage
+  - `azblob://` — Azure Blob Storage
+  - `postgres://` — PostgreSQL (custom driver in `postgres/`)
+- No HTTP auth needed; filesystem/database permissions apply
+- Optional passphrase-based secret encryption
+- Per-stack file locking for concurrent access
+
+## State Persistence
+
+```
+Step execution
+  → SnapshotManager (tracks mutations, NOT thread-safe)
+    → SnapshotPersister.Save(deployment)
+      → ValidatingPersister (integrity check wrapper)
+        → httpstate: journal API call
+        → diy: checkpoint file write (.json/.gzip)
+```
+
+**Journal entries** (`journal.go`): serialized via `SerializeJournalEntry()` with encryption, version-tracked.
+
+## Display Subsystem
+
+`display/` converts engine events to CLI output:
+
+- `ShowEvents()` — main entry, routes to JSON or human-readable
+- Display types: `DisplayProgress` (live spinner), `DisplayDiff` (hierarchical diff), `DisplayWatch` (file monitor)
+- `Options` struct controls: `Color`, `JSONDisplay`, `IsInteractive`, `SuppressOutputs`, etc.
+
+## Error Types
+
+`backenderr/backenderr.go` defines backend-specific errors:
+
+```go
+var ErrNotFound NotFoundError           // errors.Is() compatible
+var ErrLoginRequired LoginRequiredError // matches registry.UnauthorizedError
+var ErrForbidden ForbiddenError
+
+// Also:
+StackAlreadyExistsError{StackName}
+OverStackLimitError{Message}
+ConflictingUpdateError{Err}             // another update in progress
+```
+
+All implement `Unwrap()`, `Is()` for `errors.Is()`/`errors.As()` chains.
+
+## Testing
+
+`mock.go` provides `MockBackend` with function pointers for every interface method:
+
+```go
+be := &MockBackend{
+    GetStackF: func(ctx context.Context, ref StackReference) (Stack, error) {
+        return &MockStack{SnapshotF: func(...) (*deploy.Snapshot, error) { ... }}, nil
+    },
+}
+```
+
+Pattern: set only the callbacks you need; unconfigured methods panic.

--- a/pkg/backend/CLAUDE.md
+++ b/pkg/backend/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/cmd/pulumi/AGENTS.md
+++ b/pkg/cmd/pulumi/AGENTS.md
@@ -1,0 +1,120 @@
+# CLI Commands
+
+## Command Pattern
+
+Every command follows this structure:
+
+```go
+func NewFooCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Command {
+    var flagVal string
+    cmd := &cobra.Command{
+        Use:   "foo",
+        Short: "...",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            ctx := cmd.Context()
+            opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+            // ...
+            return nil
+        },
+    }
+    constrictor.AttachArguments(cmd, constrictor.NoArgs)
+    cmd.PersistentFlags().StringVarP(&flagVal, "flag", "f", "", "description")
+    return cmd
+}
+```
+
+Key elements:
+- Constructor returns `*cobra.Command`, flags declared as local vars in closure
+- Context from `cmd.Context()`, display opts from `cmdutil.GetGlobalColorization()`
+- Arguments via `constrictor.AttachArguments()` (not Cobra's `Args` field)
+- Register in `pulumi.go` → `NewPulumiCmd()` → appropriate `commandGroup`
+
+## Command Registration
+
+Commands are organized into groups in `pulumi.go` (lines 399-501):
+
+| Group | Commands |
+|-------|----------|
+| Stack Management | `new`, `config`, `stack`, `console`, `import`, `refresh`, `state`, `install` |
+| Deployment | `up`, `destroy`, `preview`, `cancel` |
+| Environment | `env` |
+| Pulumi Cloud | `login`, `logout`, `whoami`, `org`, `project`, `deployment` |
+| Policy | `policy` |
+| Plugin | `plugin`, `schema`, `package`, `template` |
+| Other | `version`, `about`, `completion` |
+
+Experimental/developer commands gated by env vars: `convert`, `watch`, `logs`, `trace`, `events`, `clispec`.
+
+## Accessing Core Services
+
+```go
+// Backend (Cloud or DIY)
+be, err := cmdBackend.CurrentBackend(ctx, ws, lm, project, opts)
+
+// Stack
+s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, lm, stackName, OfferNew, opts)
+
+// Interactive mode
+if cmdutil.Interactive() { /* prompt user */ }
+```
+
+## Argument Handling (constrictor)
+
+`constrictor/constrictor.go` provides structured argument metadata:
+
+```go
+// No arguments
+constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+// Required + optional args
+constrictor.AttachArguments(cmd, &constrictor.Arguments{
+    Arguments: []constrictor.Argument{{Name: "template-or-url", Usage: "[template|url]"}},
+    Required:  0,
+    Variadic:  false,
+})
+
+// Variadic (e.g., multiple URNs)
+constrictor.AttachArguments(cmd, &constrictor.Arguments{
+    Arguments: []constrictor.Argument{{Name: "urn"}},
+    Required:  1,
+    Variadic:  true,
+})
+```
+
+## Subcommand Pattern
+
+Parent commands share state with children via pointers:
+
+```go
+func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
+    var stack string
+    cmd := &cobra.Command{Use: "config", Short: "Manage configuration"}
+    cmd.PersistentFlags().StringVarP(&stack, "stack", "s", "", "stack name")
+    cmd.AddCommand(newConfigGetCmd(ws, &stack))
+    cmd.AddCommand(newConfigSetCmd(ws, &stack))
+    return cmd
+}
+```
+
+## Key Helper Packages
+
+| Package | Purpose |
+|---------|---------|
+| `backend/` (local) | `CurrentBackend()`, `IsDIYBackend()`, `LoginManager` |
+| `cmd/` | `DisplayErrorMessage()`, `processCmdErrors()` |
+| `ui/` | Survey-based prompts, `PromptForValue()` |
+| `constrictor/` | Structured argument specs for CLI introspection |
+| `stack/` (local) | `RequireStack()`, stack selection utilities |
+
+## Flag Patterns
+
+```go
+// Mutually exclusive
+cmd.MarkFlagsMutuallyExclusive("target", "exclude")
+
+// Hidden
+_ = cmd.PersistentFlags().MarkHidden("tracing-header")
+
+// Deprecated
+_ = cmd.PersistentFlags().MarkDeprecated("copilot", "please use --neo instead")
+```

--- a/pkg/cmd/pulumi/CLAUDE.md
+++ b/pkg/cmd/pulumi/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/codegen/AGENTS.md
+++ b/pkg/codegen/AGENTS.md
@@ -1,0 +1,97 @@
+# Code Generation
+
+## Pipeline Overview
+
+```
+Schema (JSON/YAML)
+  → schema.Package (pkg/codegen/schema/)
+    → Language Generator (go/, python/, nodejs/, dotnet/)
+      → map[string][]byte (in-memory filesystem)
+```
+
+All generators share the same entry signature:
+```go
+func GeneratePackage(tool string, pkg *schema.Package, ...) (map[string][]byte, error)
+```
+
+Returns a map of file paths to file contents.
+
+## Schema System
+
+`schema/schema.go` defines the type system:
+- Primitives: `BoolType`, `IntType`, `NumberType`, `StringType`, `ArchiveType`, `AssetType`, `JSONType`, `AnyType`
+- Complex: `MapType`, `ArrayType`, `OptionalType`, `ObjectType`, `EnumType`
+- Resources: `Resource` (InputProperties, Properties, Methods)
+- Functions: `Function` (Inputs, MultiOutputs)
+
+**Loading:** `schema/loader.go` provides `Loader` and `ReferenceLoader` interfaces.
+- `NewPluginLoader(host)` — loads from plugins
+- `NewCachedLoader(loader)` — in-memory caching decorator
+
+## Language Generators
+
+Each language has a `modContext` struct organizing types/resources/functions into modules:
+
+| Language | Generator | Program Gen | Lines |
+|----------|-----------|-------------|-------|
+| Go | `go/gen.go` | `go/gen_program.go` | ~4800 + ~2200 |
+| Python | `python/gen.go` | `python/gen_program.go` | ~3300 + ~1700 |
+| Node.js | `nodejs/gen.go` | `nodejs/gen_program.go` | ~2900 + ~1200 |
+| C#/.NET | `dotnet/gen.go` | `dotnet/gen_program.go` | ~2600 + ~1600 |
+
+**Language-specific config** imported via `schema.Language` interface:
+- Go: `GoPackageInfo` — `ImportBasePath`, `Generics` ("none"/"side-by-side"/"generics-only"), etc.
+- Python: `PackageInfo` — `PackageName`, `InputTypes` ("classes"/"classes-and-dicts")
+- C#: `CSharpPackageInfo` — `RootNamespace`, `Namespaces` map
+
+## PCL (Pulumi Configuration Language)
+
+`hcl2/` + `pcl/` transform HCL syntax into semantic nodes:
+
+```
+HCL source → syntax/ (parse) → model/ (type check) → pcl/ (bind to schema) → Program
+```
+
+PCL `Program.Nodes` contains: `Config`, `Locals`, `Resource`, `Component`, `Output`.
+
+Each language implements `GenerateProgram(program *pcl.Program)` to convert PCL to code.
+
+## Shared Interfaces
+
+**`ExpressionGenerator`** (`hcl2/model/format/gen.go:28`): Each language implements `Gen*Expression` methods for all expression types (binary ops, function calls, literals, traversals, etc.).
+
+**`DocLanguageHelper`** (`docs.go`): Language-specific documentation helpers for type names, resource names, doc links.
+
+**`Formatter`** (`hcl2/model/format/gen.go:65`): Shared indentation and output utilities.
+
+## Testing
+
+**Golden file tests** in `testing/test/testdata/<test-name>/`:
+```
+testdata/<test-name>/
+  schema.json              # Pulumi schema (if SDK test)
+  <test-name>.pp           # PCL source (if program test)
+  go/
+    codegen-manifest.json  # Expected generation config
+    example/               # Expected Go output
+  python/
+    ...
+```
+
+Tests compare generated output against golden files. Split into batches for CI:
+- `go/gen_program_test/batch1/`, `batch2/`, ...
+- `nodejs/gen_program_test/batch1/`, ...
+
+**Run codegen tests:**
+```bash
+cd pkg && go test ./codegen/go/...
+cd pkg && go test ./codegen/python/...
+```
+
+## Common Pitfalls
+
+- **Name collisions**: Schema tokens (`pkg:module/nested:TypeName`) map to language-specific names. Each language tracks `schemaNames` vs `names` with collision detection.
+- **Type variants**: `typeDetails` tracks which input/output variants are needed — don't generate unused ones.
+- **Circular references**: Schema types can be recursive. Generators must handle unbounded recursion.
+- **External packages**: Resources may reference types from other packages. Each generator caches external package contexts (Go uses `globalCache` with mutex).
+- **Temp variables**: Complex expressions need intermediates. Each language has a "spiller" pattern (`spills`, `jsonTempSpiller`).

--- a/pkg/codegen/CLAUDE.md
+++ b/pkg/codegen/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/engine/AGENTS.md
+++ b/pkg/engine/AGENTS.md
@@ -1,0 +1,105 @@
+# Engine
+
+## Deployment Flow
+
+Entry points with identical signatures:
+```go
+func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (*deploy.Plan, display.ResourceChanges, error)
+func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (...)
+func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (...)
+```
+
+**Internal flow:**
+1. Create `deploymentContext` (OpenTracing + OTel spans)
+2. Create `eventEmitter` with buffered channel (`events.go:434`)
+3. Create `deployment` struct (`deployment.go:179`)
+4. `deployment.run()` spawns goroutine for `deploy.Deployment.Execute(ctx)`
+5. Select on: panic errors, cancellation, or completion
+6. Emit summary event with duration and resource changes
+
+**Key internal components** (see `developer-docs/architecture/resource-registration.md`):
+- **Resource monitor**: gRPC `ResourceMonitor` service — shim between language SDKs and engine. Handles default provider resolution (one per package+version) and dispatches `Construct` for multi-language components.
+- **Step generator**: Processes `RegisterResourceEvent`s **serially** (critical path). Issues steps fire-and-forget to executor.
+- **Step executor**: Executes step chains in parallel via worker pool.
+
+**Refresh gotcha**: During refresh, the Diff call has an **inverted polarity** — Read results are passed as `olds` and pre-refresh inputs as `news`. The CLI then reverses the display so the user sees the expected direction.
+
+## Event System
+
+`events.go` defines event types:
+
+| Event | When |
+|-------|------|
+| `PreludeEvent` | Operation start (config info) |
+| `ResourcePreEvent` | Before step execution |
+| `ResourceOutputsEvent` | After step (outputs available) |
+| `ResourceOperationFailed` | Step failure |
+| `SummaryEvent` | Operation end (duration, changes) |
+| `DiagEvent` | Diagnostics (debug/info/warn/error) |
+| `PolicyViolationEvent` | Policy check failure |
+| `ProgressEvent` | Downloads, installs |
+| `CancelEvent` | Cancellation signal |
+
+Events flow through a buffered channel via `queueEvents()` goroutine to prevent blocking senders.
+
+**State locking**: `StepEventMetadata` uses `LockState()`/`UnlockState()` to prevent concurrent mutation of resource state during event emission.
+
+## Plugin Management
+
+`plugins.go` — `PluginManager` interface:
+- `GetPluginPath()`, `DownloadPlugin()`, `InstallPlugin()`
+- Default impl delegates to workspace methods
+- `PluginSet` map with `Deduplicate()` to remove less-specific entries
+
+Plugin gathering (`update.go:268-331`):
+1. Query language host for program requirements
+2. Query snapshot manifest + provider versions
+3. Merge via `Union()` + `Deduplicate()`
+4. Background async installation via `installManager`
+
+## Cancellation Model
+
+Three-level context hierarchy:
+
+1. **Caller context** (`Context.Cancel`): `Canceled()` channel for graceful stop, `Terminated()` for force stop
+2. **Plugin context**: `context.WithoutCancel(ctx)` — decoupled so providers shut down gracefully after main cancel
+3. **Source context**: `context.WithCancel()` — signals to deployment source, canceled on caller cancel
+
+The plugin context goroutine (`deployment.go:212`) keeps plugins alive until `Terminated()` fires.
+
+## Engine ↔ Deploy Interaction
+
+`updateActions` (`update.go:640`) implements `deploy.Events`:
+- `OnResourceStepPre(step)` — emits `ResourcePreEvent`
+- `OnResourceStepPost(ctx, step, status, err)` — emits outputs or failure event
+- `OnResourceOutputs(step)` — emits `ResourceOutputsEvent`
+- `OnSnapshotWrite(snap)` — persists via `SnapshotManager`
+
+## Error Handling
+
+- `DecryptError` (`errors.go`): config key can't be decrypted, has `Key` field + wrapped `Err`
+- `AsDecryptError(err)`: helper for type assertion
+- `trySendEvent()` (`events.go:908`): recovers from panic on closed channel (handles Ctrl+C races)
+- Partial failure: on `StatusPartialFailure`, preserves old inputs with new outputs
+
+## Lifecycle Tests
+
+`lifecycletest/framework/framework.go` — test framework for engine operations:
+
+```go
+type TestOp func(UpdateInfo, *Context, UpdateOptions, bool) (*deploy.Plan, display.ResourceChanges, error)
+```
+
+- `op.Run(project, target, opts, dryRun, validate)` — execute with snapshot validation
+- Uses `TestJournal` (in-memory) + `ValidatingPersister` + `SnapshotManager`
+- Validates snapshot integrity at every journal entry point
+- Compares snapshots from journal, snapshot manager, and persister
+
+## Fuzzing
+
+`lifecycletest/fuzz_test.go` — property-based testing with Rapid:
+- Gated by `PULUMI_LIFECYCLE_TEST_FUZZ` env var
+- Generates random fixtures via `fuzzing.GeneratedFixture()`
+- Exclusion rules in `fuzzing/exclude.go` (16+ known bugs)
+- Reproduction code written to `PULUMI_LIFECYCLE_TEST_FUZZING_REPRO_DIR`
+- Also supports loading real state files via `PULUMI_LIFECYCLE_TEST_FUZZ_FROM_STATE_FILE`

--- a/pkg/engine/CLAUDE.md
+++ b/pkg/engine/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/resource/deploy/AGENTS.md
+++ b/pkg/resource/deploy/AGENTS.md
@@ -1,0 +1,116 @@
+# Resource Deploy
+
+## Step Interface
+
+`step.go` defines the `Step` interface (11 implementations):
+
+| Type | Op | Purpose |
+|------|----|---------|
+| `SameStep` | Same | Resource unchanged, retain state |
+| `CreateStep` | Create | New resource (also `CreateReplacementStep`) |
+| `DeleteStep` | Delete | Remove resource (also `DeleteReplacementStep`) |
+| `UpdateStep` | Update | In-place update |
+| `ReplaceStep` | Replace | Marks resource for replacement |
+| `RemovePendingReplaceStep` | RemovePendingReplace | Clears pending replacement flag |
+| `ReadStep` | Read | Reads external resource state |
+| `RefreshStep` | Refresh | Syncs state from provider (async via promise) |
+| `ImportStep` | Import | Imports existing resource (async via promise) |
+| `DiffStep` | — | Async diff computation |
+| `ViewStep` | — | Component resource views |
+
+All steps implement: `Apply()`, `Op()`, `URN()`, `Type()`, `Old()`, `New()`, `Res()`, `Logical()`, `Deployment()`.
+
+## Step Generator Algorithm
+
+`step_generator.go` — core decision tree for what to do with each resource.
+
+**Critical design constraint:** The step generator processes `RegisterResourceEvent`s **serially**. This is on the deployment's critical path — any blocking in the generator slows the entire deployment. Steps issued to the executor are **fire-and-forget**; the generator moves on immediately.
+
+```
+GenerateSteps(event)
+  → generateSteps()
+    → Generate URN from type + name + parent
+    → getOldResource() via URN/alias lookup
+    → Pre-process ignoreChanges (copy old values for ignored properties)
+    → if import: async ImportStep → continueStepsFromImport()
+    → Call provider Check(inputs, oldInputs) → checked inputs
+    → Run analyzers for policy validation
+    → if no old: CreateStep (or SkippedCreate if not targeted)
+    → if old: diff resource:
+      1. Check if marked for replacement (--target-replace)
+      2. Check if provider changed (forces replace)
+      3. Call provider Diff(checkedInputs, oldState, ignoreChanges)
+      4. Apply replace-on-change options
+    → no changes: SameStep
+    → changes + no replace: UpdateStep
+    → changes + replace:
+      → Re-Check with empty old inputs (fresh defaults for replacement)
+      → if createBeforeDelete: CreateStep → DeleteStep (later)
+      → if deleteBeforeReplace: calculate dependent replacements →
+          DeleteSteps for dependents → DeleteStep → CreateStep
+```
+
+**After program exit:** Generator computes resources to delete by diffing registered vs existing sets, decomposes into antichains (parallel-safe groups) using poset decomposition, issues delete antichains in reverse dependency order.
+
+Key fields on `stepGenerator`:
+- `mode`: updateMode / destroyMode / refreshMode
+- `urns`, `reads`, `deletes`, `replaces`, `updates`, `creates`, `sames`: tracking maps
+- `skippedCreates`: resources not created due to `--target`
+- `refreshAliasLock`: mutex protecting `depGraph.Alias()` calls in goroutines
+
+## Step Executor Parallelism
+
+`step_executor.go` uses a chain/antichain model:
+
+- **Chain**: sequence of steps executed serially (e.g., Create → Replace → Delete)
+- **Antichain**: set of steps executed in parallel (independent resources)
+
+```go
+executor.ExecuteSerial(chain)    // submit chain, returns completion token
+executor.ExecuteParallel(anti)   // submit antichain, waits for all
+```
+
+Worker goroutines acquire `workerLock.RLock()` per step. The write lock is used for cancellation/shutdown.
+
+## Concurrency — Watch Out
+
+1. **`refreshAliasLock`** (`step_generator.go:88`): Protects `depGraph.Alias()` calls in goroutines. Comment at line 771 explains the race.
+
+2. **State mutation race** (`step_executor.go:500`): ReplaceStep state mutation skipped to avoid data race (issue #14994).
+
+3. **Parent registration race** (`step_generator.go:221`): Stack resource races step executor writing state.
+
+4. **Plan copy race** (`plan.go:82-83`): Concurrent goroutines copying plan state (issue #21681).
+
+5. **Async promises**: RefreshStep and ImportStep use `promise.CompletionSource` with goroutines that block on results. If promise never resolves, goroutine leaks.
+
+## Concurrent-Safe Types
+
+- `goals`, `news`, `reads`: `gsync.Map` (concurrent map)
+- `pendingNews`: `gsync.Map` in step executor
+- Provider registry: `sync.Mutex` protected
+- Per-resource: `resource.State.Lock` (RWMutex) for output marking
+
+## Testing with deploytest/
+
+Mock implementations for testing:
+
+| File | Mock Type |
+|------|-----------|
+| `deploytest/provider.go` | `Provider` with `CheckF`, `DiffF`, `CreateF`, `UpdateF`, `DeleteF` callbacks |
+| `deploytest/pluginhost.go` | Plugin host |
+| `deploytest/languageruntime.go` | Language runtime |
+| `deploytest/resourcemonitor.go` | Resource monitor |
+| `deploytest/analyzer.go` | Analyzer plugin |
+| `deploytest/backendclient.go` | Backend client |
+| `deploytest/sink.go` | `NoopSink` diagnostic sink |
+
+Pattern: set callback fields to customize behavior per test.
+
+## Providers Registry
+
+`providers/registry.go` manages provider lifecycle:
+- Thread-safe with `sync.Mutex`
+- Tracks configured vs unconfigured providers
+- Internal metadata stored in `__internal` property map
+- `ProviderRequest` is the caching key (version + name + URL + checksums)

--- a/pkg/resource/deploy/CLAUDE.md
+++ b/pkg/resource/deploy/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Adds structured AGENTS.md documentation across the key subsystems of the Pulumi CLI to give AI coding agents (Claude Code, Copilot, Cursor, etc.) the context they need to work effectively in this codebase. Each file is symlinked as CLAUDE.md so Claude Code loads it automatically when working in that directory.

The root file covers build commands, project structure, coding conventions, architecture, and known fragile areas. Subdirectory files go deeper into each subsystem: CLI command patterns, backend interface and state persistence, engine deployment flow and cancellation, step generator/executor internals and race conditions, and the codegen pipeline with its golden file testing setup.

## How the content was produced

The initial content was generated by running four parallel codebase analysis agents that each explored a different focus area (tech stack, architecture, code quality, concerns). From there, five more agents explored the specific subsystems in depth to extract concrete patterns, function signatures, and gotchas.
The results were then verified against the existing developer-docs/architecture/ documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)