### PR TITLE
Fix deadlock in message renderer when cancelling an operation

### DIFF
--- a/changelog/pending/20260401--cli-display--fix-deadlock-in-message-renderer-when-cancelling-an-operation.yaml
+++ b/changelog/pending/20260401--cli-display--fix-deadlock-in-message-renderer-when-cancelling-an-operation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Fix deadlock in message renderer when cancelling an operation

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1385,12 +1385,15 @@ func (display *ProgressDisplay) handleSystemEvent(payload engine.StdoutEventPayl
 	// We need to take the writer lock here because ensureHeaderAndStackRows expects to be
 	// called under the write lock.
 	display.eventMutex.Lock()
-	defer display.eventMutex.Unlock()
 
 	// Make sure we have a header to display
 	display.ensureHeaderAndStackRows()
 
 	display.systemEventPayloads = append(display.systemEventPayloads, payload)
+
+	// Release the lock before calling the renderer, because it may call back into a method (like generateTreeNodes)
+	// that acquires eventMutex.RLock(), causing a deadlock.
+	display.eventMutex.Unlock()
 
 	display.renderer.systemMessage(payload)
 }

--- a/pkg/backend/display/progress_test.go
+++ b/pkg/backend/display/progress_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display/internal/terminal"
 	"github.com/pulumi/pulumi/pkg/v3/display"
@@ -486,5 +487,45 @@ func testSimpleRenderer(
 	} else {
 		err = os.WriteFile(fileName, stdout.Bytes(), 0o600)
 		require.NoError(t, err)
+	}
+}
+
+// Regression test for https://github.com/pulumi/pulumi/issues/21697
+func TestSystemEventDoesNotDeadlockMessageRenderer(t *testing.T) {
+	t.Parallel()
+
+	eventChannel, doneChannel := make(chan engine.Event), make(chan bool)
+
+	var stdout bytes.Buffer
+
+	go ShowProgressEvents(
+		"test", "update", tokens.MustParseStackName("stack"), "project", "link", eventChannel, doneChannel,
+		Options{
+			IsInteractive: true,
+			Color:         colors.Raw,
+			Stdout:        &stdout,
+			Stderr:        &bytes.Buffer{},
+			// Use raw=false to get the messageRenderer
+			term:                terminal.NewMockTerminal(&stdout, 80, 24, false /* raw */),
+			DeterministicOutput: true,
+		}, false)
+
+	go func() {
+		// Send a system event: this is what Ctrl+C produces ("^C received; cancelling...").
+		eventChannel <- engine.NewEvent(engine.StdoutEventPayload{
+			Message: "^C received; cancelling.\n",
+			Color:   colors.Always,
+		})
+
+		// Send the cancel event to terminate the display.
+		eventChannel <- engine.NewCancelEvent()
+		close(eventChannel)
+	}()
+
+	select {
+	case <-doneChannel:
+		// Success: display completed without deadlocking.
+	case <-time.After(10 * time.Second):
+		t.Fatal("display deadlocked processing system event with messageRenderer")
 	}
 }


### PR DESCRIPTION
The message renderer would deadlock when sending a SystemEvent, for example a cancellation from`Ctrl-C`.

On macOS and Linux we generally use the tree renderer, which doesn’t suffer from this problem, but on Windows, and on terminals we can’t make raw, we use the message renderer.

I think we introduced this in https://github.com/pulumi/pulumi/pull/17019 and then mostly fixed in https://github.com/pulumi/pulumi/pull/19434 but missed the system event case there.

Fixes https://github.com/pulumi/pulumi/issues/21697

