### PR TITLE
Re-enable TestComponentProviderSchema for Go and Python

### DIFF
--- a/changelog/pending/20260318--pkg-testing--re-enable-testcomponentproviderschema-for-go-and-python.yaml
+++ b/changelog/pending/20260318--pkg-testing--re-enable-testcomponentproviderschema-for-go-and-python.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pkg/testing
+  description: Re-enable TestComponentProviderSchema tests for Go and Python using the plugin host framework

--- a/tests/integration/component_provider_schema/testcomponent-go/PulumiPlugin.yaml
+++ b/tests/integration/component_provider_schema/testcomponent-go/PulumiPlugin.yaml
@@ -1,0 +1,1 @@
+runtime: go

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -838,17 +838,8 @@ func TestGetResourceGo(t *testing.T) {
 
 func TestComponentProviderSchemaGo(t *testing.T) {
 	t.Parallel()
-	// TODO[https://github.com/pulumi/pulumi/issues/12365] We no longer build the go-component in
-	// component_setup.sh so there's no native binary for the testComponentProviderSchema to just exec. It
-	// _ought_ to be rewritten to use the plugin host framework so that it starts the component up the same as
-	// all the other tests are doing (via shimless).
-	t.Skip("testComponentProviderSchema needs to be updated to use a plugin host to deal with non-native-binary providers")
-
-	path := filepath.Join("component_provider_schema", "testcomponent-go", "pulumi-resource-testcomponent")
-	if runtime.GOOS == WindowsOS {
-		path += ".exe"
-	}
-	testComponentProviderSchema(t, path)
+	dir := filepath.Join("component_provider_schema", "testcomponent-go")
+	testComponentProviderSchemaPlugin(t, dir)
 }
 
 // TestTracePropagationGo checks that --tracing flag lets golang sub-process to emit traces.

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -1303,17 +1303,8 @@ func TestPythonTranslation(t *testing.T) {
 
 func TestComponentProviderSchemaPython(t *testing.T) {
 	t.Parallel()
-	// TODO[https://github.com/pulumi/pulumi/issues/12365] we no longer have shim files so there's no native
-	// binary for the testComponentProviderSchema to just exec. It _ought_ to be rewritten to use the plugin
-	// host framework so that it starts the component up the same as all the other tests are doing (via
-	// shimless).
-	t.Skip("testComponentProviderSchema needs to be updated to use a plugin host to deal with non-native-binary providers")
-
-	path := filepath.Join("component_provider_schema", "testcomponent-python", "pulumi-resource-testcomponent")
-	if runtime.GOOS == WindowsOS {
-		path += ".cmd"
-	}
-	testComponentProviderSchema(t, path)
+	dir := filepath.Join("component_provider_schema", "testcomponent-python")
+	testComponentProviderSchemaPlugin(t, dir)
 }
 
 // Test that the about command works as expected. Because about parses the

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/iotest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
@@ -112,6 +113,78 @@ func testComponentProviderSchema(t *testing.T, path string) {
 				assert.ErrorContains(t, err, test.expectedError)
 			} else {
 				assert.Equal(t, test.expected, resp.GetSchema())
+			}
+		})
+	}
+}
+
+// schemaEnvMutex protects environment variable manipulation when creating providers
+// in testComponentProviderSchemaPlugin. Multiple test functions may run in parallel,
+// so we serialize the env var set/unset and provider creation.
+var schemaEnvMutex sync.Mutex
+
+// testComponentProviderSchemaPlugin tests the GetSchema RPC for component providers
+// that don't have native binaries (shimless providers). It uses the plugin system
+// to start the provider via the appropriate language runtime.
+func testComponentProviderSchemaPlugin(t *testing.T, dir string) {
+	runComponentSetup(t, "component_provider_schema")
+
+	tests := []struct {
+		name          string
+		env           map[string]string
+		version       int32
+		expected      string
+		expectedError string
+	}{
+		{
+			name:     "Default",
+			expected: "{}",
+		},
+		{
+			name:     "Schema",
+			env:      map[string]string{"INCLUDE_SCHEMA": "true"},
+			expected: `{"hello": "world"}`,
+		},
+		{
+			name:          "Invalid Version",
+			version:       15,
+			expectedError: "unsupported schema version 15",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Serialize env var manipulation and provider creation across parallel test functions.
+			schemaEnvMutex.Lock()
+			for k, v := range test.env {
+				os.Setenv(k, v)
+			}
+
+			absDir, err := filepath.Abs(dir)
+			require.NoError(t, err)
+
+			pCtx, err := plugin.NewContext(context.Background(), nil, nil, nil, nil, absDir, nil, false, nil, nil)
+			require.NoError(t, err)
+
+			prov, err := plugin.NewProviderFromPath(pCtx.Host, pCtx, "testcomponent", absDir)
+
+			for k := range test.env {
+				os.Unsetenv(k)
+			}
+			schemaEnvMutex.Unlock()
+
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, prov.Close())
+				assert.NoError(t, pCtx.Close())
+			}()
+
+			// Call GetSchema and verify the results.
+			resp, err := prov.GetSchema(context.Background(), plugin.GetSchemaRequest{Version: test.version})
+			if test.expectedError != "" {
+				assert.ErrorContains(t, err, test.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected, string(resp.Schema))
 			}
 		})
 	}


### PR DESCRIPTION
Update the TestComponentProviderSchema tests for Go and Python to use
the plugin host framework instead of directly executing a binary. This
fixes #12365 where the tests were skipped because the Go and Python
component providers no longer have native binary executables.

The new testComponentProviderSchemaPlugin function uses
plugin.NewProviderFromPath to start providers through their language
runtimes (shimless), matching how the engine starts components in
production. Also adds a PulumiPlugin.yaml to the Go test component
so it can be loaded as a shimless plugin.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
