### PR TITLE
Correctly escape HCL strings when emiting them

### DIFF
--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1333,28 +1333,48 @@ func literalText(value cty.Value, rawBytes []byte, escaped, quoted bool) string 
 }
 
 func escapeString(s string) string {
-	// escape special characters
-	s = strconv.Quote(s)
-	s = s[1 : len(s)-1] // Remove surrounding double quote (`"`)
-
-	// Escape `${`
-	runes := []rune(s)
-	out := slice.Prealloc[rune](len(runes))
-	for i, r := range runes {
-		next := func() rune {
-			if i >= len(runes)-1 {
-				return 0
+	// Escape the string using only HCL-compatible escape sequences.
+	// HCL supports: \n, \r, \t, \\, \", \uXXXX, \UXXXXXXXX
+	// Go's strconv.Quote produces \a, \b, \f, \v, \xHH which are NOT valid HCL.
+	out := slice.Prealloc[rune](len([]rune(s)))
+	for _, r := range s {
+		switch r {
+		case '"':
+			out = append(out, '\\', '"')
+		case '\\':
+			out = append(out, '\\', '\\')
+		case '\n':
+			out = append(out, '\\', 'n')
+		case '\r':
+			out = append(out, '\\', 'r')
+		case '\t':
+			out = append(out, '\\', 't')
+		default:
+			if r < 0x20 || r == 0x7f {
+				out = append(out, []rune(fmt.Sprintf("\\u%04x", r))...)
+			} else if r > 0xFFFF {
+				out = append(out, []rune(fmt.Sprintf("\\U%08x", r))...)
+			} else {
+				out = append(out, r)
 			}
-			return runes[i+1]
 		}
-		if r == '$' && next() == '{' {
-			out = append(out, '$')
-		} else if r == '%' && next() == '{' {
-			out = append(out, '%')
-		}
-		out = append(out, r)
 	}
-	return string(out)
+
+	// Escape `${` and `%{` template sequences.
+	result := slice.Prealloc[rune](len(out))
+	for i, r := range out {
+		next := rune(0)
+		if i < len(out)-1 {
+			next = out[i+1]
+		}
+		if r == '$' && next == '{' {
+			result = append(result, '$')
+		} else if r == '%' && next == '{' {
+			result = append(result, '%')
+		}
+		result = append(result, r)
+	}
+	return string(result)
 }
 
 // LiteralValueExpression represents a semantically-analyzed literal value expression.

--- a/pkg/codegen/hcl2/model/expression_test.go
+++ b/pkg/codegen/hcl2/model/expression_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/text/unicode/norm"
+	"pgregory.net/rapid"
+)
+
+func TestEscapeStringRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.String().Draw(t, "s")
+
+		expr := &TemplateExpression{Parts: []Expression{
+			&LiteralValueExpression{Value: cty.StringVal(s)},
+		}}
+
+		hclText := fmt.Sprintf("%v", expr)
+		parsed, diags := hclsyntax.ParseExpression([]byte(hclText), "test", hcl.Pos{Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), "failed to parse %q: %s", hclText, diags.Error())
+
+		val, valDiags := parsed.Value(nil)
+		require.Empty(t, valDiags.HasErrors(), "failed to evaluate %q: %s", hclText, valDiags.Error())
+
+		// HCL applies Unicode NFC normalization to string values, so we
+		// compare against the NFC-normalized input.
+		require.Equal(t, norm.NFC.String(s), val.AsString())
+	})
+}


### PR DESCRIPTION
This was found by `claude` while debugging a YAML language test. I've confirmed the rapid test fails without the changes & passes with them.