### PR TITLE
Increase partition size for nodejs tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
             --partition-package github.com/pulumi/pulumi/sdk/pcl/v3/cmd/pulumi-language-pcl \
                 sdk/pcl/cmd/pulumi-language-pcl 2 \
             --partition-package github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3 \
-                sdk/nodejs/cmd/pulumi-language-nodejs 2 \
+                sdk/nodejs/cmd/pulumi-language-nodejs 3 \
             --partition-package github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3 \
                 sdk/python/cmd/pulumi-language-python 4 \
             --partition-module tests 2 \


### PR DESCRIPTION
We added language conformance tests for Bun and this has now become the slowest job. 

<img width="5783" height="3163" alt="jobs-on-merge" src="https://github.com/user-attachments/assets/a22bb3f2-b6ac-47cb-98d9-e75123bf11d9" />
