### PR TITLE
Add pkg/docsrender library for terminal docs rendering

### DIFF
--- a/pkg/docsrender/bundle.go
+++ b/pkg/docsrender/bundle.go
@@ -559,4 +559,3 @@ func FormatPackageDetails(body string) string {
 	}
 	return body[:afterHeading] + "\n\n" + formatted.String() + body[endIdx:]
 }
-

--- a/pkg/docsrender/bundle.go
+++ b/pkg/docsrender/bundle.go
@@ -1,0 +1,562 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+const (
+	SectionModules   = "Modules"
+	SectionResources = "Resources"
+	SectionFunctions = "Functions"
+)
+
+// CLIDocEntry represents a single resource or function in the CLI docs bundle.
+type CLIDocEntry struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	Content            string `json:"content"`
+	Deprecated         bool   `json:"deprecated,omitempty"`
+	DeprecationMessage string `json:"deprecationMessage,omitempty"`
+}
+
+// CLIDocsBundle is the bundled CLI docs JSON for a package.
+type CLIDocsBundle struct {
+	Package        string                 `json:"package"`
+	PackageVersion string                 `json:"packageVersion"`
+	Overview       string                 `json:"overview,omitempty"`
+	Resources      map[string]CLIDocEntry `json:"-"`
+	Functions      map[string]CLIDocEntry `json:"-"`
+}
+
+// cliBundleRaw is used for initial JSON unmarshaling before entries are normalized.
+type cliBundleRaw struct {
+	Package        string                     `json:"package"`
+	PackageVersion string                     `json:"packageVersion"`
+	Overview       string                     `json:"overview,omitempty"`
+	Resources      map[string]json.RawMessage `json:"resources"`
+	Functions      map[string]json.RawMessage `json:"functions"`
+}
+
+// UnmarshalJSON handles both new (CLIDocEntry) and legacy (string) bundle formats.
+func (b *CLIDocsBundle) UnmarshalJSON(data []byte) error {
+	var raw cliBundleRaw
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	b.Package = raw.Package
+	b.PackageVersion = raw.PackageVersion
+	b.Overview = raw.Overview
+	b.Resources = unmarshalEntries(raw.Resources)
+	b.Functions = unmarshalEntries(raw.Functions)
+	return nil
+}
+
+func unmarshalEntries(raw map[string]json.RawMessage) map[string]CLIDocEntry {
+	result := make(map[string]CLIDocEntry, len(raw))
+	for key, data := range raw {
+		var entry CLIDocEntry
+		if err := json.Unmarshal(data, &entry); err == nil && entry.Title != "" {
+			result[key] = entry
+			continue
+		}
+		var content string
+		if err := json.Unmarshal(data, &content); err == nil {
+			content = normalizeWhitespace(content)
+			title, body := extractLegacyTitle(content)
+			result[key] = CLIDocEntry{
+				Title:   title,
+				Content: body,
+			}
+		}
+	}
+	return result
+}
+
+// MarshalJSON serializes the bundle in the new structured format.
+func (b CLIDocsBundle) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Package        string                 `json:"package"`
+		PackageVersion string                 `json:"packageVersion"`
+		Overview       string                 `json:"overview,omitempty"`
+		Resources      map[string]CLIDocEntry `json:"resources"`
+		Functions      map[string]CLIDocEntry `json:"functions"`
+	}
+	return json.Marshal(alias(b))
+}
+
+func extractLegacyTitle(content string) (title, body string) {
+	if !strings.HasPrefix(content, "# ") {
+		return "", content
+	}
+	if idx := strings.Index(content, "\n"); idx >= 0 {
+		return content[2:idx], strings.TrimLeft(content[idx+1:], "\n")
+	}
+	return content[2:], ""
+}
+
+type bundleCacheMeta struct {
+	PackageVersion string    `json:"packageVersion"`
+	FetchedAt      time.Time `json:"fetchedAt"`
+}
+
+// BundleNotAvailableError is returned when a package's cli-docs.json is not available (404).
+type BundleNotAvailableError struct {
+	Package string
+}
+
+func (e *BundleNotAvailableError) Error() string {
+	return "CLI docs bundle not available for package: " + e.Package
+}
+
+const (
+	bundleCacheDir = "cli-docs-cache"
+	bundleCacheTTL = 1 * time.Hour
+)
+
+var bundleMemCache sync.Map
+
+func ParseAPIDocsPath(path string) (packageName, docKey string, ok bool) {
+	trimmed := strings.Trim(path, "/")
+	const prefix = "registry/packages/"
+	if !strings.HasPrefix(trimmed, prefix) {
+		return "", "", false
+	}
+	after := trimmed[len(prefix):]
+
+	if idx := strings.Index(after, "/api-docs/"); idx >= 0 {
+		packageName = after[:idx]
+		docKey = strings.Trim(after[idx+len("/api-docs/"):], "/")
+		return packageName, docKey, true
+	}
+
+	if strings.HasSuffix(after, "/api-docs") {
+		packageName = after[:len(after)-len("/api-docs")]
+		return packageName, "", true
+	}
+
+	return "", "", false
+}
+
+// FetchCLIDocsBundle fetches and caches the CLI docs bundle for a package.
+func FetchCLIDocsBundle(baseURL, packageName string) (*CLIDocsBundle, error) {
+	if cached, ok := bundleMemCache.Load(packageName); ok {
+		return cached.(*CLIDocsBundle), nil
+	}
+
+	bundle, err := loadBundleFromDisk(packageName)
+	if err == nil {
+		bundleMemCache.Store(packageName, bundle)
+		return bundle, nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Fetching %s API docs...\n", packageName)
+	bundle, err = fetchBundleHTTP(baseURL, packageName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := saveBundleToDisk(packageName, bundle); err != nil {
+		logging.V(7).Infof("failed to cache docs bundle for %s: %v", packageName, err)
+	}
+	bundleMemCache.Store(packageName, bundle)
+	return bundle, nil
+}
+
+func fetchBundleHTTP(baseURL, packageName string) (*CLIDocsBundle, error) {
+	url := fmt.Sprintf("%s/registry/packages/%s/api-docs/cli-docs.json",
+		normalizeBaseURL(baseURL), packageName)
+
+	//nolint:gosec // URL is constructed from user-provided base URL and package name
+	resp, err := BundleHTTPClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CLI docs bundle: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden {
+		return nil, &BundleNotAvailableError{Package: packageName}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d fetching CLI docs bundle for %s", resp.StatusCode, packageName)
+	}
+
+	var data []byte
+	total := resp.ContentLength
+	if total > 1024*1024 {
+		data, err = readWithProgress(resp.Body, total)
+	} else {
+		data, err = io.ReadAll(resp.Body)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading CLI docs bundle response: %w", err)
+	}
+
+	var bundle CLIDocsBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, fmt.Errorf("parsing CLI docs bundle: %w", err)
+	}
+
+	return &bundle, nil
+}
+
+func readWithProgress(r io.Reader, total int64) ([]byte, error) {
+	buf := make([]byte, 0, total)
+	tmp := make([]byte, 256*1024)
+	var read int64
+	lastPct := -1
+
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			read += int64(n)
+			if total > 0 {
+				pct := int(read * 100 / total)
+				if pct != lastPct {
+					fmt.Fprintf(os.Stderr, "\r  Downloading... %d%%", pct)
+					lastPct = pct
+				}
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintln(os.Stderr)
+			return nil, err
+		}
+	}
+	fmt.Fprintln(os.Stderr, "\r  Downloading... done.  ")
+	return buf, nil
+}
+
+func bundleCachePath() (string, error) {
+	home, err := workspace.GetPulumiHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, bundleCacheDir), nil
+}
+
+func loadBundleFromDisk(packageName string) (*CLIDocsBundle, error) {
+	cacheDir, err := bundleCachePath()
+	if err != nil {
+		return nil, err
+	}
+
+	metaPath := filepath.Join(cacheDir, packageName+".meta.json")
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, err
+	}
+	var meta bundleCacheMeta
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		return nil, err
+	}
+	if time.Since(meta.FetchedAt) > bundleCacheTTL {
+		return nil, errors.New("cache expired")
+	}
+
+	bundlePath := filepath.Join(cacheDir, packageName+".json")
+	bundleData, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return nil, err
+	}
+	var bundle CLIDocsBundle
+	if err := json.Unmarshal(bundleData, &bundle); err != nil {
+		return nil, err
+	}
+	return &bundle, nil
+}
+
+func saveBundleToDisk(packageName string, bundle *CLIDocsBundle) error {
+	cacheDir, err := bundleCachePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return err
+	}
+
+	bundleData, err := json.Marshal(bundle)
+	if err != nil {
+		return err
+	}
+	bundlePath := filepath.Join(cacheDir, packageName+".json")
+	if err := os.WriteFile(bundlePath, bundleData, 0o600); err != nil {
+		return err
+	}
+
+	meta := bundleCacheMeta{
+		PackageVersion: bundle.PackageVersion,
+		FetchedAt:      time.Now(),
+	}
+	metaData, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	metaPath := filepath.Join(cacheDir, packageName+".meta.json")
+	return os.WriteFile(metaPath, metaData, 0o600)
+}
+
+// LookupBundleDoc looks up a resource or function by key in the bundle.
+func LookupBundleDoc(bundle *CLIDocsBundle, docKey string) (body string, title string, found bool) {
+	entry, ok := bundle.Resources[docKey]
+	if !ok {
+		entry, ok = bundle.Functions[docKey]
+	}
+	if !ok {
+		return "", "", false
+	}
+
+	return entry.Content, entry.Title, true
+}
+
+// ClassifiedEntry represents a single resource or function found during bundle key scanning.
+type ClassifiedEntry struct {
+	Key         string
+	Title       string
+	Description string
+}
+
+// ClassifiedKeys is the result of scanning bundle keys for a given module prefix.
+type ClassifiedKeys struct {
+	SubModules []string
+	Resources  []ClassifiedEntry
+	Functions  []ClassifiedEntry
+}
+
+// ClassifyBundleKeys scans Resources and Functions maps, classifying each key
+// as a sub-module, direct resource, or direct function relative to modulePrefix.
+func ClassifyBundleKeys(bundle *CLIDocsBundle, modulePrefix string) ClassifiedKeys {
+	subModules := make(map[string]bool)
+	var resources, functions []ClassifiedEntry
+
+	classify := func(keys map[string]CLIDocEntry, isFunction bool) {
+		for key, doc := range keys {
+			var rel string
+			if modulePrefix == "" {
+				if strings.Contains(key, "/") {
+					subModules[strings.SplitN(key, "/", 2)[0]] = true
+					continue
+				}
+				rel = key
+			} else {
+				if !strings.HasPrefix(key, modulePrefix+"/") {
+					continue
+				}
+				rel = key[len(modulePrefix)+1:]
+				if strings.Contains(rel, "/") {
+					subModules[strings.SplitN(rel, "/", 2)[0]] = true
+					continue
+				}
+			}
+
+			title := doc.Title
+			if title == "" {
+				title = rel
+			}
+
+			entry := ClassifiedEntry{Key: key, Title: title, Description: doc.Description}
+			if isFunction {
+				functions = append(functions, entry)
+			} else {
+				resources = append(resources, entry)
+			}
+		}
+	}
+
+	classify(bundle.Resources, false)
+	classify(bundle.Functions, true)
+
+	sort.Slice(resources, func(i, j int) bool { return resources[i].Title < resources[j].Title })
+	sort.Slice(functions, func(i, j int) bool { return functions[i].Title < functions[j].Title })
+
+	sortedMods := make([]string, 0, len(subModules))
+	for mod := range subModules {
+		sortedMods = append(sortedMods, mod)
+	}
+	sort.Strings(sortedMods)
+
+	return ClassifiedKeys{
+		SubModules: sortedMods,
+		Resources:  resources,
+		Functions:  functions,
+	}
+}
+
+// APIDocsBasePath returns the base URL path for a package's API docs.
+func APIDocsBasePath(pkgName string) string {
+	return "/registry/packages/" + pkgName + "/api-docs"
+}
+
+// APIDocsModulePath returns the URL path for a submodule under a package's API docs,
+// honoring the optional parent modulePrefix.
+func APIDocsModulePath(pkgName, modulePrefix, mod string) string {
+	p := APIDocsBasePath(pkgName)
+	if modulePrefix != "" {
+		p += "/" + modulePrefix
+	}
+	return p + "/" + mod
+}
+
+// APIDocsEntryPath returns the URL path for a resource or function under a package's API docs.
+func APIDocsEntryPath(pkgName, key string) string {
+	return APIDocsBasePath(pkgName) + "/" + key
+}
+
+// absolutizeBundleLinks rewrites relative link destinations in a bundle's overview
+// markdown so they resolve under /registry/packages/<pkg>/api-docs/. Links that already
+// have a scheme, are rooted (start with "/"), or are anchors (start with "#") are left
+// alone. This lets NumberLinks recognize bundle-authored entries as registry links.
+func absolutizeBundleLinks(md, pkgName string) string {
+	if md == "" || pkgName == "" {
+		return md
+	}
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	basePath := APIDocsBasePath(pkgName) + "/"
+
+	rewrote := false
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		dest := string(link.Destination)
+		if dest == "" || strings.Contains(dest, "://") || strings.HasPrefix(dest, "/") || strings.HasPrefix(dest, "#") {
+			return ast.WalkSkipChildren, nil
+		}
+		link.Destination = []byte(basePath + dest)
+		rewrote = true
+		return ast.WalkSkipChildren, nil
+	})
+
+	if !rewrote {
+		return md
+	}
+	return string(renderTree(source, tree))
+}
+
+// BuildAPIDocsPage constructs an API docs overview page from the bundle data.
+func BuildAPIDocsPage(bundle *CLIDocsBundle, modulePrefix, intro string) string {
+	if modulePrefix == "" && bundle.Overview != "" {
+		return absolutizeBundleLinks(bundle.Overview, bundle.Package)
+	}
+	ck := ClassifyBundleKeys(bundle, modulePrefix)
+	var buf strings.Builder
+
+	if intro != "" {
+		buf.WriteString(intro)
+		buf.WriteString("\n\n")
+	}
+
+	if len(ck.SubModules) > 0 {
+		buf.WriteString("## " + SectionModules + "\n\n")
+		links := make([]string, 0, len(ck.SubModules))
+		for _, mod := range ck.SubModules {
+			links = append(links, fmt.Sprintf("[%s](%s)", mod, APIDocsModulePath(bundle.Package, modulePrefix, mod)))
+		}
+		buf.WriteString(strings.Join(links, ", "))
+		buf.WriteString("\n\n")
+	}
+
+	writeEntrySection := func(title string, entries []ClassifiedEntry) {
+		if len(entries) == 0 {
+			return
+		}
+		buf.WriteString("## " + title + "\n\n")
+		for _, e := range entries {
+			link := fmt.Sprintf("[**%s**](%s)", e.Title, APIDocsEntryPath(bundle.Package, e.Key))
+			if e.Description != "" {
+				fmt.Fprintf(&buf, "- %s — %s\n", link, truncateDescription(e.Description))
+			} else {
+				fmt.Fprintf(&buf, "- %s\n", link)
+			}
+		}
+		buf.WriteString("\n")
+	}
+
+	writeEntrySection(SectionResources, ck.Resources)
+	writeEntrySection(SectionFunctions, ck.Functions)
+
+	return buf.String()
+}
+
+// truncateDescription truncates a description to a single sentence for display.
+func truncateDescription(desc string) string {
+	if desc == "" {
+		return ""
+	}
+	if idx := strings.Index(desc, "\n"); idx >= 0 {
+		desc = desc[:idx]
+	}
+	desc = strings.TrimSpace(desc)
+	if idx := strings.Index(desc, ". "); idx >= 0 {
+		desc = desc[:idx+1]
+	}
+	const maxLen = 80
+	if len(desc) > maxLen {
+		desc = desc[:maxLen-3] + "..."
+	}
+	return desc
+}
+
+// FormatPackageDetails reformats tab-indented Package Details into clean markdown.
+func FormatPackageDetails(body string) string {
+	start, _, endIdx := FindSectionBounds(body, "## Package Details")
+	if start < 0 {
+		return body
+	}
+	afterHeading := start + len("## Package Details")
+	sectionContent := body[afterHeading:endIdx]
+
+	var formatted strings.Builder
+	lines := strings.Split(strings.TrimSpace(sectionContent), "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if i+1 < len(lines) {
+			value := strings.TrimSpace(lines[i+1])
+			formatted.WriteString("**" + line + ":** " + value + "\n\n")
+			i++
+		} else {
+			formatted.WriteString("**" + line + "**\n\n")
+		}
+	}
+	return body[:afterHeading] + "\n\n" + formatted.String() + body[endIdx:]
+}
+

