### PR TITLE
Allow templates to declare ESC environments to import

### DIFF
--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -319,6 +319,11 @@ func runNew(ctx context.Context, args newArgs) error {
 	}
 	proj.Name = tokens.PackageName(args.name)
 	proj.Description = &args.description
+	// Capture ESC environments declared by the template before clearing the template section.
+	var templateEnvironments []string
+	if proj.Template != nil {
+		templateEnvironments = append(templateEnvironments, proj.Template.Environments...)
+	}
 	proj.Template = nil
 
 	// Set the pulumi:template tag to the template name or URL.
@@ -431,6 +436,17 @@ func runNew(ctx context.Context, args newArgs) error {
 		)
 		if err != nil {
 			return err
+		}
+	}
+
+	// Apply ESC environment imports declared by the template, if any.
+	if !args.generateOnly && s != nil && len(templateEnvironments) > 0 {
+		added, err := applyTemplateEnvironments(ctx, cmdutil.Diag(), proj, s, templateEnvironments)
+		if err != nil {
+			return err
+		}
+		if len(added) > 0 {
+			fmt.Printf("Imported ESC environments: %s\n", strings.Join(added, ", "))
 		}
 	}
 

--- a/pkg/cmd/pulumi/newcmd/template_environments.go
+++ b/pkg/cmd/pulumi/newcmd/template_environments.go
@@ -1,0 +1,90 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// appendTemplateEnvironments mutates ps to import the given ESC environments,
+// skipping any that are already imported. Returns the list of envs that were
+// actually added (in input order), suitable for use in a status message.
+func appendTemplateEnvironments(ps *workspace.ProjectStack, envs []string) []string {
+	if len(envs) == 0 {
+		return nil
+	}
+
+	existing := map[string]bool{}
+	if ps.Environment != nil {
+		for _, e := range ps.Environment.Imports() {
+			existing[e] = true
+		}
+	}
+
+	var toAdd []string
+	for _, e := range envs {
+		if existing[e] {
+			continue
+		}
+		existing[e] = true
+		toAdd = append(toAdd, e)
+	}
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	if ps.Environment == nil {
+		ps.Environment = workspace.NewEnvironment(toAdd)
+	} else {
+		ps.Environment = ps.Environment.Append(toAdd...)
+	}
+	return toAdd
+}
+
+// applyTemplateEnvironments loads the stack's project stack file, appends the
+// given ESC environments as imports, and saves it. It is a no-op when envs is
+// empty or every entry is already present.
+func applyTemplateEnvironments(
+	ctx context.Context,
+	sink diag.Sink,
+	project *workspace.Project,
+	stack backend.Stack,
+	envs []string,
+) ([]string, error) {
+	if len(envs) == 0 {
+		return nil, nil
+	}
+
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack)
+	if err != nil {
+		return nil, fmt.Errorf("loading stack config: %w", err)
+	}
+
+	added := appendTemplateEnvironments(ps, envs)
+	if len(added) == 0 {
+		return nil, nil
+	}
+
+	if err := cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+		return nil, fmt.Errorf("saving stack config: %w", err)
+	}
+	return added, nil
+}

--- a/pkg/cmd/pulumi/newcmd/template_environments_test.go
+++ b/pkg/cmd/pulumi/newcmd/template_environments_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package newcmd
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendTemplateEnvironments_NoExistingEnvironment(t *testing.T) {
+	t.Parallel()
+
+	ps := &workspace.ProjectStack{}
+	added := appendTemplateEnvironments(ps, []string{"infra/aws-prod-creds", "infra/shared-tags"})
+
+	assert.Equal(t, []string{"infra/aws-prod-creds", "infra/shared-tags"}, added)
+	require.NotNil(t, ps.Environment)
+	assert.Equal(t, []string{"infra/aws-prod-creds", "infra/shared-tags"}, ps.Environment.Imports())
+}
+
+func TestAppendTemplateEnvironments_AppendsToExisting(t *testing.T) {
+	t.Parallel()
+
+	ps := &workspace.ProjectStack{
+		Environment: workspace.NewEnvironment([]string{"team/base"}),
+	}
+	added := appendTemplateEnvironments(ps, []string{"infra/aws-prod-creds"})
+
+	assert.Equal(t, []string{"infra/aws-prod-creds"}, added)
+	assert.Equal(t, []string{"team/base", "infra/aws-prod-creds"}, ps.Environment.Imports())
+}
+
+func TestAppendTemplateEnvironments_DedupesAgainstExisting(t *testing.T) {
+	t.Parallel()
+
+	ps := &workspace.ProjectStack{
+		Environment: workspace.NewEnvironment([]string{"infra/aws-prod-creds"}),
+	}
+	added := appendTemplateEnvironments(ps, []string{"infra/aws-prod-creds", "infra/shared-tags"})
+
+	assert.Equal(t, []string{"infra/shared-tags"}, added)
+	assert.Equal(t, []string{"infra/aws-prod-creds", "infra/shared-tags"}, ps.Environment.Imports())
+}
+
+func TestAppendTemplateEnvironments_EmptyInputIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ps := &workspace.ProjectStack{}
+	added := appendTemplateEnvironments(ps, nil)
+
+	assert.Empty(t, added)
+	assert.Nil(t, ps.Environment)
+}
+
+func TestAppendTemplateEnvironments_AllDuplicatesIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ps := &workspace.ProjectStack{
+		Environment: workspace.NewEnvironment([]string{"infra/aws-prod-creds"}),
+	}
+	added := appendTemplateEnvironments(ps, []string{"infra/aws-prod-creds"})
+
+	assert.Empty(t, added)
+	assert.Equal(t, []string{"infra/aws-prod-creds"}, ps.Environment.Imports())
+}

