### PR TITLE
Add pkg/docsrender/ core library

### DIFF
--- a/pkg/docsrender/chooser.go
+++ b/pkg/docsrender/chooser.go
@@ -1,0 +1,197 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// ResolveChoosers resolves chooser blocks in the markdown AST. The selections
+// map chooser type (e.g., "language") to the desired value (e.g., "python").
+// If no selection exists for a chooser type, all options are shown.
+// The source must be the original bytes used to parse tree.
+func ResolveChoosers(source []byte, tree ast.Node, selections map[string]string) []byte {
+	resolveChooserBlocks(source, tree, selections)
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, tree)
+	contract.AssertNoErrorf(err, "rendering after chooser resolution")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+// resolveChooserBlocks walks the AST looking for sequences of HTMLBlock nodes
+// that form chooser/option/close patterns, then resolves them in place.
+func resolveChooserBlocks(source []byte, tree ast.Node, selections map[string]string) {
+	// Collect top-level children into a slice for safe iteration during mutation.
+	var children []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		children = append(children, c)
+	}
+
+	i := 0
+	for i < len(children) {
+		node := children[i]
+		text := htmlBlockText(source, node)
+		kind, value, isClose, ok := parseChooserComment(text)
+		if !ok || isClose || kind != "chooser" {
+			i++
+			continue
+		}
+
+		chooserType := value
+		selected := selections[chooserType]
+
+		// Scan forward to find options and the closing tag.
+		type option struct {
+			value string
+			nodes []ast.Node
+		}
+		var options []option
+		var currentOption *option
+		j := i + 1
+		closed := false
+
+		for j < len(children) {
+			t := htmlBlockText(source, children[j])
+			k, v, ic, ok2 := parseChooserComment(t)
+			if ok2 && k == "option" && !ic {
+				if currentOption != nil {
+					options = append(options, *currentOption)
+				}
+				currentOption = &option{value: v}
+				j++
+				continue
+			}
+			if ok2 && k == "chooser" && ic {
+				if currentOption != nil {
+					options = append(options, *currentOption)
+				}
+				closed = true
+				j++
+				break
+			}
+			if currentOption != nil {
+				currentOption.nodes = append(currentOption.nodes, children[j])
+			}
+			j++
+		}
+
+		if !closed {
+			// Unclosed chooser — leave as-is.
+			i = j
+			continue
+		}
+
+		// Remove the chooser open tag, all content, and close tag.
+		for k := i; k < j; k++ {
+			tree.RemoveChild(tree, children[k])
+		}
+
+		// Find the insertion point (the node after the removed range, or nil for end).
+		var insertBefore ast.Node
+		if j < len(children) {
+			insertBefore = children[j]
+		}
+
+		if selected != "" {
+			// Insert only the selected option's content.
+			for _, opt := range options {
+				if strings.EqualFold(opt.value, selected) {
+					for _, n := range opt.nodes {
+						tree.InsertBefore(tree, insertBefore, n)
+					}
+					break
+				}
+			}
+		} else {
+			// No selection: show all options with labels.
+			for _, opt := range options {
+				for _, n := range opt.nodes {
+					tree.InsertBefore(tree, insertBefore, n)
+				}
+			}
+		}
+
+		i = j
+	}
+}
+
+// htmlBlockText extracts the text content from an HTMLBlock node.
+func htmlBlockText(source []byte, node ast.Node) string {
+	hb, ok := node.(*ast.HTMLBlock)
+	if !ok {
+		return ""
+	}
+	var buf bytes.Buffer
+	for i := 0; i < hb.Lines().Len(); i++ {
+		seg := hb.Lines().At(i)
+		buf.Write(seg.Value(source))
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// parseChooserComment parses an HTML comment that may be a chooser directive.
+// Returns (kind, value, isClose, ok).
+//
+// Examples:
+//
+//	"<!-- chooser: language -->" → ("chooser", "language", false, true)
+//	"<!-- option: typescript -->" → ("option", "typescript", false, true)
+//	"<!-- /chooser -->"          → ("chooser", "", true, true)
+//	"<!-- /option -->"           → ("option", "", true, true)
+//	"<!-- something else -->"    → ("", "", false, false)
+func parseChooserComment(text string) (kind, value string, isClose, ok bool) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "<!--") || !strings.HasSuffix(text, "-->") {
+		return "", "", false, false
+	}
+	inner := strings.TrimSpace(text[4 : len(text)-3])
+
+	// Check for close tags: /chooser or /option.
+	if strings.HasPrefix(inner, "/") {
+		tag := strings.TrimSpace(inner[1:])
+		switch tag {
+		case "chooser":
+			return "chooser", "", true, true
+		case "option":
+			return "option", "", true, true
+		default:
+			return "", "", false, false
+		}
+	}
+
+	// Check for open tags: "chooser: TYPE" or "option: VALUE".
+	parts := strings.SplitN(inner, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false, false
+	}
+	tag := strings.TrimSpace(parts[0])
+	val := strings.TrimSpace(parts[1])
+	switch tag {
+	case "chooser", "option":
+		return tag, val, false, true
+	default:
+		return "", "", false, false
+	}
+}

