### PR TITLE
Add `new` command to NodeJS Automation API

### DIFF
--- a/changelog/pending/20260403--auto-nodejs--add-new-command-to-automation-api.yaml
+++ b/changelog/pending/20260403--auto-nodejs--add-new-command-to-automation-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/nodejs
+  description: Add "new" command to the auto-generated interface

--- a/sdk/nodejs/automation/interface/index.ts
+++ b/sdk/nodejs/automation/interface/index.ts
@@ -112,6 +112,141 @@ export class API {
 
         return this.__run(options, __final);
     }
+
+    new(options: PulumiNewOptions, templateOrUrl?: string): ReturnType<API["__run"]> {
+        const __final: string[] = [];
+        __final.push("new");
+
+        const __flags: string[] = [];
+
+        __flags.push("--yes");
+
+        if (options.color != null) {
+            __flags.push("--color", "" + options.color);
+        }
+
+        if (options.disableIntegrityChecking) {
+            __flags.push("--disable-integrity-checking");
+        }
+
+        if (options.fullyQualifyStackNames) {
+            __flags.push("--fully-qualify-stack-names");
+        }
+
+        if (options.logflow) {
+            __flags.push("--logflow");
+        }
+
+        if (options.logtostderr) {
+            __flags.push("--logtostderr");
+        }
+
+        if (options.memprofilerate != null) {
+            __flags.push("--memprofilerate", "" + options.memprofilerate);
+        }
+
+        if (options.otelTraces != null) {
+            __flags.push("--otel-traces", "" + options.otelTraces);
+        }
+
+        if (options.profiling != null) {
+            __flags.push("--profiling", "" + options.profiling);
+        }
+
+        if (options.tracing != null) {
+            __flags.push("--tracing", "" + options.tracing);
+        }
+
+        if (options.tracingHeader != null) {
+            __flags.push("--tracing-header", "" + options.tracingHeader);
+        }
+
+        if (options.verbose != null) {
+            __flags.push("--verbose", "" + options.verbose);
+        }
+
+        if (options.ai != null) {
+            __flags.push("--ai", "" + options.ai);
+        }
+
+        for (const __item of options.config ?? []) {
+            if (__item != null) {
+                __flags.push("--config", "" + __item);
+            }
+        }
+
+        if (options.configPath) {
+            __flags.push("--config-path");
+        }
+
+        if (options.description != null) {
+            __flags.push("--description", "" + options.description);
+        }
+
+        if (options.dir != null) {
+            __flags.push("--dir", "" + options.dir);
+        }
+
+        if (options.force) {
+            __flags.push("--force");
+        }
+
+        if (options.generateOnly) {
+            __flags.push("--generate-only");
+        }
+
+        if (options.language != null) {
+            __flags.push("--language", "" + options.language);
+        }
+
+        if (options.listTemplates) {
+            __flags.push("--list-templates");
+        }
+
+        if (options.name != null) {
+            __flags.push("--name", "" + options.name);
+        }
+
+        if (options.offline) {
+            __flags.push("--offline");
+        }
+
+        if (options.remoteStackConfig) {
+            __flags.push("--remote-stack-config");
+        }
+
+        for (const __item of options.runtimeOptions ?? []) {
+            if (__item != null) {
+                __flags.push("--runtime-options", "" + __item);
+            }
+        }
+
+        if (options.secretsProvider != null) {
+            __flags.push("--secrets-provider", "" + options.secretsProvider);
+        }
+
+        if (options.stack != null) {
+            __flags.push("--stack", "" + options.stack);
+        }
+
+        if (options.templateMode) {
+            __flags.push("--template-mode");
+        }
+
+        __final.push(...__flags);
+
+        const __arguments: string[] = [];
+
+        if (templateOrUrl != null) {
+            __arguments.push("" + templateOrUrl);
+        }
+        if (__arguments.length > 0) {
+            __final.push("--");
+            __final.push(...__arguments);
+        }
+
+        return this.__run(options, __final);
+    }
 }
 
 /** Options for the `pulumi cancel` command. */
