### PR TITLE
Add grpcs:// support and header authentication to OTLP exporter

### DIFF
--- a/changelog/pending/20260323--cli--add-grpcs-support-and-header-authentication-to-otlp-exporter.yaml
+++ b/changelog/pending/20260323--cli--add-grpcs-support-and-header-authentication-to-otlp-exporter.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add grpcs:// support and header authentication to OTLP exporter

--- a/sdk/go/common/util/otelreceiver/exporter.go
+++ b/sdk/go/common/util/otelreceiver/exporter.go
@@ -26,6 +26,19 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
+func headersFromQuery(q url.Values) map[string]string {
+	if len(q) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(q))
+	for k, vs := range q {
+		if len(vs) > 0 {
+			m[k] = vs[0]
+		}
+	}
+	return m
+}
+
 type SpanExporter interface {
 	// ExportSpans exports the given resource spans.
 	ExportSpans(ctx context.Context, spans []*tracepb.ResourceSpans) error
@@ -36,8 +49,13 @@ type SpanExporter interface {
 // NewExporter creates a SpanExporter based on the endpoint URL.
 // Supported schemes:
 //   - file:// - writes OTLP JSON to a local file
-//   - grpc:// - sends OTLP via gRPC
-//   - no scheme - defaults to gRPC
+//   - grpc:// - sends OTLP via insecure gRPC (local collectors)
+//   - grpcs:// - sends OTLP via TLS-secured gRPC with optional header auth
+//
+// grpc:// and grpcs:// support passing arbitrary gRPC metadata headers as
+// URL query parameters:
+//
+//	grpcs://api.honeycomb.io:443?x-honeycomb-team=YOUR_API_KEY
 func NewExporter(endpoint string) (SpanExporter, error) {
 	if endpoint == "" {
 		return nil, errors.New("endpoint is required")
@@ -61,10 +79,21 @@ func NewExporter(endpoint string) (SpanExporter, error) {
 		if host == "" {
 			return nil, errors.New("host is required for grpc:// endpoint")
 		}
-		return newGRPCExporter(host)
+		return newGRPCExporterWithOptions(grpcExporterOptions{
+			target:  host,
+			headers: headersFromQuery(u.Query()),
+		})
 
-	case "":
-		return newGRPCExporter(endpoint)
+	case "grpcs":
+		host := u.Host
+		if host == "" {
+			return nil, errors.New("host is required for grpcs:// endpoint")
+		}
+		return newGRPCExporterWithOptions(grpcExporterOptions{
+			target:  host,
+			tls:     true,
+			headers: headersFromQuery(u.Query()),
+		})
 
 	default:
 		return nil, fmt.Errorf("unsupported endpoint scheme: %s", u.Scheme)

--- a/sdk/go/common/util/otelreceiver/exporter_test.go
+++ b/sdk/go/common/util/otelreceiver/exporter_test.go
@@ -15,6 +15,7 @@
 package otelreceiver
 
 import (
+	"net/url"
 	"os/user"
 	"path/filepath"
 	"runtime"
@@ -65,5 +66,77 @@ func TestResolveFilePath(t *testing.T) {
 		t.Parallel()
 		_, err := resolveFilePath("file://")
 		require.Error(t, err)
+	})
+}
+
+func TestHeadersFromQuery(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("grpcs://api.honeycomb.io:443?x-some-header=abc123&other-header=banana")
+	require.NoError(t, err)
+	result := headersFromQuery(u.Query())
+	require.NotNil(t, result)
+	require.Equal(t, "abc123", result["x-some-header"])
+	require.Equal(t, "banana", result["other-header"])
+}
+
+func TestNewExporterSchemes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty endpoint returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("")
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported scheme returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("https://example.com")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported endpoint scheme")
+	})
+
+	t.Run("grpc:// scheme requires a host", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("grpc://")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "host is required")
+	})
+
+	t.Run("grpcs:// scheme requires a host", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewExporter("grpcs://")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "host is required")
+	})
+
+	t.Run("grpc:// creates exporter", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("grpc://localhost:4317")
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+
+	t.Run("grpc:// exporter carries headers", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("grpc://localhost:4317?x-my-header=myvalue")
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+		grpcExp, ok := exp.(*GRPCExporter)
+		require.True(t, ok, "expected *GRPCExporter")
+		require.Equal(t, []string{"myvalue"}, grpcExp.headers["x-my-header"])
+		_ = exp.Shutdown(t.Context())
+	})
+
+	t.Run("grpcs:// exporter carries headers", func(t *testing.T) {
+		t.Parallel()
+		exp, err := NewExporter("grpcs://api.example.com:443?x-api-key=testkey")
+		require.NoError(t, err)
+		require.NotNil(t, exp)
+		grpcExp, ok := exp.(*GRPCExporter)
+		require.True(t, ok, "expected *GRPCExporter")
+		require.Equal(t, []string{"testkey"}, grpcExp.headers["x-api-key"])
+		require.NoError(t, exp.Shutdown(t.Context()))
 	})
 }

--- a/sdk/go/common/util/otelreceiver/grpc_exporter.go
+++ b/sdk/go/common/util/otelreceiver/grpc_exporter.go
@@ -16,40 +16,71 @@ package otelreceiver
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 // GRPCExporter sends spans to an OTLP gRPC collector.
 type GRPCExporter struct {
-	conn   *grpc.ClientConn
-	client coltracepb.TraceServiceClient
+	conn    *grpc.ClientConn
+	client  coltracepb.TraceServiceClient
+	headers metadata.MD
 }
 
-func newGRPCExporter(target string) (*GRPCExporter, error) {
-	target = strings.TrimPrefix(target, "grpc://")
+type grpcExporterOptions struct {
+	// target is the gRPC dial target (host:port).
+	target string
+	// tls enables TLS on the connection
+	tls bool
+	// headers are additional key-value pairs sent as gRPC metadata on every export call
+	headers map[string]string
+}
 
-	conn, err := grpc.NewClient(target,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+func newGRPCExporterWithOptions(opts grpcExporterOptions) (*GRPCExporter, error) {
+	target := strings.TrimPrefix(opts.target, "grpc://")
+	target = strings.TrimPrefix(target, "grpcs://")
+
+	var dialOpts []grpc.DialOption
+	if opts.tls {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			MinVersion: tls.VersionTLS12,
+		})))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conn, err := grpc.NewClient(target, dialOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to OTLP collector: %w", err)
 	}
 
+	var md metadata.MD
+	if len(opts.headers) > 0 {
+		md = metadata.New(opts.headers)
+	}
+
 	return &GRPCExporter{
-		conn:   conn,
-		client: coltracepb.NewTraceServiceClient(conn),
+		conn:    conn,
+		client:  coltracepb.NewTraceServiceClient(conn),
+		headers: md,
 	}, nil
 }
 
 func (e *GRPCExporter) ExportSpans(ctx context.Context, spans []*tracepb.ResourceSpans) error {
 	if len(spans) == 0 {
 		return nil
+	}
+
+	if len(e.headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, e.headers)
 	}
 
 	req := &coltracepb.ExportTraceServiceRequest{


### PR DESCRIPTION
Add a grpcs:// URL scheme to NewExporter that creates a TLS gRPC exporter. Both grpc:// and grpcs:// now support passing arbitrary gRPC metadata headers as URL query parameters, so we can send add an API key header:

```
export HONEYCOMB_API_KEY=<the key...>
pulumi up --otel-traces "grpcs://api.honeycomb.io:443?x-honeycomb-team=$HONEYCOMB_API_KEY
```