### PR TITLE
Fix `l2-resource-option-alias` for PCL

### DIFF
--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -98,7 +98,6 @@ var expectedFailures = map[string]string{
 	"l2-parameterized-invoke":            "dependency loading reports duplicate package definition for subpackage",
 	"l2-parameterized-resource":          "dependency loading reports duplicate package definition for subpackage",
 	"l2-explicit-parameterized-provider": "dependency loading reports duplicate package definition for goodbye",
-	"l2-resource-option-alias":           "NYI",
 	"l3-deferred-outputs":                "incorrectly detects cycle",
 }
 

--- a/sdk/pcl/cmd/pulumi-language-pcl/main.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/main.go
@@ -553,7 +553,15 @@ func (host *pclLanguageHost) GenerateProject(
 		return nil, fmt.Errorf("copy source directory: %w", err)
 	}
 
+	// Only copy local dependencies that the program actually references.
+	referencedPackages := map[string]bool{}
+	for _, ref := range program.PackageReferences() {
+		referencedPackages[ref.Name()] = true
+	}
 	for name, content := range req.LocalDependencies {
+		if !referencedPackages[name] {
+			continue
+		}
 		outPath := path.Join(directory, name+".pp")
 		err := fsutil.CopyFile(outPath, content, nil)
 		if err != nil {

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/0/component.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/0/component.pp
@@ -1,0 +1,4 @@
+package "component" {
+  baseProviderName    = "component"
+  baseProviderVersion = "13.3.7"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/0/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/0/main.pp
@@ -22,6 +22,6 @@ resource "aliasParent" "simple:index:Resource" {
     }
 }
 
-resource "aliasType" "simple:index:AltResource" {
-    value = true
+resource "aliasType" "component:index:Custom" {
+    value = "true"
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/1/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-alias/1/main.pp
@@ -36,6 +36,6 @@ resource "aliasParent" "simple:index:Resource" {
 resource "aliasType" "simple:index:Resource" {
     value = true
     options {
-        aliases = [{type = "simple:index:AltResource"}]
+        aliases = [{type = "component:index:Custom"}]
     }
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-alias/0/component.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-alias/0/component.pp
@@ -1,0 +1,4 @@
+package "component" {
+  baseProviderName    = "component"
+  baseProviderVersion = "13.3.7"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/0/component.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/0/component.pp
@@ -1,0 +1,4 @@
+package "component" {
+  baseProviderName    = "component"
+  baseProviderVersion = "13.3.7"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/0/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/0/main.pp
@@ -22,6 +22,6 @@ resource "aliasParent" "simple:index:Resource" {
     }
 }
 
-resource "aliasType" "simple:index:AltResource" {
-    value = true
+resource "aliasType" "component:index:Custom" {
+    value = "true"
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.pp
@@ -36,6 +36,6 @@ resource "aliasParent" "simple:index:Resource" {
 resource "aliasType" "simple:index:Resource" {
     value = true
     options {
-        aliases = [{type = "simple:index:AltResource"}]
+        aliases = [{type = "component:index:Custom"}]
     }
 }


### PR DESCRIPTION
The test was failing because PCL reported that it depended upon the "component" provider. This was caused by the test passing `req.LocalDependencies`. Since the test has a global provider list, we need to omit files that we don't actually depend on.