### PR TITLE
fix(cli): clarify --cloud-url flag description to specify API URL

### DIFF
--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -243,7 +243,7 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Comman
 	})
 
 	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "",
-		"The URL of the Pulumi Cloud API to log in with (e.g., 'https://api.pulumi.com' )")
+		"The URL of the Pulumi Cloud API to log in with (e.g., 'https://api.pulumi.com')")
 	cmd.PersistentFlags().StringVar(&defaultOrg, "default-org", "", "A default org to associate with the login. "+
 		"Please note, currently, only the managed and self-hosted backends support organizations")
 	cmd.PersistentFlags().BoolVarP(&localMode, "local", "l", false, "Use Pulumi in local-only mode")


### PR DESCRIPTION
## Summary
Saw this issue and wanted to give a bit of help https://github.com/pulumi/pulumi/issues/22295 since it is a simple cli doc change

The `--cloud-url` flag on `pulumi login` had a vague description that led users to pass the Pulumi Cloud UI URL (`https://app.pulumi.com`) instead of the API URL (`https://api.pulumi.com`).

This change updates the flag description to make it explicit that the expected value is the API URL.

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ X ] `make lint` — clean
- [ X ] `make test_fast` — pass until protoc install (it's not installed, I don't think we need to test protoc in the python sdk/python pcl here, aight?)
- [ X ] `make tidy_fix` — clean

## Changelog
- Updated `--cloud-url` flag description in `pulumi login` to clarify it expects the Pulumi Cloud API URL, with an example

<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? --> There was no label no-changelog-required, so yes, i did run it and created a changelog. Is it really necessary in this case?

- [ X ] Changelog entry added. 

## Risk
Changed the description of the command, only


____

I'm picking up some simple Issues as this one to get acquainted with the src, hope it helps somehow

Issue: #22295 