### PR TITLE
feat: add ability for plugin host override via env var

### DIFF
--- a/changelog/pending/20260330--sdk-go--add-pulumi-plugin-host-overrides-for-universal-proxy-support.yaml
+++ b/changelog/pending/20260330--sdk-go--add-pulumi-plugin-host-overrides-for-universal-proxy-support.yaml
@@ -1,0 +1,9 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: >
+    Add `PULUMI_PLUGIN_HOST_OVERRIDES` environment variable to transparently rewrite hostnames
+    in all plugin download requests. Format is `host1=proxy1,host2=proxy2`. Applies universally
+    to all plugin sources (GitHub, GitLab, get.pulumi.com, custom HTTP sources) without any
+    per-source configuration, making it suitable for environments that route traffic through
+    reverse proxies such as Artifactory generic remote repositories.

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -156,6 +156,25 @@ var RunProgram = env.Bool("RUN_PROGRAM",
 // will capture any GitHub-hosted plugin and redirect to its corresponding folder under https://foo.com/downloads
 var PluginDownloadURLOverrides = env.String("PLUGIN_DOWNLOAD_URL_OVERRIDES", "")
 
+// PluginHostOverrides transparently rewrites hostnames in all outgoing plugin download
+// requests. The expected format is `host1=proxy1,host2=proxy2`. Both sides are plain
+// hostnames (optionally including a port), not full URLs.
+//
+// For example:
+//
+//	PULUMI_PLUGIN_HOST_OVERRIDES=api.github.com=github-api.myproxy.example.com,github.com=github-com.myproxy.example.com
+//
+// This rewrites every request whose host is api.github.com to instead target
+// github-api.myproxy.example.com, and every request to github.com to instead target
+// github-com.myproxy.example.com. The scheme, path, and query string are preserved, making
+// it compatible with generic reverse proxies such as Artifactory generic remote repositories.
+//
+// Unlike PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES, this applies to all plugin sources
+// (GitHub, GitLab, get.pulumi.com, custom HTTP sources) without any per-source configuration.
+var PluginHostOverrides = env.String("PLUGIN_HOST_OVERRIDES",
+	"Rewrite hostnames in plugin download requests. Format: host1=proxy1,host2=proxy2. "+
+		"Applies to all plugin sources regardless of type.")
+
 // By default `pulumi preview --json` emits a "PreviewDigest" JSON object to stdout. Setting this envvar changes
 // the behavior of `pulumi preview --json` to match the behavior of `pulumi up|destroy|refresh --json`, that is,
 // to stream JSON events to stdout.

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -164,7 +164,8 @@ var PluginDownloadURLOverrides = env.String("PLUGIN_DOWNLOAD_URL_OVERRIDES", "")
 //
 // For example, to route plugin downloads through Artifactory generic remote repositories:
 //
-//	PULUMI_PLUGIN_HOST_OVERRIDES=api.github.com=https://artifactory.example.com/artifactory/github-api-remote,github.com=https://artifactory.example.com/artifactory/github-com-remote
+//	PULUMI_PLUGIN_HOST_OVERRIDES=api.github.com=https://artifactory.example.com/artifactory/github-api-remote,
+//	github.com=https://artifactory.example.com/artifactory/github-com-remote
 //
 // This rewrites a request for
 // https://api.github.com/repos/pulumi/pulumi-aws/releases/latest

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -156,23 +156,27 @@ var RunProgram = env.Bool("RUN_PROGRAM",
 // will capture any GitHub-hosted plugin and redirect to its corresponding folder under https://foo.com/downloads
 var PluginDownloadURLOverrides = env.String("PLUGIN_DOWNLOAD_URL_OVERRIDES", "")
 
-// PluginHostOverrides transparently rewrites hostnames in all outgoing plugin download
-// requests. The expected format is `host1=proxy1,host2=proxy2`. Both sides are plain
-// hostnames (optionally including a port), not full URLs.
+// PluginHostOverrides transparently rewrites hosts in all outgoing plugin download requests.
+// The expected format is `originalHost1=https://proxy1/base/path,originalHost2=https://proxy2`.
+// The key is the original hostname (with optional port); the value is the full base URL of
+// the proxy. If no scheme is given in the value, https is assumed. Any path in the proxy base
+// URL is prepended to the original request path, preserving the rest of the URL unchanged.
 //
-// For example:
+// For example, to route plugin downloads through Artifactory generic remote repositories:
 //
-//	PULUMI_PLUGIN_HOST_OVERRIDES=api.github.com=github-api.myproxy.example.com,github.com=github-com.myproxy.example.com
+//	PULUMI_PLUGIN_HOST_OVERRIDES=api.github.com=https://artifactory.example.com/artifactory/github-api-remote,github.com=https://artifactory.example.com/artifactory/github-com-remote
 //
-// This rewrites every request whose host is api.github.com to instead target
-// github-api.myproxy.example.com, and every request to github.com to instead target
-// github-com.myproxy.example.com. The scheme, path, and query string are preserved, making
-// it compatible with generic reverse proxies such as Artifactory generic remote repositories.
+// This rewrites a request for
+// https://api.github.com/repos/pulumi/pulumi-aws/releases/latest
+// into
+// https://artifactory.example.com/artifactory/github-api-remote/repos/pulumi/pulumi-aws/releases/latest
+// which is the exact URL an Artifactory generic remote expects.
 //
 // Unlike PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES, this applies to all plugin sources
 // (GitHub, GitLab, get.pulumi.com, custom HTTP sources) without any per-source configuration.
 var PluginHostOverrides = env.String("PLUGIN_HOST_OVERRIDES",
-	"Rewrite hostnames in plugin download requests. Format: host1=proxy1,host2=proxy2. "+
+	"Rewrite hosts in plugin download requests. "+
+		"Format: originalHost1=https://proxy1/path,originalHost2=https://proxy2. "+
 		"Applies to all plugin sources regardless of type.")
 
 // By default `pulumi preview --json` emits a "PreviewDigest" JSON object to stdout. Setting this envvar changes

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -83,12 +83,22 @@ var pluginDownloadURLOverridesParsed pluginDownloadOverrideArray
 
 // pluginHostOverrides is a variable instead of a constant so it can be set using the `-X`
 // ldflag at build time, if necessary. When non-empty, it is parsed into
-// `pluginHostOverridesParsed` in `init()`. The expected format is `host1=proxy1,host2=proxy2`.
+// `pluginHostOverridesParsed` in `init()`. The expected format is
+// `host1=https://proxy1/base/path,host2=https://proxy2`.
 var pluginHostOverrides string
 
+// hostOverride holds the parsed components of a single entry in pluginHostOverridesParsed.
+type hostOverride struct {
+	scheme string // replacement scheme, e.g. "https"
+	host   string // replacement host, e.g. "testartifactory.my.de"
+	// path is the base path prefix to prepend to every request path, e.g.
+	// "/artifactory/api-github-generic-remote". May be empty. Never has a trailing slash.
+	path string
+}
+
 // pluginHostOverridesParsed is the parsed map from `pluginHostOverrides`.
-// Keys and values are plain hostnames (optionally with port), e.g. "api.github.com".
-var pluginHostOverridesParsed map[string]string
+// Keys are original hostnames (optionally with port), e.g. "api.github.com".
+var pluginHostOverridesParsed map[string]hostOverride
 
 // pluginDownloadURLOverride represents a plugin download URL override, parsed from `pluginDownloadURLOverrides`.
 type pluginDownloadURLOverride struct {
@@ -146,21 +156,51 @@ func init() {
 	}
 }
 
-// parsePluginHostOverrides parses an overrides string with the expected format `host1=proxy1,host2=proxy2`.
-// Both sides are plain hostnames, optionally including a port (e.g. "api.github.com" or "localhost:8080").
-func parsePluginHostOverrides(overrides string) (map[string]string, error) {
-	result := map[string]string{}
+// parsePluginHostOverrides parses an overrides string with the expected format
+// `host1=https://proxy1/base/path,host2=https://proxy2`.
+//
+// The key is the original hostname (optionally with port) as it appears in the request URL.
+// The value is the full base URL of the proxy. If the value has no scheme, "https" is assumed.
+// Any path in the proxy base URL is prepended to the original request path, which allows
+// reverse proxies that expose upstream hosts at a subpath (e.g. Artifactory generic remotes).
+//
+// Examples:
+//
+//	api.github.com=https://artifactory.example.com/artifactory/github-api-remote
+//	github.com=https://artifactory.example.com/artifactory/github-com-remote
+//	api.github.com=github-api.simpleproxy.example.com  (bare host, https assumed)
+func parsePluginHostOverrides(overrides string) (map[string]hostOverride, error) {
+	result := map[string]hostOverride{}
 	if overrides == "" {
 		return result, nil
 	}
 	for _, pair := range strings.Split(overrides, ",") {
-		// Use SplitN so that an "=" inside a value (theoretically impossible for a hostname,
-		// but defensive) does not silently truncate it.
+		// SplitN with n=2 so that "://" and "=" inside the proxy URL are not treated as
+		// delimiters — only the first "=" separates the key from the value.
 		parts := strings.SplitN(pair, "=", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return nil, fmt.Errorf("expected format to be \"host1=proxy1,host2=proxy2\"; got %q", overrides)
+			return nil, fmt.Errorf(
+				"expected format to be \"host1=https://proxy1/path,host2=https://proxy2\"; got %q",
+				overrides)
 		}
-		result[parts[0]] = parts[1]
+		from := parts[0]
+		rawTo := parts[1]
+		// Accept bare hostnames for convenience; assume https.
+		if !strings.Contains(rawTo, "://") {
+			rawTo = "https://" + rawTo
+		}
+		toURL, err := url.Parse(rawTo)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy base URL %q: %w", parts[1], err)
+		}
+		if toURL.Host == "" {
+			return nil, fmt.Errorf("proxy base URL %q has no host", parts[1])
+		}
+		result[from] = hostOverride{
+			scheme: toURL.Scheme,
+			host:   toURL.Host,
+			path:   strings.TrimSuffix(toURL.Path, "/"),
+		}
 	}
 	return result, nil
 }
@@ -1660,9 +1700,18 @@ func buildHTTPRequest(ctx context.Context, pluginEndpoint string, authorization 
 	// (e.g. newDownloadError's private-repo hint for api.github.com 404s) will see the proxy
 	// hostname instead of the original one.  Those hints are best-effort and this is an
 	// acceptable trade-off for the simplicity of a single rewrite point.
-	if to, ok := pluginHostOverridesParsed[req.URL.Host]; ok {
-		logging.V(9).Infof("plugin host override: %s -> %s (full URL: %s)", req.URL.Host, to, req.URL)
-		req.URL.Host = to
+	if override, ok := pluginHostOverridesParsed[req.URL.Host]; ok {
+		original := req.URL.String()
+		req.URL.Scheme = override.scheme
+		req.URL.Host = override.host
+		if override.path != "" {
+			req.URL.Path = override.path + req.URL.Path
+			// Keep RawPath in sync when the original URL had percent-encoded path segments.
+			if req.URL.RawPath != "" {
+				req.URL.RawPath = override.path + req.URL.RawPath
+			}
+		}
+		logging.V(9).Infof("plugin host override: %s -> %s", original, req.URL)
 	}
 
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1655,6 +1655,11 @@ func buildHTTPRequest(ctx context.Context, pluginEndpoint string, authorization 
 	// at the single point where all plugin download requests are constructed, so it is
 	// transparently effective for every source type (GitHub, GitLab, get.pulumi.com, custom
 	// HTTP sources) without requiring any source-specific logic.
+	//
+	// Note: mutating req.URL.Host means that downstream error helpers which inspect the host
+	// (e.g. newDownloadError's private-repo hint for api.github.com 404s) will see the proxy
+	// hostname instead of the original one.  Those hints are best-effort and this is an
+	// acceptable trade-off for the simplicity of a single rewrite point.
 	if to, ok := pluginHostOverridesParsed[req.URL.Host]; ok {
 		logging.V(9).Infof("plugin host override: %s -> %s (full URL: %s)", req.URL.Host, to, req.URL)
 		req.URL.Host = to
@@ -1740,6 +1745,9 @@ func newGithubPrivateRepoError(statusCode int, url *url.URL) error {
 }
 
 // Create a new downloadError.
+// Note: when PULUMI_PLUGIN_HOST_OVERRIDES is set the host in url will be the proxy hostname
+// rather than "api.github.com", so the private-repo hint below will not fire for proxied
+// requests. This is a known, accepted limitation of the host-rewrite approach.
 func newDownloadError(statusCode int, url *url.URL, header http.Header) error {
 	if url.Host == "api.github.com" && statusCode == 404 {
 		return newGithubPrivateRepoError(statusCode, url)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1704,6 +1704,7 @@ func buildHTTPRequest(ctx context.Context, pluginEndpoint string, authorization 
 		original := req.URL.String()
 		req.URL.Scheme = override.scheme
 		req.URL.Host = override.host
+		req.Host = req.URL.Host
 		if override.path != "" {
 			req.URL.Path = override.path + req.URL.Path
 			// Keep RawPath in sync when the original URL had percent-encoded path segments.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -81,6 +81,15 @@ var pluginDownloadURLOverrides string
 // pluginDownloadURLOverridesParsed is the parsed array from `pluginDownloadURLOverrides`.
 var pluginDownloadURLOverridesParsed pluginDownloadOverrideArray
 
+// pluginHostOverrides is a variable instead of a constant so it can be set using the `-X`
+// ldflag at build time, if necessary. When non-empty, it is parsed into
+// `pluginHostOverridesParsed` in `init()`. The expected format is `host1=proxy1,host2=proxy2`.
+var pluginHostOverrides string
+
+// pluginHostOverridesParsed is the parsed map from `pluginHostOverrides`.
+// Keys and values are plain hostnames (optionally with port), e.g. "api.github.com".
+var pluginHostOverridesParsed map[string]string
+
 // pluginDownloadURLOverride represents a plugin download URL override, parsed from `pluginDownloadURLOverrides`.
 type pluginDownloadURLOverride struct {
 	reg *regexp.Regexp // The regex used to match against the plugin's name.
@@ -126,6 +135,34 @@ func init() {
 	if pluginDownloadURLOverridesParsed, err = parsePluginDownloadURLOverrides(overrides); err != nil {
 		panic(fmt.Errorf("error parsing `pluginDownloadURLOverrides`: %w", err))
 	}
+
+	// Parse host overrides. Environment variable takes precedence over compile-time flags.
+	hostOverrides := pluginHostOverrides
+	if v := env.PluginHostOverrides.Value(); v != "" {
+		hostOverrides = v
+	}
+	if pluginHostOverridesParsed, err = parsePluginHostOverrides(hostOverrides); err != nil {
+		panic(fmt.Errorf("error parsing `pluginHostOverrides`: %w", err))
+	}
+}
+
+// parsePluginHostOverrides parses an overrides string with the expected format `host1=proxy1,host2=proxy2`.
+// Both sides are plain hostnames, optionally including a port (e.g. "api.github.com" or "localhost:8080").
+func parsePluginHostOverrides(overrides string) (map[string]string, error) {
+	result := map[string]string{}
+	if overrides == "" {
+		return result, nil
+	}
+	for _, pair := range strings.Split(overrides, ",") {
+		// Use SplitN so that an "=" inside a value (theoretically impossible for a hostname,
+		// but defensive) does not silently truncate it.
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("expected format to be \"host1=proxy1,host2=proxy2\"; got %q", overrides)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
 }
 
 // parsePluginDownloadURLOverrides parses an overrides string with the expected format `regexp1=URL1,regexp2=URL2`.
@@ -1612,6 +1649,15 @@ func buildHTTPRequest(ctx context.Context, pluginEndpoint string, authorization 
 	req, err := http.NewRequestWithContext(ctx, "GET", pluginEndpoint, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Apply any host overrides from PULUMI_PLUGIN_HOST_OVERRIDES.  The rewrite happens here,
+	// at the single point where all plugin download requests are constructed, so it is
+	// transparently effective for every source type (GitHub, GitLab, get.pulumi.com, custom
+	// HTTP sources) without requiring any source-specific logic.
+	if to, ok := pluginHostOverridesParsed[req.URL.Host]; ok {
+		logging.V(9).Infof("plugin host override: %s -> %s (full URL: %s)", req.URL.Host, to, req.URL)
+		req.URL.Host = to
 	}
 
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1151,7 +1151,7 @@ func TestParsePluginHostOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "full URL with subpath — trailing slash stripped",
+			name:  "full URL with subpath — trailing slash stripped",
 			input: "api.github.com=https://testartifactory.my.de/artifactory/github-api-remote/",
 			expected: map[string]hostOverride{
 				"api.github.com": {
@@ -1204,19 +1204,19 @@ func TestParsePluginHostOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "missing value",
+			name:  "missing value",
 			input: "api.github.com=",
 			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
 				`got "api.github.com="`,
 		},
 		{
-			name: "missing key",
+			name:  "missing key",
 			input: "=https://myproxy.test",
 			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
 				`got "=https://myproxy.test"`,
 		},
 		{
-			name: "no equals sign",
+			name:  "no equals sign",
 			input: "api.github.com",
 			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
 				`got "api.github.com"`,
@@ -1271,6 +1271,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t, artifactoryHost, req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.Host)
 			assert.Equal(t,
 				"https://"+artifactoryHost+apiPath+"/repos/pulumi/pulumi-mockdl/releases/latest",
 				req.URL.String())
@@ -1297,6 +1298,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t, artifactoryHost, req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.Host)
 			assert.Equal(t,
 				"https://"+artifactoryHost+dlPath+
 					"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+
@@ -1336,6 +1338,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		var seen []string
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			seen = append(seen, req.URL.String())
+			assert.Equal(t, artifactoryHost, req.Host)
 			switch req.URL.String() {
 			case "https://" + artifactoryHost + dlPath +
 				"/pulumi/pulumi-mockdl/releases/download/v1.2.3/" + assetName:
@@ -1392,6 +1395,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			if req.URL.Host == artifactoryHost && req.URL.Path == pulumiPath+
 				"/releases/plugins/pulumi-resource-otherdl-v1.2.3-linux-amd64.tar.gz" {
+				assert.Equal(t, artifactoryHost, req.Host)
 				return newMockReadCloser(expectedBytes)
 			}
 			// GitHub attempts return 404 to trigger the fallback.
@@ -1421,6 +1425,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t, artifactoryHost, req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.Host)
 			assert.True(t, strings.HasPrefix(req.URL.Path, "/artifactory/gitlab-remote/"),
 				"expected path to start with Artifactory prefix, got: %s", req.URL.Path)
 			return newMockReadCloser(expectedBytes)
@@ -1444,6 +1449,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t, "simpleproxy.myproxy.test", req.URL.Host)
+			assert.Equal(t, "simpleproxy.myproxy.test", req.Host)
 			assert.Equal(t,
 				"https://simpleproxy.myproxy.test/repos/pulumi/pulumi-mockdl/releases/latest",
 				req.URL.String())
@@ -1463,6 +1469,7 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			assert.Equal(t, "api.github.com", req.URL.Host)
+			assert.Equal(t, "api.github.com", req.Host)
 			return newMockReadCloserString(`{"tag_name":"v1.2.3"}`)
 		}
 		_, err = source.GetLatestVersion(t.Context(), getHTTPResponse)

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1124,59 +1124,102 @@ func TestParsePluginHostOverrides(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
-		expected    map[string]string
+		expected    map[string]hostOverride
 		expectedErr string
 	}{
 		{
 			name:     "empty string returns empty map",
 			input:    "",
-			expected: map[string]string{},
+			expected: map[string]hostOverride{},
 		},
 		{
-			name:  "single pair",
+			name:  "bare hostname assumes https and empty path",
 			input: "api.github.com=github-api.myproxy.test",
-			expected: map[string]string{
-				"api.github.com": "github-api.myproxy.test",
+			expected: map[string]hostOverride{
+				"api.github.com": {scheme: "https", host: "github-api.myproxy.test", path: ""},
 			},
 		},
 		{
-			name:  "multiple pairs",
-			input: "api.github.com=github-api.myproxy.test,github.com=github-com.myproxy.test",
-			expected: map[string]string{
-				"api.github.com": "github-api.myproxy.test",
-				"github.com":     "github-com.myproxy.test",
+			name:  "full URL with subpath (Artifactory generic remote)",
+			input: "api.github.com=https://testartifactory.my.de/artifactory/github-api-remote",
+			expected: map[string]hostOverride{
+				"api.github.com": {
+					scheme: "https",
+					host:   "testartifactory.my.de",
+					path:   "/artifactory/github-api-remote",
+				},
+			},
+		},
+		{
+			name: "full URL with subpath — trailing slash stripped",
+			input: "api.github.com=https://testartifactory.my.de/artifactory/github-api-remote/",
+			expected: map[string]hostOverride{
+				"api.github.com": {
+					scheme: "https",
+					host:   "testartifactory.my.de",
+					path:   "/artifactory/github-api-remote",
+				},
+			},
+		},
+		{
+			name:  "full URL without path",
+			input: "api.github.com=https://simpleproxy.myproxy.test",
+			expected: map[string]hostOverride{
+				"api.github.com": {scheme: "https", host: "simpleproxy.myproxy.test", path: ""},
+			},
+		},
+		{
+			name: "multiple pairs with subpaths",
+			input: "api.github.com=https://artifactory.example.com/artifactory/github-api," +
+				"github.com=https://artifactory.example.com/artifactory/github-com",
+			expected: map[string]hostOverride{
+				"api.github.com": {
+					scheme: "https",
+					host:   "artifactory.example.com",
+					path:   "/artifactory/github-api",
+				},
+				"github.com": {
+					scheme: "https",
+					host:   "artifactory.example.com",
+					path:   "/artifactory/github-com",
+				},
 			},
 		},
 		{
 			name:  "host with port",
-			input: "localhost:8080=proxy.example.com:9090",
-			expected: map[string]string{
-				"localhost:8080": "proxy.example.com:9090",
+			input: "localhost:8080=https://proxy.example.com:9090/base",
+			expected: map[string]hostOverride{
+				"localhost:8080": {scheme: "https", host: "proxy.example.com:9090", path: "/base"},
 			},
 		},
 		{
-			name:        "missing value",
-			input:       "api.github.com=",
-			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "api.github.com="`,
-		},
-		{
-			name:        "missing key",
-			input:       "=myproxy.test",
-			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "=myproxy.test"`,
-		},
-		{
-			name:        "no equals sign",
-			input:       "api.github.com",
-			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "api.github.com"`,
-		},
-		{
-			name:  "three pairs",
-			input: "api.github.com=a.proxy.test,github.com=b.proxy.test,get.pulumi.com=c.proxy.test",
-			expected: map[string]string{
-				"api.github.com": "a.proxy.test",
-				"github.com":     "b.proxy.test",
-				"get.pulumi.com": "c.proxy.test",
+			name: "three pairs covering all default sources",
+			input: "api.github.com=https://a.proxy.test/gh-api," +
+				"github.com=https://a.proxy.test/gh-com," +
+				"get.pulumi.com=https://a.proxy.test/pulumi",
+			expected: map[string]hostOverride{
+				"api.github.com": {scheme: "https", host: "a.proxy.test", path: "/gh-api"},
+				"github.com":     {scheme: "https", host: "a.proxy.test", path: "/gh-com"},
+				"get.pulumi.com": {scheme: "https", host: "a.proxy.test", path: "/pulumi"},
 			},
+		},
+		{
+			name: "missing value",
+			input: "api.github.com=",
+			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
+				`got "api.github.com="`,
+		},
+		{
+			name: "missing key",
+			input: "=https://myproxy.test",
+			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
+				`got "=https://myproxy.test"`,
+		},
+		{
+			name: "no equals sign",
+			input: "api.github.com",
+			expectedErr: `expected format to be "host1=https://proxy1/path,host2=https://proxy2"; ` +
+				`got "api.github.com"`,
 		},
 	}
 
@@ -1195,37 +1238,41 @@ func TestParsePluginHostOverrides(t *testing.T) {
 }
 
 // TestPluginHostOverridesBuildRequest verifies that host overrides are applied transparently
-// in buildHTTPRequest for every source type.
+// in buildHTTPRequest for every source type, including the Artifactory subpath case.
 //
 //nolint:paralleltest // mutates pluginHostOverridesParsed
 func TestPluginHostOverridesBuildRequest(t *testing.T) {
 	const (
-		apiProxy = "github-api.myproxy.test"
-		dlProxy  = "github-com.myproxy.test"
+		artifactoryHost = "testartifactory.my.de"
+		apiPath         = "/artifactory/github-api-generic-remote"
+		dlPath          = "/artifactory/github-com-generic-remote"
+		pulumiPath      = "/artifactory/pulumi-generic-remote"
 	)
 	expectedBytes := []byte{1, 2, 3}
 	version := semver.MustParse("1.2.3")
 
 	// setOverrides sets pluginHostOverridesParsed for the duration of the sub-test and
-	// restores it afterwards.
-	setOverrides := func(t *testing.T, m map[string]string) {
+	// restores it on cleanup.
+	setOverrides := func(t *testing.T, m map[string]hostOverride) {
 		t.Helper()
 		orig := pluginHostOverridesParsed
 		pluginHostOverridesParsed = m
 		t.Cleanup(func() { pluginHostOverridesParsed = orig })
 	}
 
-	t.Run("GitHub API host override redirects GetLatestVersion", func(t *testing.T) {
-		setOverrides(t, map[string]string{"api.github.com": apiProxy})
+	t.Run("Artifactory subpath - GetLatestVersion prepends path prefix", func(t *testing.T) {
+		setOverrides(t, map[string]hostOverride{
+			"api.github.com": {scheme: "https", host: artifactoryHost, path: apiPath},
+		})
 
 		spec := PluginDescriptor{Name: "mockdl", Kind: apitype.ResourcePlugin}
 		source, err := spec.GetSource()
 		require.NoError(t, err)
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			assert.Equal(t, apiProxy, req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.URL.Host)
 			assert.Equal(t,
-				"https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/latest",
+				"https://"+artifactoryHost+apiPath+"/repos/pulumi/pulumi-mockdl/releases/latest",
 				req.URL.String())
 			return newMockReadCloserString(`{"tag_name":"v1.2.3"}`)
 		}
@@ -1234,10 +1281,10 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		assert.Equal(t, version, *got)
 	})
 
-	t.Run("GitHub download host override redirects direct archive download", func(t *testing.T) {
-		setOverrides(t, map[string]string{
-			"api.github.com": apiProxy, // needed so GetSource finds latest via proxy
-			"github.com":     dlProxy,
+	t.Run("Artifactory subpath - direct archive download prepends path prefix", func(t *testing.T) {
+		setOverrides(t, map[string]hostOverride{
+			"api.github.com": {scheme: "https", host: artifactoryHost, path: apiPath},
+			"github.com":     {scheme: "https", host: artifactoryHost, path: dlPath},
 		})
 
 		spec := PluginDescriptor{
@@ -1249,9 +1296,10 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			assert.Equal(t, dlProxy, req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.URL.Host)
 			assert.Equal(t,
-				"https://"+dlProxy+"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+
+				"https://"+artifactoryHost+dlPath+
+					"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+
 					"pulumi-resource-mockdl-v1.2.3-linux-amd64.tar.gz",
 				req.URL.String())
 			return newMockReadCloser(expectedBytes)
@@ -1264,13 +1312,13 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		assert.Equal(t, expectedBytes, b)
 	})
 
-	t.Run("both GitHub hosts overridden - API fallback path rewrites asset URL", func(t *testing.T) {
+	t.Run("Artifactory subpath - API fallback rewrites asset URL host+path", func(t *testing.T) {
 		// Direct download returns 404 → falls back to release API.
-		// The asset URL embedded in the API JSON response references api.github.com; because
-		// buildHTTPRequest rewrites the host, the follow-up download also goes to the proxy.
-		setOverrides(t, map[string]string{
-			"api.github.com": apiProxy,
-			"github.com":     dlProxy,
+		// The asset URL in the API JSON references api.github.com; buildHTTPRequest rewrites it
+		// to the Artifactory path before the follow-up download is made.
+		setOverrides(t, map[string]hostOverride{
+			"api.github.com": {scheme: "https", host: artifactoryHost, path: apiPath},
+			"github.com":     {scheme: "https", host: artifactoryHost, path: dlPath},
 		})
 
 		spec := PluginDescriptor{
@@ -1282,20 +1330,22 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		assetName := "pulumi-resource-mockdl-v1.2.3-linux-amd64.tar.gz"
-		// GitHub API always returns api.github.com-absolute asset URLs.
+		// GitHub API always returns api.github.com-absolute asset URLs in its JSON.
 		apiAssetURL := "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/99"
 
 		var seen []string
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
 			seen = append(seen, req.URL.String())
 			switch req.URL.String() {
-			case "https://" + dlProxy + "/pulumi/pulumi-mockdl/releases/download/v1.2.3/" + assetName:
+			case "https://" + artifactoryHost + dlPath +
+				"/pulumi/pulumi-mockdl/releases/download/v1.2.3/" + assetName:
 				return nil, -1, errors.New("404 not found")
-			case "https://" + apiProxy + "/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3":
+			case "https://" + artifactoryHost + apiPath +
+				"/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3":
 				return newMockReadCloserString(
 					`{"assets":[{"name":"` + assetName + `","url":"` + apiAssetURL + `"}]}`)
-			case "https://" + apiProxy + "/repos/pulumi/pulumi-mockdl/releases/assets/99":
-				// buildHTTPRequest rewrote api.github.com → apiProxy before the request fired.
+			case "https://" + artifactoryHost + apiPath +
+				"/repos/pulumi/pulumi-mockdl/releases/assets/99":
 				return newMockReadCloser(expectedBytes)
 			default:
 				t.Errorf("unexpected request: %s", req.URL)
@@ -1310,16 +1360,23 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		assert.Equal(t, expectedBytes, b)
 
 		require.Len(t, seen, 3)
-		assert.Equal(t, "https://"+dlProxy+"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+assetName, seen[0])
-		assert.Equal(t, "https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3", seen[1])
-		assert.Equal(t, "https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/assets/99", seen[2])
+		assert.Equal(t,
+			"https://"+artifactoryHost+dlPath+"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+assetName,
+			seen[0])
+		assert.Equal(t,
+			"https://"+artifactoryHost+apiPath+"/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3",
+			seen[1])
+		assert.Equal(t,
+			"https://"+artifactoryHost+apiPath+"/repos/pulumi/pulumi-mockdl/releases/assets/99",
+			seen[2])
 	})
 
-	t.Run("get.pulumi.com host override redirects fallback source", func(t *testing.T) {
-		setOverrides(t, map[string]string{
-			"api.github.com": apiProxy,   // make GitHub steps fail visibly
-			"github.com":     dlProxy,    // make GitHub direct download fail
-			"get.pulumi.com": "pulumi-proxy.myproxy.test",
+	t.Run("Artifactory subpath - get.pulumi.com fallback prepends path prefix", func(t *testing.T) {
+		setOverrides(t, map[string]hostOverride{
+			// Make GitHub attempts fail so fallbackSource reaches get.pulumi.com.
+			"api.github.com": {scheme: "https", host: artifactoryHost, path: apiPath},
+			"github.com":     {scheme: "https", host: artifactoryHost, path: dlPath},
+			"get.pulumi.com": {scheme: "https", host: artifactoryHost, path: pulumiPath},
 		})
 
 		spec := PluginDescriptor{
@@ -1333,21 +1390,12 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			switch req.URL.Host {
-			case dlProxy:
-				return nil, -1, errors.New("404 not found")
-			case apiProxy:
-				return nil, -1, errors.New("404 not found")
-			case "pulumi-proxy.myproxy.test":
-				assert.Equal(t,
-					"https://pulumi-proxy.myproxy.test/releases/plugins/"+
-						"pulumi-resource-otherdl-v1.2.3-linux-amd64.tar.gz",
-					req.URL.String())
+			if req.URL.Host == artifactoryHost && req.URL.Path == pulumiPath+
+				"/releases/plugins/pulumi-resource-otherdl-v1.2.3-linux-amd64.tar.gz" {
 				return newMockReadCloser(expectedBytes)
-			default:
-				t.Errorf("unexpected host: %s", req.URL.Host)
-				return nil, -1, errors.New("unexpected host")
 			}
+			// GitHub attempts return 404 to trigger the fallback.
+			return nil, -1, errors.New("404 not found")
 		}
 		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
 		require.NoError(t, err)
@@ -1357,8 +1405,10 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		assert.Equal(t, expectedBytes, b)
 	})
 
-	t.Run("GitLab host override redirects download", func(t *testing.T) {
-		setOverrides(t, map[string]string{"gitlab.com": "gitlab-proxy.myproxy.test"})
+	t.Run("Artifactory subpath - GitLab download prepends path prefix", func(t *testing.T) {
+		setOverrides(t, map[string]hostOverride{
+			"gitlab.com": {scheme: "https", host: artifactoryHost, path: "/artifactory/gitlab-remote"},
+		})
 
 		spec := PluginDescriptor{
 			Name:              "mockdl",
@@ -1370,7 +1420,9 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
-			assert.Equal(t, "gitlab-proxy.myproxy.test", req.URL.Host)
+			assert.Equal(t, artifactoryHost, req.URL.Host)
+			assert.True(t, strings.HasPrefix(req.URL.Path, "/artifactory/gitlab-remote/"),
+				"expected path to start with Artifactory prefix, got: %s", req.URL.Path)
 			return newMockReadCloser(expectedBytes)
 		}
 		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
@@ -1381,8 +1433,29 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		assert.Equal(t, expectedBytes, b)
 	})
 
+	t.Run("bare hostname (no path) still works", func(t *testing.T) {
+		setOverrides(t, map[string]hostOverride{
+			"api.github.com": {scheme: "https", host: "simpleproxy.myproxy.test", path: ""},
+		})
+
+		spec := PluginDescriptor{Name: "mockdl", Kind: apitype.ResourcePlugin}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t, "simpleproxy.myproxy.test", req.URL.Host)
+			assert.Equal(t,
+				"https://simpleproxy.myproxy.test/repos/pulumi/pulumi-mockdl/releases/latest",
+				req.URL.String())
+			return newMockReadCloserString(`{"tag_name":"v1.2.3"}`)
+		}
+		got, err := source.GetLatestVersion(t.Context(), getHTTPResponse)
+		require.NoError(t, err)
+		assert.Equal(t, version, *got)
+	})
+
 	t.Run("no overrides leaves URLs unchanged", func(t *testing.T) {
-		setOverrides(t, map[string]string{})
+		setOverrides(t, map[string]hostOverride{})
 
 		spec := PluginDescriptor{Name: "mockdl", Kind: apitype.ResourcePlugin}
 		source, err := spec.GetSource()

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1118,6 +1118,283 @@ func TestParsePluginDownloadURLOverride(t *testing.T) {
 	}
 }
 
+func TestParsePluginHostOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    map[string]string
+		expectedErr string
+	}{
+		{
+			name:     "empty string returns empty map",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:  "single pair",
+			input: "api.github.com=github-api.myproxy.test",
+			expected: map[string]string{
+				"api.github.com": "github-api.myproxy.test",
+			},
+		},
+		{
+			name:  "multiple pairs",
+			input: "api.github.com=github-api.myproxy.test,github.com=github-com.myproxy.test",
+			expected: map[string]string{
+				"api.github.com": "github-api.myproxy.test",
+				"github.com":     "github-com.myproxy.test",
+			},
+		},
+		{
+			name:  "host with port",
+			input: "localhost:8080=proxy.example.com:9090",
+			expected: map[string]string{
+				"localhost:8080": "proxy.example.com:9090",
+			},
+		},
+		{
+			name:        "missing value",
+			input:       "api.github.com=",
+			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "api.github.com="`,
+		},
+		{
+			name:        "missing key",
+			input:       "=myproxy.test",
+			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "=myproxy.test"`,
+		},
+		{
+			name:        "no equals sign",
+			input:       "api.github.com",
+			expectedErr: `expected format to be "host1=proxy1,host2=proxy2"; got "api.github.com"`,
+		},
+		{
+			name:  "three pairs",
+			input: "api.github.com=a.proxy.test,github.com=b.proxy.test,get.pulumi.com=c.proxy.test",
+			expected: map[string]string{
+				"api.github.com": "a.proxy.test",
+				"github.com":     "b.proxy.test",
+				"get.pulumi.com": "c.proxy.test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parsePluginHostOverrides(tt.input)
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestPluginHostOverridesBuildRequest verifies that host overrides are applied transparently
+// in buildHTTPRequest for every source type.
+//
+//nolint:paralleltest // mutates pluginHostOverridesParsed
+func TestPluginHostOverridesBuildRequest(t *testing.T) {
+	const (
+		apiProxy = "github-api.myproxy.test"
+		dlProxy  = "github-com.myproxy.test"
+	)
+	expectedBytes := []byte{1, 2, 3}
+	version := semver.MustParse("1.2.3")
+
+	// setOverrides sets pluginHostOverridesParsed for the duration of the sub-test and
+	// restores it afterwards.
+	setOverrides := func(t *testing.T, m map[string]string) {
+		t.Helper()
+		orig := pluginHostOverridesParsed
+		pluginHostOverridesParsed = m
+		t.Cleanup(func() { pluginHostOverridesParsed = orig })
+	}
+
+	t.Run("GitHub API host override redirects GetLatestVersion", func(t *testing.T) {
+		setOverrides(t, map[string]string{"api.github.com": apiProxy})
+
+		spec := PluginDescriptor{Name: "mockdl", Kind: apitype.ResourcePlugin}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t, apiProxy, req.URL.Host)
+			assert.Equal(t,
+				"https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/latest",
+				req.URL.String())
+			return newMockReadCloserString(`{"tag_name":"v1.2.3"}`)
+		}
+		got, err := source.GetLatestVersion(t.Context(), getHTTPResponse)
+		require.NoError(t, err)
+		assert.Equal(t, version, *got)
+	})
+
+	t.Run("GitHub download host override redirects direct archive download", func(t *testing.T) {
+		setOverrides(t, map[string]string{
+			"api.github.com": apiProxy, // needed so GetSource finds latest via proxy
+			"github.com":     dlProxy,
+		})
+
+		spec := PluginDescriptor{
+			Name:    "mockdl",
+			Kind:    apitype.ResourcePlugin,
+			Version: &version,
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t, dlProxy, req.URL.Host)
+			assert.Equal(t,
+				"https://"+dlProxy+"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+
+					"pulumi-resource-mockdl-v1.2.3-linux-amd64.tar.gz",
+				req.URL.String())
+			return newMockReadCloser(expectedBytes)
+		}
+		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, int(l), len(b))
+		assert.Equal(t, expectedBytes, b)
+	})
+
+	t.Run("both GitHub hosts overridden - API fallback path rewrites asset URL", func(t *testing.T) {
+		// Direct download returns 404 → falls back to release API.
+		// The asset URL embedded in the API JSON response references api.github.com; because
+		// buildHTTPRequest rewrites the host, the follow-up download also goes to the proxy.
+		setOverrides(t, map[string]string{
+			"api.github.com": apiProxy,
+			"github.com":     dlProxy,
+		})
+
+		spec := PluginDescriptor{
+			Name:    "mockdl",
+			Kind:    apitype.ResourcePlugin,
+			Version: &version,
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		assetName := "pulumi-resource-mockdl-v1.2.3-linux-amd64.tar.gz"
+		// GitHub API always returns api.github.com-absolute asset URLs.
+		apiAssetURL := "https://api.github.com/repos/pulumi/pulumi-mockdl/releases/assets/99"
+
+		var seen []string
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			seen = append(seen, req.URL.String())
+			switch req.URL.String() {
+			case "https://" + dlProxy + "/pulumi/pulumi-mockdl/releases/download/v1.2.3/" + assetName:
+				return nil, -1, errors.New("404 not found")
+			case "https://" + apiProxy + "/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3":
+				return newMockReadCloserString(
+					`{"assets":[{"name":"` + assetName + `","url":"` + apiAssetURL + `"}]}`)
+			case "https://" + apiProxy + "/repos/pulumi/pulumi-mockdl/releases/assets/99":
+				// buildHTTPRequest rewrote api.github.com → apiProxy before the request fired.
+				return newMockReadCloser(expectedBytes)
+			default:
+				t.Errorf("unexpected request: %s", req.URL)
+				return nil, -1, errors.New("unexpected request")
+			}
+		}
+		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, int(l), len(b))
+		assert.Equal(t, expectedBytes, b)
+
+		require.Len(t, seen, 3)
+		assert.Equal(t, "https://"+dlProxy+"/pulumi/pulumi-mockdl/releases/download/v1.2.3/"+assetName, seen[0])
+		assert.Equal(t, "https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/tags/v1.2.3", seen[1])
+		assert.Equal(t, "https://"+apiProxy+"/repos/pulumi/pulumi-mockdl/releases/assets/99", seen[2])
+	})
+
+	t.Run("get.pulumi.com host override redirects fallback source", func(t *testing.T) {
+		setOverrides(t, map[string]string{
+			"api.github.com": apiProxy,   // make GitHub steps fail visibly
+			"github.com":     dlProxy,    // make GitHub direct download fail
+			"get.pulumi.com": "pulumi-proxy.myproxy.test",
+		})
+
+		spec := PluginDescriptor{
+			Name:    "otherdl", // not in the "pulumi" org fast-path
+			Kind:    apitype.ResourcePlugin,
+			Version: &version,
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			switch req.URL.Host {
+			case dlProxy:
+				return nil, -1, errors.New("404 not found")
+			case apiProxy:
+				return nil, -1, errors.New("404 not found")
+			case "pulumi-proxy.myproxy.test":
+				assert.Equal(t,
+					"https://pulumi-proxy.myproxy.test/releases/plugins/"+
+						"pulumi-resource-otherdl-v1.2.3-linux-amd64.tar.gz",
+					req.URL.String())
+				return newMockReadCloser(expectedBytes)
+			default:
+				t.Errorf("unexpected host: %s", req.URL.Host)
+				return nil, -1, errors.New("unexpected host")
+			}
+		}
+		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, int(l), len(b))
+		assert.Equal(t, expectedBytes, b)
+	})
+
+	t.Run("GitLab host override redirects download", func(t *testing.T) {
+		setOverrides(t, map[string]string{"gitlab.com": "gitlab-proxy.myproxy.test"})
+
+		spec := PluginDescriptor{
+			Name:              "mockdl",
+			Kind:              apitype.ResourcePlugin,
+			Version:           &version,
+			PluginDownloadURL: "gitlab://gitlab.com/12345",
+		}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t, "gitlab-proxy.myproxy.test", req.URL.Host)
+			return newMockReadCloser(expectedBytes)
+		}
+		r, l, err := source.Download(t.Context(), version, "linux", "amd64", getHTTPResponse)
+		require.NoError(t, err)
+		b, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, int(l), len(b))
+		assert.Equal(t, expectedBytes, b)
+	})
+
+	t.Run("no overrides leaves URLs unchanged", func(t *testing.T) {
+		setOverrides(t, map[string]string{})
+
+		spec := PluginDescriptor{Name: "mockdl", Kind: apitype.ResourcePlugin}
+		source, err := spec.GetSource()
+		require.NoError(t, err)
+
+		getHTTPResponse := func(req *http.Request) (io.ReadCloser, int64, error) {
+			assert.Equal(t, "api.github.com", req.URL.Host)
+			return newMockReadCloserString(`{"tag_name":"v1.2.3"}`)
+		}
+		_, err = source.GetLatestVersion(t.Context(), getHTTPResponse)
+		require.NoError(t, err)
+	})
+}
+
 func TestPluginDownloadOverrideArray_Get(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1323,7 +1323,9 @@ func TestPluginHostOverridesBuildRequest(t *testing.T) {
 		})
 
 		spec := PluginDescriptor{
-			Name:    "otherdl", // not in the "pulumi" org fast-path
+			// "otherdl" has no real GitHub releases, so both GitHub download attempts
+			// return 404 and fallbackSource falls through to get.pulumi.com.
+			Name:    "otherdl",
 			Kind:    apitype.ResourcePlugin,
 			Version: &version,
 		}


### PR DESCRIPTION
## Summary

Test with the override url env var but not working because it still modifies the URL in code on how to download the files from github.

What I need is really a simple replace of the hostname with something from Artifactory for example (working for a comp with lot of things like artifactory, proxy etc in place where we need to redirect all things as much as possible).

They also have endpoints for github api and github itself so I want to use this as  plain replacements.

Related:
- https://github.com/pulumi/pulumi/issues/16240


<details>
<summary>Log output form pulumi install</summary>


I0330 15:33:55.503930  182680 plugins.go:532] EnsurePluginsAreInstalled(): plugin gitlab 9.8.2 not installed, doing install
I0330 15:33:55.503967  182680 plugins.go:567] installPlugin(gitlab, 9.8.2): beginning install
I0330 15:33:55.503972  182680 plugins.go:581] installPlugin(gitlab, 9.8.2): initiating download
I0330 15:33:55.504368  182680 plugins.go:733] gitlab trying direct download from https://github.com/pulumi/pulumi-gitlab/releases/download/v9.8.2/pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz
I0330 15:33:55.504411  182680 plugins.go:1646] plugin host override: https://github.com/pulumi/pulumi-gitlab/releases/download/v9.8.2/pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz -> https://myartifactory.test.com/artifactory/github-generic-remote/pulumi/pulumi-gitlab/releases/download/v9.8.2/pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz
I0330 15:33:55.504425  182680 plugins.go:1660] full plugin download url: https://myartifactory.test.com/artifactory/github-generic-remote/pulumi/pulumi-gitlab/releases/download/v9.8.2/pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz
I0330 15:33:55.504442  182680 plugins.go:1663] plugin install request headers: map[Accept:[application/octet-stream] User-Agent:[pulumi-cli/1 (3.229.0-dev.0; linux)]]
I0330 15:33:55.710979  182680 plugins.go:1672] plugin install response headers: map[Accept-Ranges:[bytes] Content-Disposition:[attachment; filename="pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz"; filename*=UTF-8''pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz] Content-Length:[20471761] Content-Type:[application/x-gzip] Date:[Mon, 30 Mar 2026 13:33:55 GMT] Etag:[e2bd088dad262ed9c21daeb6f97b86a6d34dac9d] Last-Modified:[Tue, 20 Jan 2026 19:09:41 GMT] Strict-Transport-Security:[max-age=63072000; includeSubDomains; preload] X-Artifactory-Filename:[pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz] X-Artifactory-Id:[123] X-Artifactory-Node-Id:[artifactory-3] X-Artifactory-Origin-Remote-Path:[https://github.com/pulumi/pulumi-gitlab/releases/download/v9.8.2/pulumi-resource-gitlab-v9.8.2-linux-amd64.tar.gz] X-Checksum-Md5:[37e8cc62a2768b85e586bfef903904c2] X-Checksum-Sha1:[e2bd088dad262ed9c21daeb6f97b86a6d34dac9d] X-Checksum-Sha256:[410765e0d76d0bf40690cd90345bbd0250f8ab776a9c7cc49d07dc0ae009e691] X-Jfrog-Version:[Artifactory/7.117.15 81715900]]
I0330 15:33:56.095643  182680 plugins.go:1839] try downloaded plugin gitlab-9.8.2 to /tmp/pulumi-plugin-tar568619052: <nil> <nil>
I0330 15:33:56.095688  182680 plugins.go:627] installPlugin(gitlab, 9.8.2): extracting tarball to installation directory
I0330 15:33:56.610100  182680 plugins.go:665] installPlugin(gitlab, 9.8.2): installation complete
I0330 15:33:56.611898  182680 plugin.go:616] killing plugin /home/linuxbrew/.linuxbrew/bin/pulumi-language-nodejs


</details>

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->

None, new functionality to rewrite host url to download plugins etc.