--- a/pkg/docsrender/chooser_test.go
+++ b/pkg/docsrender/chooser_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseChooserComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input   string
+		kind    string
+		value   string
+		isClose bool
+		ok      bool
+	}{
+		{"<!-- chooser: language -->", "chooser", "language", false, true},
+		{"<!-- option: typescript -->", "option", "typescript", false, true},
+		{"<!-- option: python -->", "option", "python", false, true},
+		{"<!-- /chooser -->", "chooser", "", true, true},
+		{"<!-- /option -->", "option", "", true, true},
+		{"<!-- chooser: os -->", "chooser", "os", false, true},
+		{"<!-- something else -->", "", "", false, false},
+		{"not a comment", "", "", false, false},
+		{"", "", "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			kind, value, isClose, ok := parseChooserComment(tt.input)
+			assert.Equal(t, tt.kind, kind)
+			assert.Equal(t, tt.value, value)
+			assert.Equal(t, tt.isClose, isClose)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestResolveChoosersWithSelection(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TypeScript content here.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+Python content here.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+Some text after.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "python"}))
+
+	assert.Contains(t, result, "Some text before.")
+	assert.Contains(t, result, "Python content here.")
+	assert.NotContains(t, result, "TypeScript content here.")
+	assert.Contains(t, result, "Some text after.")
+}
+
+func TestResolveChoosersShowAll(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS code.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+PY code.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+After.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "TS code.")
+	assert.Contains(t, result, "PY code.")
+	assert.Contains(t, result, "After.")
+}
+
+func TestResolveChoosersEmptyChooser(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- /chooser -->
+
+After.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "python"}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "After.")
+}
+
+func TestResolveChoosersUnknownSelection(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS only.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	// Selection for a value not present in options — nothing is emitted for the chooser.
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "go"}))
+
+	assert.NotContains(t, result, "TS only.")
+}
+
+func TestResolveChoosersUnclosed(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS code.
+
+After without close.
+`)
+	tree := ParseMarkdown(source)
+	// Unclosed chooser is left as-is.
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "typescript"}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "TS code.")
+}
+
+func TestResolveChoosersCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: TypeScript -->
+
+TS content.
+
+<!-- /option -->
+
+<!-- option: Python -->
+
+PY content.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "typescript"}))
+
+	assert.Contains(t, result, "TS content.")
+	assert.NotContains(t, result, "PY content.")
+}
+
+func TestResolveChoosersMultipleChoosers(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+PY.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+Middle text.
+
+<!-- chooser: os -->
+
+<!-- option: macos -->
+
+Mac instructions.
+
+<!-- /option -->
+
+<!-- option: linux -->
+
+Linux instructions.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{
+		"language": "python",
+		"os":       "linux",
+	}))
+
+	assert.Contains(t, result, "PY.")
+	assert.NotContains(t, result, "TS.")
+	assert.Contains(t, result, "Middle text.")
+	assert.Contains(t, result, "Linux instructions.")
+	assert.NotContains(t, result, "Mac instructions.")
+}

--- a/pkg/docsrender/fetch.go
+++ b/pkg/docsrender/fetch.go
@@ -1,0 +1,130 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+)
+
+// FetchArgs configures how docs content is fetched.
+type FetchArgs struct {
+	Client          *http.Client
+	DocsBaseURL     string
+	RegistryBaseURL string
+}
+
+func (a FetchArgs) client() *http.Client {
+	if a.Client != nil {
+		return a.Client
+	}
+	return http.DefaultClient
+}
+
+func (a FetchArgs) docsBase() string {
+	if a.DocsBaseURL != "" {
+		return strings.TrimRight(a.DocsBaseURL, "/")
+	}
+	return DefaultDocsBaseURL
+}
+
+func (a FetchArgs) registryBase() string {
+	if a.RegistryBaseURL != "" {
+		return strings.TrimRight(a.RegistryBaseURL, "/")
+	}
+	return DefaultRegistryBaseURL
+}
+
+// FetchDocsPage fetches a docs page by path. Returns nil, nil for 404.
+func FetchDocsPage(ctx context.Context, args FetchArgs, path string) ([]byte, error) {
+	path = strings.Trim(path, "/")
+	url := fmt.Sprintf("%s/docs/%s/index.md", args.docsBase(), path)
+	return fetchMarkdown(ctx, args.client(), url)
+}
+
+// FetchRegistryPage fetches a registry page by path. Returns nil, nil for 404.
+func FetchRegistryPage(ctx context.Context, args FetchArgs, path string) ([]byte, error) {
+	path = strings.Trim(path, "/")
+	// Strip leading "registry/" if present since we add it in the URL.
+	path = strings.TrimPrefix(path, "registry/")
+	url := fmt.Sprintf("%s/registry/%s/index.md", args.registryBase(), path)
+	return fetchMarkdown(ctx, args.client(), url)
+}
+
+func fetchMarkdown(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", url, err)
+	}
+	req.Header.Set("User-Agent", userAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", url, err)
+	}
+	return body, nil
+}
+
+func userAgent() string {
+	return fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
+}
+
+// StripFrontmatter removes YAML frontmatter delimited by "---\n" from content.
+func StripFrontmatter(content []byte) []byte {
+	if !bytes.HasPrefix(content, []byte("---\n")) && !bytes.HasPrefix(content, []byte("---\r\n")) {
+		return content
+	}
+
+	// Skip past the opening "---\n" or "---\r\n".
+	rest := content[3:]
+	idx := bytes.Index(rest, []byte("\n"))
+	if idx < 0 {
+		return content
+	}
+	rest = rest[idx+1:]
+
+	// Find the closing "---" delimiter.
+	closeLF := bytes.Index(rest, []byte("\n---\n"))
+	closeCRLF := bytes.Index(rest, []byte("\r\n---\r\n"))
+
+	switch {
+	case closeLF >= 0 && (closeCRLF < 0 || closeLF <= closeCRLF):
+		return rest[closeLF+5:]
+	case closeCRLF >= 0:
+		return rest[closeCRLF+7:]
+	default:
+		return content
+	}
+}

--- a/pkg/docsrender/fetch_test.go
+++ b/pkg/docsrender/fetch_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchDocsPage(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/docs/iac/concepts/stacks/index.md":
+			fmt.Fprint(w, "# Stacks\n\nContent here.")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	args := FetchArgs{
+		Client:      srv.Client(),
+		DocsBaseURL: srv.URL,
+	}
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+		body, err := FetchDocsPage(t.Context(), args, "iac/concepts/stacks")
+		require.NoError(t, err)
+		assert.Equal(t, "# Stacks\n\nContent here.", string(body))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		body, err := FetchDocsPage(t.Context(), args, "nonexistent/path")
+		require.NoError(t, err)
+		assert.Nil(t, body)
+	})
+}
+
+func TestFetchRegistryPage(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/registry/packages/aws/index.md":
+			fmt.Fprint(w, "# AWS Provider")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	args := FetchArgs{
+		Client:          srv.Client(),
+		RegistryBaseURL: srv.URL,
+	}
+
+	t.Run("found", func(t *testing.T) {
+		t.Parallel()
+		body, err := FetchRegistryPage(t.Context(), args, "registry/packages/aws")
+		require.NoError(t, err)
+		assert.Equal(t, "# AWS Provider", string(body))
+	})
+
+	t.Run("path without registry prefix", func(t *testing.T) {
+		t.Parallel()
+		body, err := FetchRegistryPage(t.Context(), args, "packages/aws")
+		require.NoError(t, err)
+		assert.Equal(t, "# AWS Provider", string(body))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		body, err := FetchRegistryPage(t.Context(), args, "packages/nonexistent")
+		require.NoError(t, err)
+		assert.Nil(t, body)
+	})
+}
+
+func TestFetchHTTPError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	args := FetchArgs{
+		Client:      srv.Client(),
+		DocsBaseURL: srv.URL,
+	}
+
+	_, err := FetchDocsPage(t.Context(), args, "some/page")
+	assert.ErrorContains(t, err, "HTTP 500")
+}
+
+func TestFetchUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	args := FetchArgs{
+		Client:      srv.Client(),
+		DocsBaseURL: srv.URL,
+	}
+	_, err := FetchDocsPage(t.Context(), args, "test")
+	require.NoError(t, err)
+	assert.Contains(t, gotUA, "pulumi-cli/1")
+}
+
+func TestStripFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "with frontmatter",
+			input:    "---\ntitle: Hello\nweight: 1\n---\n# Content\n\nBody here.",
+			expected: "# Content\n\nBody here.",
+		},
+		{
+			name:     "without frontmatter",
+			input:    "# Just Content\n\nNo frontmatter.",
+			expected: "# Just Content\n\nNo frontmatter.",
+		},
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only frontmatter no close",
+			input:    "---\ntitle: Hello\n",
+			expected: "---\ntitle: Hello\n",
+		},
+		{
+			name: "frontmatter with windows line endings",
+			input: "---\r\ntitle: Hello\r\n" +
+				"---\r\n# Content",
+			expected: "# Content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, string(StripFrontmatter([]byte(tt.input))))
+		})
+	}
+}

--- a/pkg/docsrender/preferences.go
+++ b/pkg/docsrender/preferences.go
@@ -1,0 +1,85 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+const preferencesFile = "docs-preferences.json"
+
+// Preferences stores user preferences for docs rendering.
+type Preferences struct {
+	Language   string `json:"language,omitempty"`
+	OS         string `json:"os,omitempty"`
+	LastPage   string `json:"lastPage,omitempty"`
+	BrowseMode string `json:"browseMode,omitempty"`
+}
+
+// preferencesPath returns the path to the preferences file.
+func preferencesPath() (string, error) {
+	return workspace.GetPulumiPath(preferencesFile)
+}
+
+// LoadPreferences reads preferences from disk. Returns empty preferences
+// if the file is missing or malformed.
+func LoadPreferences() *Preferences {
+	path, err := preferencesPath()
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not resolve path: %v", err)
+		return &Preferences{}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logging.V(7).Infof("docs preferences: could not read %s: %v", path, err)
+		}
+		return &Preferences{}
+	}
+
+	var prefs Preferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		logging.V(7).Infof("docs preferences: could not parse %s: %v", path, err)
+		return &Preferences{}
+	}
+
+	return &prefs
+}
+
+// SavePreferences writes preferences to disk. Errors are logged at V(7)
+// and not returned; a failed save must never abort a render.
+func SavePreferences(prefs *Preferences) {
+	path, err := preferencesPath()
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not resolve path: %v", err)
+		return
+	}
+
+	data, err := json.MarshalIndent(prefs, "", "  ")
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not marshal: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		logging.V(7).Infof("docs preferences: could not write %s: %v", path, err)
+	}
+}

--- a/pkg/docsrender/preferences_test.go
+++ b/pkg/docsrender/preferences_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSaveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	prefs := &Preferences{
+		Language:   "python",
+		OS:         "macos",
+		LastPage:   "iac/concepts/stacks",
+		BrowseMode: "sections",
+	}
+	SavePreferences(prefs)
+
+	loaded := LoadPreferences()
+	assert.Equal(t, prefs, loaded)
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	prefs := LoadPreferences()
+	assert.Equal(t, &Preferences{}, prefs)
+}
+
+func TestLoadMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	err := os.WriteFile(filepath.Join(dir, preferencesFile), []byte("{not json!"), 0o600)
+	require.NoError(t, err)
+
+	prefs := LoadPreferences()
+	assert.Equal(t, &Preferences{}, prefs)
+}
+
+func TestSaveCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	SavePreferences(&Preferences{Language: "go"})
+
+	data, err := os.ReadFile(filepath.Join(dir, preferencesFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"language": "go"`)
+}