--- a/pkg/docsrender/bundle_test.go
+++ b/pkg/docsrender/bundle_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIDocsPaths(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "/registry/packages/aws/api-docs", APIDocsBasePath("aws"))
+	assert.Equal(t, "/registry/packages/aws/api-docs/s3", APIDocsModulePath("aws", "", "s3"))
+	assert.Equal(t,
+		"/registry/packages/aws/api-docs/ec2/transitgateway",
+		APIDocsModulePath("aws", "ec2", "transitgateway"))
+	assert.Equal(t, "/registry/packages/aws/api-docs/s3/bucket", APIDocsEntryPath("aws", "s3/bucket"))
+	assert.Equal(t, "/registry/packages/aws/api-docs/rootresource", APIDocsEntryPath("aws", "rootresource"))
+}
+
+func TestAbsolutizeBundleLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rewrites relative links", func(t *testing.T) {
+		t.Parallel()
+		md := "- [Bucket](bucket/)\n- [Instance](ec2/instance/)\n"
+		got := absolutizeBundleLinks(md, "aws")
+		assert.Contains(t, got, "[Bucket](/registry/packages/aws/api-docs/bucket/)")
+		assert.Contains(t, got, "[Instance](/registry/packages/aws/api-docs/ec2/instance/)")
+	})
+
+	t.Run("leaves absolute paths alone", func(t *testing.T) {
+		t.Parallel()
+		md := "[Other](/registry/packages/other)"
+		got := absolutizeBundleLinks(md, "aws")
+		assert.Contains(t, got, "[Other](/registry/packages/other)")
+	})
+
+	t.Run("leaves external URLs alone", func(t *testing.T) {
+		t.Parallel()
+		md := "[Site](https://example.com/path)"
+		got := absolutizeBundleLinks(md, "aws")
+		assert.Contains(t, got, "[Site](https://example.com/path)")
+	})
+
+	t.Run("leaves anchors alone", func(t *testing.T) {
+		t.Parallel()
+		md := "[Section](#heading)"
+		got := absolutizeBundleLinks(md, "aws")
+		assert.Contains(t, got, "[Section](#heading)")
+	})
+
+	t.Run("returns input unchanged when nothing to rewrite", func(t *testing.T) {
+		t.Parallel()
+		md := "Just text, [no](https://x.io) relative links."
+		got := absolutizeBundleLinks(md, "aws")
+		assert.Equal(t, md, got)
+	})
+
+	t.Run("handles empty inputs", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", absolutizeBundleLinks("", "aws"))
+		assert.Equal(t, "x", absolutizeBundleLinks("x", ""))
+	})
+
+	t.Run("output is recognized by NumberLinks", func(t *testing.T) {
+		t.Parallel()
+		md := "- [Bucket](bucket/)\n- [Policy](bucketpolicy/)\n"
+		rewritten := absolutizeBundleLinks(md, "aws")
+		_, links := NumberLinks(rewritten)
+		assert.Len(t, links, 2)
+	})
+}

--- a/pkg/docsrender/bundle_test.go
+++ b/pkg/docsrender/bundle_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIDocsPaths(t *testing.T) {
@@ -82,6 +83,6 @@ func TestAbsolutizeBundleLinks(t *testing.T) {
 		md := "- [Bucket](bucket/)\n- [Policy](bucketpolicy/)\n"
 		rewritten := absolutizeBundleLinks(md, "aws")
 		_, links := NumberLinks(rewritten)
-		assert.Len(t, links, 2)
+		require.Len(t, links, 2)
 	})
 }

