### PR TITLE
Improve traces for newPlugin

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -202,7 +202,8 @@ func newDeployment(
 
 	// Create a context for plugins.
 	debugContext := newDebugContext(opts.Events, opts.AttachDebugger)
-	pwd, main, plugctx, err := ProjectInfoContext(ctx.Cancel.Base(), projinfo, opts.Host,
+	baseCtx := trace.ContextWithSpan(ctx.Cancel.Base(), info.otelSpan)
+	pwd, main, plugctx, err := ProjectInfoContext(baseCtx, projinfo, opts.Host,
 		opts.Diag, opts.StatusDiag, debugContext, opts.DisableProviderPreview, info.TracingSpan, config)
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -81,6 +81,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 		}
 
 		conn, handshakeResponse, err := dialPlugin(
+			ctx.Base(),
 			port,
 			"pulumi-language-"+runtime,
 			runtime+" (Language Plugin)",

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -39,6 +39,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -169,6 +170,7 @@ var errRunPolicyModuleNotFound = errors.New("pulumi SDK does not support policy 
 var errPluginNotFound = errors.New("plugin not found")
 
 func dialPlugin[T any](
+	ctx context.Context,
 	portNum int,
 	bin string,
 	prefix string,
@@ -192,7 +194,7 @@ func dialPlugin[T any](
 	// TODO[pulumi/pulumi#337]: in theory, this should be unnecessary.  gRPC's default WaitForReady behavior
 	//     should auto-retry appropriately.  On Linux, however, we are observing different behavior.  In the meantime
 	//     while this bug exists, we'll simply do a bit of waiting of our own up front.
-	timeout, cancel := context.WithTimeout(context.Background(), pluginRPCConnectionTimeout)
+	timeout, cancel := context.WithTimeout(ctx, pluginRPCConnectionTimeout)
 	defer cancel()
 	for {
 		s := conn.GetState()
@@ -227,7 +229,10 @@ func dialPlugin[T any](
 	return conn, handshakeRes, nil
 }
 
-func testConnection(ctx context.Context, bin string, prefix string, conn *grpc.ClientConn) (*struct{}, error) {
+func testConnection(ctx context.Context, bin string, prefix string, conn *grpc.ClientConn) (_ *struct{}, retErr error) {
+	ctx, span := otel.Tracer("pulumi-cli").Start(ctx, "testConnection")
+	defer span.End()
+
 	err := conn.Invoke(ctx, "", nil, nil)
 	if err != nil {
 		status, ok := status.FromError(err)
@@ -249,7 +254,7 @@ func newPlugin[T any](
 	handshake func(context.Context, string, string, *grpc.ClientConn) (*T, error),
 	dialOptions []grpc.DialOption,
 	attachDebugger bool,
-) (*Plugin, *T, error) {
+) (_ *Plugin, _ *T, retErr error) {
 	if logging.V(9) {
 		var argstr strings.Builder
 		for i, arg := range args {
@@ -274,13 +279,21 @@ func newPlugin[T any](
 	defer tracingSpan.Finish()
 
 	tracer := otel.Tracer("pulumi-cli")
-	_, otelSpan := cmdutil.StartSpan(context.Background(), tracer, "newPlugin",
+	_, otelSpan := cmdutil.StartSpan(ctx.Base(), tracer, "newPlugin",
 		trace.WithAttributes(
 			attribute.String("prefix", prefix),
 			attribute.String("bin", bin),
+			attribute.String("kind", string(kind)),
+			attribute.Bool("attachDebugger", attachDebugger),
 			attribute.String("pulumi-decorator", prefix+":"+bin),
 		))
-	defer otelSpan.End()
+	defer func() {
+		if retErr != nil {
+			otelSpan.SetStatus(otelcodes.Error, retErr.Error())
+			otelSpan.RecordError(retErr)
+		}
+		otelSpan.End()
+	}()
 
 	// Try to execute the binary.
 	plug, err := ExecPlugin(ctx, bin, prefix, kind, args, pwd, env, attachDebugger)
@@ -416,7 +429,8 @@ func newPlugin[T any](
 	plug.stdoutDone = stdoutDone
 	go runtrace(plug.Stdout, outStreamID, stdoutDone)
 
-	conn, handshakeRes, err := dialPlugin(port, bin, prefix, handshake, dialOptions)
+	dialCtx := trace.ContextWithSpan(ctx.Base(), otelSpan)
+	conn, handshakeRes, err := dialPlugin(dialCtx, port, bin, prefix, handshake, dialOptions)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sdk/go/common/resource/plugin/plugin_test.go
+++ b/sdk/go/common/resource/plugin/plugin_test.go
@@ -130,7 +130,7 @@ func TestHealthCheck(t *testing.T) {
 			return &foo{}, nil
 		}
 
-		conn, _, err := dialPlugin(port, "test", "test", handshake, []grpc.DialOption{
+		conn, _, err := dialPlugin(t.Context(), port, "test", "test", handshake, []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		})
 		require.NoError(t, err)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -205,7 +205,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 		}
 
 		var conn *grpc.ClientConn
-		conn, handshakeRes, err = dialPlugin(port, pkg.String(), prefix,
+		conn, handshakeRes, err = dialPlugin(ctx.Base(), port, pkg.String(), prefix,
 			handshake, providerPluginDialOptions(ctx, pkg, ""))
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/util/rpcutil/interceptor.go
+++ b/sdk/go/common/util/rpcutil/interceptor.go
@@ -349,6 +349,9 @@ func otelStreamClientInterceptor() grpc.StreamClientInterceptor {
 func startClientSpan(ctx context.Context, method, target string) (context.Context, trace.Span) {
 	// Parse method name: "/package.Service/Method" -> "package.Service/Method"
 	name := strings.TrimPrefix(method, "/")
+	if name == "" {
+		name = "<empty method>"
+	}
 
 	var attrs []attribute.KeyValue
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {


### PR DESCRIPTION
Now that we have OTEL tracing in place, I was looking a bit at the traces and found a couple small things to improve.

This PR ensures newPlugin is parented to the deployment context, and the handshake is parented to the appropriate newPlugin call.

<img width="777" height="204" alt="Screenshot 2026-03-20 at 08 54 30" src="https://github.com/user-attachments/assets/8f54f404-e495-4b4e-b4ee-738706ea3c5d" />