### PR TITLE
Fix flaky TestFuzz

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -757,11 +757,15 @@ func ExcludeTargetedUpdateRefreshWithChildProvider(
 	return false
 }
 
-// ExcludeComponentPropertyDepsRefreshV2 excludes snapshots where a component
-// resource (non-custom, non-provider) has property dependencies that reference
-// another component resource during a refreshV2 operation. During refreshV2,
+// ExcludeComponentPropertyDepsRefreshV2 excludes scenarios where the program
+// registers a new component resource (one not present in the snapshot) that has
+// property dependencies on a component that IS in the snapshot. During refreshV2,
 // component resources do not receive refresh steps and can end up reordered
 // relative to their property dependencies, violating snapshot integrity.
+//
+// This is narrower than excluding all component-to-component property deps: if
+// both components already exist in the snapshot, their relative order is preserved
+// since neither gets a refresh step.
 func ExcludeComponentPropertyDepsRefreshV2(
 	snap *SnapshotSpec,
 	prog *ProgramSpec,
@@ -772,40 +776,27 @@ func ExcludeComponentPropertyDepsRefreshV2(
 		return false
 	}
 
-	// Collect URNs of all component resources (non-custom, non-provider) in both
-	// the snapshot and the program.
-	components := make(map[resource.URN]bool)
+	// Collect component URNs present in the snapshot.
+	snapComponents := make(map[resource.URN]bool)
 	for _, res := range snap.Resources {
 		if !res.Custom && !providers.IsProviderType(res.Type) {
-			components[res.URN()] = true
-		}
-	}
-	for _, res := range prog.ResourceRegistrations {
-		if !res.Custom && !providers.IsProviderType(res.Type) {
-			components[res.URN()] = true
+			snapComponents[res.URN()] = true
 		}
 	}
 
-	// Check if any component has a property dependency on another component.
-	for _, res := range snap.Resources {
-		if !components[res.URN()] {
-			continue
-		}
-		for _, deps := range res.PropertyDependencies {
-			for _, dep := range deps {
-				if components[dep] {
-					return true
-				}
-			}
-		}
-	}
+	// Check if any program-registered component that is NOT in the snapshot has a
+	// property dependency on a component that IS in the snapshot.
 	for _, res := range prog.ResourceRegistrations {
-		if !components[res.URN()] {
+		if res.Custom || providers.IsProviderType(res.Type) {
+			continue
+		}
+		if snapComponents[res.URN()] {
+			// Existing component — its position is preserved.
 			continue
 		}
 		for _, deps := range res.PropertyDependencies {
 			for _, dep := range deps {
-				if components[dep] {
+				if snapComponents[dep] {
 					return true
 				}
 			}

--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -66,6 +66,8 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludeDeletedWithRefreshV2,
 		// TODO[pulumi/pulumi#22511]
 		ExcludeTargetedUpdateRefreshWithChildProvider,
+		// TODO[pulumi/pulumi#22578]
+		ExcludeComponentPropertyDepsRefreshV2,
 	}
 }
 
@@ -748,6 +750,64 @@ func ExcludeTargetedUpdateRefreshWithChildProvider(
 			resPkg := res.Type.Module().Package()
 			if childProviderPkgs[resPkg] {
 				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// ExcludeComponentPropertyDepsRefreshV2 excludes snapshots where a component
+// resource (non-custom, non-provider) has property dependencies that reference
+// another component resource during a refreshV2 operation. During refreshV2,
+// component resources do not receive refresh steps and can end up reordered
+// relative to their property dependencies, violating snapshot integrity.
+func ExcludeComponentPropertyDepsRefreshV2(
+	snap *SnapshotSpec,
+	prog *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation != PlanOperationRefreshV2 {
+		return false
+	}
+
+	// Collect URNs of all component resources (non-custom, non-provider) in both
+	// the snapshot and the program.
+	components := make(map[resource.URN]bool)
+	for _, res := range snap.Resources {
+		if !res.Custom && !providers.IsProviderType(res.Type) {
+			components[res.URN()] = true
+		}
+	}
+	for _, res := range prog.ResourceRegistrations {
+		if !res.Custom && !providers.IsProviderType(res.Type) {
+			components[res.URN()] = true
+		}
+	}
+
+	// Check if any component has a property dependency on another component.
+	for _, res := range snap.Resources {
+		if !components[res.URN()] {
+			continue
+		}
+		for _, deps := range res.PropertyDependencies {
+			for _, dep := range deps {
+				if components[dep] {
+					return true
+				}
+			}
+		}
+	}
+	for _, res := range prog.ResourceRegistrations {
+		if !components[res.URN()] {
+			continue
+		}
+		for _, deps := range res.PropertyDependencies {
+			for _, dep := range deps {
+				if components[dep] {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -3718,9 +3718,10 @@ func TestRefreshV2DeletedWithOrdering(t *testing.T) {
 }
 
 // TestComponentPropertyDependencyOrderingRefreshV2 reproduces a snapshot integrity error
-// where a component resource's property dependency ends up after it in the snapshot during
-// refreshV2. Component resources do not receive refresh steps, so they can be reordered
-// relative to their property dependencies.
+// where a new component resource's property dependency on an existing component ends up
+// after it in the snapshot during refreshV2. Component resources do not receive refresh
+// steps, so when a new component is created that depends on an existing component, the
+// existing component can appear after it in the resulting snapshot.
 func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
 	t.Parallel()
 
@@ -3733,17 +3734,9 @@ func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
 	}
 	project := p.GetProject()
 
-	// Initial snapshot: provA, provB, resA (component using provB).
+	// Snapshot: provB and resA (component using provB).
 	setupSnap := func() *deploy.Snapshot {
 		s := &deploy.Snapshot{}
-
-		provA := &resource.State{
-			Type:   "pulumi:providers:pkgA",
-			URN:    "urn:pulumi:test-stack::test-project::pulumi:providers:pkgA::provA",
-			Custom: true,
-			ID:     "id-provA",
-		}
-		s.Resources = append(s.Resources, provA)
 
 		provB := &resource.State{
 			Type:   "pulumi:providers:pkgB",
@@ -3772,26 +3765,22 @@ func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{}, nil
 		}),
-		deploytest.NewProviderLoader("pkgB", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return &deploytest.Provider{
-				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
-					return plugin.ReadResponse{
-						ReadResult: plugin.ReadResult{Outputs: resource.PropertyMap{}},
-						Status:     resource.StatusOK,
-					}, nil
-				},
-			}, nil
-		}),
 	}
 
-	// Program registers: provA, provB, resA (component), resB (component with
-	// property dep on resA). The property dependency between two components triggers
-	// the reordering bug during refreshV2.
+	// Program: provA (new), resX (new custom resource), provB (existing), resA
+	// (existing component with property dep on resX), resB (new component with
+	// property dep on resA). During refreshV2, resB gets created before resA's
+	// position is finalized, violating the ordering constraint.
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		provA, err := monitor.RegisterResource("pulumi:providers:pkgA", "provA", true, deploytest.ResourceOptions{})
 		require.NoError(t, err)
 
 		provRefA, err := providers.NewReference(provA.URN, provA.ID)
+		require.NoError(t, err)
+
+		resX, err := monitor.RegisterResource("pkgA:mod:typ", "resX", true, deploytest.ResourceOptions{
+			Provider: provRefA.String(),
+		})
 		require.NoError(t, err)
 
 		provB, err := monitor.RegisterResource("pulumi:providers:pkgB", "provB", true, deploytest.ResourceOptions{})
@@ -3802,10 +3791,13 @@ func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
 
 		resA, err := monitor.RegisterResource("pkgB:mod:typ", "resA", false, deploytest.ResourceOptions{
 			Provider: provRefB.String(),
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{
+				"prop": {resX.URN},
+			},
 		})
 		require.NoError(t, err)
 
-		_, err = monitor.RegisterResource("pkgA:mod:typ", "resB", false, deploytest.ResourceOptions{
+		_, err = monitor.RegisterResource("pkgA:mod:typ2", "resB", false, deploytest.ResourceOptions{
 			Provider: provRefA.String(),
 			PropertyDeps: map[resource.PropertyKey][]resource.URN{
 				"prop": {resA.URN},
@@ -3818,12 +3810,9 @@ func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
 
 	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
 	opts := lt.TestUpdateOptions{
-		T:     t,
-		HostF: hostF,
-		UpdateOptions: engine.UpdateOptions{
-			Refresh:        true,
-			RefreshProgram: true,
-		},
+		T:                t,
+		HostF:            hostF,
+		SkipDisplayTests: true,
 	}
 
 	_, err := lt.TestOp(engine.RefreshV2).

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -3716,3 +3716,117 @@ func TestRefreshV2DeletedWithOrdering(t *testing.T) {
 		RunStep(project, p.GetTarget(t, setupSnap), reproOpts, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 }
+
+// TestComponentPropertyDependencyOrderingRefreshV2 reproduces a snapshot integrity error
+// where a component resource's property dependency ends up after it in the snapshot during
+// refreshV2. Component resources do not receive refresh steps, so they can be reordered
+// relative to their property dependencies.
+func TestComponentPropertyDependencyOrderingRefreshV2(t *testing.T) {
+	t.Parallel()
+
+	// TODO[pulumi/pulumi#22578]: Fix the underlying engine issue and re-enable this test.
+	t.Skip("Skipping test due to snapshot integrity bug in RefreshV2 with component property dependencies")
+
+	p := &lt.TestPlan{
+		Project: "test-project",
+		Stack:   "test-stack",
+	}
+	project := p.GetProject()
+
+	// Initial snapshot: provA, provB, resA (component using provB).
+	setupSnap := func() *deploy.Snapshot {
+		s := &deploy.Snapshot{}
+
+		provA := &resource.State{
+			Type:   "pulumi:providers:pkgA",
+			URN:    "urn:pulumi:test-stack::test-project::pulumi:providers:pkgA::provA",
+			Custom: true,
+			ID:     "id-provA",
+		}
+		s.Resources = append(s.Resources, provA)
+
+		provB := &resource.State{
+			Type:   "pulumi:providers:pkgB",
+			URN:    "urn:pulumi:test-stack::test-project::pulumi:providers:pkgB::provB",
+			Custom: true,
+			ID:     "id-provB",
+		}
+		s.Resources = append(s.Resources, provB)
+
+		provRefB, err := providers.NewReference(provB.URN, provB.ID)
+		require.NoError(t, err)
+
+		resA := &resource.State{
+			Type:     "pkgB:mod:typ",
+			URN:      "urn:pulumi:test-stack::test-project::pkgB:mod:typ::resA",
+			Custom:   false,
+			Provider: provRefB.String(),
+		}
+		s.Resources = append(s.Resources, resA)
+
+		return s
+	}()
+	require.NoError(t, setupSnap.VerifyIntegrity(), "initial snapshot is not valid")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgB", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ReadF: func(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{Outputs: resource.PropertyMap{}},
+						Status:     resource.StatusOK,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	// Program registers: provA, provB, resA (component), resB (component with
+	// property dep on resA). The property dependency between two components triggers
+	// the reordering bug during refreshV2.
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		provA, err := monitor.RegisterResource("pulumi:providers:pkgA", "provA", true, deploytest.ResourceOptions{})
+		require.NoError(t, err)
+
+		provRefA, err := providers.NewReference(provA.URN, provA.ID)
+		require.NoError(t, err)
+
+		provB, err := monitor.RegisterResource("pulumi:providers:pkgB", "provB", true, deploytest.ResourceOptions{})
+		require.NoError(t, err)
+
+		provRefB, err := providers.NewReference(provB.URN, provB.ID)
+		require.NoError(t, err)
+
+		resA, err := monitor.RegisterResource("pkgB:mod:typ", "resA", false, deploytest.ResourceOptions{
+			Provider: provRefB.String(),
+		})
+		require.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:mod:typ", "resB", false, deploytest.ResourceOptions{
+			Provider: provRefA.String(),
+			PropertyDeps: map[resource.PropertyKey][]resource.URN{
+				"prop": {resA.URN},
+			},
+		})
+		require.NoError(t, err)
+
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	opts := lt.TestUpdateOptions{
+		T:     t,
+		HostF: hostF,
+		UpdateOptions: engine.UpdateOptions{
+			Refresh:        true,
+			RefreshProgram: true,
+		},
+	}
+
+	_, err := lt.TestOp(engine.RefreshV2).
+		RunStep(project, p.GetTarget(t, setupSnap), opts, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #22554

During refreshV2, component resources do not receive refresh steps, so they can end up reordered relative to their property dependencies in the snapshot. This is the same class of bug as #22481 but for property dependencies instead of DeletedWith.

The engine bug is tracked in #22578.

Changes:
- Added ExcludeComponentPropertyDepsRefreshV2 exclusion rule
- Added a skipped deterministic lifecycle test TestComponentPropertyDependencyOrderingRefreshV2

Reproduction:
cd pkg && PULUMI_LIFECYCLE_TEST_FUZZ=1 go test ./engine/lifecycletest -run TestFuzz -tags all -rapid.seed=15899120879758589620 -v

Fails without the exclusion rule, passes with it.