### PR TITLE
fix(backend/service): deployment run event truncation

### DIFF
--- a/changelog/pending/20260324--backend-service--fix-deployment-run-event-truncation.yaml
+++ b/changelog/pending/20260324--backend-service--fix-deployment-run-event-truncation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/service
+  description: deployment run event truncation

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2466,7 +2466,7 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 				// find the associated update and show the normal rendering of the operation's events.
 				if l.Header == fmt.Sprintf("pulumi %v", req.Op) {
 					fmt.Println()
-					return b.showDeploymentEvents(ctx, stackID, apitype.UpdateKind(req.Op), id, opts)
+					return b.showDeploymentEvents(ctx, stackID, apitype.UpdateKind(req.Op), id, opts, logs.NextToken)
 				}
 			} else {
 				fmt.Print(l.Line)
@@ -2491,6 +2491,7 @@ func (b *cloudBackend) RunDeployment(ctx context.Context, stackRef backend.Stack
 
 func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.StackIdentifier,
 	kind apitype.UpdateKind, deploymentID string, opts display.Options,
+	deploymentLogsToken string,
 ) error {
 	getUpdateID := func() (string, int, error) {
 		for tries := 0; tries < 10; tries++ {
@@ -2548,9 +2549,33 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 		}
 
 		continuationToken = resp.ContinuationToken
-		// A nil continuation token means there are no more events to read and the update has finished.
+		// A nil continuation token normally means there are no more events and the update has
+		// finished. However, when using deployment run, there is a race where the local CLI
+		// queries for events before the deployment executor has written any. In that case, the
+		// service prematurely marks the update as having no events ("NoState"), and every
+		// subsequent call returns empty + nil. When that batch was empty, check whether the
+		// deployment is still alive before concluding — if it is, retry so the executor has
+		// time to write its events and clear the NoState marker.
 		if continuationToken == nil {
-			// If the event stream does not terminate with a cancel event, synthesize one here.
+			if len(resp.Events) == 0 {
+				// Check whether the deployment is still running. This is best-effort: if the
+				// logs API call fails, fall through and treat the update as done rather than
+				// propagating a new failure mode for an otherwise-successful deployment.
+				logs, logsErr := b.client.GetDeploymentLogs(ctx, stackID, deploymentID, deploymentLogsToken)
+				if logsErr == nil && logs.NextToken != "" {
+					// Deployment is still in progress. Advance the logs cursor and retry.
+					deploymentLogsToken = logs.NextToken
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+			}
+
+			// NOTE: There is no hard retry limit here. The ctx deadline/cancellation serves as
+			// the ultimate timeout for long-running deployments. The 500ms sleep above bounds
+			// throughput to ~2 checks/sec.
+
+			// The update has finished (or we could not check). Synthesize a cancel event if
+			// the event stream did not end with one naturally.
 			if lastEvent.Type != engine.CancelEvent {
 				events <- engine.NewCancelEvent()
 			}

--- a/pkg/backend/httpstate/deployment_run_test.go
+++ b/pkg/backend/httpstate/deployment_run_test.go
@@ -1,0 +1,270 @@
+// Copyright 2016, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cancelEngineEvent constructs a minimal cancel engine event for tests.
+func cancelEngineEvent(seq int) apitype.EngineEvent {
+	return apitype.EngineEvent{
+		Sequence:    seq,
+		Timestamp:   0,
+		CancelEvent: &apitype.CancelEvent{},
+	}
+}
+
+// mustJSON marshals v to JSON bytes, panicking on error (test helper only).
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// TestShowDeploymentEvents_RaceConditionRetries verifies that showDeploymentEvents retries
+// GetUpdateEngineEvents when the first call returns empty+nil (the NoState race condition)
+// while GetDeploymentLogs reports the deployment is still running (NextToken != "").
+func TestShowDeploymentEvents_RaceConditionRetries(t *testing.T) {
+	t.Parallel()
+
+	const (
+		org       = "myorg"
+		project   = "myproject"
+		stack     = "mystack"
+		deployID  = "deploy-1"
+		updateID  = "update-1"
+		logsToken = "log-cursor-after-header" //nolint:gosec // not a credential, just a pagination cursor
+	)
+
+	var eventsCallCount atomic.Int32
+	var logsCallCount atomic.Int32
+
+	transport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			writeJSON := func(v any) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(mustJSON(v)))),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/updates", deployID)):
+				return writeJSON([]apitype.GetDeploymentUpdatesUpdateInfo{
+					{UpdateID: updateID, Version: 1},
+				})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/update/%s/events", updateID)):
+				n := eventsCallCount.Add(1)
+				if n == 1 {
+					// Simulate the NoState race: no events yet, nil continuation token.
+					return writeJSON(apitype.GetUpdateEventsResponse{})
+				}
+				// Second call: executor has written events and cleared NoState.
+				return writeJSON(apitype.GetUpdateEventsResponse{
+					Events: []apitype.EngineEvent{cancelEngineEvent(1)},
+				})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/logs", deployID)):
+				n := logsCallCount.Add(1)
+				nextToken := ""
+				if n == 1 {
+					// First check: deployment still running.
+					nextToken = "log-cursor-after-executor-step" //nolint:gosec // not a credential, just a pagination cursor
+				}
+				return writeJSON(apitype.DeploymentLogs{NextToken: nextToken})
+
+			default:
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"code":404,"message":"not found"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}
+		},
+	}
+
+	apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+	apiClient.WithHTTPClient(&http.Client{Transport: transport})
+	b := &cloudBackend{
+		client: apiClient,
+		d:      diagtest.LogSink(t),
+	}
+
+	stackID := client.StackIdentifier{Owner: org, Project: project, Stack: tokens.MustParseStackName(stack)}
+	opts := display.Options{Color: colors.Never, SuppressPermalink: true}
+
+	err := b.showDeploymentEvents(t.Context(), stackID, apitype.PreviewUpdate, deployID, opts, logsToken)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), eventsCallCount.Load(),
+		"should retry GetUpdateEngineEvents when first response is empty+nil and deployment is running")
+	assert.GreaterOrEqual(t, logsCallCount.Load(), int32(1),
+		"should check deployment liveness via GetDeploymentLogs")
+}
+
+// TestShowDeploymentEvents_NormalPath verifies the happy path: events are returned on the
+// first call and showDeploymentEvents exits cleanly without checking deployment logs.
+func TestShowDeploymentEvents_NormalPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		org      = "myorg"
+		project  = "myproject"
+		stack    = "mystack"
+		deployID = "deploy-2"
+		updateID = "update-2"
+	)
+
+	var eventsCallCount atomic.Int32
+	var logsCallCount atomic.Int32
+
+	transport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			writeJSON := func(v any) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(mustJSON(v)))),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/updates", deployID)):
+				return writeJSON([]apitype.GetDeploymentUpdatesUpdateInfo{
+					{UpdateID: updateID, Version: 1},
+				})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/update/%s/events", updateID)):
+				eventsCallCount.Add(1)
+				// Events available immediately — no race condition.
+				return writeJSON(apitype.GetUpdateEventsResponse{
+					Events: []apitype.EngineEvent{cancelEngineEvent(1)},
+				})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/logs", deployID)):
+				logsCallCount.Add(1)
+				return writeJSON(apitype.DeploymentLogs{NextToken: ""})
+
+			default:
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"code":404,"message":"not found"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}
+		},
+	}
+
+	apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+	apiClient.WithHTTPClient(&http.Client{Transport: transport})
+	b := &cloudBackend{
+		client: apiClient,
+		d:      diagtest.LogSink(t),
+	}
+
+	stackID := client.StackIdentifier{Owner: org, Project: project, Stack: tokens.MustParseStackName(stack)}
+	opts := display.Options{Color: colors.Never, SuppressPermalink: true}
+
+	err := b.showDeploymentEvents(t.Context(), stackID, apitype.PreviewUpdate, deployID, opts, "log-token")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), eventsCallCount.Load(),
+		"should call GetUpdateEngineEvents exactly once when events are returned immediately")
+	assert.Equal(t, int32(0), logsCallCount.Load(),
+		"should NOT check deployment logs when events are returned on the first call")
+}
+
+// TestShowDeploymentEvents_NoEventsDeploymentDone verifies that showDeploymentEvents exits
+// gracefully (without hanging) when empty+nil is returned AND the deployment is confirmed
+// done (GetDeploymentLogs returns NextToken == "").
+func TestShowDeploymentEvents_NoEventsDeploymentDone(t *testing.T) {
+	t.Parallel()
+
+	const (
+		org      = "myorg"
+		project  = "myproject"
+		stack    = "mystack"
+		deployID = "deploy-3"
+		updateID = "update-3"
+	)
+
+	transport := &mockTransport{
+		roundTrip: func(r *http.Request) (*http.Response, error) {
+			writeJSON := func(v any) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(string(mustJSON(v)))),
+					Header:     make(http.Header),
+				}, nil
+			}
+
+			switch {
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/updates", deployID)):
+				return writeJSON([]apitype.GetDeploymentUpdatesUpdateInfo{
+					{UpdateID: updateID, Version: 1},
+				})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/update/%s/events", updateID)):
+				// Deployment has no engine events (e.g., failed before engine started).
+				return writeJSON(apitype.GetUpdateEventsResponse{})
+
+			case strings.HasSuffix(r.URL.Path, fmt.Sprintf("/deployments/%s/logs", deployID)):
+				// Deployment is done — no more logs.
+				return writeJSON(apitype.DeploymentLogs{NextToken: ""})
+
+			default:
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"code":404,"message":"not found"}`)),
+					Header:     make(http.Header),
+				}, nil
+			}
+		},
+	}
+
+	apiClient := client.NewClient(client.PulumiCloudURL, "test-token", false, diagtest.LogSink(t))
+	apiClient.WithHTTPClient(&http.Client{Transport: transport})
+	b := &cloudBackend{
+		client: apiClient,
+		d:      diagtest.LogSink(t),
+	}
+
+	stackID := client.StackIdentifier{Owner: org, Project: project, Stack: tokens.MustParseStackName(stack)}
+	opts := display.Options{Color: colors.Never, SuppressPermalink: true}
+
+	// Must return without hanging even with no engine events.
+	err := b.showDeploymentEvents(t.Context(), stackID, apitype.PreviewUpdate, deployID, opts, "log-token")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Fixes `pulumi deployment run --suppress-stream-logs=false` showing only the "View Live:" URL with no resource table or summary
- Root cause: CLI calls `GetUpdateEngineEvents` before the deployment executor has written any events; the service permanently marks the update as `NoState`, returning empty results with a nil continuation token, causing the CLI to close the event channel immediately
- Fix: when `showDeploymentEvents` receives empty events and a nil token, it checks `GetDeploymentLogs` for a non-empty `NextToken`; if the deployment is still running, it advances the log cursor and retries after 500ms

## Changes

- `pkg/backend/httpstate/deployment_run_test.go` — three tests covering the race condition retry, the normal (no-retry) path, and the graceful-exit path when deployment is already done
- `pkg/backend/httpstate/backend.go` — thread `deploymentLogsToken` through `showDeploymentEvents`; add liveness check + retry loop when empty events and nil continuation token are received

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
