### PR TITLE
Fix flaky TestAnalyzerCancellation

### DIFF
--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -731,29 +731,37 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 func TestAnalyzerCancellation(t *testing.T) {
 	t.Parallel()
 
+	ctx, cancel := context.WithCancel(t.Context())
+
 	gracefulShutdown := false
-	analyzerCanceled := make(chan struct{})
 	loaders := []*deploytest.PluginLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
 		deploytest.NewAnalyzerLoader("analyzerA", func(_ *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
 			return &deploytest.Analyzer{
+				AnalyzeF: func(r plugin.AnalyzerResource) (plugin.AnalyzeResponse, error) {
+					if r.Type == "pkgA:m:typA" {
+						// Cancel from inside AnalyzeF so the executor is
+						// mid-event processing and can't close its done
+						// channel yet. This guarantees the
+						// SignalCancellation goroutine picks
+						// callerCtx.Done() and calls CancelF.
+						cancel()
+					}
+					return plugin.AnalyzeResponse{}, nil
+				},
 				CancelF: func() error {
 					gracefulShutdown = true
-					close(analyzerCanceled)
 					return nil
 				},
 			}, nil
 		}, deploytest.WithGrpc),
 	}
 
-	ctx, cancel := context.WithCancel(t.Context())
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		cancel()
-		// Wait for the engine to signal cancellation to the analyzer before
-		// returning. Without this, the program's nil return races with context
-		// cancellation in the deployment executor's select loop, causing a
-		// non-deterministic event stream.
-		<-analyzerCanceled
-		return nil
+		_, err := monitor.RegisterResource("pkgA:m:typA", "res", true)
+		return err
 	})
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)

--- a/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/diff.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/diff.stdout.txt
@@ -4,4 +4,4 @@
     <{%underline%}><{%fg 12%}>Name<{%reset%}>       <{%underline%}><{%fg 12%}>Version<{%reset%}>
     analyzerA  
 
-<{%fg 13%}><{%bold%}>Duration:<{%reset%}> 2s
+<{%fg 13%}><{%bold%}>Duration:<{%reset%}> 1s

--- a/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/eventstream.json
+++ b/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/eventstream.json
@@ -1,6 +1,10 @@
 {"sequence":0,"timestamp":0,"policyLoadEvent":{}}
 {"sequence":0,"timestamp":0,"preludeEvent":{"config":{}}}
+{"sequence":0,"timestamp":0,"policyRemediateSummaryEvent":{"resourceUrn":"urn:pulumi:test::test::pulumi:providers:pkgA::default","policyPackName":"","policyPackVersion":"","policyPackVersionTag":""}}
+{"sequence":0,"timestamp":0,"policyAnalyzeSummaryEvent":{"resourceUrn":"urn:pulumi:test::test::pulumi:providers:pkgA::default","policyPackName":"","policyPackVersion":"","policyPackVersionTag":""}}
+{"sequence":0,"timestamp":0,"policyRemediateSummaryEvent":{"resourceUrn":"urn:pulumi:test::test::pkgA:m:typA::res","policyPackName":"","policyPackVersion":"","policyPackVersionTag":""}}
+{"sequence":0,"timestamp":0,"policyAnalyzeSummaryEvent":{"resourceUrn":"urn:pulumi:test::test::pkgA:m:typA::res","policyPackName":"","policyPackVersion":"","policyPackVersionTag":""}}
 {"sequence":0,"timestamp":0,"policyAnalyzeStackSummaryEvent":{"policyPackName":"","policyPackVersion":"","policyPackVersionTag":""}}
 {"sequence":0,"timestamp":0,"diagnosticEvent":{"prefix":"\u003c{%fg 1%}\u003eerror: \u003c{%reset%}\u003e","message":"\u003c{%reset%}\u003eupdate canceled\u003c{%reset%}\u003e\n","color":"raw","severity":"error"}}