--- a/pkg/docsrender/render.go
+++ b/pkg/docsrender/render.go
@@ -1,0 +1,144 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// RenderMarkdown renders markdown content for terminal display.
+// If raw is true, the content is returned as-is.
+func RenderMarkdown(content string, raw bool) (string, error) {
+	if raw {
+		return content, nil
+	}
+
+	r, err := glamour.NewTermRenderer(glamour.WithAutoStyle(), glamour.WithWordWrap(0))
+	if err != nil {
+		return content, nil
+	}
+
+	rendered, err := r.Render(content)
+	if err != nil {
+		return content, nil
+	}
+	return rendered, nil
+}
+
+// FilterCodeBlocksByLanguage filters fenced code blocks to keep only those
+// matching lang (or "sh"). Isolated code blocks not adjacent to other code
+// blocks are always preserved. Adapts the pattern from pkg/codegen/docs.go.
+func FilterCodeBlocksByLanguage(source []byte, tree ast.Node, lang string) []byte {
+	if lang == "" {
+		return renderTree(source, tree)
+	}
+	filterCodeBlocks(source, tree, lang)
+	return renderTree(source, tree)
+}
+
+func filterCodeBlocks(source []byte, node ast.Node, lang string) {
+	var c, next ast.Node
+	for c = node.FirstChild(); c != nil; c = next {
+		filterCodeBlocks(source, c, lang)
+		next = c.NextSibling()
+
+		cb, ok := c.(*ast.FencedCodeBlock)
+		if !ok {
+			continue
+		}
+
+		cbLang := string(cb.Language(source))
+		if cbLang == "" || cbLang == lang || cbLang == "sh" || cbLang == "bash" || cbLang == "shell" {
+			continue
+		}
+
+		// Only filter if this code block is part of a group (adjacent to other code blocks).
+		if !hasAdjacentCodeBlock(c) {
+			continue
+		}
+
+		node.RemoveChild(node, c)
+	}
+}
+
+// hasAdjacentCodeBlock checks whether a node has a sibling code block nearby
+// (within one node in either direction, skipping blank paragraphs).
+func hasAdjacentCodeBlock(node ast.Node) bool {
+	if prev := node.PreviousSibling(); prev != nil {
+		if _, ok := prev.(*ast.FencedCodeBlock); ok {
+			return true
+		}
+	}
+	if next := node.NextSibling(); next != nil {
+		if _, ok := next.(*ast.FencedCodeBlock); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractLinks extracts all hyperlinks from the document, deduplicating by URL.
+func ExtractLinks(source []byte, tree ast.Node) []Link {
+	seen := map[string]bool{}
+	var links []Link
+
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		url := string(link.Destination)
+		if seen[url] {
+			return ast.WalkSkipChildren, nil
+		}
+		seen[url] = true
+
+		title := linkPlainText(source, link)
+		links = append(links, Link{URL: url, Title: title})
+		return ast.WalkSkipChildren, nil
+	})
+
+	return links
+}
+
+func linkPlainText(source []byte, link *ast.Link) string {
+	var buf bytes.Buffer
+	for c := link.FirstChild(); c != nil; c = c.NextSibling() {
+		if t, ok := c.(*ast.Text); ok {
+			buf.Write(t.Segment.Value(source))
+		}
+	}
+	return buf.String()
+}
+
+func renderTree(source []byte, tree ast.Node) []byte {
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, tree)
+	contract.AssertNoErrorf(err, "rendering markdown tree")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}

