### PR TITLE
Add pulumi docs command for terminal documentation browsing

### DIFF
--- a/changelog/pending/20260407--cli--add-pulumi-docs-command.yaml
+++ b/changelog/pending/20260407--cli--add-pulumi-docs-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi docs` command for reading and browsing Pulumi documentation in the terminal

--- a/pkg/cmd/pulumi/docs/browse.go
+++ b/pkg/cmd/pulumi/docs/browse.go
@@ -665,4 +665,3 @@ func collectDescendants(pages []docsrender.SitemapPage, prefix string, result *[
 		}
 	}
 }
-

--- a/pkg/cmd/pulumi/docs/browse.go
+++ b/pkg/cmd/pulumi/docs/browse.go
@@ -1,0 +1,668 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+const (
+	navUp       = "↑ Up a level"
+	navBack     = "← Back"
+	navHome     = "🏠 Home"
+	navDone     = "🛑 Done"
+	navSections = "📑 Sections"
+	navFullPage = "📄 View full page"
+	navDrill    = " ▸"
+	navNext     = "⏩ Next section"
+	navPrev     = "⏪ Previous section"
+)
+
+type browseNode struct {
+	path  string
+	title string
+	body  string
+	items []navOption
+}
+
+type navOption struct {
+	label string
+	path  string
+	href  string
+}
+
+func (dc *docsCmd) browseLoop(startPath string) error {
+	path := strings.Trim(startPath, "/")
+	var history []string
+
+	for {
+		node := dc.resolveNode(path)
+		path = node.path
+
+		// Resolve choosers early so that headings and links extracted below
+		// only reflect the selected language/OS/cloud option.
+		if node.body != "" {
+			node.body = dc.resolveContent(node.body)
+		}
+
+		headings := docsrender.GetHeadings(node.body)
+		hasSections := len(headings) > 0 && node.body != ""
+
+		prefs := docsrender.LoadPreferences()
+
+		showFull := dc.fullPage
+		if !showFull && !dc.sectionsView {
+			showFull = prefs.BrowseMode == docsrender.BrowseModeFull
+		}
+		useSections := hasSections && !showFull
+
+		if dc.fullPage {
+			prefs.BrowseMode = docsrender.BrowseModeFull
+		} else if dc.sectionsView {
+			prefs.BrowseMode = docsrender.BrowseModeSections
+		}
+
+		var navItems []navOption
+		introIncludesFirstSection := false
+		if node.body != "" {
+			if useSections {
+				introIncludesFirstSection = docsrender.IntroContainsFirstHeading(node.body)
+				introNav, err := renderIntro(dc, node.body, node.title, path)
+				if err != nil {
+					return err
+				}
+				navItems = introNav
+			} else {
+				displayBody, links := docsrender.NumberLinks(node.body)
+				rendered, err := dc.renderBody(displayBody, node.title)
+				if err != nil {
+					return err
+				}
+				fmt.Print(rendered)
+				fmt.Print(docsrender.BrowseFooter(dc.baseURLForPath(path), path))
+				navItems = numberedNavLinks(links)
+			}
+			prefs.LastPage = path
+		}
+
+		docsrender.SavePreferences(prefs)
+
+		if !cmdutil.Interactive() {
+			if node.body == "" && len(node.items) > 0 {
+				for _, item := range node.items {
+					fmt.Printf("  %s  (%s)\n", item.label, item.path)
+				}
+			}
+			return nil
+		}
+
+		navItems = append(navItems, node.items...)
+
+		if len(navItems) == 0 && node.body == "" {
+			pageURL := docsrender.WebURL(dc.baseURLForPath(path), path)
+			fmt.Fprintf(os.Stderr, "\n  This page is not available for terminal viewing.\n\n  🔗 %s\n\n", pageURL)
+			if len(history) > 0 {
+				path = history[len(history)-1]
+				history = history[:len(history)-1]
+				continue
+			}
+			return nil
+		}
+
+		activeItems := navItems
+		sectionIdx := -1
+		if !useSections {
+			// Full page mode — signal that all sections are visible
+			// so the menu doesn't offer prev/next navigation.
+			sectionIdx = len(headings)
+		} else if introIncludesFirstSection {
+			sectionIdx = 0
+		}
+		navigated := false
+		for !navigated {
+			isRoot := path == ""
+			hasHeadings := len(headings) > 0
+			menuItems := activeItems
+			menu := buildBrowseMenu(browseMenuContext{
+				items:       menuItems,
+				isRoot:      isRoot,
+				hasHeadings: hasHeadings,
+				hasHistory:  len(history) > 0,
+				hasIntro:    !introIncludesFirstSection,
+				sectionIdx:  sectionIdx,
+				headings:    headings,
+			})
+
+			promptTitle := node.title
+			if promptTitle == "" {
+				promptTitle = path
+			}
+			if promptTitle == "" {
+				promptTitle = "Pulumi"
+			}
+
+			defaultIdx := 0
+			if !isRoot && len(menu) > 1 {
+				defaultIdx = 1
+			}
+
+			fmt.Println()
+			selected := ui.PromptUser(
+				fmt.Sprintf("Browse %s:", promptTitle),
+				menu,
+				menu[defaultIdx],
+				cmdutil.GetGlobalColorization(),
+			)
+
+			switch selected {
+			case "", navDone:
+				return nil
+
+			case navBack:
+				path = history[len(history)-1]
+				history = history[:len(history)-1]
+				navigated = true
+
+			case navUp:
+				history = append(history, path)
+				path = parentPath(path)
+				navigated = true
+
+			case navHome:
+				history = append(history, path)
+				path = ""
+				navigated = true
+
+			case navSections:
+				hasIntro := !introIncludesFirstSection
+				idx := showBrowseSectionsIdx(headings, hasIntro)
+				if idx == -1 {
+					introNav, renderErr := renderIntro(dc, node.body, node.title, path)
+					if renderErr == nil {
+						activeItems = introNav
+					}
+					sectionIdx = -1
+				} else if idx >= 0 {
+					activeItems = renderSectionByIdx(dc, node.body, headings, idx)
+					sectionIdx = idx
+				}
+
+			case navFullPage:
+				displayBody, links := docsrender.NumberLinks(node.body)
+				rendered, err := dc.renderBody(displayBody, node.title)
+				if err == nil {
+					fmt.Print(rendered)
+					fmt.Print(docsrender.BrowseFooter(dc.baseURLForPath(path), path))
+				}
+				activeItems = numberedNavLinks(links)
+				activeItems = append(activeItems, node.items...)
+				sectionIdx = len(headings)
+
+			default:
+				if strings.HasPrefix(selected, navPrev) && sectionIdx > -1 {
+					sectionIdx--
+					if sectionIdx == -1 {
+						introNav, renderErr := renderIntro(dc, node.body, node.title, path)
+						if renderErr == nil {
+							activeItems = introNav
+						}
+					} else {
+						activeItems = renderSectionByIdx(dc, node.body, headings, sectionIdx)
+					}
+				} else if strings.HasPrefix(selected, navNext) && sectionIdx+1 < len(headings) {
+					sectionIdx++
+					activeItems = renderSectionByIdx(dc, node.body, headings, sectionIdx)
+				} else {
+					for _, item := range menuItems {
+						if item.label == selected {
+							if item.href != "" {
+								fmt.Fprintf(os.Stderr, "\n  🔗 %s\n\n", item.href)
+								break
+							}
+							history = append(history, path)
+							path = item.path
+							navigated = true
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func (dc *docsCmd) resolveNode(path string) browseNode {
+	path = strings.Trim(path, "/")
+
+	if path == "" {
+		return dc.resolveRoot()
+	}
+	if path == "docs" {
+		return dc.resolveDocsSitemap()
+	}
+	if path == "registry" || path == "registry/packages" {
+		return dc.resolveRegistryList()
+	}
+	if docsrender.IsRegistryPath(path) {
+		return dc.resolveRegistryPage(path)
+	}
+	return dc.resolveDocsPage(path)
+}
+
+func (dc *docsCmd) resolveRoot() browseNode {
+	var items []navOption
+
+	docsPages, _ := docsrender.FetchSitemap(dc.baseURL)
+	registryPages, _ := docsrender.FetchRegistrySitemap(dc.registryBaseURL)
+
+	if len(docsPages) > 0 {
+		items = append(items, navOption{label: "Docs" + navDrill, path: "docs"})
+	}
+	if len(registryPages) > 0 {
+		items = append(items, navOption{label: "Registry" + navDrill, path: "registry"})
+	}
+
+	return browseNode{path: "", title: "Pulumi", items: items}
+}
+
+func (dc *docsCmd) resolveDocsSitemap() browseNode {
+	return dc.resolveSitemap("docs", "Docs", dc.baseURL, docsrender.FetchSitemap)
+}
+
+func (dc *docsCmd) resolveRegistryList() browseNode {
+	return dc.resolveSitemap("registry", "Registry", dc.registryBaseURL, docsrender.FetchRegistrySitemap)
+}
+
+func (dc *docsCmd) resolveSitemap(
+	path, title, baseURL string, fetch func(string) ([]docsrender.SitemapPage, error),
+) browseNode {
+	pages, err := fetch(baseURL)
+	if err != nil {
+		return browseNode{path: path, title: title}
+	}
+	return browseNode{path: path, title: title, items: sitemapToNavOptions(pages, baseURL)}
+}
+
+func (dc *docsCmd) resolveRegistryPage(path string) browseNode {
+	node := browseNode{path: path}
+
+	var pkgName, docKey string
+	var bundle *docsrender.CLIDocsBundle
+	if docsrender.IsAPIDocsPath(path) {
+		var ok bool
+		pkgName, docKey, ok = docsrender.ParseAPIDocsPath(path)
+		if ok {
+			bundle, _ = docsrender.FetchCLIDocsBundle(dc.registryBaseURL, pkgName)
+		}
+	}
+
+	if bundle != nil {
+		if docKey != "" {
+			if b, t, found := docsrender.LookupBundleDoc(bundle, docKey); found {
+				node.body = b
+				node.title = t
+			}
+		}
+		if node.body == "" && docKey == "" && bundle.Overview != "" {
+			node.body = docsrender.BuildAPIDocsPage(bundle, docKey, "")
+			node.title = bundle.Package
+		}
+	}
+
+	if node.body == "" {
+		body, title, resolvedPath, err := docsrender.FetchDoc(dc.registryBaseURL, path)
+		if err == nil {
+			if resolvedPath != "" {
+				path = resolvedPath
+				node.path = path
+			}
+			node.body = body
+			node.title = title
+			if bundle != nil {
+				intro := docsrender.GetIntro(node.body)
+				node.body = docsrender.BuildAPIDocsPage(bundle, docKey, intro)
+			} else if !docsrender.IsAPIDocsPath(path) {
+				node.body = docsrender.FormatPackageDetails(node.body)
+			}
+			trimmedPath := strings.Trim(path, "/")
+			for _, item := range dc.registryNavItems(path) {
+				if strings.Trim(item.path, "/") != trimmedPath {
+					node.items = append(node.items, item)
+				}
+			}
+		} else if bundle != nil {
+			// FetchDoc failed but we have a bundle: synthesize a page from it so
+			// the user still gets numbered links to drill into resources/functions.
+			node.body = docsrender.BuildAPIDocsPage(bundle, docKey, "")
+			if node.title == "" {
+				node.title = pathLastSegment(path)
+			}
+		} else {
+			var regErr *docsrender.RegistryNotAvailableError
+			if errors.As(err, &regErr) {
+				url := docsrender.WebURL(dc.registryBaseURL, path)
+				node.title = pathLastSegment(path)
+				fmt.Fprintf(os.Stderr,
+					"Registry docs are not yet available for terminal viewing.\nVisit %s instead.\n\n", url)
+			}
+		}
+	}
+
+	if len(node.items) == 0 && node.body == "" {
+		node.items = dc.registryNavItems(path)
+	}
+
+	if node.title == "" {
+		node.title = pathLastSegment(path)
+	}
+
+	return node
+}
+
+func (dc *docsCmd) resolveDocsPage(path string) browseNode {
+	forceContent := strings.HasSuffix(path, "/__view")
+	if forceContent {
+		path = strings.TrimSuffix(path, "/__view")
+	}
+
+	node := browseNode{path: path}
+
+	body, title, resolvedPath, err := docsrender.FetchDoc(dc.baseURL, path)
+	if err == nil {
+		if resolvedPath != "" {
+			path = resolvedPath
+			node.path = path
+		}
+		node.body = body
+		node.title = title
+	}
+
+	node.items = dc.docsSitemapNavItems(path)
+
+	if len(node.items) > 0 && node.body != "" && !forceContent {
+		viewLabel := "Introduction"
+		pages, err := docsrender.FetchSitemap(dc.baseURL)
+		if err == nil {
+			if p := findPage(pages, "/docs/"+strings.Trim(path, "/")+"/"); p != nil {
+				viewLabel = p.ViewLabel()
+			}
+		}
+		selfItem := navOption{label: viewLabel, path: path + "/__view"}
+		node.items = append([]navOption{selfItem}, node.items...)
+		node.body = ""
+	}
+
+	if node.title == "" {
+		node.title = pathLastSegment(path)
+	}
+
+	return node
+}
+
+type browseMenuContext struct {
+	items       []navOption
+	isRoot      bool
+	hasHeadings bool
+	hasHistory  bool
+	hasIntro    bool
+	sectionIdx  int
+	headings    []docsrender.Heading
+}
+
+func buildBrowseMenu(ctx browseMenuContext) []string {
+	var menu []string
+
+	if !ctx.isRoot {
+		menu = append(menu, navUp)
+	}
+	if ctx.hasHeadings {
+		menu = append(menu, navSections)
+	}
+	inSectionView := ctx.sectionIdx >= 0 && ctx.sectionIdx < len(ctx.headings)
+	minIdx := 0
+	if ctx.hasIntro {
+		minIdx = -1
+	}
+	if ctx.sectionIdx > minIdx && (inSectionView || ctx.sectionIdx == -1) {
+		prevLabel := "Introduction"
+		if ctx.sectionIdx > 0 {
+			prevLabel = ctx.headings[ctx.sectionIdx-1].Title
+		}
+		menu = append(menu, navPrev+" — "+prevLabel)
+	}
+	if inSectionView || ctx.sectionIdx == -1 {
+		nextIdx := ctx.sectionIdx + 1
+		if nextIdx < len(ctx.headings) {
+			menu = append(menu, navNext+" — "+ctx.headings[nextIdx].Title)
+		}
+	}
+	for _, item := range ctx.items {
+		menu = append(menu, item.label)
+	}
+	if ctx.hasHeadings && ctx.sectionIdx < len(ctx.headings) {
+		menu = append(menu, navFullPage)
+	}
+	if ctx.hasHistory {
+		menu = append(menu, navBack)
+	}
+	if !ctx.isRoot {
+		menu = append(menu, navHome)
+	}
+	menu = append(menu, navDone)
+
+	return menu
+}
+
+func showBrowseSectionsIdx(headings []docsrender.Heading, hasIntro bool) int {
+	if len(headings) == 0 {
+		return -2
+	}
+
+	var options []string
+	introOffset := 0
+	if hasIntro {
+		options = append(options, "Introduction")
+		introOffset = 1
+	}
+	for _, h := range headings {
+		indent := strings.Repeat("  ", h.Level-2)
+		options = append(options, indent+h.Title)
+	}
+	options = append(options, navBack)
+
+	selected := ui.PromptUser(
+		"Jump to section:",
+		options,
+		options[0],
+		cmdutil.GetGlobalColorization(),
+	)
+	if selected == "" || selected == navBack {
+		return -2
+	}
+	if hasIntro && selected == "Introduction" {
+		return -1
+	}
+
+	for i, opt := range options {
+		idx := i - introOffset
+		if opt == selected && idx >= 0 && idx < len(headings) {
+			return idx
+		}
+	}
+	return -2
+}
+
+func renderIntro(dc *docsCmd, body, title, path string) ([]navOption, error) {
+	intro := docsrender.GetIntro(body)
+	displayIntro, links := docsrender.NumberLinks(intro)
+	rendered, err := dc.renderBody(displayIntro, title)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Print(rendered)
+	fmt.Print(docsrender.BrowseFooter(dc.baseURLForPath(path), path))
+	return numberedNavLinks(links), nil
+}
+
+func renderSectionByIdx(dc *docsCmd, body string, headings []docsrender.Heading, idx int) []navOption {
+	heading := headings[idx]
+
+	section := docsrender.GetSection(body, heading.Slug)
+	if section == "" {
+		return nil
+	}
+	numbered, sectionLinks := docsrender.NumberLinks(section)
+	if rendered, err := dc.renderBody(numbered, ""); err == nil {
+		fmt.Print(rendered)
+	}
+	return numberedNavLinks(sectionLinks)
+}
+
+func parentPath(path string) string {
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	if len(parts) <= 1 {
+		return ""
+	}
+	parent := strings.Join(parts[:len(parts)-1], "/")
+	if parent == "registry/packages" {
+		return "registry"
+	}
+	return parent
+}
+
+func pathLastSegment(path string) string {
+	path = strings.Trim(path, "/")
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}
+
+func numberedNavLinks(links []docsrender.Link) []navOption {
+	if len(links) == 0 {
+		return nil
+	}
+	var opts []navOption
+	n := 0
+	for _, l := range links {
+		text := strings.TrimSpace(strings.ReplaceAll(l.Title, "`", ""))
+		if text == "" {
+			continue
+		}
+		n++
+		label := fmt.Sprintf("🔗%d %s", n, text)
+		opts = append(opts, navOption{label: label, path: docsrender.HrefToPath(l.URL)})
+	}
+	return opts
+}
+
+func sitemapToNavOptions(pages []docsrender.SitemapPage, baseURL string) []navOption {
+	opts := make([]navOption, 0, len(pages))
+	for _, p := range pages {
+		label := p.Title
+		if len(p.Children) > 0 {
+			label += navDrill
+		}
+		opt := navOption{label: label, path: docsrender.HrefToPath(p.Path)}
+		if strings.HasPrefix(p.Path, "http://") || strings.HasPrefix(p.Path, "https://") {
+			opt.href = p.Path
+		} else if strings.HasSuffix(p.Path, ".html") {
+			base := strings.TrimRight(baseURL, "/")
+			if base == "" {
+				base = "https://www.pulumi.com"
+			}
+			opt.href = base + p.Path
+		}
+		opts = append(opts, opt)
+	}
+	return opts
+}
+
+func childNavOptions(pages []docsrender.SitemapPage, targetPath, baseURL string) []navOption {
+	children := findExactChildren(pages, targetPath)
+	if children == nil {
+		var matches []docsrender.SitemapPage
+		collectDescendants(pages, targetPath, &matches)
+		children = matches
+	}
+	return sitemapToNavOptions(children, baseURL)
+}
+
+func (dc *docsCmd) docsSitemapNavItems(path string) []navOption {
+	pages, err := docsrender.FetchSitemap(dc.baseURL)
+	if err != nil {
+		return nil
+	}
+	target := "/docs/" + strings.Trim(path, "/") + "/"
+	return childNavOptions(pages, target, dc.baseURL)
+}
+
+func (dc *docsCmd) registryNavItems(path string) []navOption {
+	trimmed := strings.Trim(path, "/")
+	parts := strings.Split(trimmed, "/")
+
+	if len(parts) >= 3 && parts[0] == "registry" && parts[1] == "packages" {
+		pkgName := parts[2]
+		pages, err := docsrender.FetchPackageSitemap(dc.registryBaseURL, pkgName)
+		if err != nil {
+			return nil
+		}
+
+		if len(parts) == 3 {
+			return sitemapToNavOptions(pages, dc.registryBaseURL)
+		}
+
+		target := "/" + trimmed + "/"
+		return childNavOptions(pages, target, dc.registryBaseURL)
+	}
+
+	return nil
+}
+
+func findPage(pages []docsrender.SitemapPage, targetPath string) *docsrender.SitemapPage {
+	for i := range pages {
+		if pages[i].Path == targetPath {
+			return &pages[i]
+		}
+		if found := findPage(pages[i].Children, targetPath); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findExactChildren(pages []docsrender.SitemapPage, targetPath string) []docsrender.SitemapPage {
+	if p := findPage(pages, targetPath); p != nil {
+		return p.Children
+	}
+	return nil
+}
+
+func collectDescendants(pages []docsrender.SitemapPage, prefix string, result *[]docsrender.SitemapPage) {
+	for _, p := range pages {
+		if strings.HasPrefix(p.Path, prefix) && p.Path != prefix {
+			*result = append(*result, p)
+		} else if len(p.Children) > 0 {
+			collectDescendants(p.Children, prefix, result)
+		}
+	}
+}
+

--- a/pkg/cmd/pulumi/docs/browse_test.go
+++ b/pkg/cmd/pulumi/docs/browse_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParentPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "multi-segment", path: "iac/concepts/stacks", want: "iac/concepts"},
+		{name: "single segment", path: "iac", want: ""},
+		{name: "registry packages collapses", path: "registry/packages", want: "registry"},
+		{name: "registry package child", path: "registry/packages/aws", want: "registry"},
+		{name: "trailing slashes", path: "/iac/concepts/", want: "iac"},
+		{name: "empty string", path: "", want: ""},
+		{name: "deep path", path: "a/b/c/d", want: "a/b/c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parentPath(tt.path))
+		})
+	}
+}
+
+func TestPathLastSegment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "multi-segment", path: "iac/concepts/stacks", want: "stacks"},
+		{name: "single segment", path: "iac", want: "iac"},
+		{name: "trailing slash", path: "iac/concepts/", want: "concepts"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, pathLastSegment(tt.path))
+		})
+	}
+}
+
+func TestFindPage(t *testing.T) {
+	t.Parallel()
+
+	pages := []docsrender.SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []docsrender.SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+				{Title: "Projects", Path: "/docs/concepts/projects/"},
+			},
+		},
+		{Title: "Install", Path: "/docs/install/"},
+	}
+
+	t.Run("found at root", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/install/")
+		require.NotNil(t, p)
+		assert.Equal(t, "Install", p.Title)
+	})
+
+	t.Run("found in children", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/concepts/stacks/")
+		require.NotNil(t, p)
+		assert.Equal(t, "Stacks", p.Title)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		p := findPage(pages, "/docs/nonexistent/")
+		assert.Nil(t, p)
+	})
+}
+
+func TestFindExactChildren(t *testing.T) {
+	t.Parallel()
+
+	pages := []docsrender.SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []docsrender.SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+			},
+		},
+	}
+
+	t.Run("has children", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/concepts/")
+		require.Len(t, children, 1)
+		assert.Equal(t, "Stacks", children[0].Title)
+	})
+
+	t.Run("no children", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/concepts/stacks/")
+		assert.Empty(t, children)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+		children := findExactChildren(pages, "/docs/missing/")
+		assert.Nil(t, children)
+	})
+}
+
+func TestCollectDescendants(t *testing.T) {
+	t.Parallel()
+
+	pages := []docsrender.SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []docsrender.SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+				{Title: "Projects", Path: "/docs/concepts/projects/"},
+			},
+		},
+		{Title: "Install", Path: "/docs/install/"},
+	}
+
+	t.Run("finds nested descendants", func(t *testing.T) {
+		t.Parallel()
+		var result []docsrender.SitemapPage
+		collectDescendants(pages, "/docs/concepts/", &result)
+		require.Len(t, result, 2)
+	})
+
+	t.Run("skips exact match", func(t *testing.T) {
+		t.Parallel()
+		var result []docsrender.SitemapPage
+		collectDescendants(pages, "/docs/concepts/", &result)
+		for _, p := range result {
+			assert.NotEqual(t, "/docs/concepts/", p.Path)
+		}
+	})
+
+	t.Run("no matches", func(t *testing.T) {
+		t.Parallel()
+		var result []docsrender.SitemapPage
+		collectDescendants(pages, "/docs/missing/", &result)
+		assert.Empty(t, result)
+	})
+}
+
+func TestSitemapToNavOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("children get drill suffix", func(t *testing.T) {
+		t.Parallel()
+		pages := []docsrender.SitemapPage{
+			{Title: "Concepts", Path: "/docs/concepts/", Children: []docsrender.SitemapPage{{Title: "Child"}}},
+			{Title: "Install", Path: "/docs/install/"},
+		}
+		opts := sitemapToNavOptions(pages, "https://www.pulumi.com")
+		assert.Equal(t, "Concepts"+navDrill, opts[0].label)
+		assert.Equal(t, "Install", opts[1].label)
+	})
+
+	t.Run("external URLs preserved", func(t *testing.T) {
+		t.Parallel()
+		pages := []docsrender.SitemapPage{
+			{Title: "GitHub", Path: "https://github.com/pulumi/pulumi"},
+		}
+		opts := sitemapToNavOptions(pages, "")
+		assert.Equal(t, "https://github.com/pulumi/pulumi", opts[0].href)
+	})
+
+	t.Run("html paths get full href", func(t *testing.T) {
+		t.Parallel()
+		pages := []docsrender.SitemapPage{
+			{Title: "API Reference", Path: "/docs/reference/pkg/nodejs/pulumi/aws/index.html"},
+		}
+		opts := sitemapToNavOptions(pages, "https://www.pulumi.com")
+		assert.Equal(t, "https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/aws/index.html", opts[0].href)
+	})
+}
+
+func TestChildNavOptions(t *testing.T) {
+	t.Parallel()
+
+	pages := []docsrender.SitemapPage{
+		{
+			Title: "Concepts",
+			Path:  "/docs/concepts/",
+			Children: []docsrender.SitemapPage{
+				{Title: "Stacks", Path: "/docs/concepts/stacks/"},
+			},
+		},
+	}
+
+	t.Run("exact match returns children", func(t *testing.T) {
+		t.Parallel()
+		opts := childNavOptions(pages, "/docs/concepts/", "")
+		require.Len(t, opts, 1)
+		assert.Equal(t, "Stacks", opts[0].label)
+	})
+
+	t.Run("no exact match falls back to descendants", func(t *testing.T) {
+		t.Parallel()
+		// "/docs/concepts" (no trailing slash) won't match exactly
+		opts := childNavOptions(pages, "/docs/concepts", "")
+		// collectDescendants should find stacks
+		require.Len(t, opts, 1)
+	})
+}
+
+func TestBuildBrowseMenu(t *testing.T) {
+	t.Parallel()
+
+	headings := []docsrender.Heading{
+		{Level: 2, Title: "Overview", Slug: "overview"},
+		{Level: 2, Title: "Details", Slug: "details"},
+	}
+
+	t.Run("root has no Up", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(browseMenuContext{isRoot: true, hasIntro: true, sectionIdx: -1})
+		assert.NotContains(t, menu, navUp)
+		assert.Contains(t, menu, navDone)
+		assert.NotContains(t, menu, navHome)
+	})
+
+	t.Run("non-root has Up and Home", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(browseMenuContext{hasIntro: true, sectionIdx: -1})
+		assert.Contains(t, menu, navUp)
+		assert.Contains(t, menu, navHome)
+	})
+
+	t.Run("with sections shows Sections option", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(browseMenuContext{hasHeadings: true, hasIntro: true, sectionIdx: -1, headings: headings})
+		assert.Contains(t, menu, navSections)
+	})
+
+	t.Run("with history shows Back", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(browseMenuContext{hasHistory: true, hasIntro: true, sectionIdx: -1})
+		assert.Contains(t, menu, navBack)
+	})
+
+	t.Run("section view shows prev/next", func(t *testing.T) {
+		t.Parallel()
+		menu := buildBrowseMenu(browseMenuContext{hasHeadings: true, hasIntro: true, sectionIdx: 0, headings: headings})
+		// At section 0, should have next but not prev (intro is the prev when hasIntro)
+		found := false
+		for _, item := range menu {
+			if len(item) >= len(navNext) && item[:len(navNext)] == navNext {
+				found = true
+			}
+		}
+		assert.True(t, found, "should have next section option")
+	})
+
+	t.Run("nav items included", func(t *testing.T) {
+		t.Parallel()
+		items := []navOption{{label: "My Link", path: "some/path"}}
+		menu := buildBrowseMenu(browseMenuContext{items: items, isRoot: true, hasIntro: true, sectionIdx: -1})
+		assert.Contains(t, menu, "My Link")
+	})
+}
+
+func TestNumberedNavLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("numbered labels", func(t *testing.T) {
+		t.Parallel()
+		links := []docsrender.Link{
+			{Title: "Stacks", URL: "/docs/stacks"},
+			{Title: "Projects", URL: "/docs/projects"},
+		}
+		opts := numberedNavLinks(links)
+		require.Len(t, opts, 2)
+		assert.Equal(t, "🔗1 Stacks", opts[0].label)
+		assert.Equal(t, "🔗2 Projects", opts[1].label)
+		assert.Equal(t, "stacks", opts[0].path)
+	})
+
+	t.Run("empty returns nil", func(t *testing.T) {
+		t.Parallel()
+		opts := numberedNavLinks(nil)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("backticks stripped from label", func(t *testing.T) {
+		t.Parallel()
+		links := []docsrender.Link{{Title: "`pulumi up`", URL: "/docs/up"}}
+		opts := numberedNavLinks(links)
+		assert.Equal(t, "🔗1 pulumi up", opts[0].label)
+	})
+}

--- a/pkg/cmd/pulumi/docs/chooser.go
+++ b/pkg/cmd/pulumi/docs/chooser.go
@@ -1,0 +1,83 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// buildChooserSelections resolves chooser selections from flags, preferences, and prompts.
+func buildChooserSelections(
+	choosers []docsrender.ChooserInfo, prefs *docsrender.Preferences,
+	flagLang, flagOS string,
+	session map[string]string,
+) map[string]string {
+	selections := map[string]string{}
+
+	if flagLang != "" {
+		selections[docsrender.ChooserLanguage] = flagLang
+	}
+	if flagOS != "" {
+		selections[docsrender.ChooserOS] = flagOS
+	}
+
+	for k, v := range session {
+		if _, ok := selections[k]; !ok {
+			selections[k] = v
+		}
+	}
+
+	for _, t := range []string{docsrender.ChooserLanguage, docsrender.ChooserOS, docsrender.ChooserCloud} {
+		if _, ok := selections[t]; !ok {
+			if v := prefs.Get(t); v != "" {
+				selections[t] = v
+			}
+		}
+	}
+
+	if cmdutil.Interactive() {
+		for _, ci := range choosers {
+			if _, ok := selections[ci.Type]; ok {
+				continue
+			}
+			if len(ci.Options) == 0 {
+				continue
+			}
+			defaultOpt := ci.Options[0]
+			if pref := prefs.Get(ci.Type); pref != "" {
+				defaultOpt = pref
+			}
+			selected := ui.PromptUser(
+				"Select "+ci.Type+":",
+				ci.Options,
+				defaultOpt,
+				cmdutil.GetGlobalColorization(),
+			)
+			if selected != "" {
+				selections[ci.Type] = selected
+			}
+		}
+	}
+
+	for k, v := range selections {
+		session[k] = v
+		prefs.Set(k, v)
+	}
+	docsrender.SavePreferences(prefs)
+
+	return selections
+}

--- a/pkg/cmd/pulumi/docs/chooser_test.go
+++ b/pkg/cmd/pulumi/docs/chooser_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildChooserSelectionsNonInteractive(t *testing.T) {
+	// buildChooserSelections calls cmdutil.Interactive() which returns false in tests,
+	// so it won't prompt. We can test the flag/session/preference resolution logic.
+
+	t.Run("flag takes priority over preferences", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{Language: "python"}
+		session := map[string]string{}
+		selections := buildChooserSelections(nil, prefs, "typescript", "", session)
+		assert.Equal(t, "typescript", selections["language"])
+	})
+
+	t.Run("preferences used when no flag", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{Language: "python"}
+		session := map[string]string{}
+		selections := buildChooserSelections(nil, prefs, "", "", session)
+		assert.Equal(t, "python", selections["language"])
+	})
+
+	t.Run("session reused over preferences", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{Language: "python"}
+		session := map[string]string{"language": "go"}
+		selections := buildChooserSelections(nil, prefs, "", "", session)
+		assert.Equal(t, "go", selections["language"])
+	})
+
+	t.Run("flag overrides session", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{}
+		session := map[string]string{"language": "go"}
+		selections := buildChooserSelections(nil, prefs, "typescript", "", session)
+		assert.Equal(t, "typescript", selections["language"])
+	})
+
+	t.Run("os flag applied", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{}
+		session := map[string]string{}
+		selections := buildChooserSelections(nil, prefs, "", "macos", session)
+		assert.Equal(t, "macos", selections["os"])
+	})
+
+	t.Run("session updated with selections", func(t *testing.T) {
+		t.Parallel()
+		prefs := &docsrender.Preferences{}
+		session := map[string]string{}
+		_ = buildChooserSelections(nil, prefs, "go", "linux", session)
+		assert.Equal(t, "go", session["language"])
+		assert.Equal(t, "linux", session["os"])
+	})
+}