--- a/pkg/docsrender/chooser.go
+++ b/pkg/docsrender/chooser.go
@@ -1,0 +1,249 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// ChooserInfo describes a chooser block found in a document.
+type ChooserInfo struct {
+	Type    string   // e.g. "language", "os", "cloud"
+	Options []string // available option values
+}
+
+// ScanChoosers finds chooser blocks in the AST and returns their types and options.
+func ScanChoosers(source []byte, tree ast.Node) []ChooserInfo {
+	seen := map[string]bool{}
+	var result []ChooserInfo
+
+	var children []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		children = append(children, c)
+	}
+
+	i := 0
+	for i < len(children) {
+		text := htmlBlockText(source, children[i])
+		kind, value, isClose, ok := parseChooserComment(text)
+		if !ok || isClose || kind != "chooser" {
+			i++
+			continue
+		}
+
+		chooserType := value
+		var options []string
+		j := i + 1
+		closed := false
+
+		for j < len(children) {
+			t := htmlBlockText(source, children[j])
+			k, v, ic, ok2 := parseChooserComment(t)
+			if ok2 && k == "option" && !ic {
+				options = append(options, v)
+				j++
+				continue
+			}
+			if ok2 && k == "chooser" && ic {
+				closed = true
+				j++
+				break
+			}
+			j++
+		}
+
+		if !closed {
+			i = j
+			continue
+		}
+
+		if !seen[chooserType] {
+			seen[chooserType] = true
+			result = append(result, ChooserInfo{Type: chooserType, Options: options})
+		}
+
+		i = j
+	}
+
+	return result
+}
+
+// ResolveChoosers resolves chooser blocks in the markdown AST. The selections
+// map chooser type (e.g., "language") to the desired value (e.g., "python").
+// If no selection exists for a chooser type, all options are shown.
+// The source must be the original bytes used to parse tree.
+func ResolveChoosers(source []byte, tree ast.Node, selections map[string]string) []byte {
+	resolveChooserBlocks(source, tree, selections)
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, tree)
+	contract.AssertNoErrorf(err, "rendering after chooser resolution")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+// resolveChooserBlocks walks the AST looking for sequences of HTMLBlock nodes
+// that form chooser/option/close patterns, then resolves them in place.
+func resolveChooserBlocks(source []byte, tree ast.Node, selections map[string]string) {
+	var children []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		children = append(children, c)
+	}
+
+	i := 0
+	for i < len(children) {
+		node := children[i]
+		text := htmlBlockText(source, node)
+		kind, value, isClose, ok := parseChooserComment(text)
+		if !ok || isClose || kind != "chooser" {
+			i++
+			continue
+		}
+
+		chooserType := value
+		selected := selections[chooserType]
+
+		type option struct {
+			value string
+			nodes []ast.Node
+		}
+		var options []option
+		var currentOption *option
+		j := i + 1
+		closed := false
+
+		for j < len(children) {
+			t := htmlBlockText(source, children[j])
+			k, v, ic, ok2 := parseChooserComment(t)
+			if ok2 && k == "option" && !ic {
+				if currentOption != nil {
+					options = append(options, *currentOption)
+				}
+				currentOption = &option{value: v}
+				j++
+				continue
+			}
+			if ok2 && k == "chooser" && ic {
+				if currentOption != nil {
+					options = append(options, *currentOption)
+				}
+				closed = true
+				j++
+				break
+			}
+			if currentOption != nil {
+				currentOption.nodes = append(currentOption.nodes, children[j])
+			}
+			j++
+		}
+
+		if !closed {
+			i = j
+			continue
+		}
+
+		for k := i; k < j; k++ {
+			tree.RemoveChild(tree, children[k])
+		}
+
+		var insertBefore ast.Node
+		if j < len(children) {
+			insertBefore = children[j]
+		}
+
+		if selected != "" {
+			for _, opt := range options {
+				if strings.EqualFold(opt.value, selected) {
+					for _, n := range opt.nodes {
+						tree.InsertBefore(tree, insertBefore, n)
+					}
+					break
+				}
+			}
+		} else {
+			for _, opt := range options {
+				for _, n := range opt.nodes {
+					tree.InsertBefore(tree, insertBefore, n)
+				}
+			}
+		}
+
+		i = j
+	}
+}
+
+func htmlBlockText(source []byte, node ast.Node) string {
+	hb, ok := node.(*ast.HTMLBlock)
+	if !ok {
+		return ""
+	}
+	var buf bytes.Buffer
+	for i := 0; i < hb.Lines().Len(); i++ {
+		seg := hb.Lines().At(i)
+		buf.Write(seg.Value(source))
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+// parseChooserComment parses an HTML comment that may be a chooser directive.
+// Returns (kind, value, isClose, ok).
+//
+// Examples:
+//
+//	"<!-- chooser: language -->" → ("chooser", "language", false, true)
+//	"<!-- option: typescript -->" → ("option", "typescript", false, true)
+//	"<!-- /chooser -->"          → ("chooser", "", true, true)
+//	"<!-- /option -->"           → ("option", "", true, true)
+//	"<!-- something else -->"    → ("", "", false, false)
+func parseChooserComment(text string) (kind, value string, isClose, ok bool) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "<!--") || !strings.HasSuffix(text, "-->") {
+		return "", "", false, false
+	}
+	inner := strings.TrimSpace(text[4 : len(text)-3])
+
+	if strings.HasPrefix(inner, "/") {
+		tag := strings.TrimSpace(inner[1:])
+		switch tag {
+		case "chooser":
+			return "chooser", "", true, true
+		case "option":
+			return "option", "", true, true
+		default:
+			return "", "", false, false
+		}
+	}
+
+	parts := strings.SplitN(inner, ":", 2)
+	if len(parts) != 2 {
+		return "", "", false, false
+	}
+	tag := strings.TrimSpace(parts[0])
+	val := strings.TrimSpace(parts[1])
+	switch tag {
+	case "chooser", "option":
+		return tag, val, false, true
+	default:
+		return "", "", false, false
+	}
+}

