### PR TITLE
[auth] prefer keyring for access token storage

### DIFF
--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -113,6 +113,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	cloud.google.com/go v0.112.1 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.1.6 // indirect
@@ -169,6 +170,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -258,6 +260,7 @@ require (
 	github.com/yuin/goldmark v1.7.13 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.55.0 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -215,6 +217,8 @@ github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -680,6 +684,8 @@ github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18W
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/texttheater/golang-levenshtein v1.0.1
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/crypto v0.48.0
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.51.0
@@ -66,6 +67,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
@@ -86,6 +88,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/git-pkgs/packageurl-go v0.3.1 // indirect
@@ -95,6 +98,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -60,6 +62,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -103,6 +107,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -117,6 +123,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
@@ -266,6 +274,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -16,19 +16,21 @@ package workspace
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/rogpeppe/go-internal/lockedfile"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/rogpeppe/go-internal/lockedfile"
+	goKeyring "github.com/zalando/go-keyring"
 )
 
 // PulumiCredentialsPathEnvVar is a path to the folder where credentials are stored.
@@ -37,6 +39,8 @@ import (
 //
 //nolint:gosec
 const PulumiCredentialsPathEnvVar = "PULUMI_CREDENTIALS_PATH"
+
+const pulumiCredentialsKeyringService = "pulumi"
 
 // GetAccount returns an account underneath a given key.
 //
@@ -78,6 +82,10 @@ func DeleteAccount(key string) error {
 }
 
 func DeleteAllAccounts() error {
+	if err := deleteAllKeyringTokens(); err != nil {
+		return err
+	}
+
 	credsFile, err := getCredsFilePath()
 	if err != nil {
 		return err
@@ -213,6 +221,69 @@ func getCredsFilePath() (string, error) {
 
 // GetStoredCredentials returns any credentials stored on the local machine.
 func GetStoredCredentials() (Credentials, error) {
+	rawCreds, err := readCredentialsFile()
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	creds, migrated, err := hydrateCredentials(rawCreds)
+	if err != nil {
+		return Credentials{}, err
+	}
+
+	if migrated {
+		if err := writeCredentialsFile(credentialsMetadata(creds)); err != nil {
+			return Credentials{}, err
+		}
+	}
+
+	secrets := slice.Prealloc[string](len(creds.AccessTokens))
+	for _, v := range creds.AccessTokens {
+		secrets = append(secrets, v)
+	}
+
+	logging.AddGlobalFilter(logging.CreateFilter(secrets, "[credential]"))
+
+	return creds, nil
+}
+
+// StoreCredentials updates the stored credentials on the machine, replacing the existing set.  If the credentials
+// are empty, the auth file will be deleted rather than just serializing an empty map.
+func StoreCredentials(creds Credentials) error {
+	existingCreds, err := readCredentialsFile()
+	if err != nil {
+		return err
+	}
+
+	if !hasCredentialMetadata(creds) {
+		if err := deleteAllKeyringTokens(); err != nil {
+			return err
+		}
+		return deleteCredentialsFile()
+	}
+
+	tokens := credentialsTokens(creds)
+	for key, token := range tokens {
+		if err := setKeyringToken(key, token); err != nil {
+			// Fall back to the legacy plaintext file when a secure store is unavailable.
+			return writeCredentialsFile(creds)
+		}
+	}
+
+	existingKeys := credentialKeys(existingCreds)
+	for _, key := range existingKeys {
+		if _, ok := tokens[key]; ok {
+			continue
+		}
+		if err := deleteKeyringToken(key); err != nil {
+			return err
+		}
+	}
+
+	return writeCredentialsFile(credentialsMetadata(creds))
+}
+
+func readCredentialsFile() (Credentials, error) {
 	credsFile, err := getCredsFilePath()
 	if err != nil {
 		return Credentials{}, err
@@ -240,30 +311,17 @@ func GetStoredCredentials() (Credentials, error) {
 			"or delete invalid credentials file: '%s': %w", credsFile, err)
 	}
 
-	secrets := slice.Prealloc[string](len(creds.AccessTokens))
-	for _, v := range creds.AccessTokens {
-		secrets = append(secrets, v)
-	}
-
-	logging.AddGlobalFilter(logging.CreateFilter(secrets, "[credential]"))
-
 	return creds, nil
 }
 
-// StoreCredentials updates the stored credentials on the machine, replacing the existing set.  If the credentials
-// are empty, the auth file will be deleted rather than just serializing an empty map.
-func StoreCredentials(creds Credentials) error {
+func writeCredentialsFile(creds Credentials) error {
 	credsFile, err := getCredsFilePath()
 	if err != nil {
 		return err
 	}
 
-	if len(creds.AccessTokens) == 0 {
-		err = os.Remove(credsFile)
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		return nil
+	if !hasCredentialMetadata(creds) {
+		return deleteCredentialsFile()
 	}
 
 	raw, err := json.MarshalIndent(creds, "", "    ")
@@ -272,6 +330,172 @@ func StoreCredentials(creds Credentials) error {
 	}
 
 	return lockedfile.Write(credsFile, bytes.NewReader(raw), 0o600)
+}
+
+func deleteCredentialsFile() error {
+	credsFile, err := getCredsFilePath()
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(credsFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func hydrateCredentials(rawCreds Credentials) (Credentials, bool, error) {
+	creds := rawCreds
+	if creds.AccessTokens == nil {
+		creds.AccessTokens = map[string]string{}
+	}
+
+	plaintextTokens := credentialsTokens(rawCreds)
+	sawLegacyPlaintext := len(plaintextTokens) > 0
+	allLegacyTokensMigrated := true
+
+	for _, key := range credentialKeys(rawCreds) {
+		token, hasPlaintext := plaintextTokens[key]
+		if hasPlaintext {
+			if err := setKeyringToken(key, token); err != nil {
+				allLegacyTokensMigrated = false
+			}
+		}
+
+		if !hasPlaintext {
+			storedToken, err := getKeyringToken(key)
+			if err == nil {
+				token = storedToken
+			} else if !errors.Is(err, goKeyring.ErrNotFound) {
+				return Credentials{}, false, err
+			}
+		}
+
+		if token == "" {
+			delete(creds.AccessTokens, key)
+			if account, ok := creds.Accounts[key]; ok {
+				account.AccessToken = ""
+				creds.Accounts[key] = account
+			}
+			continue
+		}
+
+		creds.AccessTokens[key] = token
+		if account, ok := creds.Accounts[key]; ok {
+			account.AccessToken = token
+			creds.Accounts[key] = account
+		}
+	}
+
+	return creds, sawLegacyPlaintext && allLegacyTokensMigrated, nil
+}
+
+func credentialsTokens(creds Credentials) map[string]string {
+	tokens := map[string]string{}
+	for key, token := range creds.AccessTokens {
+		if token != "" {
+			tokens[key] = token
+		}
+	}
+	for key, account := range creds.Accounts {
+		if account.AccessToken != "" {
+			tokens[key] = account.AccessToken
+		}
+	}
+	return tokens
+}
+
+func credentialKeys(creds Credentials) []string {
+	keys := map[string]struct{}{}
+	for key := range creds.AccessTokens {
+		keys[key] = struct{}{}
+	}
+	for key := range creds.Accounts {
+		keys[key] = struct{}{}
+	}
+
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func credentialsMetadata(creds Credentials) Credentials {
+	metadata := Credentials{
+		Current:      creds.Current,
+		AccessTokens: map[string]string{},
+		Accounts:     map[string]Account{},
+	}
+
+	for key := range credentialsTokens(creds) {
+		metadata.AccessTokens[key] = ""
+	}
+	if len(metadata.AccessTokens) == 0 {
+		metadata.AccessTokens = nil
+	}
+
+	for key, account := range creds.Accounts {
+		account.AccessToken = ""
+		metadata.Accounts[key] = account
+	}
+	if len(metadata.Accounts) == 0 {
+		metadata.Accounts = nil
+	}
+
+	return metadata
+}
+
+func hasCredentialMetadata(creds Credentials) bool {
+	return creds.Current != "" || len(creds.Accounts) > 0 || len(creds.AccessTokens) > 0
+}
+
+func keyringUser(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return fmt.Sprintf("backend-%x", sum)
+}
+
+func getKeyringToken(key string) (string, error) {
+	token, err := goKeyring.Get(pulumiCredentialsKeyringService, keyringUser(key))
+	if err != nil {
+		if errors.Is(err, goKeyring.ErrUnsupportedPlatform) {
+			return "", err
+		}
+		if errors.Is(err, goKeyring.ErrNotFound) {
+			return "", err
+		}
+		return "", fmt.Errorf("reading secure credentials for %q: %w", key, err)
+	}
+	return token, nil
+}
+
+func setKeyringToken(key string, token string) error {
+	err := goKeyring.Set(pulumiCredentialsKeyringService, keyringUser(key), token)
+	if err != nil {
+		if errors.Is(err, goKeyring.ErrUnsupportedPlatform) {
+			return err
+		}
+		return fmt.Errorf("writing secure credentials for %q: %w", key, err)
+	}
+	return nil
+}
+
+func deleteKeyringToken(key string) error {
+	err := goKeyring.Delete(pulumiCredentialsKeyringService, keyringUser(key))
+	if err != nil && !errors.Is(err, goKeyring.ErrNotFound) && !errors.Is(err, goKeyring.ErrUnsupportedPlatform) {
+		return fmt.Errorf("deleting secure credentials for %q: %w", key, err)
+	}
+	return nil
+}
+
+func deleteAllKeyringTokens() error {
+	err := goKeyring.DeleteAll(pulumiCredentialsKeyringService)
+	if err != nil && !errors.Is(err, goKeyring.ErrUnsupportedPlatform) {
+		return fmt.Errorf("deleting secure credentials: %w", err)
+	}
+	return nil
 }
 
 type BackendConfig struct {

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -15,23 +15,22 @@
 package workspace
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	goKeyring "github.com/zalando/go-keyring"
 )
 
 //nolint:paralleltest // mutates environment
 func TestConcurrentCredentialsWrites(t *testing.T) {
-	// save and remember to restore creds in ~/.pulumi/credentials
-	// as the test will be modifying them
-	oldCreds, err := GetStoredCredentials()
-	require.NoError(t, err)
-	defer func() {
-		err := StoreCredentials(oldCreds)
-		require.NoError(t, err)
-	}()
+	tempDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, tempDir)
+	goKeyring.MockInitWithError(errors.New("keyring unavailable"))
 
 	// use test creds that have at least 1 AccessToken to force a
 	// disk write and contention
@@ -49,7 +48,7 @@ func TestConcurrentCredentialsWrites(t *testing.T) {
 
 	// Store testCreds initially so asserts in
 	// GetStoredCredentials goroutines find the expected data
-	err = StoreCredentials(testCreds)
+	err := StoreCredentials(testCreds)
 	require.NoError(t, err)
 
 	for i := 0; i < n; i++ {
@@ -66,4 +65,110 @@ func TestConcurrentCredentialsWrites(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+//nolint:paralleltest // mutates environment
+func TestStoreCredentialsUsesKeyringAndWritesMetadataOnly(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, tempDir)
+	goKeyring.MockInit()
+
+	creds := Credentials{
+		Current: "https://api.pulumi.com",
+		Accounts: map[string]Account{
+			"https://api.pulumi.com": {
+				AccessToken: "token-value",
+				Username:    "alice",
+			},
+		},
+		AccessTokens: map[string]string{
+			"https://api.pulumi.com": "token-value",
+		},
+	}
+
+	err := StoreCredentials(creds)
+	require.NoError(t, err)
+
+	rawCreds, err := readCredentialsFile()
+	require.NoError(t, err)
+	assert.Equal(t, creds.Current, rawCreds.Current)
+	assert.Empty(t, rawCreds.AccessTokens["https://api.pulumi.com"])
+	assert.Empty(t, rawCreds.Accounts["https://api.pulumi.com"].AccessToken)
+
+	storedToken, err := goKeyring.Get(pulumiCredentialsKeyringService, keyringUser("https://api.pulumi.com"))
+	require.NoError(t, err)
+	assert.Equal(t, "token-value", storedToken)
+
+	hydratedCreds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "token-value", hydratedCreds.AccessTokens["https://api.pulumi.com"])
+	assert.Equal(t, "token-value", hydratedCreds.Accounts["https://api.pulumi.com"].AccessToken)
+}
+
+//nolint:paralleltest // mutates environment
+func TestGetStoredCredentialsMigratesLegacyPlaintextTokens(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, tempDir)
+	goKeyring.MockInit()
+
+	legacyCreds := Credentials{
+		Current: "https://api.pulumi.com",
+		Accounts: map[string]Account{
+			"https://api.pulumi.com": {
+				AccessToken: "legacy-token",
+				Username:    "alice",
+			},
+		},
+		AccessTokens: map[string]string{
+			"https://api.pulumi.com": "legacy-token",
+		},
+	}
+
+	err := writeCredentialsFile(legacyCreds)
+	require.NoError(t, err)
+
+	creds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-token", creds.AccessTokens["https://api.pulumi.com"])
+	assert.Equal(t, "legacy-token", creds.Accounts["https://api.pulumi.com"].AccessToken)
+
+	rawCreds, err := readCredentialsFile()
+	require.NoError(t, err)
+	assert.Empty(t, rawCreds.AccessTokens["https://api.pulumi.com"])
+	assert.Empty(t, rawCreds.Accounts["https://api.pulumi.com"].AccessToken)
+
+	storedToken, err := goKeyring.Get(pulumiCredentialsKeyringService, keyringUser("https://api.pulumi.com"))
+	require.NoError(t, err)
+	assert.Equal(t, "legacy-token", storedToken)
+}
+
+//nolint:paralleltest // mutates environment
+func TestStoreCredentialsFallsBackToPlaintextWhenKeyringUnavailable(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, tempDir)
+	goKeyring.MockInitWithError(errors.New("keyring unavailable"))
+
+	creds := Credentials{
+		Current: "https://api.pulumi.com",
+		Accounts: map[string]Account{
+			"https://api.pulumi.com": {
+				AccessToken: "token-value",
+			},
+		},
+		AccessTokens: map[string]string{
+			"https://api.pulumi.com": "token-value",
+		},
+	}
+
+	err := StoreCredentials(creds)
+	require.NoError(t, err)
+
+	credsPath := filepath.Join(tempDir, "credentials.json")
+	content, err := os.ReadFile(credsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "token-value")
+
+	readCreds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "token-value", readCreds.AccessTokens["https://api.pulumi.com"])
 }

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -23,6 +23,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
@@ -56,6 +58,7 @@ require (
 	github.com/go-git/go-git/v5 v5.17.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -111,6 +114,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.55.0 // indirect

--- a/sdk/go/pulumi-language-go/go.sum
+++ b/sdk/go/pulumi-language-go/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -160,6 +162,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -219,6 +223,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -501,6 +507,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
@@ -62,6 +64,7 @@ require (
 	github.com/go-git/go-git/v5 v5.17.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -115,6 +118,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.55.0 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -160,6 +162,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -216,6 +220,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -498,6 +504,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -44,6 +45,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
@@ -59,6 +61,7 @@ require (
 	github.com/go-git/go-git/v5 v5.17.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -115,6 +118,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/zalando/go-keyring v0.2.6 // indirect
 	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.55.0 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.sum
+++ b/sdk/python/cmd/pulumi-language-python/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -160,6 +162,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -219,6 +223,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
 github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -501,6 +507,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,3 +1,4 @@
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20200407214033-5883e5a4b512/go.mod h1:FbcW6z/2VytnFDhZfumh8Ss8zxHE6qpMP5sHTRe0EaM=
 cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
@@ -3371,6 +3372,7 @@ github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1S
 github.com/d2g/dhcp4client v1.0.0/go.mod h1:j0hNfjhrt2SxUOw55nL0ATM/z4Yt3t2Kd1mW34z5W5s=
 github.com/d2g/dhcp4server v0.0.0-20181031114812-7d4a0a7f59a5/go.mod h1:Eo87+Kg/IX2hfWJfwxMzLyuSZyxSoAug2nGa1G2QAi8=
 github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjIciD2oAxI7DmWRx6gbeqrkoLqv3MV0vzNad+I=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/dave/astrid v0.0.0-20170323122508-8c2895878b14/go.mod h1:Sth2QfxfATb/nW4EsrSi2KyJmbcniZ8TgTaji17D6ms=
 github.com/dave/brenda v1.1.0/go.mod h1:4wCUr6gSlu5/1Tk7akE5X7UorwiQ8Rij0SKH3/BGMOM=
 github.com/dave/courtney v0.3.0/go.mod h1:BAv3hA06AYfNUjfjQr+5gc6vxeBVOupLqrColj+QSD8=
@@ -5071,6 +5073,7 @@ github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.13.0/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=


### PR DESCRIPTION
## Summary
Move Pulumi CLI credential storage toward OS-backed secure storage by using go-keyring for access tokens, while preserving compatibility with existing ~/.pulumi/credentials.json users.

What changed

- Store access tokens in the OS keyring via github.com/zalando/go-keyring.
- Keep credentials.json for non-secret metadata only:
    - current
    - account metadata like username, orgs, token info, insecure flag
- Preserve the existing in-memory Credentials/Account API by hydrating tokens back into AccessTokens and Account.AccessToken on read.
- Add migration on read for legacy plaintext credentials:
    - read existing credentials.json
    - import plaintext tokens into keyring
    - rewrite credentials.json without token values after successful migration
- Fall back to legacy plaintext file storage if keyring storage is unavailable, so existing users are not locked out and headless/non-keychain environments still work.
- Delete keyring-backed secrets during logout / delete-all flows.

Why

The CLI currently stores tokens in plaintext in ~/.pulumi/credentials.json. This change reduces local secret exposure on macOS/Linux/Windows while keeping the UX and compatibility model intact.

Compatibility / migration

- Existing users do not need to do anything manually.
- Legacy plaintext credentials are migrated automatically on next successful read.
- If keyring access fails, the CLI continues using the plaintext file behavior instead of failing auth.

Tests

Added coverage for:

- keyring-backed writes with metadata-only file output
- migration from legacy plaintext credentials
- plaintext fallback when keyring is unavailable
- concurrent credential read/write behavior

Modules updated

Added go-keyring dependency and checksum updates in the SDK and affected nested language-host / build modules so repo builds continue to work.

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
