### PR TITLE
feat(asset): add stringAssetOutput function to all SDKs

### DIFF
--- a/changelog/pending/20260410--sdk--add-stringassetoutput-function.yaml
+++ b/changelog/pending/20260410--sdk--add-stringassetoutput-function.yaml
@@ -1,0 +1,10 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: Add NewStringAssetOutput function to create a StringAsset from an Output[string]
+- type: feat
+  scope: sdk/nodejs
+  description: Add stringAssetOutput function to create a StringAsset from an Input<string>
+- type: feat
+  scope: sdk/python
+  description: Add string_asset_output function to create a StringAsset from an Input[str]

--- a/sdk/go/pulumi/asset.go
+++ b/sdk/go/pulumi/asset.go
@@ -62,6 +62,14 @@ func NewStringAsset(text string) Asset {
 	return &asset{text: text}
 }
 
+// NewStringAssetOutput creates an asset backed by an Output[string].
+// This allows using a string value that is not known until deployment time.
+func NewStringAssetOutput(text StringInput) AssetOutput {
+	return text.ToStringOutput().ApplyT(func(s string) Asset {
+		return NewStringAsset(s)
+	}).(AssetOutput)
+}
+
 // NewRemoteAsset creates an asset backed by a remote file and specified by that file's URL.
 func NewRemoteAsset(uri string) Asset {
 	return &asset{uri: uri}

--- a/sdk/go/pulumi/asset_test.go
+++ b/sdk/go/pulumi/asset_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStringAssetOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("from plain string", func(t *testing.T) {
+		t.Parallel()
+
+		out := NewStringAssetOutput(String("hello"))
+		v, known, secret, _, err := await(out)
+		require.NoError(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		require.NotNil(t, v)
+		assert.Equal(t, "hello", v.(Asset).Text())
+	})
+
+	t.Run("from string output", func(t *testing.T) {
+		t.Parallel()
+
+		strOut := StringOutput{internal.NewOutputState(nil, reflect.TypeOf(""))}
+		go func() {
+			internal.ResolveOutput(strOut, "world", true, false, resourcesToInternal(nil))
+		}()
+		out := NewStringAssetOutput(strOut)
+		v, known, secret, _, err := await(out)
+		require.NoError(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		require.NotNil(t, v)
+		assert.Equal(t, "world", v.(Asset).Text())
+	})
+
+	t.Run("unknown string output produces unknown asset", func(t *testing.T) {
+		t.Parallel()
+
+		strOut := StringOutput{internal.NewOutputState(nil, reflect.TypeOf(""))}
+		go func() {
+			internal.ResolveOutput(strOut, "", false, false, resourcesToInternal(nil))
+		}()
+		out := NewStringAssetOutput(strOut)
+		_, known, _, _, err := await(out)
+		require.NoError(t, err)
+		assert.False(t, known)
+	})
+}

--- a/sdk/nodejs/asset/asset.ts
+++ b/sdk/nodejs/asset/asset.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Input, Output, output } from "../output";
 import * as utils from "../utils";
 
 /**
@@ -86,4 +87,12 @@ export class RemoteAsset extends Asset {
         super();
         this.uri = Promise.resolve(uri);
     }
+}
+
+/**
+ * Creates a {@link StringAsset} from an {@link Input} string, allowing the use
+ * of an {@link Output}&lt;string&gt; or plain string value.
+ */
+export function stringAssetOutput(text: Input<string>): Output<StringAsset> {
+    return output(text).apply((t) => new StringAsset(t));
 }

--- a/sdk/nodejs/biome.json
+++ b/sdk/nodejs/biome.json
@@ -16,7 +16,8 @@
             "tests/runtime/testdata/closure-tests",
             "tests/sxs_ts_test/tsconfig*.json",
             "tools/automation/output/",
-            "vendor/"
+            "vendor/",
+            "tests/automation/data/testproj_dotnet/"
         ]
     },
     "formatter": {

--- a/sdk/nodejs/tests/asset.spec.ts
+++ b/sdk/nodejs/tests/asset.spec.ts
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable */
+
+import * as assert from "assert";
+import { output, Output } from "../output";
+import { StringAsset, stringAssetOutput } from "../asset";
+
+describe("stringAssetOutput", () => {
+    it("creates a StringAsset from a plain string", async () => {
+        const result = stringAssetOutput("hello");
+        assert.ok(result instanceof Output);
+        const val = await result.promise();
+        assert.ok(val instanceof StringAsset);
+        assert.strictEqual(await val.text, "hello");
+    });
+
+    it("creates a StringAsset from a Promise<string>", async () => {
+        const result = stringAssetOutput(Promise.resolve("world"));
+        const val = await result.promise();
+        assert.ok(val instanceof StringAsset);
+        assert.strictEqual(await val.text, "world");
+    });
+
+    it("creates a StringAsset from an Output<string>", async () => {
+        const strOut = output("from-output");
+        const result = stringAssetOutput(strOut);
+        assert.ok(result instanceof Output);
+        const val = await result.promise();
+        assert.ok(val instanceof StringAsset);
+        assert.strictEqual(await val.text, "from-output");
+    });
+
+    it("preserves known/unknown state from the input output", async () => {
+        const knownOut = output("known");
+        const result = stringAssetOutput(knownOut);
+        const isKnown = await result.isKnown;
+        assert.strictEqual(isKnown, true);
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -95,6 +95,7 @@
         "tests/init.spec.ts",
         "tests/iterable.spec.ts",
         "tests/options.spec.ts",
+        "tests/asset.spec.ts",
         "tests/output.spec.ts",
         "tests/resource.spec.ts",
         "tests/stackReference.spec.ts",

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -32,6 +32,7 @@ from .asset import (
     RemoteArchive,
     RemoteAsset,
     StringAsset,
+    string_asset_output,
 )
 
 from .config import (
@@ -149,6 +150,7 @@ __all__ = [
     "RemoteArchive",
     "RemoteAsset",
     "StringAsset",
+    "string_asset_output",
     # config
     "Config",
     "ConfigMissingError",

--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -123,3 +123,13 @@ class RemoteArchive(Archive):
         if not isinstance(uri, str):
             raise TypeError("RemoteArchive URI must be a string")
         self.uri = uri
+
+
+def string_asset_output(text: "Input[str]") -> "Output[StringAsset]":
+    """
+    Creates a StringAsset from an Output[str] or any Input[str] value.
+    This allows using a string value that is not known until deployment time.
+    """
+    from .output import Output  # local import to avoid circular dependency
+
+    return Output.from_input(text).apply(StringAsset)

--- a/sdk/python/lib/test/test_asset.py
+++ b/sdk/python/lib/test/test_asset.py
@@ -1,0 +1,64 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pulumi
+from pulumi import StringAsset, string_asset_output
+from pulumi.output import Output
+from pulumi.runtime import rpc, settings
+
+
+def pulumi_test(coro):
+    wrapped = pulumi.runtime.test(coro)
+
+    def wrapper(*args, **kwargs):
+        settings.configure(settings.Settings("project", "stack"))
+        rpc._RESOURCE_PACKAGES.clear()
+        rpc._RESOURCE_MODULES.clear()
+        wrapped(*args, **kwargs)
+
+    return wrapper
+
+
+class StringAssetOutputTests(unittest.IsolatedAsyncioTestCase):
+    @pulumi_test
+    async def test_from_plain_string(self):
+        out = string_asset_output("hello")
+        val = await out.future()
+        self.assertIsInstance(val, StringAsset)
+        self.assertEqual(val.text, "hello")
+
+    @pulumi_test
+    async def test_from_output_string(self):
+        str_out = Output.from_input("world")
+        out = string_asset_output(str_out)
+        val = await out.future()
+        self.assertIsInstance(val, StringAsset)
+        self.assertEqual(val.text, "world")
+
+    @pulumi_test
+    async def test_result_is_output(self):
+        out = string_asset_output("test")
+        self.assertIsInstance(out, Output)
+
+    @pulumi_test
+    async def test_secret_output_preserves_secret(self):
+        str_out = Output.secret("my-secret")
+        out = string_asset_output(str_out)
+        is_secret = await out.is_secret()
+        self.assertTrue(is_secret)
+        val = await out.future()
+        self.assertIsInstance(val, StringAsset)
+        self.assertEqual(val.text, "my-secret")


### PR DESCRIPTION
## Summary

- Add `NewStringAssetOutput(text StringInput) AssetOutput` to the Go SDK
- Add `string_asset_output(text: Input[str]) -> Output[StringAsset]` to the Python SDK
- Add `stringAssetOutput(text: Input<string>): Output<StringAsset>` to the NodeJS SDK

These functions work identically to the existing `StringAsset`/`NewStringAsset` constructors but accept `Output<string>` (and any `Input<string>`) in addition to plain strings, allowing users to pass deployment-time values directly when creating string assets.

## Test plan

- [ ] Go: `cd sdk/go && go test ./pulumi/... -run TestNewStringAssetOutput`
- [ ] Python: `cd sdk/python && python -m pytest lib/test/test_asset.py`
- [ ] NodeJS: `cd sdk/nodejs && npm test -- --grep stringAssetOutput`