--- a/pkg/docsrender/chooser_test.go
+++ b/pkg/docsrender/chooser_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChooserComment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input   string
+		kind    string
+		value   string
+		isClose bool
+		ok      bool
+	}{
+		{"<!-- chooser: language -->", "chooser", "language", false, true},
+		{"<!-- option: typescript -->", "option", "typescript", false, true},
+		{"<!-- option: python -->", "option", "python", false, true},
+		{"<!-- /chooser -->", "chooser", "", true, true},
+		{"<!-- /option -->", "option", "", true, true},
+		{"<!-- chooser: os -->", "chooser", "os", false, true},
+		{"<!-- something else -->", "", "", false, false},
+		{"not a comment", "", "", false, false},
+		{"", "", "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			kind, value, isClose, ok := parseChooserComment(tt.input)
+			assert.Equal(t, tt.kind, kind)
+			assert.Equal(t, tt.value, value)
+			assert.Equal(t, tt.isClose, isClose)
+			assert.Equal(t, tt.ok, ok)
+		})
+	}
+}
+
+func TestScanChoosers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single chooser with two options", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("Before.\n\n<!-- chooser: language -->\n\n" +
+			"<!-- option: typescript -->\n\nconsole.log('hi');\n\n<!-- /option -->\n\n" +
+			"<!-- option: python -->\n\nprint('hi')\n\n<!-- /option -->\n\n" +
+			"<!-- /chooser -->\n\nAfter.")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		require.Len(t, result, 1)
+		assert.Equal(t, "language", result[0].Type)
+		assert.Equal(t, []string{"typescript", "python"}, result[0].Options)
+	})
+
+	t.Run("plain text only", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("Just plain text with no choosers.")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		assert.Empty(t, result)
+	})
+
+	t.Run("unmatched chooser open tag", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("Before.\n\n<!-- chooser: language -->\n\nNo closing tag.")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		assert.Empty(t, result)
+	})
+
+	t.Run("multiple choosers", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("<!-- chooser: language -->\n\n<!-- option: go -->\n\n" +
+			"Go code\n\n<!-- /option -->\n\n<!-- /chooser -->\n\nMiddle text.\n\n" +
+			"<!-- chooser: os -->\n\n<!-- option: linux -->\n\n" +
+			"Linux\n\n<!-- /option -->\n\n<!-- /chooser -->")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		require.Len(t, result, 2)
+		assert.Equal(t, "language", result[0].Type)
+		assert.Equal(t, "os", result[1].Type)
+	})
+
+	t.Run("duplicate chooser types deduplicated", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("<!-- chooser: language -->\n\n<!-- option: go -->\n\n" +
+			"Go code\n\n<!-- /option -->\n\n<!-- /chooser -->\n\n" +
+			"<!-- chooser: language -->\n\n<!-- option: python -->\n\n" +
+			"Python code\n\n<!-- /option -->\n\n<!-- /chooser -->")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		require.Len(t, result, 1)
+		assert.Equal(t, "language", result[0].Type)
+		assert.Equal(t, []string{"go"}, result[0].Options)
+	})
+
+	t.Run("chooser with three options", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("<!-- chooser: language -->\n\n" +
+			"<!-- option: typescript -->\n\nTS\n\n<!-- /option -->\n\n" +
+			"<!-- option: python -->\n\nPY\n\n<!-- /option -->\n\n" +
+			"<!-- option: go -->\n\nGO\n\n<!-- /option -->\n\n" +
+			"<!-- /chooser -->")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		require.Len(t, result, 1)
+		assert.Equal(t, []string{"typescript", "python", "go"}, result[0].Options)
+	})
+
+	t.Run("os chooser", func(t *testing.T) {
+		t.Parallel()
+		source := []byte("<!-- chooser: os -->\n\n" +
+			"<!-- option: linux -->\n\napt-get install\n\n<!-- /option -->\n\n" +
+			"<!-- option: macos -->\n\nbrew install\n\n<!-- /option -->\n\n" +
+			"<!-- /chooser -->")
+		tree := ParseMarkdown(source)
+		result := ScanChoosers(source, tree)
+		require.Len(t, result, 1)
+		assert.Equal(t, "os", result[0].Type)
+		assert.Equal(t, []string{"linux", "macos"}, result[0].Options)
+	})
+}
+
+func TestResolveChoosersWithSelection(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TypeScript content here.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+Python content here.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+Some text after.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "python"}))
+
+	assert.Contains(t, result, "Some text before.")
+	assert.Contains(t, result, "Python content here.")
+	assert.NotContains(t, result, "TypeScript content here.")
+	assert.Contains(t, result, "Some text after.")
+}
+
+func TestResolveChoosersShowAll(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS code.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+PY code.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+After.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "TS code.")
+	assert.Contains(t, result, "PY code.")
+	assert.Contains(t, result, "After.")
+}
+
+func TestResolveChoosersEmptyChooser(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- /chooser -->
+
+After.
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "python"}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "After.")
+}
+
+func TestResolveChoosersUnknownSelection(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS only.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	// Selection for a value not present in options — nothing is emitted for the chooser.
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "go"}))
+
+	assert.NotContains(t, result, "TS only.")
+}
+
+func TestResolveChoosersUnclosed(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Before.
+
+<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS code.
+
+After without close.
+`)
+	tree := ParseMarkdown(source)
+	// Unclosed chooser is left as-is.
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "typescript"}))
+
+	assert.Contains(t, result, "Before.")
+	assert.Contains(t, result, "TS code.")
+}
+
+func TestResolveChoosersCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: TypeScript -->
+
+TS content.
+
+<!-- /option -->
+
+<!-- option: Python -->
+
+PY content.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{"language": "typescript"}))
+
+	assert.Contains(t, result, "TS content.")
+	assert.NotContains(t, result, "PY content.")
+}
+
+func TestResolveChoosersMultipleChoosers(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`<!-- chooser: language -->
+
+<!-- option: typescript -->
+
+TS.
+
+<!-- /option -->
+
+<!-- option: python -->
+
+PY.
+
+<!-- /option -->
+
+<!-- /chooser -->
+
+Middle text.
+
+<!-- chooser: os -->
+
+<!-- option: macos -->
+
+Mac instructions.
+
+<!-- /option -->
+
+<!-- option: linux -->
+
+Linux instructions.
+
+<!-- /option -->
+
+<!-- /chooser -->
+`)
+	tree := ParseMarkdown(source)
+	result := string(ResolveChoosers(source, tree, map[string]string{
+		"language": "python",
+		"os":       "linux",
+	}))
+
+	assert.Contains(t, result, "PY.")
+	assert.NotContains(t, result, "TS.")
+	assert.Contains(t, result, "Middle text.")
+	assert.Contains(t, result, "Linux instructions.")
+	assert.NotContains(t, result, "Mac instructions.")
+}

--- a/pkg/docsrender/fetch.go
+++ b/pkg/docsrender/fetch.go
@@ -1,0 +1,250 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+// HTTPClient is the shared HTTP client for doc fetches. Tests can replace it.
+var HTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// BundleHTTPClient uses a longer timeout for large bundle downloads.
+var BundleHTTPClient = &http.Client{Timeout: 5 * time.Minute}
+
+// redirectClient follows no redirects so we can inspect 301/302 responses.
+var redirectClient = &http.Client{
+	Timeout: 10 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// sitemapCache provides session-level caching for sitemap fetches, keyed by URL.
+var sitemapCache sync.Map
+
+var metaRefreshRe = regexp.MustCompile(`(?i)url=([^"'>]+)`)
+
+func normalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(baseURL, "/")
+}
+
+// normalizeWhitespace converts CRLF to LF and tabs to 4 spaces.
+func normalizeWhitespace(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	return strings.ReplaceAll(s, "\t", "    ")
+}
+
+func userAgent() string {
+	return fmt.Sprintf("pulumi-cli/1 (%s; %s)", runtime.GOOS, runtime.GOARCH)
+}
+
+// FetchDoc fetches a markdown doc page from the docs or registry site.
+// Returns the body (with frontmatter stripped), the title, and the resolved
+// path (which may differ from the requested path if a redirect was followed).
+// If the markdown 404s, it tries the HTML page to find redirects or meta refreshes.
+// For registry paths that 404, returns a RegistryNotAvailableError.
+func FetchDoc(baseURL, path string) (body string, title string, resolvedPath string, err error) {
+	base := normalizeBaseURL(baseURL)
+	prefix, trimmedPath := ContentPrefix(path)
+	mdURL := fmt.Sprintf("%s%s%s/index.md", base, prefix, trimmedPath)
+
+	req, err := http.NewRequest(http.MethodGet, mdURL, nil) //nolint:gosec // URL from user base URL
+	if err != nil {
+		return "", "", "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent())
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", "", "", fmt.Errorf("fetching docs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		// Detect content redirects (path changed) vs benign redirects (scheme/CDN).
+		finalPath := strings.TrimSuffix(strings.TrimSuffix(resp.Request.URL.Path, "/index.md"), "/")
+		requestedPath := strings.TrimSuffix(strings.TrimSuffix(req.URL.Path, "/index.md"), "/")
+		if finalPath != requestedPath {
+			redirectPath := extractContentPath(finalPath, "")
+			if redirectPath != "" && redirectPath != strings.Trim(path, "/") {
+				return FetchDoc(baseURL, redirectPath)
+			}
+		}
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", "", "", fmt.Errorf("reading docs response: %w", err)
+		}
+		body, title = StripFrontmatter(normalizeWhitespace(string(data)))
+		return body, title, strings.Trim(path, "/"), nil
+	}
+
+	// CloudFront returns 403 for missing content, so treat it the same as 404.
+	notFound := resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden
+
+	if !notFound {
+		return "", "", "", fmt.Errorf("unexpected status %d fetching docs page: %s", resp.StatusCode, path)
+	}
+
+	if IsRegistryPath(path) {
+		return "", "", "", &RegistryNotAvailableError{Path: path}
+	}
+
+	// 404 on .md — try the HTML page to find a redirect
+	redirectPath, err := resolveRedirect(base, path)
+	if err != nil || redirectPath == "" || redirectPath == strings.Trim(path, "/") {
+		return "", "", "", fmt.Errorf("documentation page not found: %s", path)
+	}
+
+	return FetchDoc(baseURL, redirectPath)
+}
+
+func resolveRedirect(base, path string) (string, error) {
+	prefix, trimmedPath := ContentPrefix(path)
+	htmlURL := fmt.Sprintf("%s%s%s/", base, prefix, trimmedPath)
+
+	//nolint:gosec // URL is constructed from user-provided base URL and path
+	resp, err := redirectClient.Get(htmlURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		loc := resp.Header.Get("Location")
+		if loc != "" {
+			return extractContentPath(loc, base), nil
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", nil
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	html := string(data)
+	if m := metaRefreshRe.FindStringSubmatch(html); m != nil {
+		return extractContentPath(m[1], base), nil
+	}
+
+	return "", nil
+}
+
+func extractContentPath(rawURL, base string) string {
+	rawURL = strings.TrimPrefix(rawURL, base)
+	if idx := strings.Index(rawURL, "/registry/"); idx >= 0 {
+		path := rawURL[idx+1:]
+		return strings.Trim(path, "/")
+	}
+	if idx := strings.Index(rawURL, "/docs/"); idx >= 0 {
+		rawURL = rawURL[idx:]
+	}
+	path := strings.TrimPrefix(rawURL, "/docs/")
+	return strings.Trim(path, "/")
+}
+
+// StripFrontmatter removes YAML frontmatter delimited by --- and extracts the title.
+func StripFrontmatter(raw string) (body string, title string) {
+	if !strings.HasPrefix(raw, "---") {
+		return raw, ""
+	}
+
+	rest := raw[3:]
+	frontmatter, after, ok := strings.Cut(rest, "\n---")
+	if !ok {
+		return raw, ""
+	}
+	body = strings.TrimLeft(after, "\n")
+
+	for line := range strings.SplitSeq(frontmatter, "\n") {
+		if after, ok := strings.CutPrefix(strings.TrimSpace(line), "title:"); ok {
+			title = strings.TrimSpace(after)
+			title = strings.Trim(title, "\"'")
+			break
+		}
+	}
+
+	return body, title
+}
+
+type sitemapResponse struct {
+	Pages []SitemapPage `json:"pages"`
+}
+
+// FetchSitemap fetches the docs site navigation structure.
+func FetchSitemap(baseURL string) ([]SitemapPage, error) {
+	url := normalizeBaseURL(baseURL) + "/docs/cli-sitemap.json"
+	return fetchSitemapJSON(url, "sitemap")
+}
+
+// FetchRegistrySitemap fetches the top-level registry navigation (list of all packages).
+func FetchRegistrySitemap(baseURL string) ([]SitemapPage, error) {
+	url := normalizeBaseURL(baseURL) + "/registry/cli-sitemap.json"
+	return fetchSitemapJSON(url, "registry sitemap")
+}
+
+// FetchPackageSitemap fetches the per-package navigation for a registry package.
+func FetchPackageSitemap(baseURL, packageName string) ([]SitemapPage, error) {
+	url := fmt.Sprintf("%s/registry/packages/%s/cli-sitemap.json",
+		normalizeBaseURL(baseURL), packageName)
+	return fetchSitemapJSON(url, "package sitemap for "+packageName)
+}
+
+func fetchSitemapJSON(url, label string) ([]SitemapPage, error) {
+	if cached, ok := sitemapCache.Load(url); ok {
+		return cached.([]SitemapPage), nil
+	}
+
+	//nolint:gosec // URL is constructed from user-provided base URL
+	resp, err := HTTPClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", label, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s not available (status %d)", label, resp.StatusCode)
+	}
+
+	var result sitemapResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding %s: %w", label, err)
+	}
+	sitemapCache.Store(url, result.Pages)
+	return result.Pages, nil
+}
+
+// HrefToPath strips /docs/ or /registry/ prefix from an href, returning a clean path.
+func HrefToPath(href string) string {
+	if idx := strings.IndexAny(href, "?#"); idx >= 0 {
+		href = href[:idx]
+	}
+	href = strings.Trim(href, "/")
+	if strings.HasPrefix(href, "registry/") {
+		return href
+	}
+	path := strings.TrimPrefix(href, "docs/")
+	return strings.Trim(path, "/")
+}

--- a/pkg/docsrender/fetch_test.go
+++ b/pkg/docsrender/fetch_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchDoc(t *testing.T) { //nolint:paralleltest // mutates package-level HTTPClient
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/docs/iac/concepts/stacks/index.md":
+			fmt.Fprint(w, "---\ntitle: Stacks\n---\n# Stacks\n\nContent here.")
+		case "/registry/packages/aws/index.md":
+			fmt.Fprint(w, "---\ntitle: AWS Provider\n---\n# AWS\n\nAWS content.")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	t.Cleanup(func() { HTTPClient = origClient })
+
+	t.Run("docs page found", func(t *testing.T) { //nolint:paralleltest // shares HTTPClient
+		body, title, resolved, err := FetchDoc(srv.URL, "iac/concepts/stacks")
+		require.NoError(t, err)
+		assert.Equal(t, "Stacks", title)
+		assert.Contains(t, body, "Content here.")
+		assert.Equal(t, "iac/concepts/stacks", resolved)
+	})
+
+	t.Run("registry page found", func(t *testing.T) { //nolint:paralleltest // shares HTTPClient
+		body, title, resolved, err := FetchDoc(srv.URL, "registry/packages/aws")
+		require.NoError(t, err)
+		assert.Equal(t, "AWS Provider", title)
+		assert.Contains(t, body, "AWS content.")
+		assert.Equal(t, "registry/packages/aws", resolved)
+	})
+
+	t.Run("docs page not found", func(t *testing.T) { //nolint:paralleltest // shares HTTPClient
+		_, _, _, err := FetchDoc(srv.URL, "nonexistent/path")
+		assert.Error(t, err)
+	})
+
+	//nolint:paralleltest // shares HTTPClient
+	t.Run("registry not found returns RegistryNotAvailableError", func(t *testing.T) {
+		_, _, _, err := FetchDoc(srv.URL, "registry/packages/nonexistent")
+		assert.Error(t, err)
+		var regErr *RegistryNotAvailableError
+		assert.ErrorAs(t, err, &regErr)
+	})
+}
+
+func TestStripFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantBody  string
+		wantTitle string
+	}{
+		{
+			name:      "with frontmatter and title",
+			input:     "---\ntitle: Getting Started\n---\nHello world.",
+			wantBody:  "Hello world.",
+			wantTitle: "Getting Started",
+		},
+		{
+			name:      "quoted title",
+			input:     "---\ntitle: \"Hello World\"\n---\nBody here.",
+			wantBody:  "Body here.",
+			wantTitle: "Hello World",
+		},
+		{
+			name:      "no frontmatter",
+			input:     "Just plain markdown.",
+			wantBody:  "Just plain markdown.",
+			wantTitle: "",
+		},
+		{
+			name:      "unclosed frontmatter",
+			input:     "---\ntitle: Hello\n",
+			wantBody:  "---\ntitle: Hello\n",
+			wantTitle: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body, title := StripFrontmatter(tt.input)
+			assert.Equal(t, tt.wantBody, body)
+			assert.Equal(t, tt.wantTitle, title)
+		})
+	}
+}
+
+func TestHrefToPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		href string
+		want string
+	}{
+		{name: "docs prefix stripped", href: "/docs/iac/concepts/stacks/", want: "iac/concepts/stacks"},
+		{name: "registry prefix kept", href: "/registry/packages/aws/", want: "registry/packages/aws"},
+		{name: "query params stripped", href: "/docs/install?ref=nav", want: "install"},
+		{name: "fragment stripped", href: "/docs/install#linux", want: "install"},
+		{name: "bare path", href: "/docs/", want: "docs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, HrefToPath(tt.href))
+		})
+	}
+}

