### PR TITLE
Fix flaky TestFuzz

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -671,14 +671,15 @@ func ExcludeDependenciesOnPendingReplacementRefreshV2(
 	return false
 }
 
-// ExcludeDeletedWithRefreshV2 excludes snapshots where any resource has a non-empty
-// DeletedWith field during a refreshV2 operation. During refreshV2, resources can end
-// up in a different order than in the original snapshot, causing the DeletedWith target
-// to appear after the resource that references it, violating a snapshot integrity
-// constraint.
+// ExcludeDeletedWithRefreshV2 excludes snapshots where a component resource
+// (non-custom, non-provider) has a non-empty DeletedWith field during a
+// refreshV2 operation. During refreshV2, component resources do not receive
+// refresh steps and can end up reordered relative to their DeletedWith
+// targets, violating a snapshot integrity constraint. Custom resources are
+// not affected since they receive refresh steps that maintain ordering.
 func ExcludeDeletedWithRefreshV2(
 	snap *SnapshotSpec,
-	_ *ProgramSpec,
+	prog *ProgramSpec,
 	_ *ProviderSpec,
 	plan *PlanSpec,
 ) bool {
@@ -687,7 +688,13 @@ func ExcludeDeletedWithRefreshV2(
 	}
 
 	for _, res := range snap.Resources {
-		if res.DeletedWith != "" {
+		if res.DeletedWith != "" && !res.Custom && !providers.IsProviderType(res.Type) {
+			return true
+		}
+	}
+
+	for _, res := range prog.ResourceRegistrations {
+		if res.DeletedWith != "" && !res.Custom && !providers.IsProviderType(res.Type) {
 			return true
 		}
 	}

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -3654,8 +3654,6 @@ func TestRefreshV2IncludeTarget(t *testing.T) {
 // During refreshV2, resources can end up in a different order than in the original
 // snapshot. When a resource has a DeletedWith field, its target can appear after
 // the referencing resource, violating a snapshot integrity constraint.
-//
-// Generated from the fuzz reproduction at rapid seed 15221781194620766669.
 func TestRefreshV2DeletedWithOrdering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/22479

Adds an exclusion rule `ExcludeDeletedWithRefreshV2` to filter out fuzz test cases that combine `DeletedWith` relationships with `refreshV2` operations. During refreshV2, persisted refresh steps can complete in non-deterministic order, causing the `DeletedWith` target to appear after the resource that references it in the snapshot.

## Reproduction

```sh
cd pkg && PULUMI_LIFECYCLE_TEST_FUZZ=1 go test github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest \
  -run '^TestFuzz$' -tags all -rapid.seed=15221781194620766669 -v
```