--- a/pkg/cmd/pulumi/docs/docs.go
+++ b/pkg/cmd/pulumi/docs/docs.go
@@ -1,0 +1,438 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+type docsCmd struct {
+	baseURL         string
+	registryBaseURL string
+	language        string
+	osFlag          string
+	raw             bool
+	toc             bool
+	tocJSON         bool
+	jsonOutput      bool
+	fullPage        bool
+	sectionsView    bool
+
+	// session tracks chooser selections within a single CLI invocation
+	// so the user isn't prompted repeatedly for the same chooser type.
+	session map[string]string
+}
+
+// NewDocsCmd creates the `pulumi docs` command.
+func NewDocsCmd() *cobra.Command {
+	dc := &docsCmd{session: map[string]string{}}
+
+	cmd := &cobra.Command{
+		Use:   "docs",
+		Short: "View Pulumi documentation in the terminal",
+		Long: "Read and browse Pulumi documentation in the terminal.\n\n" +
+			"  pulumi docs                    Browse interactively\n" +
+			"  pulumi docs read <path>        Read a specific page\n" +
+			"  pulumi docs browse [path]      Browse interactively\n" +
+			"  pulumi docs registry <pkg>     Read a registry package\n" +
+			"  pulumi docs search <query>     Search documentation\n" +
+			"  pulumi docs sitemap            List available pages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmdutil.Interactive() {
+				return dc.browseLoop("")
+			}
+			return cmd.Help()
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&dc.baseURL, "base-url", "https://www.pulumi.com",
+		"Base URL for Pulumi documentation")
+	cmd.PersistentFlags().StringVar(&dc.registryBaseURL, "registry-base-url", "",
+		"Base URL for Pulumi registry (defaults to --base-url)")
+	cmd.PersistentFlags().MarkHidden("base-url")          //nolint:errcheck
+	cmd.PersistentFlags().MarkHidden("registry-base-url") //nolint:errcheck
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if dc.registryBaseURL == "" {
+			dc.registryBaseURL = dc.baseURL
+		}
+		return nil
+	}
+	cmd.PersistentFlags().StringVar(&dc.language, "language", "",
+		"Filter code examples in docs by language (e.g., python, typescript, go); choice is remembered")
+	cmd.PersistentFlags().StringVar(&dc.osFlag, "os", "",
+		"Filter OS-specific content in docs (e.g., macos, linux, windows); choice is remembered")
+
+	cmd.AddCommand(dc.newReadCmd())
+	cmd.AddCommand(dc.newBrowseCmd())
+	cmd.AddCommand(dc.newSearchCmd())
+	cmd.AddCommand(dc.newRegistryCmd())
+	cmd.AddCommand(dc.newSitemapCmd())
+
+	return cmd
+}
+
+func (dc *docsCmd) newReadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "read <path[#section]>",
+		Short: "Read a documentation page",
+		Long: "Fetch and display a Pulumi documentation page.\n\n" +
+			"  pulumi docs read iac/concepts/stacks               Read a docs page\n" +
+			"  pulumi docs read iac/concepts/stacks#stack-tags    Jump to a section\n" +
+			"  pulumi docs read registry/packages/aws             Read a registry page\n" +
+			"  pulumi docs read --toc                             Show sections on last viewed page",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dc.tocJSON {
+				dc.toc = true
+			}
+			if dc.toc && len(args) == 0 {
+				prefs := docsrender.LoadPreferences()
+				if prefs.LastPage == "" {
+					return errors.New("no page specified and no previously viewed page — provide a path")
+				}
+				return dc.fetchAndRender(prefs.LastPage)
+			}
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			return dc.fetchAndRender(args[0])
+		},
+	}
+	cmd.Flags().BoolVar(&dc.raw, "raw", false,
+		"Output raw markdown without formatting or chooser resolution")
+	cmd.Flags().BoolVar(&dc.toc, "toc", false,
+		"Show table of contents (list of sections)")
+	cmd.Flags().BoolVar(&dc.tocJSON, "toc-json", false,
+		"Output table of contents as JSON")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "path", Usage: "path[#section]"}},
+	})
+	return cmd
+}
+
+func (dc *docsCmd) newBrowseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "browse [path]",
+		Short: "Browse Pulumi documentation interactively",
+		Long: "Browse docs and registry by following links between pages.\n\n" +
+			"  pulumi docs browse             Browse from last viewed page or root\n" +
+			"  pulumi docs browse <path>      Start browsing at a specific page\n" +
+			"  pulumi docs browse /           Browse from the site map root\n" +
+			"  pulumi docs browse registry/   Browse all registry packages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := ""
+			if len(args) > 0 && args[0] != "/" {
+				path = args[0]
+			} else if len(args) == 0 {
+				prefs := docsrender.LoadPreferences()
+				path = prefs.LastPage
+			}
+			return dc.browseLoop(path)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.fullPage, "full", false,
+		"Show full page instead of sections view (saved as default when used)")
+	cmd.Flags().BoolVar(&dc.sectionsView, "sections", false,
+		"Show sections view instead of full page (saved as default when used)")
+	cmd.MarkFlagsMutuallyExclusive("full", "sections")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "path"}},
+	})
+	return cmd
+}
+
+func (dc *docsCmd) newSearchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <query>...",
+		Short: "Search Pulumi documentation",
+		Long:  "Search Pulumi documentation using Algolia and display results.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			return runSearch(dc, query)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.jsonOutput, "json", false,
+		"Output results as JSON")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "query"}},
+		Required:  1,
+		Variadic:  true,
+	})
+	return cmd
+}
+
+func (dc *docsCmd) baseURLForPath(path string) string {
+	if docsrender.IsRegistryPath(path) {
+		return dc.registryBaseURL
+	}
+	return dc.baseURL
+}
+
+// fetchAndRender fetches a page, resolves choosers, and prints the rendered output.
+func (dc *docsCmd) fetchAndRender(path string) error {
+	section := ""
+	if idx := strings.Index(path, "#"); idx >= 0 {
+		section = path[idx+1:]
+		path = path[:idx]
+	}
+
+	fetchBase := dc.baseURLForPath(path)
+
+	var body, title string
+	var err error
+	bundle := dc.tryBundleLookup(fetchBase, path, &body, &title)
+
+	if body == "" {
+		var resolvedPath string
+		body, title, resolvedPath, err = docsrender.FetchDoc(fetchBase, path)
+		if resolvedPath != "" {
+			path = resolvedPath
+		}
+	}
+	if err != nil {
+		var regErr *docsrender.RegistryNotAvailableError
+		if errors.As(err, &regErr) {
+			return dc.handleRegistryFallback(path)
+		}
+		return err
+	}
+
+	if bundle != nil {
+		if _, docKey, ok := docsrender.ParseAPIDocsPath(path); ok {
+			intro := docsrender.GetIntro(body)
+			body = docsrender.BuildAPIDocsPage(bundle, docKey, intro)
+		}
+	} else if docsrender.IsRegistryPath(path) {
+		body = docsrender.FormatPackageDetails(body)
+	}
+
+	if dc.toc {
+		if err := dc.showTOC(body, &section); err != nil {
+			return err
+		}
+		if section == "" {
+			return nil
+		}
+	}
+
+	if section == docsrender.SectionIntroduction {
+		body = docsrender.GetIntro(body)
+	} else if section != "" {
+		extracted := docsrender.GetSection(body, section)
+		if extracted == "" {
+			return fmt.Errorf("section %q not found — use --toc to list sections", section)
+		}
+		body = extracted
+		title = ""
+	}
+
+	if dc.raw {
+		if title != "" {
+			fmt.Printf("# %s\n\n", title)
+		}
+		fmt.Print(body)
+		return nil
+	}
+
+	rendered, err := dc.renderBody(body, title)
+	if err != nil {
+		return err
+	}
+	fmt.Print(rendered)
+
+	prefs := docsrender.LoadPreferences()
+	prefs.LastPage = path
+	docsrender.SavePreferences(prefs)
+
+	if section == "" {
+		fmt.Print(docsrender.PageFooter(fetchBase, path))
+	}
+
+	return nil
+}
+
+// resolveContent applies chooser resolution and language filtering without
+// terminal rendering. Use this to get the resolved markdown before extracting
+// links or headings so that only the selected chooser option's content is visible.
+func (dc *docsCmd) resolveContent(body string) string {
+	prefs := docsrender.LoadPreferences()
+
+	source := []byte(body)
+	tree := docsrender.ParseMarkdown(source)
+	choosers := docsrender.ScanChoosers(source, tree)
+	selections := buildChooserSelections(choosers, prefs, dc.language, dc.osFlag, dc.session)
+	resolved := docsrender.ResolveChoosers(source, tree, selections)
+
+	lang := dc.language
+	if lang == "" {
+		lang = prefs.Language
+	}
+	filtered := docsrender.FilterCodeBlocksByLanguage(resolved, docsrender.ParseMarkdown(resolved), lang)
+	return string(filtered)
+}
+
+func (dc *docsCmd) renderBody(body, title string) (string, error) {
+	return docsrender.RenderMarkdown(title, dc.resolveContent(body))
+}
+
+func (dc *docsCmd) showTOC(body string, section *string) error {
+	headings := docsrender.GetHeadings(body)
+	if len(headings) == 0 {
+		fmt.Println("No sections found.")
+		return nil
+	}
+
+	hasIntro := !docsrender.IntroContainsFirstHeading(body)
+
+	if dc.tocJSON {
+		type tocEntry struct {
+			Title string `json:"title"`
+			Slug  string `json:"slug"`
+			Depth int    `json:"depth"`
+		}
+		var entries []tocEntry
+		if hasIntro {
+			entries = append(entries, tocEntry{Title: "Introduction", Slug: docsrender.SectionIntroduction, Depth: 2})
+		}
+		for _, h := range headings {
+			entries = append(entries, tocEntry{Title: h.Title, Slug: h.Slug, Depth: h.Level})
+		}
+		return ui.PrintJSON(entries)
+	}
+
+	if !cmdutil.Interactive() {
+		if hasIntro {
+			fmt.Println("Introduction  (#introduction)")
+		}
+		for _, h := range headings {
+			indent := strings.Repeat("  ", h.Level-2)
+			fmt.Printf("%s%s  (#%s)\n", indent, h.Title, h.Slug)
+		}
+		return nil
+	}
+
+	var options []string
+	if hasIntro {
+		options = append(options, "Introduction")
+	}
+	for _, h := range headings {
+		options = append(options, h.Title)
+	}
+	selected := ui.PromptUser(
+		"Select a section:",
+		options,
+		options[0],
+		cmdutil.GetGlobalColorization(),
+	)
+	if selected == "" {
+		return nil
+	}
+	if selected == "Introduction" {
+		*section = docsrender.SectionIntroduction
+		return nil
+	}
+	for _, h := range headings {
+		if h.Title == selected {
+			*section = h.Slug
+			break
+		}
+	}
+	return nil
+}
+
+func (dc *docsCmd) viewPage(href string) error {
+	path := docsrender.HrefToPath(href)
+	if path == "" {
+		return fmt.Errorf("invalid page path: %s", href)
+	}
+	return dc.fetchAndRender(path)
+}
+
+func (dc *docsCmd) handleRegistryFallback(path string) error {
+	pageWebURL := docsrender.WebURL(dc.registryBaseURL, path)
+
+	var overviewPath string
+	trimmed := strings.Trim(path, "/")
+	if idx := strings.Index(trimmed, "/api-docs"); idx >= 0 {
+		overviewPath = trimmed[:idx]
+	}
+
+	fmt.Fprintln(os.Stderr)
+	if overviewPath != "" {
+		fmt.Fprintln(os.Stderr, "Registry API docs are not available for terminal viewing.")
+	} else {
+		fmt.Fprintln(os.Stderr, "This registry page is not available for terminal viewing.")
+	}
+
+	if cmdutil.Interactive() && overviewPath != "" {
+		optBrowseAPI := "Browse API docs"
+		optOverview := "View package overview"
+		options := []string{optBrowseAPI, optOverview}
+
+		fmt.Fprintln(os.Stderr)
+		selected := ui.PromptUser(
+			"What would you like to do?",
+			options,
+			optBrowseAPI,
+			cmdutil.GetGlobalColorization(),
+		)
+
+		switch selected {
+		case optBrowseAPI:
+			return dc.browseLoop(overviewPath + "/api-docs")
+		case optOverview:
+			return dc.fetchAndRender(overviewPath)
+		}
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "Visit: %s\n", pageWebURL)
+	if overviewPath != "" {
+		fmt.Fprintf(os.Stderr, "Or view the package overview: pulumi docs read %s\n", overviewPath)
+	}
+	fmt.Fprintln(os.Stderr)
+	return nil
+}
+
+func (dc *docsCmd) tryBundleLookup(fetchBase, path string, body, title *string) *docsrender.CLIDocsBundle {
+	if !docsrender.IsAPIDocsPath(path) {
+		return nil
+	}
+	pkgName, docKey, ok := docsrender.ParseAPIDocsPath(path)
+	if !ok {
+		return nil
+	}
+	bundle, _ := docsrender.FetchCLIDocsBundle(fetchBase, pkgName)
+	if bundle == nil {
+		return nil
+	}
+	if docKey != "" {
+		if b, t, found := docsrender.LookupBundleDoc(bundle, docKey); found {
+			*body, *title = b, t
+		}
+	} else if bundle.Overview != "" {
+		*body = docsrender.BuildAPIDocsPage(bundle, "", "")
+		*title = bundle.Package
+	}
+	return bundle
+}

