### PR TITLE
Remove state lock for destroy and import with preview only for diy backend

### DIFF
--- a/changelog/pending/20260410--backend-diy--remove-state-lock-for-destroy-and-import-with-preview-only-for-diy-backend.yaml
+++ b/changelog/pending/20260410--backend-diy--remove-state-lock-for-destroy-and-import-with-preview-only-for-diy-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: Remove state lock for destroy and import with preview only for diy backend

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1096,12 +1096,6 @@ func (b *diyBackend) Update(ctx context.Context, stack backend.Stack,
 func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, imports []deploy.Import,
 ) (sdkDisplay.ResourceChanges, error) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, err
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	op.Imports = imports
 
 	if op.Opts.PreviewOnly {
@@ -1116,6 +1110,12 @@ func (b *diyBackend) Import(ctx context.Context, stack backend.Stack,
 			ctx, apitype.ResourceImportUpdate, stack, op, opts, nil /*events*/)
 		return changes, err
 	}
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, err
+	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply, nil, nil)
 }
@@ -1148,12 +1148,6 @@ func (b *diyBackend) Refresh(ctx context.Context, stack backend.Stack,
 func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation,
 ) (sdkDisplay.ResourceChanges, error) {
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, err
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	if op.Opts.PreviewOnly {
 		// We can skip PreviewThenPromptThenExecute, and just go straight to Execute.
 		opts := backend.ApplierOptions{
@@ -1166,6 +1160,12 @@ func (b *diyBackend) Destroy(ctx context.Context, stack backend.Stack,
 			ctx, apitype.DestroyUpdate, stack, op, opts, nil /*events*/)
 		return changes, err
 	}
+
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, err
+	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply, nil, nil)
 }


### PR DESCRIPTION
## Summary
In https://github.com/pulumi/pulumi/issues/1666,  --preview-only was added to pulumi refresh/destroy/import. However, it still locks the state when running the command. This is a followup to https://github.com/pulumi/pulumi/pull/22385 where it was modified to not lock the state for refresh with preview only. This removes the state lock for destroy and import when the --preview-only flag is enabled.

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
