### PR TITLE
Add --diff to automation api for destroy

### DIFF
--- a/changelog/pending/20260410--auto-go-nodejs-python--add-diff-to-automation-api-for-destroy.yaml
+++ b/changelog/pending/20260410--auto-go-nodejs-python--add-diff-to-automation-api-for-destroy.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: auto/go,nodejs,python
+  description: Add --diff to automation api for destroy

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -165,6 +165,13 @@ func RunProgram(f bool) Option {
 	})
 }
 
+// Diff displays operation as a rich diff showing the overall change
+func Diff() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Diff = true
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Destroy() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -216,6 +223,8 @@ type Options struct {
 	ConfigFile string
 	// When set to true, run the program in the workspace to perform the destroy.
 	RunProgram *bool
+	// Diff displays operation as a rich diff showing the overall change
+	Diff bool
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -1115,6 +1115,9 @@ func destroyOptsToCmd(destroyOpts *optdestroy.Options, s *Stack) ([]string, io.C
 			args = append(args, "--run-program=false")
 		}
 	}
+	if destroyOpts.Diff {
+		args = append(args, "--diff")
+	}
 
 	kind := constant.ExecKindAutoLocal
 	var closer io.Closer

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -792,6 +792,9 @@ Event: ${line}\n${e.toString()}`);
                     args.push("--run-program=false");
                 }
             }
+            if (opts.diff) {
+                args.push("--diff");
+            }
             applyGlobalOpts(opts, args);
         }
 
@@ -2216,6 +2219,11 @@ export interface DestroyOptions extends GlobalOpts {
      * Run the program in the workspace to perform the destroy.
      */
     runProgram?: boolean;
+
+    /**
+     * Display the operation as a rich diff showing the overall change.
+     */
+    diff?: boolean;
 }
 
 /**

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -910,6 +910,7 @@ class Stack:
         run_program: Optional[bool] = None,
         config_file: Optional[str] = None,
         program: Optional[PulumiFn] = None,
+        diff: Optional[bool] = None,
     ) -> DestroyResult:
         """
         Destroy deletes all resources in a stack, leaving all history and configuration intact.
@@ -938,6 +939,7 @@ class Stack:
         :param preview_only: Deprecated, use `preview_destroy` instead. Only show a preview of the destroy, but don't perform the destroy itself
         :param run_program: Run the program in the workspace to destroy the stack
         :param config_file: Path to a Pulumi config file to use for this update.
+        :param diff: Display operation as a rich diff showing the overall change.
         :returns: DestroyResult
         """
         program = program or self.workspace.program


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->
Add --diff support to automation api for destroy to nodejs, python, and go.

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