--- a/pkg/docsrender/preferences.go
+++ b/pkg/docsrender/preferences.go
@@ -1,0 +1,109 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+const preferencesFile = "docs-preferences.json"
+
+// Preferences stores user preferences for docs rendering.
+type Preferences struct {
+	Language   string `json:"language,omitempty"`
+	OS         string `json:"os,omitempty"`
+	Cloud      string `json:"cloud,omitempty"`
+	LastPage   string `json:"lastPage,omitempty"`
+	BrowseMode string `json:"browseMode,omitempty"`
+}
+
+// Get returns the stored preference for the given chooser type.
+func (p *Preferences) Get(chooserType string) string {
+	switch chooserType {
+	case ChooserLanguage:
+		return p.Language
+	case ChooserOS:
+		return p.OS
+	case ChooserCloud:
+		return p.Cloud
+	default:
+		return ""
+	}
+}
+
+// Set updates the stored preference for the given chooser type.
+func (p *Preferences) Set(chooserType, value string) {
+	switch chooserType {
+	case ChooserLanguage:
+		p.Language = value
+	case ChooserOS:
+		p.OS = value
+	case ChooserCloud:
+		p.Cloud = value
+	}
+}
+
+func preferencesPath() (string, error) {
+	return workspace.GetPulumiPath(preferencesFile)
+}
+
+// LoadPreferences reads preferences from disk, returning defaults on failure.
+func LoadPreferences() *Preferences {
+	path, err := preferencesPath()
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not resolve path: %v", err)
+		return &Preferences{}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logging.V(7).Infof("docs preferences: could not read %s: %v", path, err)
+		}
+		return &Preferences{}
+	}
+
+	var prefs Preferences
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		logging.V(7).Infof("docs preferences: could not parse %s: %v", path, err)
+		return &Preferences{}
+	}
+
+	return &prefs
+}
+
+// SavePreferences persists preferences; errors are logged, not returned.
+func SavePreferences(prefs *Preferences) {
+	path, err := preferencesPath()
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not resolve path: %v", err)
+		return
+	}
+
+	data, err := json.MarshalIndent(prefs, "", "  ")
+	if err != nil {
+		logging.V(7).Infof("docs preferences: could not marshal: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		logging.V(7).Infof("docs preferences: could not write %s: %v", path, err)
+	}
+}

