### PR TITLE
Remove state lock for refresh --preview-only for diy backend

### DIFF
--- a/changelog/pending/20260328--backend-diy--remove-state-lock-for-refresh-preview-only-for-diy-backend.yaml
+++ b/changelog/pending/20260328--backend-diy--remove-state-lock-for-refresh-preview-only-for-diy-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Remove state lock for refresh --preview-only for diy backend

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1119,12 +1119,6 @@ func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
 func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, error) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, err
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	if op.Opts.PreviewOnly {
 		// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
 		opts := backend.ApplierOptions{
@@ -1137,6 +1131,12 @@ func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 			ctx, apitype.RefreshUpdate, stack, op, opts, nil /*events*/)
 		return changes, err
 	}
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, err
+	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply, nil, nil)
 }


### PR DESCRIPTION
## Summary
Fixes https://github.com/pulumi/pulumi/issues/22384
In https://github.com/pulumi/pulumi/issues/1666, --preview-only was added to pulumi refresh. However, it still locks the state when running the command which is not consistent with https://github.com/pulumi/pulumi/pull/8642. Pulumi refresh with --preview-only should not lock the state in this case as there are no updates to the state file.

Removes state lock for `pulumi refresh --preview-only` in diy backend as no state is changed

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
