### PR TITLE
Fix flake in TestSignalCancellationForceKill

### DIFF
--- a/tests/integration/signal_cancellation/python/Pulumi.yaml
+++ b/tests/integration/signal_cancellation/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: signal-cancellation-python
 description: Test that Python programs receive SIGINT on cancellation
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/signal_cancellation/python_ignore/Pulumi.yaml
+++ b/tests/integration/signal_cancellation/python_ignore/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: signal-cancellation-python
 description: Test that Python programs receive SIGINT on cancellation
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv


### PR DESCRIPTION
These tests were using the global venv, which can cause install races. Use `uv` instead so we get an isolated venv, and also make it a little faster.

Fixes https://github.com/pulumi/pulumi/issues/22476

