### PR TITLE
feat: Add `pulumi docs browse` interactive documentation browsing

### DIFF
--- a/changelog/pending/20260330--cli--add-pulumi-docs-browse.yaml
+++ b/changelog/pending/20260330--cli--add-pulumi-docs-browse.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi docs browse` for interactive documentation browsing

--- a/pkg/cmd/pulumi/docs/browse.go
+++ b/pkg/cmd/pulumi/docs/browse.go
@@ -1,0 +1,752 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/browser"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// Navigation label constants used across all browse menus.
+const (
+	navUp       = "↑ Up a level"
+	navBack     = "← Back"
+	navHome     = "🏠 Home"
+	navDone     = "🛑 Done"
+	navSections = "📑 Sections"
+	navFullPage = "📄 View full page"
+	navDrill    = " ▸"
+	navNext     = "⏩ Next section"
+	navPrev     = "⏪ Previous section"
+)
+
+// browseNode represents what to display at a given location in the content tree.
+type browseNode struct {
+	path        string                 // current location
+	title       string                 // display title
+	body        string                 // raw markdown body (empty for containers/virtual nodes)
+	items       []navOption            // navigation choices (child pages, links, etc.)
+	bundleTable string                 // pre-rendered table of resources/functions (shown before menu)
+	sectionNav  map[string][]navOption // nav items to inject when viewing specific sections (e.g. "Modules")
+	pinnedNav   []navOption            // nav items that always appear in the menu regardless of context
+}
+
+// navOption represents a navigation choice in browse mode.
+type navOption struct {
+	label string
+	path  string // content path (e.g. "iac/concepts/stacks" or "registry/packages/aws")
+	href  string // original URL for external links (bypasses path-based navigation)
+}
+
+// browseLoop is the single interactive browse loop. The user is always at a
+// location in the content tree. They can go deeper, go up, go back, or quit.
+func (dc *docsCmd) browseLoop(startPath string) error {
+	path := strings.Trim(startPath, "/")
+	var history []string
+
+	for {
+		node := dc.resolveNode(path)
+		path = node.path // sync with any path cleanup (e.g. /__view stripping)
+
+		headings := extractHeadings(node.body)
+		hasSections := len(headings) > 0 && node.body != ""
+
+		// Determine whether to default to sections view or full page.
+		// Flags override saved preference; default is sections.
+		showFull := dc.fullPage
+		if !showFull && !dc.sectionsView {
+			prefs, _ := LoadPreferences()
+			showFull = prefs.BrowseMode == "full"
+		}
+		useSections := hasSections && !showFull
+
+		// Save the preference when a flag is explicitly used
+		if dc.fullPage || dc.sectionsView {
+			prefs, _ := LoadPreferences()
+			if dc.fullPage {
+				prefs.BrowseMode = "full"
+			} else {
+				prefs.BrowseMode = "sections"
+			}
+			if err := prefs.Save(); err != nil {
+				logging.V(7).Infof("failed to save docs preferences: %v", err)
+			}
+		}
+
+		var navItems []navOption
+		introIncludesFirstSection := false
+		if node.body != "" {
+			if useSections {
+				introIncludesFirstSection = introContainsFirstHeading(node.body)
+				introNav, err := renderIntro(dc, node.body, node.title, path)
+				if err != nil {
+					return err
+				}
+				navItems = introNav
+			} else {
+				displayBody, links := numberLinks(node.body)
+				rendered, err := dc.renderBody(displayBody, node.title)
+				if err != nil {
+					return err
+				}
+				fmt.Print(rendered)
+				fmt.Print(browseFooter(dc.baseURLForPath(path), path))
+				navItems = numberedNavLinks(links)
+			}
+		}
+
+		if node.body != "" {
+			prefs, _ := LoadPreferences()
+			prefs.LastPage = path
+			if err := prefs.Save(); err != nil {
+				logging.V(7).Infof("failed to save docs preferences: %v", err)
+			}
+		}
+
+		if !cmdutil.Interactive() {
+			if node.body == "" && len(node.items) > 0 {
+				for _, item := range node.items {
+					fmt.Printf("  %s  (%s)\n", item.label, item.path)
+				}
+			}
+			return nil
+		}
+
+		// Merge sitemap/bundle nav items with any numbered links from the body.
+		navItems = append(navItems, node.items...)
+
+		// Display bundle table (modules/resources/functions) before the menu,
+		// but only when the page has no body content (pure listing page).
+		if node.bundleTable != "" && node.body == "" {
+			fmt.Print(node.bundleTable)
+		}
+
+		if len(navItems) == 0 && len(node.pinnedNav) == 0 && node.body == "" {
+			// No terminal content — try to open in browser, otherwise show the URL.
+			pageURL := webURL(dc.baseURLForPath(path), path)
+			if err := browser.OpenURL(pageURL); err != nil {
+				fmt.Fprintf(os.Stderr, "\n  🌐 This page is available on the web:\n     %s\n", pageURL)
+			} else {
+				fmt.Fprintf(os.Stderr, "\n  🌐 Opened in browser: %s\n", pageURL)
+			}
+			// Go back to previous page
+			if len(history) > 0 {
+				path = history[len(history)-1]
+				history = history[:len(history)-1]
+				continue
+			}
+			return nil
+		}
+
+		activeItems := navItems
+		sectionIdx := -1
+		if introIncludesFirstSection {
+			sectionIdx = 0
+		}
+		navigated := false
+		for !navigated {
+			isRoot := path == ""
+			hasHeadings := len(headings) > 0
+			// Always include pinned nav items (e.g. "API Docs" shortcut) even after
+			// section navigation replaces activeItems.
+			menuItems := append(activeItems, node.pinnedNav...)
+			menu := buildBrowseMenu(menuItems, isRoot, hasHeadings,
+				len(history) > 0, !introIncludesFirstSection, sectionIdx, headings)
+
+			promptTitle := node.title
+			if promptTitle == "" {
+				promptTitle = path
+			}
+			if promptTitle == "" {
+				promptTitle = "Pulumi"
+			}
+
+			// Default to first nav item (skip Up if present)
+			defaultIdx := 0
+			if !isRoot && len(menu) > 1 {
+				defaultIdx = 1
+			}
+
+			fmt.Println()
+			selected := ui.PromptUser(
+				fmt.Sprintf("Browse %s:", promptTitle),
+				menu,
+				menu[defaultIdx],
+				cmdutil.GetGlobalColorization(),
+			)
+
+			switch selected {
+			case "", navDone:
+				return nil
+
+			case navBack:
+				path = history[len(history)-1]
+				history = history[:len(history)-1]
+				navigated = true
+
+			case navUp:
+				history = append(history, path)
+				path = parentPath(path)
+				navigated = true
+
+			case navHome:
+				history = append(history, path)
+				path = ""
+				navigated = true
+
+			case navSections:
+				hasIntro := !introIncludesFirstSection
+				idx := showBrowseSectionsIdx(headings, hasIntro)
+				if idx == -1 {
+					introNav, renderErr := renderIntro(dc, node.body, node.title, path)
+					if renderErr == nil {
+						activeItems = introNav
+					}
+					sectionIdx = -1
+				} else if idx >= 0 {
+					renderSectionByIdx(dc, node.body, headings, idx, &activeItems, node.sectionNav)
+					sectionIdx = idx
+				}
+
+			case navFullPage:
+				displayBody, links := numberLinks(node.body)
+				rendered, err := dc.renderBody(displayBody, node.title)
+				if err == nil {
+					fmt.Print(rendered)
+					fmt.Print(browseFooter(dc.baseURLForPath(path), path))
+				}
+				activeItems = numberedNavLinks(links)
+				sectionIdx = len(headings) // past all sections — suppresses prev/next
+
+			default:
+				if strings.HasPrefix(selected, navPrev) && sectionIdx > -1 {
+					sectionIdx--
+					if sectionIdx == -1 {
+						introNav, renderErr := renderIntro(dc, node.body, node.title, path)
+						if renderErr == nil {
+							activeItems = introNav
+						}
+					} else {
+						renderSectionByIdx(dc, node.body, headings, sectionIdx, &activeItems, node.sectionNav)
+					}
+				} else if strings.HasPrefix(selected, navNext) && sectionIdx+1 < len(headings) {
+					sectionIdx++
+					renderSectionByIdx(dc, node.body, headings, sectionIdx, &activeItems, node.sectionNav)
+				} else {
+					// Find the selected nav item (search menuItems which includes pinnedNav)
+					for _, item := range menuItems {
+						if item.label == selected {
+							// External link — open in browser instead of navigating
+							if item.href != "" {
+								if err := browser.OpenURL(item.href); err != nil {
+									fmt.Fprintf(os.Stderr, "\n  🌐 This page is available on the web:\n     %s\n", item.href)
+								} else {
+									fmt.Fprintf(os.Stderr, "\n  🌐 Opened in browser: %s\n", item.href)
+								}
+								break
+							}
+							history = append(history, path)
+							path = item.path
+							navigated = true
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// resolveNode determines what to display at a given path in the content tree.
+func (dc *docsCmd) resolveNode(path string) browseNode {
+	path = strings.Trim(path, "/")
+
+	// Root — synthetic Docs/Registry menu
+	if path == "" {
+		return dc.resolveRoot()
+	}
+
+	// "docs" — docs sitemap top level
+	if path == "docs" {
+		return dc.resolveDocsSitemap()
+	}
+
+	// "registry" or "registry/packages" — registry package list
+	if path == "registry" || path == "registry/packages" {
+		return dc.resolveRegistryList()
+	}
+
+	// Registry package paths — try content + lazy-load sitemap
+	if isRegistryPath(path) {
+		return dc.resolveRegistryPage(path)
+	}
+
+	// Docs paths — try content, fall back to sitemap for containers
+	return dc.resolveDocsPage(path)
+}
+
+func (dc *docsCmd) resolveRoot() browseNode {
+	var items []navOption
+
+	// Try to fetch both sitemaps to determine what's available
+	docsPages, _ := FetchSitemap(dc.baseURL)
+	registryPages, _ := FetchRegistrySitemap(dc.registryBaseURL)
+
+	if len(docsPages) > 0 {
+		items = append(items, navOption{label: "Docs" + navDrill, path: "docs"})
+	}
+	if len(registryPages) > 0 {
+		items = append(items, navOption{label: "Registry" + navDrill, path: "registry"})
+	}
+
+	return browseNode{path: "", title: "Pulumi", items: items}
+}
+
+func (dc *docsCmd) resolveDocsSitemap() browseNode {
+	pages, err := FetchSitemap(dc.baseURL)
+	if err != nil {
+		return browseNode{path: "docs", title: "Docs"}
+	}
+	return browseNode{
+		path:  "docs",
+		title: "Docs",
+		items: sitemapToNavOptions(pages, dc.baseURL),
+	}
+}
+
+func (dc *docsCmd) resolveRegistryList() browseNode {
+	pages, err := FetchRegistrySitemap(dc.registryBaseURL)
+	if err != nil {
+		return browseNode{path: "registry", title: "Registry"}
+	}
+	return browseNode{
+		path:  "registry",
+		title: "Registry",
+		items: sitemapToNavOptions(pages, dc.registryBaseURL),
+	}
+}
+
+func (dc *docsCmd) resolveRegistryPage(path string) browseNode {
+	node := browseNode{path: path}
+
+	// For API docs paths, try the CLI docs bundle for content and navigation
+	if isAPIDocsPath(path) {
+		pkgName, docKey, ok := ParseAPIDocsPath(path)
+		if ok {
+			bundle, bundleErr := FetchCLIDocsBundle(dc.registryBaseURL, pkgName)
+			if bundleErr == nil {
+				// If we have a specific resource/function key, look up its content
+				if docKey != "" {
+					if b, t, found := LookupBundleDoc(bundle, docKey); found {
+						node.body = b
+						node.title = t
+					}
+				}
+				// Generate nav items from bundle keys for this module level.
+				// If we found content (a resource/function page), skip bundle nav.
+				// Otherwise docKey is a module prefix — list its children.
+				if node.body == "" {
+					bundleNav := BundleNavItems(bundle, docKey, pkgName)
+					if len(bundleNav) > 0 {
+						node.items = bundleNav
+						node.bundleTable = RenderBundleTable(bundle, docKey)
+					}
+				}
+			}
+		}
+	}
+
+	// Fall back to FetchDoc if bundle didn't provide content
+	if node.body == "" {
+		body, title, err := FetchDoc(dc.registryBaseURL, path)
+		if err == nil {
+			node.body = body
+			node.title = title
+			// Page has its own content — don't flood the menu with bundle items.
+			// Users navigate via sections; bundle nav is only for pure listing pages.
+			// But replace Modules/Resources/Functions sections with formatted bundle content,
+			// and provide per-section nav items so users can drill into modules/resources.
+			if isAPIDocsPath(path) {
+				pkgName, docKey, ok := ParseAPIDocsPath(path)
+				if ok {
+					if bundle, bundleErr := FetchCLIDocsBundle(dc.registryBaseURL, pkgName); bundleErr == nil {
+						node.body = ReplaceBundleSections(node.body, bundle, docKey)
+						node.sectionNav = BundleSectionNav(bundle, docKey, pkgName)
+					}
+				}
+			}
+			node.items = nil
+			node.bundleTable = ""
+		} else {
+			var regErr *RegistryNotAvailableError
+			if errors.As(err, &regErr) {
+				url := webURL(dc.registryBaseURL, path)
+				node.title = pathLastSegment(path)
+				fmt.Fprintf(os.Stderr,
+					"Registry docs are not yet available for terminal viewing.\nVisit %s instead.\n\n", url)
+			}
+		}
+	}
+
+	// Fall back to sitemap nav if no nav items set and no body content.
+	// Pages with body content use section-based navigation instead.
+	if len(node.items) == 0 && node.body == "" {
+		node.items = dc.registryNavItems(path)
+	}
+
+	if node.title == "" {
+		node.title = pathLastSegment(path)
+	}
+
+	// Add an "API Docs" shortcut when viewing any package page that isn't already under api-docs.
+	trimmed := strings.Trim(path, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) >= 3 && parts[0] == "registry" && parts[1] == "packages" && !isAPIDocsPath(path) {
+		apiDocsPath := fmt.Sprintf("registry/packages/%s/api-docs", parts[2])
+		node.pinnedNav = append(node.pinnedNav, navOption{label: "📖 API Docs" + navDrill, path: apiDocsPath})
+	}
+
+	return node
+}
+
+func (dc *docsCmd) resolveDocsPage(path string) browseNode {
+	// The /__view suffix forces content mode (user selected the self-view option).
+	forceContent := strings.HasSuffix(path, "/__view")
+	if forceContent {
+		path = strings.TrimSuffix(path, "/__view")
+	}
+
+	node := browseNode{path: path}
+
+	// Try fetching page content
+	body, title, err := FetchDoc(dc.baseURL, path)
+	if err == nil {
+		node.body = body
+		node.title = title
+	}
+
+	// Sitemap nav items
+	node.items = dc.docsSitemapNavItems(path)
+
+	// When a page has both content and children, act as a hub:
+	// show children with a self-view option, don't render content immediately.
+	if len(node.items) > 0 && node.body != "" && !forceContent {
+		viewLabel := dc.docsPageViewLabel(path)
+		selfItem := navOption{label: viewLabel, path: path + "/__view"}
+		node.items = append([]navOption{selfItem}, node.items...)
+		node.body = "" // suppress content rendering — let the user choose
+	}
+
+	if node.title == "" {
+		node.title = pathLastSegment(path)
+	}
+
+	return node
+}
+
+// buildBrowseMenu constructs the menu options for a browse prompt.
+// sectionIdx is the current section index (-1 if not viewing a section).
+func buildBrowseMenu(
+	items []navOption, isRoot, hasHeadings, hasHistory, hasIntro bool,
+	sectionIdx int, headings []heading,
+) []string {
+	var menu []string
+
+	if !isRoot {
+		menu = append(menu, navUp)
+	}
+	if hasHeadings {
+		menu = append(menu, navSections)
+	}
+	// Show "Previous"/"Next" when viewing a section, not when viewing the full page.
+	inSectionView := sectionIdx >= 0 && sectionIdx < len(headings)
+	minIdx := 0
+	if hasIntro {
+		minIdx = -1
+	}
+	if sectionIdx > minIdx && (inSectionView || sectionIdx == -1) {
+		prevLabel := "Introduction"
+		if sectionIdx > 0 {
+			prevLabel = headings[sectionIdx-1].text
+		}
+		menu = append(menu, navPrev+" — "+prevLabel)
+	}
+	if inSectionView || sectionIdx == -1 {
+		nextIdx := sectionIdx + 1
+		if nextIdx < len(headings) {
+			menu = append(menu, navNext+" — "+headings[nextIdx].text)
+		}
+	}
+	for _, item := range items {
+		menu = append(menu, item.label)
+	}
+	if hasHeadings && sectionIdx < len(headings) {
+		menu = append(menu, navFullPage)
+	}
+	if hasHistory {
+		menu = append(menu, navBack)
+	}
+	if !isRoot {
+		menu = append(menu, navHome)
+	}
+	menu = append(menu, navDone)
+
+	return menu
+}
+
+// showBrowseSectionsIdx displays a TOC picker. Returns the selected heading
+// index, or -1 for "Introduction" (when hasIntro is true), or -2 if cancelled.
+func showBrowseSectionsIdx(headings []heading, hasIntro bool) int {
+	if len(headings) == 0 {
+		return -2
+	}
+
+	var options []string
+	introOffset := 0
+	if hasIntro {
+		options = append(options, "Introduction")
+		introOffset = 1
+	}
+	for _, h := range headings {
+		indent := strings.Repeat("  ", h.level-2)
+		options = append(options, indent+h.text)
+	}
+	options = append(options, navBack)
+
+	selected := ui.PromptUser(
+		"Jump to section:",
+		options,
+		options[0],
+		cmdutil.GetGlobalColorization(),
+	)
+	if selected == "" || selected == navBack {
+		return -2
+	}
+	if hasIntro && selected == "Introduction" {
+		return -1
+	}
+
+	for i, opt := range options {
+		idx := i - introOffset
+		if opt == selected && idx >= 0 && idx < len(headings) {
+			return idx
+		}
+	}
+	return -2
+}
+
+// renderIntro renders the page introduction (content before the first heading),
+// prints it with the footer, and returns the nav options from any links found.
+func renderIntro(dc *docsCmd, body, title, path string) ([]navOption, error) {
+	intro := extractIntro(body)
+	displayIntro, links := numberLinks(intro)
+	rendered, err := dc.renderBody(displayIntro, title)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Print(rendered)
+	fmt.Print(browseFooter(dc.baseURLForPath(path), path))
+	return numberedNavLinks(links), nil
+}
+
+// renderSectionByIdx renders the section at the given heading index and
+// updates activeItems with any links found in that section.
+// If sectionNav contains items matching the heading text, those are appended
+// to activeItems so users can drill into modules/resources/functions.
+func renderSectionByIdx(dc *docsCmd, body string, headings []heading, idx int,
+	activeItems *[]navOption, sectionNav map[string][]navOption,
+) {
+	section := extractSection(body, headings[idx].slug)
+	if section == "" {
+		return
+	}
+	numbered, sectionLinks := numberLinks(section)
+	rendered, err := dc.renderBody(numbered, "")
+	if err == nil {
+		fmt.Print(rendered)
+	}
+	*activeItems = numberedNavLinks(sectionLinks)
+
+	// Inject bundle nav items for this section (e.g. module drill items for "Modules")
+	if sectionNav != nil {
+		if nav, ok := sectionNav[headings[idx].text]; ok {
+			*activeItems = append(*activeItems, nav...)
+		}
+	}
+}
+
+// parentPath returns the parent of a path by removing the last segment.
+// Returns "" (root) for single-segment paths.
+// Collapses dead intermediate levels (e.g. "registry/packages" → "registry").
+func parentPath(path string) string {
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) <= 1 {
+		return ""
+	}
+	parent := strings.Join(parts[:len(parts)-1], "/")
+	// "registry/packages" is not a real level — the package list lives at "registry"
+	if parent == "registry/packages" {
+		return "registry"
+	}
+	return parent
+}
+
+// pathLastSegment returns the last segment of a path for use as a fallback title.
+func pathLastSegment(path string) string {
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}
+
+// numberedNavLinks returns navigation options from internal links, with numbered
+// labels matching the **[N]** markers in the rendered output.
+func numberedNavLinks(links []docLink) []navOption {
+	if len(links) == 0 {
+		return nil
+	}
+	var opts []navOption
+	for i, l := range links {
+		text := strings.ReplaceAll(l.text, "`", "")
+		label := fmt.Sprintf("🔗%d %s", i+1, text)
+		opts = append(opts, navOption{label: label, path: hrefToPath(l.href)})
+	}
+	return opts
+}
+
+// sitemapToNavOptions converts sitemap pages to nav options.
+// baseURL is used to build full URLs for external/case-sensitive links.
+func sitemapToNavOptions(pages []SitemapPage, baseURL string) []navOption {
+	opts := make([]navOption, 0, len(pages))
+	for _, p := range pages {
+		label := p.Title
+		if len(p.Children) > 0 {
+			label += navDrill
+		}
+		opt := navOption{label: label, path: hrefToPath(p.Path)}
+		// Preserve original href for external URLs and case-sensitive paths.
+		if strings.HasPrefix(p.Path, "http://") || strings.HasPrefix(p.Path, "https://") {
+			opt.href = p.Path
+		} else if strings.HasSuffix(p.Path, ".html") {
+			// Case-sensitive path — build full URL
+			base := strings.TrimRight(baseURL, "/")
+			if base == "" {
+				base = "https://www.pulumi.com"
+			}
+			opt.href = base + p.Path
+		}
+		opts = append(opts, opt)
+	}
+	return opts
+}
+
+// childNavOptions finds children for a target path in a sitemap tree,
+// falling back to collecting descendants if no exact match exists.
+func childNavOptions(pages []SitemapPage, targetPath, baseURL string) []navOption {
+	children := findExactChildren(pages, targetPath)
+	if children == nil {
+		var matches []SitemapPage
+		collectDescendants(pages, targetPath, &matches)
+		children = matches
+	}
+	return sitemapToNavOptions(children, baseURL)
+}
+
+// docsSitemapNavItems returns nav items from the docs sitemap for a given path.
+func (dc *docsCmd) docsSitemapNavItems(path string) []navOption {
+	pages, err := FetchSitemap(dc.baseURL)
+	if err != nil {
+		return nil
+	}
+	target := "/docs/" + strings.Trim(path, "/") + "/"
+	return childNavOptions(pages, target, dc.baseURL)
+}
+
+// registryNavItems returns nav items for a registry path from sitemaps.
+func (dc *docsCmd) registryNavItems(path string) []navOption {
+	trimmed := strings.Trim(path, "/")
+	parts := strings.Split(trimmed, "/")
+
+	// "registry/packages/<pkg>" or deeper — lazy-load per-package sitemap
+	if len(parts) >= 3 && parts[0] == "registry" && parts[1] == "packages" {
+		pkgName := parts[2]
+		pages, err := FetchPackageSitemap(dc.registryBaseURL, pkgName)
+		if err != nil {
+			return nil
+		}
+
+		// At package root, return top-level pages
+		if len(parts) == 3 {
+			return sitemapToNavOptions(pages, dc.registryBaseURL)
+		}
+
+		// Deeper — find children within package sitemap
+		target := "/" + trimmed + "/"
+		return childNavOptions(pages, target, dc.registryBaseURL)
+	}
+
+	return nil
+}
+
+// docsPageViewLabel returns the self-view label for a docs page (e.g. "Overview" or "Introduction").
+func (dc *docsCmd) docsPageViewLabel(path string) string {
+	pages, err := FetchSitemap(dc.baseURL)
+	if err != nil {
+		return "Introduction"
+	}
+	target := "/docs/" + strings.Trim(path, "/") + "/"
+	if p := findPage(pages, target); p != nil {
+		return p.ViewLabel()
+	}
+	return "Introduction"
+}
+
+// findPage recursively searches for a page with the given path in the sitemap tree.
+func findPage(pages []SitemapPage, targetPath string) *SitemapPage {
+	for i := range pages {
+		if pages[i].Path == targetPath {
+			return &pages[i]
+		}
+		if found := findPage(pages[i].Children, targetPath); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findExactChildren(pages []SitemapPage, targetPath string) []SitemapPage {
+	if p := findPage(pages, targetPath); p != nil {
+		return p.Children
+	}
+	return nil
+}
+
+// collectDescendants finds pages whose path starts with the target prefix.
+func collectDescendants(pages []SitemapPage, prefix string, result *[]SitemapPage) {
+	for _, p := range pages {
+		if strings.HasPrefix(p.Path, prefix) && p.Path != prefix {
+			*result = append(*result, p)
+		} else if len(p.Children) > 0 {
+			collectDescendants(p.Children, prefix, result)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/docs/browse_test.go
+++ b/pkg/cmd/pulumi/docs/browse_test.go
@@ -1,0 +1,320 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParentPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "multi-segment", path: "iac/concepts/stacks", want: "iac/concepts"},
+		{name: "single segment", path: "iac", want: ""},
+		{name: "registry packages collapses", path: "registry/packages", want: "registry"},
+		{name: "registry package child", path: "registry/packages/aws", want: "registry"},
+		{name: "trailing slashes", path: "/iac/concepts/", want: "iac"},
+		{name: "empty string", path: "", want: ""},
+		{name: "deep path", path: "a/b/c/d", want: "a/b/c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parentPath(tt.path))
+		})
+	}
+}
+
+func TestPathLastSegment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "multi-segment", path: "iac/concepts/stacks", want: "stacks"},
+		{name: "single segment", path: "iac", want: "iac"},
+		{name: "trailing slash", path: "iac/concepts/", want: "concepts"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, pathLastSegment(tt.path))
+		})
+	}
+}
+
+func TestFindPage(t *testing.T) {
+	t.Parallel()
+
+	pages := []SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+				{Title: "Projects", Path: "/docs/concepts/projects/"},
+			},
+		},
+		{Title: "Install", Path: "/docs/install/"},
+	}
+
+	t.Run("found at root", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/install/")
+		require.NotNil(t, p)
+		assert.Equal(t, "Install", p.Title)
+	})
+
+	t.Run("found in children", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/concepts/stacks/")
+		require.NotNil(t, p)
+		assert.Equal(t, "Stacks", p.Title)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/nonexistent/")
+		assert.Nil(t, p)
+	})
+}
+
+func TestFindExactChildren(t *testing.T) {
+	t.Parallel()
+
+	pages := []SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+			},
+		},
+	}
+
+	t.Run("has children", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/concepts/")
+		require.Len(t, children, 1)
+		assert.Equal(t, "Stacks", children[0].Title)
+	})
+
+	t.Run("no children", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/concepts/stacks/")
+		assert.Empty(t, children)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/missing/")
+		assert.Nil(t, children)
+	})
+}
+
+func TestCollectDescendants(t *testing.T) {
+	t.Parallel()
+
+	pages := []SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+				{Title: "Projects", Path: "/docs/concepts/projects/"},
+			},
+		},
+		{Title: "Install", Path: "/docs/install/"},
+	}
+
+	t.Run("finds nested descendants", func(t *testing.T) {
+		t.Parallel()
+		var result []SitemapPage
+		collectDescendants(pages, "/docs/concepts/", &result)
+		require.Len(t, result, 2)
+	})
+
+	t.Run("skips exact match", func(t *testing.T) {
+		t.Parallel()
+		var result []SitemapPage
+		collectDescendants(pages, "/docs/concepts/", &result)
+		for _, p := range result {
+			assert.NotEqual(t, "/docs/concepts/", p.Path)
+		}
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		t.Parallel()
+		var result []SitemapPage
+		collectDescendants(pages, "/docs/missing/", &result)
+		assert.Empty(t, result)
+	})
+}
+
+func TestSitemapToNavOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("children get drill suffix", func(t *testing.T) {
+		t.Parallel()
+		pages := []SitemapPage{
+			{Title: "Concepts", Path: "/docs/concepts/", Children: []SitemapPage{{Title: "Child"}}},
+			{Title: "Install", Path: "/docs/install/"},
+		}
+		opts := sitemapToNavOptions(pages, "https://www.pulumi.com")
+		assert.Equal(t, "Concepts"+navDrill, opts[0].label)
+		assert.Equal(t, "Install", opts[1].label)
+	})
+
+	t.Run("external URLs preserved", func(t *testing.T) {
+		t.Parallel()
+		pages := []SitemapPage{
+			{Title: "GitHub", Path: "https://github.com/pulumi/pulumi"},
+		}
+		opts := sitemapToNavOptions(pages, "")
+		assert.Equal(t, "https://github.com/pulumi/pulumi", opts[0].href)
+	})
+
+	t.Run("html paths get full href", func(t *testing.T) {
+		t.Parallel()
+		pages := []SitemapPage{
+			{Title: "API Reference", Path: "/docs/reference/pkg/nodejs/pulumi/aws/index.html"},
+		}
+		opts := sitemapToNavOptions(pages, "https://www.pulumi.com")
+		assert.Equal(t, "https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/index.html", opts[0].href)
+	})
+}
+
+func TestChildNavOptions(t *testing.T) {
+	t.Parallel()
+
+	pages := []SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+			},
+		},
+	}
+
+	t.Run("exact match returns children", func(t *testing.T) {
+		t.Parallel()
+		opts := childNavOptions(pages, "/docs/concepts/", "")
+		require.Len(t, opts, 1)
+		assert.Equal(t, "Stacks", opts[0].label)
+	})
+
+	t.Run("no exact match falls back to descendants", func(t *testing.T) {
+		t.Parallel()
+		// "/docs/concepts" (no trailing slash) won't match exactly
+		opts := childNavOptions(pages, "/docs/concepts", "")
+		// collectDescendants should find stacks
+		require.Len(t, opts, 1)
+	})
+}
+
+func TestBuildBrowseMenu(t *testing.T) {
+	t.Parallel()
+
+	headings := []heading{
+		{level: 2, text: "Overview", slug: "overview"},
+		{level: 2, text: "Details", slug: "details"},
+	}
+
+	t.Run("root has no Up", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(nil, true, false, false, true, -1, nil)
+		assert.NotContains(t, menu, navUp)
+		assert.Contains(t, menu, navDone)
+		assert.NotContains(t, menu, navHome)
+	})
+
+	t.Run("non-root has Up and Home", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(nil, false, false, false, true, -1, nil)
+		assert.Contains(t, menu, navUp)
+		assert.Contains(t, menu, navHome)
+	})
+
+	t.Run("with sections shows Sections option", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(nil, false, true, false, true, -1, headings)
+		assert.Contains(t, menu, navSections)
+	})
+
+	t.Run("with history shows Back", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(nil, false, false, true, true, -1, nil)
+		assert.Contains(t, menu, navBack)
+	})
+
+	t.Run("section view shows prev/next", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(nil, false, true, false, true, 0, headings)
+		// At section 0, should have next but not prev (intro is the prev when hasIntro)
+		found := false
+		for _, item := range menu {
+			if len(item) >= len(navNext) && item[:len(navNext)] == navNext {
+				found = true
+			}
+		}
+		assert.True(t, found, "should have next section option")
+	})
+
+	t.Run("nav items included", func(t *testing.T) {
+		t.Parallel()
+		items := []navOption{{label: "My Link", path: "some/path"}}
+		menu := buildBrowseMenu(items, true, false, false, true, -1, nil)
+		assert.Contains(t, menu, "My Link")
+	})
+}
+
+func TestNumberedNavLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("numbered labels", func(t *testing.T) {
+		t.Parallel()
+		links := []docLink{
+			{text: "Stacks", href: "/docs/stacks"},
+			{text: "Projects", href: "/docs/projects"},
+		}
+		opts := numberedNavLinks(links)
+		require.Len(t, opts, 2)
+		assert.Equal(t, "🔗1 Stacks", opts[0].label)
+		assert.Equal(t, "🔗2 Projects", opts[1].label)
+		assert.Equal(t, "stacks", opts[0].path)
+	})
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		t.Parallel()
+		opts := numberedNavLinks(nil)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("backticks stripped from label", func(t *testing.T) {
+		t.Parallel()
+		links := []docLink{{text: "`pulumi up`", href: "/docs/up"}}
+		opts := numberedNavLinks(links)
+		assert.Equal(t, "🔗1 pulumi up", opts[0].label)
+	})
+}

