### PR TITLE
Fix inherited input properties missing from Python component schema

### DIFF
--- a/changelog/pending/20260407--sdk-python--fix-inherited-input-properties-in-component-schema.yaml
+++ b/changelog/pending/20260407--sdk-python--fix-inherited-input-properties-in-component-schema.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix inherited input properties missing from component schema when args class inherits from a base class

--- a/sdk/python/lib/pulumi/provider/experimental/analyzer.py
+++ b/sdk/python/lib/pulumi/provider/experimental/analyzer.py
@@ -381,7 +381,14 @@ class Analyzer:
                 }
             )
         """
-        ann = inspect.get_annotations(typ)
+        # Walk the MRO to include annotations from base classes, filtering
+        # out private attributes and Pulumi SDK base classes.
+        ann: dict[str, type] = {}
+        for cls in reversed(typ.__mro__):
+            if cls is object or cls is Resource or cls is ComponentResource:
+                continue
+            ann.update(inspect.get_annotations(cls))
+        ann = {k: v for k, v in ann.items() if not k.startswith("_")}
         mapping: dict[str, str] = {camel_case(k): k for k in ann.keys()}
         return {
             camel_case(k): self.analyze_property(

--- a/sdk/python/lib/test/provider/experimental/test_analyzer.py
+++ b/sdk/python/lib/test/provider/experimental/test_analyzer.py
@@ -124,6 +124,40 @@ def test_analyze_component_empty():
     )
 
 
+def test_analyze_component_inherited_inputs():
+    class BaseArgs(TypedDict):
+        base_prop: str
+
+    class DerivedArgs(BaseArgs):
+        child_prop: str
+
+    class MyComponent(pulumi.ComponentResource):
+        out_result: pulumi.Output[str]
+
+        def __init__(self, args: DerivedArgs): ...
+
+    analyzer = Analyzer("inherited")
+    component = analyzer.analyze_component(MyComponent)
+    assert component == ComponentDefinition(
+        name="MyComponent",
+        module="test_analyzer",
+        inputs={
+            "baseProp": PropertyDefinition(type=PropertyType.STRING, plain=True),
+            "childProp": PropertyDefinition(type=PropertyType.STRING, plain=True),
+        },
+        inputs_mapping={
+            "baseProp": "base_prop",
+            "childProp": "child_prop",
+        },
+        outputs={
+            "outResult": PropertyDefinition(type=PropertyType.STRING),
+        },
+        outputs_mapping={
+            "outResult": "out_result",
+        },
+    )
+
+
 def test_analyze_component_plain_types():
     class ComplexTypeInput(TypedDict):
         a_input_list_str: Optional[pulumi.Input[list[str]]]


### PR DESCRIPTION
## Summary

- When an args class inherits from a base class, only annotations on the immediate class were included in the generated schema - inherited properties were missing
- Root cause: `inspect.get_annotations(typ)` only returns annotations declared directly on a class, not inherited ones
- Changed `analyze_type` to walk the MRO and collect annotations from all base classes, filtering out private attributes (`_` prefix) and Pulumi SDK base types (`Resource`, `ComponentResource`)
- Related fixes: pulumi/pulumi-dotnet#930 (C#), pulumi/pulumi#22446 (TypeScript)

**Note:** Outputs have the same limitation with class inheritance but are left as a separate fix since `ComponentResource` base class annotations would need filtering.

The same bug also exists in the Java SDK (`pulumi/pulumi-java`).

## Test plan

- [x] Added `test_analyze_component_inherited_inputs` test with `BaseArgs`/`DerivedArgs` using `TypedDict` inheritance
- [x] All 35 analyzer tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)