### PR TITLE
Add Cancel handler to Python & Node.js providers

### DIFF
--- a/changelog/pending/20260408--sdk-nodejs-python--add-cancel-handler-to-python-and-node-js-providers.yaml
+++ b/changelog/pending/20260408--sdk-nodejs-python--add-cancel-handler-to-python-and-node-js-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs,python
+  description: Add Cancel handler to Python & Node.js providers

--- a/sdk/nodejs/provider/provider.ts
+++ b/sdk/nodejs/provider/provider.ts
@@ -317,4 +317,9 @@ export interface Provider {
      *   The embedded value from the sub-package.
      */
     parameterizeValue?: (name: string, version: string, value: string) => Promise<ParameterizeResult>;
+
+    /**
+     * Signals the provider to gracefully shut down and abort any ongoing operations.
+     */
+    cancel?: () => Promise<void>;
 }

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -69,7 +69,14 @@ class Server implements grpc.UntypedServiceImplementation {
     // Misc. methods
 
     public cancel(call: any, callback: any): void {
-        callback(undefined, new emptyproto.Empty());
+        if (this.provider.cancel) {
+            this.provider.cancel().then(
+                () => callback(undefined, new emptyproto.Empty()),
+                (e: any) => callback(e),
+            );
+        } else {
+            callback(undefined, new emptyproto.Empty());
+        }
     }
 
     public attach(call: any, callback: any): void {

--- a/sdk/python/lib/pulumi/provider/experimental/provider.py
+++ b/sdk/python/lib/pulumi/provider/experimental/provider.py
@@ -736,3 +736,6 @@ class Provider(ABC):
         Handle the call request.
         """
         raise NotImplementedError("The method 'call' is not implemented")
+
+    async def cancel(self) -> None:
+        """Cancel signals the provider to gracefully shut down and abort any ongoing operations."""

--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -103,6 +103,10 @@ class ProviderServicer(ResourceProviderServicer):
     async def GetPluginInfo(self, request, context) -> proto.PluginInfo:
         return proto.PluginInfo(version=self._version)
 
+    async def Cancel(self, request, context):
+        await self._provider.cancel()
+        return empty_pb2.Empty()
+
     def create_grpc_invalid_properties_status(
         self, message: str, errors: Optional[list[InputPropertyErrorDetails]]
     ) -> grpc.Status:

--- a/sdk/python/lib/pulumi/provider/provider.py
+++ b/sdk/python/lib/pulumi/provider/provider.py
@@ -134,3 +134,6 @@ class Provider:
         """
 
         raise Exception(f"Unknown function {token}")
+
+    def cancel(self) -> None:
+        """Cancel signals the provider to gracefully shut down and abort any ongoing operations."""

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -27,7 +27,7 @@ import traceback
 import grpc
 import grpc.aio
 
-from google.protobuf import struct_pb2
+from google.protobuf import empty_pb2, struct_pb2
 from pulumi.provider.provider import InvokeResult, Provider, CallResult, ConstructResult
 from pulumi.resource import (
     ProviderResource,
@@ -478,6 +478,10 @@ class ProviderServicer(ResourceProviderServicer):
         return proto.ConfigureResponse(
             acceptSecrets=True, acceptResources=True, acceptOutputs=True
         )
+
+    async def Cancel(self, request, context):
+        self.provider.cancel()
+        return empty_pb2.Empty()
 
     async def GetPluginInfo(self, request, context) -> proto.PluginInfo:
         if self.provider.version is None:


### PR DESCRIPTION
Adds a default no-op `cancel` hook on the Provider base class  and wires it up to the gRPC Cancel method.