--- a/pkg/cmd/pulumi/docs/bundle.go
+++ b/pkg/cmd/pulumi/docs/bundle.go
@@ -363,6 +363,69 @@ func classifyBundleKeys(bundle *CLIDocsBundle, modulePrefix string) classifiedKe
 	}
 }
 
+// BundleNavItems generates navigation items from bundle keys for a given module prefix.
+func BundleNavItems(bundle *CLIDocsBundle, modulePrefix string, pkgName string) []navOption {
+	basePath := fmt.Sprintf("registry/packages/%s/api-docs", pkgName)
+	ck := classifyBundleKeys(bundle, modulePrefix)
+
+	opts := make([]navOption, 0, len(ck.subModules)+len(ck.resources)+len(ck.functions))
+
+	for _, mod := range ck.subModules {
+		modPath := basePath
+		if modulePrefix != "" {
+			modPath += "/" + modulePrefix
+		}
+		modPath += "/" + mod
+		opts = append(opts, navOption{label: "🔗 " + mod + navDrill, path: modPath})
+	}
+	for _, r := range ck.resources {
+		opts = append(opts, navOption{label: "🔗 " + r.title, path: basePath + "/" + r.key})
+	}
+	for _, f := range ck.functions {
+		opts = append(opts, navOption{label: "🔗 " + f.title, path: basePath + "/" + f.key})
+	}
+
+	return opts
+}
+
+// BundleSectionNav returns per-section nav items for drilling into modules, resources, and functions.
+func BundleSectionNav(bundle *CLIDocsBundle, modulePrefix string, pkgName string) map[string][]navOption {
+	basePath := fmt.Sprintf("registry/packages/%s/api-docs", pkgName)
+	ck := classifyBundleKeys(bundle, modulePrefix)
+
+	result := map[string][]navOption{}
+
+	if len(ck.subModules) > 0 {
+		modNav := make([]navOption, 0, len(ck.subModules))
+		for _, mod := range ck.subModules {
+			modPath := basePath
+			if modulePrefix != "" {
+				modPath += "/" + modulePrefix
+			}
+			modPath += "/" + mod
+			modNav = append(modNav, navOption{label: "🔗 " + mod + navDrill, path: modPath})
+		}
+		result[sectionModules] = modNav
+	}
+
+	if len(ck.resources) > 0 {
+		resNav := make([]navOption, 0, len(ck.resources))
+		for _, r := range ck.resources {
+			resNav = append(resNav, navOption{label: "🔗 " + r.title, path: basePath + "/" + r.key})
+		}
+		result[sectionResources] = resNav
+	}
+
+	if len(ck.functions) > 0 {
+		fnNav := make([]navOption, 0, len(ck.functions))
+		for _, f := range ck.functions {
+			fnNav = append(fnNav, navOption{label: "🔗 " + f.title, path: basePath + "/" + f.key})
+		}
+		result[sectionFunctions] = fnNav
+	}
+
+	return result
+}
 
 // extractBundleTitle extracts the title from a "# Title" first line.
 func extractBundleTitle(content string) string {

--- a/pkg/cmd/pulumi/docs/bundle_test.go
+++ b/pkg/cmd/pulumi/docs/bundle_test.go
@@ -142,6 +142,126 @@ func TestLookupBundleDoc(t *testing.T) {
 	})
 }
 
