### PR TITLE
Replace busy-wait polling in wait_for_rpcs with asyncio.wait

### DIFF
--- a/changelog/pending/20260331--sdk-python--replace-busy-wait-polling-in-wait_for_rpcs-with-asyncio-wait.yaml
+++ b/changelog/pending/20260331--sdk-python--replace-busy-wait-polling-in-wait_for_rpcs-with-asyncio-wait.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Replace busy-wait polling in wait_for_rpcs with asyncio.wait

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -141,27 +141,30 @@ async def wait_for_rpcs(await_all_outstanding_tasks=True) -> None:
 
         # If the RPCs have successfully completed, now await all remaining outstanding tasks.
         if await_all_outstanding_tasks:
-            while len(SETTINGS.outputs) != 0:
-                await asyncio.sleep(0)
-                if settings.excessive_debug_output:
-                    log.debug(
-                        f"waiting for quiescence; {len(SETTINGS.outputs)} outputs outstanding"
-                    )
+            while True:
                 with SETTINGS.lock:
                     # the task may have been removed from the queue by the time we get to it, so we need to re-check if
                     # its empty.
                     if len(SETTINGS.outputs) == 0:
                         break
-                    task: asyncio.Task = SETTINGS.outputs.popleft()
+                    # Copy the outputs and clear so new outputs added while we wait are picked up on the next iteration.
+                    pending_outputs: list[asyncio.Task] = list(SETTINGS.outputs)
+                    SETTINGS.outputs.clear()
 
-                # check if the task is ready yet, else just add it back to the queue. This is so if a long running task
-                # is added to the queue first, then a short running task that fails is added to the queue we quickly see
-                # that short running failure and exit, not waiting for the long running task to complete.
-                if task.done():
+                # Wait for a task to complete or be cancelled
+                done, not_done = await asyncio.wait(
+                    pending_outputs, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Await the completed task so any exception is re-raised here.
+                for task in done:
                     await task
-                else:
+
+                # Put unfinished tasks back for the next iteration.
+                if not_done:
                     with SETTINGS.lock:
-                        SETTINGS.outputs.append(task)
+                        for task in not_done:
+                            SETTINGS.outputs.append(task)
 
             log.debug("All outstanding outputs completed.")
 


### PR DESCRIPTION
The outputs drain loop used `asyncio.sleep(0)` and re-queued undone tasks. By using `asyncio.wait` to wait for the first task that’s ready, we drastically reduce the CPU time used. This does also reduce wall clock time, although actual waiting for resources to be ready in cloud providers still dominiates. My test program deploying to kubernetes reduced its time from 88s to 68s, but the benchmark is very noisy.

Before
```
Tue Mar 31 10:40:51 2026    profile_1.prof

         19917496 function calls (20243591 primitive calls) in 61.014 seconds

   Random listing order was used
   List reduced from 5251 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   586542    4.609    0.000   81.980    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/asyncio/base_events.py:1966(_UnixSelectorEventLoop._run_once)
   612043    1.109    0.000   69.856    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/asyncio/events.py:92(Handle._run)
        1    1.022    1.022   51.573   51.573 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/runtime/stack.py:174(run_in_stack)
        1    1.006    1.006   50.551   50.551 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/runtime/stack.py:79(run_pulumi_func)
        1    9.687    9.687   49.545   49.545 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/runtime/stack.py:104(wait_for_rpcs)
  3539933   12.220    0.000   32.559    0.000 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/_utils.py:217(ContextProperty.__get__)
  7079866   11.621    0.000   17.435    0.000 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/_utils.py:203(ContextProperty.fget)
      121    0.012    0.000    7.696    0.064 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/runtime/resource.py:1013(do_register)
   611791    1.659    0.000    6.203    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/asyncio/base_events.py:817(_UnixSelectorEventLoop.call_soon)
     1780    0.067    0.000    5.287    0.003 /Users/julien/Projects/experiments/pulumi-program-k8s-py/.venv/lib/python3.14/site-packages/pulumi/_types.py:734(_types_from_py_properties)
```

After
```
Tue Mar 31 12:38:46 2026    profile_2.prof

         2979270 function calls (3305365 primitive calls) in 9.392 seconds

   Random listing order was used
   List reduced from 5255 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      968    0.061    0.000   11.643    0.012 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/asyncio/base_events.py:1966(_UnixSelectorEventLoop._run_once)
    29130    0.049    0.000   11.539    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/asyncio/events.py:92(Handle._run)
      121    0.011    0.000    7.034    0.058 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:1013(do_register)
     1780    0.059    0.000    4.818    0.003 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/_types.py:734(_types_from_py_properties)
      121    0.004    0.000    4.114    0.034 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:183(prepare_resource)
      126    0.005    0.000    4.095    0.032 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:162(serialize_properties)
 690/5512    0.084    0.000    3.671    0.001 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:351(serialize_property)
    12987    0.131    0.000    3.536    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/typing.py:2327(get_type_hints)
      770    0.003    0.000    3.198    0.004 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/_types.py:501(input_type_types)
        1    0.177    0.177    2.863    2.863 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/stack.py:104(wait_for_rpcs)
```