### PR TITLE
Add update metadata to the otel root span

### DIFF
--- a/changelog/pending/20260325--cli--add-update-metadata-to-the-otel-root-span.yaml
+++ b/changelog/pending/20260325--cli--add-update-metadata-to-the-otel-root-span.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli
+  description: Add update metadata to the otel root span

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -247,6 +247,7 @@ func NewDestroyCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
+			cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -940,6 +940,7 @@ func NewImportCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
+			cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -431,6 +431,7 @@ func NewPreviewCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
+			cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -222,6 +222,7 @@ func NewRefreshCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
+			cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -175,6 +175,7 @@ func NewUpCmd() *cobra.Command {
 		if err != nil {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
+		cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 		decrypter := sm.Decrypter()
 		encrypter := sm.Encrypter()
@@ -449,6 +450,7 @@ func NewUpCmd() *cobra.Command {
 		if err != nil {
 			return fmt.Errorf("gathering environment metadata: %w", err)
 		}
+		cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 		decrypter := sm.Decrypter()
 		encrypter := sm.Encrypter()

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -127,6 +127,7 @@ func NewWatchCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("gathering environment metadata: %w", err)
 			}
+			cmdutil.SetStringSpanAttributes(ctx, m.Environment)
 
 			decrypter := sm.Decrypter()
 			encrypter := sm.Encrypter()

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -387,6 +387,16 @@ func StartSpan(
 	return tracer.Start(ctx, name, opts...)
 }
 
+func SetStringSpanAttributes(ctx context.Context, attrs map[string]string) {
+	span := trace.SpanFromContext(ctx)
+	if !span.SpanContext().IsValid() {
+		return
+	}
+	for k, v := range attrs {
+		span.SetAttributes(attribute.String(k, v))
+	}
+}
+
 // Starts an AppDash server listening on any available TCP port
 // locally and sends the spans and annotations to the given collector.
 // Returns a Pulumi-formatted tracing endpoint pointing to this


### PR DESCRIPTION
Grab the metadata we send with updates and add them to the current otel span.