--- a/pkg/cmd/pulumi/docs/registry.go
+++ b/pkg/cmd/pulumi/docs/registry.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/spf13/cobra"
+)
+
+func (dc *docsCmd) newRegistryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry <package> [install|api [module]]",
+		Short: "View registry package documentation",
+		Long: "Browse Pulumi registry package documentation in the terminal.\n\n" +
+			"Shorthands:\n" +
+			"  pulumi docs registry <package>              Package overview\n" +
+			"  pulumi docs registry <package> install       Installation & configuration\n" +
+			"  pulumi docs registry <package> api            API docs overview\n" +
+			"  pulumi docs registry <package> api <module>   API docs for a module\n\n" +
+			"Full path syntax also works:\n" +
+			"  pulumi docs registry/packages/<package>",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			if strings.Contains(args[0], "/") {
+				path := "registry/" + strings.TrimPrefix(args[0], "registry/")
+				return dc.fetchAndRender(path)
+			}
+			path := resolveRegistryPath(args)
+			return dc.fetchAndRender(path)
+		},
+	}
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package"},
+			{Name: "subpage"},
+			{Name: "module"},
+		},
+	})
+	return cmd
+}
+
+// resolveRegistryPath converts registry subcommand arguments into a content path.
+func resolveRegistryPath(args []string) string {
+	pkg := args[0]
+	base := "registry/packages/" + pkg
+
+	if len(args) < 2 {
+		return base
+	}
+
+	switch strings.ToLower(args[1]) {
+	case "install", "installation", "config", "configuration":
+		return base + "/installation-configuration"
+	case "api", "api-docs":
+		if len(args) >= 3 {
+			return base + "/api-docs/" + args[2]
+		}
+		return base + "/api-docs"
+	default:
+		return base + "/" + strings.Join(args[1:], "/")
+	}
+}

