### PR TITLE
implement log rotation functionality

### DIFF
--- a/pkg/backend/logging/rotation.go
+++ b/pkg/backend/logging/rotation.go
@@ -1,0 +1,126 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// timestampRe matches the timestamp embedded in log filenames (e.g. "stack-20260401T030000.log").
+var timestampRe = regexp.MustCompile(`(\d{8}T\d{6})`)
+
+const (
+	defaultMaxAgeDays = 7
+	defaultMaxTotalMB = 500
+)
+
+// RotateLogs deletes old log files from the given directory.
+// Logs are deleted if they are older than maxAge, or if the total
+// size exceeds maxTotal (oldest first). Defaults are 7 days and 500 MB,
+// overridable via PULUMI_LOG_ROTATION_MAX_AGE_DAYS and
+// PULUMI_LOG_ROTATION_MAX_TOTAL_MB.
+func RotateLogs(logsDir string) {
+	rotateLogs(logsDir, time.Now())
+}
+
+func rotateLogs(logsDir string, now time.Time) {
+	maxAgeDays := defaultMaxAgeDays
+	if v := env.LogRotationMaxAgeDays.Value(); v > 0 {
+		maxAgeDays = v
+	}
+	maxTotalBytes := int64(defaultMaxTotalMB) * 1024 * 1024
+	if v := env.LogRotationMaxTotalMB.Value(); v > 0 {
+		maxTotalBytes = int64(v) * 1024 * 1024
+	}
+
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		logging.V(5).Infof("log rotation: could not read %s: %v", logsDir, err)
+		return
+	}
+
+	type logFile struct {
+		path      string
+		size      int64
+		timestamp time.Time
+	}
+
+	var files []logFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		m := timestampRe.FindString(e.Name())
+		if m == "" {
+			continue
+		}
+		ts, err := time.Parse("20060102T150405", m)
+		if err != nil {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, logFile{
+			path:      filepath.Join(logsDir, e.Name()),
+			size:      info.Size(),
+			timestamp: ts,
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].timestamp.Before(files[j].timestamp)
+	})
+
+	cutoff := now.Add(-time.Duration(maxAgeDays) * 24 * time.Hour)
+
+	var remaining []logFile
+	for _, f := range files {
+		if f.timestamp.Before(cutoff) {
+			logging.V(7).Infof("log rotation: removing expired %s", f.path)
+			if err := os.Remove(f.path); err != nil {
+				logging.V(5).Infof("log rotation: could not remove %s: %v", f.path, err)
+				remaining = append(remaining, f)
+			}
+		} else {
+			remaining = append(remaining, f)
+		}
+	}
+
+	// Second pass: if total size exceeds limit, delete oldest until under.
+	var totalSize int64
+	for _, f := range remaining {
+		totalSize += f.size
+	}
+
+	for i := 0; i < len(remaining) && totalSize > maxTotalBytes; i++ {
+		f := remaining[i]
+		logging.V(7).Infof("log rotation: removing %s (total %d > %d)", f.path, totalSize, maxTotalBytes)
+		if err := os.Remove(f.path); err != nil {
+			logging.V(5).Infof("log rotation: could not remove %s: %v", f.path, err)
+		} else {
+			totalSize -= f.size
+		}
+	}
+}

--- a/pkg/backend/logging/rotation_test.go
+++ b/pkg/backend/logging/rotation_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRotateByAge(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create files with different ages.
+	old := filepath.Join(dir, "old-20260101T000000.log")
+	recent := filepath.Join(dir, "recent-20260401T000000.log")
+	notALog := filepath.Join(dir, "keep.txt")
+
+	require.NoError(t, os.WriteFile(old, []byte("old"), 0o600))
+	require.NoError(t, os.WriteFile(recent, []byte("recent"), 0o600))
+	require.NoError(t, os.WriteFile(notALog, []byte("keep"), 0o600))
+
+	now := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	rotateLogs(dir, now)
+
+	// Old .log file should be deleted, recent .log and .txt should remain.
+	_, err := os.Stat(old)
+	assert.True(t, os.IsNotExist(err), "old log should be deleted")
+
+	_, err = os.Stat(recent)
+	require.NoError(t, err, "recent log should remain")
+
+	_, err = os.Stat(notALog)
+	require.NoError(t, err, "non-log file should remain")
+}
+
+func TestRotateBySize(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create files that together exceed defaultMaxTotalMB.
+	// Use a low max by setting the env var.
+	t.Setenv("PULUMI_LOG_ROTATION_MAX_TOTAL_MB", "1")
+
+	// Create 3 files, ~400KB each = 1.2MB total, exceeding 1MB limit.
+	data := make([]byte, 400*1024)
+	f1 := filepath.Join(dir, "c-20260401T010000.log")
+	f2 := filepath.Join(dir, "b-20260401T020000.log")
+	f3 := filepath.Join(dir, "a-20260401T030000.log")
+
+	require.NoError(t, os.WriteFile(f1, data, 0o600))
+	require.NoError(t, os.WriteFile(f2, data, 0o600))
+	require.NoError(t, os.WriteFile(f3, data, 0o600))
+
+	now := time.Date(2026, 4, 7, 0, 0, 0, 0, time.UTC)
+	rotateLogs(dir, now)
+
+	// Total is 1.2MB > 1MB limit. Delete oldest (f1) → 800KB, under limit.
+	// f1 should be deleted; f2 and f3 should remain.
+	_, err := os.Stat(f1)
+	assert.True(t, os.IsNotExist(err), "oldest file should be deleted")
+
+	_, err = os.Stat(f2)
+	require.NoError(t, err, "second file should remain")
+
+	_, err = os.Stat(f3)
+	require.NoError(t, err, "newest file should remain")
+}

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -245,6 +245,12 @@ var (
 var DisableJournaling = env.Bool("DISABLE_JOURNALING",
 	"Disable journaling of engine operations to the backend")
 
+var LogRotationMaxAgeDays = env.Int("LOG_ROTATION_MAX_AGE_DAYS",
+	"Maximum age in days for automatic log files before rotation deletes them (default 7)")
+
+var LogRotationMaxTotalMB = env.Int("LOG_ROTATION_MAX_TOTAL_MB",
+	"Maximum total size in MB for automatic log files before rotation deletes oldest (default 500)")
+
 var JournalingBatchSize = env.Int("JOURNALING_BATCH_SIZE", "Maximum batch size for journal entries")
 
 var JournalingBatchPeriod = env.Int("JOURNALING_BATCH_PERIOD",


### PR DESCRIPTION
Implement log rotation functionality, that allows us to keep the log directory under a certain amount of space (by default 500MB), and only logs newer than 7 days.  This isn't used anywhere yet, the functionality will be used in a subsequent PR.

Co-authored-by: Claude

Fixes https://github.com/pulumi/pulumi/issues/22415