### PR TITLE
feat: Add `pulumi docs search`, `sitemap`, and `registry` subcommands

### DIFF
--- a/changelog/pending/20260330--cli--add-pulumi-docs-search-sitemap-registry.yaml
+++ b/changelog/pending/20260330--cli--add-pulumi-docs-search-sitemap-registry.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi docs search`, `pulumi docs sitemap`, and `pulumi docs registry` subcommands

--- a/pkg/cmd/pulumi/docs/docs.go
+++ b/pkg/cmd/pulumi/docs/docs.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/browser"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +35,7 @@ type docsCmd struct {
 	raw             bool
 	toc             bool
 	tocJSON         bool
+	jsonOutput      bool
 }
 
 // NewDocsCmd creates the `pulumi docs` command.
@@ -44,7 +47,10 @@ func NewDocsCmd() *cobra.Command {
 		Short: "View Pulumi documentation in the terminal",
 		Long: "Read and browse Pulumi documentation in the terminal.\n\n" +
 			"  pulumi docs                    Show help\n" +
-			"  pulumi docs read <path>        Read a specific page",
+			"  pulumi docs read <path>        Read a specific page\n" +
+			"  pulumi docs registry <pkg>     Read a registry package\n" +
+			"  pulumi docs search <query>     Search documentation\n" +
+			"  pulumi docs sitemap            List available pages",
 	}
 
 	cmd.PersistentFlags().StringVar(&dc.baseURL, "base-url", "https://www.pulumi.com",
@@ -59,6 +65,9 @@ func NewDocsCmd() *cobra.Command {
 		"Filter OS-specific content in docs (e.g., macos, linux, windows); choice is remembered")
 
 	cmd.AddCommand(dc.newReadCmd())
+	cmd.AddCommand(dc.newSearchCmd())
+	cmd.AddCommand(dc.newRegistryCmd())
+	cmd.AddCommand(dc.newSitemapCmd())
 
 	return cmd
 }
@@ -122,6 +131,11 @@ func (dc *docsCmd) fetchAndRender(path string) error {
 
 	body, title, err := FetchDoc(fetchBase, path)
 	if err != nil {
+		// Graceful fallback for registry pages that aren't available in the terminal
+		var regErr *RegistryNotAvailableError
+		if errors.As(err, &regErr) {
+			return dc.handleRegistryFallback(path)
+		}
 		return err
 	}
 
@@ -165,7 +179,9 @@ func (dc *docsCmd) fetchAndRender(path string) error {
 	prefs, _ := LoadPreferences()
 	if section == "" {
 		prefs.LastPage = path
-		_ = prefs.Save()
+		if err := prefs.Save(); err != nil {
+			logging.V(7).Infof("failed to save docs preferences: %v", err)
+		}
 	}
 
 	// Show navigation footer when viewing a full page
@@ -263,5 +279,85 @@ func (dc *docsCmd) showTOC(body string, section *string) error {
 			break
 		}
 	}
+	return nil
+}
+
+func (dc *docsCmd) newSearchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <query>...",
+		Short: "Search Pulumi documentation",
+		Long:  "Search Pulumi documentation using Algolia and display results.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			return runSearch(dc, query)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.jsonOutput, "json", false,
+		"Output results as JSON")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "query"}},
+		Required:  1,
+		Variadic:  true,
+	})
+	return cmd
+}
+
+// viewPage fetches and renders a page given its href path (e.g. /docs/iac/concepts/stacks/ or /registry/packages/aws/).
+func (dc *docsCmd) viewPage(href string) error {
+	path := hrefToPath(href)
+	if path == "" {
+		return fmt.Errorf("invalid page path: %s", href)
+	}
+	return dc.fetchAndRender(path)
+}
+
+// handleRegistryFallback provides a graceful fallback when a registry page (typically
+// an API docs page) isn't available as markdown for terminal viewing.
+func (dc *docsCmd) handleRegistryFallback(path string) error {
+	pageWebURL := webURL(dc.registryBaseURL, path)
+
+	// Check if this is an API docs page and extract the package overview path.
+	var overviewPath string
+	trimmed := strings.Trim(path, "/")
+	if idx := strings.Index(trimmed, "/api-docs"); idx >= 0 {
+		overviewPath = trimmed[:idx]
+	}
+
+	fmt.Fprintln(os.Stderr)
+	if overviewPath != "" {
+		fmt.Fprintln(os.Stderr, "Registry API docs are not available for terminal viewing.")
+	} else {
+		fmt.Fprintln(os.Stderr, "This registry page is not available for terminal viewing.")
+	}
+
+	if cmdutil.Interactive() && overviewPath != "" {
+		optOverview := "View package overview"
+		optBrowser := "Open in web browser"
+		options := []string{optOverview, optBrowser}
+
+		fmt.Fprintln(os.Stderr)
+		selected := ui.PromptUser(
+			"What would you like to do?",
+			options,
+			optOverview,
+			cmdutil.GetGlobalColorization(),
+		)
+
+		switch selected {
+		case optOverview:
+			return dc.fetchAndRender(overviewPath)
+		case optBrowser:
+			fmt.Fprintf(os.Stderr, "Opening %s\n\n", pageWebURL)
+			return browser.OpenURL(pageWebURL)
+		}
+		return nil
+	}
+
+	// Non-interactive or no overview available
+	fmt.Fprintf(os.Stderr, "Visit: %s\n", pageWebURL)
+	if overviewPath != "" {
+		fmt.Fprintf(os.Stderr, "Or view the package overview: pulumi docs read %s\n", overviewPath)
+	}
+	fmt.Fprintln(os.Stderr)
 	return nil
 }

--- a/pkg/cmd/pulumi/docs/registry.go
+++ b/pkg/cmd/pulumi/docs/registry.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/spf13/cobra"
+)
+
+// newRegistryCmd creates the `pulumi docs registry` subcommand for browsing
+// registry package documentation with convenient shorthands.
+func (dc *docsCmd) newRegistryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry <package> [install|api [module]]",
+		Short: "View registry package documentation",
+		Long: "Browse Pulumi registry package documentation in the terminal.\n\n" +
+			"Shorthands:\n" +
+			"  pulumi docs registry <package>              Package overview\n" +
+			"  pulumi docs registry <package> install       Installation & configuration\n" +
+			"  pulumi docs registry <package> api            API docs overview\n" +
+			"  pulumi docs registry <package> api <module>   API docs for a module\n\n" +
+			"Full path syntax also works:\n" +
+			"  pulumi docs registry/packages/<package>",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+
+			// If the first arg looks like a full path (contains /), treat it as such
+			if strings.Contains(args[0], "/") {
+				path := "registry/" + strings.TrimPrefix(args[0], "registry/")
+				return dc.fetchAndRender(path)
+			}
+
+			path := resolveRegistryPath(args)
+			return dc.fetchAndRender(path)
+		},
+	}
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package"},
+			{Name: "subpage"},
+			{Name: "module"},
+		},
+	})
+	return cmd
+}
+
+// resolveRegistryPath converts registry subcommand arguments into a content path.
+//
+//	["aws"]                → "registry/packages/aws"
+//	["aws", "install"]     → "registry/packages/aws/installation-configuration"
+//	["aws", "api"]         → "registry/packages/aws/api-docs"
+//	["aws", "api", "s3"]   → "registry/packages/aws/api-docs/s3"
+func resolveRegistryPath(args []string) string {
+	pkg := args[0]
+	base := "registry/packages/" + pkg
+
+	if len(args) < 2 {
+		return base
+	}
+
+	switch strings.ToLower(args[1]) {
+	case "install", "installation", "config", "configuration":
+		return base + "/installation-configuration"
+	case "api", "api-docs":
+		if len(args) >= 3 {
+			return base + "/api-docs/" + args[2]
+		}
+		return base + "/api-docs"
+	default:
+		// Treat as a sub-path
+		return base + "/" + strings.Join(args[1:], "/")
+	}
+}

--- a/pkg/cmd/pulumi/docs/registry_test.go
+++ b/pkg/cmd/pulumi/docs/registry_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveRegistryPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "package only", args: []string{"aws"}, want: "registry/packages/aws"},
+		{name: "install", args: []string{"aws", "install"}, want: "registry/packages/aws/installation-configuration"},
+		{
+			name: "configuration",
+			args: []string{"aws", "configuration"},
+			want: "registry/packages/aws/installation-configuration",
+		},
+		{name: "api", args: []string{"aws", "api"}, want: "registry/packages/aws/api-docs"},
+		{name: "api with module", args: []string{"aws", "api", "s3"}, want: "registry/packages/aws/api-docs/s3"},
+		{name: "unknown subpage", args: []string{"aws", "changelog"}, want: "registry/packages/aws/changelog"},
+		{name: "api-docs alias", args: []string{"aws", "api-docs"}, want: "registry/packages/aws/api-docs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, resolveRegistryPath(tt.args))
+		})
+	}
+}

--- a/pkg/cmd/pulumi/docs/search.go
+++ b/pkg/cmd/pulumi/docs/search.go
@@ -1,0 +1,257 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// cliConfig is the structure served by the docs site at /docs/cli-config.json.
+type cliConfig struct {
+	Algolia algoliaConfig `json:"algolia"`
+}
+
+type algoliaConfig struct {
+	AppID     string `json:"appId"`
+	SearchKey string `json:"searchKey"`
+	IndexName string `json:"indexName"`
+}
+
+type algoliaResponse struct {
+	Hits []algoliaHit `json:"hits"`
+}
+
+type algoliaHit struct {
+	ObjectID    string `json:"objectID"`
+	Title       string `json:"title"`
+	H1          string `json:"h1"`
+	Description string `json:"description"`
+	Href        string `json:"href"`
+	Section     string `json:"section"`
+}
+
+func (h algoliaHit) displayTitle() string {
+	title := h.H1
+	if title == "" {
+		title = h.Title
+	}
+	if title == "" {
+		title = h.Href
+	}
+	return title
+}
+
+// sectionName returns "registry" or "docs" based on the hit's href.
+func (h algoliaHit) sectionName() string {
+	if strings.Contains(h.Href, "/registry/") {
+		return "registry"
+	}
+	return "docs"
+}
+
+// sectionTag returns a short tag like "[docs]" or "[registry]" for display in search results.
+func (h algoliaHit) sectionTag() string {
+	return "[" + h.sectionName() + "]"
+}
+
+// fetchCLIConfig fetches the CLI config file from the docs site.
+func fetchCLIConfig(baseURL string) (*cliConfig, error) {
+	configURL := strings.TrimRight(baseURL, "/") + "/docs/cli-config.json"
+
+	//nolint:gosec // URL is constructed from user-provided base URL
+	resp, err := http.Get(configURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CLI config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CLI config not available (status %d) — "+
+			"set ALGOLIA_APP_ID and ALGOLIA_APP_SEARCH_KEY as a fallback", resp.StatusCode)
+	}
+
+	var cfg cliConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decoding CLI config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// getAlgoliaCredentials resolves Algolia credentials. It checks env vars first,
+// then fetches cli-config.json from the docs site.
+func getAlgoliaCredentials(baseURL string) (appID, apiKey, indexName string, err error) {
+	// Env vars take precedence (useful for overrides and testing)
+	appID = os.Getenv("ALGOLIA_APP_ID")
+	apiKey = os.Getenv("ALGOLIA_APP_SEARCH_KEY")
+	if appID != "" && apiKey != "" {
+		indexName = os.Getenv("ALGOLIA_INDEX_NAME")
+		if indexName == "" {
+			indexName = "production"
+		}
+		return appID, apiKey, indexName, nil
+	}
+
+	// Fetch from docs site
+	cfg, err := fetchCLIConfig(baseURL)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	if cfg.Algolia.AppID == "" || cfg.Algolia.SearchKey == "" {
+		return "", "", "", errors.New("CLI config missing Algolia credentials")
+	}
+
+	indexName = cfg.Algolia.IndexName
+	if indexName == "" {
+		indexName = "production"
+	}
+	return cfg.Algolia.AppID, cfg.Algolia.SearchKey, indexName, nil
+}
+
+func searchDocs(query, appID, apiKey, indexName string) ([]algoliaHit, error) {
+	searchURL := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/%s/query", appID, indexName)
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("hitsPerPage", "10")
+	params.Set("facetFilters", `[["section:Docs","section:Registry"]]`)
+
+	reqBody, err := json.Marshal(map[string]string{
+		"params": params.Encode(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding search request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", searchURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating search request: %w", err)
+	}
+	req.Header.Set("X-Algolia-Application-Id", appID)
+	req.Header.Set("X-Algolia-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing search: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("search returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result algoliaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding search response: %w", err)
+	}
+
+	return result.Hits, nil
+}
+
+func runSearch(cmd *docsCmd, query string) error {
+	appID, apiKey, indexName, err := getAlgoliaCredentials(cmd.baseURL)
+	if err != nil {
+		return err
+	}
+
+	hits, err := searchDocs(query, appID, apiKey, indexName)
+	if err != nil {
+		return err
+	}
+
+	if len(hits) == 0 {
+		if cmd.jsonOutput {
+			fmt.Println("[]")
+			return nil
+		}
+		fmt.Println("No results found.")
+		return nil
+	}
+
+	if cmd.jsonOutput {
+		type searchResult struct {
+			Title       string `json:"title"`
+			Section     string `json:"section"`
+			Description string `json:"description,omitempty"`
+			Href        string `json:"href"`
+		}
+		results := make([]searchResult, len(hits))
+		for i, hit := range hits {
+			results[i] = searchResult{
+				Title:       hit.displayTitle(),
+				Section:     hit.sectionName(),
+				Description: hit.Description,
+				Href:        hit.Href,
+			}
+		}
+		return ui.PrintJSON(results)
+	}
+
+	interactive := cmdutil.Interactive()
+
+	if interactive {
+		// Build selectable list with title on first line and description indented on second.
+		options := make([]string, len(hits))
+		for i, hit := range hits {
+			tag := hit.sectionTag()
+			desc := hit.Description
+			if len(desc) > 80 {
+				desc = desc[:77] + "..."
+			}
+			if desc != "" {
+				options[i] = fmt.Sprintf("%s %s\n     %s", tag, hit.displayTitle(), desc)
+			} else {
+				options[i] = fmt.Sprintf("%s %s", tag, hit.displayTitle())
+			}
+		}
+
+		selected := ui.PromptUser(
+			"Select a page to view:",
+			options,
+			options[0],
+			cmdutil.GetGlobalColorization(),
+		)
+
+		for i, opt := range options {
+			if opt == selected {
+				return cmd.viewPage(hits[i].Href)
+			}
+		}
+		return nil
+	}
+
+	// Non-interactive: print list
+	for i, hit := range hits {
+		fmt.Printf("%d. %s %s\n", i+1, hit.sectionTag(), hit.displayTitle())
+		if hit.Description != "" {
+			fmt.Printf("   %s\n", hit.Description)
+		}
+		fmt.Printf("   %s\n\n", hit.Href)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/docs/sitemap.go
+++ b/pkg/cmd/pulumi/docs/sitemap.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/spf13/cobra"
+)
+
+func (dc *docsCmd) newSitemapCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sitemap [scope]",
+		Short: "List available documentation pages",
+		Long: "Display the documentation site map as a navigable list of pages.\n\n" +
+			"  pulumi docs sitemap                                List all docs pages\n" +
+			"  pulumi docs sitemap registry                       List all registry packages\n" +
+			"  pulumi docs sitemap registry/packages/<pkg>        List pages for a specific package\n" +
+			"  pulumi docs sitemap --json                         Output as JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scope := ""
+			if len(args) > 0 {
+				scope = strings.Trim(args[0], "/")
+			}
+			return dc.runSitemap(scope)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.jsonOutput, "json", false, "Output as JSON")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "scope"}},
+	})
+	return cmd
+}
+
+func (dc *docsCmd) runSitemap(scope string) error {
+	pages, err := dc.fetchSitemapForScope(scope)
+	if err != nil {
+		return err
+	}
+
+	if dc.jsonOutput {
+		return ui.PrintJSON(pages)
+	}
+
+	printSitemapTree(pages, 0)
+	return nil
+}
+
+func (dc *docsCmd) fetchSitemapForScope(scope string) ([]SitemapPage, error) {
+	// Per-package sitemap: registry/packages/<pkg>
+	if strings.HasPrefix(scope, "registry/packages/") {
+		parts := strings.SplitN(strings.TrimPrefix(scope, "registry/packages/"), "/", 2)
+		pkg := parts[0]
+		if pkg == "" {
+			return nil, errors.New("missing package name — use: pulumi docs sitemap registry/packages/<pkg>")
+		}
+		return FetchPackageSitemap(dc.registryBaseURL, pkg)
+	}
+
+	// Registry top-level
+	if scope == "registry" || strings.HasPrefix(scope, "registry/") {
+		return FetchRegistrySitemap(dc.registryBaseURL)
+	}
+
+	// Default: docs sitemap
+	return FetchSitemap(dc.baseURL)
+}
+
+func printSitemapTree(pages []SitemapPage, depth int) {
+	for _, p := range pages {
+		indent := strings.Repeat("  ", depth)
+		fmt.Printf("%s%s  (%s)\n", indent, p.Title, p.Path)
+		if len(p.Children) > 0 {
+			printSitemapTree(p.Children, depth+1)
+		}
+	}
+}


### PR DESCRIPTION
## Summary (PR 2 of 4)

> **Review/merge order:** Requires PR 1 (#22398) to be merged first. Review and merge before PRs 3–4.

Adds three new subcommands to the `pulumi docs` command:

- `pulumi docs search <query>` — Algolia-powered full-text search with interactive result selection
- `pulumi docs sitemap [scope]` — list available docs/registry pages hierarchically
- `pulumi docs registry <pkg> [install|api [module]]` — convenient shorthands for registry packages

Also adds graceful fallback handling when registry pages aren't available as terminal markdown.

### PR series

1. `pulumi docs read` (#22398) — core read pipeline
2. **`pulumi docs search/sitemap/registry`** (this PR) — additional subcommands
3. Bundle system — registry API docs with caching
4. `pulumi docs browse` — interactive browse mode

## Test plan

- [x] `go build ./cmd/pulumi/docs/...` compiles
- [x] `go test -count=1 ./cmd/pulumi/docs/...` passes
- [x] `golangci-lint run ./cmd/pulumi/docs/...` clean