--- a/pkg/cmd/pulumi/docs/registry_test.go
+++ b/pkg/cmd/pulumi/docs/registry_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveRegistryPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "package only", args: []string{"aws"}, want: "registry/packages/aws"},
+		{name: "install", args: []string{"aws", "install"}, want: "registry/packages/aws/installation-configuration"},
+		{
+			name: "configuration",
+			args: []string{"aws", "configuration"},
+			want: "registry/packages/aws/installation-configuration",
+		},
+		{name: "api", args: []string{"aws", "api"}, want: "registry/packages/aws/api-docs"},
+		{name: "api with module", args: []string{"aws", "api", "s3"}, want: "registry/packages/aws/api-docs/s3"},
+		{name: "unknown subpage", args: []string{"aws", "changelog"}, want: "registry/packages/aws/changelog"},
+		{name: "api-docs alias", args: []string{"aws", "api-docs"}, want: "registry/packages/aws/api-docs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, resolveRegistryPath(tt.args))
+		})
+	}
+}

--- a/pkg/cmd/pulumi/docs/search.go
+++ b/pkg/cmd/pulumi/docs/search.go
@@ -1,0 +1,250 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+var searchHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+type cliConfig struct {
+	Algolia algoliaConfig `json:"algolia"`
+}
+
+type algoliaConfig struct {
+	AppID     string `json:"appId"`
+	SearchKey string `json:"searchKey"`
+	IndexName string `json:"indexName"`
+}
+
+type algoliaResponse struct {
+	Hits []algoliaHit `json:"hits"`
+}
+
+type algoliaHit struct {
+	ObjectID    string `json:"objectID"`
+	Title       string `json:"title"`
+	H1          string `json:"h1"`
+	Description string `json:"description"`
+	Href        string `json:"href"`
+	Section     string `json:"section"`
+}
+
+func (h algoliaHit) displayTitle() string {
+	title := h.H1
+	if title == "" {
+		title = h.Title
+	}
+	if title == "" {
+		title = h.Href
+	}
+	return title
+}
+
+func (h algoliaHit) sectionName() string {
+	if strings.Contains(h.Href, "/registry/") {
+		return "registry"
+	}
+	return "docs"
+}
+
+func (h algoliaHit) sectionTag() string {
+	return "[" + h.sectionName() + "]"
+}
+
+func fetchCLIConfig(baseURL string) (*cliConfig, error) {
+	configURL := strings.TrimRight(baseURL, "/") + "/docs/cli-config.json"
+
+	//nolint:gosec // URL is constructed from user-provided base URL
+	resp, err := searchHTTPClient.Get(configURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CLI config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CLI config not available (status %d) — "+
+			"set ALGOLIA_APP_ID and ALGOLIA_APP_SEARCH_KEY as a fallback", resp.StatusCode)
+	}
+
+	var cfg cliConfig
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decoding CLI config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func getAlgoliaCredentials(baseURL string) (appID, apiKey, indexName string, err error) {
+	appID = os.Getenv("ALGOLIA_APP_ID")
+	apiKey = os.Getenv("ALGOLIA_APP_SEARCH_KEY")
+	if appID != "" && apiKey != "" {
+		indexName = os.Getenv("ALGOLIA_INDEX_NAME")
+		if indexName == "" {
+			indexName = "production"
+		}
+		return appID, apiKey, indexName, nil
+	}
+
+	cfg, err := fetchCLIConfig(baseURL)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	if cfg.Algolia.AppID == "" || cfg.Algolia.SearchKey == "" {
+		return "", "", "", errors.New("CLI config missing Algolia credentials")
+	}
+
+	indexName = cfg.Algolia.IndexName
+	if indexName == "" {
+		indexName = "production"
+	}
+	return cfg.Algolia.AppID, cfg.Algolia.SearchKey, indexName, nil
+}
+
+func searchDocs(query, appID, apiKey, indexName string) ([]algoliaHit, error) {
+	searchURL := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/%s/query", appID, indexName)
+
+	params := url.Values{}
+	params.Set("query", query)
+	params.Set("hitsPerPage", "10")
+	params.Set("facetFilters", `[["section:Docs","section:Registry"]]`)
+
+	reqBody, err := json.Marshal(map[string]string{
+		"params": params.Encode(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encoding search request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", searchURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating search request: %w", err)
+	}
+	req.Header.Set("X-Algolia-Application-Id", appID)
+	req.Header.Set("X-Algolia-API-Key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := searchHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing search: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("search returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result algoliaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding search response: %w", err)
+	}
+
+	return result.Hits, nil
+}
+
+func runSearch(cmd *docsCmd, query string) error {
+	appID, apiKey, indexName, err := getAlgoliaCredentials(cmd.baseURL)
+	if err != nil {
+		return err
+	}
+
+	hits, err := searchDocs(query, appID, apiKey, indexName)
+	if err != nil {
+		return err
+	}
+
+	if len(hits) == 0 {
+		if cmd.jsonOutput {
+			fmt.Println("[]")
+			return nil
+		}
+		fmt.Println("No results found.")
+		return nil
+	}
+
+	if cmd.jsonOutput {
+		type searchResult struct {
+			Title       string `json:"title"`
+			Section     string `json:"section"`
+			Description string `json:"description,omitempty"`
+			Href        string `json:"href"`
+		}
+		results := make([]searchResult, len(hits))
+		for i, hit := range hits {
+			results[i] = searchResult{
+				Title:       hit.displayTitle(),
+				Section:     hit.sectionName(),
+				Description: hit.Description,
+				Href:        hit.Href,
+			}
+		}
+		return ui.PrintJSON(results)
+	}
+
+	interactive := cmdutil.Interactive()
+
+	if interactive {
+		options := make([]string, len(hits))
+		for i, hit := range hits {
+			tag := hit.sectionTag()
+			desc := hit.Description
+			if len(desc) > 80 {
+				desc = desc[:77] + "..."
+			}
+			if desc != "" {
+				options[i] = fmt.Sprintf("%s %s\n     %s", tag, hit.displayTitle(), desc)
+			} else {
+				options[i] = fmt.Sprintf("%s %s", tag, hit.displayTitle())
+			}
+		}
+
+		selected := ui.PromptUser(
+			"Select a page to view:",
+			options,
+			options[0],
+			cmdutil.GetGlobalColorization(),
+		)
+
+		for i, opt := range options {
+			if opt == selected {
+				return cmd.viewPage(hits[i].Href)
+			}
+		}
+		return nil
+	}
+
+	for i, hit := range hits {
+		fmt.Printf("%d. %s %s\n", i+1, hit.sectionTag(), hit.displayTitle())
+		if hit.Description != "" {
+			fmt.Printf("   %s\n", hit.Description)
+		}
+		fmt.Printf("   %s\n\n", hit.Href)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/docs/sitemap.go
+++ b/pkg/cmd/pulumi/docs/sitemap.go
@@ -1,0 +1,91 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/docsrender"
+	"github.com/spf13/cobra"
+)
+
+func (dc *docsCmd) newSitemapCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sitemap [scope]",
+		Short: "List available documentation pages",
+		Long: "Display the documentation site map as a navigable list of pages.\n\n" +
+			"  pulumi docs sitemap                                List all docs pages\n" +
+			"  pulumi docs sitemap registry                       List all registry packages\n" +
+			"  pulumi docs sitemap registry/packages/<pkg>        List pages for a specific package\n" +
+			"  pulumi docs sitemap --json                         Output as JSON",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scope := ""
+			if len(args) > 0 {
+				scope = strings.Trim(args[0], "/")
+			}
+			return dc.runSitemap(scope)
+		},
+	}
+	cmd.Flags().BoolVar(&dc.jsonOutput, "json", false, "Output as JSON")
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "scope"}},
+	})
+	return cmd
+}
+
+func (dc *docsCmd) runSitemap(scope string) error {
+	pages, err := dc.fetchSitemapForScope(scope)
+	if err != nil {
+		return err
+	}
+
+	if dc.jsonOutput {
+		return ui.PrintJSON(pages)
+	}
+
+	printSitemapTree(pages, 0)
+	return nil
+}
+
+func (dc *docsCmd) fetchSitemapForScope(scope string) ([]docsrender.SitemapPage, error) {
+	if after, ok := strings.CutPrefix(scope, "registry/packages/"); ok {
+		parts := strings.SplitN(after, "/", 2)
+		pkg := parts[0]
+		if pkg == "" {
+			return nil, errors.New("missing package name — use: pulumi docs sitemap registry/packages/<pkg>")
+		}
+		return docsrender.FetchPackageSitemap(dc.registryBaseURL, pkg)
+	}
+
+	if scope == "registry" || strings.HasPrefix(scope, "registry/") {
+		return docsrender.FetchRegistrySitemap(dc.registryBaseURL)
+	}
+
+	return docsrender.FetchSitemap(dc.baseURL)
+}
+
+func printSitemapTree(pages []docsrender.SitemapPage, depth int) {
+	for _, p := range pages {
+		indent := strings.Repeat("  ", depth)
+		fmt.Printf("%s%s  (%s)\n", indent, p.Title, p.Path)
+		if len(p.Children) > 0 {
+			printSitemapTree(p.Children, depth+1)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/console"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/docs"
 	cmdEnv "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/env"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/events"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
@@ -469,6 +470,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				schema.NewSchemaCmd(),
 				packagecmd.NewPackageCmd(),
 				templatecmd.NewTemplateCmd(),
+				docs.NewDocsCmd(),
 			},
 		},
 		{


### PR DESCRIPTION
Second of two PRs for `pulumi docs`. Depends on #22538 (the library). Targeted at the library branch so the diff is reviewable in isolation; GitHub will retarget to the integration branch when #22538 merges. Until then, this PR's diff includes the library code too. Review #22538 first.

This adds the `pulumi docs` command and its subcommands on top of `pkg/docsrender`. Lets users read, browse, search, and list Pulumi documentation without leaving the terminal.

```
pulumi docs                  Browse interactively from root or last page
pulumi docs read <path>      Read a specific page
pulumi docs browse [path]    Browse interactively (sections or full-page)
pulumi docs search <query>   Algolia-backed search
pulumi docs registry <pkg>   Registry shorthand: install / api / api <module>
pulumi docs sitemap [scope]  List pages as tree or JSON
```

Highlights:

- Language/OS/cloud chooser selections persist between invocations and can be set with `--language`/`--os` or by interactive prompt.
- Code blocks for non-selected languages are hidden when adjacent to alternatives, but isolated examples are kept.
- Browse mode numbers internal links (`🔗1`, `🔗2`) so you can pick them from the menu.
- Registry API docs come from per-package JSON bundles, cached locally so a single fetch covers a whole provider.

The only change to existing code is two lines in `pkg/cmd/pulumi/pulumi.go` to register the new command. Everything else is new files in `pkg/cmd/pulumi/docs/`.

## Reviewer's guide

Symbol-by-symbol walkthrough with a suggested reading order and smoke test commands: https://gist.github.com/CamSoper/3099acb6ea04d5117f26a6ca4851d74c