### PR TITLE
Mark pulumi-language-bun as a bundled plugin

### DIFF
--- a/changelog/pending/20260318--sdk-bun--mark-pulumi-language-bun-as-a-bundled-plugin.yaml
+++ b/changelog/pending/20260318--sdk-bun--mark-pulumi-language-bun-as-a-bundled-plugin.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/bun
+  description: Mark pulumi-language-bun as a bundled plugin

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1998,6 +1998,7 @@ func GetPluginsFromDir(dir string) ([]PluginInfo, error) {
 // Eventually we want to fix this so new plugins are true plugins in the plugin cache.
 func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 	return (kind == apitype.LanguagePlugin && name == "nodejs") ||
+		(kind == apitype.LanguagePlugin && name == "bun") ||
 		(kind == apitype.LanguagePlugin && name == "go") ||
 		(kind == apitype.LanguagePlugin && name == "python") ||
 		(kind == apitype.LanguagePlugin && name == "dotnet") ||


### PR DESCRIPTION
Avoid the `warning: using pulumi-language-bun from $PATH at <bleh>/pulumi-language-bun` warning.

