### PR TITLE
Record the time to first output for operations

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -66,6 +66,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // UpgradeOptions customizes the behavior of the upgrade operation.
@@ -1190,6 +1193,13 @@ func (b *diyBackend) apply(
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 
 	if !op.Opts.Display.JSONDisplay && op.Opts.Display.Type != display.DisplayWatch {
+		// We're about to print the first line of output, record the time it took to get here. This is more of a metric
+		// than a logical span, but this is a convenient way to record this information.
+		if startTime, ok := cmdutil.ProcessStartTimeFromContext(ctx); ok && cmdutil.IsOTelEnabled() {
+			tracer := otel.Tracer("pulumi-cli")
+			_, span := tracer.Start(ctx, "time-to-first-print", trace.WithTimestamp(startTime))
+			span.End()
+		}
 		// Print a banner so it's clear this is a diy deployment.
 		fmt.Printf(op.Opts.Display.Color.Colorize(
 			colors.SpecHeadline+"%s (%s):"+colors.Reset+"\n"), actionLabel, stackRef)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -69,6 +69,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/retry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+
+	"go.opentelemetry.io/otel"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 var ErrUnauthorized = errors.New("Unauthorized: No credentials provided or are invalid.")
@@ -1641,6 +1644,13 @@ func (b *cloudBackend) apply(
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 
 	if !op.Opts.Display.JSONDisplay && op.Opts.Display.Type != display.DisplayWatch {
+		// We're about to print the first line of output, record the time it took to get here. This is more of a metric
+		// than a logical span, but this is a convenient way to record this information.
+		if startTime, ok := cmdutil.ProcessStartTimeFromContext(ctx); ok && cmdutil.IsOTelEnabled() {
+			tracer := otel.Tracer("pulumi-cli")
+			_, span := tracer.Start(ctx, "time-to-first-print", oteltrace.WithTimestamp(startTime))
+			span.End()
+		}
 		// Print a banner so it's clear this is going to the cloud.
 		fmt.Printf(op.Opts.Display.Color.Colorize(
 			colors.SpecHeadline+"%s (%s)"+colors.Reset+"\n\n"), actionLabel, stack.Ref())

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -194,6 +194,8 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	var memProfileRate int
 	var rootSpan oteltrace.Span
 
+	processStartTime := time.Now()
+
 	updateCheckResult := make(chan *updateCheckResult)
 
 	cleanup := func() {
@@ -311,7 +313,8 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 					ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
 				}
 
-				ctx, rootSpan = cmdutil.StartSpan(ctx, tracer, "pulumi")
+				ctx, rootSpan = cmdutil.StartSpan(ctx, tracer, "pulumi",
+					oteltrace.WithTimestamp(processStartTime))
 
 				for k, v := range metadata {
 					rootSpan.SetAttributes(attribute.String("cli."+strings.ToLower(k), v))
@@ -321,6 +324,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				sc := rootSpan.SpanContext()
 				cmdutil.SetAppDashTraceParent(sc.TraceID(), sc.SpanID())
 			}
+			ctx = cmdutil.ContextWithProcessStartTime(ctx, processStartTime)
 			cmd.SetContext(ctx)
 
 			cmdutil.InitPprofServer(ctx)

--- a/sdk/go/common/util/cmdutil/trace.go
+++ b/sdk/go/common/util/cmdutil/trace.go
@@ -387,6 +387,19 @@ func StartSpan(
 	return tracer.Start(ctx, name, opts...)
 }
 
+type processStartTimeKey struct{}
+
+// ContextWithProcessStartTime returns a new context with the given process start time.
+func ContextWithProcessStartTime(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, processStartTimeKey{}, t)
+}
+
+// ProcessStartTimeFromContext retrieves the process start time from the context.
+func ProcessStartTimeFromContext(ctx context.Context) (time.Time, bool) {
+	t, ok := ctx.Value(processStartTimeKey{}).(time.Time)
+	return t, ok
+}
+
 func SetStringSpanAttributes(ctx context.Context, attrs map[string]string) {
 	span := trace.SpanFromContext(ctx)
 	if !span.SpanContext().IsValid() {


### PR DESCRIPTION
Track the process start time and emit a fake span when we’re about to print out the first output. This makes no attempt to be smart about figuring out when we first print anything, we simply create the span at the right place in the code. This is also more of a metric than a logical span, but this tracks the information in a convenient place for us.

<img width="867" height="166" alt="Screenshot 2026-03-27 at 11 14 27" src="https://github.com/user-attachments/assets/8b335a0a-77b1-4e57-a241-0c9f6be1407a" />

