### PR TITLE
Don't apply the secrets filter to true and false

### DIFF
--- a/changelog/pending/20260319--cli--dont-apply-the-secrets-filter-to-true-and-false.yaml
+++ b/changelog/pending/20260319--cli--dont-apply-the-secrets-filter-to-true-and-false.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Don't apply the secrets filter to `true` and `false` (case-insensitive)

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -182,6 +182,9 @@ func CreateFilter(secrets []string, replacement string) Filter {
 		if len(secret) < 3 {
 			continue
 		}
+		if strings.EqualFold(secret, "true") || strings.EqualFold(secret, "false") {
+			continue
+		}
 		items = append(items, secret, replacement)
 
 		// Catch secrets that are serialized to JSON.

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -83,4 +83,12 @@ func TestFilter(t *testing.T) {
 	assert.Equal(t,
 		"These are my secrets: [secret]",
 		msg6)
+
+	// Boolean strings "true" and "false" are not masked, regardless of case.
+	filter7 := CreateFilter([]string{"true", "false", "True", "FALSE", "realsecret"}, "[secret]")
+	msg7 := filter7.Filter(
+		"value is True and FALSE but realsecret is hidden")
+	assert.Equal(t,
+		"value is True and FALSE but [secret] is hidden",
+		msg7)
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -206,9 +206,6 @@ func testLanguage(t *testing.T, runtime string, forceTsc bool) {
 								"On linux bun has trouble resolving indirect dependencies that point to a local file" +
 									"https://github.com/pulumi/pulumi/issues/22100")
 						}
-						if strings.HasPrefix(tt, "policy-") {
-							t.Skip("Policy tests are intermittently failing on bun, printing values as [[secret]]")
-						}
 					}
 
 					if expected, ok := expectedFailures[tt]; ok {


### PR DESCRIPTION
This is causing more confusion than it helps, and causes issues in tests. I don’t think true or false are very secret values. CircleCI also does this https://github.com/circleci/circleci-docs/blob/main/docs/guides/modules/ROOT/partials/shared-sections/secrets-masking.adoc, so we're in good company here.