### PR TITLE
Save outputs to state files

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1247,7 +1247,8 @@ func (b *diyBackend) apply(
 	var manager *backend.SnapshotManager
 	if kind != apitype.PreviewUpdate && !opts.DryRun {
 		persister := b.newSnapshotPersister(ctx, diyStackRef)
-		manager = backend.NewSnapshotManager(persister, op.SecretsManager, update.Target.Snapshot, nil)
+		snapCtx := backend.SnapshotContext(ctx, op)
+		manager = backend.NewSnapshotManager(snapCtx, persister, op.SecretsManager, update.Target.Snapshot, nil)
 		engineCtx.SnapshotManager = manager
 	}
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1797,8 +1797,9 @@ func (b *cloudBackend) runEngineAction(
 			}
 		} else {
 			persister := b.newSnapshotPersister(ctx, update, tokenSource)
+			snapCtx := backend.SnapshotContext(ctx, op)
 			snapshotJournaler, err = backend.NewSnapshotJournaler(
-				ctx, journalPersister, op.SecretsManager, backend_secrets.DefaultProvider, u.Target.Snapshot)
+				snapCtx, journalPersister, op.SecretsManager, backend_secrets.DefaultProvider, u.Target.Snapshot)
 			if err != nil {
 				validationErrs = append(validationErrs, err)
 			}