--- a/pkg/cmd/pulumi/templatecmd/template_publish_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_publish_test.go
@@ -549,3 +549,100 @@ dist/
 		})
 	}
 }
+
+// TestTemplatePublishCmd_PreservesTemplateEnvironments verifies that the
+// template.environments field declared in Pulumi.yaml survives the full
+// publish round-trip: archive create → extract → LoadTemplate. This is the
+// regression test for the ESC-imports-in-templates feature against the
+// registry path. The publish command tar.gz's the directory verbatim and the
+// service stores it as an opaque blob, so the field travels inside Pulumi.yaml
+// rather than as separate service-side metadata.
+//
+//nolint:paralleltest // testutil.MockBackendInstance mutates a global
+func TestTemplatePublishCmd_PreservesTemplateEnvironments(t *testing.T) {
+	templateDir := t.TempDir()
+
+	pulumiYAML := `name: ${PROJECT}
+runtime: yaml
+description: ${DESCRIPTION}
+template:
+  displayName: ESC Imports Demo
+  description: Imports a shared ESC env declared in the template
+  environments:
+    - infra/aws-prod-creds
+    - infra/shared-tags
+resources:
+  bucket:
+    type: aws:s3:BucketV2
+`
+	require.NoError(t, os.WriteFile(filepath.Join(templateDir, "Pulumi.yaml"), []byte(pulumiYAML), 0o600))
+
+	var capturedArchive []byte
+	mockCloudRegistry := &backend.MockCloudRegistry{
+		PublishTemplateF: func(ctx context.Context, op apitype.TemplatePublishOp) error {
+			b, err := io.ReadAll(op.Archive)
+			require.NoError(t, err)
+			capturedArchive = b
+			return nil
+		},
+	}
+
+	testutil.MockBackendInstance(t, &backend.MockBackend{
+		GetCloudRegistryF: func() (backend.CloudRegistry, error) {
+			return mockCloudRegistry, nil
+		},
+	})
+
+	cmd := &templatePublishCmd{
+		defaultOrg: func(context.Context, backend.Backend, *workspace.Project) (string, error) {
+			return "default-org", nil
+		},
+	}
+	require.NoError(t, cmd.Run(t.Context(), &cobra.Command{}, publishTemplateArgs{
+		publisher: "testpublisher",
+		name:      "esc-imports-demo",
+		version:   "1.0.0",
+	}, templateDir))
+
+	require.NotEmpty(t, capturedArchive, "publish should produce a non-empty archive")
+
+	// Extract the captured archive to a fresh temp dir, mirroring what the
+	// CLI does on the consumer side after downloading from the registry.
+	extractDir := t.TempDir()
+	gzr, err := gzip.NewReader(bytes.NewReader(capturedArchive))
+	require.NoError(t, err)
+	defer gzr.Close()
+
+	tarReader := tar.NewReader(gzr)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		dst := filepath.Join(extractDir, header.Name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		f, err := os.Create(dst)
+		require.NoError(t, err)
+		_, err = io.Copy(f, tarReader)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+
+	// Re-parse the extracted Pulumi.yaml using the same loader the consumer-side
+	// `pulumi new` flow uses (`ws.ReadProject()` → `LoadProject()` under the hood).
+	// This is the assertion that proves template.environments survives the
+	// registry round-trip end-to-end. workspace.LoadTemplate() is intentionally
+	// not used here because it flattens to a subset of ProjectTemplate fields
+	// and `pulumi new` itself reads proj.Template.Environments directly.
+	proj, err := workspace.LoadProject(filepath.Join(extractDir, "Pulumi.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, proj.Template, "Pulumi.yaml's template section should be parsed")
+	assert.Equal(t,
+		[]string{"infra/aws-prod-creds", "infra/shared-tags"},
+		proj.Template.Environments,
+		"template.environments should be preserved through publish + extract + LoadProject")
+}

--- a/sdk/go/common/apitype/templates.go
+++ b/sdk/go/common/apitype/templates.go
@@ -90,6 +90,9 @@ type ProjectTemplate struct {
 	Important bool `json:"important,omitempty" yaml:"important,omitempty"`
 	// Metadata are key/value pairs used to attach additional metadata to a template.
 	Metadata map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	// Environments is an optional list of ESC environments (project/name) to import
+	// into the consumer's stack file when scaffolding from this template.
+	Environments []string `json:"environments,omitempty" yaml:"environments,omitempty"`
 }
 
 // ProjectTemplateConfigValue is a config value included in the project template manifest.

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -214,6 +214,16 @@
                             }
                         }
                     }