--- a/pkg/docsrender/preferences_test.go
+++ b/pkg/docsrender/preferences_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSaveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	prefs := &Preferences{
+		Language:   "python",
+		OS:         "macos",
+		LastPage:   "iac/concepts/stacks",
+		BrowseMode: "sections",
+	}
+	SavePreferences(prefs)
+
+	loaded := LoadPreferences()
+	assert.Equal(t, prefs, loaded)
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	prefs := LoadPreferences()
+	assert.Equal(t, &Preferences{}, prefs)
+}
+
+func TestLoadMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	err := os.WriteFile(filepath.Join(dir, preferencesFile), []byte("{not json!"), 0o600)
+	require.NoError(t, err)
+
+	prefs := LoadPreferences()
+	assert.Equal(t, &Preferences{}, prefs)
+}
+
+func TestSaveCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PULUMI_HOME", dir)
+
+	SavePreferences(&Preferences{Language: "go"})
+
+	data, err := os.ReadFile(filepath.Join(dir, preferencesFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"language": "go"`)
+}

--- a/pkg/docsrender/render.go
+++ b/pkg/docsrender/render.go
@@ -1,0 +1,617 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"golang.org/x/term"
+)
+
+const defaultWidth = 80
+
+// pageMargin is the left margin glamour applies to rendered content.
+const pageMargin = "  "
+
+// GetTerminalWidth returns the current terminal width, defaulting to 80.
+func GetTerminalWidth() int {
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 { //nolint:gosec // fd fits int
+		return w
+	}
+	return defaultWidth
+}
+
+// renderBlock represents a classified AST node group for rendering.
+type renderBlock struct {
+	kind     blockKind
+	nodes    []ast.Node // AST nodes to render
+	lang     string     // language for code blocks
+	noteType string     // "note", "warning", "tip" for note blocks
+}
+
+type blockKind int
+
+const (
+	blockMarkdown blockKind = iota
+	blockCode
+	blockNote
+)
+
+var noteLabels = map[string]string{
+	"note":    "ℹ️  Note",
+	"warning": "⚠️  Warning",
+	"tip":     "💡 Tip",
+}
+
+var noteKeywords = map[string]bool{"note": true, "warning": true, "tip": true}
+
+var langDisplayNames = map[string]string{
+	"csharp": "C#", "bash": "Bash", "typescript": "TypeScript",
+	"javascript": "JavaScript", "python": "Python", "go": "Go",
+	"yaml": "YAML", "json": "JSON", "java": "Java",
+	"shell": "Shell", "sh": "Shell", "html": "HTML",
+	"css": "CSS", "sql": "SQL", "ts": "TypeScript",
+	"js": "JavaScript", "py": "Python",
+}
+
+func displayLang(lang string) string {
+	if name, ok := langDisplayNames[lang]; ok {
+		return name
+	}
+	return lang
+}
+
+// RenderMarkdown renders markdown for terminal display.
+func RenderMarkdown(title, body string) (string, error) {
+	fullMD := body
+	if title != "" && !strings.HasPrefix(strings.TrimSpace(fullMD), "# ") {
+		fullMD = fmt.Sprintf("# %s\n\n%s", title, fullMD)
+	}
+
+	source := []byte(fullMD)
+	tree := ParseMarkdown(source)
+	width := GetTerminalWidth()
+	blocks := classifyBlocks(source, tree)
+
+	if !cmdutil.InteractiveTerminal() {
+		var buf strings.Builder
+		for _, b := range blocks {
+			buf.Write(renderNodesToMarkdown(source, b.nodes))
+			buf.WriteByte('\n')
+		}
+		return buf.String(), nil
+	}
+
+	glamourRenderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(width),
+	)
+	if err != nil {
+		return fullMD, nil
+	}
+
+	var buf strings.Builder
+	for _, b := range blocks {
+		switch b.kind {
+		case blockCode:
+			buf.WriteString(pageMargin + boxHeader(displayLang(b.lang), width-len(pageMargin)) + "\n")
+			codeMD := string(renderNodesToMarkdown(source, b.nodes))
+			rendered, renderErr := glamourRenderer.Render(codeMD)
+			if renderErr != nil {
+				buf.WriteString(codeMD)
+			} else {
+				buf.WriteString(trimCodeBlock(rendered))
+			}
+			buf.WriteString("\n" + pageMargin + boxFooter(width-len(pageMargin)) + "\n")
+
+		case blockNote:
+			label := noteLabels[b.noteType]
+			noteBody := extractNoteBody(source, b.nodes[0])
+			buf.WriteString(renderNoteBox(label, noteBody, width))
+
+		case blockMarkdown:
+			md := string(renderNodesToMarkdown(source, b.nodes))
+			rendered, renderErr := glamourRenderer.Render(md)
+			if renderErr != nil {
+				buf.WriteString(md)
+			} else {
+				buf.WriteString(rendered)
+			}
+		}
+	}
+
+	return buf.String(), nil
+}
+
+// classifyBlocks walks top-level AST nodes and groups them into render blocks.
+func classifyBlocks(source []byte, tree ast.Node) []renderBlock {
+	var blocks []renderBlock
+	var mdNodes []ast.Node
+
+	flushMD := func() {
+		if len(mdNodes) > 0 {
+			blocks = append(blocks, renderBlock{kind: blockMarkdown, nodes: mdNodes})
+			mdNodes = nil
+		}
+	}
+
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		switch n := c.(type) {
+		case *ast.FencedCodeBlock:
+			flushMD()
+			lang := string(n.Language(source))
+			blocks = append(blocks, renderBlock{kind: blockCode, nodes: []ast.Node{c}, lang: lang})
+
+		case *ast.Blockquote:
+			if noteType := detectNoteType(source, n); noteType != "" {
+				flushMD()
+				blocks = append(blocks, renderBlock{kind: blockNote, nodes: []ast.Node{c}, noteType: noteType})
+			} else {
+				mdNodes = append(mdNodes, c)
+			}
+
+		default:
+			mdNodes = append(mdNodes, c)
+		}
+	}
+
+	flushMD()
+	return blocks
+}
+
+func detectNoteType(source []byte, bq *ast.Blockquote) string {
+	first := bq.FirstChild()
+	if first == nil {
+		return ""
+	}
+
+	child := first.FirstChild()
+	if child == nil {
+		return ""
+	}
+
+	var keyword string
+	switch n := child.(type) {
+	case *ast.Emphasis:
+		keyword = extractNoteKeyword(source, n)
+	case *ast.Text:
+		keyword = extractNoteKeywordFromText(string(n.Segment.Value(source)))
+	}
+
+	return keyword
+}
+
+func extractNoteKeyword(source []byte, em *ast.Emphasis) string {
+	text := plainText(source, em)
+	return extractNoteKeywordFromText(text)
+}
+
+func extractNoteKeywordFromText(text string) string {
+	text = strings.TrimSpace(text)
+	word, _, ok := strings.Cut(text, ":")
+	if !ok {
+		return ""
+	}
+	word = strings.ToLower(word)
+	if noteKeywords[word] {
+		return word
+	}
+	return ""
+}
+
+func plainText(source []byte, node ast.Node) string {
+	var buf bytes.Buffer
+	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := n.(*ast.Text); ok {
+			buf.Write(t.Segment.Value(source))
+		}
+		return ast.WalkContinue, nil
+	})
+	return buf.String()
+}
+
+// extractNoteBody returns the note body with the leading label stripped.
+func extractNoteBody(source []byte, bqNode ast.Node) string {
+	bq, ok := bqNode.(*ast.Blockquote)
+	if !ok {
+		return string(renderNodesToMarkdown(source, []ast.Node{bqNode}))
+	}
+
+	doc := ast.NewDocument()
+	var children []ast.Node
+	for c := bq.FirstChild(); c != nil; c = c.NextSibling() {
+		children = append(children, c)
+	}
+	for _, c := range children {
+		bq.RemoveChild(bq, c)
+		doc.AppendChild(doc, c)
+	}
+
+	first := doc.FirstChild()
+	if first != nil {
+		removeNoteLabel(source, first)
+	}
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, doc)
+	contract.AssertNoErrorf(err, "rendering note body")
+	return strings.TrimSpace(buf.String())
+}
+
+func removeNoteLabel(source []byte, para ast.Node) {
+	child := para.FirstChild()
+	if child == nil {
+		return
+	}
+
+	switch n := child.(type) {
+	case *ast.Emphasis:
+		text := plainText(source, n)
+		if extractNoteKeywordFromText(text) != "" {
+			para.RemoveChild(para, n)
+			trimLeadingSpace(source, para)
+		}
+	case *ast.Text:
+		seg := n.Segment
+		text := string(seg.Value(source))
+		kw := extractNoteKeywordFromText(text)
+		if kw != "" {
+			prefix := text[:len(kw)+1]
+			rest := strings.TrimPrefix(text[len(prefix):], " ")
+			if rest != "" {
+				advance := len(text) - len(rest)
+				n.Segment = n.Segment.WithStart(n.Segment.Start + advance)
+			} else {
+				para.RemoveChild(para, n)
+				trimLeadingSpace(source, para)
+			}
+		}
+	}
+}
+
+func trimLeadingSpace(source []byte, para ast.Node) {
+	next := para.FirstChild()
+	if next == nil {
+		return
+	}
+	if t, ok := next.(*ast.Text); ok {
+		text := string(t.Segment.Value(source))
+		trimmed := strings.TrimLeft(text, " ")
+		if trimmed == "" {
+			para.RemoveChild(para, next)
+		} else {
+			advance := len(text) - len(trimmed)
+			t.Segment = t.Segment.WithStart(t.Segment.Start + advance)
+		}
+	}
+}
+
+func renderNodesToMarkdown(source []byte, nodes []ast.Node) []byte {
+	doc := ast.NewDocument()
+	for _, n := range nodes {
+		if n.Parent() != nil {
+			n.Parent().RemoveChild(n.Parent(), n)
+		}
+		doc.AppendChild(doc, n)
+	}
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, doc)
+	contract.AssertNoErrorf(err, "rendering nodes to markdown")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+func renderNoteBox(label, body string, width int) string {
+	boxWidth := width - len(pageMargin)
+	contentWidth := width - 6
+
+	var buf strings.Builder
+	buf.WriteString(pageMargin + boxHeader(label, boxWidth) + "\n")
+
+	rendered := body
+	noteRenderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(contentWidth),
+	)
+	if err == nil {
+		if r, err := noteRenderer.Render(body); err == nil {
+			rendered = r
+		}
+	}
+
+	rendered = strings.TrimSpace(rendered)
+	buf.WriteString(pageMargin + "│\n")
+	for line := range strings.SplitSeq(rendered, "\n") {
+		buf.WriteString(pageMargin + "│ " + line + "\n")
+	}
+	buf.WriteString(pageMargin + "│\n")
+	buf.WriteString(pageMargin + boxFooter(boxWidth) + "\n")
+	return buf.String()
+}
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func isVisuallyBlank(line string) bool {
+	return strings.TrimSpace(ansiRegex.ReplaceAllString(line, "")) == ""
+}
+
+func trimCodeBlock(s string) string {
+	lines := strings.Split(s, "\n")
+
+	start := 0
+	for start < len(lines) && isVisuallyBlank(lines[start]) {
+		start++
+	}
+	if start > 0 {
+		lines = append([]string{""}, lines[start:]...)
+	}
+
+	end := len(lines) - 1
+	for end >= 0 && isVisuallyBlank(lines[end]) {
+		end--
+	}
+	lines = append(lines[:end+1], "")
+
+	return strings.Join(lines, "\n")
+}
+
+func boxHeader(label string, width int) string {
+	if label == "" {
+		return "┌" + strings.Repeat("─", width-1)
+	}
+	inner := "─ " + label + " "
+	padding := width - 1 - len([]rune(inner))
+	if padding < 1 {
+		padding = 1
+	}
+	return "┌" + inner + strings.Repeat("─", padding)
+}
+
+func boxFooter(width int) string {
+	return "└" + strings.Repeat("─", width-1)
+}
+
+func termRule() string {
+	return strings.Repeat("─", GetTerminalWidth()-len(pageMargin))
+}
+
+// PageFooter returns a formatted footer for standalone page views.
+func PageFooter(baseURL, path string) string {
+	url := WebURL(baseURL, path)
+	var buf strings.Builder
+	buf.WriteString("\n")
+	buf.WriteString(pageMargin + termRule() + "\n")
+	buf.WriteString(pageMargin + "🔗 " + url + "\n")
+	buf.WriteString(pageMargin + "🧭 " + ANSIBold + "pulumi docs browse" + ANSIReset + "       Browse from here\n")
+	buf.WriteString("\n")
+	return buf.String()
+}
+
+// BrowseFooter returns a compact footer for browse mode showing the web URL.
+func BrowseFooter(baseURL, path string) string {
+	return fmt.Sprintf("\n%s%s\n%s🔗 %s\n", pageMargin, termRule(), pageMargin, WebURL(baseURL, path))
+}
+
+// FindSectionBounds returns the start index, the index after the heading,
+// and the end index of a section identified by its heading text.
+// Returns -1, -1, -1 if the heading is not found.
+func FindSectionBounds(body, heading string) (start, afterHeading, end int) {
+	idx := strings.Index(body, heading)
+	if idx < 0 {
+		return -1, -1, -1
+	}
+	after := idx + len(heading)
+	endIdx := len(body)
+	if nextH := strings.Index(body[after:], "\n## "); nextH >= 0 {
+		endIdx = after + nextH
+	}
+	return idx, after, endIdx
+}
+
+// FilterCodeBlocksByLanguage filters fenced code blocks to keep only those
+// matching lang (or "sh"). Isolated code blocks not adjacent to other code
+// blocks are always preserved.
+func FilterCodeBlocksByLanguage(source []byte, tree ast.Node, lang string) []byte {
+	if lang == "" {
+		return renderTree(source, tree)
+	}
+	filterCodeBlocks(source, tree, lang)
+	return renderTree(source, tree)
+}
+
+func filterCodeBlocks(source []byte, node ast.Node, lang string) {
+	var c, next ast.Node
+	for c = node.FirstChild(); c != nil; c = next {
+		filterCodeBlocks(source, c, lang)
+		next = c.NextSibling()
+
+		cb, ok := c.(*ast.FencedCodeBlock)
+		if !ok {
+			continue
+		}
+
+		cbLang := string(cb.Language(source))
+		if cbLang == "" || cbLang == lang || cbLang == "sh" || cbLang == "bash" || cbLang == "shell" {
+			continue
+		}
+
+		if !hasAdjacentCodeBlock(c) {
+			continue
+		}
+
+		node.RemoveChild(node, c)
+	}
+}
+
+func hasAdjacentCodeBlock(node ast.Node) bool {
+	if prev := node.PreviousSibling(); prev != nil {
+		if _, ok := prev.(*ast.FencedCodeBlock); ok {
+			return true
+		}
+	}
+	if next := node.NextSibling(); next != nil {
+		if _, ok := next.(*ast.FencedCodeBlock); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractLinks extracts all hyperlinks from the document, deduplicating by URL.
+func ExtractLinks(source []byte, tree ast.Node) []Link {
+	seen := map[string]bool{}
+	var links []Link
+
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+
+		url := string(link.Destination)
+		if seen[url] {
+			return ast.WalkSkipChildren, nil
+		}
+		seen[url] = true
+
+		title := linkPlainText(source, link)
+		links = append(links, Link{URL: url, Title: title})
+		return ast.WalkSkipChildren, nil
+	})
+
+	return links
+}
+
+// ExtractInternalLinks extracts internal doc/registry links, deduplicated by URL.
+func ExtractInternalLinks(md string) []Link {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	all := ExtractLinks(source, tree)
+
+	var internal []Link
+	for _, l := range all {
+		if strings.HasPrefix(l.URL, "/docs/") || strings.HasPrefix(l.URL, "/registry/") {
+			internal = append(internal, l)
+		}
+	}
+	return internal
+}
+
+// NumberLinks replaces internal doc/registry links in the markdown with numbered
+// references (e.g. "🔗1 [Link text](url)") and returns the annotated markdown along
+// with the ordered list of links. Uses goldmark AST to find and modify links.
+func NumberLinks(md string) (annotated string, links []Link) {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+
+	seen := map[string]bool{}
+	linkNum := map[string]int{}
+	n := 0
+
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		url := string(link.Destination)
+		if !strings.HasPrefix(url, "/docs/") && !strings.HasPrefix(url, "/registry/") {
+			return ast.WalkSkipChildren, nil
+		}
+		if !seen[url] {
+			seen[url] = true
+			n++
+			linkNum[url] = n
+			title := linkPlainText(source, link)
+			links = append(links, Link{URL: url, Title: title})
+		}
+		return ast.WalkSkipChildren, nil
+	})
+
+	if len(links) == 0 {
+		return md, nil
+	}
+
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		num, ok := linkNum[string(link.Destination)]
+		if !ok {
+			return ast.WalkSkipChildren, nil
+		}
+		prefix := ast.NewString(fmt.Appendf(nil, "🔗%d ", num))
+		prefix.SetRaw(true)
+		first := link.FirstChild()
+		if first != nil {
+			link.InsertBefore(link, first, prefix)
+		} else {
+			link.AppendChild(link, prefix)
+		}
+		return ast.WalkSkipChildren, nil
+	})
+
+	return string(renderTree(source, tree)), links
+}
+
+func linkPlainText(source []byte, link *ast.Link) string {
+	var buf bytes.Buffer
+	_ = ast.Walk(link, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		if t, ok := node.(*ast.Text); ok {
+			buf.Write(t.Segment.Value(source))
+		}
+		return ast.WalkContinue, nil
+	})
+	return buf.String()
+}
+
+func renderTree(source []byte, tree ast.Node) []byte {
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, tree)
+	contract.AssertNoErrorf(err, "rendering markdown tree")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}

--- a/pkg/docsrender/render_test.go
+++ b/pkg/docsrender/render_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderMarkdown(t *testing.T) {
+	t.Parallel()
+
+	body := "Some **bold** text."
+	result, err := RenderMarkdown("Hello", body)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+	assert.Contains(t, result, "Hello")
+}
+
+func TestRenderMarkdownNoTitle(t *testing.T) {
+	t.Parallel()
+
+	body := "# Already has title\n\nSome text."
+	result, err := RenderMarkdown("", body)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+}
+
+func TestFilterCodeBlocksByLanguageMultiLang(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text.
+
+` + "```typescript" + `
+console.log('hello');
+` + "```" + `
+
+` + "```python" + `
+print('hello')
+` + "```" + `
+
+` + "```go" + `
+fmt.Println("hello")
+` + "```" + `
+
+More text.
+`)
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "print('hello')")
+	assert.NotContains(t, result, "console.log")
+	assert.NotContains(t, result, "fmt.Println")
+	assert.Contains(t, result, "Some text.")
+	assert.Contains(t, result, "More text.")
+}
+
+func TestFilterCodeBlocksPreservesShell(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(
+		"```python\nprint('hi')\n```\n\n" +
+			"```sh\ncurl example.com\n```\n\n" +
+			"```typescript\nconsole.log('hi');\n```\n")
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "print('hi')")
+	assert.Contains(t, result, "curl example.com")
+	assert.NotContains(t, result, "console.log")
+}
+
+func TestFilterCodeBlocksPreservesIsolated(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some text.
+
+` + "```yaml" + `
+key: value
+` + "```" + `
+
+More text.
+`)
+	tree := ParseMarkdown(source)
+	result := string(FilterCodeBlocksByLanguage(source, tree, "python"))
+
+	assert.Contains(t, result, "key: value")
+}
+
+func TestExtractLinks(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Check [Stacks](/docs/iac/concepts/stacks) and
+[AWS Provider](/registry/packages/aws) for details.
+Also see [Stacks](/docs/iac/concepts/stacks) again.
+And [Google](https://google.com).
+`)
+	tree := ParseMarkdown(source)
+	links := ExtractLinks(source, tree)
+
+	assert.Equal(t, []Link{
+		{URL: "/docs/iac/concepts/stacks", Title: "Stacks"},
+		{URL: "/registry/packages/aws", Title: "AWS Provider"},
+		{URL: "https://google.com", Title: "Google"},
+	}, links)
+}
+
+func TestExtractInternalLinks(t *testing.T) {
+	t.Parallel()
+
+	md := `Check [Stacks](/docs/iac/concepts/stacks) and [Google](https://google.com).`
+	links := ExtractInternalLinks(md)
+
+	require.Len(t, links, 1)
+	assert.Equal(t, "/docs/iac/concepts/stacks", links[0].URL)
+}
+
+func TestNumberLinks(t *testing.T) {
+	t.Parallel()
+
+	md := `See [Stacks](/docs/stacks) and [Projects](/docs/projects).`
+	annotated, links := NumberLinks(md)
+
+	require.Len(t, links, 2)
+	assert.Contains(t, annotated, "🔗1")
+	assert.Contains(t, annotated, "🔗2")
+}
+
+func TestWebURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("docs path", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "https://www.pulumi.com/docs/iac/concepts/stacks/",
+			WebURL("https://www.pulumi.com", "iac/concepts/stacks"))
+	})
+
+	t.Run("registry path", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "https://www.pulumi.com/registry/packages/aws/",
+			WebURL("https://www.pulumi.com", "registry/packages/aws"))
+	})
+}
+
+func TestPipelineChooserAndFilter(t *testing.T) {
+	t.Parallel()
+
+	input := "# How-To Guides\n\n" +
+		"<!-- chooser: language -->\n" +
+		"<!-- option: typescript -->\n" +
+		"See [TS Guide](/docs/ts-guide).\n\n" +
+		"```typescript\nconsole.log('hello');\n```\n\n" +
+		"<!-- /option -->\n" +
+		"<!-- option: python -->\n" +
+		"See [Python Guide](/docs/python-guide).\n\n" +
+		"```python\nprint('hello')\n```\n\n" +
+		"<!-- /option -->\n" +
+		"<!-- /chooser -->\n\n" +
+		"Some shared content with a [Shared Link](/docs/shared).\n"
+
+	tests := []struct {
+		name         string
+		lang         string
+		wantLinks    []string
+		notWantLinks []string
+		wantCode     string
+		notWantCode  string
+	}{
+		{
+			name:         "python selected",
+			lang:         "python",
+			wantLinks:    []string{"/docs/python-guide", "/docs/shared"},
+			notWantLinks: []string{"/docs/ts-guide"},
+			wantCode:     "print('hello')",
+			notWantCode:  "console.log",
+		},
+		{
+			name:         "typescript selected",
+			lang:         "typescript",
+			wantLinks:    []string{"/docs/ts-guide", "/docs/shared"},
+			notWantLinks: []string{"/docs/python-guide"},
+			wantCode:     "console.log",
+			notWantCode:  "print('hello')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			source := []byte(input)
+			tree := ParseMarkdown(source)
+
+			selections := map[string]string{"language": tt.lang}
+			resolved := ResolveChoosers(source, tree, selections)
+
+			filtered := FilterCodeBlocksByLanguage(resolved, ParseMarkdown(resolved), tt.lang)
+			result := string(filtered)
+
+			assert.Contains(t, result, tt.wantCode)
+			assert.NotContains(t, result, tt.notWantCode)
+
+			links := ExtractInternalLinks(result)
+			var linkURLs []string
+			for _, l := range links {
+				linkURLs = append(linkURLs, l.URL)
+			}
+			for _, want := range tt.wantLinks {
+				assert.Contains(t, linkURLs, want)
+			}
+			for _, notWant := range tt.notWantLinks {
+				assert.NotContains(t, linkURLs, notWant)
+			}
+
+			// Re-resolution is a no-op: no chooser comments should remain.
+			choosers := ScanChoosers(filtered, ParseMarkdown(filtered))
+			assert.Empty(t, choosers)
+		})
+	}
+}

