### PR TITLE
docs: Fix incorrect package name in integration test docs

### DIFF
--- a/docs/architecture/testing/integration.md
+++ b/docs/architecture/testing/integration.md
@@ -12,7 +12,7 @@ Prefer [language conformance tests](language-conformance-tests) over integration
 
 :::{attention}
 
-Integration tests should have a TestMain which calls the `testutils.SetupPulumiBinary()` method to set an explicit path to the binaries under test to avoid reliance on the `$PATH` which can cause the wrong binary to be used in tests, resulting in incorrect test results.
+Integration tests should have a TestMain which calls the `testutil.SetupPulumiBinary()` method to set an explicit path to the binaries under test to avoid reliance on the `$PATH` which can cause the wrong binary to be used in tests, resulting in incorrect test results.
 
 :::
 


### PR DESCRIPTION
## Summary

- Fixes `testutils.SetupPulumiBinary()` → `testutil.SetupPulumiBinary()` in integration test documentation. The package is `testutil`, not `testutils`.

## Evidence

The function is defined in [`tests/testutil/test_main_util.go`](https://github.com/pulumi/pulumi/blob/b2ecd0eb63cddca4e4e7354a29b06a9f1b3e0a41/tests/testutil/test_main_util.go#L34) in the `testutil` package. All callers in the codebase use `testutil.SetupPulumiBinary()`:

- [`tests/integration/main_test.go`](https://github.com/pulumi/pulumi/blob/f87b8e16a141e25b4b2b4820a7f7e8eac0ae28d4/tests/integration/main_test.go#L25)
- [`tests/smoke/main_test.go`](https://github.com/pulumi/pulumi/blob/master/tests/smoke/main_test.go)
- [`tests/stack/main_test.go`](https://github.com/pulumi/pulumi/blob/master/tests/stack/main_test.go)

## Test plan

- [x] `make ensure` passes
- [x] `make lint` passes
- No functional changes; documentation-only fix