+func TestBundleNavItems(t *testing.T) {
+	t.Parallel()
+	bundle := &CLIDocsBundle{
+		Package: "aws",
+		Resources: map[string]string{
+			"s3/bucket":                "# Bucket\n\nContent",
+			"s3/bucketPolicy":          "# BucketPolicy\n\nContent",
+			"ec2/instance":             "# Instance\n\nContent",
+			"ec2/vpc":                  "# Vpc\n\nContent",
+			"ec2/transitgateway/route": "# Route\n\nContent",
+			"rootresource":             "# RootResource\n\nContent",
+		},
+		Functions: map[string]string{
+			"s3/getBucket": "# getBucket\n\nContent",
+			"rootfunc":     "# rootFunc\n\nContent",
+		},
+	}
+
+	t.Run("module level - s3", func(t *testing.T) {
+		t.Parallel()
+		items := BundleNavItems(bundle, "s3", "aws")
+
+		// Should have: Bucket, BucketPolicy (resources), getBucket (function)
+		require.Len(t, items, 3)
+
+		labels := make([]string, len(items))
+		for i, item := range items {
+			labels[i] = item.label
+		}
+		assert.Contains(t, labels, "🔗 Bucket")
+		assert.Contains(t, labels, "🔗 BucketPolicy")
+		assert.Contains(t, labels, "🔗 getBucket")
+
+		// Check paths
+		for _, item := range items {
+			assert.True(t, len(item.path) > 0)
+			assert.Contains(t, item.path, "registry/packages/aws/api-docs/s3/")
+		}
+	})
+
+	t.Run("module level - ec2 with sub-modules", func(t *testing.T) {
+		t.Parallel()
+		items := BundleNavItems(bundle, "ec2", "aws")
+
+		labels := make([]string, len(items))
+		for i, item := range items {
+			labels[i] = item.label
+		}
+
+		// Should have: transitgateway (sub-module drill), Instance, Vpc (resources)
+		assert.Contains(t, labels, "🔗 transitgateway"+navDrill)
+		assert.Contains(t, labels, "🔗 Instance")
+		assert.Contains(t, labels, "🔗 Vpc")
+	})
+
+	t.Run("root level - empty prefix", func(t *testing.T) {
+		t.Parallel()
+		items := BundleNavItems(bundle, "", "aws")
+
+		labels := make([]string, len(items))
+		for i, item := range items {
+			labels[i] = item.label
+		}
+
+		// Should have sub-modules: ec2, s3 (drill), plus root-level: RootResource, rootFunc
+		assert.Contains(t, labels, "🔗 ec2"+navDrill)
+		assert.Contains(t, labels, "🔗 s3"+navDrill)
+		assert.Contains(t, labels, "🔗 RootResource")
+		assert.Contains(t, labels, "🔗 rootFunc")
+	})
+
+	t.Run("nested module", func(t *testing.T) {
+		t.Parallel()
+		items := BundleNavItems(bundle, "ec2/transitgateway", "aws")
+
+		require.Len(t, items, 1)
+		assert.Equal(t, "🔗 Route", items[0].label)
+		assert.Equal(t, "registry/packages/aws/api-docs/ec2/transitgateway/route", items[0].path)
+	})
+
+	t.Run("empty bundle", func(t *testing.T) {
+		t.Parallel()
+		empty := &CLIDocsBundle{}
+		items := BundleNavItems(empty, "s3", "aws")
+		assert.Empty(t, items)
+	})
+}
+
+func TestBundleSectionNav(t *testing.T) {
+	t.Parallel()
+
+	bundle := &CLIDocsBundle{
+		Package: "aws",
+		Resources: map[string]string{
+			"s3/bucket":    "# Bucket\n\nContent",
+			"rootresource": "# RootResource\n\nContent",
+		},
+		Functions: map[string]string{
+			"rootfunc": "# rootFunc\n\nContent",
+		},
+	}
+
+	t.Run("returns nav for sections", func(t *testing.T) {
+		t.Parallel()
+		nav := BundleSectionNav(bundle, "", "aws")
+		assert.Contains(t, nav, sectionModules)
+		assert.Contains(t, nav, sectionResources)
+		assert.Contains(t, nav, sectionFunctions)
+		require.Len(t, nav[sectionModules], 1)
+		assert.Contains(t, nav[sectionModules][0].label, "s3")
+	})
+
+	t.Run("empty bundle returns empty map", func(t *testing.T) {
+		t.Parallel()
+		empty := &CLIDocsBundle{}
+		nav := BundleSectionNav(empty, "", "test")
+		assert.Empty(t, nav)
+	})
+}
+
 func TestFetchCLIDocsBundle(t *testing.T) {
 	testBundle := CLIDocsBundle{
 		Version:        1,

--- a/pkg/cmd/pulumi/docs/docs.go
+++ b/pkg/cmd/pulumi/docs/docs.go
@@ -17,6 +17,7 @@ package docs
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/browser"
@@ -36,6 +37,8 @@ type docsCmd struct {
 	toc             bool
 	tocJSON         bool
 	jsonOutput      bool
+	fullPage        bool
+	sectionsView    bool
 }
 
 // NewDocsCmd creates the `pulumi docs` command.
@@ -46,11 +49,18 @@ func NewDocsCmd() *cobra.Command {
 		Use:   "docs",
 		Short: "View Pulumi documentation in the terminal",
 		Long: "Read and browse Pulumi documentation in the terminal.\n\n" +
-			"  pulumi docs                    Show help\n" +
+			"  pulumi docs                    Browse interactively\n" +
 			"  pulumi docs read <path>        Read a specific page\n" +
+			"  pulumi docs browse [path]      Browse interactively\n" +
 			"  pulumi docs registry <pkg>     Read a registry package\n" +
 			"  pulumi docs search <query>     Search documentation\n" +
 			"  pulumi docs sitemap            List available pages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmdutil.Interactive() {
+				return dc.browseLoop("")
+			}
+			return cmd.Help()
+		},
 	}
 
 	cmd.PersistentFlags().StringVar(&dc.baseURL, "base-url", "https://www.pulumi.com",
@@ -65,6 +75,7 @@ func NewDocsCmd() *cobra.Command {
 		"Filter OS-specific content in docs (e.g., macos, linux, windows); choice is remembered")
 
 	cmd.AddCommand(dc.newReadCmd())
+	cmd.AddCommand(dc.newBrowseCmd())
 	cmd.AddCommand(dc.newSearchCmd())
 	cmd.AddCommand(dc.newRegistryCmd())
 	cmd.AddCommand(dc.newSitemapCmd())
@@ -308,6 +319,37 @@ func (dc *docsCmd) showTOC(body string, section *string) error {
 	return nil
 }
 
+func (dc *docsCmd) newBrowseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "browse [path]",
+		Short: "Browse Pulumi documentation interactively",
+		Long: "Browse docs and registry by following links between pages.\n\n" +
+			"  pulumi docs browse             Browse from last viewed page or root\n" +
+			"  pulumi docs browse <path>      Start browsing at a specific page\n" +
+			"  pulumi docs browse /           Browse from the site map root\n" +
+			"  pulumi docs browse registry/   Browse all registry packages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := ""
+			if len(args) > 0 && args[0] != "/" {
+				path = args[0]
+			} else if len(args) == 0 {
+				prefs, _ := LoadPreferences()
+				path = prefs.LastPage
+			}
+			return dc.browseLoop(path)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.fullPage, "full", false,
+		"Show full page instead of sections view (saved as default when used)")
+	cmd.Flags().BoolVar(&dc.sectionsView, "sections", false,
+		"Show sections view instead of full page (saved as default when used)")
+	cmd.MarkFlagsMutuallyExclusive("full", "sections")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "path"}},
+	})
+	return cmd
+}
+
 func (dc *docsCmd) newSearchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>...",