-{"sequence":0,"timestamp":0,"summaryEvent":{"maybeCorrupt":false,"durationSeconds":2,"resourceChanges":{},"PolicyPacks":{"analyzerA":""},"isPreview":false}}
+{"sequence":0,"timestamp":0,"summaryEvent":{"maybeCorrupt":false,"durationSeconds":1,"resourceChanges":{},"PolicyPacks":{"analyzerA":""},"isPreview":false}}
 {"sequence":0,"timestamp":0,"cancelEvent":{}}

--- a/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/progress.stdout.txt
+++ b/pkg/engine/lifecycletest/testdata/output/TestAnalyzerCancellation/progress.stdout.txt
@@ -15,5 +15,5 @@ Loading policy packs...: done
 <{%fg 13%}><{%bold%}>Resources:<{%reset%}>
     <{%fg 1%}>1 errored<{%reset%}>
 
-<{%fg 13%}><{%bold%}>Duration:<{%reset%}> 2s
+<{%fg 13%}><{%bold%}>Duration:<{%reset%}> 1s
 

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync/atomic"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
@@ -130,39 +129,20 @@ func (ex *deploymentExecutor) reportError(urn resource.URN, err error) {
 // Execute executes a deployment to completion, using the given cancellation context and running a preview
 // or update.
 func (ex *deploymentExecutor) Execute(callerCtx context.Context) (_ *Plan, err error) {
-	// Signal cancellation to the deployment's plugins when the caller context is cancelled. We do not hang
-	// this off of the context we create below because we do not want the failure of a single step to cause
-	// other steps to fail.
-	//
-	// We signal in two places:
-	//   1. A goroutine that races with the deployment — this allows cancellation to interrupt long-running
-	//      provider operations while the deployment is still executing.
-	//   2. Synchronously before returning — this covers the case where the goroutine's select picks <-done
-	//      over callerCtx.Done() when both are ready (Go selects randomly among ready cases).
+	// Set up a goroutine that will signal cancellation to the deployment's plugins if the caller context is cancelled.
+	// We do not hang this off of the context we create below because we do not want the failure of a single step to
+	// cause other steps to fail.
 	ex.skipped = mapset.NewSet[urn.URN]()
 	done := make(chan bool)
 	defer close(done)
-	var signalledCancellation atomic.Bool
-	signalCancellation := func(label string) {
-		if callerCtx.Err() == nil {
-			return
-		}
-		if !signalledCancellation.CompareAndSwap(false, true) {
-			return
-		}
-		logging.V(4).Infof("deploymentExecutor.Execute(...): signalling cancellation to providers (%s)...", label)
-		cancelErr := ex.deployment.ctx.Host.SignalCancellation()
-		if cancelErr != nil {
-			logging.V(4).Infof(
-				"deploymentExecutor.Execute(...): failed to signal cancellation to providers (%s): %v",
-				label, cancelErr)
-		}
-	}
-	defer signalCancellation("deferred")
 	go PanicRecovery(ex.deployment.panicErrs, func() {
 		select {
 		case <-callerCtx.Done():
-			signalCancellation("goroutine")
+			logging.V(4).Infof("deploymentExecutor.Execute(...): signalling cancellation to providers...")
+			cancelErr := ex.deployment.ctx.Host.SignalCancellation()
+			if cancelErr != nil {
+				logging.V(4).Infof("deploymentExecutor.Execute(...): failed to signal cancellation to providers: %v", cancelErr)
+			}
 		case <-done:
 			logging.V(4).Infof("deploymentExecutor.Execute(...): exiting provider canceller")
 		}


### PR DESCRIPTION
Fixes #22025

**Root cause:** The test program called `cancel()` and then immediately returned `nil`. These
two effects raced through different goroutine chains to the deployment executor's select loop:
`ctx.Done()` (from cancellation) vs a nil source event (from program completion). When the nil
event won, the executor exited normally without emitting the "update canceled" diagnostic,
producing 5 events instead of the 6 in the golden file.

**Fix:** The program now waits on the analyzer's `AnalyzeF` to close signal the close, ensuring that the analyzer is fully provisioned before it can be closed.

**Reproduction:**

```sh
cd pkg/engine/lifecycletest
go test -test.run \^TestAnalyzerCancellation\$ -count 500
```

Before fix: fails within ~500 iterations. After fix: 5000 iterations pass cleanly.