--- a/pkg/docsrender/render_test.go
+++ b/pkg/docsrender/render_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMarkdownRaw(t *testing.T) {
+	t.Parallel()
+
+	content := "# Hello\n\nSome **bold** text."
+	result, err := RenderMarkdown(content, true)
+	require.NoError(t, err)
+	assert.Equal(t, content, result)
+}
+
+func TestRenderMarkdownGlamour(t *testing.T) {
+	t.Parallel()
+
+	content := "# Hello\n\nSome **bold** text."
+	result, err := RenderMarkdown(content, false)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.Contains(t, result, "Hello")
+}
+
+func TestFilterCodeBlocksByLanguageMultiLang(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text.
+
+` + "```typescript" + `
+console.log('hello');
+` + "```" + `
+
+` + "```python" + `
+print('hello')
+` + "```" + `
+
+` + "```go" + `
+fmt.Println("hello")
+` + "```" + `
+
+More text.
+`)
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "print('hello')")
+	assert.NotContains(t, result, "console.log")
+	assert.NotContains(t, result, "fmt.Println")
+	assert.Contains(t, result, "Some text.")
+	assert.Contains(t, result, "More text.")
+}
+
+func TestFilterCodeBlocksPreservesShell(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(
+		"```python\nprint('hi')\n```\n\n" +
+			"```sh\ncurl example.com\n```\n\n" +
+			"```typescript\nconsole.log('hi');\n```\n")
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "print('hi')")
+	assert.Contains(t, result, "curl example.com")
+	assert.NotContains(t, result, "console.log")
+}
+
+func TestFilterCodeBlocksPreservesIsolated(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text.
+
+` + "```yaml" + `
+key: value
+` + "```" + `
+
+More text.
+`)
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "key: value")
+}
+
+func TestFilterCodeBlocksNoLanguage(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("```\nplain code\n```\n")
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "plain code")
+}
+
+func TestFilterCodeBlocksEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("")
+	tree := ParseMarkdown(source)
+	result := FilterCodeBlocksByLanguage(source, tree, "python")
+
+	assert.Empty(t, result)
+}
+
+func TestFilterCodeBlocksNoLang(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("# Title\n\nSome text.\n")
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, ""))
+
+	assert.Contains(t, result, "# Title")
+	assert.Contains(t, result, "Some text.")
+}
+
+func TestExtractLinks(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Check [Stacks](/docs/iac/concepts/stacks) and
+[AWS Provider](/registry/packages/aws) for details.
+Also see [Stacks](/docs/iac/concepts/stacks) again.
+And [Google](https://google.com).
+`)
+	tree := ParseMarkdown(source)
+	links := ExtractLinks(source, tree)
+
+	assert.Equal(t, []Link{
+		{URL: "/docs/iac/concepts/stacks", Title: "Stacks"},
+		{URL: "/registry/packages/aws", Title: "AWS Provider"},
+		{URL: "https://google.com", Title: "Google"},
+	}, links)
+}
+
+func TestExtractLinksNoLinks(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("Just plain text with no links.\n")
+	tree := ParseMarkdown(source)
+	links := ExtractLinks(source, tree)
+
+	assert.Empty(t, links)
+}

--- a/pkg/docsrender/sections.go
+++ b/pkg/docsrender/sections.go
@@ -1,0 +1,148 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// ExtractHeadings returns all headings found in the document in order.
+func ExtractHeadings(source []byte, tree ast.Node) []Heading {
+	var headings []Heading
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := node.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		title := headingPlainText(source, h)
+		headings = append(headings, Heading{
+			Slug:  slugify(title),
+			Title: title,
+			Level: h.Level,
+		})
+		return ast.WalkSkipChildren, nil
+	})
+	return headings
+}
+
+// ExtractSection returns the markdown content for the section identified by slug.
+// A section starts at its heading and extends to the next heading of equal or higher
+// level (lower number), or to the end of the document. Returns nil if not found.
+// Slug matching is case-insensitive.
+func ExtractSection(source []byte, tree ast.Node, slug string) []byte {
+	slug = strings.ToLower(slug)
+
+	var startNode ast.Node
+	var startLevel int
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		h, ok := c.(*ast.Heading)
+		if !ok {
+			continue
+		}
+		title := headingPlainText(source, h)
+		if strings.EqualFold(slugify(title), slug) {
+			startNode = c
+			startLevel = h.Level
+			break
+		}
+	}
+	if startNode == nil {
+		return nil
+	}
+
+	// Collect nodes from the heading until the next same-or-higher-level heading.
+	var nodes []ast.Node
+	for c := startNode; c != nil; c = c.NextSibling() {
+		if c != startNode {
+			if h, ok := c.(*ast.Heading); ok && h.Level <= startLevel {
+				break
+			}
+		}
+		nodes = append(nodes, c)
+	}
+
+	return renderNodes(source, nodes)
+}
+
+// ExtractIntro returns all content before the first heading, or nil if the
+// document starts with a heading.
+func ExtractIntro(source []byte, tree ast.Node) []byte {
+	var nodes []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		if _, ok := c.(*ast.Heading); ok {
+			break
+		}
+		nodes = append(nodes, c)
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+	return renderNodes(source, nodes)
+}
+
+// headingPlainText extracts plain text from a heading, stripping inline formatting.
+func headingPlainText(source []byte, h *ast.Heading) string {
+	var buf bytes.Buffer
+	_ = ast.Walk(h, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := node.(type) {
+		case *ast.Text:
+			buf.Write(n.Segment.Value(source))
+			if n.SoftLineBreak() {
+				buf.WriteByte(' ')
+			}
+		case *ast.CodeSpan:
+			for gc := n.FirstChild(); gc != nil; gc = gc.NextSibling() {
+				if t, ok := gc.(*ast.Text); ok {
+					buf.Write(t.Segment.Value(source))
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	return buf.String()
+}
+
+// renderNodes renders a slice of sibling AST nodes back to markdown.
+func renderNodes(source []byte, nodes []ast.Node) []byte {
+	doc := ast.NewDocument()
+	for _, n := range nodes {
+		// Detach from original parent before appending.
+		if n.Parent() != nil {
+			n.Parent().RemoveChild(n.Parent(), n)
+		}
+		doc.AppendChild(doc, n)
+	}
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, doc)
+	contract.AssertNoErrorf(err, "rendering nodes to markdown")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}

--- a/pkg/docsrender/sections_test.go
+++ b/pkg/docsrender/sections_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractHeadings(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`# Title
+
+Some intro text.
+
+## Getting Started
+
+Start here.
+
+## Configuration
+
+### Basic Config
+
+Set things up.
+
+### Advanced Config
+
+More options.
+
+## Conclusion
+
+Done.
+`)
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Equal(t, []Heading{
+		{Slug: "title", Title: "Title", Level: 1},
+		{Slug: "getting-started", Title: "Getting Started", Level: 2},
+		{Slug: "configuration", Title: "Configuration", Level: 2},
+		{Slug: "basic-config", Title: "Basic Config", Level: 3},
+		{Slug: "advanced-config", Title: "Advanced Config", Level: 3},
+		{Slug: "conclusion", Title: "Conclusion", Level: 2},
+	}, headings)
+}
+
+func TestExtractHeadingsWithInlineFormatting(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## The `foo` method\n\n## **Bold** heading\n")
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Equal(t, []Heading{
+		{Slug: "the-foo-method", Title: "The foo method", Level: 2},
+		{Slug: "bold-heading", Title: "Bold heading", Level: 2},
+	}, headings)
+}
+
+func TestExtractHeadingsEmpty(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("Just a paragraph with no headings.\n")
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Empty(t, headings)
+}
+
+func TestExtractSectionMiddle(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## First
+
+Content of first.
+
+## Second
+
+Content of second.
+
+## Third
+
+Content of third.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "second")
+
+	assert.Equal(t, "## Second\n\nContent of second.", string(section))
+}
+
+func TestExtractSectionLast(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## First
+
+Content.
+
+## Last
+
+Final content here.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "last")
+
+	assert.Equal(t, "## Last\n\nFinal content here.", string(section))
+}
+
+func TestExtractSectionWithNestedSubheadings(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## Overview
+
+Intro.
+
+### Sub One
+
+Sub content.
+
+### Sub Two
+
+More sub content.
+
+## Next Section
+
+Other stuff.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "overview")
+
+	assert.Contains(t, string(section), "## Overview")
+	assert.Contains(t, string(section), "### Sub One")
+	assert.Contains(t, string(section), "### Sub Two")
+	assert.NotContains(t, string(section), "## Next Section")
+}
+
+func TestExtractSectionNotFound(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Existing\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "nonexistent")
+
+	assert.Nil(t, section)
+}
+
+func TestExtractSectionCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Getting Started\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "GETTING-STARTED")
+
+	require.NotNil(t, section)
+	assert.Contains(t, string(section), "Getting Started")
+}
+
+func TestExtractIntro(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some introductory text.
+
+More intro.
+
+## First Section
+
+Content.
+`)
+	tree := ParseMarkdown(source)
+	intro := ExtractIntro(source, tree)
+
+	assert.Equal(t, "Some introductory text.\n\nMore intro.", string(intro))
+}
+
+func TestExtractIntroNoIntro(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Starts with heading\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	intro := ExtractIntro(source, tree)
+
+	assert.Nil(t, intro)
+}

