### PR TITLE
Fix conversion conformance tests for NodeJS

### DIFF
--- a/changelog/pending/20260409--programgen-nodejs--add-necessary-casts-between-types-in-generated-programs.yaml
+++ b/changelog/pending/20260409--programgen-nodejs--add-necessary-casts-between-types-in-generated-programs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/nodejs
+  description: Add necessary casts between types in generated programs

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -409,14 +409,36 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case pcl.IntrinsicConvert:
 		from := expr.Args[0]
 		to := pcl.LowerConversion(from, expr.Signature.ReturnType)
-		output, isOutput := to.(*model.OutputType)
-		if isOutput {
+		if output, ok := to.(*model.OutputType); ok {
 			to = output.ElementType
+		}
+		if cns, ok := to.(*model.ConstType); ok {
+			to = cns.Type
+		}
+		fromType := from.Type()
+		isFromOutput := isOutputType(fromType)
+		if output, ok := fromType.(*model.OutputType); ok {
+			fromType = output.ElementType
+		}
+		if cns, ok := fromType.(*model.ConstType); ok {
+			fromType = cns.Type
+		}
+
+		genMaybeOutputConversion := func(conversionExpr func(string)) {
+			if isFromOutput {
+				g.Fgenf(w, "%.v.apply(x =>", from)
+				conversionExpr("x")
+				g.Fgenf(w, ")")
+				return
+			}
+			var t bytes.Buffer
+			g.Fgenf(&t, "%.v", from)
+			conversionExpr(t.String())
 		}
 		switch to := to.(type) {
 		case *model.EnumType:
 			if enum, err := enumName(to); err == nil {
-				if isOutput {
+				if isFromOutput {
 					g.Fgenf(w, "%.v.apply((x) => %s[x])", from, enum)
 				} else {
 					diag := pcl.GenEnum(to, from, func(member *schema.Enum) {
@@ -434,7 +456,29 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				g.Fgenf(w, "%v", from)
 			}
 		default:
-			g.Fgenf(w, "%v", from)
+			switch {
+			case model.BoolType.AssignableFrom(to) && !model.BoolType.AssignableFrom(fromType):
+				genMaybeOutputConversion(func(v string) {
+					g.Fgenf(w, `%s === "true"`, v)
+				})
+			case model.StringType.AssignableFrom(to) && !model.StringType.AssignableFrom(fromType):
+				genMaybeOutputConversion(func(v string) {
+					g.Fgenf(w, "String(%s)", v)
+				})
+			// ints and numbers are treated interchangeably in JavaScript, so if we are casting to int but
+			// already have int _or_ number that's fine. Same for casting to number.
+			case model.NumberType.AssignableFrom(to) &&
+				!model.NumberType.AssignableFrom(fromType) &&
+				!model.IntType.AssignableFrom(fromType),
+				model.IntType.AssignableFrom(to) &&
+					!model.NumberType.AssignableFrom(fromType) &&
+					!model.IntType.AssignableFrom(fromType):
+				genMaybeOutputConversion(func(v string) {
+					g.Fgenf(w, "Number(%s)", v)
+				})
+			default:
+				g.Fgenf(w, "%v", from)
+			}
 		}
 	case pcl.IntrinsicApply:
 		g.genApply(w, expr)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -101,7 +101,6 @@ var expectedFailures = map[string]string{
 	"l2-resource-optional":               "optional outputs are not assignable to optional inputs",
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
 	"l3-range-ref":                       "Property 'k1' does not exist on type 'Target[]'",
-	"l2-resource-primitive-conversions":  "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 }
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-config-types-object/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-config-types-object/index.ts
@@ -9,7 +9,7 @@ export const theMap = {
 const anObject = config.requireObject<{prop?: Array<boolean>}>("anObject");
 export const theObject = anObject.prop?.[0];
 const anyObject = config.requireObject<any>("anyObject");
-export const theThing = anyObject.a + anyObject.b;
+export const theThing = Number(anyObject.a) + Number(anyObject.b);
 const optionalUntypedObject = config.getObject<any>("optionalUntypedObject") || {
     key: "value",
 };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-primitive-conversions
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/index.ts
@@ -1,0 +1,66 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as primitive from "@pulumi/primitive";
+
+const config = new pulumi.Config();
+const plainBool = config.requireBoolean("plainBool");
+const plainNumber = config.requireNumber("plainNumber");
+const plainInteger = config.requireNumber("plainInteger");
+const plainString = config.require("plainString");
+const plainNumericString = config.require("plainNumericString");
+const secretNumber = config.requireSecretNumber("secretNumber");
+const secretInteger = config.requireSecretNumber("secretInteger");
+const secretString = config.requireSecret("secretString");
+const secretNumericString = config.requireSecret("secretNumericString");
+const plainValues = new primitive.Resource("plainValues", {
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainNumber),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const secretValues = new primitive.Resource("secretValues", {
+    boolean: secretString.apply(x =>x === "true"),
+    float: secretInteger,
+    integer: secretNumericString.apply(x =>Number(x)),
+    string: secretNumber.apply(x =>String(x)),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeResult = primitive.invokeOutput({
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainBool),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeValues = new primitive.Resource("invokeValues", {
+    boolean: invokeResult.boolean,
+    float: invokeResult.float,
+    integer: invokeResult.integer,
+    string: invokeResult.string,
+    numberArray: invokeResult.numberArray,
+    booleanMap: invokeResult.booleanMap,
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "l2-resource-primitive-conversions",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/primitive": "ROOT/artifacts/pulumi-primitive-7.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-primitive-conversions/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-config-types-object/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-config-types-object/index.ts
@@ -9,7 +9,7 @@ export const theMap = {
 const anObject = config.requireObject<{prop?: Array<boolean>}>("anObject");
 export const theObject = anObject.prop?.[0];
 const anyObject = config.requireObject<any>("anyObject");
-export const theThing = anyObject.a + anyObject.b;
+export const theThing = Number(anyObject.a) + Number(anyObject.b);
 const optionalUntypedObject = config.getObject<any>("optionalUntypedObject") || {
     key: "value",
 };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l2-resource-primitive-conversions
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/index.ts
@@ -1,0 +1,66 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as primitive from "@pulumi/primitive";
+
+const config = new pulumi.Config();
+const plainBool = config.requireBoolean("plainBool");
+const plainNumber = config.requireNumber("plainNumber");
+const plainInteger = config.requireNumber("plainInteger");
+const plainString = config.require("plainString");
+const plainNumericString = config.require("plainNumericString");
+const secretNumber = config.requireSecretNumber("secretNumber");
+const secretInteger = config.requireSecretNumber("secretInteger");
+const secretString = config.requireSecret("secretString");
+const secretNumericString = config.requireSecret("secretNumericString");
+const plainValues = new primitive.Resource("plainValues", {
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainNumber),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const secretValues = new primitive.Resource("secretValues", {
+    boolean: secretString.apply(x =>x === "true"),
+    float: secretInteger,
+    integer: secretNumericString.apply(x =>Number(x)),
+    string: secretNumber.apply(x =>String(x)),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeResult = primitive.invokeOutput({
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainBool),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeValues = new primitive.Resource("invokeValues", {
+    boolean: invokeResult.boolean,
+    float: invokeResult.float,
+    integer: invokeResult.integer,
+    string: invokeResult.string,
+    numberArray: invokeResult.numberArray,
+    booleanMap: invokeResult.booleanMap,
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-resource-primitive-conversions",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/primitive": "ROOT/artifacts/pulumi-primitive-7.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-primitive-conversions/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-config-types-object/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-config-types-object/index.ts
@@ -9,7 +9,7 @@ export const theMap = {
 const anObject = config.requireObject<{prop?: Array<boolean>}>("anObject");
 export const theObject = anObject.prop?.[0];
 const anyObject = config.requireObject<any>("anyObject");
-export const theThing = anyObject.a + anyObject.b;
+export const theThing = Number(anyObject.a) + Number(anyObject.b);
 const optionalUntypedObject = config.getObject<any>("optionalUntypedObject") || {
     key: "value",
 };

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-primitive-conversions
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/index.ts
@@ -1,0 +1,66 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as primitive from "@pulumi/primitive";
+
+const config = new pulumi.Config();
+const plainBool = config.requireBoolean("plainBool");
+const plainNumber = config.requireNumber("plainNumber");
+const plainInteger = config.requireNumber("plainInteger");
+const plainString = config.require("plainString");
+const plainNumericString = config.require("plainNumericString");
+const secretNumber = config.requireSecretNumber("secretNumber");
+const secretInteger = config.requireSecretNumber("secretInteger");
+const secretString = config.requireSecret("secretString");
+const secretNumericString = config.requireSecret("secretNumericString");
+const plainValues = new primitive.Resource("plainValues", {
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainNumber),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const secretValues = new primitive.Resource("secretValues", {
+    boolean: secretString.apply(x =>x === "true"),
+    float: secretInteger,
+    integer: secretNumericString.apply(x =>Number(x)),
+    string: secretNumber.apply(x =>String(x)),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeResult = primitive.invokeOutput({
+    boolean: plainString === "true",
+    float: plainInteger,
+    integer: Number(plainNumericString),
+    string: String(plainBool),
+    numberArray: [
+        plainInteger,
+        Number(plainNumericString),
+        plainNumber,
+    ],
+    booleanMap: {
+        fromBool: plainBool,
+        fromString: plainString === "true",
+    },
+});
+const invokeValues = new primitive.Resource("invokeValues", {
+    boolean: invokeResult.boolean,
+    float: invokeResult.float,
+    integer: invokeResult.integer,
+    string: invokeResult.string,
+    numberArray: invokeResult.numberArray,
+    booleanMap: invokeResult.booleanMap,
+});

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l2-resource-primitive-conversions",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/primitive": "ROOT/artifacts/pulumi-primitive-7.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-primitive-conversions/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+	]
+}

--- a/tests/testdata/codegen/aws-eks-pp/nodejs/aws-eks.ts
+++ b/tests/testdata/codegen/aws-eks-pp/nodejs/aws-eks.ts
@@ -47,7 +47,7 @@ export = async () => {
     for (const range of zones.names.map((v, k) => ({key: k, value: v}))) {
         rta.push(new aws.ec2.RouteTableAssociation(`rta-${range.key}`, {
             routeTableId: eksRouteTable.id,
-            subnetId: vpcSubnet[range.key].id,
+            subnetId: String(vpcSubnet[range.key].id),
         }));
     }
     const subnetIds = vpcSubnet.map(__item => __item.id);

--- a/tests/testdata/codegen/aws-fargate-pp/nodejs/aws-fargate.ts
+++ b/tests/testdata/codegen/aws-fargate-pp/nodejs/aws-fargate.ts
@@ -10,7 +10,7 @@ const subnets = vpc.then(vpc => aws.ec2.getSubnetIds({
 }));
 // Create a security group that permits HTTP ingress and unrestricted egress.
 const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {
-    vpcId: vpc.then(vpc => vpc.id),
+    vpcId: String(vpc.then(vpc => vpc.id)),
     egress: [{
         protocol: "-1",
         fromPort: 0,
@@ -51,7 +51,7 @@ const webTargetGroup = new aws.elasticloadbalancingv2.TargetGroup("webTargetGrou
     port: 80,
     protocol: "HTTP",
     targetType: "ip",
-    vpcId: vpc.then(vpc => vpc.id),
+    vpcId: String(vpc.then(vpc => vpc.id)),
 });
 const webListener = new aws.elasticloadbalancingv2.Listener("webListener", {
     loadBalancerArn: webLoadBalancer.arn,

--- a/tests/testdata/codegen/aws-webserver-pp/nodejs/aws-webserver.ts
+++ b/tests/testdata/codegen/aws-webserver-pp/nodejs/aws-webserver.ts
@@ -24,7 +24,7 @@ const server = new aws.ec2.Instance("server", {
     },
     instanceType: aws.ec2.InstanceType.T2_Micro,
     securityGroups: [securityGroup.name],
-    ami: ami.then(ami => ami.id),
+    ami: String(ami.then(ami => ami.id)),
     userData: `#!/bin/bash
 echo "Hello, World!" > index.html
 nohup python -m SimpleHTTPServer 80 &

--- a/tests/testdata/codegen/inline-invokes-pp/nodejs/inline-invokes.ts
+++ b/tests/testdata/codegen/inline-invokes-pp/nodejs/inline-invokes.ts
@@ -1,6 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {vpcId: aws.ec2.getVpc({
+const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {vpcId: String(aws.ec2.getVpc({
     "default": true,
-}).then(invoke => invoke.id)});
+}).then(invoke => invoke.id))});

--- a/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
+++ b/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
@@ -41,7 +41,7 @@ export = async () => {
             ipv6CidrBlock: enableIpv6 && publicSubnetIpv6Prefixes.length > 0 ? currentVpc.ipv6CidrBlock.apply(ipv6CidrBlock => std.cidrsubnetOutput({
                 input: ipv6CidrBlock,
                 newbits: 8,
-                netnum: publicSubnetIpv6Prefixes[range.value],
+                netnum: Number(publicSubnetIpv6Prefixes[range.value]),
             })).apply(invoke => invoke.result) : null,
             ipv6Native: enableIpv6 && publicSubnetIpv6Native,
             vpcId: currentVpc.id,

--- a/tests/testdata/codegen/transpiled_examples/webserver-json-pp/nodejs/webserver-json.ts
+++ b/tests/testdata/codegen/transpiled_examples/webserver-json-pp/nodejs/webserver-json.ts
@@ -11,14 +11,14 @@ const webSecGrp = new aws.ec2.SecurityGroup("WebSecGrp", {ingress: [{
 }]});
 const webServer = new aws.ec2.Instance("WebServer", {
     instanceType: instanceType,
-    ami: aws.getAmi({
+    ami: String(aws.getAmi({
         filters: [{
             name: "name",
             values: ["amzn-ami-hvm-*-x86_64-ebs"],
         }],
         owners: ["137112412989"],
         mostRecent: true,
-    }).then(invoke => invoke.id),
+    }).then(invoke => invoke.id)),
     userData: webSecGrp.arn.apply(arn => [
         "#!/bin/bash",
         `echo 'Hello, World from ${arn}!' > index.html`,


### PR DESCRIPTION
Fix l2-resource-primitive-conversions for NodeJS. This is adding a load of type cast login into the convert intrinsic, so for example if we have a number and are converting to a string we'll emit the TypeScript code to cast explicitly to `String(x)`.

Part of fixing https://github.com/pulumi/pulumi/issues/13582