### PR TITLE
Add ESC environment resolution for policy packs

### DIFF
--- a/changelog/pending/20260401--cli-policy--add-client-side-esc-environment-resolution-for-policy-packs.yaml
+++ b/changelog/pending/20260401--cli-policy--add-client-side-esc-environment-resolution-for-policy-packs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Resolve ESC environments for policy packs, merging policyConfig and injecting environment variables into the analyzer process

--- a/changelog/pending/20260401--cli-policy--add-client-side-esc-environment-resolution-for-policy-packs.yaml
+++ b/changelog/pending/20260401--cli-policy--add-client-side-esc-environment-resolution-for-policy-packs.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/policy
-  description: Resolve ESC environments for policy packs, merging policyConfig and injecting environment variables into the analyzer process
+  description: Add ESC environment resolution for policy packs

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -777,7 +777,7 @@ func (b *cloudBackend) GetStackPolicyPacks(
 	}
 
 	return slices.Collect(fxs.Map(resp.RequiredPolicies, func(policy apitype.RequiredPolicy) engine.RequiredPolicy {
-		return newCloudRequiredPolicy(b.client, b.escClient, policy, stackID.Owner)
+		return newCloudRequiredPolicy(b.client, b, policy, stackID.Owner)
 	})), nil
 }
 
@@ -1572,7 +1572,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	//
 	for _, policy := range updateDetails.RequiredPolicies {
 		op.Opts.Engine.RequiredPolicies = append(
-			op.Opts.Engine.RequiredPolicies, newCloudRequiredPolicy(b.client, b.escClient, policy, update.Owner))
+			op.Opts.Engine.RequiredPolicies, newCloudRequiredPolicy(b.client, b, policy, update.Owner))
 	}
 
 	// Start the update. We use this opportunity to pass new tags to the service, to pick up any

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -777,7 +777,7 @@ func (b *cloudBackend) GetStackPolicyPacks(
 	}
 
 	return slices.Collect(fxs.Map(resp.RequiredPolicies, func(policy apitype.RequiredPolicy) engine.RequiredPolicy {
-		return newCloudRequiredPolicy(b.client, policy, stackID.Owner)
+		return newCloudRequiredPolicy(b.client, b.escClient, policy, stackID.Owner)
 	})), nil
 }
 
@@ -1572,7 +1572,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	//
 	for _, policy := range updateDetails.RequiredPolicies {
 		op.Opts.Engine.RequiredPolicies = append(
-			op.Opts.Engine.RequiredPolicies, newCloudRequiredPolicy(b.client, policy, update.Owner))
+			op.Opts.Engine.RequiredPolicies, newCloudRequiredPolicy(b.client, b.escClient, policy, update.Owner))
 	}
 
 	// Start the update. We use this opportunity to pass new tags to the service, to pick up any

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/pulumi/esc"
-	escclient "github.com/pulumi/esc/cmd/esc/cli/client"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -46,19 +45,19 @@ import (
 
 type cloudRequiredPolicy struct {
 	apitype.RequiredPolicy
-	client    *client.Client
-	escClient escclient.Client
-	orgName   string
+	client  *client.Client
+	envs    backend.EnvironmentsBackend
+	orgName string
 }
 
 var _ engine.RequiredPolicy = (*cloudRequiredPolicy)(nil)
 
-func newCloudRequiredPolicy(client *client.Client, escClient escclient.Client,
+func newCloudRequiredPolicy(client *client.Client, envs backend.EnvironmentsBackend,
 	policy apitype.RequiredPolicy, orgName string,
 ) *cloudRequiredPolicy {
 	return &cloudRequiredPolicy{
 		client:         client,
-		escClient:      escClient,
+		envs:           envs,
 		RequiredPolicy: policy,
 		orgName:        orgName,
 	}
@@ -134,7 +133,7 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 	// This reuses the ESC composition model to handle ordering and merging.
 	yaml := buildImportsYAML(rp.Environments)
 
-	id, diags, err := rp.escClient.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
+	env, diags, err := rp.envs.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("opening ESC environments for policy pack %q: %w", rp.RequiredPolicy.Name, err)
 	}
@@ -145,11 +144,6 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 		}
 		return nil, fmt.Errorf(
 			"opening ESC environments for policy pack %q:\n%s", rp.RequiredPolicy.Name, diagMsgs.String())
-	}
-
-	env, err := rp.escClient.GetAnonymousOpenEnvironment(ctx, rp.orgName, id)
-	if err != nil {
-		return nil, fmt.Errorf("getting resolved ESC environment for policy pack %q: %w", rp.RequiredPolicy.Name, err)
 	}
 
 	result := &engine.ResolvedPolicyEnvironment{}
@@ -163,13 +157,18 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 		result.Config = policyConfig
 	}
 
-	// Extract environmentVariables from the resolved environment.
-	if envVarsVal, ok := env.Properties["environmentVariables"]; ok {
-		envVars := escValueToStringMap(envVarsVal)
-		if len(envVars) > 0 {
-			result.EnvironmentVariables = envVars
-		}
+	// Extract environment variables and secrets using the environment's typed
+	// accessors (GetEnvironmentVariables, GetTemporaryFiles). This mirrors the
+	// stack resolution path's use of cli.PrepareEnvironment.
+	envVars, secrets, tempFiles, err := prepareEnvironment(env)
+	if err != nil {
+		return nil, fmt.Errorf("preparing ESC environment for policy pack %q: %w", rp.RequiredPolicy.Name, err)
 	}
+	if len(envVars) > 0 {
+		result.EnvironmentVariables = envVars
+	}
+	result.Secrets = secrets
+	result.TempFiles = tempFiles
 
 	return result, nil
 }
@@ -182,6 +181,58 @@ func buildImportsYAML(envRefs []string) []byte {
 		fmt.Fprintf(&buf, "  - %s\n", ref)
 	}
 	return buf.Bytes()
+}
+
+// prepareEnvironment extracts environment variables, secrets, and temporary file
+// projections from a resolved ESC environment. This mirrors cli.PrepareEnvironment
+// from the esc package but avoids the import cycle (cli → httpstate).
+func prepareEnvironment(env *esc.Environment) (envVars map[string]string, secrets, tempFiles []string, err error) {
+	// Extract environment variables.
+	vars := env.GetEnvironmentVariables()
+	files := env.GetTemporaryFiles()
+
+	if len(vars) > 0 || len(files) > 0 {
+		envVars = make(map[string]string, len(vars)+len(files))
+	}
+
+	for k, v := range vars {
+		s := v.Value.(string)
+		envVars[k] = s
+		if v.Secret {
+			secrets = append(secrets, s)
+		}
+	}
+
+	// Create temporary files and map their paths as environment variables.
+	for k, v := range files {
+		s := v.Value.(string)
+		if v.Secret {
+			secrets = append(secrets, s)
+		}
+
+		f, fErr := os.CreateTemp("", "esc-*")
+		if fErr != nil {
+			// Clean up any temp files already created.
+			for _, p := range tempFiles {
+				contract.IgnoreError(os.Remove(p))
+			}
+			return nil, nil, nil, fmt.Errorf("creating temporary file for %q: %w", k, fErr)
+		}
+		if _, fErr = f.Write([]byte(s)); fErr != nil {
+			contract.IgnoreClose(f)
+			contract.IgnoreError(os.Remove(f.Name()))
+			for _, p := range tempFiles {
+				contract.IgnoreError(os.Remove(p))
+			}
+			return nil, nil, nil, fmt.Errorf("writing temporary file for %q: %w", k, fErr)
+		}
+		contract.IgnoreClose(f)
+
+		tempFiles = append(tempFiles, f.Name())
+		envVars[k] = f.Name()
+	}
+
+	return envVars, secrets, tempFiles, nil
 }
 
 // escValueToConfigMap converts an esc.Value representing policyConfig into the
@@ -203,21 +254,6 @@ func escValueToConfigMap(val esc.Value) (map[string]*json.RawMessage, error) {
 		result[k] = &raw
 	}
 	return result, nil
-}
-
-// escValueToStringMap converts an esc.Value expected to be a map of string keys to string values.
-func escValueToStringMap(val esc.Value) map[string]string {
-	m, ok := val.Value.(map[string]esc.Value)
-	if !ok {
-		return nil
-	}
-	result := make(map[string]string, len(m))
-	for k, v := range m {
-		if s, ok := v.Value.(string); ok {
-			result[k] = s
-		}
-	}
-	return result
 }
 
 // escValueToInterface recursively converts an esc.Value to a plain Go any for JSON serialization.

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-
 	"time"
 
 	"github.com/pulumi/esc"
