### PR TITLE
Check for an SDK version compatible with bun

### DIFF
--- a/changelog/pending/20260318--sdk-bun--check-for-an-sdk-version-compatible-with-bun.yaml
+++ b/changelog/pending/20260318--sdk-bun--check-for-an-sdk-version-compatible-with-bun.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/bun
+  description: Check for an SDK version compatible with bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -384,6 +384,43 @@ func (host *nodeLanguageHost) connectToEngine() (pulumirpc.EngineClient, io.Clos
 	return engineClient, conn, nil
 }
 
+// minBunPulumiSDKVersion is the minimum @pulumi/pulumi version required for the bun runtime.
+var minBunPulumiSDKVersion = semver.MustParse("3.226.0")
+
+// checkPulumiSDKVersion verifies that the installed @pulumi/pulumi package meets the minimum version required by the
+// bun runtime.
+func checkPulumiSDKVersion(ctx context.Context, programDirectory string) error {
+	pm, err := npm.ResolvePackageManager(npm.BunPackageManager, programDirectory)
+	if err != nil {
+		return fmt.Errorf("could not resolve package manager: %w", err)
+	}
+
+	packages, err := pm.ListPackages(ctx, programDirectory, true /*transitive*/)
+	if err != nil {
+		logging.V(5).Infof("skipping @pulumi/pulumi version check: %v", err)
+		return nil
+	}
+
+	for _, pkg := range packages {
+		if pkg.Name == "@pulumi/pulumi" {
+			v, err := semver.Parse(pkg.Version)
+			if err != nil {
+				logging.V(5).Infof("skipping @pulumi/pulumi version check: could not parse version %q: %v",
+					pkg.Version, err)
+				continue
+			}
+			if v.LT(minBunPulumiSDKVersion) {
+				return fmt.Errorf("the bun runtime requires @pulumi/pulumi >= %s, but %s is installed; "+
+					"ensure all copies of @pulumi/pulumi are updated to >= %s and re-run `pulumi install`",
+					minBunPulumiSDKVersion, v, minBunPulumiSDKVersion)
+			}
+		}
+	}
+
+	logging.V(5).Info("skipping @pulumi/pulumi version check: package not found in lockfile")
+	return nil
+}
+
 func compatibleVersions(a, b semver.Version) (bool, string) {
 	switch {
 	case a.Major == 0 && b.Major == 0:
@@ -763,6 +800,12 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		return &pulumirpc.RunResponse{
 			Error: fmt.Sprintf("could not find %s on the $PATH: %s", runtimeExec, err.Error()),
 		}, nil
+	}
+
+	if host.runtime == "bun" {
+		if err := checkPulumiSDKVersion(ctx, req.Info.ProgramDirectory); err != nil {
+			return &pulumirpc.RunResponse{Error: err.Error()}, nil
+		}
 	}
 
 	runPath := os.Getenv("PULUMI_LANGUAGE_NODEJS_RUN_PATH")
@@ -1494,6 +1537,12 @@ func (host *nodeLanguageHost) RunPlugin(
 	}
 	// best effort close, but we try an explicit close and error check at the end as well
 	defer closer.Close()
+
+	if host.runtime == "bun" {
+		if err := checkPulumiSDKVersion(ctx, req.Info.ProgramDirectory); err != nil {
+			return err
+		}
+	}
 
 	runtimeExec := host.runtime
 	if runtimeExec == "nodejs" {


### PR DESCRIPTION
When running with bun we need `@pulumi/pulumi` to be `>=3.226.0`. When creating a new project we’re usually fine, but when converting an existing Node.js project to use bun, we are likely to run into this, because bun [automatically migrates existing lockfiles](https://bun.com/docs/pm/lockfile#automatic-lockfile-migration).

Ideally we'd have an SDK handshake to check this, but this will have to do.