### PR TITLE
replace underlying logging library with slog

### DIFF
--- a/changelog/pending/20260415--cli--switch-logging-library-from-glog-to-slog.yaml
+++ b/changelog/pending/20260415--cli--switch-logging-library-from-glog-to-slog.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Switch logging library from glog to slog

--- a/changelog/pending/20260415--cli--switch-logging-library-from-glog-to-slog.yaml
+++ b/changelog/pending/20260415--cli--switch-logging-library-from-glog-to-slog.yaml
@@ -1,4 +1,7 @@
 changes:
 - type: feat
   scope: cli
-  description: Switch logging library from glog to slog
+  description: |
+    Switch logging library from glog to slog.
+
+    BREAKING: any `if logging.V(x) {` need to be changed to `if logging.V(x).Enabled()`

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -337,7 +337,7 @@ func pulumiAPICall(ctx context.Context,
 	}
 
 	logging.V(apiRequestLogLevel).Infof("Making Pulumi API call: %s", url)
-	if logging.V(apiRequestDetailLogLevel) {
+	if logging.V(apiRequestDetailLogLevel).Enabled() {
 		logging.V(apiRequestDetailLogLevel).Infof(
 			"Pulumi API call details (%s): headers=%v; body=%v", url, req.Header, string(body))
 	}
@@ -528,7 +528,7 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 	if err != nil {
 		return fmt.Errorf("reading response from API: %w", err)
 	}
-	if logging.V(apiRequestDetailLogLevel) {
+	if logging.V(apiRequestDetailLogLevel).Enabled() {
 		logging.V(apiRequestDetailLogLevel).Infof("Pulumi API call response body (%s): %v", url, string(respBody))
 	}
 

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -73,7 +73,7 @@ func (persister *cloudSnapshotPersister) Save(deployment apitype.TypedDeployment
 			return err
 		}
 		if err := persister.saveDiff(ctx, diff, version, persister.tokenSource); err != nil {
-			if logging.V(3) {
+			if logging.V(3).Enabled() {
 				logging.V(3).Infof("ignoring error saving checkpoint "+
 					"with PatchUpdateCheckpointDelta, falling back to "+
 					"PatchUpdateCheckpoint: %v", err)

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -200,7 +200,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	updateCheckResult := make(chan *updateCheckResult)
 
 	cleanup := func() {
-		logging.Flush()
 		cmdutil.CloseTracing()
 
 		if rootSpan != nil {
@@ -212,7 +211,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			logFile, err := logging.GetLogfilePath()
 			if err != nil {
 				logging.Warningf("could not find the log file: %s", err)
-				logging.Flush()
 			} else {
 				fmt.Fprintf(os.Stderr, "The log file for this run is at %s\n", logFile)
 			}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -200,6 +200,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	updateCheckResult := make(chan *updateCheckResult)
 
 	cleanup := func() {
+		logging.Flush()
 		cmdutil.CloseTracing()
 
 		if rootSpan != nil {
@@ -211,6 +212,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			logFile, err := logging.GetLogfilePath()
 			if err != nil {
 				logging.Warningf("could not find the log file: %s", err)
+				logging.Flush()
 			} else {
 				fmt.Fprintf(os.Stderr, "The log file for this run is at %s\n", logFile)
 			}

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -22,10 +22,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 const pulumiSDKVersion = "v3"
@@ -97,8 +97,9 @@ func (d DocLanguageHelper) GetTypeName(pkg schema.PackageReference, t schema.Typ
 	goPkg := moduleToPackage(d.goPkgInfo.ModuleToPackage, relativeToModule)
 	modPkg, ok := d.packages[goPkg]
 	if !ok {
-		glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
+		logging.Errorf("cannot calculate type string for type %q. could not find a package for module %q",
 			t.String(), goPkg)
+		return ""
 	}
 	return modPkg.typeString(t)
 }
@@ -179,8 +180,9 @@ func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modN
 		t := objectReturnType.Properties[0].Type
 		modPkg, ok := d.packages[modName]
 		if !ok {
-			glog.Fatalf("cannot calculate type string for type %q. could not find a package for module %q",
+			logging.Errorf("cannot calculate type string for type %q. could not find a package for module %q",
 				t.String(), modName)
+			return ""
 		}
 		return modPkg.outputType(t)
 	}

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -915,7 +915,7 @@ func trySendEvent(ch chan<- Event, ev Event) (sent bool) {
 	defer func() {
 		if recover() != nil {
 			sent = false
-			if logging.V(9) {
+			if logging.V(9).Enabled() {
 				logging.V(9).Infof(
 					"Ignoring %v send on a closed channel %p",
 					ev.Type, ch)
@@ -934,7 +934,7 @@ func tryCloseEventChan(ch chan<- Event) (closed bool) {
 	defer func() {
 		if recover() != nil {
 			closed = false
-			if logging.V(9) {
+			if logging.V(9).Enabled() {
 				logging.V(9).Infof(
 					"Ignoring close of a closed event channel %p",
 					ch)

--- a/pkg/engine/eventsink.go
+++ b/pkg/engine/eventsink.go
@@ -58,7 +58,7 @@ func (s *eventSink) Debugf(d *diag.Diag, args ...any) {
 	// For debug messages, write both to the glogger and a stream, if there is one.
 	logging.V(3).Infof(d.Message, args...)
 	prefix, msg := s.Stringify(diag.Debug, d, args...)
-	if logging.V(9) {
+	if logging.V(9).Enabled() {
 		logging.V(9).Infof("eventSink::Debug(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagDebugEvent(d, prefix, msg, s.statusSink)
@@ -66,7 +66,7 @@ func (s *eventSink) Debugf(d *diag.Diag, args ...any) {
 
 func (s *eventSink) Infof(d *diag.Diag, args ...any) {
 	prefix, msg := s.Stringify(diag.Info, d, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Info(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagInfoEvent(d, prefix, msg, s.statusSink)
@@ -74,7 +74,7 @@ func (s *eventSink) Infof(d *diag.Diag, args ...any) {
 
 func (s *eventSink) Infoerrf(d *diag.Diag, args ...any) {
 	prefix, msg := s.Stringify(diag.Info /* not Infoerr, just "info: "*/, d, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Infoerr(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagInfoerrEvent(d, prefix, msg, s.statusSink)
@@ -82,7 +82,7 @@ func (s *eventSink) Infoerrf(d *diag.Diag, args ...any) {
 
 func (s *eventSink) Errorf(d *diag.Diag, args ...any) {
 	prefix, msg := s.Stringify(diag.Error, d, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Error(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagErrorEvent(d, prefix, msg, s.statusSink)
@@ -90,7 +90,7 @@ func (s *eventSink) Errorf(d *diag.Diag, args ...any) {
 
 func (s *eventSink) Warningf(d *diag.Diag, args ...any) {
 	prefix, msg := s.Stringify(diag.Warning, d, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("eventSink::Warning(%v)", msg[:len(msg)-1])
 	}
 	s.events.diagWarningEvent(d, prefix, msg, s.statusSink)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -731,7 +731,7 @@ func computeDefaultProviderPackages(
 		defaultProviderPlugins[name] = p
 	}
 
-	if logging.V(preparePluginLog) {
+	if logging.V(preparePluginLog).Enabled() {
 		logging.V(preparePluginLog).Infoln("computeDefaultProviderPlugins(): summary of default plugins:")
 		for pkg, info := range defaultProviderPlugins {
 			logging.V(preparePluginLog).Infof("  %-15s = %s", pkg, info.Version)

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/djherbis/times v1.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gofrs/uuid v4.2.0+incompatible
-	github.com/golang/glog v1.2.5
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-querystring v1.1.0
 	github.com/google/pprof v0.0.0-20230406165453-00490a63f317

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -295,8 +295,6 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -629,7 +629,7 @@ func (se *stepExecutor) continueExecuteStep(payload any, workerID int, step Step
 
 // log is a simple logging helper for the step executor.
 func (se *stepExecutor) log(workerID int, msg string, args ...any) {
-	if logging.V(stepExecutorLogLevel) {
+	if logging.V(stepExecutorLogLevel).Enabled() {
 		message := fmt.Sprintf(msg, args...)
 		logging.V(stepExecutorLogLevel).Infof("StepExecutor worker(%d): %s", workerID, message)
 	}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -351,7 +351,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, err
 		}, nil
 	}
 
-	if bool(logging.V(7)) && old != nil && old.ID == event.ID() {
+	if logging.V(7).Enabled() && old != nil && old.ID == event.ID() {
 		logging.V(7).Infof("stepGenerator.GenerateReadSteps(...): recognized relinquish of resource %s", urn)
 	}
 
@@ -1866,7 +1866,7 @@ func (sg *stepGenerator) continueStepsFromDiff(diffEvent ContinueResourceDiffEve
 				new.Inputs = inputs
 			}
 
-			if logging.V(7) {
+			if logging.V(7).Enabled() {
 				logging.V(7).Infof("Planner decided to replace '%v' (oldprops=%v inputs=%v replaceKeys=%v)",
 					urn, old.Inputs, new.Inputs, diff.ReplaceKeys)
 			}
@@ -2005,7 +2005,7 @@ func (sg *stepGenerator) continueStepsFromDiff(diffEvent ContinueResourceDiffEve
 
 		// If we fell through, it's an update.
 		sg.updates[urn] = true
-		if logging.V(7) {
+		if logging.V(7).Enabled() {
 			logging.V(7).Infof("Planner decided to update '%v' (oldprops=%v inputs=%v)", urn, old.Inputs, new.Inputs)
 		}
 		oldViews := sg.deployment.GetOldViews(old.URN)
@@ -2436,7 +2436,7 @@ func (sg *stepGenerator) determineAllowedResourcesToDeleteFromTargets(
 		}
 	}
 
-	if logging.V(7) {
+	if logging.V(7).Enabled() {
 		keys := []resource.URN{}
 		for k := range resourcesToDelete {
 			keys = append(keys, k)
@@ -2474,7 +2474,7 @@ func (sg *stepGenerator) determineForbiddenResourcesToDeleteFromExcludes(
 		resourcesToKeep[exclude] = true
 	}
 
-	if logging.V(7) {
+	if logging.V(7).Enabled() {
 		keys := []resource.URN{}
 		for k := range resourcesToKeep {
 			keys = append(keys, k)

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cheggaaa/pb v1.0.29
 	github.com/djherbis/times v1.5.0
-	github.com/golang/glog v1.2.5
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/go-ps v1.0.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -107,8 +107,6 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/sdk/go/common/diag/sink.go
+++ b/sdk/go/common/diag/sink.go
@@ -146,7 +146,7 @@ func (d *defaultSink) Debugf(diag *Diag, args ...any) {
 	// For debug messages, write both to the glogger and a stream, if there is one.
 	logging.V(3).Infof(diag.Message, args...)
 	msg := d.createMessage(Debug, diag, args...)
-	if logging.V(9) {
+	if logging.V(9).Enabled() {
 		logging.V(9).Infof("defaultSink::Debug(%v)", msg[:len(msg)-1])
 	}
 	d.print(Debug, msg)
@@ -154,7 +154,7 @@ func (d *defaultSink) Debugf(diag *Diag, args ...any) {
 
 func (d *defaultSink) Infof(diag *Diag, args ...any) {
 	msg := d.createMessage(Info, diag, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("defaultSink::Info(%v)", msg[:len(msg)-1])
 	}
 	d.print(Info, msg)
@@ -162,7 +162,7 @@ func (d *defaultSink) Infof(diag *Diag, args ...any) {
 
 func (d *defaultSink) Infoerrf(diag *Diag, args ...any) {
 	msg := d.createMessage(Info /* not Infoerr, just "info: "*/, diag, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("defaultSink::Infoerr(%v)", msg[:len(msg)-1])
 	}
 	d.print(Infoerr, msg)
@@ -170,7 +170,7 @@ func (d *defaultSink) Infoerrf(diag *Diag, args ...any) {
 
 func (d *defaultSink) Errorf(diag *Diag, args ...any) {
 	msg := d.createMessage(Error, diag, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("defaultSink::Error(%v)", msg[:len(msg)-1])
 	}
 	d.print(Error, msg)
@@ -178,7 +178,7 @@ func (d *defaultSink) Errorf(diag *Diag, args ...any) {
 
 func (d *defaultSink) Warningf(diag *Diag, args ...any) {
 	msg := d.createMessage(Warning, diag, args...)
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		logging.V(5).Infof("defaultSink::Warning(%v)", msg[:len(msg)-1])
 	}
 	d.print(Warning, msg)

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -258,7 +258,7 @@ func newPlugin[T any](
 	dialOptions []grpc.DialOption,
 	attachDebugger bool,
 ) (_ *Plugin, _ *T, retErr error) {
-	if logging.V(9) {
+	if logging.V(9).Enabled() {
 		var argstr strings.Builder
 		for i, arg := range args {
 			if i > 0 {

--- a/sdk/go/common/util/cmdutil/profile_unix.go
+++ b/sdk/go/common/util/cmdutil/profile_unix.go
@@ -32,8 +32,6 @@ import (
 func InitPprofServer(ctx context.Context) {
 	sigusr := make(chan os.Signal, 1)
 	go func() {
-		defer logging.Flush()
-
 		<-sigusr
 
 		listener, err := net.Listen("tcp", "localhost:0")
@@ -56,7 +54,6 @@ func InitPprofServer(ctx context.Context) {
 		u := fmt.Sprintf("http://localhost:%d/debug/pprof/", listener.Addr().(*net.TCPAddr).Port)
 		// Don't use logging.V here, we always want to create & write a log file here.
 		logging.Infof("pprof server running on %s", u)
-		logging.Flush() // Immediately flush after logging the URL so we don't have to wait for the periodic flush.
 
 		select {
 		case <-ctx.Done():

--- a/sdk/go/common/util/cmdutil/profile_unix.go
+++ b/sdk/go/common/util/cmdutil/profile_unix.go
@@ -32,6 +32,8 @@ import (
 func InitPprofServer(ctx context.Context) {
 	sigusr := make(chan os.Signal, 1)
 	go func() {
+		defer logging.Flush()
+
 		<-sigusr
 
 		listener, err := net.Listen("tcp", "localhost:0")
@@ -54,6 +56,7 @@ func InitPprofServer(ctx context.Context) {
 		u := fmt.Sprintf("http://localhost:%d/debug/pprof/", listener.Addr().(*net.TCPAddr).Port)
 		// Don't use logging.V here, we always want to create & write a log file here.
 		logging.Infof("pprof server running on %s", u)
+		logging.Flush() // Immediately flush after logging the URL so we don't have to wait for the periodic flush.
 
 		select {
 		case <-ctx.Done():

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -14,24 +14,24 @@
 
 package logging
 
-// Wrapper around the glog API that allows us to intercept all logging calls and manipulate them as
+// Wrapper around slog that allows us to intercept all logging calls and manipulate them as
 // necessary.  This is primarily used so we can make a best effort approach to filtering out secrets
 // from any logs we emit before they get written to log-files/stderr.
 //
-// Code in pulumi should use this package instead of directly importing glog itself.  If any glog
+// Code in pulumi should use this package instead of directly importing slog itself.  If any slog
 // methods are needed that are not exported from this, they can be added, with the caveat that they
 // should be updated to properly filter as well before forwarding things along.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
-	"strconv"
+	"log/slog"
+	"os"
 	"strings"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
 
@@ -50,108 +50,107 @@ var (
 	filters []Filter
 )
 
-// VerboseLogger logs messages only if verbosity matches the level it was built with.
-//
-// It may be used as a boolean to check if it's enabled.
-//
-//	if log := logging.V(lvl); log {
-//		log.Infoln(expensiveComputation())
-//	}
-type VerboseLogger glog.Verbose
+var (
+	slogHandler *slog.Logger
+	logFilePath string
+)
 
-// Info is equivalent to the global Info function, guarded by the value of v.
-// See the documentation of V for usage.
+func init() {
+	slogHandler = slog.New(discardHandler{})
+}
+
+const LevelTrace = slog.LevelDebug - 4
+
+// VerboseLogger logs messages only if verbosity matches the level it was built with.
+// The value is 0 when disabled, or the verbosity level when enabled.
+type VerboseLogger int32
+
+func (v VerboseLogger) Enabled() bool { return v > 0 }
+
+// slogLevel maps the pulumi verbosity level to a slog level:
+//
+//	V(1)–V(6)  → Info
+//	V(7)–V(9)  → Info
+//	V(10)      → Debug
+//	V(11)+     → Trace
+func (v VerboseLogger) slogLevel() slog.Level {
+	switch {
+	case v >= 11:
+		return LevelTrace
+	case v >= 10:
+		return slog.LevelDebug
+	default:
+		return slog.LevelInfo
+	}
+}
+
 func (v VerboseLogger) Info(args ...any) {
-	if v {
-		glog.Verbose(v).InfoDepth(1, FilterString(fmt.Sprint(args...)))
+	if v.Enabled() {
+		msg := FilterString(fmt.Sprint(args...))
+		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
 	}
 }
 
 // Infoln is equivalent to the global Infoln function, guarded by the value of v.
-// See the documentation of V for usage.
 func (v VerboseLogger) Infoln(args ...any) {
-	if v {
-		glog.Verbose(v).Infoln(FilterString(fmt.Sprint(args...)))
+	if v.Enabled() {
+		msg := FilterString(fmt.Sprint(args...))
+		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
 	}
 }
 
 // Infof is equivalent to the global Infof function, guarded by the value of v.
-// See the documentation of V for usage.
 func (v VerboseLogger) Infof(format string, args ...any) {
-	if v {
-		glog.Verbose(v).InfoDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
+	if v.Enabled() {
+		msg := FilterString(fmt.Sprintf(format, args...))
+		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
 	}
 }
 
-// V builds a logger that logs messages only if verbosity is at least at the provided level.
-func V(level glog.Level) VerboseLogger {
-	return VerboseLogger(glog.V(level))
+func V(level int32) VerboseLogger {
+	return VerboseLogger(level)
 }
 
 func Errorf(format string, args ...any) {
-	glog.ErrorDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
+	msg := FilterString(fmt.Sprintf(format, args...))
+	slogHandler.Error(msg)
 }
 
 func Infof(format string, args ...any) {
-	glog.InfoDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
+	msg := FilterString(fmt.Sprintf(format, args...))
+	slogHandler.Info(msg)
 }
 
 func Warningf(format string, args ...any) {
-	glog.WarningDepthf(1, "%s", FilterString(fmt.Sprintf(format, args...)))
+	msg := FilterString(fmt.Sprintf(format, args...))
+	slogHandler.Warn(msg)
 }
 
-func Flush() {
-	glog.Flush()
-}
-
-func maybeSetFlag(name, value string) {
-	if f := flag.Lookup(name); f != nil {
-		err := f.Value.Set(value)
-		assertNoError(err)
-	}
-}
-
-// InitLogging ensures the logging library has been initialized with the given settings.
 func InitLogging(logToStderr bool, verbose int, logFlow bool) {
-	// Remember the settings in case someone inquires.
 	LogToStderr = logToStderr
 	Verbose = verbose
 	LogFlow = logFlow
 
-	// glog uses golang's built in flags package to set configuration values, which is incompatible with how
-	// we use cobra. In order to accommodate this, we call flag.CommandLine.Parse() with an empty array and
-	// explicitly set the flags we care about here.
-	if !flag.Parsed() {
-		err := flag.CommandLine.Parse([]string{})
-		assertNoError(err)
-	}
 	if logToStderr {
-		maybeSetFlag("logtostderr", "true")
-	}
-	if verbose > 0 {
-		maybeSetFlag("v", strconv.Itoa(verbose))
+		slogHandler = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+			Level: LevelTrace,
+		}))
+	} else if verbose > 0 {
+		f, err := os.CreateTemp("", "pulumi-*.log")
+		if err == nil {
+			logFilePath = f.Name()
+			slogHandler = slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{
+				Level: LevelTrace,
+			}))
+		}
 	}
 }
 
 func GetLogfilePath() (string, error) {
-	logFiles, err := glog.Names("INFO")
-	if err != nil {
-		return "", err
+	if logFilePath != "" {
+		return logFilePath, nil
 	}
-	if len(logFiles) == 0 {
-		return "", errors.New("no log files found")
-	}
-	return logFiles[0], nil
-}
-
-func assertNoError(err error) {
-	if err != nil {
-		failfast(err.Error())
-	}
-}
-
-func failfast(msg string) {
-	panic(fmt.Sprintf("fatal: %v", msg))
+	return "", errors.New("no log files found")
 }
 
 type nopFilter struct{}
@@ -215,3 +214,10 @@ func FilterString(msg string) string {
 
 	return msg
 }
+
+type discardHandler struct{}
+
+func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (d discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return d }
+func (d discardHandler) WithGroup(string) slog.Handler           { return d }

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -190,6 +190,9 @@ func logFileName() string {
 	username := "unknownuser"
 	if u, err := user.Current(); err == nil {
 		username = u.Username
+		// On Windows, Username is often DOMAIN\user. Replace path separators
+		// so the log filename doesn't accidentally create subdirectories.
+		username = strings.ReplaceAll(username, string(filepath.Separator), "_")
 	}
 	now := time.Now()
 	name := fmt.Sprintf("%s.%s.%s.log.INFO.%04d%02d%02d-%02d%02d%02d.%d",

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -30,8 +30,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/user"
+	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 )
@@ -165,7 +168,7 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 			Level: LevelTrace,
 		})})
 	} else if Verbose > 0 {
-		f, err := os.CreateTemp("", "pulumi-*.log")
+		f, err := os.Create(logFileName())
 		if err == nil {
 			logFilePath = f.Name()
 			logFile = f
@@ -174,6 +177,25 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 			})})
 		}
 	}
+}
+
+// logFileName returns a log file path matching the glog naming convention:
+// <program>.<host>.<user>.log.<severity>.<YYYYMMDD>-<HHMMSS>.<pid>
+func logFileName() string {
+	program := filepath.Base(os.Args[0])
+	host, _ := os.Hostname()
+	if i := strings.IndexByte(host, '.'); i >= 0 {
+		host = host[:i]
+	}
+	username := "unknownuser"
+	if u, err := user.Current(); err == nil {
+		username = u.Username
+	}
+	now := time.Now()
+	name := fmt.Sprintf("%s.%s.%s.log.INFO.%04d%02d%02d-%02d%02d%02d.%d",
+		program, host, username, now.Year(), now.Month(), now.Day(),
+		now.Hour(), now.Minute(), now.Second(), os.Getpid())
+	return filepath.Join(os.TempDir(), name)
 }
 
 // Flush flushes any pending log I/O.

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -54,6 +54,7 @@ var (
 var (
 	slogHandler *slog.Logger
 	logFilePath string
+	logFile     *os.File
 )
 
 func init() {
@@ -63,10 +64,17 @@ func init() {
 	// the behavior glog had via its own init(). Plugin binaries (language
 	// hosts) use the standard flag package and receive these flags from
 	// the CLI when --logflow is enabled.
-	flag.BoolVar(&LogToStderr, "logtostderr", false,
-		"Log to stderr instead of to files")
-	flag.IntVar(&Verbose, "v", 0,
-		"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
+	//
+	// Guard with Lookup so we don't panic if a transitive dependency
+	// (e.g. glog) has already registered the same flag name.
+	if flag.CommandLine.Lookup("logtostderr") == nil {
+		flag.BoolVar(&LogToStderr, "logtostderr", false,
+			"Log to stderr instead of to files")
+	}
+	if flag.CommandLine.Lookup("v") == nil {
+		flag.IntVar(&Verbose, "v", 0,
+			"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
+	}
 }
 
 const LevelTrace = slog.LevelDebug - 4
@@ -75,12 +83,11 @@ const LevelTrace = slog.LevelDebug - 4
 // The value is 0 when disabled, or the verbosity level when enabled.
 type VerboseLogger int32
 
-func (v VerboseLogger) Enabled() bool { return v > 0 }
+func (v VerboseLogger) Enabled() bool { return Verbose >= int(v) && v > 0 }
 
 // slogLevel maps the pulumi verbosity level to a slog level:
 //
-//	V(1)–V(6)  → Info
-//	V(7)–V(9)  → Info
+//	V(1)–V(9)  → Info
 //	V(10)      → Debug
 //	V(11)+     → Trace
 func (v VerboseLogger) slogLevel() slog.Level {
@@ -96,24 +103,21 @@ func (v VerboseLogger) slogLevel() slog.Level {
 
 func (v VerboseLogger) Info(args ...any) {
 	if v.Enabled() {
-		msg := FilterString(fmt.Sprint(args...))
-		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
+		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprint(args...), "v", int(v))
 	}
 }
 
 // Infoln is equivalent to the global Infoln function, guarded by the value of v.
 func (v VerboseLogger) Infoln(args ...any) {
 	if v.Enabled() {
-		msg := FilterString(fmt.Sprint(args...))
-		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
+		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprint(args...), "v", int(v))
 	}
 }
 
 // Infof is equivalent to the global Infof function, guarded by the value of v.
 func (v VerboseLogger) Infof(format string, args ...any) {
 	if v.Enabled() {
-		msg := FilterString(fmt.Sprintf(format, args...))
-		slogHandler.Log(context.TODO(), v.slogLevel(), msg, "v", int(v))
+		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprintf(format, args...), "v", int(v))
 	}
 }
 
@@ -122,18 +126,15 @@ func V(level int32) VerboseLogger {
 }
 
 func Errorf(format string, args ...any) {
-	msg := FilterString(fmt.Sprintf(format, args...))
-	slogHandler.Error(msg)
+	slogHandler.Error(fmt.Sprintf(format, args...))
 }
 
 func Infof(format string, args ...any) {
-	msg := FilterString(fmt.Sprintf(format, args...))
-	slogHandler.Info(msg)
+	slogHandler.Info(fmt.Sprintf(format, args...))
 }
 
 func Warningf(format string, args ...any) {
-	msg := FilterString(fmt.Sprintf(format, args...))
-	slogHandler.Warn(msg)
+	slogHandler.Warn(fmt.Sprintf(format, args...))
 }
 
 func InitLogging(logToStderr bool, verbose int, logFlow bool) {
@@ -141,18 +142,44 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	Verbose = verbose
 	LogFlow = logFlow
 
+	// Parse flags so that CLI-provided values (e.g. -v, -logtostderr passed
+	// via --logflow) are available. Then let non-default function arguments
+	// win, matching the original glog-era behavior where InitLogging(false,0,false)
+	// preserved whatever the flags said.
+	if !flag.Parsed() {
+		flag.CommandLine.Parse([]string{}) //nolint:errcheck
+	}
 	if logToStderr {
-		slogHandler = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		LogToStderr = true
+	} else if f := flag.CommandLine.Lookup("logtostderr"); f != nil {
+		LogToStderr = f.Value.String() == "true"
+	}
+	if verbose > 0 {
+		Verbose = verbose
+	} else if f := flag.CommandLine.Lookup("v"); f != nil {
+		fmt.Sscan(f.Value.String(), &Verbose) //nolint:errcheck
+	}
+
+	if LogToStderr {
+		slogHandler = slog.New(filteringHandler{inner: slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: LevelTrace,
-		}))
-	} else if verbose > 0 {
+		})})
+	} else if Verbose > 0 {
 		f, err := os.CreateTemp("", "pulumi-*.log")
 		if err == nil {
 			logFilePath = f.Name()
-			slogHandler = slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{
+			logFile = f
+			slogHandler = slog.New(filteringHandler{inner: slog.NewJSONHandler(f, &slog.HandlerOptions{
 				Level: LevelTrace,
-			}))
+			})})
 		}
+	}
+}
+
+// Flush flushes any pending log I/O.
+func Flush() {
+	if logFile != nil {
+		logFile.Sync() //nolint:errcheck
 	}
 }
 
@@ -231,3 +258,42 @@ func (discardHandler) Enabled(context.Context, slog.Level) bool  { return false 
 func (discardHandler) Handle(context.Context, slog.Record) error { return nil }
 func (d discardHandler) WithAttrs([]slog.Attr) slog.Handler      { return d }
 func (d discardHandler) WithGroup(string) slog.Handler           { return d }
+
+// filteringHandler wraps any slog.Handler and applies FilterString
+// to the record's message and string-typed attributes before forwarding.
+type filteringHandler struct {
+	inner slog.Handler
+}
+
+func (f filteringHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return f.inner.Enabled(ctx, level)
+}
+
+func (f filteringHandler) Handle(ctx context.Context, r slog.Record) error {
+	r.Message = FilterString(r.Message)
+	newRec := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		newRec.AddAttrs(filterAttr(a))
+		return true
+	})
+	return f.inner.Handle(ctx, newRec)
+}
+
+func (f filteringHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	filtered := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		filtered[i] = filterAttr(a)
+	}
+	return filteringHandler{inner: f.inner.WithAttrs(filtered)}
+}
+
+func (f filteringHandler) WithGroup(name string) slog.Handler {
+	return filteringHandler{inner: f.inner.WithGroup(name)}
+}
+
+func filterAttr(a slog.Attr) slog.Attr {
+	if a.Value.Kind() == slog.KindString {
+		a.Value = slog.StringValue(FilterString(a.Value.String()))
+	}
+	return a
+}

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"log/slog"
 	"os"
@@ -57,6 +58,15 @@ var (
 
 func init() {
 	slogHandler = slog.New(discardHandler{})
+
+	// Register the standard logging flags on flag.CommandLine, matching
+	// the behavior glog had via its own init(). Plugin binaries (language
+	// hosts) use the standard flag package and receive these flags from
+	// the CLI when --logflow is enabled.
+	flag.BoolVar(&LogToStderr, "logtostderr", false,
+		"Log to stderr instead of to files")
+	flag.IntVar(&Verbose, "v", 0,
+		"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
 }
 
 const LevelTrace = slog.LevelDebug - 4

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -18,7 +18,7 @@ package logging
 // necessary.  This is primarily used so we can make a best effort approach to filtering out secrets
 // from any logs we emit before they get written to log-files/stderr.
 //
-// Code in pulumi should use this package instead of directly importing slog itself.  If any slog
+// Code in pulumi may use this package instead of directly importing slog itself.  If any slog
 // methods are needed that are not exported from this, they can be added, with the caveat that they
 // should be updated to properly filter as well before forwarding things along.
 
@@ -81,9 +81,9 @@ const LevelTrace = slog.LevelDebug - 4
 
 // VerboseLogger logs messages only if verbosity matches the level it was built with.
 // The value is 0 when disabled, or the verbosity level when enabled.
-type VerboseLogger int32
+type VerboseLogger struct{ level int32 }
 
-func (v VerboseLogger) Enabled() bool { return Verbose >= int(v) && v > 0 }
+func (v VerboseLogger) Enabled() bool { return Verbose >= int(v.level) && v.level > 0 }
 
 // slogLevel maps the pulumi verbosity level to a slog level:
 //
@@ -92,9 +92,9 @@ func (v VerboseLogger) Enabled() bool { return Verbose >= int(v) && v > 0 }
 //	V(11)+     → Trace
 func (v VerboseLogger) slogLevel() slog.Level {
 	switch {
-	case v >= 11:
+	case v.level >= 11:
 		return LevelTrace
-	case v >= 10:
+	case v.level >= 10:
 		return slog.LevelDebug
 	default:
 		return slog.LevelInfo
@@ -103,26 +103,24 @@ func (v VerboseLogger) slogLevel() slog.Level {
 
 func (v VerboseLogger) Info(args ...any) {
 	if v.Enabled() {
-		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprint(args...), "v", int(v))
+		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprint(args...), "v", int(v.level))
 	}
 }
 
 // Infoln is equivalent to the global Infoln function, guarded by the value of v.
 func (v VerboseLogger) Infoln(args ...any) {
-	if v.Enabled() {
-		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprint(args...), "v", int(v))
-	}
+	v.Info(args...)
 }
 
 // Infof is equivalent to the global Infof function, guarded by the value of v.
 func (v VerboseLogger) Infof(format string, args ...any) {
 	if v.Enabled() {
-		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprintf(format, args...), "v", int(v))
+		slogHandler.Log(context.TODO(), v.slogLevel(), fmt.Sprintf(format, args...), "v", int(v.level))
 	}
 }
 
 func V(level int32) VerboseLogger {
-	return VerboseLogger(level)
+	return VerboseLogger{level: level}
 }
 
 func Errorf(format string, args ...any) {
@@ -147,7 +145,9 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	// win, matching the original glog-era behavior where InitLogging(false,0,false)
 	// preserved whatever the flags said.
 	if !flag.Parsed() {
-		flag.CommandLine.Parse([]string{}) //nolint:errcheck
+		if err := flag.CommandLine.Parse([]string{}); err != nil {
+			panic(fmt.Sprintf("failed to parse flags: %v", err))
+		}
 	}
 	if logToStderr {
 		LogToStderr = true

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/sdk/go/pulumi-language-go/go.sum
+++ b/sdk/go/pulumi-language-go/go.sum
@@ -227,8 +227,6 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -191,7 +191,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logging.InitLogging(false, 0, false)
+	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -191,7 +191,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
+	logging.InitLogging(false, 0, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.sum
@@ -224,8 +224,6 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -918,7 +918,7 @@ func (host *nodeLanguageHost) execRuntime(ctx context.Context, req *pulumirpc.Ru
 
 	runtimeArgs = append(runtimeArgs, args...)
 
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		commandStr := strings.Join(runtimeArgs, " ")
 		logging.V(5).Infoln("Language host launching process: ", runtimeBin, commandStr)
 	}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -131,7 +131,7 @@ func main() {
 	}
 
 	args := flag.Args()
-	logging.InitLogging(false, 0, false)
+	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -131,7 +131,7 @@ func main() {
 	}
 
 	args := flag.Args()
-	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
+	logging.InitLogging(false, 0, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -60,7 +60,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/sdk/python/cmd/pulumi-language-python/go.sum
+++ b/sdk/python/cmd/pulumi-language-python/go.sum
@@ -227,8 +227,6 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
 github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1023,7 +1023,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		return nil, err
 	}
 
-	if logging.V(5) {
+	if logging.V(5).Enabled() {
 		commandStr := strings.Join(args, " ")
 		logging.V(5).Infoln("Language host launching process: ", host.exec, commandStr)
 	}

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -130,7 +130,7 @@ func main() {
 	}
 
 	args := flag.Args()
-	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
+	logging.InitLogging(false, 0, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -130,7 +130,7 @@ func main() {
 	}
 
 	args := flag.Args()
-	logging.InitLogging(false, 0, false)
+	logging.InitLogging(logging.LogToStderr, logging.Verbose, false)
 
 	// Use OTel when the CLI provides an OTLP endpoint; fall back to
 	// OpenTracing otherwise.  Only one system should be active to avoid

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -141,7 +141,6 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -3797,7 +3797,6 @@ github.com/golang/glog v1.2.1/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwm
 github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.3/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.sum
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.sum
@@ -82,8 +82,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/tests/integration/construct_component_provider_propagation/go/go.sum
+++ b/tests/integration/construct_component_provider_propagation/go/go.sum
@@ -82,8 +82,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/tests/integration/construct_component_resource_options/go/go.sum
+++ b/tests/integration/construct_component_resource_options/go/go.sum
@@ -82,8 +82,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/tests/integration/construct_nested_component/go/go.sum
+++ b/tests/integration/construct_nested_component/go/go.sum
@@ -82,8 +82,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
-github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=


### PR DESCRIPTION
Replace the underlying logging library from glog to slog.  This changes the log format somewhat, in that we are now using JSON output for our logs. It doesn't change yet how we log things, that will come in a future PR.

Note that there is a minor API change here, in that we can no longer use `if logging.V(x) {`, but need to use the `.Enabled()` function instead.  This is only used in `pulumi/pulumi` and our language repository, according to a GitHub search, so there shouldn't be any additional work for providers here at this stage.

At this point we can also use the regular `slog` APIs, and things will get logged correctly into the right sinks.  We don't do that in this PR to avoid additional churn.

Co-authored-by: Claude