--- a/pkg/docsrender/types.go
+++ b/pkg/docsrender/types.go
@@ -1,0 +1,84 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/pgavlin/goldmark"
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/text"
+)
+
+const (
+	DefaultDocsBaseURL     = "https://www.pulumi.com"
+	DefaultRegistryBaseURL = "https://www.pulumi.com"
+)
+
+// Heading represents an extracted heading from a markdown document.
+type Heading struct {
+	Slug  string
+	Title string
+	Level int
+}
+
+// Link represents an extracted hyperlink from a markdown document.
+type Link struct {
+	URL   string
+	Title string
+}
+
+// ParseMarkdown parses markdown source into a goldmark AST.
+func ParseMarkdown(source []byte) ast.Node {
+	p := goldmark.DefaultParser()
+	return p.Parse(text.NewReader(source))
+}
+
+// slugify converts heading text to a URL-safe slug.
+func slugify(title string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(title) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			prevHyphen = false
+		case unicode.IsSpace(r) || r == '-' || r == '_':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// IsRegistryPath reports whether the path refers to registry content.
+func IsRegistryPath(path string) bool {
+	p := strings.TrimPrefix(path, "/")
+	return strings.HasPrefix(p, "registry/") || p == "registry"
+}
+
+// IsAPIDocsPath reports whether the path refers to registry API documentation.
+func IsAPIDocsPath(path string) bool {
+	p := strings.TrimPrefix(path, "/")
+	parts := strings.Split(p, "/")
+	// registry/packages/{pkg}/api-docs/...
+	if len(parts) >= 5 && parts[0] == "registry" && parts[1] == "packages" && parts[3] == "api-docs" {
+		return true
+	}
+	return false
+}

--- a/pkg/docsrender/types_test.go
+++ b/pkg/docsrender/types_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello World", "hello-world"},
+		{"Getting Started", "getting-started"},
+		{"foo--bar", "foo-bar"},
+		{"  leading spaces  ", "leading-spaces"},
+		{"Special!@#Characters$%^Here", "specialcharactershere"},
+		{"already-slug", "already-slug"},
+		{"MixedCase123", "mixedcase123"},
+		{"", ""},
+		{"with_underscores_here", "with-underscores-here"},
+		{"multiple   spaces", "multiple-spaces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, slugify(tt.input))
+		})
+	}
+}
+
+func TestIsRegistryPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsRegistryPath("registry/packages/aws"))
+	assert.True(t, IsRegistryPath("/registry/packages/aws"))
+	assert.True(t, IsRegistryPath("registry"))
+	assert.False(t, IsRegistryPath("docs/iac/concepts"))
+	assert.False(t, IsRegistryPath(""))
+	assert.False(t, IsRegistryPath("registryfoo"))
+}
+
+func TestIsAPIDocsPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsAPIDocsPath("registry/packages/aws/api-docs/s3"))
+	assert.True(t, IsAPIDocsPath("/registry/packages/aws/api-docs/s3/bucket"))
+	assert.False(t, IsAPIDocsPath("registry/packages/aws"))
+	assert.False(t, IsAPIDocsPath("registry/packages/aws/install"))
+	assert.False(t, IsAPIDocsPath("docs/iac/concepts"))
+	assert.False(t, IsAPIDocsPath(""))
+}


