### PR TITLE
feat: Add CLI docs bundle system for registry API docs

### DIFF
--- a/changelog/pending/20260330--cli--add-cli-docs-bundle-system.yaml
+++ b/changelog/pending/20260330--cli--add-cli-docs-bundle-system.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add CLI docs bundle system for offline registry API documentation

--- a/pkg/cmd/pulumi/docs/bundle.go
+++ b/pkg/cmd/pulumi/docs/bundle.go
@@ -1,0 +1,643 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Section name constants used as map keys in sectionNav and for heading matching.
+const (
+	sectionModules   = "Modules"
+	sectionResources = "Resources"
+	sectionFunctions = "Functions"
+)
+
+// CLIDocsBundle represents the bundled CLI docs JSON for a package.
+// All API docs for a package are served as a single JSON file.
+type CLIDocsBundle struct {
+	Version        int               `json:"version"`
+	Package        string            `json:"package"`
+	PackageVersion string            `json:"packageVersion"`
+	Resources      map[string]string `json:"resources"`
+	Functions      map[string]string `json:"functions"`
+}
+
+type bundleCacheMeta struct {
+	PackageVersion string    `json:"packageVersion"`
+	FetchedAt      time.Time `json:"fetchedAt"`
+}
+
+// BundleNotAvailableError is returned when a package's cli-docs.json is not available (404).
+type BundleNotAvailableError struct {
+	Package string
+}
+
+func (e *BundleNotAvailableError) Error() string {
+	return "CLI docs bundle not available for package: " + e.Package
+}
+
+const (
+	bundleCacheDir = "cli-docs-cache"
+	bundleCacheTTL = 1 * time.Hour
+)
+
+var bundleMemCache sync.Map
+
+// ParseAPIDocsPath extracts the package name and doc key from an API docs path.
+// For example:
+//
+//	"registry/packages/aws/api-docs/s3/bucket" → "aws", "s3/bucket", true
+//	"registry/packages/random/api-docs/randomstring" → "random", "randomstring", true
+//	"registry/packages/aws/api-docs" → "aws", "", true
+//	"registry/packages/aws" → "", "", false
+func ParseAPIDocsPath(path string) (packageName, docKey string, ok bool) {
+	trimmed := strings.Trim(path, "/")
+	const prefix = "registry/packages/"
+	if !strings.HasPrefix(trimmed, prefix) {
+		return "", "", false
+	}
+	after := trimmed[len(prefix):]
+
+	if idx := strings.Index(after, "/api-docs/"); idx >= 0 {
+		packageName = after[:idx]
+		docKey = strings.Trim(after[idx+len("/api-docs/"):], "/")
+		return packageName, docKey, true
+	}
+
+	if strings.HasSuffix(after, "/api-docs") {
+		packageName = after[:len(after)-len("/api-docs")]
+		return packageName, "", true
+	}
+
+	return "", "", false
+}
+
+// FetchCLIDocsBundle fetches the CLI docs bundle for a package, using in-memory
+// and disk caches to avoid redundant HTTP requests.
+func FetchCLIDocsBundle(baseURL, packageName string) (*CLIDocsBundle, error) {
+	if cached, ok := bundleMemCache.Load(packageName); ok {
+		return cached.(*CLIDocsBundle), nil
+	}
+
+	bundle, err := loadBundleFromDisk(packageName)
+	if err == nil && bundle != nil {
+		bundleMemCache.Store(packageName, bundle)
+		return bundle, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching %s API docs...\n", packageName)
+	bundle, err = fetchBundleHTTP(baseURL, packageName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := saveBundleToDisk(packageName, bundle); err != nil {
+		logging.V(7).Infof("failed to cache docs bundle for %s: %v", packageName, err)
+	}
+	bundleMemCache.Store(packageName, bundle)
+	return bundle, nil
+}
+
+func fetchBundleHTTP(baseURL, packageName string) (*CLIDocsBundle, error) {
+	url := fmt.Sprintf("%s/registry/packages/%s/api-docs/cli-docs.json",
+		strings.TrimRight(baseURL, "/"), packageName)
+
+	//nolint:gosec // URL is constructed from user-provided base URL and package name
+	resp, err := bundleHTTPClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CLI docs bundle: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		return nil, &BundleNotAvailableError{Package: packageName}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching CLI docs bundle for %s", resp.StatusCode, packageName)
+	}
+
+	// Read with a progress indicator for large downloads.
+	var data []byte
+	total := resp.ContentLength
+	if total > 1024*1024 { // Show progress for downloads > 1 MB
+		data, err = readWithProgress(resp.Body, total)
+	} else {
+		data, err = io.ReadAll(resp.Body)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading CLI docs bundle response: %w", err)
+	}
+
+	var bundle CLIDocsBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, fmt.Errorf("parsing CLI docs bundle: %w", err)
+	}
+
+	return &bundle, nil
+}
+
+// readWithProgress reads from r while showing a progress bar on stderr.
+func readWithProgress(r io.Reader, total int64) ([]byte, error) {
+	buf := make([]byte, 0, total)
+	tmp := make([]byte, 256*1024) // 256 KB chunks
+	var read int64
+	lastPct := -1
+
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			read += int64(n)
+			if total > 0 {
+				pct := int(read * 100 / total)
+				if pct != lastPct {
+					fmt.Fprintf(os.Stderr, "\r  Downloading... %d%%", pct)
+					lastPct = pct
+				}
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr) // clear progress line
+			return nil, err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "\r  Downloading... done.  ")
+	return buf, nil
+}
+
+func bundleCachePath() (string, error) {
+	home, err := workspace.GetPulumiHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, bundleCacheDir), nil
+}
+
+func loadBundleFromDisk(packageName string) (*CLIDocsBundle, error) {
+	cacheDir, err := bundleCachePath()
+	if err != nil {
+		return nil, err
+	}
+
+	metaPath := filepath.Join(cacheDir, packageName+".meta.json")
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, err
+	}
+	var meta bundleCacheMeta
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		return nil, err
+	}
+	if time.Since(meta.FetchedAt) > bundleCacheTTL {
+		return nil, errors.New("cache expired")
+	}
+
+	bundlePath := filepath.Join(cacheDir, packageName+".json")
+	bundleData, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return nil, err
+	}
+	var bundle CLIDocsBundle
+	if err := json.Unmarshal(bundleData, &bundle); err != nil {
+		return nil, err
+	}
+	return &bundle, nil
+}
+
+func saveBundleToDisk(packageName string, bundle *CLIDocsBundle) error {
+	cacheDir, err := bundleCachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return err
+	}
+
+	bundleData, err := json.Marshal(bundle)
+	if err != nil {
+		return err
+	}
+	bundlePath := filepath.Join(cacheDir, packageName+".json")
+	if err := os.WriteFile(bundlePath, bundleData, 0o600); err != nil {
+		return err
+	}
+
+	meta := bundleCacheMeta{
+		PackageVersion: bundle.PackageVersion,
+		FetchedAt:      time.Now(),
+	}
+	metaData, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	metaPath := filepath.Join(cacheDir, packageName+".meta.json")
+	return os.WriteFile(metaPath, metaData, 0o600)
+}
+
+// LookupBundleDoc looks up a resource or function by key in the bundle.
+// Returns the body (with title line stripped), the title, and whether the key was found.
+func LookupBundleDoc(bundle *CLIDocsBundle, docKey string) (body string, title string, found bool) {
+	content, ok := bundle.Resources[docKey]
+	if !ok {
+		content, ok = bundle.Functions[docKey]
+	}
+	if !ok {
+		return "", "", false
+	}
+
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\t", "    ")
+
+	title = extractBundleTitle(content)
+	if title != "" {
+		if idx := strings.Index(content, "\n"); idx >= 0 {
+			content = strings.TrimLeft(content[idx+1:], "\n")
+		}
+	}
+
+	return content, title, true
+}
+
+
+// classifiedEntry represents a single resource or function found during bundle key scanning.
+type classifiedEntry struct {
+	key     string // bundle key (e.g. "s3/bucket")
+	title   string // extracted title (e.g. "Bucket")
+	content string // raw markdown content
+}
+
+// classifiedKeys is the result of scanning bundle keys for a given module prefix.
+type classifiedKeys struct {
+	subModules []string          // sorted sub-module names
+	resources  []classifiedEntry // sorted direct-child resources
+	functions  []classifiedEntry // sorted direct-child functions
+}
+
+// classifyBundleKeys scans Resources and Functions maps, classifying each key
+// as a sub-module, direct resource, or direct function relative to modulePrefix.
+// This is the single source of truth for key classification — all callers
+// (BundleNavItems, BundleSectionNav, RenderBundleTable) use this.
+func classifyBundleKeys(bundle *CLIDocsBundle, modulePrefix string) classifiedKeys {
+	subModules := make(map[string]bool)
+	var resources, functions []classifiedEntry
+
+	classify := func(keys map[string]string, isFunction bool) {
+		for key, content := range keys {
+			var rel string
+			if modulePrefix == "" {
+				if strings.Contains(key, "/") {
+					subModules[strings.SplitN(key, "/", 2)[0]] = true
+					continue
+				}
+				rel = key
+			} else {
+				if !strings.HasPrefix(key, modulePrefix+"/") {
+					continue
+				}
+				rel = key[len(modulePrefix)+1:]
+				if strings.Contains(rel, "/") {
+					subModules[strings.SplitN(rel, "/", 2)[0]] = true
+					continue
+				}
+			}
+
+			title := extractBundleTitle(content)
+			if title == "" {
+				title = rel
+			}
+
+			entry := classifiedEntry{key: key, title: title, content: content}
+			if isFunction {
+				functions = append(functions, entry)
+			} else {
+				resources = append(resources, entry)
+			}
+		}
+	}
+
+	classify(bundle.Resources, false)
+	classify(bundle.Functions, true)
+
+	sort.Slice(resources, func(i, j int) bool { return resources[i].title < resources[j].title })
+	sort.Slice(functions, func(i, j int) bool { return functions[i].title < functions[j].title })
+
+	sortedMods := make([]string, 0, len(subModules))
+	for mod := range subModules {
+		sortedMods = append(sortedMods, mod)
+	}
+	sort.Strings(sortedMods)
+
+	return classifiedKeys{
+		subModules: sortedMods,
+		resources:  resources,
+		functions:  functions,
+	}
+}
+
+
+// extractBundleTitle extracts the title from a "# Title" first line.
+func extractBundleTitle(content string) string {
+	if !strings.HasPrefix(content, "# ") {
+		return ""
+	}
+	if idx := strings.Index(content, "\n"); idx >= 0 {
+		return strings.TrimPrefix(content[:idx], "# ")
+	}
+	return strings.TrimPrefix(content, "# ")
+}
+
+// extractBundleDescription extracts the first sentence of the description.
+// Skips the title line, blank lines, and deprecation notices.
+func extractBundleDescription(content string) string {
+	body := content
+	if strings.HasPrefix(body, "# ") {
+		if idx := strings.Index(body, "\n"); idx >= 0 {
+			body = body[idx+1:]
+		} else {
+			return ""
+		}
+	}
+	body = strings.TrimLeft(body, "\n")
+
+	if strings.HasPrefix(body, "> **Deprecated:") {
+		if idx := strings.Index(body, "\n"); idx >= 0 {
+			body = strings.TrimLeft(body[idx+1:], "\n")
+		}
+	}
+
+	if body == "" {
+		return ""
+	}
+
+	firstLine := body
+	if idx := strings.Index(body, "\n"); idx >= 0 {
+		firstLine = body[:idx]
+	}
+	firstLine = strings.TrimSpace(firstLine)
+
+	if strings.HasPrefix(firstLine, "#") || strings.HasPrefix(firstLine, "<!--") {
+		return ""
+	}
+
+	if idx := strings.Index(firstLine, ". "); idx >= 0 {
+		firstLine = firstLine[:idx+1]
+	}
+
+	const maxLen = 80
+	if len(firstLine) > maxLen {
+		firstLine = firstLine[:maxLen-3] + "..."
+	}
+
+	return firstLine
+}
+
+
+// tableEntry represents a resource, function, or module for table rendering.
+type tableEntry struct {
+	name string
+	desc string
+}
+
+// RenderBundleTable renders a formatted table of modules, resources, and/or functions.
+func RenderBundleTable(bundle *CLIDocsBundle, modulePrefix string) string {
+	ck := classifyBundleKeys(bundle, modulePrefix)
+
+	if len(ck.subModules) == 0 && len(ck.resources) == 0 && len(ck.functions) == 0 {
+		return ""
+	}
+
+	modules := make([]tableEntry, len(ck.subModules))
+	for i, mod := range ck.subModules {
+		modules[i] = tableEntry{name: mod}
+	}
+
+	resources := make([]tableEntry, len(ck.resources))
+	for i, r := range ck.resources {
+		resources[i] = tableEntry{name: r.title, desc: extractBundleDescription(r.content)}
+	}
+
+	functions := make([]tableEntry, len(ck.functions))
+	for i, f := range ck.functions {
+		functions[i] = tableEntry{name: f.title, desc: extractBundleDescription(f.content)}
+	}
+
+	maxName := 0
+	for _, list := range [][]tableEntry{resources, functions} {
+		for _, e := range list {
+			if len(e.name) > maxName {
+				maxName = len(e.name)
+			}
+		}
+	}
+
+	var buf strings.Builder
+
+	if len(modules) > 0 {
+		fmt.Fprintf(&buf, "\n  %s\n", sectionModules)
+		renderColumns(&buf, modules)
+	}
+
+	renderDescSection := func(label string, entries []tableEntry) {
+		if len(entries) == 0 {
+			return
+		}
+		fmt.Fprintf(&buf, "\n  %s\n\n```\n", label)
+		for _, e := range entries {
+			if e.desc != "" {
+				fmt.Fprintf(&buf, "%-*s  %s\n", maxName, e.name, e.desc)
+			} else {
+				fmt.Fprintf(&buf, "%s\n", e.name)
+			}
+		}
+		buf.WriteString("```\n")
+	}
+
+	renderDescSection(sectionResources, resources)
+	renderDescSection(sectionFunctions, functions)
+	buf.WriteString("\n")
+
+	return buf.String()
+}
+
+// renderBundleSectionTable renders the table content for a single section (Modules, Resources, or Functions).
+// Used by ReplaceBundleSections to avoid the string round-trip of rendering and re-parsing.
+func renderBundleSectionTable(ck classifiedKeys, section string) string {
+	var buf strings.Builder
+
+	switch section {
+	case sectionModules:
+		if len(ck.subModules) == 0 {
+			return ""
+		}
+		modules := make([]tableEntry, len(ck.subModules))
+		for i, mod := range ck.subModules {
+			modules[i] = tableEntry{name: mod}
+		}
+		renderColumns(&buf, modules)
+
+	case sectionResources, sectionFunctions:
+		var entries []classifiedEntry
+		if section == sectionResources {
+			entries = ck.resources
+		} else {
+			entries = ck.functions
+		}
+		if len(entries) == 0 {
+			return ""
+		}
+
+		maxName := 0
+		for _, e := range entries {
+			if len(e.title) > maxName {
+				maxName = len(e.title)
+			}
+		}
+
+		buf.WriteString("```\n")
+		for _, e := range entries {
+			desc := extractBundleDescription(e.content)
+			if desc != "" {
+				fmt.Fprintf(&buf, "%-*s  %s\n", maxName, e.title, desc)
+			} else {
+				fmt.Fprintf(&buf, "%s\n", e.title)
+			}
+		}
+		buf.WriteString("```")
+	}
+
+	return buf.String()
+}
+
+// ReplaceBundleSections replaces the Modules, Resources, and Functions sections
+// in a body with formatted bundle content.
+func ReplaceBundleSections(body string, bundle *CLIDocsBundle, modulePrefix string) string {
+	ck := classifyBundleKeys(bundle, modulePrefix)
+
+	for _, section := range []string{sectionModules, sectionResources, sectionFunctions} {
+		heading := "## " + section
+		idx := strings.Index(body, heading)
+		if idx < 0 {
+			continue
+		}
+
+		content := renderBundleSectionTable(ck, section)
+		if content == "" {
+			continue
+		}
+
+		afterHeading := idx + len(heading)
+		endIdx := len(body)
+		if nextH := strings.Index(body[afterHeading:], "\n## "); nextH >= 0 {
+			endIdx = afterHeading + nextH
+		}
+		body = body[:afterHeading] + "\n\n" + content + "\n\n" + body[endIdx:]
+	}
+
+	return body
+}
+
+
+// renderColumns writes entries in a compact multi-column layout with variable-width
+// columns, similar to how `ls` formats output. Wrapped in a code fence for Glamour.
+func renderColumns(buf *strings.Builder, entries []tableEntry) {
+	if len(entries) == 0 {
+		return
+	}
+
+	availWidth := getTerminalWidth() - 8 // Glamour margins + code block padding
+	const gap = 2
+
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.name
+	}
+
+	// Find optimal column count (column-first layout like `ls`).
+	bestCols := 1
+	for tryC := 2; tryC <= len(names); tryC++ {
+		rows := (len(names) + tryC - 1) / tryC
+		totalWidth := 0
+		fits := true
+		for c := 0; c < tryC; c++ {
+			colMax := 0
+			for r := 0; r < rows; r++ {
+				idx := c*rows + r
+				if idx < len(names) && len(names[idx]) > colMax {
+					colMax = len(names[idx])
+				}
+			}
+			if c < tryC-1 {
+				totalWidth += colMax + gap
+			} else {
+				totalWidth += colMax
+			}
+			if totalWidth > availWidth {
+				fits = false
+				break
+			}
+		}
+		if fits {
+			bestCols = tryC
+		} else {
+			break
+		}
+	}
+
+	rows := (len(names) + bestCols - 1) / bestCols
+
+	colWidths := make([]int, bestCols)
+	for c := 0; c < bestCols; c++ {
+		for r := 0; r < rows; r++ {
+			idx := c*rows + r
+			if idx < len(names) && len(names[idx]) > colWidths[c] {
+				colWidths[c] = len(names[idx])
+			}
+		}
+	}
+
+	buf.WriteString("```\n")
+	for r := 0; r < rows; r++ {
+		for c := 0; c < bestCols; c++ {
+			idx := c*rows + r
+			if idx >= len(names) {
+				break
+			}
+			if c < bestCols-1 {
+				fmt.Fprintf(buf, "%-*s", colWidths[c]+gap, names[idx])
+			} else {
+				buf.WriteString(names[idx])
+			}
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString("```\n")
+}

--- a/pkg/cmd/pulumi/docs/bundle_test.go
+++ b/pkg/cmd/pulumi/docs/bundle_test.go
@@ -1,0 +1,463 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIDocsPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		path    string
+		wantPkg string
+		wantKey string
+		wantOK  bool
+	}{
+		{
+			name:    "resource in module",
+			path:    "registry/packages/aws/api-docs/s3/bucket",
+			wantPkg: "aws",
+			wantKey: "s3/bucket",
+			wantOK:  true,
+		},
+		{
+			name:    "root-level resource",
+			path:    "registry/packages/random/api-docs/randomstring",
+			wantPkg: "random",
+			wantKey: "randomstring",
+			wantOK:  true,
+		},
+		{
+			name:    "nested module resource",
+			path:    "registry/packages/aws/api-docs/ec2/transitgateway/route",
+			wantPkg: "aws",
+			wantKey: "ec2/transitgateway/route",
+			wantOK:  true,
+		},
+		{
+			name:    "api-docs index",
+			path:    "registry/packages/aws/api-docs",
+			wantPkg: "aws",
+			wantKey: "",
+			wantOK:  true,
+		},
+		{
+			name:    "package root - no api-docs",
+			path:    "registry/packages/aws",
+			wantPkg: "",
+			wantKey: "",
+			wantOK:  false,
+		},
+		{
+			name:    "non-registry path",
+			path:    "docs/iac/concepts/stacks",
+			wantPkg: "",
+			wantKey: "",
+			wantOK:  false,
+		},
+		{
+			name:    "leading and trailing slashes",
+			path:    "/registry/packages/aws/api-docs/s3/bucket/",
+			wantPkg: "aws",
+			wantKey: "s3/bucket",
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pkg, key, ok := ParseAPIDocsPath(tt.path)
+			assert.Equal(t, tt.wantOK, ok, "ok")
+			assert.Equal(t, tt.wantPkg, pkg, "packageName")
+			assert.Equal(t, tt.wantKey, key, "docKey")
+		})
+	}
+}
+
+func TestLookupBundleDoc(t *testing.T) {
+	t.Parallel()
+	bundle := &CLIDocsBundle{
+		Resources: map[string]string{
+			"s3/bucket":    "# aws.s3.Bucket\n\nA bucket resource.",
+			"randomstring": "# RandomString\r\n\r\nA random string.\tDone.",
+		},
+		Functions: map[string]string{
+			"s3/getBucket": "# aws.s3.getBucket\n\nGet a bucket.",
+		},
+	}
+
+	t.Run("resource found", func(t *testing.T) {
+		t.Parallel()
+		body, title, found := LookupBundleDoc(bundle, "s3/bucket")
+		assert.True(t, found)
+		assert.Equal(t, "aws.s3.Bucket", title)
+		assert.Equal(t, "A bucket resource.", body)
+	})
+
+	t.Run("function found", func(t *testing.T) {
+		t.Parallel()
+		body, title, found := LookupBundleDoc(bundle, "s3/getBucket")
+		assert.True(t, found)
+		assert.Equal(t, "aws.s3.getBucket", title)
+		assert.Equal(t, "Get a bucket.", body)
+	})
+
+	t.Run("normalizes line endings and tabs", func(t *testing.T) {
+		t.Parallel()
+		body, title, found := LookupBundleDoc(bundle, "randomstring")
+		assert.True(t, found)
+		assert.Equal(t, "RandomString", title)
+		assert.Contains(t, body, "    Done.") // tab replaced with spaces
+		assert.NotContains(t, body, "\r\n")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		_, _, found := LookupBundleDoc(bundle, "nonexistent")
+		assert.False(t, found)
+	})
+}
+
+func TestFetchCLIDocsBundle(t *testing.T) {
+	testBundle := CLIDocsBundle{
+		Version:        1,
+		Package:        "testpkg",
+		PackageVersion: "1.0.0",
+		Resources: map[string]string{
+			"myresource": "# MyResource\n\nHello",
+		},
+		Functions: map[string]string{
+			"myfunction": "# myFunction\n\nWorld",
+		},
+	}
+
+	t.Run("successful fetch", func(t *testing.T) {
+		// Clear any cached entry for this test
+		bundleMemCache.Delete("testpkg-fetch")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/registry/packages/testpkg-fetch/api-docs/cli-docs.json", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(testBundle)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		t.Setenv("PULUMI_HOME", t.TempDir())
+
+		bundle, err := FetchCLIDocsBundle(srv.URL, "testpkg-fetch")
+		require.NoError(t, err)
+		assert.Equal(t, "testpkg", bundle.Package)
+		assert.Equal(t, "1.0.0", bundle.PackageVersion)
+		assert.Contains(t, bundle.Resources, "myresource")
+		assert.Contains(t, bundle.Functions, "myfunction")
+
+		// Clean up memory cache
+		bundleMemCache.Delete("testpkg-fetch")
+	})
+
+	t.Run("404 returns BundleNotAvailableError", func(t *testing.T) {
+		bundleMemCache.Delete("notfound-pkg")
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		t.Setenv("PULUMI_HOME", t.TempDir())
+
+		_, err := FetchCLIDocsBundle(srv.URL, "notfound-pkg")
+		require.Error(t, err)
+		var bundleErr *BundleNotAvailableError
+		assert.ErrorAs(t, err, &bundleErr)
+		assert.Equal(t, "notfound-pkg", bundleErr.Package)
+	})
+
+	t.Run("in-memory cache hit", func(t *testing.T) {
+		t.Parallel()
+		// Pre-populate memory cache
+		cacheKey := "mem-cached-pkg"
+		bundleMemCache.Store(cacheKey, &testBundle)
+		defer bundleMemCache.Delete(cacheKey)
+
+		// Server should not be called
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("should not have made HTTP request — cache should have been used")
+		}))
+		defer srv.Close()
+
+		bundle, err := FetchCLIDocsBundle(srv.URL, cacheKey)
+		require.NoError(t, err)
+		assert.Equal(t, "testpkg", bundle.Package)
+	})
+}
+
+func TestDiskCacheRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, bundleCacheDir)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+
+	bundle := &CLIDocsBundle{
+		Version:        1,
+		Package:        "testpkg",
+		PackageVersion: "2.0.0",
+		Resources:      map[string]string{"res": "# Res\n\nContent"},
+		Functions:      map[string]string{"fn": "# Fn\n\nContent"},
+	}
+
+	t.Setenv("PULUMI_HOME", tmpDir)
+
+	// Save
+	err := saveBundleToDisk("testpkg", bundle)
+	require.NoError(t, err)
+
+	// Verify files exist
+	assert.FileExists(t, filepath.Join(cacheDir, "testpkg.json"))
+	assert.FileExists(t, filepath.Join(cacheDir, "testpkg.meta.json"))
+
+	// Load
+	loaded, err := loadBundleFromDisk("testpkg")
+	require.NoError(t, err)
+	assert.Equal(t, "testpkg", loaded.Package)
+	assert.Equal(t, "2.0.0", loaded.PackageVersion)
+	assert.Contains(t, loaded.Resources, "res")
+	assert.Contains(t, loaded.Functions, "fn")
+}
+
+func TestDiskCacheTTLExpiry(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, bundleCacheDir)
+	require.NoError(t, os.MkdirAll(cacheDir, 0o700))
+
+	t.Setenv("PULUMI_HOME", tmpDir)
+
+	// Write an expired metadata file
+	meta := bundleCacheMeta{
+		PackageVersion: "1.0.0",
+		FetchedAt:      time.Now().Add(-2 * time.Hour), // 2 hours ago, past the 1-hour TTL
+	}
+	metaData, _ := json.Marshal(meta)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "expired.meta.json"), metaData, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "expired.json"), []byte(`{}`), 0o600))
+
+	_, err := loadBundleFromDisk("expired")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cache expired")
+}
+
+func TestExtractBundleTitle(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "MyResource", extractBundleTitle("# MyResource\n\nContent"))
+	assert.Equal(t, "aws.s3.Bucket", extractBundleTitle("# aws.s3.Bucket\n\nContent"))
+	assert.Equal(t, "", extractBundleTitle("No title here"))
+	assert.Equal(t, "SingleLine", extractBundleTitle("# SingleLine"))
+}
+
+func TestExtractBundleDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "basic description",
+			content: "# Bucket\n\nProvides an S3 bucket resource. This is great.",
+			want:    "Provides an S3 bucket resource.",
+		},
+		{
+			name:    "description without period",
+			content: "# Bucket\n\nManages an S3 bucket",
+			want:    "Manages an S3 bucket",
+		},
+		{
+			name:    "skips deprecation notice",
+			content: "# Old\n\n> **Deprecated:** Use New instead.\n\nThe old resource.",
+			want:    "The old resource.",
+		},
+		{
+			name:    "no description",
+			content: "# Bucket\n\n## Section",
+			want:    "",
+		},
+		{
+			name:    "title only",
+			content: "# Bucket",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractBundleDescription(tt.content)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRenderBundleTable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("root level with modules", func(t *testing.T) {
+		t.Parallel()
+		bundle := &CLIDocsBundle{
+			Package: "aws",
+			Resources: map[string]string{
+				"provider":   "# Provider\n\nThe provider type.",
+				"s3/bucket":  "# Bucket\n\nAn S3 bucket.",
+				"ec2/vpc":    "# Vpc\n\nA VPC.",
+				"ec2/subnet": "# Subnet\n\nA subnet.",
+			},
+			Functions: map[string]string{
+				"getarn":       "# getArn\n\nParses an ARN.",
+				"s3/getbucket": "# getBucket\n\nLooks up a bucket.",
+			},
+		}
+
+		table := RenderBundleTable(bundle, "")
+		assert.Contains(t, table, "Modules")
+		assert.Contains(t, table, "s3")
+		assert.Contains(t, table, "ec2")
+		assert.Contains(t, table, "Resources")
+		assert.Contains(t, table, "Provider")
+		assert.Contains(t, table, "Functions")
+		assert.Contains(t, table, "getArn")
+		// Items in sub-modules should NOT appear at root level
+		assert.NotContains(t, table, "Bucket")
+		assert.NotContains(t, table, "Vpc")
+	})
+
+	t.Run("module level", func(t *testing.T) {
+		t.Parallel()
+		bundle := &CLIDocsBundle{
+			Package: "random",
+			Resources: map[string]string{
+				"randomstring":   "# RandomString\n\nGenerates a random string.",
+				"randompassword": "# RandomPassword\n\nGenerates a random password.",
+			},
+			Functions: map[string]string{
+				"getrandomstring": "# getRandomString\n\nLooks up a random string.",
+			},
+		}
+
+		table := RenderBundleTable(bundle, "")
+		assert.Contains(t, table, "Resources")
+		assert.Contains(t, table, "RandomString")
+		assert.Contains(t, table, "Generates a random string.")
+		assert.Contains(t, table, "Functions")
+		assert.Contains(t, table, "getRandomString")
+	})
+}
+
+func TestClassifyBundleKeys(t *testing.T) {
+	t.Parallel()
+
+	bundle := &CLIDocsBundle{
+		Package: "aws",
+		Resources: map[string]string{
+			"s3/bucket":       "# Bucket\n\nContent",
+			"s3/bucketPolicy": "# BucketPolicy\n\nContent",
+			"ec2/instance":    "# Instance\n\nContent",
+			"rootresource":    "# RootResource\n\nContent",
+		},
+		Functions: map[string]string{
+			"s3/getBucket": "# getBucket\n\nContent",
+			"rootfunc":     "# rootFunc\n\nContent",
+		},
+	}
+
+	t.Run("root level", func(t *testing.T) {
+		t.Parallel()
+		ck := classifyBundleKeys(bundle, "")
+		assert.Contains(t, ck.subModules, "s3")
+		assert.Contains(t, ck.subModules, "ec2")
+		require.Len(t, ck.resources, 1)
+		assert.Equal(t, "RootResource", ck.resources[0].title)
+		require.Len(t, ck.functions, 1)
+		assert.Equal(t, "rootFunc", ck.functions[0].title)
+	})
+
+	t.Run("specific module", func(t *testing.T) {
+		t.Parallel()
+		ck := classifyBundleKeys(bundle, "s3")
+		assert.Empty(t, ck.subModules)
+		require.Len(t, ck.resources, 2)
+		require.Len(t, ck.functions, 1)
+	})
+
+	t.Run("module with no keys", func(t *testing.T) {
+		t.Parallel()
+		ck := classifyBundleKeys(bundle, "nonexistent")
+		assert.Empty(t, ck.subModules)
+		assert.Empty(t, ck.resources)
+		assert.Empty(t, ck.functions)
+	})
+
+	t.Run("empty bundle", func(t *testing.T) {
+		t.Parallel()
+		empty := &CLIDocsBundle{}
+		ck := classifyBundleKeys(empty, "")
+		assert.Empty(t, ck.subModules)
+		assert.Empty(t, ck.resources)
+		assert.Empty(t, ck.functions)
+	})
+}
+
+func TestReplaceBundleSections(t *testing.T) {
+	t.Parallel()
+
+	bundle := &CLIDocsBundle{
+		Package: "aws",
+		Resources: map[string]string{
+			"s3/bucket": "# Bucket\n\nAn S3 bucket.",
+		},
+		Functions: map[string]string{
+			"s3/getBucket": "# getBucket\n\nLooks up a bucket.",
+		},
+	}
+
+	t.Run("replaces sections", func(t *testing.T) {
+		t.Parallel()
+		body := "# aws\n\nOverview.\n\n## Modules\n\nOld module list.\n\n" +
+			"## Resources\n\nOld resource list.\n\n## Other\n\nUnchanged."
+		result := ReplaceBundleSections(body, bundle, "")
+		assert.Contains(t, result, "## Modules")
+		assert.Contains(t, result, "s3")
+		assert.NotContains(t, result, "Old module list.")
+		assert.Contains(t, result, "## Other")
+		assert.Contains(t, result, "Unchanged.")
+	})
+
+	t.Run("no matching sections unchanged", func(t *testing.T) {
+		t.Parallel()
+		body := "# Page\n\n## Overview\n\nJust text."
+		result := ReplaceBundleSections(body, bundle, "")
+		assert.Equal(t, body, result)
+	})
+}

