### PR TITLE
Fix flaky TestPropertyValueSchema/serialized

### DIFF
--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -910,6 +910,22 @@ func ArchiveObjectGenerator(maxDepth int) *rapid.Generator[map[string]any] {
 	return LiteralArchiveObjectGenerator(maxDepth)
 }
 
+// FloatObjectGenerator generates float object values representing NaN and Inf, matching the
+// wire format used by SerializePropertyValue.
+func FloatObjectGenerator() *rapid.Generator[map[string]any] {
+	return rapid.Custom(func(t *rapid.T) map[string]any {
+		hex := rapid.SampledFrom([]string{
+			"7ff8000000000001", // NaN
+			"7ff0000000000000", // +Inf
+			"fff0000000000000", // -Inf
+		}).Draw(t, "float hex")
+		return map[string]any{
+			resource.SigKey: floatSignature,
+			"value":         hex,
+		}
+	})
+}
+
 // ResourceReferenceObjectGenerator generates resource reference object values.
 func ResourceReferenceObjectGenerator() *rapid.Generator[any] {
 	return rapid.Custom(func(t *rapid.T) any {
@@ -971,6 +987,7 @@ func ObjectValueGenerator(maxDepth int) *rapid.Generator[any] {
 		NumberObjectGenerator().AsAny(),
 		StringObjectGenerator().AsAny(),
 		AssetObjectGenerator().AsAny(),
+		FloatObjectGenerator().AsAny(),
 		ResourceReferenceObjectGenerator(),
 	}
 	if maxDepth > 0 {

--- a/sdk/go/common/apitype/property-values.json
+++ b/sdk/go/common/apitype/property-values.json
@@ -226,6 +226,23 @@
                 }
             },
             "required": ["4dabf18193072939515e22adb298388d", "urn"]
+        },
+        {
+            "title": "Float property values",
+            "description": "Serialized representation of NaN and Inf float64 values, which cannot be represented directly in JSON.",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Float signature",
+                    "const": "8ad145fe-0d11-4827-bfd7-1abcbf086f5c"
+                },
+                "value": {
+                    "description": "The IEEE 754 representation of the float value, encoded as a 16-character hexadecimal string.",
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{16}$"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d", "value"]
         }
     ]
 }


### PR DESCRIPTION
Fixes #21581

## Root cause

`SerializePropertyValue` serializes NaN and Inf float64 values as objects with a special float signature (`8ad145fe-0d11-4827-bfd7-1abcbf086f5c`) and a hex-encoded IEEE 754 value. The property value JSON schema (`property-values.json`) was missing this signature type, so schema validation failed whenever `rapid.Float64()` generated a NaN or Inf.

## Fix

Add a "Float property values" entry to the `oneOf` in `property-values.json` that matches objects with the float signature and a 16-character hex value string. Also add a `FloatObjectGenerator` to the synthetic test's `ObjectValueGenerator` so the `synthetic` subtest covers float wire objects.

## Reproduction

```sh
# Before fix (from pkg/):
go test -run 'TestPropertyValueSchema/serialized' ./resource/stack/... -count=100 -timeout=30m
# Fails intermittently when rapid generates NaN/Inf

# After fix:
go test -run 'TestPropertyValueSchema/serialized' ./resource/stack/... -count=100 -timeout=30m
# Passes reliably

# With race detector:
go test -run 'TestPropertyValueSchema/serialized' ./resource/stack/... -count=20 -race -timeout=30m
# Also passes
```