+                },
+                "environments":{
+                    "description":"List of ESC environments (project/name) to import into stacks scaffolded from this template.",
+                    "type":[
+                        "array",
+                        "null"
+                    ],
+                    "items":{
+                        "type":"string"
+                    }
                 }
             },
             "additionalProperties":false

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -353,7 +353,7 @@ func TestProjectLoadJSONInformativeErrors(t *testing.T) {
 		// Assert.
 		assert.ErrorContains(t, err, "'displayNameDisplayName' not allowed")
 		assert.ErrorContains(t, err, "'displayNameDisplayName' not allowed; the allowed attributes are "+
-			"'config', 'description', 'displayName', 'important', 'metadata' and 'quickstart'")
+			"'config', 'description', 'displayName', 'environments', 'important', 'metadata' and 'quickstart'")
 	})
 
 	t.Run("specific errors when only a single attribute is expected", func(t *testing.T) {
@@ -2405,4 +2405,39 @@ func TestAddPackage(t *testing.T) {
 		// Verify the internal representation was converted to PackageSpec
 		requireTextualRepresentationIsSpec(t, proj.Packages["string-package"])
 	})
+}
+
+func TestProjectTemplateEnvironmentsParses(t *testing.T) {
+	t.Parallel()
+
+	projectYaml := `
+name: eks-template
+runtime: nodejs
+description: EKS cluster with shared infra creds
+template:
+  displayName: EKS Cluster
+  environments:
+    - infra/aws-prod-creds
+    - infra/shared-tags
+`
+	project, err := loadProjectFromText(t, projectYaml)
+	require.NoError(t, err)
+	require.NotNil(t, project.Template)
+	assert.Equal(t, "EKS Cluster", project.Template.DisplayName)
+	assert.Equal(t, []string{"infra/aws-prod-creds", "infra/shared-tags"}, project.Template.Environments)
+}
+
+func TestProjectTemplateEnvironmentsOmittedIsNil(t *testing.T) {
+	t.Parallel()
+
+	projectYaml := `
+name: eks-template
+runtime: nodejs
+template:
+  displayName: EKS Cluster
+`
+	project, err := loadProjectFromText(t, projectYaml)
+	require.NoError(t, err)
+	require.NotNil(t, project.Template)
+	assert.Nil(t, project.Template.Environments)
 }


### PR DESCRIPTION
## Summary

Adds a new `template.environments` field to `Pulumi.yaml`. When a template author declares a list of ESC environments under `template:`, `pulumi new` automatically writes them as imports into the consumer's `Pulumi.<stack>.yaml`. This lets infra teams ship a template that "just works" — app teams running `pulumi new <template>` get shared credentials, tags, and config from ESC without any manual `pulumi config env add` step.

**This is a prototype / draft PR** for engineering discussion. End-to-end verified against prod pulumi.com using a real OIDC AWS env: a template-declared import composed an existing creds env, and `pulumi up` successfully created an `aws:s3:BucketV2` in `us-west-2`.

### Example

Template author writes:
```yaml
# /tmp/eks-template/Pulumi.yaml
name: ${PROJECT}
runtime: yaml
description: ${DESCRIPTION}
template:
  displayName: EKS Cluster
  environments:
    - infra/aws-prod-creds
    - infra/shared-tags
resources: ...
```