--- a/pkg/docsrender/sections.go
+++ b/pkg/docsrender/sections.go
@@ -1,0 +1,218 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// ExtractHeadings returns all headings found in the document in order.
+func ExtractHeadings(source []byte, tree ast.Node) []Heading {
+	var headings []Heading
+	_ = ast.Walk(tree, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		h, ok := node.(*ast.Heading)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		title := headingPlainText(source, h)
+		headings = append(headings, Heading{
+			Slug:  slugify(title),
+			Title: title,
+			Level: h.Level,
+		})
+		return ast.WalkSkipChildren, nil
+	})
+	return headings
+}
+
+// ExtractSection returns the markdown content for the section identified by slug.
+// A section starts at its heading and extends to the next heading of equal or higher
+// level (lower number), or to the end of the document. Returns nil if not found.
+func ExtractSection(source []byte, tree ast.Node, slug string) []byte {
+	slug = strings.ToLower(slug)
+
+	var startNode ast.Node
+	var startLevel int
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		h, ok := c.(*ast.Heading)
+		if !ok {
+			continue
+		}
+		title := headingPlainText(source, h)
+		if strings.EqualFold(slugify(title), slug) {
+			startNode = c
+			startLevel = h.Level
+			break
+		}
+	}
+	if startNode == nil {
+		return nil
+	}
+
+	var nodes []ast.Node
+	for c := startNode; c != nil; c = c.NextSibling() {
+		if c != startNode {
+			if h, ok := c.(*ast.Heading); ok && h.Level <= startLevel {
+				break
+			}
+		}
+		nodes = append(nodes, c)
+	}
+
+	return renderNodes(source, nodes)
+}
+
+// ExtractIntro returns all content before the first heading, or nil if the
+// document starts with a heading.
+func ExtractIntro(source []byte, tree ast.Node) []byte {
+	var nodes []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		if _, ok := c.(*ast.Heading); ok {
+			break
+		}
+		nodes = append(nodes, c)
+	}
+	if len(nodes) == 0 {
+		return nil
+	}
+	return renderNodes(source, nodes)
+}
+
+// GetHeadings parses the markdown and returns top-level (H2) headings.
+func GetHeadings(md string) []Heading {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	all := ExtractHeadings(source, tree)
+	var h2s []Heading
+	for _, h := range all {
+		if h.Level == 2 {
+			h2s = append(h2s, h)
+		}
+	}
+	return h2s
+}
+
+// GetSection parses the markdown and returns the section content for the given slug.
+func GetSection(md, slug string) string {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, slug)
+	if section == nil {
+		return ""
+	}
+	return string(section)
+}
+
+// GetIntro returns the introductory content of a document — the content that
+// precedes the first navigable (H2) section. If there is text before the first
+// heading, that text is the intro. If the document starts with an H1 heading,
+// the H1 and content up to the first H2 form the intro. If the document starts
+// with an H2, the first H2 section is included as the intro.
+func GetIntro(md string) string {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	intro := ExtractIntro(source, tree)
+	if intro != nil {
+		return string(intro)
+	}
+
+	var nodes []ast.Node
+	for c := tree.FirstChild(); c != nil; c = c.NextSibling() {
+		if h, ok := c.(*ast.Heading); ok && h.Level <= 2 && len(nodes) > 0 {
+			break
+		}
+		nodes = append(nodes, c)
+	}
+	if len(nodes) == 0 {
+		return md
+	}
+	return string(renderNodes(source, nodes))
+}
+
+// IntroContainsFirstHeading returns true if the document starts with a heading
+// and the intro overlaps with the first H2 section. Returns false when the
+// document starts with an H1 that is separate from the H2 sections, or when
+// there is text before the first heading.
+func IntroContainsFirstHeading(md string) bool {
+	source := []byte(md)
+	tree := ParseMarkdown(source)
+	if ExtractIntro(source, tree) != nil {
+		return false
+	}
+	first := tree.FirstChild()
+	if first == nil {
+		return false
+	}
+	if h, ok := first.(*ast.Heading); ok && h.Level == 1 {
+		for c := first.NextSibling(); c != nil; c = c.NextSibling() {
+			if h2, ok := c.(*ast.Heading); ok && h2.Level == 2 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func headingPlainText(source []byte, h *ast.Heading) string {
+	var buf bytes.Buffer
+	_ = ast.Walk(h, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := node.(type) {
+		case *ast.Text:
+			buf.Write(n.Segment.Value(source))
+			if n.SoftLineBreak() {
+				buf.WriteByte(' ')
+			}
+		case *ast.CodeSpan:
+			for gc := n.FirstChild(); gc != nil; gc = gc.NextSibling() {
+				if t, ok := gc.(*ast.Text); ok {
+					buf.Write(t.Segment.Value(source))
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	return buf.String()
+}
+
+func renderNodes(source []byte, nodes []ast.Node) []byte {
+	doc := ast.NewDocument()
+	for _, n := range nodes {
+		if n.Parent() != nil {
+			n.Parent().RemoveChild(n.Parent(), n)
+		}
+		doc.AppendChild(doc, n)
+	}
+
+	md := &markdown.Renderer{}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(md, 100)))
+	var buf bytes.Buffer
+	err := r.Render(&buf, source, doc)
+	contract.AssertNoErrorf(err, "rendering nodes to markdown")
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}

--- a/pkg/docsrender/sections_test.go
+++ b/pkg/docsrender/sections_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractHeadings(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`# Title
+
+Some intro text.
+
+## Getting Started
+
+Start here.
+
+## Configuration
+
+### Basic Config
+
+Set things up.
+
+### Advanced Config
+
+More options.
+
+## Conclusion
+
+Done.
+`)
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Equal(t, []Heading{
+		{Slug: "title", Title: "Title", Level: 1},
+		{Slug: "getting-started", Title: "Getting Started", Level: 2},
+		{Slug: "configuration", Title: "Configuration", Level: 2},
+		{Slug: "basic-config", Title: "Basic Config", Level: 3},
+		{Slug: "advanced-config", Title: "Advanced Config", Level: 3},
+		{Slug: "conclusion", Title: "Conclusion", Level: 2},
+	}, headings)
+}
+
+func TestExtractHeadingsWithInlineFormatting(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## The `foo` method\n\n## **Bold** heading\n")
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Equal(t, []Heading{
+		{Slug: "the-foo-method", Title: "The foo method", Level: 2},
+		{Slug: "bold-heading", Title: "Bold heading", Level: 2},
+	}, headings)
+}
+
+func TestExtractHeadingsEmpty(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("Just a paragraph with no headings.\n")
+	tree := ParseMarkdown(source)
+	headings := ExtractHeadings(source, tree)
+
+	assert.Empty(t, headings)
+}
+
+func TestExtractSectionMiddle(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## First
+
+Content of first.
+
+## Second
+
+Content of second.
+
+## Third
+
+Content of third.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "second")
+
+	assert.Equal(t, "## Second\n\nContent of second.", string(section))
+}
+
+func TestExtractSectionLast(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## First
+
+Content.
+
+## Last
+
+Final content here.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "last")
+
+	assert.Equal(t, "## Last\n\nFinal content here.", string(section))
+}
+
+func TestExtractSectionWithNestedSubheadings(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`## Overview
+
+Intro.
+
+### Sub One
+
+Sub content.
+
+### Sub Two
+
+More sub content.
+
+## Next Section
+
+Other stuff.
+`)
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "overview")
+
+	assert.Contains(t, string(section), "## Overview")
+	assert.Contains(t, string(section), "### Sub One")
+	assert.Contains(t, string(section), "### Sub Two")
+	assert.NotContains(t, string(section), "## Next Section")
+}
+
+func TestExtractSectionNotFound(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Existing\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "nonexistent")
+
+	assert.Nil(t, section)
+}
+
+func TestExtractSectionCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Getting Started\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	section := ExtractSection(source, tree, "GETTING-STARTED")
+
+	require.NotNil(t, section)
+	assert.Contains(t, string(section), "Getting Started")
+}
+
+func TestExtractIntro(t *testing.T) {
+	t.Parallel()
+
+	source := []byte(`Some introductory text.
+
+More intro.
+
+## First Section
+
+Content.
+`)
+	tree := ParseMarkdown(source)
+	intro := ExtractIntro(source, tree)
+
+	assert.Equal(t, "Some introductory text.\n\nMore intro.", string(intro))
+}
+
+func TestExtractIntroNoIntro(t *testing.T) {
+	t.Parallel()
+
+	source := []byte("## Starts with heading\n\nContent.\n")
+	tree := ParseMarkdown(source)
+	intro := ExtractIntro(source, tree)
+
+	assert.Nil(t, intro)
+}

