### PR TITLE
[esc] Add tests for environment version pinning in stack config

### DIFF
--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -286,6 +286,85 @@ func TestOpenStackEnvLiteral(t *testing.T) {
 	assert.Equal(t, env, openEnv.Properties)
 }
 
+func TestOpenStackEnvVersionPinned(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]esc.Value{
+		"pulumiConfig": esc.NewValue(map[string]esc.Value{
+			"test:string": esc.NewValue("esc"),
+		}),
+	}
+
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+		},
+		OpenYAMLEnvironmentF: func(
+			ctx context.Context,
+			org string,
+			yamlBody []byte,
+			duration time.Duration,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			assert.Equal(t, "test-org", org)
+			assert.Contains(t, string(yamlBody), "project/env@3")
+			assert.Contains(t, string(yamlBody), "project/other@stable")
+			return &esc.Environment{Properties: env}, nil, nil
+		},
+	}
+	stack := &backend.MockStack{
+		OrgNameF: func() string { return "test-org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	var projectStack workspace.ProjectStack
+	err := yaml.Unmarshal([]byte("environment:\n  - project/env@3\n  - project/other@stable"), &projectStack)
+	require.NoError(t, err)
+
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	require.NoError(t, err)
+	require.Len(t, diags, 0)
+	assert.Equal(t, env, openEnv.Properties)
+}
+
+func TestOpenStackEnvVersionPinnedLiteral(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]esc.Value{
+		"pulumiConfig": esc.NewValue(map[string]esc.Value{
+			"test:string": esc.NewValue("esc"),
+		}),
+	}
+
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+		},
+		OpenYAMLEnvironmentF: func(
+			ctx context.Context,
+			org string,
+			yamlBody []byte,
+			duration time.Duration,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			assert.Equal(t, "test-org", org)
+			assert.Contains(t, string(yamlBody), "project/env@3")
+			return &esc.Environment{Properties: env}, nil, nil
+		},
+	}
+	stack := &backend.MockStack{
+		OrgNameF: func() string { return "test-org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	var projectStack workspace.ProjectStack
+	err := yaml.Unmarshal([]byte("environment:\n  imports:\n    - project/env@3\n  values:\n    pulumiConfig:\n      test:string: esc"), &projectStack)
+	require.NoError(t, err)
+
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	require.NoError(t, err)
+	require.Len(t, diags, 0)
+	assert.Equal(t, env, openEnv.Properties)
+}
+
 func TestStackEnvConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -356,7 +356,9 @@ func TestOpenStackEnvVersionPinnedLiteral(t *testing.T) {
 	}
 
 	var projectStack workspace.ProjectStack
-	err := yaml.Unmarshal([]byte("environment:\n  imports:\n    - project/env@3\n  values:\n    pulumiConfig:\n      test:string: esc"), &projectStack)
+	stackYAML := "environment:\n  imports:\n    - project/env@3\n" +
+		"  values:\n    pulumiConfig:\n      test:string: esc"
+	err := yaml.Unmarshal([]byte(stackYAML), &projectStack)
 	require.NoError(t, err)
 
 	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -1658,6 +1658,120 @@ runtime: yaml`
 	})
 }
 
+func TestEnvironmentVersionPinning(t *testing.T) {
+	t.Parallel()
+
+	projectYaml := `name: test
+runtime: yaml`
+
+	t.Run("YAML list preserves @version syntax", func(t *testing.T) {
+		t.Parallel()
+
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+		stack, err := loadProjectStackFromText(t, sink, project, "")
+		require.NoError(t, err)
+
+		stack.Environment = stack.Environment.Append("project/env@3")
+		marshaled, err := encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+		assert.Equal(t, "environment:\n  - project/env@3\n", string(marshaled))
+
+		stack.Environment = stack.Environment.Append("project/other@stable")
+		marshaled, err = encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+		assert.Equal(t, "environment:\n  - project/env@3\n  - project/other@stable\n", string(marshaled))
+	})
+
+	t.Run("JSON list preserves @version syntax", func(t *testing.T) {
+		t.Parallel()
+
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+		stack, err := loadProjectStackFromJSONText(t, sink, project, "{}")
+		require.NoError(t, err)
+
+		stack.Environment = stack.Environment.Append("project/env@3")
+		marshaled, err := encoding.JSON.Marshal(stack)
+		require.NoError(t, err)
+		assert.Equal(t, "{\n    \"environment\": [\n        \"project/env@3\"\n    ]\n}\n", string(marshaled))
+	})
+
+	t.Run("YAML literal preserves @version syntax", func(t *testing.T) {
+		t.Parallel()
+
+		projectStackYaml := `environment:
+  values:
+    pulumiConfig:
+      aws:region: us-west-2`
+
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+		stack, err := loadProjectStackFromText(t, sink, project, projectStackYaml)
+		require.NoError(t, err)
+
+		stack.Environment = stack.Environment.Append("project/env@3")
+		marshaled, err := encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+
+		expected := `environment:
+  values:
+    pulumiConfig:
+      aws:region: us-west-2
+  imports:
+    - project/env@3
+`
+		assert.Equal(t, expected, string(marshaled))
+	})
+
+	t.Run("Definition produces correct bytes for versioned imports", func(t *testing.T) {
+		t.Parallel()
+
+		env := NewEnvironment([]string{"project/env@3", "project/other@stable"})
+		def := env.Definition()
+		require.NotNil(t, def)
+
+		var parsed map[string]any
+		err := json.Unmarshal(def, &parsed)
+		require.NoError(t, err)
+
+		imports, ok := parsed["imports"].([]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"project/env@3", "project/other@stable"}, imports)
+	})
+
+	t.Run("Imports returns versioned names unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		env := NewEnvironment([]string{"project/env@3", "project/other@stable", "project/plain"})
+		imports := env.Imports()
+		assert.Equal(t, []string{"project/env@3", "project/other@stable", "project/plain"}, imports)
+	})
+
+	t.Run("YAML unmarshal round-trip preserves @version", func(t *testing.T) {
+		t.Parallel()
+
+		project, err := loadProjectFromText(t, projectYaml)
+		require.NoError(t, err)
+		var stdout, stderr bytes.Buffer
+		sink := diagtest.MockSink(&stdout, &stderr)
+
+		stackYaml := "environment:\n  - project/env@3\n  - project/other@stable\n"
+		stack, err := loadProjectStackFromText(t, sink, project, stackYaml)
+		require.NoError(t, err)
+
+		marshaled, err := encoding.YAML.Marshal(stack)
+		require.NoError(t, err)
+		assert.Equal(t, stackYaml, string(marshaled))
+	})
+}
+
 func TestEnvironmentRemove(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The `@version` syntax (e.g., `project/env@3`, `project/env@stable`) for
pinning ESC environment imports to specific revisions or tags is already
supported end-to-end but had no test coverage on the CLI side.

Add unit tests for the `Environment` type round-trip (YAML/JSON
marshal/unmarshal, `Definition()`, `Imports()`) and integration tests
verifying that `openStackEnv()` passes version-pinned import names
through to `OpenYAMLEnvironment` unchanged.

## Test plan

- `cd sdk && go test -count=1 -run TestEnvironmentVersionPinning ./go/common/workspace/`
- `cd pkg && go test -count=1 -run TestOpenStackEnvVersionPinned ./cmd/pulumi/config/`