### PR TITLE
Extend `l2-resource-option-custom-timeouts` with a non-literal

### DIFF
--- a/pkg/testing/pulumi-test-language/tests/assert.go
+++ b/pkg/testing/pulumi-test-language/tests/assert.go
@@ -31,11 +31,9 @@ import (
 func AssertStackResource(t TestingT, err error, changes display.ResourceChanges) (ok bool) {
 	t.Helper()
 
-	ok = true
-	ok = ok && assert.Nil(t, err, "expected no error, got %v", err)
-	ok = ok && assert.NotEmpty(t, changes, "expected at least 1 StepOp")
-	ok = ok && assert.NotZero(t, changes[deploy.OpCreate], "expected at least 1 Create")
-	return ok
+	return assert.Nil(t, err, "expected no error, got %v", err) &&
+		assert.NotEmpty(t, changes, "expected at least 1 StepOp") &&
+		assert.NotZero(t, changes[deploy.OpCreate], "expected at least 1 Create")
 }
 
 func RequireStackResource(t TestingT, err error, changes display.ResourceChanges) {

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_option_custom_timeouts.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_option_custom_timeouts.go
@@ -17,49 +17,65 @@ package tests
 import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func init() {
+	createRun := func(timeout string, seconds float64) TestRun {
+		return TestRun{
+			Config: config.Map{
+				config.MustMakeKey("l2-resource-option-custom-timeouts", "createTimeout"): config.NewValue(timeout),
+			},
+			Assert: func(l *L, res AssertArgs) {
+				require.NoError(l, res.Err)
+				require.Len(l, res.Snap.Resources, 8)
+
+				noTimeouts := RequireSingleNamedResource(l, res.Snap.Resources, "noTimeouts")
+				createOnly := RequireSingleNamedResource(l, res.Snap.Resources, "createOnly")
+				updateOnly := RequireSingleNamedResource(l, res.Snap.Resources, "updateOnly")
+				deleteOnly := RequireSingleNamedResource(l, res.Snap.Resources, "deleteOnly")
+				allTimeouts := RequireSingleNamedResource(l, res.Snap.Resources, "allTimeouts")
+
+				assert.Equal(l, resource.CustomTimeouts{}, noTimeouts.CustomTimeouts)
+
+				require.Equal(l, resource.CustomTimeouts{
+					Create: 300,
+				}, createOnly.CustomTimeouts)
+
+				assert.Equal(l, resource.CustomTimeouts{
+					Update: 600,
+				}, updateOnly.CustomTimeouts)
+
+				assert.Equal(l, resource.CustomTimeouts{
+					Delete: 180,
+				}, deleteOnly.CustomTimeouts)
+
+				assert.Equal(l, resource.CustomTimeouts{
+					Create: 120,
+					Update: 240,
+					Delete: 60,
+				}, allTimeouts.CustomTimeouts)
+
+				configTimeout := RequireSingleNamedResource(l, res.Snap.Resources, "configTimeout")
+				assert.Equal(l, resource.CustomTimeouts{
+					Create: seconds,
+				}, configTimeout.CustomTimeouts)
+			},
+		}
+	}
+
 	LanguageTests["l2-resource-option-custom-timeouts"] = LanguageTest{
+		RunsShareSource: true,
 		Providers: []func() plugin.Provider{
 			func() plugin.Provider { return &providers.SimpleProvider{} },
 		},
 		Runs: []TestRun{
-			{
-				Assert: func(l *L, res AssertArgs) {
-					RequireStackResource(l, res.Err, res.Changes)
-					require.Len(l, res.Snap.Resources, 7)
-
-					noTimeouts := RequireSingleNamedResource(l, res.Snap.Resources, "noTimeouts")
-					createOnly := RequireSingleNamedResource(l, res.Snap.Resources, "createOnly")
-					updateOnly := RequireSingleNamedResource(l, res.Snap.Resources, "updateOnly")
-					deleteOnly := RequireSingleNamedResource(l, res.Snap.Resources, "deleteOnly")
-					allTimeouts := RequireSingleNamedResource(l, res.Snap.Resources, "allTimeouts")
-
-					assert.Equal(l, resource.CustomTimeouts{}, noTimeouts.CustomTimeouts)
-
-					require.Equal(l, resource.CustomTimeouts{
-						Create: 300,
-					}, createOnly.CustomTimeouts)
-
-					assert.Equal(l, resource.CustomTimeouts{
-						Update: 600,
-					}, updateOnly.CustomTimeouts)
-
-					assert.Equal(l, resource.CustomTimeouts{
-						Delete: 180,
-					}, deleteOnly.CustomTimeouts)
-
-					assert.Equal(l, resource.CustomTimeouts{
-						Create: 120,
-						Update: 240,
-						Delete: 60,
-					}, allTimeouts.CustomTimeouts)
-				},
-			},
+			createRun("7m", 420),
+			createRun("1h", 60*60),
+			createRun(".2m", 12),
 		},
 	}
 }

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-option-custom-timeouts/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-option-custom-timeouts/main.pp
@@ -1,3 +1,5 @@
+config createTimeout "string" {}
+
 resource "noTimeouts" "simple:index:Resource" {
     value = true
 }
@@ -36,6 +38,15 @@ resource "allTimeouts" "simple:index:Resource" {
             create = "2m"
             update = "4m"
             delete = "1m"
+        }
+    }
+}
+
+resource "configTimeout" "simple:index:Resource" {
+    value = true
+    options {
+        customTimeouts = {
+            create = createTimeout
         }
     }
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-option-custom-timeouts/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-option-custom-timeouts/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"example.com/pulumi-simple/sdk/go/v2/simple"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		createTimeout := cfg.Require("createTimeout")
 		_, err := simple.NewResource(ctx, "noTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		})
@@ -34,6 +37,12 @@ func main() {
 		_, err = simple.NewResource(ctx, "allTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "2m", Update: "4m", Delete: "1m"}))
+		if err != nil {
+			return err
+		}
+		_, err = simple.NewResource(ctx, "configTimeout", &simple.ResourceArgs{
+			Value: pulumi.Bool(true),
+		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: createTimeout}))
 		if err != nil {
 			return err
 		}

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-option-custom-timeouts/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-option-custom-timeouts/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"example.com/pulumi-simple/sdk/go/v2/simple"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		createTimeout := cfg.Require("createTimeout")
 		_, err := simple.NewResource(ctx, "noTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		})
@@ -34,6 +37,12 @@ func main() {
 		_, err = simple.NewResource(ctx, "allTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "2m", Update: "4m", Delete: "1m"}))
+		if err != nil {
+			return err
+		}
+		_, err = simple.NewResource(ctx, "configTimeout", &simple.ResourceArgs{
+			Value: pulumi.Bool(true),
+		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: createTimeout}))
 		if err != nil {
 			return err
 		}

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-option-custom-timeouts/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-option-custom-timeouts/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"example.com/pulumi-simple/sdk/go/v2/simple"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		cfg := config.New(ctx, "")
+		createTimeout := cfg.Require("createTimeout")
 		_, err := simple.NewResource(ctx, "noTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		})
@@ -34,6 +37,12 @@ func main() {
 		_, err = simple.NewResource(ctx, "allTimeouts", &simple.ResourceArgs{
 			Value: pulumi.Bool(true),
 		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: "2m", Update: "4m", Delete: "1m"}))
+		if err != nil {
+			return err
+		}
+		_, err = simple.NewResource(ctx, "configTimeout", &simple.ResourceArgs{
+			Value: pulumi.Bool(true),
+		}, pulumi.Timeouts(&pulumi.CustomTimeouts{Create: createTimeout}))
 		if err != nil {
 			return err
 		}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-option-custom-timeouts/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-option-custom-timeouts/index.ts
@@ -1,6 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple from "@pulumi/simple";
 
+const config = new pulumi.Config();
+const createTimeout = config.require("createTimeout");
 const noTimeouts = new simple.Resource("noTimeouts", {value: true});
 const createOnly = new simple.Resource("createOnly", {value: true}, {
     customTimeouts: {
@@ -22,5 +24,10 @@ const allTimeouts = new simple.Resource("allTimeouts", {value: true}, {
         create: "2m",
         update: "4m",
         "delete": "1m",
+    },
+});
+const configTimeout = new simple.Resource("configTimeout", {value: true}, {
+    customTimeouts: {
+        create: createTimeout,
     },
 });

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-option-custom-timeouts/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-option-custom-timeouts/index.ts
@@ -1,6 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple from "@pulumi/simple";
 
+const config = new pulumi.Config();
+const createTimeout = config.require("createTimeout");
 const noTimeouts = new simple.Resource("noTimeouts", {value: true});
 const createOnly = new simple.Resource("createOnly", {value: true}, {
     customTimeouts: {
@@ -22,5 +24,10 @@ const allTimeouts = new simple.Resource("allTimeouts", {value: true}, {
         create: "2m",
         update: "4m",
         "delete": "1m",
+    },
+});
+const configTimeout = new simple.Resource("configTimeout", {value: true}, {
+    customTimeouts: {
+        create: createTimeout,
     },
 });

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-option-custom-timeouts/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-option-custom-timeouts/index.ts
@@ -1,6 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple from "@pulumi/simple";
 
+const config = new pulumi.Config();
+const createTimeout = config.require("createTimeout");
 const noTimeouts = new simple.Resource("noTimeouts", {value: true});
 const createOnly = new simple.Resource("createOnly", {value: true}, {
     customTimeouts: {
@@ -22,5 +24,10 @@ const allTimeouts = new simple.Resource("allTimeouts", {value: true}, {
         create: "2m",
         update: "4m",
         "delete": "1m",
+    },
+});
+const configTimeout = new simple.Resource("configTimeout", {value: true}, {
+    customTimeouts: {
+        create: createTimeout,
     },
 });

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-custom-timeouts/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-option-custom-timeouts/main.pp
@@ -1,3 +1,5 @@
+config createTimeout "string" {}
+
 resource "noTimeouts" "simple:index:Resource" {
     value = true
 }
@@ -36,6 +38,15 @@ resource "allTimeouts" "simple:index:Resource" {
             create = "2m"
             update = "4m"
             delete = "1m"
+        }
+    }
+}
+
+resource "configTimeout" "simple:index:Resource" {
+    value = true
+    options {
+        customTimeouts = {
+            create = createTimeout
         }
     }
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-custom-timeouts/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-option-custom-timeouts/main.pp
@@ -1,3 +1,5 @@
+config createTimeout "string" {}
+
 resource "noTimeouts" "simple:index:Resource" {
     value = true
 }
@@ -36,6 +38,15 @@ resource "allTimeouts" "simple:index:Resource" {
             create = "2m"
             update = "4m"
             delete = "1m"
+        }
+    }
+}
+
+resource "configTimeout" "simple:index:Resource" {
+    value = true
+    options {
+        customTimeouts = {
+            create = createTimeout
         }
     }
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-custom-timeouts/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-option-custom-timeouts/main.pp
@@ -1,3 +1,5 @@
+config createTimeout "string" {}
+
 resource "noTimeouts" "simple:index:Resource" {
     value = true
 }
@@ -36,6 +38,15 @@ resource "allTimeouts" "simple:index:Resource" {
             create = "2m"
             update = "4m"
             delete = "1m"
+        }
+    }
+}
+
+resource "configTimeout" "simple:index:Resource" {
+    value = true
+    options {
+        customTimeouts = {
+            create = createTimeout
         }
     }
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-option-custom-timeouts/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-option-custom-timeouts/__main__.py
@@ -1,6 +1,8 @@
 import pulumi
 import pulumi_simple as simple
 
+config = pulumi.Config()
+create_timeout = config.require("createTimeout")
 no_timeouts = simple.Resource("noTimeouts", value=True)
 create_only = simple.Resource("createOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="5m")))
@@ -10,3 +12,5 @@ delete_only = simple.Resource("deleteOnly", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(delete="3m")))
 all_timeouts = simple.Resource("allTimeouts", value=True,
 opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create="2m", update="4m", delete="1m")))
+config_timeout = simple.Resource("configTimeout", value=True,
+opts = pulumi.ResourceOptions(custom_timeouts=pulumi.CustomTimeouts(create=create_timeout)))


### PR DESCRIPTION
This should prevent issues like
https://github.com/pulumi/pulumi-dotnet/pull/953#discussion_r3063546583https://github.com/pulumi/pulumi-dotnet/pull/953#discussion_r3063546583 from sneaking in.