@@ -1806,7 +1807,7 @@ func (b *cloudBackend) runEngineAction(
 			if err != nil {
 				validationErrs = append(validationErrs, err)
 			}
-			snapshotManager = backend.NewSnapshotManager(persister, op.SecretsManager, u.Target.Snapshot, engineEvents)
+			snapshotManager = backend.NewSnapshotManager(snapCtx, persister, op.SecretsManager, u.Target.Snapshot, engineEvents)
 			combinedManager = &engine.CombinedManager{
 				Managers:          []engine.SnapshotManager{snapshotManager, journalManager},
 				CollectErrorsOnly: []bool{false, true},

--- a/pkg/backend/httpstate/snapshot_benchmark_test.go
+++ b/pkg/backend/httpstate/snapshot_benchmark_test.go
@@ -689,7 +689,7 @@ func BenchmarkSnapshot(b *testing.B) {
 
 	p := newServerPersister(b)
 	getManager := func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {
-		return backend.NewSnapshotManager(p, base.SecretsManager, base, nil)
+		return backend.NewSnapshotManager(b.Context(), p, base.SecretsManager, base, nil)
 	}
 	if useJournal {
 		getManager = func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -77,6 +77,7 @@ type SnapshotManager struct {
 	secretsManager secrets.Manager      // The default secrets manager to use
 	resources      []*resource.State    // The list of resources operated upon by this plan
 	operations     []resource.Operation // The set of operations known to be outstanding in this plan
+	ctx            context.Context      // Context used for serialization (may carry stack.WithSaveOutputDependencies)
 
 	// The set of resources that have been operated upon already by this plan. These resources could also have
 	// been added to `resources` by other operations but need to be filtered out before writing the snapshot.
@@ -761,8 +762,12 @@ func (sm *SnapshotManager) Deployment() (apitype.TypedDeployment, error) {
 		return apitype.TypedDeployment{}, fmt.Errorf("failed to normalize URN references: %w", err)
 	}
 
+	ctx := sm.ctx
+	if ctx == nil {
+		ctx = context.TODO()
+	}
 	deploymentV3, version, features, err := stack.SerializeDeploymentWithMetadata(
-		context.TODO(), snap, false /*showSecrets*/)
+		ctx, snap, false /*showSecrets*/)
 	if err != nil {
 		return apitype.TypedDeployment{}, fmt.Errorf("failed to serialize snapshot: %w", err)
 	}
@@ -939,6 +944,7 @@ func (sm *SnapshotManager) unsafeServiceLoop(mutationRequests chan mutationReque
 // mutate this object and correctness of the SnapshotManager depends on being able to observe this mutation. (This is
 // not ideal...)
 func NewSnapshotManager(
+	ctx context.Context,
 	persister SnapshotPersister,
 	secretsManager secrets.Manager,
 	baseSnap *deploy.Snapshot,
@@ -947,6 +953,7 @@ func NewSnapshotManager(
 	mutationRequests, cancel, done := make(chan mutationRequest), make(chan bool), make(chan error)
 
 	manager := &SnapshotManager{
+		ctx:              ctx,
 		persister:        persister,
 		secretsManager:   secretsManager,
 		baseSnapshot:     baseSnap,
@@ -967,4 +974,14 @@ func NewSnapshotManager(
 	go serviceLoop(mutationRequests, done)
 
 	return manager
+}
+
+// SnapshotContext returns a context enriched with snapshot serialization options derived from the
+// project configuration in op. If the project has SaveOutputDependencies enabled, the context will
+// instruct the serialization layer to preserve Output dependency information in the state file.
+func SnapshotContext(ctx context.Context, op UpdateOperation) context.Context {
+	if op.Proj != nil && op.Proj.Options != nil && op.Proj.Options.SaveOutputDependencies {
+		ctx = stack.WithSaveOutputDependencies(ctx)
+	}
+	return ctx
 }

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -62,7 +62,7 @@ func MockSetup(t *testing.T, baseSnap *deploy.Snapshot) (*SnapshotManager, *Mock
 	require.NoError(t, err)
 
 	sp := &MockStackPersister{}
-	return NewSnapshotManager(sp, baseSnap.SecretsManager, baseSnap, nil), sp
+	return NewSnapshotManager(t.Context(), sp, baseSnap.SecretsManager, baseSnap, nil), sp
 }
 
 func NewResourceWithDeps(urn resource.URN, deps []resource.URN) *resource.State {
@@ -1081,7 +1081,7 @@ func TestSnapshotAutoRepairSucceedsForInvalidSnapshots(t *testing.T) {
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
 	events := make(chan engine.Event, 1)
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, events)
 
 	err := sm.saveSnapshot()
 
@@ -1106,7 +1106,7 @@ func TestSnapshotAutoRepairErrorIsSurfacedWhenRepairFails(t *testing.T) {
 	snap := NewSnapshot([]*resource.State{rA, rB})
 	sp := &MockStackPersister{}
 	events := make(chan engine.Event, 1)
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, events)
 
 	err := sm.saveSnapshot()
 
@@ -1128,7 +1128,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshots(t *testing.T
 	r := NewResource("a", "b")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, nil)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1148,7 +1148,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshots(t *testing.T) 
 	snap.Metadata.IntegrityErrorMetadata = &deploy.SnapshotIntegrityErrorMetadata{}
 
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, nil)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1171,7 +1171,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisable
 	r := NewResource("a", "b")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, nil)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1194,7 +1194,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsChecksDisabled(
 	r := NewResource("a")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(t.Context(), sp, snap.SecretsManager, snap, nil)
 
 	// Act.
 	err := sm.saveSnapshot()

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -324,6 +324,7 @@ func NewDestroyCmd() *cobra.Command {
 				Experimental:              env.Experimental.Value(),
 				ContinueOnError:           continueOnError,
 				DestroyProgram:            runProgram,
+				SaveOutputDependencies:    proj.Options != nil && proj.Options.SaveOutputDependencies,
 			}
 
 			_, destroyErr := backend.DestroyStack(ctx, s, backend.UpdateOperation{

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -496,10 +496,11 @@ func NewPreviewCmd() *cobra.Command {
 					ExcludeDependents:         excludeDependents,
 					// If we're trying to save a plan then we _need_ to generate it. We also turn this on in
 					// experimental mode to just get more testing of it.
-					GeneratePlan:   env.Experimental.Value() || planFilePath != "",
-					Experimental:   env.Experimental.Value(),
-					AttachDebugger: attachDebugger,
-					Autonamer:      autonamer,
+					GeneratePlan:           env.Experimental.Value() || planFilePath != "",
+					Experimental:           env.Experimental.Value(),
+					AttachDebugger:         attachDebugger,
+					Autonamer:              autonamer,
+					SaveOutputDependencies: proj.Options != nil && proj.Options.SaveOutputDependencies,
 				},
 				Display: displayOpts,
 			}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -313,6 +313,7 @@ func NewRefreshCmd() *cobra.Command {
 				Experimental:              env.Experimental.Value(),
 				ExecKind:                  execKind,
 				RefreshProgram:            runProgram,
+				SaveOutputDependencies:    proj.Options != nil && proj.Options.SaveOutputDependencies,
 			}
 
 			changes, err := backend.RefreshStack(ctx, s, backend.UpdateOperation{

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -236,12 +236,13 @@ func NewUpCmd() *cobra.Command {
 			ExcludeDependents:         excludeDependents,
 			// Trigger a plan to be generated during the preview phase which can be constrained to during the
 			// update phase.
-			GeneratePlan:    env.Experimental.Value() || strict,
-			Experimental:    env.Experimental.Value(),
-			Strict:          strict,
-			ContinueOnError: continueOnError,
-			AttachDebugger:  attachDebugger,
-			Autonamer:       autonamer,
+			GeneratePlan:           env.Experimental.Value() || strict,
+			Experimental:           env.Experimental.Value(),
+			Strict:                 strict,
+			ContinueOnError:        continueOnError,
+			AttachDebugger:         attachDebugger,
+			Autonamer:              autonamer,
+			SaveOutputDependencies: proj.Options != nil && proj.Options.SaveOutputDependencies,
 		}
 
 		if planFilePath != "" {
@@ -490,7 +491,8 @@ func NewUpCmd() *cobra.Command {
 			UseLegacyRefreshDiff: env.EnableLegacyRefreshDiff.Value(),
 			ContinueOnError:      continueOnError,
 
-			AttachDebugger: attachDebugger,
+			AttachDebugger:         attachDebugger,
+			SaveOutputDependencies: proj.Options != nil && proj.Options.SaveOutputDependencies,
 		}
 
 		start := time.Now()

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -159,6 +159,7 @@ func NewWatchCmd() *cobra.Command {
 				DisableResourceReferences: env.DisableResourceReferences.Value(),
 				DisableOutputValues:       env.DisableOutputValues.Value(),
 				Experimental:              env.Experimental.Value(),
+				SaveOutputDependencies:    proj.Options != nil && proj.Options.SaveOutputDependencies,
 			}
 
 			err = backend.WatchStack(ctx, s, backend.UpdateOperation{

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -261,12 +261,20 @@ func (op TestOp) runWithContext(
 			},
 		}
 
+		journalerCtx := context.Background()
+		if opts.SaveOutputDependencies {
+			journalerCtx = stack.WithSaveOutputDependencies(journalerCtx)
+		}
 		var err error
 		journaler, err = backend.NewSnapshotJournaler(
-			context.Background(), journalPersister, secretsManager, secretsProvider, target.Snapshot)
+			journalerCtx, journalPersister, secretsManager, secretsProvider, target.Snapshot)
 		require.NoErrorf(opts.T, err, "got error setting up journaler")
 
-		snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot, nil)
+		snapCtx := context.Background()
+		if opts.SaveOutputDependencies {
+			snapCtx = stack.WithSaveOutputDependencies(snapCtx)
+		}
+		snapshotManager := backend.NewSnapshotManager(snapCtx, persister, secretsManager, target.Snapshot, nil)
 		journalSnapshotManager, err := engine.NewJournalSnapshotManager(journaler, target.Snapshot, secretsManager)
 		require.NoError(opts.T, err)
 
@@ -385,8 +393,12 @@ func (op TestOp) runWithContext(
 		// The test jounrnaler doesn't support secrets managers, so we need to add it to
 		// the snapshot here before serializing it.
 		snap.SecretsManager = secretsManager
+		serCtx := context.TODO()
+		if opts.SaveOutputDependencies {
+			serCtx = stack.WithSaveOutputDependencies(serCtx)
+		}
 		serializedSnap, _, _, err = stack.SerializeDeploymentWithMetadata(
-			context.TODO(), snap, false)
+			serCtx, snap, false)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("could not serialize snapshot: %w", err))
 		}

--- a/pkg/engine/lifecycletest/output_dependencies_test.go
+++ b/pkg/engine/lifecycletest/output_dependencies_test.go
@@ -1,0 +1,303 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	rstack "github.com/pulumi/pulumi/pkg/v3/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestOutputDependenciesRoundTrip verifies that when SaveOutputDependencies is set in the
+// project options, Output values with dependency information are preserved through a state file
+// round-trip (serialize → deserialize → serialize), and that the resulting deployment is tagged
+// with the "outputDependencies" feature and written at schema version 4 so that older CLIs
+// refuse to open it.
+func TestOutputDependenciesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var componentURN resource.URN
+	var innerResURN resource.URN
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ConstructF: func(
+					_ context.Context,
+					req plugin.ConstructRequest,
+					monitor *deploytest.ResourceMonitor,
+				) (plugin.ConstructResponse, error) {
+					// Register the component itself.
+					resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{
+						Parent: req.Parent,
+					})
+					require.NoError(t, err)
+					componentURN = resp.URN
+
+					// Register a child custom resource that the component owns.
+					innerResp, err := monitor.RegisterResource("pkgA:m:typB", "inner", true, deploytest.ResourceOptions{
+						Parent: resp.URN,
+					})
+					require.NoError(t, err)
+					innerResURN = innerResp.URN
+
+					// Return outputs that are Output values with dependency info pointing at
+					// the inner resource.
+					deps := []resource.URN{innerResURN}
+					outputs := resource.PropertyMap{
+						"knownOutput": resource.NewProperty(resource.Output{
+							Element:      resource.NewProperty("hello"),
+							Known:        true,
+							Secret:       false,
+							Dependencies: deps,
+						}),
+						"secretOutput": resource.NewProperty(resource.Output{
+							Element:      resource.NewProperty("secret-value"),
+							Known:        true,
+							Secret:       true,
+							Dependencies: deps,
+						}),
+						"unknownOutput": resource.NewProperty(resource.Output{
+							Known:        false,
+							Dependencies: deps,
+						}),
+					}
+
+					err = monitor.RegisterResourceOutputs(resp.URN, outputs)
+					require.NoError(t, err)
+
+					return plugin.ConstructResponse{
+						URN:     resp.URN,
+						Outputs: outputs,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pkgA:m:typA", "comp", false, deploytest.ResourceOptions{
+			Remote: true,
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			T:                t,
+			HostF:            hostF,
+			SkipDisplayTests: true,
+			UpdateOptions: engine.UpdateOptions{
+				SaveOutputDependencies: true,
+			},
+		},
+	}
+
+	p.Steps = []lt.TestStep{
+		{
+			Op:          engine.Update,
+			SkipPreview: true,
+			Validate: func(
+				project workspace.Project,
+				target deploy.Target,
+				entries engine.JournalEntries,
+				_ []engine.Event,
+				err error,
+			) error {
+				require.NoError(t, err)
+
+				snap, snapErr := entries.Snap(target.Snapshot)
+				require.NoError(t, snapErr)
+				require.NotNil(t, snap)
+
+				// Serialize the snapshot with the feature enabled.
+				serCtx := rstack.WithSaveOutputDependencies(t.Context())
+				deployment, version, features, serErr := rstack.SerializeDeploymentWithMetadata(
+					serCtx, snap, false /*showSecrets*/)
+				require.NoError(t, serErr)
+
+				// The state file must be version 4 (feature-gated) because we have output
+				// values with dependency info.
+				assert.Equal(t, apitype.DeploymentSchemaVersionLatest, version,
+					"expected schema version 4 when outputDependencies feature is active")
+				assert.Contains(t, features, "outputDependencies",
+					"expected outputDependencies feature in serialized deployment")
+
+				// Find the component resource in the serialized deployment and verify
+				// its output values have the OutputValueSig.
+				var compRes *apitype.ResourceV3
+				for i := range deployment.Resources {
+					if deployment.Resources[i].URN == componentURN {
+						compRes = &deployment.Resources[i]
+						break
+					}
+				}
+				require.NotNil(t, compRes, "component resource not found in deployment")
+
+				checkOutputValueSig := func(key string) {
+					v, ok := compRes.Outputs[key]
+					require.True(t, ok, "output %q not found", key)
+					m, ok := v.(map[string]any)
+					require.True(t, ok, "output %q is not a map", key)
+					assert.Equal(t, resource.OutputValueSig, m[resource.SigKey],
+						"output %q missing OutputValueSig", key)
+					deps, ok := m["dependencies"].([]any)
+					require.True(t, ok, "output %q has no dependencies array", key)
+					assert.Equal(t, []any{string(innerResURN)}, deps,
+						"output %q has wrong dependencies", key)
+				}
+				checkOutputValueSig("knownOutput")
+				checkOutputValueSig("secretOutput")
+				checkOutputValueSig("unknownOutput")
+
+				// Also verify that the values can be deserialized back to resource.Output
+				// values with their dependency info intact.
+				deserialized, deserErr := rstack.DeserializeDeploymentV3(
+					t.Context(), *deployment, nil /*secretsProvider*/)
+				require.NoError(t, deserErr)
+
+				var compState *resource.State
+				for _, res := range deserialized.Resources {
+					if res.URN == componentURN {
+						compState = res
+						break
+					}
+				}
+				require.NotNil(t, compState, "component resource not found after deserialization")
+
+				checkRoundTrip := func(key string, wantKnown, wantSecret bool) {
+					v, ok := compState.Outputs[resource.PropertyKey(key)]
+					require.True(t, ok, "output %q not found after deserialization", key)
+					require.True(t, v.IsOutput(), "output %q is not an Output after deserialization", key)
+					o := v.OutputValue()
+					assert.Equal(t, wantKnown, o.Known, "output %q Known mismatch", key)
+					assert.Equal(t, wantSecret, o.Secret, "output %q Secret mismatch", key)
+					require.Len(t, o.Dependencies, 1, "output %q Dependencies length mismatch", key)
+					assert.Equal(t, innerResURN, o.Dependencies[0],
+						"output %q dependency URN mismatch", key)
+				}
+				checkRoundTrip("knownOutput", true, false)
+				checkRoundTrip("secretOutput", true, true)
+				checkRoundTrip("unknownOutput", false, false)
+
+				return nil
+			},
+		},
+	}
+
+	p.Run(t, nil)
+}
+
+// TestOutputDependenciesNotSavedByDefault verifies that without SaveOutputDependencies in the
+// project options, Output values are degraded to their plain values (existing behaviour), the
+// state remains at schema version 3, and old CLIs can continue to read it.
+func TestOutputDependenciesNotSavedByDefault(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ConstructF: func(
+					_ context.Context,
+					req plugin.ConstructRequest,
+					monitor *deploytest.ResourceMonitor,
+				) (plugin.ConstructResponse, error) {
+					resp, err := monitor.RegisterResource(req.Type, req.Name, false, deploytest.ResourceOptions{
+						Parent: req.Parent,
+					})
+					require.NoError(t, err)
+
+					innerResp, err := monitor.RegisterResource("pkgA:m:typB", "inner", true, deploytest.ResourceOptions{
+						Parent: resp.URN,
+					})
+					require.NoError(t, err)
+
+					deps := []resource.URN{innerResp.URN}
+					outputs := resource.PropertyMap{
+						"out": resource.NewProperty(resource.Output{
+							Element:      resource.NewProperty("value"),
+							Known:        true,
+							Dependencies: deps,
+						}),
+					}
+					err = monitor.RegisterResourceOutputs(resp.URN, outputs)
+					require.NoError(t, err)
+
+					return plugin.ConstructResponse{URN: resp.URN, Outputs: outputs}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pkgA:m:typA", "comp", false, deploytest.ResourceOptions{
+			Remote: true,
+		})
+		return err
+	})
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+
+	p.Steps = []lt.TestStep{
+		{
+			Op:          engine.Update,
+			SkipPreview: true,
+			Validate: func(
+				project workspace.Project,
+				target deploy.Target,
+				entries engine.JournalEntries,
+				_ []engine.Event,
+				err error,
+			) error {
+				require.NoError(t, err)
+
+				snap, snapErr := entries.Snap(target.Snapshot)
+				require.NoError(t, snapErr)
+				require.NotNil(t, snap)
+
+				_, version, features, serErr := rstack.SerializeDeploymentWithMetadata(
+					t.Context(), snap, false /*showSecrets*/)
+				require.NoError(t, serErr)
+
+				// Without the option, we should NOT get version 4 or the outputDependencies feature.
+				assert.Equal(t, apitype.DeploymentSchemaVersionCurrent, version,
+					"expected schema version 3 when outputDependencies is disabled")
+				assert.NotContains(t, features, "outputDependencies",
+					"did not expect outputDependencies feature when option is unset")
+
+				return nil
+			},
+		},
+	}
+
+	p.Run(t, nil)
+}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -271,6 +271,11 @@ type UpdateOptions struct {
 
 	// ShowSecrets is true if the engine should display secrets in the CLI.
 	ShowSecrets bool
+
+	// SaveOutputDependencies controls whether Output values are serialized with their full dependency
+	// information in the state file. Requires the "outputDependencies" state feature; older CLIs will
+	// refuse to open a stack that uses this feature.
+	SaveOutputDependencies bool
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.
@@ -676,6 +681,7 @@ func newUpdateSource(ctx context.Context,
 		DisableResourceReferences: opts.DisableResourceReferences,
 		DisableOutputValues:       opts.DisableOutputValues,
 		AttachDebugger:            opts.AttachDebugger,
+		SaveOutputDependencies:    opts.SaveOutputDependencies,
 	}, panicErrs), nil
 }
 

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -628,8 +628,9 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 func (rm *ResourceMonitor) RegisterResourceOutputs(urn resource.URN, outputs resource.PropertyMap) error {
 	// marshal outputs
 	outs, err := plugin.MarshalProperties(outputs, plugin.MarshalOptions{
-		KeepUnknowns:  true,
-		KeepResources: rm.supportsResourceReferences,
+		KeepUnknowns:     true,
+		KeepResources:    rm.supportsResourceReferences,
+		KeepOutputValues: true, // Preserve Output values so the server can decide whether to retain them.
 	})
 	if err != nil {
 		return err

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -93,6 +93,8 @@ type EvalSourceOptions struct {
 	DisableOutputValues bool
 	// AttachDebugger is the list of things to debug.  This can be "program", "all", "plugins", or "plugin:<plugin-name>".
 	AttachDebugger []string
+	// true to preserve Output values with dependency info in RegisterResourceOutputs.
+	SaveOutputDependencies bool
 }
 
 // NewEvalSource returns a planning source that fetches resources by evaluating a package with a set of args and
@@ -3058,7 +3060,11 @@ func (rm *resmon) RegisterResourceOutputs(ctx context.Context,
 			ComputeAssetHashes: true,
 			KeepSecrets:        true,
 			KeepResources:      true,
-			WorkingDirectory:   rm.workingDirectory,
+			// Preserve Output values with dependency info when the feature is opted in.
+			// This allows the serialization layer to persist dependency information in
+			// state files so that stack references can surface richer details.
+			KeepOutputValues: rm.opts.SaveOutputDependencies,
+			WorkingDirectory: rm.workingDirectory,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("cannot unmarshal output properties: %w", err)

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -69,7 +69,23 @@ const (
 	hooksFeature               = "hooks"
 	taintFeature               = "taint"
 	replaceWithFeature         = "replaceWith"
+	outputDependenciesFeature  = "outputDependencies"
 )
+
+// saveOutputDepsKey is a context key used to signal that Output values should be
+// serialized with their full dependency information.
+type saveOutputDepsKey struct{}
+
+// WithSaveOutputDependencies returns a context that instructs SerializePropertyValue to
+// preserve Output dependency information.
+func WithSaveOutputDependencies(ctx context.Context) context.Context {
+	return context.WithValue(ctx, saveOutputDepsKey{}, true)
+}
+
+func getSaveOutputDependencies(ctx context.Context) bool {
+	v, _ := ctx.Value(saveOutputDepsKey{}).(bool)
+	return v
+}
 
 var (
 	// ErrDeploymentSchemaVersionTooOld is returned from `DeserializeDeployment` if the
@@ -125,6 +141,7 @@ var supportedFeatures = map[string]bool{
 	hooksFeature:               true,
 	taintFeature:               true,
 	replaceWithFeature:         true,
+	outputDependenciesFeature:  true,
 }
 
 // validateSupportedFeatures validates that the features used in a deployment are supported.
@@ -158,6 +175,41 @@ func ApplyFeatures(res apitype.ResourceV3, features map[string]bool) {
 	if len(res.ReplaceWith) > 0 {
 		features[replaceWithFeature] = true
 	}
+	if anyOutputValueSig(res.Outputs) || anyOutputValueSig(res.Inputs) {
+		features[outputDependenciesFeature] = true
+	}
+}
+
+// anyOutputValueSig reports whether any value in the property map (recursively) is an
+// output value with the OutputValueSig signature.
+func anyOutputValueSig(props map[string]any) bool {
+	for _, v := range props {
+		if containsOutputValueSig(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsOutputValueSig(v any) bool {
+	switch w := v.(type) {
+	case map[string]any:
+		if sig, ok := w[resource.SigKey]; ok && sig == resource.OutputValueSig {
+			return true
+		}
+		for _, val := range w {
+			if containsOutputValueSig(val) {
+				return true
+			}
+		}
+	case []any:
+		for _, elem := range w {
+			if containsOutputValueSig(elem) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ValidateUntypedDeployment validates a deployment against the Deployment JSON schema.
@@ -613,10 +665,41 @@ func SerializePropertyValue(ctx context.Context, prop resource.PropertyValue, en
 		return computedValuePlaceholder, nil
 	}
 
-	// We can't currently serialize output values fully, we lose the dependency information. But we can
-	// at least serialize the inner value so that we can preserve the shape of the data.
+	// Serialize output values. When the context has saveOutputDependencies set (opt-in via
+	// PULUMI_SAVE_OUTPUT_DEPENDENCIES), or when the output already carries dependency info
+	// (i.e. it was read from a state file that had the outputDependencies feature), we
+	// serialize the full output value including dependencies. This causes ApplyFeatures to
+	// add the "outputDependencies" feature flag, which bumps the state file to version 4
+	// so that older CLIs that don't understand this format refuse to open it.
+	//
+	// Without the flag (the default), we degrade the output to its inner value to preserve
+	// compatibility with older state readers.
 	if prop.IsOutput() {
 		o := prop.OutputValue()
+
+		if getSaveOutputDependencies(ctx) {
+			obj := map[string]any{
+				resource.SigKey: resource.OutputValueSig,
+			}
+			if o.Known {
+				elem, err := SerializePropertyValue(ctx, o.Element, enc, showSecrets)
+				if err != nil {
+					return nil, err
+				}
+				obj["value"] = elem
+			}
+			if o.Secret {
+				obj["secret"] = true
+			}
+			if len(o.Dependencies) > 0 {
+				deps := make([]any, len(o.Dependencies))
+				for i, dep := range o.Dependencies {
+					deps[i] = string(dep)
+				}
+				obj["dependencies"] = deps
+			}
+			return obj, nil
+		}
 
 		element := o.Element
 		if !o.Known {
@@ -988,6 +1071,48 @@ func DeserializePropertyValue(v any, dec config.Decrypter,
 					}
 					floatVal := math.Float64frombits(bits)
 					return resource.NewProperty(floatVal), nil
+				case resource.OutputValueSig:
+					// An output value serialized with full dependency info (requires
+					// the "outputDependencies" state feature).
+					elemRaw, known := objmap["value"]
+					var element resource.PropertyValue
+					if known {
+						element, err = DeserializePropertyValue(elemRaw, dec)
+						if err != nil {
+							return resource.PropertyValue{},
+								fmt.Errorf("deserializing output value element: %w", err)
+						}
+					}
+
+					var secret bool
+					if secretRaw, ok := objmap["secret"]; ok {
+						secret, _ = secretRaw.(bool)
+					}
+
+					var dependencies []resource.URN
+					if depsRaw, ok := objmap["dependencies"]; ok {
+						depsArr, ok := depsRaw.([]any)
+						if !ok {
+							return resource.PropertyValue{},
+								errors.New("malformed output value: dependencies must be an array")
+						}
+						dependencies = make([]resource.URN, len(depsArr))
+						for i, d := range depsArr {
+							s, ok := d.(string)
+							if !ok {
+								return resource.PropertyValue{},
+									errors.New("malformed output value: dependency element must be a string")
+							}
+							dependencies[i] = resource.URN(s)
+						}
+					}
+
+					return resource.NewProperty(resource.Output{
+						Element:      element,
+						Known:        known,
+						Secret:       secret,
+						Dependencies: dependencies,
+					}), nil
 				default:
 					return resource.PropertyValue{}, fmt.Errorf("unrecognized signature '%v' in property map", sig)
 				}

--- a/sdk/go/common/apitype/property-values.json
+++ b/sdk/go/common/apitype/property-values.json
@@ -243,6 +243,33 @@
                 }
             },
             "required": ["4dabf18193072939515e22adb298388d", "value"]
+        },
+        {
+            "title": "Output property values",
+            "description": "An output value with optional dependency information. Only present in state files that use the 'outputDependencies' feature (version 4+).",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Output value signature",
+                    "const": "d0e6a833031e9bbcd3f4e8bde6ca49a4"
+                },
+                "value": {
+                    "description": "The resolved value of the output, if known.",
+                    "$ref": "#property_value"
+                },
+                "secret": {
+                    "description": "Whether the output value is secret.",
+                    "type": "boolean"
+                },
+                "dependencies": {
+                    "description": "The URNs of resources this output depends on.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d"]
         }
     ]
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -94,6 +94,10 @@ type ProjectBackend struct {
 type ProjectOptions struct {
 	// Refresh is the ability to always run a refresh as part of a pulumi update / preview / destroy
 	Refresh string `json:"refresh,omitempty" yaml:"refresh,omitempty"`
+	// SaveOutputDependencies controls whether Output values are serialized with their full dependency
+	// information in the state file. When true, the state file requires a Pulumi CLI that understands
+	// the "outputDependencies" feature; older CLIs will refuse to open the stack.
+	SaveOutputDependencies bool `json:"saveOutputDependencies,omitempty" yaml:"saveOutputDependencies,omitempty"`
 }
 
 type PluginOptions struct {

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/main.go
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/main.go
@@ -55,7 +55,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func call(ctx *pulumi.Context, tok string, args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {

--- a/tests/integration/construct_component_methods/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods/testcomponent-go/main.go
@@ -89,7 +89,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {

--- a/tests/integration/construct_component_methods_provider/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_provider/testcomponent-go/main.go
@@ -89,7 +89,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {

--- a/tests/integration/construct_component_methods_resources/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_resources/testcomponent-go/main.go
@@ -73,7 +73,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {

--- a/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
@@ -73,7 +73,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {

--- a/tests/integration/construct_component_output_values/testcomponent-go/main.go
+++ b/tests/integration/construct_component_output_values/testcomponent-go/main.go
@@ -109,7 +109,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 	}
 
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {

--- a/tests/integration/resource_refs_get_resource/go/main.go
+++ b/tests/integration/resource_refs_get_resource/go/main.go
@@ -158,7 +158,7 @@ func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi
 		return nil, fmt.Errorf("unknown resource type: %s", typ)
 	}
 	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
-	return
+	return r, err
 }
 
 func main() {


### PR DESCRIPTION
WIP Claude coded 

Add a new flag in Pulumi.yaml to tell the project to save output values to state to allow us finer dependency tracking across stack references. Part 1 of being able to do precise multi-stack updates.

We want this opt-in because old CLIs will not be able to read state file written with output values. This is using the state "feature" list for this.

We also need to work out what to do with the outputs when reading a stack reference. I think for phase 1 we just drop them at that point, so we're just getting base states updated, not dependents. But at some point we need to start propagating the information down and saving in dependent stacks. That has a whole load of issues, like dependencies now listing resources that don't even live in the current stack.