### PR DESCRIPTION
> [!NOTE]
> **PR 1 of 5** targeting the `CamSoper/docs-cli` feature branch (not master). This builds the foundational library for a new `pulumi docs` CLI command. **All subsequent PRs are blocked on this one** — they build directly on the types and functions introduced here. The PR chain:
>
> 1. **`pkg/docsrender/` core library** ← this PR
> 2. `pkg/docsrender/` bundle system (registry API doc caching)
> 3. `pkg/cmd/pulumi/docs/` CLI commands (cobra wiring)
> 4. `pkg/cmd/pulumi/docs/` interactive browse mode
> 5. Integration PR into `master` (includes changelog entry)
>
> My intention is for these smaller PRs to be reviewed as they merge into the feature branch, so the feature branch can be merged in one PR. This will enable shorter, more iterative review cycles and avoid the monolithic approach that my previous hackathon-derived PRs employed.

## Summary

- Adds `pkg/docsrender/`, a new library package for the `pulumi docs` CLI feature
- Goldmark AST-based markdown parsing for chooser resolution, heading/section extraction, and code block filtering
- Glamour-based terminal rendering with raw passthrough option
- HTTP fetching for docs and registry pages with frontmatter stripping
- User preference persistence at `~/.pulumi/docs-preferences.json`
- Comprehensive test coverage for all exported functions

