### PR TITLE
Move CloudConsoleURL from httpstate to httpstate/client

### DIFF
--- a/changelog/pending/20260318--backend--move-cloudconsoleurl-from-httpstate-to-httpstate-client.yaml
+++ b/changelog/pending/20260318--backend--move-cloudconsoleurl-from-httpstate-to-httpstate-client.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend
+  description: Move CloudConsoleURL from httpstate to httpstate/client

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -166,7 +166,7 @@ func ValueOrDefaultURL(ws pkgWorkspace.Context, cloudURL string) string {
 	}
 
 	// If none of those led to a cloud URL, simply return the default.
-	return PulumiCloudURL
+	return client.PulumiCloudURL
 }
 
 // Backend extends the base backend interface with specific information about cloud backends.
@@ -259,8 +259,8 @@ func loginWithBrowser(
 	// the nonce and the pulumi access token we created as part of the OAuth flow. If the nonces match, we set the
 	// access token that was passed to us and the redirect to a special welcome page on Pulumi.com
 
-	loginURL := cloudConsoleURL(cloudURL, "cli-login")
-	finalWelcomeURL := cloudConsoleURL(cloudURL, "welcome", "cli")
+	loginURL := client.CloudConsoleURL(cloudURL, "cli-login")
+	finalWelcomeURL := client.CloudConsoleURL(cloudURL, "welcome", "cli")
 
 	if loginURL == "" || finalWelcomeURL == "" {
 		return nil, errors.New("could not determine login url")
@@ -504,7 +504,7 @@ func (m defaultLoginManager) Login(
 
 	cloudURL = ValueOrDefaultURL(pkgWorkspace.Instance, cloudURL)
 	var accessToken string
-	accountLink := cloudConsoleURL(cloudURL, "account", "tokens")
+	accountLink := client.CloudConsoleURL(cloudURL, "account", "tokens")
 
 	if !cmdutil.Interactive() {
 		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.
@@ -668,7 +668,7 @@ func (b *cloudBackend) StackConsoleURL(stackRef backend.StackReference) (string,
 }
 
 func (b *cloudBackend) Name() string {
-	if b.url == PulumiCloudURL {
+	if b.url == client.PulumiCloudURL {
 		return "pulumi.com"
 	}
 
@@ -678,9 +678,9 @@ func (b *cloudBackend) Name() string {
 func (b *cloudBackend) URL() string {
 	user, _, _, err := b.CurrentUser()
 	if err != nil {
-		return cloudConsoleURL(b.url)
+		return client.CloudConsoleURL(b.url)
 	}
-	return cloudConsoleURL(b.url, user)
+	return client.CloudConsoleURL(b.url, user)
 }
 
 func (b *cloudBackend) SetCurrentProject(project *workspace.Project) {
@@ -954,7 +954,7 @@ func validateProjectName(s string) error {
 // CloudConsoleURL returns a link to the cloud console with the given path elements.  If a console link cannot be
 // created, we return the empty string instead (this can happen if the endpoint isn't a recognized pattern).
 func (b *cloudBackend) CloudConsoleURL(paths ...string) string {
-	return cloudConsoleURL(b.CloudURL(), paths...)
+	return client.CloudConsoleURL(b.CloudURL(), paths...)
 }
 
 // serveBrowserLoginServer hosts the server that completes the browser based login flow.

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -62,10 +62,10 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -122,10 +122,10 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -280,10 +280,10 @@ func TestDisableIntegrityChecking(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -383,7 +383,7 @@ func TestCopilotExplainer(t *testing.T) {
 	}
 
 	// Create a backend and API client using our mock transport
-	apiClient := client.NewClient(PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+	apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
 	apiClient.WithHTTPClient(&http.Client{Transport: mockTransport})
 	b := &cloudBackend{
 		client: apiClient,
@@ -435,10 +435,10 @@ func TestListStackNames(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
 	require.NoError(t, err)
 
 	// Create test stacks
@@ -550,10 +550,10 @@ func TestListStackNamesVsListStacks(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := NewLoginManager().Login(ctx, PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
 	require.NoError(t, err)
 
 	// Create a test stack
@@ -1327,7 +1327,7 @@ func TestCreateNeoTaskOnError(t *testing.T) {
 			},
 		}
 
-		apiClient := client.NewClient(PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+		apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
 		apiClient.WithHTTPClient(&http.Client{Transport: mockTransport})
 		b := &cloudBackend{
 			client: apiClient,
@@ -1365,7 +1365,7 @@ func TestCreateNeoTaskOnError(t *testing.T) {
 			},
 		}
 
-		apiClient := client.NewClient(PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+		apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
 		apiClient.WithHTTPClient(&http.Client{Transport: mockTransport})
 		b := &cloudBackend{
 			client: apiClient,

--- a/pkg/backend/httpstate/client/console.go
+++ b/pkg/backend/httpstate/client/console.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package httpstate
+package client
 
 import (
 	"net/url"
@@ -36,9 +36,9 @@ const (
 	defaultConsoleDomainPrefix = "app."
 )
 
-// cloudConsoleURL returns a URL to the Pulumi Cloud Console, rooted at cloudURL. If there is
+// CloudConsoleURL returns a URL to the Pulumi Cloud Console, rooted at cloudURL. If there is
 // an error, returns "".
-func cloudConsoleURL(cloudURL string, paths ...string) string {
+func CloudConsoleURL(cloudURL string, paths ...string) string {
 	u, err := url.Parse(cloudURL)
 	if err != nil {
 		return ""

--- a/pkg/backend/httpstate/client/console_test.go
+++ b/pkg/backend/httpstate/client/console_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package httpstate
+package client
 
 import (
 	"os"
@@ -28,34 +28,34 @@ func TestConsoleURL(t *testing.T) {
 		t.Setenv("PULUMI_CONSOLE_DOMAIN", "pulumi-console.contoso.com")
 		assert.Equal(t,
 			"https://pulumi-console.contoso.com/1/2",
-			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
+			CloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
 
 		// Unset the variable, confirm the "standard behavior" where we
 		// replace "api." with "app.".
 		os.Unsetenv("PULUMI_CONSOLE_DOMAIN")
 		assert.Equal(t,
 			"https://app.pulumi.contoso.com/1/2",
-			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
+			CloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
 	})
 
 	t.Run("CloudURLUsingStandardPattern", func(t *testing.T) {
 		assert.Equal(t,
 			"https://app.pulumi.com/pulumi-bot/my-stack",
-			cloudConsoleURL("https://api.pulumi.com", "pulumi-bot", "my-stack"))
+			CloudConsoleURL("https://api.pulumi.com", "pulumi-bot", "my-stack"))
 
 		assert.Equal(t,
 			"http://app.pulumi.example.com/pulumi-bot/my-stack",
-			cloudConsoleURL("http://api.pulumi.example.com", "pulumi-bot", "my-stack"))
+			CloudConsoleURL("http://api.pulumi.example.com", "pulumi-bot", "my-stack"))
 	})
 
 	t.Run("LocalDevelopment", func(t *testing.T) {
 		assert.Equal(t,
 			"http://localhost:3000/pulumi-bot/my-stack",
-			cloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
+			CloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
 	})
 
 	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
-		assert.Equal(t, "", cloudConsoleURL("https://pulumi.example.com", "pulumi-bot", "my-stack"))
-		assert.Equal(t, "", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "", CloudConsoleURL("https://pulumi.example.com", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "", CloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
 	})
 }

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -44,7 +44,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ai"
@@ -342,7 +341,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				// If there is a new version to report, we will do so after the command has finished.
 				waitForUpdateCheck = true
 				go func() {
-					updateCheckResult <- checkForUpdate(ctx, httpstate.PulumiCloudURL, metadata)
+					updateCheckResult <- checkForUpdate(ctx, client.PulumiCloudURL, metadata)
 					close(updateCheckResult)
 				}()
 			}

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -136,7 +137,7 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 
 	be := s.Backend()
 	cloudBe, isCloud := be.(httpstate.Backend)
-	if !isCloud || cloudBe.CloudURL() != httpstate.PulumiCloudURL {
+	if !isCloud || cloudBe.CloudURL() != client.PulumiCloudURL {
 		fmt.Fprintf(out, "    Managed by %s\n", be.Name())
 	}
 	if isCloud {


### PR DESCRIPTION
This makes the console URL logic available to the client package, which will be needed to construct SAML SSO reauth URLs in a follow-up change.

Ref https://github.com/pulumi/pulumi/issues/21534