### PR TITLE
Add optional inputs/outputs test

### DIFF
--- a/pkg/testing/pulumi-test-language/providers/optional_primitive_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/optional_primitive_provider.go
@@ -1,0 +1,311 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// A small provider with a single resource "Resource" that has a boolean, number, string, array, and map property.
+// All inputs and outputs are optional to exercise optional value flow through resources and stack outputs.
+type OptionalPrimitiveProvider struct {
+	plugin.UnimplementedProvider
+}
+
+var _ plugin.Provider = (*OptionalPrimitiveProvider)(nil)
+
+func (p *OptionalPrimitiveProvider) Close() error {
+	return nil
+}
+
+func (p *OptionalPrimitiveProvider) Configure(
+	context.Context, plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
+}
+
+func (p *OptionalPrimitiveProvider) Pkg() tokens.Package {
+	return "optionalprimitive"
+}
+
+func (p *OptionalPrimitiveProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
+	makePrimitive := func(t string) schema.PropertySpec {
+		return schema.PropertySpec{
+			TypeSpec: schema.TypeSpec{
+				Type: t,
+			},
+		}
+	}
+	resourceProperties := map[string]schema.PropertySpec{
+		"boolean": makePrimitive("boolean"),
+		"float":   makePrimitive("number"),
+		"integer": makePrimitive("integer"),
+		"string":  makePrimitive("string"),
+		"numberArray": {
+			TypeSpec: schema.TypeSpec{
+				Type:  "array",
+				Items: &schema.TypeSpec{Type: "number"},
+			},
+		},
+		"booleanMap": {
+			TypeSpec: schema.TypeSpec{
+				Type:                 "object",
+				AdditionalProperties: &schema.TypeSpec{Type: "boolean"},
+			},
+		},
+	}
+
+	pkg := schema.PackageSpec{
+		Name:    "optionalprimitive",
+		Version: "34.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"optionalprimitive:index:Resource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type:       "object",
+					Properties: resourceProperties,
+				},
+				InputProperties: resourceProperties,
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(pkg)
+	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
+}
+
+func (p *OptionalPrimitiveProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
+	// Expect just the version
+	version, ok := req.News["version"]
+	if !ok {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("version", "missing version"),
+		}, nil
+	}
+	if !version.IsString() {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("version", "version is not a string"),
+		}, nil
+	}
+	if version.StringValue() != "34.0.0" {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("version", "version is not 34.0.0"),
+		}, nil
+	}
+
+	if len(req.News) != 1 {
+		return plugin.CheckConfigResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("too many properties: %v", req.News)),
+		}, nil
+	}
+
+	return plugin.CheckConfigResponse{Properties: req.News}, nil
+}
+
+func (p *OptionalPrimitiveProvider) Check(
+	_ context.Context, req plugin.CheckRequest,
+) (plugin.CheckResponse, error) {
+	// URN should be of the form "optionalprimitive:index:Resource"
+	if req.URN.Type() != "optionalprimitive:index:Resource" {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
+		}, nil
+	}
+
+	unsecret := func(v resource.PropertyValue) resource.PropertyValue {
+		if v.IsSecret() {
+			return v.SecretValue().Element
+		}
+		return v
+	}
+
+	isNullLike := func(v resource.PropertyValue) bool {
+		v = unsecret(v)
+		if v.IsNull() {
+			return true
+		}
+		if v.IsOutput() {
+			return v.OutputValue().Element.IsNull()
+		}
+		return false
+	}
+
+	validate := func(key resource.PropertyKey, value resource.PropertyValue,
+		assertType func(resource.PropertyValue) bool, typ string,
+	) *plugin.CheckResponse {
+		unwrapped := unsecret(value)
+		if unwrapped.IsComputed() || unwrapped.IsOutput() || isNullLike(unwrapped) {
+			return nil
+		}
+		if !assertType(unwrapped) {
+			return &plugin.CheckResponse{
+				Failures: makeCheckFailure(key, "value is not a "+typ),
+			}
+		}
+		return nil
+	}
+
+	result := resource.PropertyMap{}
+	for key, value := range req.News {
+		switch key {
+		case "boolean":
+			check := validate("boolean", value, resource.PropertyValue.IsBool, "boolean")
+			if check != nil {
+				return *check, nil
+			}
+		case "integer":
+			check := validate("integer", value, resource.PropertyValue.IsNumber, "number")
+			if check != nil {
+				return *check, nil
+			}
+		case "float":
+			check := validate("float", value, resource.PropertyValue.IsNumber, "number")
+			if check != nil {
+				return *check, nil
+			}
+		case "string":
+			check := validate("string", value, resource.PropertyValue.IsString, "string")
+			if check != nil {
+				return *check, nil
+			}
+		case "numberArray":
+			check := validate("numberArray", value, resource.PropertyValue.IsArray, "array")
+			if check != nil {
+				return *check, nil
+			}
+			unwrapped := unsecret(value)
+			if unwrapped.IsArray() {
+				for _, v := range unwrapped.ArrayValue() {
+					uv := unsecret(v)
+					if uv.IsComputed() || uv.IsOutput() || uv.IsNull() {
+						continue
+					}
+					if !uv.IsNumber() {
+						return plugin.CheckResponse{
+							Failures: makeCheckFailure("numberArray", "array element is not a number"),
+						}, nil
+					}
+				}
+			}
+		case "booleanMap":
+			check := validate("booleanMap", value, resource.PropertyValue.IsObject, "map")
+			if check != nil {
+				return *check, nil
+			}
+			unwrapped := unsecret(value)
+			if unwrapped.IsObject() {
+				for _, v := range unwrapped.ObjectValue() {
+					uv := unsecret(v)
+					if uv.IsComputed() || uv.IsOutput() || uv.IsNull() {
+						continue
+					}
+					if !uv.IsBool() {
+						return plugin.CheckResponse{
+							Failures: makeCheckFailure("booleanMap", "map value is not a boolean"),
+						}, nil
+					}
+				}
+			}
+		default:
+			return plugin.CheckResponse{
+				Failures: makeCheckFailure("", fmt.Sprintf("unexpected property: %s", key)),
+			}, nil
+		}
+
+		if !isNullLike(value) {
+			result[key] = value
+		}
+	}
+
+	return plugin.CheckResponse{Properties: result}, nil
+}
+
+func (p *OptionalPrimitiveProvider) Create(
+	_ context.Context, req plugin.CreateRequest,
+) (plugin.CreateResponse, error) {
+	// URN should be of the form "optionalprimitive:index:Resource"
+	if req.URN.Type() != "optionalprimitive:index:Resource" {
+		return plugin.CreateResponse{
+			Status: resource.StatusUnknown,
+		}, fmt.Errorf("invalid URN type: %s", req.URN.Type())
+	}
+
+	id := "id"
+	if req.Preview {
+		id = ""
+	}
+
+	isMissingLike := func(v resource.PropertyValue) bool {
+		if v.IsSecret() {
+			v = v.SecretValue().Element
+		}
+		if v.IsNull() {
+			return true
+		}
+		if v.IsOutput() {
+			return v.OutputValue().Element.IsNull()
+		}
+		return false
+	}
+
+	properties := resource.PropertyMap{}
+	for k, v := range req.Properties {
+		if isMissingLike(v) {
+			continue
+		}
+		properties[k] = v
+	}
+
+	return plugin.CreateResponse{
+		ID:         resource.ID(id),
+		Properties: properties,
+		Status:     resource.StatusOK,
+	}, nil
+}
+
+func (p *OptionalPrimitiveProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
+	ver := semver.MustParse("34.0.0")
+	return plugin.PluginInfo{
+		Version: &ver,
+	}, nil
+}
+
+func (p *OptionalPrimitiveProvider) SignalCancellation(context.Context) error {
+	return nil
+}
+
+func (p *OptionalPrimitiveProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
+}
+
+func (p *OptionalPrimitiveProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
+}

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_optional.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_optional.go
@@ -1,0 +1,96 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l2-resource-optional"] = LanguageTest{
+		Providers: []func() plugin.Provider{
+			func() plugin.Provider { return &providers.OptionalPrimitiveProvider{} },
+			func() plugin.Provider { return &providers.PrimitiveProvider{} },
+		},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L, res AssertArgs) {
+					err := res.Err
+					snap := res.Snap
+					changes := res.Changes
+
+					RequireStackResource(l, err, changes)
+					require.Len(l, snap.Resources, 9, "expected 9 resources in snapshot")
+
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:optionalprimitive")
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:primitive")
+
+					unsetA := RequireSingleNamedResource(l, snap.Resources, "unsetA")
+					unsetB := RequireSingleNamedResource(l, snap.Resources, "unsetB")
+					setA := RequireSingleNamedResource(l, snap.Resources, "setA")
+					setB := RequireSingleNamedResource(l, snap.Resources, "setB")
+					fromPrimitive := RequireSingleNamedResource(l, snap.Resources, "fromPrimitive")
+
+					require.Empty(l, unsetA.Inputs, "unsetA inputs should be empty")
+					require.Empty(l, unsetA.Outputs, "unsetA outputs should be empty")
+					require.Empty(l, unsetB.Inputs, "unsetB inputs should be empty")
+					require.Empty(l, unsetB.Outputs, "unsetB outputs should be empty")
+
+					want := resource.NewPropertyMapFromMap(map[string]any{
+						"boolean":     true,
+						"float":       3.14,
+						"integer":     42,
+						"string":      "hello",
+						"numberArray": []any{-1.0, 0.0, 1.0},
+						"booleanMap":  map[string]any{"t": true, "f": false},
+					})
+					require.Equal(l, want, setA.Inputs)
+					require.Equal(l, want, setA.Outputs)
+					require.Equal(l, want, setB.Inputs)
+					require.Equal(l, want, setB.Outputs)
+					require.Equal(l, want, fromPrimitive.Inputs)
+					require.Equal(l, want, fromPrimitive.Outputs)
+
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
+					outputs := stack.Outputs
+
+					AssertPropertyMapMember(l, outputs, "unsetBoolean", resource.NewProperty("null"))
+					AssertPropertyMapMember(l, outputs, "unsetFloat", resource.NewProperty("null"))
+					AssertPropertyMapMember(l, outputs, "unsetInteger", resource.NewProperty("null"))
+					AssertPropertyMapMember(l, outputs, "unsetString", resource.NewProperty("null"))
+					AssertPropertyMapMember(l, outputs, "unsetNumberArray", resource.NewProperty("null"))
+					AssertPropertyMapMember(l, outputs, "unsetBooleanMap", resource.NewProperty("null"))
+
+					AssertPropertyMapMember(l, outputs, "setBoolean", resource.NewProperty(true))
+					AssertPropertyMapMember(l, outputs, "setFloat", resource.NewProperty(3.14))
+					AssertPropertyMapMember(l, outputs, "setInteger", resource.NewProperty(42.0))
+					AssertPropertyMapMember(l, outputs, "setString", resource.NewProperty("hello"))
+					AssertPropertyMapMember(l, outputs, "setNumberArray", resource.NewProperty([]resource.PropertyValue{
+						resource.NewProperty(-1.0),
+						resource.NewProperty(0.0),
+						resource.NewProperty(1.0),
+					}))
+					AssertPropertyMapMember(l, outputs, "setBooleanMap", resource.NewProperty(resource.PropertyMap{
+						"t": resource.NewProperty(true),
+						"f": resource.NewProperty(false),
+					}))
+				},
+			},
+		},
+	}
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-optional/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-optional/main.pp
@@ -1,0 +1,100 @@
+resource "unsetA" "optionalprimitive:index:Resource" {}
+
+resource "unsetB" "optionalprimitive:index:Resource" {
+    boolean = unsetA.boolean
+    float = unsetA.float
+    integer = unsetA.integer
+    string = unsetA.string
+    numberArray = unsetA.numberArray
+    booleanMap = unsetA.booleanMap
+}
+
+output "unsetBoolean" {
+    value = unsetB.boolean == null ? "null" : "not null"
+}
+
+output "unsetFloat" {
+    value = unsetB.float == null ? "null" : "not null"
+}
+
+output "unsetInteger" {
+    value = unsetB.integer == null ? "null" : "not null"
+}
+
+output "unsetString" {
+    value = unsetB.string == null ? "null" : "not null"
+}
+
+output "unsetNumberArray" {
+    value = unsetB.numberArray == null ? "null" : "not null"
+}
+
+output "unsetBooleanMap" {
+    value = unsetB.booleanMap == null ? "null" : "not null"
+}
+
+resource "setA" "optionalprimitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "setB" "optionalprimitive:index:Resource" {
+    boolean = setA.boolean
+    float = setA.float
+    integer = setA.integer
+    string = setA.string
+    numberArray = setA.numberArray
+    booleanMap = setA.booleanMap
+}
+
+resource "sourcePrimitive" "primitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "fromPrimitive" "optionalprimitive:index:Resource" {
+    boolean = sourcePrimitive.boolean
+    float = sourcePrimitive.float
+    integer = sourcePrimitive.integer
+    string = sourcePrimitive.string
+    numberArray = sourcePrimitive.numberArray
+    booleanMap = sourcePrimitive.booleanMap
+}
+
+output "setBoolean" {
+    value = setB.boolean
+}
+
+output "setFloat" {
+    value = setB.float
+}
+
+output "setInteger" {
+    value = setB.integer
+}
+
+output "setString" {
+    value = setB.string
+}
+
+output "setNumberArray" {
+    value = setB.numberArray
+}
+
+output "setBooleanMap" {
+    value = setB.booleanMap
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -124,6 +124,8 @@ var expectedFailures = map[string]string{
 
 	"l3-component-config-primitives": "does not compile; missing necessary casts for pulumi inputs",
 	"l3-component-config-objects":    "does not compile; missing necessary casts for pulumi inputs",
+
+	"l2-resource-optional": "Ternary operator isn't resolving names correctly",
 }
 
 // Add program overrides here for programs that can't yet be generated correctly due to programgen bugs.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -98,7 +98,8 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
-	"l3-deferred-outputs": "Cannot find name '_arg0_'.",
+	"l2-resource-optional": "optional outputs are not assignable to optional inputs",
+	"l3-deferred-outputs":  "Cannot find name '_arg0_'.",
 }
 
 // testLanguage runs the language conformance tests for the given runtime ("nodejs" or "bun").

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/main.pp
@@ -1,0 +1,100 @@
+resource "unsetA" "optionalprimitive:index:Resource" {}
+
+resource "unsetB" "optionalprimitive:index:Resource" {
+    boolean = unsetA.boolean
+    float = unsetA.float
+    integer = unsetA.integer
+    string = unsetA.string
+    numberArray = unsetA.numberArray
+    booleanMap = unsetA.booleanMap
+}
+
+output "unsetBoolean" {
+    value = unsetB.boolean == null ? "null" : "not null"
+}
+
+output "unsetFloat" {
+    value = unsetB.float == null ? "null" : "not null"
+}
+
+output "unsetInteger" {
+    value = unsetB.integer == null ? "null" : "not null"
+}
+
+output "unsetString" {
+    value = unsetB.string == null ? "null" : "not null"
+}
+
+output "unsetNumberArray" {
+    value = unsetB.numberArray == null ? "null" : "not null"
+}
+
+output "unsetBooleanMap" {
+    value = unsetB.booleanMap == null ? "null" : "not null"
+}
+
+resource "setA" "optionalprimitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "setB" "optionalprimitive:index:Resource" {
+    boolean = setA.boolean
+    float = setA.float
+    integer = setA.integer
+    string = setA.string
+    numberArray = setA.numberArray
+    booleanMap = setA.booleanMap
+}
+
+resource "sourcePrimitive" "primitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "fromPrimitive" "optionalprimitive:index:Resource" {
+    boolean = sourcePrimitive.boolean
+    float = sourcePrimitive.float
+    integer = sourcePrimitive.integer
+    string = sourcePrimitive.string
+    numberArray = sourcePrimitive.numberArray
+    booleanMap = sourcePrimitive.booleanMap
+}
+
+output "setBoolean" {
+    value = setB.boolean
+}
+
+output "setFloat" {
+    value = setB.float
+}
+
+output "setInteger" {
+    value = setB.integer
+}
+
+output "setString" {
+    value = setB.string
+}
+
+output "setNumberArray" {
+    value = setB.numberArray
+}
+
+output "setBooleanMap" {
+    value = setB.booleanMap
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/optionalprimitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/optionalprimitive.pp
@@ -1,0 +1,4 @@
+package "optionalprimitive" {
+  baseProviderName    = "optionalprimitive"
+  baseProviderVersion = "34.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/primitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-optional/primitive.pp
@@ -1,0 +1,4 @@
+package "primitive" {
+  baseProviderName    = "primitive"
+  baseProviderVersion = "7.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/main.pp
@@ -1,0 +1,100 @@
+resource "unsetA" "optionalprimitive:index:Resource" {}
+
+resource "unsetB" "optionalprimitive:index:Resource" {
+    boolean = unsetA.boolean
+    float = unsetA.float
+    integer = unsetA.integer
+    string = unsetA.string
+    numberArray = unsetA.numberArray
+    booleanMap = unsetA.booleanMap
+}
+
+output "unsetBoolean" {
+    value = unsetB.boolean == null ? "null" : "not null"
+}
+
+output "unsetFloat" {
+    value = unsetB.float == null ? "null" : "not null"
+}
+
+output "unsetInteger" {
+    value = unsetB.integer == null ? "null" : "not null"
+}
+
+output "unsetString" {
+    value = unsetB.string == null ? "null" : "not null"
+}
+
+output "unsetNumberArray" {
+    value = unsetB.numberArray == null ? "null" : "not null"
+}
+
+output "unsetBooleanMap" {
+    value = unsetB.booleanMap == null ? "null" : "not null"
+}
+
+resource "setA" "optionalprimitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "setB" "optionalprimitive:index:Resource" {
+    boolean = setA.boolean
+    float = setA.float
+    integer = setA.integer
+    string = setA.string
+    numberArray = setA.numberArray
+    booleanMap = setA.booleanMap
+}
+
+resource "sourcePrimitive" "primitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "fromPrimitive" "optionalprimitive:index:Resource" {
+    boolean = sourcePrimitive.boolean
+    float = sourcePrimitive.float
+    integer = sourcePrimitive.integer
+    string = sourcePrimitive.string
+    numberArray = sourcePrimitive.numberArray
+    booleanMap = sourcePrimitive.booleanMap
+}
+
+output "setBoolean" {
+    value = setB.boolean
+}
+
+output "setFloat" {
+    value = setB.float
+}
+
+output "setInteger" {
+    value = setB.integer
+}
+
+output "setString" {
+    value = setB.string
+}
+
+output "setNumberArray" {
+    value = setB.numberArray
+}
+
+output "setBooleanMap" {
+    value = setB.booleanMap
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/optionalprimitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/optionalprimitive.pp
@@ -1,0 +1,4 @@
+package "optionalprimitive" {
+  baseProviderName    = "optionalprimitive"
+  baseProviderVersion = "34.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/primitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-optional/primitive.pp
@@ -1,0 +1,4 @@
+package "primitive" {
+  baseProviderName    = "primitive"
+  baseProviderVersion = "7.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-optional
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/main.pp
@@ -1,0 +1,100 @@
+resource "unsetA" "optionalprimitive:index:Resource" {}
+
+resource "unsetB" "optionalprimitive:index:Resource" {
+    boolean = unsetA.boolean
+    float = unsetA.float
+    integer = unsetA.integer
+    string = unsetA.string
+    numberArray = unsetA.numberArray
+    booleanMap = unsetA.booleanMap
+}
+
+output "unsetBoolean" {
+    value = unsetB.boolean == null ? "null" : "not null"
+}
+
+output "unsetFloat" {
+    value = unsetB.float == null ? "null" : "not null"
+}
+
+output "unsetInteger" {
+    value = unsetB.integer == null ? "null" : "not null"
+}
+
+output "unsetString" {
+    value = unsetB.string == null ? "null" : "not null"
+}
+
+output "unsetNumberArray" {
+    value = unsetB.numberArray == null ? "null" : "not null"
+}
+
+output "unsetBooleanMap" {
+    value = unsetB.booleanMap == null ? "null" : "not null"
+}
+
+resource "setA" "optionalprimitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "setB" "optionalprimitive:index:Resource" {
+    boolean = setA.boolean
+    float = setA.float
+    integer = setA.integer
+    string = setA.string
+    numberArray = setA.numberArray
+    booleanMap = setA.booleanMap
+}
+
+resource "sourcePrimitive" "primitive:index:Resource" {
+    boolean = true
+    float = 3.14
+    integer = 42
+    string = "hello"
+    numberArray = [-1.0, 0.0, 1.0]
+    booleanMap = {
+        "t": true,
+        "f": false,
+    }
+}
+
+resource "fromPrimitive" "optionalprimitive:index:Resource" {
+    boolean = sourcePrimitive.boolean
+    float = sourcePrimitive.float
+    integer = sourcePrimitive.integer
+    string = sourcePrimitive.string
+    numberArray = sourcePrimitive.numberArray
+    booleanMap = sourcePrimitive.booleanMap
+}
+
+output "setBoolean" {
+    value = setB.boolean
+}
+
+output "setFloat" {
+    value = setB.float
+}
+
+output "setInteger" {
+    value = setB.integer
+}
+
+output "setString" {
+    value = setB.string
+}
+
+output "setNumberArray" {
+    value = setB.numberArray
+}
+
+output "setBooleanMap" {
+    value = setB.booleanMap
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/optionalprimitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/optionalprimitive.pp
@@ -1,0 +1,4 @@
+package "optionalprimitive" {
+  baseProviderName    = "optionalprimitive"
+  baseProviderVersion = "34.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/primitive.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-optional/primitive.pp
@@ -1,0 +1,4 @@
+package "primitive" {
+  baseProviderName    = "primitive"
+  baseProviderVersion = "7.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/optionalprimitive-34.0.0/optionalprimitive-34.0.0.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/optionalprimitive-34.0.0/optionalprimitive-34.0.0.pp
@@ -1,0 +1,4 @@
+package "optionalprimitive" {
+  baseProviderName    = "optionalprimitive"
+  baseProviderVersion = "34.0.0"
+}

--- a/sdk/pcl/runtime/interpreter.go
+++ b/sdk/pcl/runtime/interpreter.go
@@ -1471,13 +1471,18 @@ func (i *Interpreter) registerResourceWith(
 	outputs["__name"] = resource.NewProperty(request.Name)
 	outputs["__type"] = resource.NewProperty(request.Type)
 
-	// We need to ensure _all_ resource outputs exist in the output object so any the provider didn't send back we
-	// default to unknown here.
+	// We need to ensure all schema outputs exist in the output object, even if they weren't returned by the engine.
+	// - preview: unknown/computed
+	// - update: explicit null
 	if schemaResource != nil {
 		for _, prop := range schemaResource.Properties {
 			key := resource.PropertyKey(prop.Name)
 			if _, ok := outputs[key]; !ok {
-				outputs[key] = resource.NewProperty(resource.Computed{Element: resource.NewProperty("")})
+				if i.info.DryRun {
+					outputs[key] = resource.NewProperty(resource.Computed{Element: resource.NewProperty("")})
+				} else {
+					outputs[key] = resource.NewNullProperty()
+				}
 			}
 		}
 	}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -106,6 +106,7 @@ var expectedFailures = map[string]string{
 	"l3-deferred-outputs":            "does not type-check",
 	"l2-resource-config-primitives":  "Argument integer to Resource has incompatible type Output[float]",
 	"l3-component-config-primitives": "Argument integer to Resource has incompatible type Output[float]",
+	"l2-resource-optional":           "optional outputs are not assignable to optional inputs",
 }
 
 type languageTestConfig struct {


### PR DESCRIPTION
Add a conformance test for optional inputs and outputs. Checking that we can set _or_ not set them, and that optional outputs can be used for optional inputs, and that non-optional outputs can be used as optional inputs. We don't need to check that optional outputs can be used as non-optional inputs because they can't, that's a bind error.

This currently fails everywhere except PCL. 

Go due to some bad scope lookups when generating ternary conditions. Python and Node because they use the wrong types for optional inputs (https://github.com/pulumi/pulumi/issues/6175)