### PR TITLE
Remove stacks in tests

### DIFF
--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -987,6 +987,13 @@ func TestStackLifecycleInlineProgramRemoveWithoutDestroy(t *testing.T) {
 		t.FailNow()
 	}
 
+	defer func() {
+		_, err = s.Destroy(ctx)
+		require.NoError(t, err, "failed to destroy stack. Resources have leaked.")
+		err = s.Workspace().RemoveStack(ctx, s.Name())
+		require.NoError(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
 	_, err = s.Up(ctx, optup.UserAgent(agent), optup.Refresh())
 	require.NoError(t, err, "up failed")
 
@@ -1412,6 +1419,11 @@ func TestConfigFlagLike(t *testing.T) {
 		t.FailNow()
 	}
 
+	defer func() {
+		err = s.Workspace().RemoveStack(ctx, s.Name())
+		require.NoError(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
 	err = s.SetConfig(ctx, "key", ConfigValue{"-value", false})
 	if err != nil {
 		t.Error(err)
@@ -1428,9 +1440,6 @@ func TestConfigFlagLike(t *testing.T) {
 	assert.Equalf(t, "-value", cm["testproj:secret-key"].Value, "wrong secret-key")
 	assert.Equalf(t, false, cm["testproj:key"].Secret, "key should not be secret")
 	assert.Equalf(t, true, cm["testproj:secret-key"].Secret, "secret-key should be secret")
-
-	err = s.Workspace().RemoveStack(ctx, stackName)
-	require.NoError(t, err, "failed to remove stack. Resources have leaked.")
 }
 
 func TestGetAllConfigCorrectArgs(t *testing.T) {
@@ -2375,6 +2384,11 @@ func TestTagFunctions(t *testing.T) {
 	}
 	ws := s.Workspace()
 
+	defer func() {
+		err = s.Workspace().RemoveStack(ctx, s.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
 	// -- lists tag values --
 	tags, err := ws.ListTags(ctx, stackName)
 	if err != nil {
@@ -2406,9 +2420,6 @@ func TestTagFunctions(t *testing.T) {
 	}
 	tags, _ = ws.ListTags(ctx, stackName)
 	assert.NotContains(t, tags, "foo", "failed to remove tag")
-
-	err = s.Workspace().RemoveStack(ctx, stackName)
-	require.NoError(t, err, "failed to remove stack. Resources have leaked.")
 }
 
 //nolint:paralleltest // mutates environment variables
@@ -2545,6 +2556,10 @@ func TestStackImportResources(t *testing.T) {
 		t.Errorf("failed to initialize stack, err: %v", err)
 		t.FailNow()
 	}
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
 
 	randomPluginVersion := "4.16.3"
 	err = stack.Workspace().InstallPlugin(ctx, "random", randomPluginVersion)
@@ -3327,6 +3342,11 @@ func TestWhoAmIDetailed(t *testing.T) {
 		t.FailNow()
 	}
 
+	defer func() {
+		err = s.Workspace().RemoveStack(ctx, s.Name())
+		require.NoError(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
 	whoAmIDetailedInfo, err := s.Workspace().WhoAmIDetails(ctx)
 	if err != nil {
 		t.Errorf("failed to get WhoAmIDetailedInfo, err: %v", err)
@@ -3334,18 +3354,6 @@ func TestWhoAmIDetailed(t *testing.T) {
 	}
 	require.NotNil(t, whoAmIDetailedInfo.User, "failed to get WhoAmIDetailedInfo user")
 	require.NotNil(t, whoAmIDetailedInfo.URL, "failed to get WhoAmIDetailedInfo url")
-
-	// cleanup
-	_, err = s.Destroy(ctx)
-	if err != nil {
-		t.Errorf("destroy failed during cleanup, err: %v", err)
-		t.FailNow()
-	}
-	err = s.Workspace().RemoveStack(ctx, s.Name())
-	if err != nil {
-		t.Errorf("failed to remove stack during cleanup. Resources have leaked, err: %v", err)
-		t.FailNow()
-	}
 }
 
 func TestListStacks(t *testing.T) {
@@ -3883,6 +3891,11 @@ func TestStackLifecycleInlineProgramRunProgram(t *testing.T) {
 		t.Errorf("failed to initialize stack, err: %v", err)
 		t.FailNow()
 	}
+
+	defer func() {
+		err = s.Workspace().RemoveStack(ctx, s.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
 
 	_, err = s.Up(ctx, optup.UserAgent(agent), optup.Refresh())
 	require.NoError(t, err, "up failed")

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -263,6 +263,11 @@ func TestDestroyOptsConfigFile(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
 	args, _, err := destroyOptsToCmd(
 		&optdestroy.Options{
 			ConfigFile: filepath.Join(stack.workspace.WorkDir(), "test.yaml"),
@@ -291,6 +296,11 @@ func TestRefreshOptsConfigFile(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
 	args, _, err := refreshOptsToCmd(
 		&optrefresh.Options{
 			ConfigFile: filepath.Join(stack.workspace.WorkDir(), "test.yaml"),
@@ -318,6 +328,11 @@ func TestRefreshOptsDiff(t *testing.T) {
 	stack, err := NewStackLocalSource(ctx, ptesting.RandomStackName(), pDir)
 	require.NoError(t, err)
 
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
+
 	argsUp, _, err := refreshOptsToCmd(&optrefresh.Options{Diff: true}, &stack, true)
 	require.NoError(t, err)
 	assert.Contains(t, argsUp, "--diff", argsUp)
@@ -340,6 +355,11 @@ func TestRefreshOptsClearPendingCreates(t *testing.T) {
 
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
+
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
 
 	args, _, err := refreshOptsToCmd(
 		&optrefresh.Options{
@@ -366,6 +386,11 @@ func TestRename(t *testing.T) {
 
 	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
+
+	defer func() {
+		err = stack.Workspace().RemoveStack(ctx, stack.Name(), optremove.Force())
+		require.NoError(t, err, "failed to remove stack.")
+	}()
 
 	args := renameOptsToCmd(
 		&optrename.Options{

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -320,12 +320,14 @@ func TestRefreshOptsDiff(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
+	sName := ptesting.RandomStackName()
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 	// Copy the test project to a temp directory.
 	pDir := t.TempDir()
 	err := fsutil.CopyFile(pDir, filepath.Join(".", "test", "testproj"), nil)
 	require.NoError(t, err)
 
-	stack, err := NewStackLocalSource(ctx, ptesting.RandomStackName(), pDir)
+	stack, err := NewStackLocalSource(ctx, stackName, pDir)
 	require.NoError(t, err)
 
 	defer func() {

--- a/sdk/nodejs/tests/automation/localWorkspace.config.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.config.spec.ts
@@ -96,6 +96,8 @@ describe("LocalWorkspace - Config", () => {
         assert.strictEqual(values2["config_flag_like:key"].secret, false);
         assert.strictEqual(values2["config_flag_like:secret-key"].value, "-value2");
         assert.strictEqual(values2["config_flag_like:secret-key"].secret, true);
+
+        await ws.removeStack(stackName);
     });
     it(`Config path`, async () => {
         const projectName = "node_test";
@@ -253,6 +255,8 @@ describe("LocalWorkspace - Config", () => {
         const list = await stack.getConfig("myList");
         assert.strictEqual(list.secret, false);
         assert.strictEqual(list.value, '["one","two","three"]');
+
+        await stack.workspace.removeStack(stackName);
     });
     // TODO[https://github.com/pulumi/pulumi/issues/7127]: Re-enabled the warning.
     // Temporarily skipping test until we've re-enabled the warning.

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -520,7 +520,7 @@ describe("LocalWorkspace", () => {
 
         await assert.rejects(stack.up(), /input rejected/);
 
-        await stack.destroy();
+        await stack.destroy({ remove: true });
     });
     it(`refreshes with refresh option`, async () => {
         // We create a simple program, and scan the output for an indication
@@ -547,7 +547,7 @@ describe("LocalWorkspace", () => {
         const upRes = await stack.up({ userAgent, refresh });
         assert.match(upRes.stdout, /refreshing/);
 
-        const destroyRes = await stack.destroy({ userAgent, refresh });
+        const destroyRes = await stack.destroy({ userAgent, refresh, remove: true });
         assert.match(destroyRes.stdout, /refreshing/);
     });
     it(`operations accept configFile option`, async () => {
@@ -1058,5 +1058,6 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(true, beforeDeleteCalled);
         state = await stack.exportStack();
         assert.strictEqual(state.deployment.resources, undefined);
+        await stack.workspace.removeStack(stackName);
     });
 });

--- a/sdk/nodejs/tests/automation/localWorkspace.stack.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.stack.spec.ts
@@ -387,7 +387,7 @@ describe("LocalWorkspace - Stack", () => {
                 LocalWorkspace.createStack({ stackName, projectName, program }, withTestBackend({}, "inline_node")),
             ),
         );
-        await stacks.map((stack) => stack.workspace.removeStack(stack.name));
+        await Promise.all(stacks.map((stack) => stack.workspace.removeStack(stack.name)));
     });
 
     it(`imports and exports stacks`, async () => {

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -115,6 +115,9 @@ async def test_parallel_updates():
         }
     )
 
+    for stack in stacks:
+        stack.workspace.remove_stack(stack.name)
+
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="TODO[pulumi/pulumi#8716] fails on Windows"

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -601,6 +601,8 @@ class TestLocalWorkspace(unittest.TestCase):
         self.assertFalse(arr.secret)
         self.assertEqual(arr.value, '["one","two","three"]')
 
+        stack.workspace.remove_stack(stack_name)
+
     def test_tag_methods(self):
         if os.getenv("PULUMI_ACCESS_TOKEN") is None:
             self.skipTest(


### PR DESCRIPTION
There are a couple of places in the automation API tests where we don’t cleanup the created stack at the end of the test.

Note that this does not clean up stacks when a test fails (well for go it does in some cases).