--- a/pkg/docsrender/types.go
+++ b/pkg/docsrender/types.go
@@ -1,0 +1,145 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/pgavlin/goldmark"
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/text"
+)
+
+const (
+	DefaultDocsBaseURL     = "https://www.pulumi.com"
+	DefaultRegistryBaseURL = "https://www.pulumi.com"
+
+	ChooserLanguage = "language"
+	ChooserOS       = "os"
+	ChooserCloud    = "cloud"
+
+	ANSIBold  = "\033[1m"
+	ANSIReset = "\033[0m"
+
+	BrowseModeFull     = "full"
+	BrowseModeSections = "sections"
+
+	SectionIntroduction = "introduction"
+)
+
+// Heading represents an extracted heading from a markdown document.
+type Heading struct {
+	Slug  string
+	Title string
+	Level int
+}
+
+// Link represents an extracted hyperlink from a markdown document.
+type Link struct {
+	URL   string
+	Title string
+}
+
+// SitemapPage represents a page in the docs site navigation.
+type SitemapPage struct {
+	Title     string        `json:"title"`
+	Path      string        `json:"path"`
+	SelfLabel string        `json:"selfLabel,omitempty"`
+	Children  []SitemapPage `json:"children,omitempty"`
+}
+
+// ViewLabel returns the label for viewing this page itself (when it has children).
+func (p SitemapPage) ViewLabel() string {
+	if p.SelfLabel != "" {
+		return p.SelfLabel
+	}
+	return "Introduction"
+}
+
+// RegistryNotAvailableError is returned when a registry page returns 404.
+type RegistryNotAvailableError struct {
+	Path string
+}
+
+func (e *RegistryNotAvailableError) Error() string {
+	return "registry docs not available for: " + e.Path
+}
+
+// ParseMarkdown parses markdown source into a goldmark AST.
+func ParseMarkdown(source []byte) ast.Node {
+	p := goldmark.DefaultParser()
+	return p.Parse(text.NewReader(source))
+}
+
+// Slugify converts heading text to a URL-safe slug.
+func Slugify(title string) string {
+	return slugify(title)
+}
+
+func slugify(title string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(title) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			prevHyphen = false
+		case unicode.IsSpace(r) || r == '-' || r == '_':
+			if !prevHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// IsRegistryPath reports whether the path refers to registry content.
+func IsRegistryPath(path string) bool {
+	p := strings.TrimPrefix(path, "/")
+	return strings.HasPrefix(p, "registry/") || p == "registry"
+}
+
+// IsAPIDocsPath reports whether the path refers to registry API documentation.
+func IsAPIDocsPath(path string) bool {
+	p := strings.TrimPrefix(path, "/")
+	parts := strings.Split(p, "/")
+	// Match both "registry/packages/{pkg}/api-docs" and "registry/packages/{pkg}/api-docs/{key}"
+	return len(parts) >= 4 && parts[0] == "registry" && parts[1] == "packages" && parts[3] == "api-docs"
+}
+
+// ContentPrefix returns the URL path prefix ("/docs/" or "/registry/") for a given path,
+// and the trimmed path with that prefix removed.
+func ContentPrefix(path string) (prefix, trimmedPath string) {
+	trimmedPath = strings.Trim(path, "/")
+	if IsRegistryPath(trimmedPath) {
+		after := strings.TrimPrefix(trimmedPath, "registry")
+		after = strings.TrimPrefix(after, "/")
+		return "/registry/", after
+	}
+	return "/docs/", trimmedPath
+}
+
+// WebURL builds the full web URL for a content path, using the correct prefix.
+func WebURL(baseURL, path string) string {
+	base := normalizeBaseURL(baseURL)
+	prefix, trimmed := ContentPrefix(path)
+	if trimmed == "" {
+		return base + prefix
+	}
+	return fmt.Sprintf("%s%s%s/", base, prefix, trimmed)
+}

--- a/pkg/docsrender/types_test.go
+++ b/pkg/docsrender/types_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docsrender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSlugify(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello World", "hello-world"},
+		{"Getting Started", "getting-started"},
+		{"foo--bar", "foo-bar"},
+		{"  leading spaces  ", "leading-spaces"},
+		{"Special!@#Characters$%^Here", "specialcharactershere"},
+		{"already-slug", "already-slug"},
+		{"MixedCase123", "mixedcase123"},
+		{"", ""},
+		{"with_underscores_here", "with-underscores-here"},
+		{"multiple   spaces", "multiple-spaces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, slugify(tt.input))
+		})
+	}
+}
+
+func TestIsRegistryPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsRegistryPath("registry/packages/aws"))
+	assert.True(t, IsRegistryPath("/registry/packages/aws"))
+	assert.True(t, IsRegistryPath("registry"))
+	assert.False(t, IsRegistryPath("docs/iac/concepts"))
+	assert.False(t, IsRegistryPath(""))
+	assert.False(t, IsRegistryPath("registryfoo"))
+}
+
+func TestIsAPIDocsPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsAPIDocsPath("registry/packages/aws/api-docs/s3"))
+	assert.True(t, IsAPIDocsPath("/registry/packages/aws/api-docs/s3/bucket"))
+	assert.False(t, IsAPIDocsPath("registry/packages/aws"))
+	assert.False(t, IsAPIDocsPath("registry/packages/aws/install"))
+	assert.False(t, IsAPIDocsPath("docs/iac/concepts"))
+	assert.False(t, IsAPIDocsPath(""))
+}


### PR DESCRIPTION
First of two PRs for the new `pulumi docs` command. This one adds the library; #22539 adds the command on top.

`pkg/docsrender` is a Go package for fetching, parsing, filtering, and rendering Pulumi documentation pages and registry API bundles. It has no UI of its own and doesn't touch any existing code. All 14 files are new.

Files:

- `fetch.go` fetches markdown from `/docs/` and `/registry/`. Handles 3xx, meta-refresh redirects, and CloudFront's 403-for-missing-content quirk.
- `bundle.go` handles per-package `cli-docs.json` bundles. Three-tier cache (memory, disk, HTTP) with classification helpers for module/resource/function navigation.
- `render.go` is the terminal rendering pipeline. Glamour for prose, custom box-drawn code blocks, callout boxes for note/warning/tip blockquotes, link numbering for the consumer's interactive UI.
- `chooser.go` scans and resolves the `<!-- chooser: language --><!-- option: typescript --><!-- /chooser -->` blocks Pulumi docs use for tabbed content.
- `sections.go` extracts headings and section content via goldmark AST.
- `preferences.go` persists chooser selections, last viewed page, and browse mode to `~/.pulumi/docs-preferences.json`.
- `types.go` has the shared types and path helpers.

Targeting `CamSoper/docs-cli-feature` (an integration branch off master) rather than master directly, so the second PR can stack cleanly.

No changelog entry: no user-visible change yet. That's in #22539.

## Reviewer's guide

I wrote a symbol-by-symbol walkthrough: https://gist.github.com/CamSoper/94cd692c7d6fb06433627ba23700cf30

Suggested reading order: types → preferences → fetch → chooser → sections → render → bundle.
