### PR TITLE
Document behavior of pulumi whoami for org and team tokens

### DIFF
--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -38,7 +38,11 @@ func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Co
 		Short: "Display the current logged-in user",
 		Long: "Display the current logged-in user\n" +
 			"\n" +
-			"Displays the username of the currently logged in user.",
+			"Displays the username of the currently logged in user.\n" +
+			"\n" +
+			"When the current token is a Pulumi Cloud team token or an organization token, " +
+			"the command will return the name of the organization with which the token is associated.",
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			stdout := cmd.OutOrStdout()


### PR DESCRIPTION
## Description
Adds a note to the `pulumi whoami` long description clarifying that when you're using a team or org token the command returns the organization name rather than a username.

There was a PR opened by a bot but I guess that didn't go through. Am I missing something here?

Fixes #19898