@@ -140,4 +275,62 @@ export interface PulumiCancelOptions extends BaseOptions {
     verbose?: number;
     /** The name of the stack to operate on. Defaults to the current stack */
     stack?: string;
+}
+
+/** Options for the `pulumi new` command. */
+export interface PulumiNewOptions extends BaseOptions {
+    /** Colorize output. Choices are: always, never, raw, auto */
+    color?: string;
+    /** Disable integrity checking of checkpoint files */
+    disableIntegrityChecking?: boolean;
+    /** Show fully-qualified stack names */
+    fullyQualifyStackNames?: boolean;
+    /** Flow log settings to child processes (like plugins) */
+    logflow?: boolean;
+    /** Log to stderr instead of to files */
+    logtostderr?: boolean;
+    /** Enable more precise (and expensive) memory allocation profiles by setting runtime.MemProfileRate */
+    memprofilerate?: number;
+    /** Export OpenTelemetry traces to the specified endpoint. Use file:// for local JSON files, grpc:// for remote collectors */
+    otelTraces?: string;
+    /** Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively */
+    profiling?: string;
+    /** Emit tracing to the specified endpoint. Use the `file:` scheme to write tracing data to a local file */
+    tracing?: string;
+    /** Include the tracing header with the given contents. */
+    tracingHeader?: string;
+    /** Enable verbose logging (e.g., v=3); anything >3 is very verbose */
+    verbose?: number;
+    /** Prompt to use for Pulumi AI */
+    ai?: string;
+    /** Config to save */
+    config?: string[];
+    /** Config keys contain a path to a property in a map or list to set */
+    configPath?: boolean;
+    /** The project description; if not specified, a prompt will request it */
+    description?: string;
+    /** The location to place the generated project; if not specified, the current directory is used */
+    dir?: string;
+    /** Forces content to be generated even if it would change existing files */
+    force?: boolean;
+    /** Generate the project only; do not create a stack, save config, or install dependencies */
+    generateOnly?: boolean;
+    /** Language to use for Pulumi AI (must be one of TypeScript, JavaScript, Python, Go, C#, Java, or YAML) */
+    language?: string;
+    /** List locally installed templates and exit */
+    listTemplates?: boolean;
+    /** The project name; if not specified, a prompt will request it */
+    name?: string;
+    /** Use locally cached templates without making any network requests */
+    offline?: boolean;
+    /** Store stack configuration remotely */
+    remoteStackConfig?: boolean;
+    /** Additional options for the language runtime (format: key1=value1,key2=value2) */
+    runtimeOptions?: string[];
+    /** The type of the provider that should be used to encrypt and decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault) */
+    secretsProvider?: string;
+    /** The stack name; either an existing stack or stack to create; if not specified, a prompt will request it */
+    stack?: string;
+    /** Run in template mode, which will skip prompting for AI or Template functionality */
+    templateMode?: boolean;
 }

--- a/sdk/nodejs/tools/automation/src/index.ts
+++ b/sdk/nodejs/tools/automation/src/index.ts
@@ -255,7 +255,11 @@ function generateBody(structure: Structure, breadcrumbs: string[], allFlags: Rec
                 writer.writeLine("}");
             }
 
-            writer.blankLine();
+            // Skip trailing blank line for recursive calls (inside a for loop)
+            // to avoid biome formatting violations from empty lines before closing braces.
+            if (!override) {
+                writer.blankLine();
+            }
         }
 
         /**

--- a/sdk/nodejs/tools/automation/tests/index.spec.ts
+++ b/sdk/nodejs/tools/automation/tests/index.spec.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { API, PulumiCancelOptions } from "../output";
+import { API, PulumiCancelOptions, PulumiNewOptions } from "../output";
 import { describe, it } from "mocha";
 import * as assert from "assert";
 
@@ -23,5 +23,37 @@ describe("Command examples", () => {
         const options: PulumiCancelOptions = {};
         const command = api.cancel(options, "my-stack");
         assert.strictEqual(command, "pulumi cancel --yes -- my-stack");
+    });
+
+    it("new with template", () => {
+        const options: PulumiNewOptions = {};
+        const command = api.new(options, "typescript");
+        assert.strictEqual(command, "pulumi new --yes -- typescript");
+    });
+
+    it("new with flags", () => {
+        const options: PulumiNewOptions = {
+            name: "my-project",
+            description: "A test project",
+            stack: "dev",
+            generateOnly: true,
+        };
+        const command = api.new(options, "typescript");
+        assert.strictEqual(
+            command,
+            "pulumi new --yes --description A test project --generate-only --name my-project --stack dev -- typescript",
+        );
+    });
+
+    it("new with config flags", () => {
+        const options: PulumiNewOptions = {
+            config: ["aws:region=us-east-1", "project:env=dev"],
+            configPath: true,
+        };
+        const command = api.new(options, "aws-typescript");
+        assert.strictEqual(
+            command,
+            "pulumi new --yes --config aws:region=us-east-1 --config project:env=dev --config-path -- aws-typescript",
+        );
     });
 });

--- a/tools/automation/automation-overrides.json
+++ b/tools/automation/automation-overrides.json
@@ -226,7 +226,6 @@
         {
             "path": ["new"],
             "propagate": true,
-            "exclude": true,
             "flags": {}
         },
         {


### PR DESCRIPTION
## Summary
- Remove the exclusion of `pulumi new` from the automation codegen overrides
- Regenerate the auto-generated NodeJS Automation API interface with the `new()` method and `PulumiNewOptions` type
- Fix codegen tests to use a mock `PulumiCommand` (the constructor now requires one) and add test coverage for the new command

## Test plan
- [x] Codegen tests pass (`cd sdk/nodejs/tools/automation && npm test`) — 4 tests passing
- [ ] CI runs full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)