### PR TITLE
Fix concurrent map write in conformance tests

### DIFF
--- a/pkg/testing/pulumi-test-language/test_host.go
+++ b/pkg/testing/pulumi-test-language/test_host.go
@@ -49,7 +49,8 @@ type testHost struct {
 	runtimeName string
 	providers   map[string]func() (plugin.Provider, error)
 
-	connections map[plugin.Provider]io.Closer
+	connectionsMutex sync.Mutex
+	connections      map[plugin.Provider]io.Closer
 
 	policies []plugin.Analyzer
 
@@ -173,6 +174,8 @@ func (h *testHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (p
 	if err != nil {
 		return nil, err
 	}
+	h.connectionsMutex.Lock()
+	defer h.connectionsMutex.Unlock()
 	h.connections[grpcProvider] = closer
 
 	return grpcProvider, nil
@@ -283,6 +286,8 @@ func (h *testHost) Close() error {
 	h.closeMutex.Lock()
 	defer h.closeMutex.Unlock()
 	errs := make([]error, 0)
+	h.connectionsMutex.Lock()
+	defer h.connectionsMutex.Unlock()
 	for _, closer := range h.connections {
 		if err := closer.Close(); err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
We've been seeing the occasional flake in conformance tests due to a concurrent map write: https://github.com/pulumi/pulumi/actions/runs/23223002771/job/67500378528?pr=22255

This wraps those map writes (for grpc connections) with a mutex, should stop the panics.