### PR TITLE
Fix missing trace-file argument in convert-trace otel docs example

### DIFF
--- a/docs/debugging/performance.md
+++ b/docs/debugging/performance.md
@@ -25,7 +25,7 @@ pulumi convert-trace up.trace > trace.pprof && go tool pprof -web trace.pprof
 ```
 
 ```
-OTEL_SERVICE_NAME=pulumi OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<endpoint> pulumi convert-trace --otel
+OTEL_SERVICE_NAME=pulumi OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<endpoint> pulumi convert-trace --otel up.trace
 ```
 
 ## Profiles


### PR DESCRIPTION
## Summary

- The `pulumi convert-trace` command requires a positional `trace-file` argument ([source](https://github.com/pulumi/pulumi/blob/955ffc096dab7c6b68312f0b1ae3c9cc8262249e/pkg/cmd/pulumi/trace/convert.go#L729-L732)). The pprof example on the same page correctly includes it (`pulumi convert-trace up.trace > trace.pprof`), but the otel example was missing it.

## Test plan

- [ ] Verify the command runs successfully with the corrected example