## Design decisions

- **Chooser resolution uses a post-parse AST walker** — HTML comments (`<!-- chooser: language -->`) are parsed by goldmark as `HTMLBlock` nodes. We walk the AST to find and resolve them rather than writing a custom block parser.
- **Uses `pgavlin/goldmark` fork** (already in `pkg/go.mod`) which has `renderer/markdown` that upstream `yuin/goldmark` does not.
- **`FetchArgs` accepts `*http.Client`** for testability via `httptest.NewServer`.
- **Preferences are best-effort** — missing or malformed files return empty prefs with V(7) logging on failure.
- **No cobra dependency** — this is a pure library package. CLI wiring comes in PR 3.

## Exported API surface (context for subsequent PRs)

| Function | File | Used by |
|----------|------|---------|
| `ParseMarkdown` | types.go | All AST-based operations |
| `IsRegistryPath`, `IsAPIDocsPath` | types.go | Content routing |
| `FetchDocsPage`, `FetchRegistryPage` | fetch.go | CLI commands, browse mode |
| `StripFrontmatter` | fetch.go | Content pipeline |
| `ExtractHeadings`, `ExtractSection`, `ExtractIntro` | sections.go | TOC, section view, browse |
| `RenderMarkdown` | render.go | All display paths |
| `FilterCodeBlocksByLanguage` | render.go | Language filtering |
| `ExtractLinks` | render.go | Browse mode navigation |
| `ResolveChoosers` | chooser.go | Chooser resolution |
| `LoadPreferences`, `SavePreferences` | preferences.go | Preference persistence |

## Test plan

- [x] All unit tests pass: `go test -count=1 ./docsrender/...`
- [x] `go vet ./docsrender/...` clean
- [x] `golangci-lint run ./docsrender/...` — 0 issues
- [x] `go mod tidy` — no changes needed