@@ -127,13 +126,13 @@ func (rp *cloudRequiredPolicy) Config() map[string]*json.RawMessage { return rp.
 // ResolveEnvironments opens any referenced ESC environments and returns resolved
 // config (from policyConfig) and environment variables. Returns nil if no environments are referenced.
 func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine.ResolvedPolicyEnvironment, error) {
-	if len(rp.RequiredPolicy.Environments) == 0 {
+	if len(rp.Environments) == 0 {
 		return nil, nil
 	}
 
 	// Build a synthetic YAML environment that imports all referenced environments.
 	// This reuses the ESC composition model to handle ordering and merging.
-	yaml := buildImportsYAML(rp.RequiredPolicy.Environments)
+	yaml := buildImportsYAML(rp.Environments)
 
 	id, diags, err := rp.escClient.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
 	if err != nil {
@@ -221,17 +220,17 @@ func escValueToStringMap(val esc.Value) map[string]string {
 	return result
 }
 
-// escValueToInterface recursively converts an esc.Value to a plain Go interface{} for JSON serialization.
-func escValueToInterface(val esc.Value) interface{} {
+// escValueToInterface recursively converts an esc.Value to a plain Go any for JSON serialization.
+func escValueToInterface(val esc.Value) any {
 	switch v := val.Value.(type) {
 	case map[string]esc.Value:
-		m := make(map[string]interface{}, len(v))
+		m := make(map[string]any, len(v))
 		for k, child := range v {
 			m[k] = escValueToInterface(child)
 		}
 		return m
 	case []esc.Value:
-		s := make([]interface{}, len(v))
+		s := make([]any, len(v))
 		for i, child := range v {
 			s[i] = escValueToInterface(child)
 		}

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -160,7 +162,7 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 	// Extract environment variables and secrets using the environment's typed
 	// accessors (GetEnvironmentVariables, GetTemporaryFiles). This mirrors the
 	// stack resolution path's use of cli.PrepareEnvironment.
-	envVars, secrets, tempFiles, err := prepareEnvironment(env)
+	envVars, secrets, _, err := prepareEnvironment(env)
 	if err != nil {
 		return nil, fmt.Errorf("preparing ESC environment for policy pack %q: %w", rp.RequiredPolicy.Name, err)
 	}
@@ -168,7 +170,6 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 		result.EnvironmentVariables = envVars
 	}
 	result.Secrets = secrets
-	result.TempFiles = tempFiles
 
 	return result, nil
 }
@@ -187,7 +188,6 @@ func buildImportsYAML(envRefs []string) []byte {
 // projections from a resolved ESC environment. This mirrors cli.PrepareEnvironment
 // from the esc package but avoids the import cycle (cli → httpstate).
 func prepareEnvironment(env *esc.Environment) (envVars map[string]string, secrets, tempFiles []string, err error) {
-	// Extract environment variables.
 	vars := env.GetEnvironmentVariables()
 	files := env.GetTemporaryFiles()
 
@@ -195,8 +195,13 @@ func prepareEnvironment(env *esc.Environment) (envVars map[string]string, secret
 		envVars = make(map[string]string, len(vars)+len(files))
 	}
 
-	for k, v := range vars {
-		s := v.Value.(string)
+	// Sort keys for deterministic output, matching cli.PrepareEnvironment.
+	for _, k := range slices.Sorted(maps.Keys(vars)) {
+		v := vars[k]
+		s, ok := v.Value.(string)
+		if !ok {
+			continue
+		}
 		envVars[k] = s
 		if v.Secret {
 			secrets = append(secrets, s)
@@ -204,26 +209,23 @@ func prepareEnvironment(env *esc.Environment) (envVars map[string]string, secret
 	}
 
 	// Create temporary files and map their paths as environment variables.
-	for k, v := range files {
-		s := v.Value.(string)
+	// Temp files persist for the process lifetime (matching the stack path).
+	for _, k := range slices.Sorted(maps.Keys(files)) {
+		v := files[k]
+		s, ok := v.Value.(string)
+		if !ok {
+			continue
+		}
 		if v.Secret {
 			secrets = append(secrets, s)
 		}
 
 		f, fErr := os.CreateTemp("", "esc-*")
 		if fErr != nil {
-			// Clean up any temp files already created.
-			for _, p := range tempFiles {
-				contract.IgnoreError(os.Remove(p))
-			}
 			return nil, nil, nil, fmt.Errorf("creating temporary file for %q: %w", k, fErr)
 		}
 		if _, fErr = f.Write([]byte(s)); fErr != nil {
 			contract.IgnoreClose(f)
-			contract.IgnoreError(os.Remove(f.Name()))
-			for _, p := range tempFiles {
-				contract.IgnoreError(os.Remove(p))
-			}
 			return nil, nil, nil, fmt.Errorf("writing temporary file for %q: %w", k, fErr)
 		}
 		contract.IgnoreClose(f)

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -25,6 +25,11 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
+	"github.com/pulumi/esc"
+	escclient "github.com/pulumi/esc/cmd/esc/cli/client"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -42,17 +47,19 @@ import (
 
 type cloudRequiredPolicy struct {
 	apitype.RequiredPolicy
-	client  *client.Client
-	orgName string
+	client    *client.Client
+	escClient escclient.Client
+	orgName   string
 }
 
 var _ engine.RequiredPolicy = (*cloudRequiredPolicy)(nil)
 
-func newCloudRequiredPolicy(client *client.Client,
+func newCloudRequiredPolicy(client *client.Client, escClient escclient.Client,
 	policy apitype.RequiredPolicy, orgName string,
 ) *cloudRequiredPolicy {
 	return &cloudRequiredPolicy{
 		client:         client,
+		escClient:      escClient,
 		RequiredPolicy: policy,
 		orgName:        orgName,
 	}
@@ -116,6 +123,123 @@ func (rp *cloudRequiredPolicy) Install(ctx *plugin.Context, content io.ReadClose
 }
 
 func (rp *cloudRequiredPolicy) Config() map[string]*json.RawMessage { return rp.RequiredPolicy.Config }
+
+// ResolveEnvironments opens any referenced ESC environments and returns resolved
+// config (from policyConfig) and environment variables. Returns nil if no environments are referenced.
+func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine.ResolvedPolicyEnvironment, error) {
+	if len(rp.RequiredPolicy.Environments) == 0 {
+		return nil, nil
+	}
+
+	// Build a synthetic YAML environment that imports all referenced environments.
+	// This reuses the ESC composition model to handle ordering and merging.
+	yaml := buildImportsYAML(rp.RequiredPolicy.Environments)
+
+	id, diags, err := rp.escClient.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
+	if err != nil {
+		return nil, fmt.Errorf("opening ESC environments for policy pack %q: %w", rp.RequiredPolicy.Name, err)
+	}
+	if len(diags) != 0 {
+		var diagMsgs strings.Builder
+		for _, d := range diags {
+			fmt.Fprintf(&diagMsgs, "  %s\n", d.Summary)
+		}
+		return nil, fmt.Errorf(
+			"opening ESC environments for policy pack %q:\n%s", rp.RequiredPolicy.Name, diagMsgs.String())
+	}
+
+	env, err := rp.escClient.GetAnonymousOpenEnvironment(ctx, rp.orgName, id)
+	if err != nil {
+		return nil, fmt.Errorf("getting resolved ESC environment for policy pack %q: %w", rp.RequiredPolicy.Name, err)
+	}
+
+	result := &engine.ResolvedPolicyEnvironment{}
+
+	// Extract policyConfig from the resolved environment.
+	if policyConfigVal, ok := env.Properties["policyConfig"]; ok {
+		policyConfig, err := escValueToConfigMap(policyConfigVal)
+		if err != nil {
+			return nil, fmt.Errorf("extracting policyConfig from ESC environment for %q: %w", rp.RequiredPolicy.Name, err)
+		}
+		result.Config = policyConfig
+	}
+
+	// Extract environmentVariables from the resolved environment.
+	if envVarsVal, ok := env.Properties["environmentVariables"]; ok {
+		envVars := escValueToStringMap(envVarsVal)
+		if len(envVars) > 0 {
+			result.EnvironmentVariables = envVars
+		}
+	}
+
+	return result, nil
+}
+
+// buildImportsYAML constructs a synthetic ESC YAML document that imports the given environment refs.
+func buildImportsYAML(envRefs []string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("imports:\n")
+	for _, ref := range envRefs {
+		fmt.Fprintf(&buf, "  - %s\n", ref)
+	}
+	return buf.Bytes()
+}
+
+// escValueToConfigMap converts an esc.Value representing policyConfig into the
+// map[string]*json.RawMessage format expected by policy pack configuration.
+// The policyConfig is expected to be a map of policy names to config objects.
+func escValueToConfigMap(val esc.Value) (map[string]*json.RawMessage, error) {
+	m, ok := val.Value.(map[string]esc.Value)
+	if !ok {
+		return nil, fmt.Errorf("expected policyConfig to be a map, got %T", val.Value)
+	}
+
+	result := make(map[string]*json.RawMessage, len(m))
+	for k, v := range m {
+		jsonBytes, err := json.Marshal(escValueToInterface(v))
+		if err != nil {
+			return nil, fmt.Errorf("marshaling config for policy %q: %w", k, err)
+		}
+		raw := json.RawMessage(jsonBytes)
+		result[k] = &raw
+	}
+	return result, nil
+}
+
+// escValueToStringMap converts an esc.Value expected to be a map of string keys to string values.
+func escValueToStringMap(val esc.Value) map[string]string {
+	m, ok := val.Value.(map[string]esc.Value)
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.Value.(string); ok {
+			result[k] = s
+		}
+	}
+	return result
+}
+
+// escValueToInterface recursively converts an esc.Value to a plain Go interface{} for JSON serialization.
+func escValueToInterface(val esc.Value) interface{} {
+	switch v := val.Value.(type) {
+	case map[string]esc.Value:
+		m := make(map[string]interface{}, len(v))
+		for k, child := range v {
+			m[k] = escValueToInterface(child)
+		}
+		return m
+	case []esc.Value:
+		s := make([]interface{}, len(v))
+		for i, child := range v {
+			s[i] = escValueToInterface(child)
+		}
+		return s
+	default:
+		return v
+	}
+}
 
 func newCloudBackendPolicyPackReference(
 	cloudConsoleURL, orgName string, name tokens.QName,

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -131,9 +131,9 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 		return nil, nil
 	}
 
-	// Build a synthetic YAML environment that imports all referenced environments.
-	// This reuses the ESC composition model to handle ordering and merging.
-	yaml := buildImportsYAML(rp.Environments)
+	// Build a synthetic environment that imports all referenced environments.
+	// This reuses the same path as stack ESC resolution.
+	yaml := workspace.NewEnvironment(rp.Environments).Definition()
 
 	env, diags, err := rp.envs.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
 	if err != nil {
@@ -172,16 +172,6 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 	result.Secrets = secrets
 
 	return result, nil
-}
-
-// buildImportsYAML constructs a synthetic ESC YAML document that imports the given environment refs.
-func buildImportsYAML(envRefs []string) []byte {
-	var buf bytes.Buffer
-	buf.WriteString("imports:\n")
-	for _, ref := range envRefs {
-		fmt.Fprintf(&buf, "  - %s\n", ref)
-	}
-	return buf.Bytes()
 }
 
 // prepareEnvironment extracts environment variables, secrets, and temporary file

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -46,6 +46,22 @@ func TestBuildImportsYAML(t *testing.T) {
 			envRefs:  []string{"shared/base", "prod/secrets", "prod/config"},
 			expected: "imports:\n  - shared/base\n  - prod/secrets\n  - prod/config\n",
 		},
+		{
+			name:     "environment with version tag",
+			envRefs:  []string{"prod/secrets@v1.2.3"},
+			expected: "imports:\n  - prod/secrets@v1.2.3\n",
+		},
+		{
+			name:     "environment with named tag",
+			envRefs:  []string{"prod/secrets@stable"},
+			expected: "imports:\n  - prod/secrets@stable\n",
+		},
+		{
+			name:    "mixed tagged and untagged environments",
+			envRefs: []string{"shared/base", "prod/secrets@v2", "prod/config@my-tag"},
+			expected: "imports:\n  - shared/base\n" +
+				"  - prod/secrets@v2\n  - prod/config@my-tag\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -444,6 +460,48 @@ func TestResolveEnvironments(t *testing.T) {
 		require.NotNil(t, result)
 		assert.Nil(t, result.Config)
 		assert.Equal(t, map[string]string{"KEY": "val"}, result.EnvironmentVariables)
+	})
+
+	t.Run("resolves version-pinned environment references", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(
+				_ context.Context, org string, yaml []byte, _ time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
+				assert.Equal(t, "test-org", org)
+				yamlStr := string(yaml)
+				assert.Contains(t, yamlStr, "prod/policy-config@v2.1.0")
+				assert.Contains(t, yamlStr, "shared/base@stable")
+				return "open-id-456", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(_ context.Context, org, id string) (*esc.Environment, error) {
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "open-id-456", id)
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"policyConfig": {Value: map[string]esc.Value{
+							"cost-policy": {Value: map[string]esc.Value{
+								"maxMonthlyCost": {Value: json.Number("500")},
+							}},
+						}},
+					},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "test-org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "test-pack",
+				Environments: []string{"prod/policy-config@v2.1.0", "shared/base@stable"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Contains(t, result.Config, "cost-policy")
 	})
 
 	t.Run("namespaced policyConfig keys pass through", func(t *testing.T) {

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -465,7 +465,7 @@ func TestResolveEnvironments(t *testing.T) {
 					Properties: map[string]esc.Value{
 						"files": {Value: map[string]esc.Value{
 							"KUBECONFIG": {Value: "apiVersion: v1\nkind: Config\n"},
-							"TLS_CERT":  {Value: "-----BEGIN CERTIFICATE-----\nMIIB...", Secret: true},
+							"TLS_CERT":   {Value: "-----BEGIN CERTIFICATE-----\nMIIB...", Secret: true},
 						}},
 					},
 				}, nil, nil

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -445,4 +445,45 @@ func TestResolveEnvironments(t *testing.T) {
 		assert.Nil(t, result.Config)
 		assert.Equal(t, map[string]string{"KEY": "val"}, result.EnvironmentVariables)
 	})
+
+	t.Run("namespaced policyConfig keys pass through", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "id", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"policyConfig": {Value: map[string]esc.Value{
+							"my-pack:cost-policy": {Value: map[string]esc.Value{
+								"maxCost": {Value: json.Number("500")},
+							}},
+							"naming-policy": {Value: map[string]esc.Value{
+								"enforcement": {Value: "mandatory"},
+							}},
+						}},
+					},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "my-pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// Raw keys pass through as-is; namespace parsing happens during merge in update.go.
+		assert.Contains(t, result.Config, "my-pack:cost-policy")
+		assert.Contains(t, result.Config, "naming-policy")
+	})
 }

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/pulumi/esc"
-	escclient "github.com/pulumi/esc/cmd/esc/cli/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,52 +136,6 @@ func TestEscValueToInterface(t *testing.T) {
 	}
 }
 
-func TestEscValueToStringMap(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    esc.Value
-		expected map[string]string
-	}{
-		{
-			name:     "non-map returns nil",
-			input:    esc.Value{Value: "not a map"},
-			expected: nil,
-		},
-		{
-			name: "string values extracted",
-			input: esc.Value{Value: map[string]esc.Value{
-				"FOO": {Value: "bar"},
-				"BAZ": {Value: "qux"},
-			}},
-			expected: map[string]string{"FOO": "bar", "BAZ": "qux"},
-		},
-		{
-			name: "non-string values filtered out",
-			input: esc.Value{Value: map[string]esc.Value{
-				"STR":  {Value: "hello"},
-				"BOOL": {Value: true},
-				"NUM":  {Value: json.Number("42")},
-			}},
-			expected: map[string]string{"STR": "hello"},
-		},
-		{
-			name:     "empty map",
-			input:    esc.Value{Value: map[string]esc.Value{}},
-			expected: map[string]string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := escValueToStringMap(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestEscValueToConfigMap(t *testing.T) {
 	t.Parallel()
 
@@ -223,27 +176,29 @@ func TestEscValueToConfigMap(t *testing.T) {
 	})
 }
 
-// mockESCClient implements the subset of escclient.Client used by ResolveEnvironments.
-// We embed the interface to satisfy the full contract and only override the methods we need.
-type mockESCClient struct {
-	escclient.Client
-
+// mockEnvironmentsBackend implements backend.EnvironmentsBackend for testing.
+type mockEnvironmentsBackend struct {
 	openYAMLEnvironmentF func(
 		ctx context.Context, org string, yaml []byte, duration time.Duration,
-	) (string, []escclient.EnvironmentDiagnostic, error)
-	getAnonymousOpenEnvironmentF func(ctx context.Context, org, id string) (*esc.Environment, error)
+	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
 }
 
-func (m *mockESCClient) OpenYAMLEnvironment(
+func (m *mockEnvironmentsBackend) CreateEnvironment(
+	context.Context, string, string, string, []byte,
+) (apitype.EnvironmentDiagnostics, error) {
+	return nil, nil
+}
+
+func (m *mockEnvironmentsBackend) CheckYAMLEnvironment(
+	context.Context, string, []byte,
+) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+	return nil, nil, nil
+}
+
+func (m *mockEnvironmentsBackend) OpenYAMLEnvironment(
 	ctx context.Context, org string, yaml []byte, duration time.Duration,
-) (string, []escclient.EnvironmentDiagnostic, error) {
+) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 	return m.openYAMLEnvironmentF(ctx, org, yaml, duration)
-}
-
-func (m *mockESCClient) GetAnonymousOpenEnvironment(
-	ctx context.Context, org, id string,
-) (*esc.Environment, error) {
-	return m.getAnonymousOpenEnvironmentF(ctx, org, id)
 }
 
 func TestResolveEnvironments(t *testing.T) {
@@ -264,17 +219,12 @@ func TestResolveEnvironments(t *testing.T) {
 
 	t.Run("resolves policyConfig and environmentVariables", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				_ context.Context, org string, yaml []byte, _ time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				assert.Equal(t, "test-org", org)
 				assert.Contains(t, string(yaml), "prod/policy-config")
-				return "open-id-123", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(_ context.Context, org, id string) (*esc.Environment, error) {
-				assert.Equal(t, "test-org", org)
-				assert.Equal(t, "open-id-123", id)
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
 						"policyConfig": {Value: map[string]esc.Value{
@@ -286,13 +236,13 @@ func TestResolveEnvironments(t *testing.T) {
 							"AWS_REGION": {Value: "us-west-2"},
 						}},
 					},
-				}, nil
+				}, nil, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "test-org",
+			envs:    mock,
+			orgName: "test-org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "test-pack",
 				Environments: []string{"prod/policy-config"},
@@ -310,23 +260,23 @@ func TestResolveEnvironments(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, float64(1000), configVal["maxMonthlyCost"])
 
-		// Verify environmentVariables were extracted.
-		assert.Equal(t, map[string]string{"AWS_REGION": "us-west-2"}, result.EnvironmentVariables)
+		// Verify environmentVariables were extracted via PrepareEnvironment.
+		assert.Equal(t, "us-west-2", result.EnvironmentVariables["AWS_REGION"])
 	})
 
 	t.Run("OpenYAMLEnvironment error", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "", nil, errors.New("connection refused")
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+				return nil, nil, errors.New("connection refused")
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "test-org",
+			envs:    mock,
+			orgName: "test-org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "test-pack",
 				Environments: []string{"env1"},
@@ -341,19 +291,19 @@ func TestResolveEnvironments(t *testing.T) {
 
 	t.Run("diagnostics returned as error", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "", []escclient.EnvironmentDiagnostic{
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+				return nil, apitype.EnvironmentDiagnostics{
 					{Summary: "unknown environment 'prod/missing'"},
 				}, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "test-org",
+			envs:    mock,
+			orgName: "test-org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "test-pack",
 				Environments: []string{"prod/missing"},
@@ -365,55 +315,25 @@ func TestResolveEnvironments(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown environment")
 	})
 
-	t.Run("GetAnonymousOpenEnvironment error", func(t *testing.T) {
-		t.Parallel()
-		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(
-				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "id", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
-				return nil, errors.New("not found")
-			},
-		}
-
-		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "test-org",
-			RequiredPolicy: apitype.RequiredPolicy{
-				Name:         "test-pack",
-				Environments: []string{"env1"},
-			},
-		}
-
-		_, err := rp.ResolveEnvironments(t.Context())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "getting resolved ESC environment")
-	})
-
 	t.Run("only policyConfig no envVars", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "id", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
 						"policyConfig": {Value: map[string]esc.Value{
 							"p1": {Value: "simple"},
 						}},
 					},
-				}, nil
+				}, nil, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "org",
+			envs:    mock,
+			orgName: "org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "pack",
 				Environments: []string{"env"},
@@ -429,26 +349,23 @@ func TestResolveEnvironments(t *testing.T) {
 
 	t.Run("only envVars no policyConfig", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "id", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
 						"environmentVariables": {Value: map[string]esc.Value{
 							"KEY": {Value: "val"},
 						}},
 					},
-				}, nil
+				}, nil, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "org",
+			envs:    mock,
+			orgName: "org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "pack",
 				Environments: []string{"env"},
@@ -464,19 +381,14 @@ func TestResolveEnvironments(t *testing.T) {
 
 	t.Run("resolves version-pinned environment references", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				_ context.Context, org string, yaml []byte, _ time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				assert.Equal(t, "test-org", org)
 				yamlStr := string(yaml)
 				assert.Contains(t, yamlStr, "prod/policy-config@v2.1.0")
 				assert.Contains(t, yamlStr, "shared/base@stable")
-				return "open-id-456", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(_ context.Context, org, id string) (*esc.Environment, error) {
-				assert.Equal(t, "test-org", org)
-				assert.Equal(t, "open-id-456", id)
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
 						"policyConfig": {Value: map[string]esc.Value{
@@ -485,13 +397,13 @@ func TestResolveEnvironments(t *testing.T) {
 							}},
 						}},
 					},
-				}, nil
+				}, nil, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "test-org",
+			envs:    mock,
+			orgName: "test-org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "test-pack",
 				Environments: []string{"prod/policy-config@v2.1.0", "shared/base@stable"},
@@ -506,13 +418,10 @@ func TestResolveEnvironments(t *testing.T) {
 
 	t.Run("namespaced policyConfig keys pass through", func(t *testing.T) {
 		t.Parallel()
-		mock := &mockESCClient{
+		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
-			) (string, []escclient.EnvironmentDiagnostic, error) {
-				return "id", nil, nil
-			},
-			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
 						"policyConfig": {Value: map[string]esc.Value{
@@ -524,13 +433,13 @@ func TestResolveEnvironments(t *testing.T) {
 							}},
 						}},
 					},
-				}, nil
+				}, nil, nil
 			},
 		}
 
 		rp := &cloudRequiredPolicy{
-			escClient: mock,
-			orgName:   "org",
+			envs:    mock,
+			orgName: "org",
 			RequiredPolicy: apitype.RequiredPolicy{
 				Name:         "my-pack",
 				Environments: []string{"env"},
@@ -543,5 +452,42 @@ func TestResolveEnvironments(t *testing.T) {
 		// Raw keys pass through as-is; namespace parsing happens during merge in update.go.
 		assert.Contains(t, result.Config, "my-pack:cost-policy")
 		assert.Contains(t, result.Config, "naming-policy")
+	})
+
+	t.Run("secrets are returned from environment", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockEnvironmentsBackend{
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"environmentVariables": {Value: map[string]esc.Value{
+							"SECRET_KEY": {
+								Value:  "super-secret-value",
+								Secret: true,
+							},
+							"PLAIN_KEY": {Value: "plain-value"},
+						}},
+					},
+				}, nil, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			envs:    mock,
+			orgName: "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, result.EnvironmentVariables, "SECRET_KEY")
+		assert.Contains(t, result.EnvironmentVariables, "PLAIN_KEY")
+		assert.Contains(t, result.Secrets, "super-secret-value")
 	})
 }

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -452,6 +453,103 @@ func TestResolveEnvironments(t *testing.T) {
 		// Raw keys pass through as-is; namespace parsing happens during merge in update.go.
 		assert.Contains(t, result.Config, "my-pack:cost-policy")
 		assert.Contains(t, result.Config, "naming-policy")
+	})
+
+	t.Run("files exports create temp files and inject paths", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockEnvironmentsBackend{
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"files": {Value: map[string]esc.Value{
+							"KUBECONFIG": {Value: "apiVersion: v1\nkind: Config\n"},
+							"TLS_CERT":  {Value: "-----BEGIN CERTIFICATE-----\nMIIB...", Secret: true},
+						}},
+					},
+				}, nil, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			envs:    mock,
+			orgName: "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// File paths should be injected as environment variables.
+		kubePath := result.EnvironmentVariables["KUBECONFIG"]
+		tlsPath := result.EnvironmentVariables["TLS_CERT"]
+		require.NotEmpty(t, kubePath, "KUBECONFIG should have a temp file path")
+		require.NotEmpty(t, tlsPath, "TLS_CERT should have a temp file path")
+
+		// Temp files should exist and contain the expected content.
+		kubeContent, err := os.ReadFile(kubePath)
+		require.NoError(t, err)
+		assert.Equal(t, "apiVersion: v1\nkind: Config\n", string(kubeContent))
+
+		tlsContent, err := os.ReadFile(tlsPath)
+		require.NoError(t, err)
+		assert.Equal(t, "-----BEGIN CERTIFICATE-----\nMIIB...", string(tlsContent))
+
+		// Secret file content should be tracked.
+		assert.Contains(t, result.Secrets, "-----BEGIN CERTIFICATE-----\nMIIB...")
+
+		// Clean up temp files.
+		os.Remove(kubePath)
+		os.Remove(tlsPath)
+	})
+
+	t.Run("files and env vars are merged", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockEnvironmentsBackend{
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"environmentVariables": {Value: map[string]esc.Value{
+							"AWS_REGION": {Value: "us-west-2"},
+						}},
+						"files": {Value: map[string]esc.Value{
+							"GOOGLE_CREDENTIALS": {Value: `{"type":"service_account"}`},
+						}},
+					},
+				}, nil, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			envs:    mock,
+			orgName: "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Both env vars and file paths should be present.
+		assert.Equal(t, "us-west-2", result.EnvironmentVariables["AWS_REGION"])
+		credPath := result.EnvironmentVariables["GOOGLE_CREDENTIALS"]
+		require.NotEmpty(t, credPath)
+
+		content, err := os.ReadFile(credPath)
+		require.NoError(t, err)
+		assert.Equal(t, `{"type":"service_account"}`, string(content))
+
+		os.Remove(credPath)
 	})
 
 	t.Run("secrets are returned from environment", func(t *testing.T) {

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -1,0 +1,434 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/esc"
+	escclient "github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildImportsYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		envRefs  []string
+		expected string
+	}{
+		{
+			name:     "single environment",
+			envRefs:  []string{"prod/secrets"},
+			expected: "imports:\n  - prod/secrets\n",
+		},
+		{
+			name:     "multiple environments",
+			envRefs:  []string{"shared/base", "prod/secrets", "prod/config"},
+			expected: "imports:\n  - shared/base\n  - prod/secrets\n  - prod/config\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := buildImportsYAML(tt.envRefs)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestEscValueToInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    esc.Value
+		expected any
+	}{
+		{
+			name:     "string value",
+			input:    esc.Value{Value: "hello"},
+			expected: "hello",
+		},
+		{
+			name:     "bool value",
+			input:    esc.Value{Value: true},
+			expected: true,
+		},
+		{
+			name:     "nil value",
+			input:    esc.Value{Value: nil},
+			expected: nil,
+		},
+		{
+			name: "map value",
+			input: esc.Value{Value: map[string]esc.Value{
+				"key": {Value: "val"},
+			}},
+			expected: map[string]any{"key": "val"},
+		},
+		{
+			name: "slice value",
+			input: esc.Value{Value: []esc.Value{
+				{Value: "a"},
+				{Value: "b"},
+			}},
+			expected: []any{"a", "b"},
+		},
+		{
+			name: "nested map with slice",
+			input: esc.Value{Value: map[string]esc.Value{
+				"list": {Value: []esc.Value{
+					{Value: "x"},
+				}},
+				"nested": {Value: map[string]esc.Value{
+					"deep": {Value: "value"},
+				}},
+			}},
+			expected: map[string]any{
+				"list":   []any{"x"},
+				"nested": map[string]any{"deep": "value"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := escValueToInterface(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEscValueToStringMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    esc.Value
+		expected map[string]string
+	}{
+		{
+			name:     "non-map returns nil",
+			input:    esc.Value{Value: "not a map"},
+			expected: nil,
+		},
+		{
+			name: "string values extracted",
+			input: esc.Value{Value: map[string]esc.Value{
+				"FOO": {Value: "bar"},
+				"BAZ": {Value: "qux"},
+			}},
+			expected: map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			name: "non-string values filtered out",
+			input: esc.Value{Value: map[string]esc.Value{
+				"STR":  {Value: "hello"},
+				"BOOL": {Value: true},
+				"NUM":  {Value: json.Number("42")},
+			}},
+			expected: map[string]string{"STR": "hello"},
+		},
+		{
+			name:     "empty map",
+			input:    esc.Value{Value: map[string]esc.Value{}},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := escValueToStringMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEscValueToConfigMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid policy config", func(t *testing.T) {
+		t.Parallel()
+		input := esc.Value{Value: map[string]esc.Value{
+			"my-policy": {Value: map[string]esc.Value{
+				"enforcement": {Value: "mandatory"},
+			}},
+		}}
+
+		result, err := escValueToConfigMap(input)
+		require.NoError(t, err)
+		require.Contains(t, result, "my-policy")
+
+		var parsed map[string]any
+		err = json.Unmarshal(*result["my-policy"], &parsed)
+		require.NoError(t, err)
+		assert.Equal(t, "mandatory", parsed["enforcement"])
+	})
+
+	t.Run("non-map returns error", func(t *testing.T) {
+		t.Parallel()
+		input := esc.Value{Value: "not a map"}
+
+		_, err := escValueToConfigMap(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected policyConfig to be a map")
+	})
+
+	t.Run("empty map", func(t *testing.T) {
+		t.Parallel()
+		input := esc.Value{Value: map[string]esc.Value{}}
+
+		result, err := escValueToConfigMap(input)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+// mockESCClient implements the subset of escclient.Client used by ResolveEnvironments.
+// We embed the interface to satisfy the full contract and only override the methods we need.
+type mockESCClient struct {
+	escclient.Client
+
+	openYAMLEnvironmentF         func(ctx context.Context, org string, yaml []byte, duration time.Duration) (string, []escclient.EnvironmentDiagnostic, error)
+	getAnonymousOpenEnvironmentF func(ctx context.Context, org, id string) (*esc.Environment, error)
+}
+
+func (m *mockESCClient) OpenYAMLEnvironment(
+	ctx context.Context, org string, yaml []byte, duration time.Duration,
+) (string, []escclient.EnvironmentDiagnostic, error) {
+	return m.openYAMLEnvironmentF(ctx, org, yaml, duration)
+}
+
+func (m *mockESCClient) GetAnonymousOpenEnvironment(
+	ctx context.Context, org, id string,
+) (*esc.Environment, error) {
+	return m.getAnonymousOpenEnvironmentF(ctx, org, id)
+}
+
+func TestResolveEnvironments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no environments returns nil", func(t *testing.T) {
+		t.Parallel()
+		rp := &cloudRequiredPolicy{
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name: "test-pack",
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("resolves policyConfig and environmentVariables", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(_ context.Context, org string, yaml []byte, _ time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				assert.Equal(t, "test-org", org)
+				assert.Contains(t, string(yaml), "prod/policy-config")
+				return "open-id-123", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(_ context.Context, org, id string) (*esc.Environment, error) {
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "open-id-123", id)
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"policyConfig": {Value: map[string]esc.Value{
+							"cost-policy": {Value: map[string]esc.Value{
+								"maxMonthlyCost": {Value: json.Number("1000")},
+							}},
+						}},
+						"environmentVariables": {Value: map[string]esc.Value{
+							"AWS_REGION": {Value: "us-west-2"},
+						}},
+					},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "test-org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "test-pack",
+				Environments: []string{"prod/policy-config"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Verify policyConfig was extracted.
+		require.Contains(t, result.Config, "cost-policy")
+		var configVal map[string]any
+		err = json.Unmarshal(*result.Config["cost-policy"], &configVal)
+		require.NoError(t, err)
+		assert.Equal(t, float64(1000), configVal["maxMonthlyCost"])
+
+		// Verify environmentVariables were extracted.
+		assert.Equal(t, map[string]string{"AWS_REGION": "us-west-2"}, result.EnvironmentVariables)
+	})
+
+	t.Run("OpenYAMLEnvironment error", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "", nil, errors.New("connection refused")
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "test-org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "test-pack",
+				Environments: []string{"env1"},
+			},
+		}
+
+		_, err := rp.ResolveEnvironments(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "opening ESC environments")
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+
+	t.Run("diagnostics returned as error", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "", []escclient.EnvironmentDiagnostic{
+					{Summary: "unknown environment 'prod/missing'"},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "test-org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "test-pack",
+				Environments: []string{"prod/missing"},
+			},
+		}
+
+		_, err := rp.ResolveEnvironments(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown environment")
+	})
+
+	t.Run("GetAnonymousOpenEnvironment error", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "id", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+				return nil, errors.New("not found")
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "test-org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "test-pack",
+				Environments: []string{"env1"},
+			},
+		}
+
+		_, err := rp.ResolveEnvironments(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "getting resolved ESC environment")
+	})
+
+	t.Run("only policyConfig no envVars", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "id", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"policyConfig": {Value: map[string]esc.Value{
+							"p1": {Value: "simple"},
+						}},
+					},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotEmpty(t, result.Config)
+		assert.Nil(t, result.EnvironmentVariables)
+	})
+
+	t.Run("only envVars no policyConfig", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockESCClient{
+			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+				return "id", nil, nil
+			},
+			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
+				return &esc.Environment{
+					Properties: map[string]esc.Value{
+						"environmentVariables": {Value: map[string]esc.Value{
+							"KEY": {Value: "val"},
+						}},
+					},
+				}, nil
+			},
+		}
+
+		rp := &cloudRequiredPolicy{
+			escClient: mock,
+			orgName:   "org",
+			RequiredPolicy: apitype.RequiredPolicy{
+				Name:         "pack",
+				Environments: []string{"env"},
+			},
+		}
+
+		result, err := rp.ResolveEnvironments(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Nil(t, result.Config)
+		assert.Equal(t, map[string]string{"KEY": "val"}, result.EnvironmentVariables)
+	})
+}

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -212,7 +212,9 @@ func TestEscValueToConfigMap(t *testing.T) {
 type mockESCClient struct {
 	escclient.Client
 
-	openYAMLEnvironmentF         func(ctx context.Context, org string, yaml []byte, duration time.Duration) (string, []escclient.EnvironmentDiagnostic, error)
+	openYAMLEnvironmentF func(
+		ctx context.Context, org string, yaml []byte, duration time.Duration,
+	) (string, []escclient.EnvironmentDiagnostic, error)
 	getAnonymousOpenEnvironmentF func(ctx context.Context, org, id string) (*esc.Environment, error)
 }
 
@@ -247,7 +249,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("resolves policyConfig and environmentVariables", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(_ context.Context, org string, yaml []byte, _ time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				_ context.Context, org string, yaml []byte, _ time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				assert.Equal(t, "test-org", org)
 				assert.Contains(t, string(yaml), "prod/policy-config")
 				return "open-id-123", nil, nil
@@ -297,7 +301,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("OpenYAMLEnvironment error", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				return "", nil, errors.New("connection refused")
 			},
 		}
@@ -320,7 +326,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("diagnostics returned as error", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				return "", []escclient.EnvironmentDiagnostic{
 					{Summary: "unknown environment 'prod/missing'"},
 				}, nil
@@ -344,7 +352,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("GetAnonymousOpenEnvironment error", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				return "id", nil, nil
 			},
 			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
@@ -369,7 +379,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("only policyConfig no envVars", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				return "id", nil, nil
 			},
 			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {
@@ -402,7 +414,9 @@ func TestResolveEnvironments(t *testing.T) {
 	t.Run("only envVars no policyConfig", func(t *testing.T) {
 		t.Parallel()
 		mock := &mockESCClient{
-			openYAMLEnvironmentF: func(context.Context, string, []byte, time.Duration) (string, []escclient.EnvironmentDiagnostic, error) {
+			openYAMLEnvironmentF: func(
+				context.Context, string, []byte, time.Duration,
+			) (string, []escclient.EnvironmentDiagnostic, error) {
 				return "id", nil, nil
 			},
 			getAnonymousOpenEnvironmentF: func(context.Context, string, string) (*esc.Environment, error) {

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -28,51 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildImportsYAML(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		envRefs  []string
-		expected string
-	}{
-		{
-			name:     "single environment",
-			envRefs:  []string{"prod/secrets"},
-			expected: "imports:\n  - prod/secrets\n",
-		},
-		{
-			name:     "multiple environments",
-			envRefs:  []string{"shared/base", "prod/secrets", "prod/config"},
-			expected: "imports:\n  - shared/base\n  - prod/secrets\n  - prod/config\n",
-		},
-		{
-			name:     "environment with version tag",
-			envRefs:  []string{"prod/secrets@v1.2.3"},
-			expected: "imports:\n  - prod/secrets@v1.2.3\n",
-		},
-		{
-			name:     "environment with named tag",
-			envRefs:  []string{"prod/secrets@stable"},
-			expected: "imports:\n  - prod/secrets@stable\n",
-		},
-		{
-			name:    "mixed tagged and untagged environments",
-			envRefs: []string{"shared/base", "prod/secrets@v2", "prod/config@my-tag"},
-			expected: "imports:\n  - shared/base\n" +
-				"  - prod/secrets@v2\n  - prod/config@my-tag\n",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := buildImportsYAML(tt.envRefs)
-			assert.Equal(t, tt.expected, string(result))
-		})
-	}
-}
-
 func TestEscValueToInterface(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/policy/policy_install_test.go
+++ b/pkg/cmd/pulumi/policy/policy_install_test.go
@@ -73,6 +73,10 @@ func (m *mockRequiredPolicy) Install(
 	return nil
 }
 
+func (m *mockRequiredPolicy) ResolveEnvironments(_ context.Context) (*engine.ResolvedPolicyEnvironment, error) {
+	return nil, nil
+}
+
 // newMockStack creates a MockStack wired to the given MockBackend.
 func newMockStack(be *backend.MockBackend) *backend.MockStack {
 	return &backend.MockStack{

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -78,6 +78,10 @@ func (p *testRequiredPolicy) Config() map[string]*json.RawMessage {
 	return p.config
 }
 
+func (p *testRequiredPolicy) ResolveEnvironments(_ context.Context) (*ResolvedPolicyEnvironment, error) {
+	return nil, nil
+}
+
 func NewRequiredPolicy(name, version string, config map[string]*json.RawMessage) RequiredPolicy {
 	return &testRequiredPolicy{
 		name:    name,
@@ -1208,6 +1212,10 @@ func (p *failingDownloadRequiredPolicy) Install(_ *plugin.Context, _ io.ReadClos
 	return nil
 }
 
+func (p *failingDownloadRequiredPolicy) ResolveEnvironments(_ context.Context) (*ResolvedPolicyEnvironment, error) {
+	return nil, nil
+}
+
 // failingInstallRequiredPolicy is a RequiredPolicy that fails during installation, used to test that
 // policy pack installation errors are properly surfaced rather than silently dropped.
 type failingInstallRequiredPolicy struct {
@@ -1228,6 +1236,10 @@ func (p *failingInstallRequiredPolicy) Download(
 
 func (p *failingInstallRequiredPolicy) Install(_ *plugin.Context, _ io.ReadCloser, _, _ io.Writer) error {
 	return errors.New("policy pack install failed")
+}
+
+func (p *failingInstallRequiredPolicy) ResolveEnvironments(_ context.Context) (*ResolvedPolicyEnvironment, error) {
+	return nil, nil
 }
 
 // TestPolicyPackDownloadFailureReturnsError is a regression test verifying that errors from the download

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -51,9 +50,6 @@ type ResolvedPolicyEnvironment struct {
 	EnvironmentVariables map[string]string
 	// Secrets are secret values from the environment that should be filtered from logs.
 	Secrets []string
-	// TempFiles are paths to temporary files created for files exports. Callers
-	// should clean these up when they are no longer needed.
-	TempFiles []string
 }
 
 // parsePolicyConfigKey splits a policyConfig key into an optional pack name
@@ -525,15 +521,6 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 			if err != nil {
 				errs <- fmt.Errorf("resolving ESC environments for %q: %w", policy.Name(), err)
 				return
-			}
-
-			// Clean up temporary files created for files exports.
-			if resolved != nil && len(resolved.TempFiles) > 0 {
-				defer func() {
-					for _, f := range resolved.TempFiles {
-						contract.IgnoreError(os.Remove(f))
-					}
-				}()
 			}
 
 			// Create per-policy analyzer options with ESC environment variables.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -42,6 +42,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// ResolvedPolicyEnvironment holds resolved ESC environment data for a policy pack.
+type ResolvedPolicyEnvironment struct {
+	// Config to merge into the policy pack's config (from ESC policyConfig).
+	Config map[string]*json.RawMessage
+	// EnvironmentVariables to inject into the analyzer process.
+	EnvironmentVariables map[string]string
+}
+
 // RequiredPolicy represents a set of policies to apply during an update.
 type RequiredPolicy interface {
 	// Name provides the user-specified name of the PolicyPack.
@@ -62,6 +70,9 @@ type RequiredPolicy interface {
 	Install(ctx *plugin.Context, content io.ReadCloser, stdout, stderr io.Writer) error
 	// Config returns the PolicyPack's configuration.
 	Config() map[string]*json.RawMessage
+	// ResolveEnvironments opens any referenced ESC environments and returns
+	// resolved config and environment variables. Returns nil, nil if no environments are referenced.
+	ResolveEnvironments(ctx context.Context) (*ResolvedPolicyEnvironment, error)
 }
 
 // LocalPolicyPack represents a set of local Policy Packs to apply during an update.
@@ -465,6 +476,19 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 		go func(policy RequiredPolicy) {
 			defer wg.Done()
 
+			// Resolve ESC environments if present.
+			resolved, err := policy.ResolveEnvironments(plugctx.Base())
+			if err != nil {
+				errs <- fmt.Errorf("resolving ESC environments for %q: %w", policy.Name(), err)
+				return
+			}
+
+			// Create per-policy analyzer options with ESC environment variables.
+			policyOpts := *analyzerOpts
+			if resolved != nil && len(resolved.EnvironmentVariables) > 0 {
+				policyOpts.AdditionalEnv = resolved.EnvironmentVariables
+			}
+
 			policyPath, err := policy.LocalPath()
 			if err != nil {
 				errs <- err
@@ -472,7 +496,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 			}
 
 			analyzer, err := loadPolicyAnalyzer(
-				plugctx.Base(), plugctx, tokens.QName(policy.Name()), policyPath, analyzerOpts)
+				plugctx.Base(), plugctx, tokens.QName(policy.Name()), policyPath, &policyOpts)
 			if err != nil {
 				errs <- err
 				return
@@ -484,14 +508,34 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 				return
 			}
 
+			// Merge ESC policyConfig under API config (API config wins on conflict).
+			mergedConfig := policy.Config()
+			if resolved != nil && len(resolved.Config) > 0 {
+				if mergedConfig == nil {
+					mergedConfig = make(map[string]*json.RawMessage)
+				} else {
+					// Copy the map to avoid mutating the original.
+					copied := make(map[string]*json.RawMessage, len(mergedConfig)+len(resolved.Config))
+					for k, v := range mergedConfig {
+						copied[k] = v
+					}
+					mergedConfig = copied
+				}
+				for k, v := range resolved.Config {
+					if _, exists := mergedConfig[k]; !exists {
+						mergedConfig[k] = v
+					}
+				}
+			}
+
 			// Parse the config, reconcile & validate it, and pass it to the policy pack.
 			if !analyzerInfo.SupportsConfig {
-				if len(policy.Config()) > 0 {
+				if len(mergedConfig) > 0 {
 					logging.V(7).Infof("policy pack %q does not support config; skipping configure", analyzerInfo.Name)
 				}
 				return
 			}
-			configFromAPI, err := resourceanalyzer.ParsePolicyPackConfigFromAPI(policy.Config())
+			configFromAPI, err := resourceanalyzer.ParsePolicyPackConfigFromAPI(mergedConfig)
 			if err != nil {
 				errs <- err
 				return

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -62,10 +62,12 @@ func parsePolicyConfigKey(key string) (packName, policyName string) {
 	return "", key
 }
 
-// mergePolicyConfig merges ESC-resolved policy config into the base API config.
-// API config (base) wins on conflict. Namespaced keys ("packName:policyName")
-// are only applied when packName matches the given pack name.
-// Returns a new map; neither input is mutated.
+// mergePolicyConfig merges ESC-resolved policy config into the base API config
+// using JSON merge patch semantics (RFC 7386), matching the stack config merge
+// behavior. API config (set by admins via the service) wins on conflict, but
+// ESC properties that don't conflict are preserved. Namespaced keys
+// ("packName:policyName") are only applied when packName matches the given pack
+// name. Returns a new map; neither input is mutated.
 func mergePolicyConfig(
 	base map[string]*json.RawMessage,
 	escConfig map[string]*json.RawMessage,
@@ -83,11 +85,42 @@ func mergePolicyConfig(
 		if packPrefix != "" && packPrefix != packName {
 			continue
 		}
-		if _, exists := merged[policyName]; !exists {
+		existing, exists := merged[policyName]
+		if !exists {
 			merged[policyName] = v
+		} else {
+			// Deep merge: ESC provides defaults, API config wins on conflict.
+			if deepMerged, err := deepMergePolicyJSON(existing, v); err == nil {
+				merged[policyName] = deepMerged
+			}
+			// On error, keep the API config value as-is.
 		}
 	}
 	return merged
+}
+
+// deepMergePolicyJSON deep-merges two JSON policy config blobs using JSON merge
+// patch semantics (RFC 7386). Properties in base (API config) take precedence
+// over override (ESC config). Override-only properties are preserved.
+// If either value is not a JSON object, base wins entirely.
+func deepMergePolicyJSON(base, override *json.RawMessage) (*json.RawMessage, error) {
+	var baseMap, overrideMap map[string]any
+	if err := json.Unmarshal(*base, &baseMap); err != nil {
+		return base, nil
+	}
+	if err := json.Unmarshal(*override, &overrideMap); err != nil {
+		return base, nil
+	}
+	// Start with ESC as defaults, then apply API config on top.
+	for k, v := range baseMap {
+		overrideMap[k] = v
+	}
+	result, err := json.Marshal(overrideMap)
+	if err != nil {
+		return nil, err
+	}
+	raw := json.RawMessage(result)
+	return &raw, nil
 }
 
 // RequiredPolicy represents a set of policies to apply during an update.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -48,6 +49,11 @@ type ResolvedPolicyEnvironment struct {
 	Config map[string]*json.RawMessage
 	// EnvironmentVariables to inject into the analyzer process.
 	EnvironmentVariables map[string]string
+	// Secrets are secret values from the environment that should be filtered from logs.
+	Secrets []string
+	// TempFiles are paths to temporary files created for files exports. Callers
+	// should clean these up when they are no longer needed.
+	TempFiles []string
 }
 
 // parsePolicyConfigKey splits a policyConfig key into an optional pack name
@@ -521,10 +527,24 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 				return
 			}
 
+			// Clean up temporary files created for files exports.
+			if resolved != nil && len(resolved.TempFiles) > 0 {
+				defer func() {
+					for _, f := range resolved.TempFiles {
+						contract.IgnoreError(os.Remove(f))
+					}
+				}()
+			}
+
 			// Create per-policy analyzer options with ESC environment variables.
 			policyOpts := *analyzerOpts
-			if resolved != nil && len(resolved.EnvironmentVariables) > 0 {
-				policyOpts.AdditionalEnv = resolved.EnvironmentVariables
+			if resolved != nil {
+				if len(resolved.EnvironmentVariables) > 0 {
+					policyOpts.AdditionalEnv = resolved.EnvironmentVariables
+				}
+				if len(resolved.Secrets) > 0 {
+					logging.AddGlobalFilter(logging.CreateFilter(resolved.Secrets, "[secret]"))
+				}
 			}
 
 			policyPath, err := policy.LocalPath()

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -60,6 +60,34 @@ func parsePolicyConfigKey(key string) (packName, policyName string) {
 	return "", key
 }
 
+// mergePolicyConfig merges ESC-resolved policy config into the base API config.
+// API config (base) wins on conflict. Namespaced keys ("packName:policyName")
+// are only applied when packName matches the given pack name.
+// Returns a new map; neither input is mutated.
+func mergePolicyConfig(
+	base map[string]*json.RawMessage,
+	escConfig map[string]*json.RawMessage,
+	packName string,
+) map[string]*json.RawMessage {
+	if len(escConfig) == 0 {
+		return base
+	}
+	merged := make(map[string]*json.RawMessage, len(base)+len(escConfig))
+	for k, v := range base {
+		merged[k] = v
+	}
+	for rawKey, v := range escConfig {
+		packPrefix, policyName := parsePolicyConfigKey(rawKey)
+		if packPrefix != "" && packPrefix != packName {
+			continue
+		}
+		if _, exists := merged[policyName]; !exists {
+			merged[policyName] = v
+		}
+	}
+	return merged
+}
+
 // RequiredPolicy represents a set of policies to apply during an update.
 type RequiredPolicy interface {
 	// Name provides the user-specified name of the PolicyPack.
@@ -519,30 +547,11 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 			}
 
 			// Merge ESC policyConfig under API config (API config wins on conflict).
-			// Keys may be "policyName" or "packName:policyName".
-			// Namespaced keys only apply to the matching pack.
-			mergedConfig := policy.Config()
-			if resolved != nil && len(resolved.Config) > 0 {
-				if mergedConfig == nil {
-					mergedConfig = make(map[string]*json.RawMessage)
-				} else {
-					// Copy the map to avoid mutating the original.
-					copied := make(map[string]*json.RawMessage, len(mergedConfig)+len(resolved.Config))
-					for k, v := range mergedConfig {
-						copied[k] = v
-					}
-					mergedConfig = copied
-				}
-				for rawKey, v := range resolved.Config {
-					packPrefix, policyName := parsePolicyConfigKey(rawKey)
-					if packPrefix != "" && packPrefix != policy.Name() {
-						continue
-					}
-					if _, exists := mergedConfig[policyName]; !exists {
-						mergedConfig[policyName] = v
-					}
-				}
+			var escConfig map[string]*json.RawMessage
+			if resolved != nil {
+				escConfig = resolved.Config
 			}
+			mergedConfig := mergePolicyConfig(policy.Config(), escConfig, policy.Name())
 
 			// Parse the config, reconcile & validate it, and pass it to the policy pack.
 			if !analyzerInfo.SupportsConfig {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -50,6 +50,16 @@ type ResolvedPolicyEnvironment struct {
 	EnvironmentVariables map[string]string
 }
 
+// parsePolicyConfigKey splits a policyConfig key into an optional pack name
+// prefix and the policy name. Keys may be "policyName" or "packName:policyName".
+// This mirrors pulumiConfig's optional namespace pattern (e.g., "aws:region").
+func parsePolicyConfigKey(key string) (packName, policyName string) {
+	if i := strings.IndexByte(key, ':'); i >= 0 {
+		return key[:i], key[i+1:]
+	}
+	return "", key
+}
+
 // RequiredPolicy represents a set of policies to apply during an update.
 type RequiredPolicy interface {
 	// Name provides the user-specified name of the PolicyPack.
@@ -509,6 +519,8 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 			}
 
 			// Merge ESC policyConfig under API config (API config wins on conflict).
+			// Keys may be "policyName" or "packName:policyName".
+			// Namespaced keys only apply to the matching pack.
 			mergedConfig := policy.Config()
 			if resolved != nil && len(resolved.Config) > 0 {
 				if mergedConfig == nil {
@@ -521,9 +533,13 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 					}
 					mergedConfig = copied
 				}
-				for k, v := range resolved.Config {
-					if _, exists := mergedConfig[k]; !exists {
-						mergedConfig[k] = v
+				for rawKey, v := range resolved.Config {
+					packPrefix, policyName := parsePolicyConfigKey(rawKey)
+					if packPrefix != "" && packPrefix != policy.Name() {
+						continue
+					}
+					if _, exists := mergedConfig[policyName]; !exists {
+						mergedConfig[policyName] = v
 					}
 				}
 			}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -99,9 +99,11 @@ func mergePolicyConfig(
 	return merged
 }
 
-// deepMergePolicyJSON deep-merges two JSON policy config blobs using JSON merge
-// patch semantics (RFC 7386). Properties in base (API config) take precedence
-// over override (ESC config). Override-only properties are preserved.
+// deepMergePolicyJSON recursively merges two JSON policy config blobs.
+// Properties in base (API config) take precedence over override (ESC config).
+// Override-only properties are preserved. When both sides have an object at the
+// same key, the merge recurses. This matches the stack config merge behavior
+// (object.Merge in sdk/go/common/resource/config/object.go).
 // If either value is not a JSON object, base wins entirely.
 func deepMergePolicyJSON(base, override *json.RawMessage) (*json.RawMessage, error) {
 	var baseMap, overrideMap map[string]any
@@ -111,16 +113,32 @@ func deepMergePolicyJSON(base, override *json.RawMessage) (*json.RawMessage, err
 	if err := json.Unmarshal(*override, &overrideMap); err != nil {
 		return base, nil
 	}
-	// Start with ESC as defaults, then apply API config on top.
-	for k, v := range baseMap {
-		overrideMap[k] = v
-	}
+	deepMergeMap(overrideMap, baseMap)
 	result, err := json.Marshal(overrideMap)
 	if err != nil {
 		return nil, err
 	}
 	raw := json.RawMessage(result)
 	return &raw, nil
+}
+
+// deepMergeMap recursively merges src into dst. Values in src take precedence.
+// When both src and dst have a map[string]any at the same key, the merge recurses.
+func deepMergeMap(dst, src map[string]any) {
+	for k, sv := range src {
+		dv, exists := dst[k]
+		if !exists {
+			dst[k] = sv
+			continue
+		}
+		srcMap, srcOk := sv.(map[string]any)
+		dstMap, dstOk := dv.(map[string]any)
+		if srcOk && dstOk {
+			deepMergeMap(dstMap, srcMap)
+		} else {
+			dst[k] = sv
+		}
+	}
 }
 
 // RequiredPolicy represents a set of policies to apply during an update.

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -314,3 +314,27 @@ func (a *mockAnalyzer) GetPluginInfo() (plugin.PluginInfo, error) {
 }
 func (a *mockAnalyzer) Configure(map[string]plugin.AnalyzerPolicyConfig) error { return nil }
 func (a *mockAnalyzer) Cancel(context.Context) error                           { return nil }
+
+func TestParsePolicyConfigKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		key        string
+		wantPack   string
+		wantPolicy string
+	}{
+		{"cost-policy", "", "cost-policy"},
+		{"my-pack:cost-policy", "my-pack", "cost-policy"},
+		{":cost-policy", "", "cost-policy"},
+		{"pack:a:b", "pack", "a:b"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			gotPack, gotPolicy := parsePolicyConfigKey(tt.key)
+			assert.Equal(t, tt.wantPack, gotPack)
+			assert.Equal(t, tt.wantPolicy, gotPolicy)
+		})
+	}
+}

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -406,6 +406,26 @@ func TestMergePolicyConfig(t *testing.T) {
 		assert.Equal(t, float64(10), m["minCost"])
 	})
 
+	t.Run("deep merge nested objects recursively", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{
+			"cost-policy": raw(`{"rules":{"a":1,"shared":"base"}}`),
+		}
+		esc := map[string]*json.RawMessage{
+			"cost-policy": raw(`{"rules":{"b":2,"shared":"esc"}}`),
+		}
+		got := mergePolicyConfig(base, esc, "pack")
+		require.Contains(t, got, "cost-policy")
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(*got["cost-policy"], &m))
+		rules := m["rules"].(map[string]any)
+		// Both sides' unique keys are present.
+		assert.Equal(t, float64(1), rules["a"])
+		assert.Equal(t, float64(2), rules["b"])
+		// Base (API) wins on conflict.
+		assert.Equal(t, "base", rules["shared"])
+	})
+
 	t.Run("namespaced key matching pack is included", func(t *testing.T) {
 		t.Parallel()
 		esc := map[string]*json.RawMessage{"my-pack:cost-policy": raw(`true`)}

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -379,12 +379,31 @@ func TestMergePolicyConfig(t *testing.T) {
 		}, got)
 	})
 
-	t.Run("base wins on conflict", func(t *testing.T) {
+	t.Run("base wins on conflict for scalar values", func(t *testing.T) {
 		t.Parallel()
 		base := map[string]*json.RawMessage{"p": raw(`"base"`)}
 		esc := map[string]*json.RawMessage{"p": raw(`"esc"`)}
 		got := mergePolicyConfig(base, esc, "pack")
 		assert.Equal(t, map[string]*json.RawMessage{"p": raw(`"base"`)}, got)
+	})
+
+	t.Run("deep merge objects with API winning on conflict", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{
+			"cost-policy": raw(`{"enforcement":"advisory","maxCost":100}`),
+		}
+		esc := map[string]*json.RawMessage{
+			"cost-policy": raw(`{"enforcement":"mandatory","minCost":10}`),
+		}
+		got := mergePolicyConfig(base, esc, "pack")
+		require.Contains(t, got, "cost-policy")
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(*got["cost-policy"], &m))
+		// API wins on conflict.
+		assert.Equal(t, "advisory", m["enforcement"])
+		assert.Equal(t, float64(100), m["maxCost"])
+		// ESC-only property is preserved.
+		assert.Equal(t, float64(10), m["minCost"])
 	})
 
 	t.Run("namespaced key matching pack is included", func(t *testing.T) {

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -337,4 +338,76 @@ func TestParsePolicyConfigKey(t *testing.T) {
 			assert.Equal(t, tt.wantPolicy, gotPolicy)
 		})
 	}
+}
+
+func TestMergePolicyConfig(t *testing.T) {
+	t.Parallel()
+
+	raw := func(s string) *json.RawMessage {
+		r := json.RawMessage(s)
+		return &r
+	}
+
+	t.Run("nil base and nil esc returns nil", func(t *testing.T) {
+		t.Parallel()
+		got := mergePolicyConfig(nil, nil, "pack")
+		assert.Nil(t, got)
+	})
+
+	t.Run("non-nil base with nil esc returns base", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{"p": raw(`"a"`)}
+		got := mergePolicyConfig(base, nil, "pack")
+		assert.Equal(t, base, got)
+	})
+
+	t.Run("nil base with esc entries", func(t *testing.T) {
+		t.Parallel()
+		esc := map[string]*json.RawMessage{"p": raw(`"x"`)}
+		got := mergePolicyConfig(nil, esc, "pack")
+		assert.Equal(t, map[string]*json.RawMessage{"p": raw(`"x"`)}, got)
+	})
+
+	t.Run("no conflict merges both", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{"a": raw(`1`)}
+		esc := map[string]*json.RawMessage{"b": raw(`2`)}
+		got := mergePolicyConfig(base, esc, "pack")
+		assert.Equal(t, map[string]*json.RawMessage{
+			"a": raw(`1`),
+			"b": raw(`2`),
+		}, got)
+	})
+
+	t.Run("base wins on conflict", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{"p": raw(`"base"`)}
+		esc := map[string]*json.RawMessage{"p": raw(`"esc"`)}
+		got := mergePolicyConfig(base, esc, "pack")
+		assert.Equal(t, map[string]*json.RawMessage{"p": raw(`"base"`)}, got)
+	})
+
+	t.Run("namespaced key matching pack is included", func(t *testing.T) {
+		t.Parallel()
+		esc := map[string]*json.RawMessage{"my-pack:cost-policy": raw(`true`)}
+		got := mergePolicyConfig(nil, esc, "my-pack")
+		assert.Equal(t, map[string]*json.RawMessage{"cost-policy": raw(`true`)}, got)
+	})
+
+	t.Run("namespaced key not matching pack is excluded", func(t *testing.T) {
+		t.Parallel()
+		esc := map[string]*json.RawMessage{"other-pack:cost-policy": raw(`true`)}
+		got := mergePolicyConfig(nil, esc, "my-pack")
+		assert.Empty(t, got)
+	})
+
+	t.Run("does not mutate original base map", func(t *testing.T) {
+		t.Parallel()
+		base := map[string]*json.RawMessage{"a": raw(`1`)}
+		esc := map[string]*json.RawMessage{"b": raw(`2`)}
+		got := mergePolicyConfig(base, esc, "pack")
+		require.Contains(t, got, "b")
+		_, inBase := base["b"]
+		assert.False(t, inBase, "original base map should not be mutated")
+	})
 }

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -92,6 +92,9 @@ type RequiredPolicy struct {
 	// mapped to their configuration. Each individual configuration must comply with the
 	// JSON schema for each Policy within the Policy Pack.
 	Config map[string]*json.RawMessage `json:"config,omitempty"`
+
+	// ESC environment references to resolve for this policy pack.
+	Environments []string `json:"environments,omitempty"`
 }
 
 // Policy defines the metadata for an individual Policy within a Policy Pack.
@@ -274,6 +277,9 @@ type PolicyPackMetadata struct {
 	// The configuration that is to be passed to the Policy Pack. This
 	// map ties Policies with their configuration.
 	Config map[string]*json.RawMessage `json:"config,omitempty"`
+
+	// ESC environment references to resolve for this policy pack.
+	Environments []string `json:"environments,omitempty"`
 }
 
 // ListPolicyPacksResponse is the response to list an organization's

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -202,9 +202,17 @@ func NewPolicyAnalyzer(
 			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
 	} else {
 		// Else we _did_ get a language plugin so just use RunPlugin to invoke the policy pack.
+		analyzerEnv := env.Global()
+		if opts != nil && len(opts.AdditionalEnv) > 0 {
+			additionalStore := envutil.MapStore{}
+			for k, v := range opts.AdditionalEnv {
+				additionalStore[k] = v
+			}
+			analyzerEnv = envutil.NewEnv(envutil.JoinStore(additionalStore, env.Global().GetStore()))
+		}
 
 		plug, _, err = newPlugin(ctx, ctx.Pwd, policyPackPath, fmt.Sprintf("%v (analyzer)", name),
-			apitype.AnalyzerPlugin, []string{host.ServerAddr()}, env.Global(),
+			apitype.AnalyzerPlugin, []string{host.ServerAddr()}, analyzerEnv,
 			handshake, analyzerPluginDialOptions(ctx, string(name)),
 			host.AttachDebugger(DebugSpec{Type: DebugTypePlugin, Name: string(name)}))
 	}
@@ -985,6 +993,11 @@ func constructEnv(opts *PolicyAnalyzerOptions, runtime string) (env.Env, error) 
 		maybeAppendEnv("PULUMI_PROJECT", opts.Project)
 		maybeAppendEnv("PULUMI_STACK", opts.Stack)
 		maybeAppendEnv("PULUMI_DRY_RUN", strconv.FormatBool(opts.DryRun))
+
+		// Inject per-pack environment variables (e.g., from ESC environments).
+		for k, v := range opts.AdditionalEnv {
+			store[k] = v
+		}
 	}
 
 	return envutil.NewEnv(envutil.JoinStore(store, env.Global().GetStore())), nil

--- a/sdk/go/common/resource/plugin/analyzer_plugin_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin_test.go
@@ -89,6 +89,61 @@ func TestAnalyzerSpawnNoConfig(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestConstructEnvWithAdditionalEnv(t *testing.T) {
+	t.Parallel()
+
+	opts := &PolicyAnalyzerOptions{
+		Organization: "test-org",
+		Project:      "test-project",
+		Stack:        "test-stack",
+		DryRun:       false,
+		AdditionalEnv: map[string]string{
+			"MY_SECRET":  "secret-value",
+			"AWS_REGION": "us-west-2",
+		},
+	}
+
+	result, err := constructEnv(opts, "nodejs")
+	require.NoError(t, err)
+
+	// Verify standard env vars are set.
+	val, found := result.GetStore().Raw("PULUMI_ORGANIZATION")
+	require.True(t, found)
+	require.Equal(t, "test-org", val)
+
+	// Verify AdditionalEnv vars are injected.
+	val, found = result.GetStore().Raw("MY_SECRET")
+	require.True(t, found)
+	require.Equal(t, "secret-value", val)
+
+	val, found = result.GetStore().Raw("AWS_REGION")
+	require.True(t, found)
+	require.Equal(t, "us-west-2", val)
+}
+
+func TestConstructEnvWithoutAdditionalEnv(t *testing.T) {
+	t.Parallel()
+
+	opts := &PolicyAnalyzerOptions{
+		Organization: "test-org",
+		Project:      "test-project",
+		Stack:        "test-stack",
+		DryRun:       true,
+	}
+
+	result, err := constructEnv(opts, "python")
+	require.NoError(t, err)
+
+	// Standard vars should still be set.
+	val, found := result.GetStore().Raw("PULUMI_DRY_RUN")
+	require.True(t, found)
+	require.Equal(t, "true", val)
+
+	// Node.js-specific vars should not be set for python runtime.
+	_, found = result.GetStore().Raw("PULUMI_NODEJS_ORGANIZATION")
+	require.False(t, found)
+}
+
 func TestAnalyzerSpawnViaLanguage(t *testing.T) {
 	d := diagtest.LogSink(t)
 	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -330,6 +330,7 @@ type PolicyAnalyzerOptions struct {
 	ConfigSecretKeys []config.Key
 	DryRun           bool
 	Tags             map[string]string // Tags for the current stack.
+	AdditionalEnv    map[string]string // Per-pack environment variables (e.g., from ESC).
 }
 
 type pluginLoadRequest struct {


### PR DESCRIPTION
Policy packs currently have no way to access secrets or dynamic configuration from ESC environments. This means policy authors who need external API tokens or environment-specific settings must hardcode them or manage them outside of Pulumi's secrets management.

This implements the preventative (CLI-driven) resolution path: when the service returns ESC environment refs on a policy pack config, the CLI opens those environments client-side, merges `policyConfig` into the pack's config, and injects `environmentVariables` into the analyzer process. This parallels how IaC stacks resolve ESC environments today — `policyConfig` mirrors `pulumiConfig`, and secrets never transit through the service.

Design doc: https://www.notion.so/Option-A-ESC-Environment-on-Policy-Pack-Config-334fdbdf1cce81ad8e65ea5433207254

## Changes

- Add `Environments` field to `apitype.RequiredPolicy` and `PolicyPackMetadata` to carry environment refs from the service
- Add `ResolveEnvironments` to the `RequiredPolicy` interface, implemented via the ESC client in `cloudRequiredPolicy`
- In `loadPolicyPlugins`, merge resolved `policyConfig` into the pack's config (API config wins on conflict) and inject `environmentVariables` into the analyzer process via `AdditionalEnv`
