### PR TITLE
Deduplicate identical apply arguments in codegen

### DIFF
--- a/changelog/pending/20260319--codegen--deduplicate-identical-apply-arguments-in-generated-code.yaml
+++ b/changelog/pending/20260319--codegen--deduplicate-identical-apply-arguments-in-generated-code.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: codegen
+  description: Deduplicate identical apply arguments to avoid unnecessary Promise.all/pulumi.all/Output.All in generated code

--- a/changelog/pending/20260319--codegen--deduplicate-identical-apply-arguments-in-generated-code.yaml
+++ b/changelog/pending/20260319--codegen--deduplicate-identical-apply-arguments-in-generated-code.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: codegen
-  description: Deduplicate identical apply arguments to avoid unnecessary Promise.all/pulumi.all/Output.All in generated code

--- a/changelog/pending/programgen-fix-20260710-105706.yaml
+++ b/changelog/pending/programgen-fix-20260710-105706.yaml
@@ -1,0 +1,4 @@
+component: programgen
+kind: fix
+body: Deduplicate identical apply arguments to avoid unnecessary Promise.all/pulumi.all/Output.All in generated code
+time: 2026-07-10T10:57:06.279085+01:00

--- a/pkg/codegen/pcl/rewrite_apply.go
+++ b/pkg/codegen/pcl/rewrite_apply.go
@@ -394,6 +394,47 @@ func (ctx *observeContext) disambiguateArgName(x model.Expression, bestName stri
 	return ctx.disambiguateName(bestName)
 }
 
+// applyArgsEqual returns true if two apply argument expressions bind to the same entity
+// and access the same traversal path. It uses pointer identity on the bound definition
+// (Parts[0]) rather than lexical name comparison, which is safer when variables in
+// different scopes share the same name. This is used to deduplicate apply arguments so
+// that the same output/promise is not passed multiple times.
+func applyArgsEqual(a, b model.Expression) bool {
+	switch a := a.(type) {
+	case *model.ScopeTraversalExpression:
+		b, ok := b.(*model.ScopeTraversalExpression)
+		if !ok || len(a.Parts) == 0 || len(b.Parts) == 0 || len(a.Traversal) != len(b.Traversal) {
+			return false
+		}
+		// Compare by binding identity: Parts[0] is the bound definition from scope resolution.
+		if a.Parts[0] != b.Parts[0] {
+			return false
+		}
+		// The root traverser is already covered by Parts[0] identity, so compare the
+		// remaining traversal steps to ensure the same field path is accessed.
+		for i := 1; i < len(a.Traversal); i++ {
+			at, bt := a.Traversal[i], b.Traversal[i]
+			switch at := at.(type) {
+			case hcl.TraverseAttr:
+				bt, ok := bt.(hcl.TraverseAttr)
+				if !ok || at.Name != bt.Name {
+					return false
+				}
+			case hcl.TraverseIndex:
+				bt, ok := bt.(hcl.TraverseIndex)
+				if !ok || !at.Key.RawEquals(bt.Key) {
+					return false
+				}
+			default:
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
 // rewriteApplyArg replaces a single expression with an apply parameter.
 func (ctx *observeContext) rewriteApplyArg(applyArg model.Expression, paramType model.Type, traversal hcl.Traversal,
 	parts []model.Traversable, isRoot bool,
@@ -402,12 +443,24 @@ func (ctx *observeContext) rewriteApplyArg(applyArg model.Expression, paramType 
 		return applyArg
 	}
 
-	callbackParam := &model.Variable{
-		Name:         fmt.Sprintf("<arg%d>", len(ctx.callbackParams)),
-		VariableType: paramType,
+	// Check for an existing identical apply argument to deduplicate.
+	// This avoids generating unnecessary Promise.all / pulumi.all / Output.All
+	// when the same output or promise is referenced multiple times.
+	var callbackParam *model.Variable
+	for i, existing := range ctx.applyArgs {
+		if applyArgsEqual(existing, applyArg) {
+			callbackParam = ctx.callbackParams[i]
+			break
+		}
 	}
 
-	ctx.applyArgs, ctx.callbackParams = append(ctx.applyArgs, applyArg), append(ctx.callbackParams, callbackParam)
+	if callbackParam == nil {
+		callbackParam = &model.Variable{
+			Name:         fmt.Sprintf("<arg%d>", len(ctx.callbackParams)),
+			VariableType: paramType,
+		}
+		ctx.applyArgs, ctx.callbackParams = append(ctx.applyArgs, applyArg), append(ctx.callbackParams, callbackParam)
+	}
 
 	// TODO(pdg): this risks information loss for nested output-typed properties... The `Types` array on traversals
 	// ought to store the original types.
@@ -483,8 +536,6 @@ func (ctx *observeContext) rewriteScopeTraversalExpression(expr *model.ScopeTrav
 	}
 
 	// Otherwise, append the access to the list of apply arguments and return an appropriate call to __applyArg.
-	//
-	// TODO: deduplicate multiple accesses to the same variable and field.
 
 	// Compute the type of the apply and callback arguments.
 	var applyArg *model.ScopeTraversalExpression

--- a/pkg/codegen/pcl/rewrite_apply_test.go
+++ b/pkg/codegen/pcl/rewrite_apply_test.go
@@ -141,6 +141,20 @@ func TestApplyRewriter(t *testing.T) {
 			input:  `resource.boolOutput ? "yes" : "no"`,
 			output: `__apply(resource.boolOutput, eval(boolOutput, boolOutput ? "yes" : "no"))`,
 		},
+		// Test deduplication of identical apply arguments (pulumi/pulumi#4635).
+		{
+			input:  `"v: ${resource.stringOutput} ${resource.stringOutput}"`,
+			output: `__apply(resource.stringOutput,eval(stringOutput, "v: ${stringOutput} ${stringOutput}"))`,
+		},
+		{
+			input:  `"v: ${resource.objectOutput.stringPlain} ${resource.objectOutput.stringPlain}"`,
+			output: `__apply(resource.objectOutput,eval(objectOutput, "v: ${objectOutput.stringPlain} ${objectOutput.stringPlain}"))`,
+		},
+		// Different outputs from the same resource should NOT be deduplicated.
+		{
+			input:  `"v: ${resource.stringOutput} ${resource.boolOutput}"`,
+			output: `__apply(resource.stringOutput, resource.boolOutput,eval(stringOutput, boolOutput, "v: ${stringOutput} ${boolOutput}"))`,
+		},
 	}
 
 	resourceType := model.NewObjectType(map[string]model.Type{


### PR DESCRIPTION
When the same output or promise was referenced multiple times in an
expression, the apply rewriter would add it as a separate argument each
time. This caused downstream code generators to emit unnecessary
Promise.all / pulumi.all / Output.All / Output.Tuple calls wrapping
duplicate references to the same value.

These changes fix rewriteApplyArg to check for equivalent apply
arguments. Equivalency checks validate that the root of each traversal
binds to the same entity, then checks that the traversal expressions
are lexically equivalent.

Fixes #4635.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
