### PR TITLE
cli: Fix formatting in pulumi convert help text

### DIFF
--- a/changelog/pending/20260409--cli--fix-formatting-in-pulumi-convert-help-text.yaml
+++ b/changelog/pending/20260409--cli--fix-formatting-in-pulumi-convert-help-text.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix missing blank line in `pulumi convert --help` output between the target languages list and the example usage section

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -75,7 +75,7 @@ func NewConvertCmd(ws pkgWorkspace.Context) *cobra.Command {
 			"\n" +
 			"Valid source languages: yaml, terraform, bicep, arm, kubernetes\n" +
 			"\n" +
-			"Valid target languages: typescript, python, csharp, go, java, yaml" +
+			"Valid target languages: typescript, python, csharp, go, java, yaml\n" +
 			"\n" +
 			"Example command usage:" +
 			"\n" +

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -77,7 +77,7 @@ func NewConvertCmd(ws pkgWorkspace.Context) *cobra.Command {
 			"\n" +
 			"Valid target languages: typescript, python, csharp, go, java, yaml\n" +
 			"\n" +
-			"Example command usage:" +
+			"Example command usage:\n" +
 			"\n" +
 			"    pulumi convert --from yaml --language java --out . \n" +
 			"\n\n" +


### PR DESCRIPTION
### Proposed changes

The `Long` description string for `pulumi convert` was missing a newline between the "Valid target languages" line and the "Example command usage:" section. Every other paragraph break in this string uses `"\n" + "\n"` to produce a blank line; this one had only a single `\n`, so the two sections ran together in both `pulumi convert --help` and the generated CLI reference docs on pulumi.com.

### Credit

Originally spotted and fixed by @absurdlylongusername in pulumi/docs#18431. That PR patched the generated markdown file directly; this PR applies the equivalent fix at the source so it survives the next docs regeneration.

cc @jkodroff

### Related issues

Closes pulumi/docs#18431 (superseded)