### PR TITLE
Add a conformance test for nested components

### DIFF
--- a/pkg/testing/pulumi-test-language/tests/l3_component_nested.go
+++ b/pkg/testing/pulumi-test-language/tests/l3_component_nested.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l3-component-nested"] = LanguageTest{
+		Providers: []func() plugin.Provider{
+			func() plugin.Provider { return &providers.SimpleProvider{} },
+		},
+		Runs: []TestRun{
+			{
+				Assert: func(l *L, res AssertArgs) {
+					RequireStackResource(l, res.Err, res.Changes)
+
+					snap := res.Snap
+					require.Len(l, snap.Resources, 5)
+
+					outer := RequireSingleResource(l, snap.Resources, "components:index:OuterComponent")
+					assert.Equal(l, "outerComponent", outer.URN.Name())
+					assert.Equal(l,
+						resource.NewPropertyMapFromMap(map[string]any{"input": true}),
+						outer.Inputs)
+					assert.Equal(l,
+						resource.NewPropertyMapFromMap(map[string]any{"output": true}),
+						outer.Outputs)
+
+					inner := RequireSingleResource(l, snap.Resources, "components:index:InnerComponent")
+					assert.Equal(l, "outerComponent-innerComponent", inner.URN.Name())
+					assert.Equal(l, outer.URN, inner.Parent)
+					assert.Equal(l,
+						resource.NewPropertyMapFromMap(map[string]any{"input": false}),
+						inner.Inputs)
+					assert.Equal(l,
+						resource.NewPropertyMapFromMap(map[string]any{"output": true}),
+						inner.Outputs)
+
+					RequireSingleResource(l, snap.Resources, "pulumi:providers:simple")
+
+					simple := RequireSingleResource(l, snap.Resources, "simple:index:Resource")
+					assert.Equal(l, "outerComponent-innerComponent-res", simple.URN.Name())
+					assert.Equal(l, inner.URN, simple.Parent)
+					assert.Equal(l,
+						resource.NewPropertyMapFromMap(map[string]any{"value": true}),
+						simple.Inputs)
+					assert.Equal(l, simple.Inputs, simple.Outputs)
+				},
+			},
+		},
+	}
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/main.pp
@@ -1,0 +1,7 @@
+component outerComponent "./outerComponent" {
+    input = true
+}
+
+output result {
+    value = outerComponent.output
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/outerComponent/innerComponent/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/outerComponent/innerComponent/main.pp
@@ -1,0 +1,11 @@
+config input bool {
+    description = "An input passed to the inner component"
+}
+
+resource "res" "simple:index:Resource" {
+    value = !input
+}
+
+output output bool {
+    value = res.value
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/outerComponent/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l3-component-nested/outerComponent/main.pp
@@ -1,0 +1,11 @@
+config input bool {
+    description = "An input passed to the outer component"
+}
+
+component innerComponent "./innerComponent" {
+    input = !input
+}
+
+output output bool {
+    value = innerComponent.output
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -118,6 +118,7 @@ var expectedFailures = map[string]string{
 	"l3-range-resource-output-traversal":  "pulumi#21678: cannot range over an ArrayOutput",
 	"l3-for":                              "syntax errors",
 	"l3-for-resource":                     "syntax errors",
+	"l3-component-nested":                 "./main.go:10:11: cannot use true (constant of type bool) as pulumi.BoolInput",
 	"l3-deferred-outputs":                 "does not compile && for expressions are not supported",
 
 	"l3-rewrite-conversions": "does not compile; missing necessary casts for pulumi inputs",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-nested
+runtime: bun

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import { OuterComponent } from "./outerComponent";
+
+const outerComponent = new OuterComponent("outerComponent", {input: true});
+export const result = outerComponent.output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/innerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/innerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface InnerComponentArgs {
+    /**
+     * An input passed to the inner component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class InnerComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: InnerComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InnerComponent", name, args, opts);
+        const res = new simple.Resource(`${name}-res`, {value: !args.input}, {
+            parent: this,
+        });
+
+        this.output = res.value;
+        this.registerOutputs({
+            output: res.value,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/outerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/outerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import { InnerComponent } from "./innerComponent";
+
+interface OuterComponentArgs {
+    /**
+     * An input passed to the outer component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class OuterComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: OuterComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:OuterComponent", name, args, opts);
+        const innerComponent = new InnerComponent(`${name}-innerComponent`, {input: !args.input}, {
+            parent: this,
+        });
+
+        this.output = innerComponent.output;
+        this.registerOutputs({
+            output: innerComponent.output,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "l3-component-nested",
+	"main": "index.ts",
+	"type": "module",
+	"devDependencies": {
+		"@types/bun": "latest"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	},
+	"dependencies": {
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l3-component-nested/tsconfig.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"jsx": "react-jsx",
+		"allowJs": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
+	},
+	"files": [
+		"index.ts",
+		"innerComponent.ts",
+		"outerComponent.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: l3-component-nested
+runtime:
+  name: nodejs
+  options:
+    typescript: false

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import { OuterComponent } from "./outerComponent";
+
+const outerComponent = new OuterComponent("outerComponent", {input: true});
+export const result = outerComponent.output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/innerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/innerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface InnerComponentArgs {
+    /**
+     * An input passed to the inner component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class InnerComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: InnerComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InnerComponent", name, args, opts);
+        const res = new simple.Resource(`${name}-res`, {value: !args.input}, {
+            parent: this,
+        });
+
+        this.output = res.value;
+        this.registerOutputs({
+            output: res.value,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/outerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/outerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import { InnerComponent } from "./innerComponent";
+
+interface OuterComponentArgs {
+    /**
+     * An input passed to the outer component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class OuterComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: OuterComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:OuterComponent", name, args, opts);
+        const innerComponent = new InnerComponent(`${name}-innerComponent`, {input: !args.input}, {
+            parent: this,
+        });
+
+        this.output = innerComponent.output;
+        this.registerOutputs({
+            output: innerComponent.output,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-component-nested",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l3-component-nested/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+		"innerComponent.ts",
+		"outerComponent.ts",
+	]
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/.gitignore
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/Pulumi.yaml
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-nested
+runtime: nodejs

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+import { OuterComponent } from "./outerComponent";
+
+const outerComponent = new OuterComponent("outerComponent", {input: true});
+export const result = outerComponent.output;

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/innerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/innerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as simple from "@pulumi/simple";
+
+interface InnerComponentArgs {
+    /**
+     * An input passed to the inner component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class InnerComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: InnerComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:InnerComponent", name, args, opts);
+        const res = new simple.Resource(`${name}-res`, {value: !args.input}, {
+            parent: this,
+        });
+
+        this.output = res.value;
+        this.registerOutputs({
+            output: res.value,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/outerComponent.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/outerComponent.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import { InnerComponent } from "./innerComponent";
+
+interface OuterComponentArgs {
+    /**
+     * An input passed to the outer component
+     */
+    input: pulumi.Input<boolean>,
+}
+
+export class OuterComponent extends pulumi.ComponentResource {
+    public output: pulumi.Output<boolean>;
+    constructor(name: string, args: OuterComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("components:index:OuterComponent", name, args, opts);
+        const innerComponent = new InnerComponent(`${name}-innerComponent`, {input: !args.input}, {
+            parent: this,
+        });
+
+        this.output = innerComponent.output;
+        this.registerOutputs({
+            output: innerComponent.output,
+        });
+    }
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/package.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "l3-component-nested",
+	"devDependencies": {
+		"@types/node": "^20"
+	},
+	"dependencies": {
+		"typescript": "^4.7.0",
+		"@pulumi/pulumi": "ROOT/artifacts/pulumi-pulumi-CORE.VERSION.tgz",
+		"@pulumi/simple": "ROOT/artifacts/pulumi-simple-2.0.0.tgz"
+	}
+}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/tsconfig.json
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l3-component-nested/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		// Output
+		"outDir": "bin",
+		"sourceMap": true,
+		// Environment
+		"target": "ES2022",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"moduleDetection": "force",
+		"types": ["node"],
+		// Type Checking
+		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitReturns": true,
+		"skipLibCheck": true
+	},
+	"files": [
+		"index.ts",
+		"innerComponent.ts",
+		"outerComponent.ts",
+	]
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -95,6 +95,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l3-deferred-outputs": "incorrectly detects cycle",
+	"l3-component-nested": "nested component outputs are not propagated correctly",
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -108,6 +108,7 @@ var expectedFailures = map[string]string{
 	"l3-range-ref":                       `Item "None" of "Target | None" has no attribute "name"  [union-attr]`,
 	"l2-resource-primitive-conversions":  "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
+	"l3-component-nested":                "syntax error",
 }
 
 type languageTestConfig struct {


### PR DESCRIPTION
This PR adds a conformance test for nested components. It passes in Nodejs. It fails in Python with syntax errors, Go with type errors and PCL with the wrong value.