### PR TITLE
Warn when pulumi convert finds no source files

### DIFF
--- a/changelog/pending/20260318--cli-convert--warn-when-no-source-files-found-during-convert.yaml
+++ b/changelog/pending/20260318--cli-convert--warn-when-no-source-files-found-during-convert.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/convert
+  description: Warn when no source files are found during `pulumi convert`. Use `--strict` to make this an error.

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -428,6 +428,29 @@ func runConvert(
 		}
 	}
 
+	// Check if the converter produced any PCL output files. If not, warn the user that no source
+	// files were detected.
+	pclFiles, err := os.ReadDir(pclDirectory)
+	if err != nil {
+		return fmt.Errorf("read PCL output directory: %w", err)
+	}
+	hasPCLFiles := false
+	for _, f := range pclFiles {
+		if !f.IsDir() && filepath.Ext(f.Name()) == ".pp" {
+			hasPCLFiles = true
+			break
+		}
+	}
+	if !hasPCLFiles {
+		if strict {
+			return fmt.Errorf("no %s source files found in '%s'", from, cwd)
+		}
+		pCtx.Diag.Warningf(
+			diag.Message("", "No %s source files were found in the current directory '%s'. "+
+				"Use --strict to make this an error."),
+			from, cwd)
+	}
+
 	// Load the project from the pcl directory if there is one. We default to a project with just
 	// the name of the original directory.
 	proj := &workspace.Project{Name: tokens.PackageName(name)}

--- a/pkg/cmd/pulumi/convert/convert_test.go
+++ b/pkg/cmd/pulumi/convert/convert_test.go
@@ -122,6 +122,56 @@ func TestProjectNameDefaults(t *testing.T) {
 	assert.Contains(t, string(yamlBytes), "name: pcl_testdata")
 }
 
+// Tests that converting from an empty directory with --strict returns an error.
+func TestConvertEmptyDirectoryStrict(t *testing.T) {
+	t.Parallel()
+
+	emptyDir := t.TempDir()
+	outDir := t.TempDir()
+
+	err := runConvert(
+		context.Background(),
+		pkgWorkspace.Instance,
+		env.Global(),
+		[]string{}, /*args*/
+		emptyDir,   /*cwd*/
+		[]string{}, /*mappings*/
+		"pcl",      /*from*/
+		"pcl",      /*language*/
+		outDir,
+		true, /*generateOnly*/
+		true, /*strict*/
+		"",   /*name*/
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pcl source files found")
+}
+
+// Tests that converting from an empty directory without --strict produces a warning but no error.
+func TestConvertEmptyDirectoryNonStrict(t *testing.T) {
+	t.Parallel()
+
+	emptyDir := t.TempDir()
+	outDir := t.TempDir()
+
+	err := runConvert(
+		context.Background(),
+		pkgWorkspace.Instance,
+		env.Global(),
+		[]string{}, /*args*/
+		emptyDir,   /*cwd*/
+		[]string{}, /*mappings*/
+		"pcl",      /*from*/
+		"pcl",      /*language*/
+		outDir,
+		true,  /*generateOnly*/
+		false, /*strict*/
+		"",    /*name*/
+	)
+	// Should not error in non-strict mode
+	assert.NoError(t, err)
+}
+
 // Tests that project names can be overridden by the user.
 func TestProjectNameOverrides(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When running `pulumi convert` with no source files in the current
directory (e.g., no .tf files for terraform), the command previously
exited silently with a zero exit code, leaving users uncertain whether
the conversion succeeded or failed.

Now, after conversion, the CLI checks whether any PCL (.pp) files were
produced. If none were found:
- In normal mode: a warning is printed telling the user no source files
  were detected, and suggesting --strict to make it an error.
- In --strict mode: the command returns an error.

Fixes #15209

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
