### PR TITLE
Cache type metadata and class references in Python SDK to reduce CPU overhead during serialization

### DIFF
--- a/changelog/pending/20260331--sdk-python--cache-type-metadata-and-class-references-in-python-sdk-to-reduce-cpu-overhead-during-serializastion.yaml
+++ b/changelog/pending/20260331--sdk-python--cache-type-metadata-and-class-references-in-python-sdk-to-reduce-cpu-overhead-during-serializastion.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Cache type metadata and class references in Python SDK to reduce CPU overhead during serialization

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -444,14 +444,17 @@ def _create_py_property(a_name: str, pulumi_name: str, typ: Any, setter: bool = 
     return builtins.property(fget=getter_fn)
 
 
-def _py_properties(cls: type) -> Iterator[tuple[str, str, builtins.property]]:
+@functools.cache
+def _py_properties(cls: type) -> tuple[tuple[str, str, builtins.property], ...]:
+    result: list[tuple[str, str, builtins.property]] = []
     for base in reversed(cls.__mro__):
         for python_name, v in base.__dict__.items():
             if isinstance(v, builtins.property):
                 prop = cast(builtins.property, v)
                 pulumi_name = getattr(prop.fget, _PULUMI_NAME, MISSING)
                 if pulumi_name is not MISSING:
-                    yield (python_name, cast(str, pulumi_name), prop)
+                    result.append((python_name, cast(str, pulumi_name), prop))
+    return tuple(result)
 
 
 def input_type(cls: type[T]) -> type[T]:
@@ -476,7 +479,7 @@ def input_type(cls: type[T]) -> type[T]:
 
     # Now, process the class's properties, replacing properties with empty setters with
     # an actual setter.
-    for python_name, _, prop in _py_properties(cls):
+    for python_name, _, prop in _py_properties(cls):  # type: ignore[arg-type] # https://github.com/python/mypy/issues/11470
         if prop.fset is not None and _utils.is_empty_function(prop.fset):
             setter_fn = create_setter(python_name)
             setter_fn.__name__ = prop.fset.__name__
@@ -517,7 +520,7 @@ def input_type_to_dict(obj: Any) -> dict[str, Any]:
 
     # Build a dictionary of properties to return
     result: dict[str, Any] = {}
-    for _, pulumi_name, prop in _py_properties(cls):
+    for _, pulumi_name, prop in _py_properties(cls):  # type: ignore[arg-type] # https://github.com/python/mypy/issues/11470
         fget = prop.fget
 
         # If the property has a _pulumi_deprecated_callable attribute, use that
@@ -571,7 +574,7 @@ def output_type(cls: type[T]) -> type[T]:
     # provider codegen, will be the translated name from _tables.CAMEL_TO_SNAKE_CASE_TABLE).
     if hasattr(cls, _TRANSLATE_PROPERTY):
         python_to_pulumi_table = None
-        for python_name, pulumi_name, _ in _py_properties(cls):
+        for python_name, pulumi_name, _ in _py_properties(cls):  # type: ignore[arg-type] # https://github.com/python/mypy/issues/11470
             if python_name != pulumi_name:
                 python_to_pulumi_table = python_to_pulumi_table or {}
                 python_to_pulumi_table[python_name] = pulumi_name
@@ -585,7 +588,7 @@ def output_type_from_dict(cls: type[T], output: dict[str, Any]) -> T:
     assert isinstance(output, dict)
     assert is_output_type(cls)
     args = {}
-    for python_name, pulumi_name, _ in _py_properties(cls):
+    for python_name, pulumi_name, _ in _py_properties(cls):  # type: ignore[arg-type] # https://github.com/python/mypy/issues/11470
         args[python_name] = output.get(pulumi_name)
     return cls(**args)  # type: ignore
 
@@ -731,6 +734,7 @@ def _globals_for_cls(cls: type) -> Optional[dict[str, Any]]:
     return globalns
 
 
+@functools.cache
 def _types_from_py_properties(cls: type) -> dict[str, type]:
     """
     Returns a dict of Pulumi names to types for a type.

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -27,74 +27,109 @@ within the functions themselves.
 
 from typing import Any
 
+# Cache class references to avoid repeated import machinery overhead. These functions are called *a lot* during
+# serialization, so this optimization does add up.
+_Asset: type | None = None
+_Archive: type | None = None
+_Resource: type | None = None
+_CustomResource: type | None = None
+_CustomTimeouts: type | None = None
+_Stack: type | None = None
+_Output: type | None = None
+_Unknown: type | None = None
+
 
 def is_asset(obj: Any) -> bool:
     """
     Returns true if the given type is an Asset, false otherwise.
     """
-    from .. import Asset
+    global _Asset  # noqa: PLW0603
+    if _Asset is None:
+        from .. import Asset
 
-    return isinstance(obj, Asset)
+        _Asset = Asset
+    return isinstance(obj, _Asset)
 
 
 def is_archive(obj: Any) -> bool:
     """
     Returns true if the given type is an Archive, false otherwise.
     """
-    from .. import Archive
+    global _Archive  # noqa: PLW0603
+    if _Archive is None:
+        from .. import Archive
 
-    return isinstance(obj, Archive)
+        _Archive = Archive
+    return isinstance(obj, _Archive)
 
 
 def is_resource(obj: Any) -> bool:
     """
     Returns true if the given type is a Resource, false otherwise.
     """
-    from .. import Resource
+    global _Resource  # noqa: PLW0603
+    if _Resource is None:
+        from .. import Resource
 
-    return isinstance(obj, Resource)
+        _Resource = Resource
+    return isinstance(obj, _Resource)
 
 
 def is_custom_resource(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomResource, false otherwise.
     """
-    from .. import CustomResource
+    global _CustomResource  # noqa: PLW0603
+    if _CustomResource is None:
+        from .. import CustomResource
 
-    return isinstance(obj, CustomResource)
+        _CustomResource = CustomResource
+    return isinstance(obj, _CustomResource)
 
 
 def is_custom_timeouts(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomTimeouts, false otherwise.
     """
-    from .. import CustomTimeouts
+    global _CustomTimeouts  # noqa: PLW0603
+    if _CustomTimeouts is None:
+        from .. import CustomTimeouts
 
-    return isinstance(obj, CustomTimeouts)
+        _CustomTimeouts = CustomTimeouts
+    return isinstance(obj, _CustomTimeouts)
 
 
 def is_stack(obj: Any) -> bool:
     """
     Returns true if the given type is a Stack, false otherwise.
     """
-    from .stack import Stack
+    global _Stack  # noqa: PLW0603
+    if _Stack is None:
+        from .stack import Stack
 
-    return isinstance(obj, Stack)
+        _Stack = Stack
+    return isinstance(obj, _Stack)
 
 
 def is_output(obj: Any) -> bool:
     """
     Returns true if the given type is an Output, false otherwise.
     """
-    from .. import Output
+    global _Output  # noqa: PLW0603
+    if _Output is None:
+        from .. import Output
 
-    return isinstance(obj, Output)
+        _Output = Output
+    return isinstance(obj, _Output)
 
 
 def is_unknown(obj: Any) -> bool:
     """
     Returns true if the given object is an Unknown, false otherwise.
     """
-    from ..output import Unknown
+    global _Unknown  # noqa: PLW0603
+    if _Unknown is None:
+        from ..output import Unknown
 
-    return isinstance(obj, Unknown)
+        _Unknown = Unknown
+    return isinstance(obj, _Unknown)


### PR DESCRIPTION
`_types_from_py_properties` and `_py_properties` are called *a lot* during serialization/deserialization but always return the same results for a given class. The classes come from our SDKs and are not modified at runtime. We can cache these functions with `@functools.cache`.

In `known_types.py` we were resolving class references via import machinery on every call. Cache them in module-level globals instead. This is really a micro-optimization, but it adds up here.

These changes result in another massive CPU time reduction on top of https://github.com/pulumi/pulumi/pull/22411. Note that real time is dominated by provider IO, but we still see a noticeable reduction, 10% in my test case.

Before
```
059398 function calls (29816234 primitive calls) in 77.627 seconds

      209    0.022    0.000  100.662    0.482 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:1013(do_register)
     7037    0.878    0.000   88.466    0.013 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/_types.py:734(_types_from_py_properties)
      218    0.007    0.000   71.854    0.330 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:162(serialize_properties)
      209    0.005    0.000   71.770    0.343 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:183(prepare_resource)
1015/61724    0.818    0.001   70.864    0.001 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:351(serialize_property)
   231164    2.239    0.000   68.443    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/typing.py:2327(get_type_hints)
     3493    0.015    0.000   64.422    0.018 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/_types.py:501(input_type_types)
231170/1925669    8.567    0.000   46.429    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/typing.py:433(_eval_type)
918653/2144790    2.908    0.000   29.005    0.000 /Users/julien/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/lib/python3.14/typing.py:478(<genexpr>)
      209    0.007    0.000   28.519    0.136 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:1440(resolve_outputs)
```

After:
```
3825824 function calls (4508390 primitive calls) in 12.028 seconds

      209    0.020    0.000    8.406    0.040 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:1013(do_register)
      218    0.007    0.000    4.756    0.022 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:162(serialize_properties)
      209    0.005    0.000    4.716    0.023 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/resource.py:183(prepare_resource)
1015/61724    0.801    0.001    4.181    0.000 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:351(serialize_property)
      209    0.006    0.000    3.333    0.016 /Users/julien/Projects/pulumi/pulumi/sdk/python/lib/pulumi/runtime/rpc.py:1440(resolve_outputs)
```
