### PR TITLE
Use ResourceRefernce.Name and Type instead of URN parsing in NodeJS and Python where possible

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -788,12 +788,17 @@ export function deserializeProperty(prop: any, keepUnknowns?: boolean): any {
                     const urn = prop["urn"];
                     const version = prop["packageVersion"];
 
-                    const urnParts = urn.split("::");
-                    const qualifiedType = urnParts[2];
-                    const urnName = urnParts[3];
-
-                    const type = qualifiedType.split("$").pop()!;
-                    const typeParts = type.split(":");
+                    // New engines send type and name as distinct fields
+                    let urnType = prop["type"];
+                    let urnName = prop["name"];
+                    // Old engines don't and we have to parse the URN.
+                    if (urnName === undefined || urnType === undefined) {
+                        const urnParts = urn.split("::");
+                        const qualifiedType = urnParts[2];
+                        urnName = urnParts[3];
+                        urnType = qualifiedType.split("$").pop()!;
+                    }
+                    const typeParts = urnType.split(":");
                     const pkgName = typeParts[0];
                     const modName = typeParts.length > 1 ? typeParts[1] : "";
                     const typName = typeParts.length > 2 ? typeParts[2] : "";
@@ -802,12 +807,12 @@ export function deserializeProperty(prop: any, keepUnknowns?: boolean): any {
                     if (isProvider) {
                         const resourcePackage = getResourcePackage(typName, version);
                         if (resourcePackage) {
-                            return resourcePackage.constructProvider(urnName, type, urn);
+                            return resourcePackage.constructProvider(urnName, urnType, urn);
                         }
                     } else {
                         const resourceModule = getResourceModule(pkgName, modName, version);
                         if (resourceModule) {
-                            return resourceModule.construct(urnName, type, urn);
+                            return resourceModule.construct(urnName, urnType, urn);
                         }
                     }
 

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -497,6 +497,33 @@ describe("runtime", () => {
             assert.ok((<CustomResource>deserialized["custom"]).__pulumiCustomResource);
             assert.deepEqual(deserialized["unregistered"], unregisteredID);
         });
+        it("deserializes resource references using explicit name and type", async () => {
+            runtime.setMocks(new TestMocks());
+            state.getStore().supportsResourceReferences = true;
+            runtime.registerResourceModule("test", "index", new TestResourceModule());
+
+            const custom = new TestCustomResource("test");
+            const customURN = await custom.urn.promise();
+            const customID = await custom.id.promise();
+
+            const outputs = {
+                custom: {
+                    [runtime.specialSigKey]: runtime.specialResourceSig,
+                    urn: customURN,
+                    id: customID,
+                    name: "name::from::field",
+                    type: "test:index:custom",
+                },
+            };
+
+            const deserialized = runtime.deserializeProperty(outputs);
+            const customRef = <CustomResource>deserialized["custom"];
+
+            assert.ok(customRef.__pulumiCustomResource);
+            assert.strictEqual(customRef.__name, "name::from::field");
+            assert.strictEqual(customRef.__pulumiType, "test:index:custom");
+            assert.strictEqual(await customRef.urn.promise(), customURN);
+        });
     });
 
     describe("serialization errors", () => {

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -983,12 +983,20 @@ def deserialize_resource(
         str(ref_struct["packageVersion"]) if "packageVersion" in ref_struct else ""
     )
 
-    urn_parts = urn_util._parse_urn(urn)
-    urn_name = urn_parts.urn_name
-    typ = urn_parts.typ
-    pkg_name = urn_parts.pkg_name
-    mod_name = urn_parts.mod_name
-    typ_name = urn_parts.typ_name
+    # New engines send type and name as distinct fields.
+    urn_name = str(ref_struct["name"]) if "name" in ref_struct else None
+    typ = str(ref_struct["type"]) if "type" in ref_struct else None
+
+    # Old engines don't and we have to parse the URN.
+    if urn_name is None or typ is None:
+        urn_parts = urn_util._parse_urn(urn)
+        urn_name = urn_parts.urn_name
+        typ = urn_parts.typ
+
+    typ_parts = typ.split(":")
+    pkg_name = typ_parts[0]
+    mod_name = typ_parts[1] if len(typ_parts) > 1 else ""
+    typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
 
     is_provider = pkg_name == "pulumi" and mod_name == "providers"
     if is_provider:

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -1148,6 +1148,48 @@ class NextSerializationTests(unittest.IsolatedAsyncioTestCase):
 
 
 class DeserializationTests(unittest.TestCase):
+    def test_deserialize_resource_reference_uses_explicit_name_and_type(self):
+        urn = "urn:pulumi:stack::project::test:index:resource::legacy-name"
+        expected = object()
+        resource_module = unittest.mock.Mock()
+        resource_module.construct.return_value = expected
+
+        ref = struct_pb2.Struct()
+        ref[rpc._special_sig_key] = rpc._special_resource_sig
+        ref["urn"] = urn
+        ref["name"] = "name::from::field"
+        ref["type"] = "test:index:resource"
+
+        with unittest.mock.patch(
+            "pulumi.runtime.rpc.get_resource_module", return_value=resource_module
+        ):
+            actual = rpc.deserialize_property(ref)
+
+        self.assertIs(actual, expected)
+        resource_module.construct.assert_called_once_with(
+            "name::from::field", "test:index:resource", urn
+        )
+
+    def test_deserialize_resource_reference_falls_back_to_urn(self):
+        urn = "urn:pulumi:stack::project::test:index:resource::name-from-urn"
+        expected = object()
+        resource_module = unittest.mock.Mock()
+        resource_module.construct.return_value = expected
+
+        ref = struct_pb2.Struct()
+        ref[rpc._special_sig_key] = rpc._special_resource_sig
+        ref["urn"] = urn
+
+        with unittest.mock.patch(
+            "pulumi.runtime.rpc.get_resource_module", return_value=resource_module
+        ):
+            actual = rpc.deserialize_property(ref)
+
+        self.assertIs(actual, expected)
+        resource_module.construct.assert_called_once_with(
+            "name-from-urn", "test:index:resource", urn
+        )
+
     def test_unsupported_sig(self):
         struct = struct_pb2.Struct()
         struct[rpc._special_sig_key] = "foobar"


### PR DESCRIPTION
In a recent update we changed the engine to start sending Name and Type as separate fields in ResourceReference values. This was intended so we could stop doing URN parsing to get those values, with the long term goal to change URN format. This is the next little step, where we change NodeJS and Python to use those new fields iff they're set. If they're blank we'll continue to fall back to URN parsing for now.