### PR TITLE
Filling in a couple of Go builtins

### DIFF
--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -223,8 +223,6 @@ func TestNotYetImplementedEmittedWhenGeneratingFunctions(t *testing.T) {
 	g := newTestGenerator(t, filepath.Join("aws-s3-logging-pp", "aws-s3-logging.pp"))
 
 	notYetImplementedFunctions := []string{
-		"split",
-		"element",
 		"entries",
 		"lookup",
 		"range",

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -375,6 +375,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "notImplemented(%v)", expr.Args[0])
 	case "singleOrNone":
 		g.Fgenf(w, "singleOrNone(%v)", expr.Args[0])
+	case "element":
+		g.Fgenf(w, "%v[%v]", expr.Args[0], expr.Args[1])
 	case "castDeferredOutput":
 		outputType := expr.Args[0].Type()
 		typeParameter := deferredOutputCastTypeParameter(outputType)
@@ -452,6 +454,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 		optionsBag = buf.String()
 		g.Fgenf(w, "%v)", optionsBag)
+	case "split":
+		g.Fgenf(w, "strings.Split(%v, %v)", expr.Args[1], expr.Args[0])
 	case "join":
 		g.Fgenf(w, "strings.Join(%v, %v)", expr.Args[1], expr.Args[0])
 	case "length":


### PR DESCRIPTION
This will eventually be tested by the l1-builtin-list conformance test, and I've checked that this generates sensible code for that, but currently that test has other issues with reading lists from config so it can't fully run. 

Still this is small and simple enough to feel worth just getting in.