### PR TITLE
propagate TRACEPARENT in pulumi parent span

### DIFF
--- a/changelog/pending/20260326--cli--allow-traceparent-to-be-set-for-cli-invocations-parenting-the-pulumi-spans-under-an-existing-parent-span.yaml
+++ b/changelog/pending/20260326--cli--allow-traceparent-to-be-set-for-cli-invocations-parenting-the-pulumi-spans-under-an-existing-parent-span.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Allow TRACEPARENT to be set for CLI invocations, parenting the pulumi spans under an existing parent span

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -89,6 +89,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -304,6 +305,12 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 
 			if cmdutil.IsOTelEnabled() {
 				tracer := otel.Tracer("pulumi-cli")
+
+				if traceparent := os.Getenv("TRACEPARENT"); traceparent != "" {
+					carrier := propagation.MapCarrier{"traceparent": traceparent}
+					ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
+				}
+
 				ctx, rootSpan = cmdutil.StartSpan(ctx, tracer, "pulumi")
 
 				for k, v := range metadata {


### PR DESCRIPTION
Sometimes it's useful to be able to set a parent for the pulumi parent otel span. For example in automation API, or when another program is calling pulumi under the hood. We already do this propagation via a TRACEPARENT env variable through the pulumi stack, so allow it to be set outside of that as well.

Fixes https://github.com/pulumi/pulumi/issues/22364