@@ -357,19 +399,22 @@ func (dc *docsCmd) handleRegistryFallback(path string) error {
 	}
 
 	if cmdutil.Interactive() && overviewPath != "" {
+		optBrowseAPI := "Browse API docs"
 		optOverview := "View package overview"
 		optBrowser := "Open in web browser"
-		options := []string{optOverview, optBrowser}
+		options := []string{optBrowseAPI, optOverview, optBrowser}
 
 		fmt.Fprintln(os.Stderr)
 		selected := ui.PromptUser(
 			"What would you like to do?",
 			options,
-			optOverview,
+			optBrowseAPI,
 			cmdutil.GetGlobalColorization(),
 		)
 
 		switch selected {
+		case optBrowseAPI:
+			return dc.browseLoop(overviewPath + "/api-docs")
 		case optOverview:
 			return dc.fetchAndRender(overviewPath)
 		case optBrowser:

--- a/pkg/cmd/pulumi/docs/render.go
+++ b/pkg/cmd/pulumi/docs/render.go
@@ -367,6 +367,13 @@ func pageFooter(baseURL, path string) string {
 	return buf.String()
 }
 
+// browseFooter returns a compact footer for browse mode showing the web URL.
+func browseFooter(baseURL, path string) string {
+	width := getTerminalWidth()
+	rule := strings.Repeat("─", width-len(glamourMargin))
+	return fmt.Sprintf("\n%s%s\n%s🔗 %s\n", glamourMargin, rule, glamourMargin, webURL(baseURL, path))
+}
+
 var noteStartRe = regexp.MustCompile(`^([>|])\s*\*{0,2}(Note|Warning|Tip):\*{0,2}\s*(.*)$`)
 
 func parseNoteLine(trimmed string) (noteType, prefix, body string, ok bool) {


### PR DESCRIPTION
## Summary (PR 4 of 4)

> **Review/merge order:** Requires PRs 1–3 (#22398, #22399, #22400) to be merged first. This is the final PR in the series.

Adds the interactive browse mode, completing the `pulumi docs` feature:

- `pulumi docs browse [path]` — interactive tree-based browsing with navigation history
- `pulumi docs` (no args) now launches browse mode when interactive
- Section-based and full-page view modes (saved as user preference)
- Previous/Next section navigation with drill-down into headings
- Bundle navigation items (`BundleNavItems`, `BundleSectionNav`) for registry API docs drill-down
- Browser fallback for pages unavailable as terminal markdown
- "Browse API docs" option in registry fallback prompt

### PR series

1. `pulumi docs read` (#22398) — core read pipeline
2. `pulumi docs search/sitemap/registry` (#22399) — additional subcommands
3. Bundle system (#22400) — registry API docs with caching
4. **`pulumi docs browse`** (this PR) — interactive browse mode

## Test plan

- [x] `go build ./cmd/pulumi/docs/...` compiles
- [x] `go test -count=1 ./cmd/pulumi/docs/...` passes
- [x] `golangci-lint run ./cmd/pulumi/docs/...` clean