### PR TITLE
Fix inherited input properties missing from TypeScript component schema

### DIFF
--- a/changelog/pending/20260407--sdk-nodejs--fix-inherited-input-properties-in-component-schema.yaml
+++ b/changelog/pending/20260407--sdk-nodejs--fix-inherited-input-properties-in-component-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/nodejs
+  description: Fix inherited input properties missing from component schema when args interface extends another interface

--- a/sdk/nodejs/provider/experimental/analyzer.ts
+++ b/sdk/nodejs/provider/experimental/analyzer.ts
@@ -323,10 +323,13 @@ Please ensure these components are properly imported to your package's entry poi
         }
 
         let inputs: Record<string, PropertyDefinition> = {};
-        if (argsSymbol.members) {
+        // Use args.getProperties() instead of argsSymbol.members to include
+        // properties inherited from extended interfaces.
+        const argsProperties = args.getProperties();
+        if (argsProperties.length > 0) {
             inputs = this.analyzeSymbols(
                 { component: componentName, inputOutput: InputOutput.Neither, typeName: argsSymbol.getName() },
-                symbolTableToSymbols(argsSymbol.members),
+                argsProperties,
             );
         }
 

--- a/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/analyzer.spec.ts
@@ -62,6 +62,39 @@ describe("Analyzer", function () {
         });
     });
 
+    it("infers inherited input properties", async function () {
+        const dir = path.join(__dirname, "testdata", "inherited-inputs");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {
+                    baseProp: { type: "string", plain: true },
+                    childProp: { type: "string", plain: true },
+                },
+                outputs: {
+                    outResult: { type: "string" },
+                },
+            },
+        });
+    });
+
+    it("handles empty args interface", async function () {
+        const dir = path.join(__dirname, "testdata", "empty-args");
+        const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));
+        const { components } = analyzer.analyze();
+        assert.deepStrictEqual(components, {
+            MyComponent: {
+                name: "MyComponent",
+                inputs: {},
+                outputs: {
+                    outResult: { type: "string" },
+                },
+            },
+        });
+    });
+
     it("infers optional types", async function () {
         const dir = path.join(__dirname, "testdata", "optional-types");
         const analyzer = new Analyzer(dir, "provider", packageJSON, new Set(["MyComponent"]));

--- a/sdk/nodejs/tests/provider/experimental/testdata/empty-args/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/empty-args/index.ts
@@ -1,0 +1,14 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+// biome-ignore lint/suspicious/noEmptyInterface: testing empty args interface behavior
+interface MyComponentArgs {}
+
+export class MyComponent extends pulumi.ComponentResource {
+    outResult: pulumi.Output<string>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}

--- a/sdk/nodejs/tests/provider/experimental/testdata/inherited-inputs/index.ts
+++ b/sdk/nodejs/tests/provider/experimental/testdata/inherited-inputs/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface BaseArgs {
+    baseProp: string;
+}
+
+interface MyComponentArgs extends BaseArgs {
+    childProp: string;
+}
+
+export class MyComponent extends pulumi.ComponentResource {
+    outResult: pulumi.Output<string>;
+
+    constructor(name: string, args: MyComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("provider:index:MyComponent", name, args, opts);
+    }
+}


### PR DESCRIPTION
## Summary

- When an args interface extends another interface, only direct members were included in the generated schema - inherited properties were missing
- Root cause: `argsSymbol.members` only contains members declared directly on the interface, not inherited from extended interfaces
- Changed to use `type.getProperties()` which includes inherited properties, consistent with how complex types are already handled elsewhere in the same file (line 555)
- Related C# fix: pulumi/pulumi-dotnet#930

**Note:** Outputs still use `classSymbol.members` (direct only). Switching outputs to `classType.getProperties()` would pull in `ComponentResource` base class members (`__pulumiComponentResource`, `__data`, `urn`, etc.) and needs a separate fix with filtering.

The same bug also exists in the Python and Java SDKs.

## Test plan

- [x] Added `inherited-inputs` testdata with an interface extending a base interface
- [x] Added test asserting both `baseProp` and `childProp` appear in inputs
- [x] All 41 analyzer tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)