Consumer runs:
```
$ pulumi new /tmp/eks-template --name demo --stack dev --yes
...
Imported ESC environments: infra/aws-prod-creds, infra/shared-tags
$ cat Pulumi.dev.yaml
environment:
  - infra/aws-prod-creds
  - infra/shared-tags
```

### Design notes

- **Where declared:** in the template's own `Pulumi.yaml`. No service-side metadata storage. Works uniformly for local, git, and registry templates because registry passes the tarball through unchanged.
- **Conflict-safe:** if the freshly-scaffolded stack already has an `environment:` block (rare for `pulumi new`, but possible via `--remote-config`), the helper appends and dedupes via the existing `workspace.Environment.Append()` rather than clobbering.
- **UX:** automatic with a single log line, no extra prompt. Mirrors how `template.config` is processed today.
- **Same-org only:** references are bare `<project>/<env>` strings, applied verbatim to the new stack file. Cross-org and templated references (`{{ .Org }}/...`) are intentionally out of scope for this prototype.
- **Pure helper for testability:** `appendTemplateEnvironments(ps, envs)` is the merge/dedupe core. The thin `applyTemplateEnvironments` wrapper does the load/save IO via the same `cmdStack.LoadProjectStack` / `SaveProjectStack` pattern already used by `HandleConfig`.

### Files changed

**Schema (commit 1):**
- `sdk/go/common/apitype/templates.go` — new `Environments []string` field on `ProjectTemplate`
- `sdk/go/common/workspace/project.json` — schema entry under the `template:` object
- `sdk/go/common/workspace/project_test.go` — new parser tests + assertion fix for the hardcoded "allowed attributes" list

**CLI (commit 2):**
- `pkg/cmd/pulumi/newcmd/template_environments.go` — new pure helper + IO wrapper
- `pkg/cmd/pulumi/newcmd/template_environments_test.go` — 5 unit tests covering empty/append/dedupe/all-dupes/no-existing
- `pkg/cmd/pulumi/newcmd/new.go` — capture envs before clearing template, apply after `HandleConfig`

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes (N/A)
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes (N/A)
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers (N/A)

Manually verified end-to-end against prod pulumi.com:
- ESC env composition: `pulumi/perlovsky-esc-template-demo/demo` imports `dperlovsky/pulumi-dev-sandbox` (OIDC AWS creds, us-west-2)
- `pulumi new` printed `Imported ESC environments: perlovsky-esc-template-demo/demo`
- Generated `Pulumi.dev.yaml` contained the declared import
- `pulumi up --yes` created a real `aws:s3:BucketV2` in 3 seconds
- `pulumi destroy` cleaned up successfully

## Validation
- [x] `go test ./go/common/workspace/...` — clean (cd sdk)
- [x] `go test ./go/common/apitype/...` — clean (cd sdk)
- [x] `go test -run TestAppendTemplateEnvironments ./cmd/pulumi/newcmd/` — 5 new tests pass (cd pkg)
- [x] `gofmt -l` — clean on all modified files
- [x] `go vet ./cmd/pulumi/newcmd/...` and sdk packages — clean
- [ ] `make lint` — not run (this branch is prototype-only; will run before un-drafting)
- [ ] `make test_fast` — not run (acceptance tests require auth not present in CI sandbox)

## Changelog
- [ ] Changelog entry added. **TBD before un-drafting.** Will add to `changelog/pending/` once design is reviewed.

## Risk
- **Backward-compat:** Adding a new optional field. Existing templates without `template.environments` are unaffected. The JSON schema's `additionalProperties: false` was the only place that could reject unknown fields, and it now permits `environments`.
- **Conflict semantics:** If a stack file is created with an existing `environment:` block (unusual for `pulumi new`, but possible via `--remote-config`), the new helper appends rather than replaces. Verified this path with a unit test.
- **Cross-org references:** Out of scope. A template referencing `infra/aws-prod-creds` only works when consumed inside an org that owns that env. This matches the primary use case (infra team paves the path for app teams in the same org). Cross-org and templated references can layer on later without breaking the contract.
- **No service-side changes.** This PR is CLI-only. The console "Create from template" wizard and `CreateStackFromTemplateRequest.Environments` already exist on the backend; that wiring is left as a follow-up.

## Follow-ups (intentionally not in this PR)
- Console "Create from template" wizard reading `template.environments` and passing it through to `CreateStackFromTemplateRequest.Environments` (backend already supports it)
- Cross-org references and templated org names
- Per-env opt-in/opt-out UX during `pulumi new`
- Permission preflight ("you don't have read access to this env")