--- a/pkg/cmd/pulumi/docs/docs.go
+++ b/pkg/cmd/pulumi/docs/docs.go
@@ -129,7 +129,26 @@ func (dc *docsCmd) fetchAndRender(path string) error {
 
 	fetchBase := dc.baseURLForPath(path)
 
-	body, title, err := FetchDoc(fetchBase, path)
+	// For registry API docs paths, try the CLI docs bundle first (all docs for a package in one JSON file).
+	// Fall back to standard FetchDoc if the bundle isn't available or the key isn't found.
+	var body, title string
+	var err error
+	var bundle *CLIDocsBundle
+	if isAPIDocsPath(path) {
+		pkgName, docKey, ok := ParseAPIDocsPath(path)
+		if ok {
+			bundle, _ = FetchCLIDocsBundle(fetchBase, pkgName)
+			if bundle != nil && docKey != "" {
+				if b, t, found := LookupBundleDoc(bundle, docKey); found {
+					body, title = b, t
+				}
+			}
+		}
+	}
+
+	if body == "" {
+		body, title, err = FetchDoc(fetchBase, path)
+	}
 	if err != nil {
 		// Graceful fallback for registry pages that aren't available in the terminal
 		var regErr *RegistryNotAvailableError
@@ -137,6 +156,13 @@ func (dc *docsCmd) fetchAndRender(path string) error {
 			return dc.handleRegistryFallback(path)
 		}
 		return err
+	}
+
+	// Replace Modules/Resources/Functions sections with formatted bundle tables
+	if bundle != nil {
+		if _, docKey, ok := ParseAPIDocsPath(path); ok {
+			body = ReplaceBundleSections(body, bundle, docKey)
+		}
 	}
 
 	// --toc: interactive section picker or plain list

--- a/pkg/cmd/pulumi/docs/fetch.go
+++ b/pkg/cmd/pulumi/docs/fetch.go
@@ -29,6 +29,9 @@ import (
 // hanging on slow or unresponsive servers (e.g. external SDK docs redirects).
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
+// bundleHTTPClient uses a longer timeout for large bundle downloads.
+var bundleHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+
 // sitemapCache provides session-level caching for sitemap fetches, keyed by URL.
 var sitemapCache sync.Map
 
@@ -60,6 +63,12 @@ func contentPrefix(path string) (prefix, trimmedPath string) {
 		return "/registry/", after
 	}
 	return "/docs/", trimmedPath
+}
+
+// isAPIDocsPath returns true if the path refers to a registry API docs page
+// (e.g. "registry/packages/aws/api-docs/provider").
+func isAPIDocsPath(path string) bool {
+	return strings.Contains(path, "/api-docs")
 }
 
 // FetchDoc fetches a markdown doc page from the docs or registry site.


### PR DESCRIPTION
## Summary (PR 3 of 4)

> **Review/merge order:** Requires PRs 1–2 (#22398, #22399) to be merged first. Review and merge before PR 4.

Adds the bundle system for fetching and rendering registry API documentation efficiently:

- Per-package JSON bundles containing all resource/function markdown in a single request
- Disk caching with 1-hour TTL in `~/.pulumi/cli-docs-cache/`
- Bundle-aware `fetchAndRender` pipeline — tries bundle first, falls back to individual fetch
- Formatted tables for modules, resources, and functions with `ReplaceBundleSections`
- Key classification system for navigating nested module hierarchies

### PR series

1. `pulumi docs read` (#22398) — core read pipeline
2. `pulumi docs search/sitemap/registry` (#22399) — additional subcommands
3. **Bundle system** (this PR) — registry API docs with caching
4. `pulumi docs browse` — interactive browse mode

## Test plan

- [x] `go build ./cmd/pulumi/docs/...` compiles
- [x] `go test -count=1 ./cmd/pulumi/docs/...` passes
- [x] `golangci-lint run ./cmd/pulumi/docs/...` clean