### PR TITLE
fix(sdk/go/pulumi-language-go/goversion): handle non-standard toolchains

### DIFF
--- a/sdk/go/pulumi-language-go/goversion/version.go
+++ b/sdk/go/pulumi-language-go/goversion/version.go
@@ -44,6 +44,8 @@ func checkMinimumGoVersion(goVersionOutput string) error {
 	}
 	version := strings.TrimSpace(split[2])
 	version = strings.TrimPrefix(version, "go")
+	// Handle non-standard toolchains (https://go.dev/doc/toolchain#name)
+	version = strings.Split(version, "-")[0]
 
 	currVersion, err := goVersion.NewVersion(version)
 	if err != nil {

--- a/sdk/go/pulumi-language-go/goversion/version_test.go
+++ b/sdk/go/pulumi-language-go/goversion/version_test.go
@@ -42,6 +42,10 @@ func Test_checkMinimumGoVersion(t *testing.T) {
 			goVersionOutput: "go version go1.18beta2 darwin/amd64",
 		},
 		{
+			name:            "Non-standard toolchain",
+			goVersionOutput: "go version go1.26.1-X:nodwarf5 linux/amd64",
+		},
+		{
 			name:            "OlderGoVersion",
 			goVersionOutput: "go version go1.13.8 linux/amd64",
 			err:             "go version must be 1.14.0 or higher (1.13.8 detected)",


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->
Currently, Pulumi fails when using a non-standard Go toolchain (https://go.dev/doc/toolchain#name). For example, on Fedora 44:
```
error: failed to discover package requirements: parsing go version: Malformed version: 1.26.1-X:nodwarf5
```
This change fixes this error.

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [NA] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [NA] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [NA] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean (not clean, but nothing regarding my change)
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format_fix` — clean (ran `make format`, `format_fix` target does not seem to exist)
- [NA] Relevant SDK tests pass (if SDK changes)
- [NA] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [NA] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->
I don’t think there are risks.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
