### PR TITLE
Support Input[Optional[T]] in Python runtime type unwrapping

### DIFF
--- a/changelog/pending/20260409--sdk-python--support-input-optional-t-in-python-runtime-type-unwrapping.yaml
+++ b/changelog/pending/20260409--sdk-python--support-input-optional-t-in-python-runtime-type-unwrapping.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Support Input[Optional[T]] in Python runtime type unwrapping

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -975,6 +975,8 @@ def unwrap_type(val: type) -> type:
         elif len(args) == 4:
             if isInput(args) and args[3] is type(None):  # Optional[Input[T]]
                 return args[0]
+            if args[1] is type(None) and isInput(args, 2):  # Input[Optional[T]]
+                return args[0]
             if isInputType(args) and isInput(args, 2):  # Input[InputType[T]]
                 return args[0]
         elif len(args) == 5:

--- a/sdk/python/lib/test/test_types.py
+++ b/sdk/python/lib/test/test_types.py
@@ -54,6 +54,7 @@ async def test_unwrap_type():
         d: pulumi.InputType[str]
         e: Optional[pulumi.InputType[str]]
         f: Optional[pulumi.Input[pulumi.InputType[str]]]
+        g: pulumi.Input[Optional[str]]
 
     # We always call `unwrap_type` with the forward references for `Output[T]` resolved.
     localns = {"Output": Output, "T": typing.TypeVar("T")}
@@ -65,3 +66,4 @@ async def test_unwrap_type():
     assert _types.unwrap_type(anno["d"]) == str
     assert _types.unwrap_type(anno["e"]) == str
     assert _types.unwrap_type(anno["f"]) == str
+    assert _types.unwrap_type(anno["g"]) == str


### PR DESCRIPTION
Support `Input[Optional[T]]` in unwrap_type. This is a prerequisite for generating `Input[Optional[T]]` type annotations for optional input properties, which will allow `Output[Optional[T]]` to be assignable to optional inputs.

Once we have this released, we can bump the code SDK version for generated SDKs in Ref https://github.com/pulumi/pulumi/pull/22552

Ref https://github.com/pulumi/pulumi/issues/6175
