### PR TITLE
Fix missing Providers section in debugging docs

### DIFF
--- a/docs/debugging/providers-and-languages.md
+++ b/docs/debugging/providers-and-languages.md
@@ -6,14 +6,32 @@ simple as attaching to the engine.
 Instead you'll have to launch them in a debugger and provide the information
 for connecting to them to the engine via environmental variables.
 
+## Providers
+
+To debug a provider, first start the provider executable (e.g. `pulumi-resource-aws`)
+in your debugger of choice and have it listen on a known port.
+
+Then set the `PULUMI_DEBUG_PROVIDERS` environment variable to tell the engine to
+connect to that port instead of launching the provider itself. The format is
+`<provider-name>:<port>`, and multiple providers can be separated by commas:
+
+```sh
+PULUMI_DEBUG_PROVIDERS="aws:12345" pulumi preview
+```
+
+For example, `PULUMI_DEBUG_PROVIDERS=aws:12345,gcp:678` will result in the
+engine attaching to port 12345 for the `aws` provider and port 678 for the `gcp`
+provider.
+
 ## Languages
 
-Languages work very similarly to [providers](#providers-and-languages).
+Languages work very similarly to [providers](#providers).
 
-Instead of PULUMI_DEBUG_PROVIDERS environmental variable, you use PULUMI_DEBUG_LANGUAGES like so:
+Instead of the `PULUMI_DEBUG_PROVIDERS` environment variable, you use
+`PULUMI_DEBUG_LANGUAGES` like so:
 
 ```sh
 PULUMI_DEBUG_LANGUAGES="go:12345" pulumi preview
 ```
 
-After opening your language executable (eg `pulumi-language-go`) in your debugger of choice.
+After opening your language executable (e.g. `pulumi-language-go`) in your debugger of choice.


### PR DESCRIPTION
## Summary

The `docs/debugging/providers-and-languages.md` file was titled "Providers and Languages" but was missing the entire **Providers** section. Only the Languages section existed, and it contained a broken cross-reference `[providers](#providers-and-languages)` that linked to the page title rather than a Providers heading.

This was the case since the file was originally created in #17821 — the Providers section was never written. A later docs cleanup in #22493 changed the broken anchor from `#Providers` to `#providers-and-languages` but didn't notice the section was missing.

This PR:
- Adds the missing **Providers** section documenting the `PULUMI_DEBUG_PROVIDERS` environment variable
- Fixes the cross-reference in the Languages section to correctly link to `#providers`
- Minor formatting improvements (inline code for env var names, consistent `e.g.` style)

The documentation is based on the source code:
- [`GetProviderAttachPort`](https://github.com/pulumi/pulumi/blob/8bd51fc536c18f74d31afecac30024d0ec4797a8/sdk/go/common/resource/plugin/provider_plugin.go#L140-L167) — parses `PULUMI_DEBUG_PROVIDERS` env var
- [`GetLanguageAttachPort`](https://github.com/pulumi/pulumi/blob/8bd51fc536c18f74d31afecac30024d0ec4797a8/sdk/go/common/resource/plugin/langruntime_plugin.go#L158-L187) — parses `PULUMI_DEBUG_LANGUAGES` env var (analogous implementation)

## Test plan
- [ ] Verify the Sphinx docs build correctly with the new section
- [ ] Verify the `#providers` anchor link from the Languages section resolves correctly