### PR TITLE
engine: add guidance for already-existing resource conflicts

### DIFF
--- a/changelog/pending/20260412--engine--add-remediation-guidance-for-already-existing-resource-conflicts-during-import-and-provider-create-failures.yaml
+++ b/changelog/pending/20260412--engine--add-remediation-guidance-for-already-existing-resource-conflicts-during-import-and-provider-create-failures.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Add remediation guidance for already-existing resource conflicts during import and provider create failures

--- a/pkg/resource/deploy/errors.go
+++ b/pkg/resource/deploy/errors.go
@@ -1,0 +1,37 @@
+// Copyright 2016, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// ExistingResourceInStateError indicates that a planned import would overwrite an existing state entry.
+type ExistingResourceInStateError struct {
+	URN resource.URN
+}
+
+var _ error = (*ExistingResourceInStateError)(nil)
+
+func (e *ExistingResourceInStateError) Error() string {
+	return fmt.Sprintf(
+		"resource '%v' already exists\n\n"+
+			"If you want to re-import this resource, first remove the existing state entry with `pulumi state delete %v`, then rerun `pulumi import`.",
+		e.URN,
+		e.URN,
+	)
+}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -1779,7 +1779,7 @@ func (s *ImportStep) Apply() (_ resource.Status, _ StepCompleteFunc, err error) 
 		contract.Assertf(s.cts == nil, "planned import should not have a completion source")
 
 		if _, ok := s.deployment.olds[s.new.URN]; ok {
-			return resource.StatusOK, nil, fmt.Errorf("resource '%v' already exists", s.new.URN)
+			return resource.StatusOK, nil, &ExistingResourceInStateError{URN: s.new.URN}
 		}
 		if s.new.Parent.QualifiedType() != resource.RootStackType {
 			_, ok := s.deployment.news.Load(s.new.Parent)

--- a/sdk/go/common/resource/plugin/errors.go
+++ b/sdk/go/common/resource/plugin/errors.go
@@ -1,0 +1,84 @@
+// Copyright 2016, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"errors"
+	"fmt"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// InitError represents a failure to initialize a resource, i.e., the resource has been successfully
+// created, but it has failed to initialize.
+type InitError struct {
+	Reasons []string
+}
+
+var _ error = (*InitError)(nil)
+
+func (ie *InitError) Error() string {
+	var err error
+	for _, reason := range ie.Reasons {
+		err = multierror.Append(err, errors.New(reason))
+	}
+	if err == nil {
+		return "resource init failed"
+	}
+	return err.Error()
+}
+
+// AlreadyExistsError represents a create failure caused by a conflicting existing resource.
+type AlreadyExistsError struct {
+	Cause        string
+	ResourceType tokens.Type
+	ResourceName string
+	ResourceID   resource.ID
+}
+
+var _ error = (*AlreadyExistsError)(nil)
+
+func (e *AlreadyExistsError) Error() string {
+	message := e.baseMessage()
+	if e.ResourceType == "" || e.ResourceName == "" {
+		return message
+	}
+
+	importID := "<id>"
+	if e.ResourceID != "" {
+		importID = string(e.ResourceID)
+	}
+
+	return fmt.Sprintf(
+		"%s\n\nTo resolve this conflict:\n"+
+			"  - If this resource should be managed by Pulumi, run `pulumi import %s %s %s`.\n"+
+			"  - If Pulumi should create a new resource instead, rename it in your program and rerun `pulumi up`.\n"+
+			"  - If the existing resource is no longer needed, delete it in the cloud provider and rerun `pulumi up`.",
+		message,
+		e.ResourceType,
+		e.ResourceName,
+		importID,
+	)
+}
+
+func (e *AlreadyExistsError) baseMessage() string {
+	if e == nil || e.Cause == "" {
+		return "resource already exists"
+	}
+
+	return e.Cause
+}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1372,6 +1372,10 @@ func (p *provider) Create(ctx context.Context, req CreateRequest) (CreateRespons
 	})
 	if err != nil {
 		resourceStatus, id, liveObject, _, refreshBeforeUpdate, resourceError = parseError(err)
+		if alreadyExistsErr, ok := resourceError.(*AlreadyExistsError); ok {
+			alreadyExistsErr.ResourceType = req.URN.Type()
+			alreadyExistsErr.ResourceName = string(req.URN.Name())
+		}
 		logging.V(7).Infof("%s failed: %v", label, resourceError)
 
 		if resourceStatus != resource.StatusPartialFailure {
@@ -2353,27 +2357,11 @@ func parseError(err error) (
 			break
 		}
 	}
+	if resourceErr == responseErr && responseErr.Code() == codes.AlreadyExists {
+		resourceErr = &AlreadyExistsError{Cause: responseErr.Message()}
+	}
 
 	return resourceStatus, id, liveObject, liveInputs, refreshBeforeUpdate, resourceErr
-}
-
-// InitError represents a failure to initialize a resource, i.e., the resource has been successfully
-// created, but it has failed to initialize.
-type InitError struct {
-	Reasons []string
-}
-
-var _ error = (*InitError)(nil)
-
-func (ie *InitError) Error() string {
-	var err error
-	for _, reason := range ie.Reasons {
-		err = multierror.Append(err, errors.New(reason))
-	}
-	if err == nil {
-		return "resource init failed"
-	}
-	return err.Error()
 }
 
 func decorateSpanWithType(span opentracing.Span, urn string) {

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -1131,3 +1131,39 @@ func TestProvider_PartialFailure_RefreshBeforeUpdate(t *testing.T) {
 	assert.ErrorAs(t, err, &initErr, "expected an InitError")
 	assert.Equal(t, []string{"update issue"}, initErr.Reasons)
 }
+
+func TestProvider_CreateAlreadyExistsIncludesGuidance(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("org/proj/dev", "foo", "", "bar:baz", "qux")
+
+	client := &stubClient{
+		ConfigureF: func(req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{}, nil
+		},
+		CreateF: func(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
+			return nil, rpcerror.New(codes.AlreadyExists, "provider reported a naming conflict")
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "foo", client, false /* disablePreview */)
+
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	_, err = p.Create(t.Context(), CreateRequest{
+		URN:        urn,
+		Name:       urn.Name(),
+		Type:       urn.Type(),
+		Properties: resource.PropertyMap{},
+	})
+	require.Error(t, err)
+
+	var alreadyExistsErr *AlreadyExistsError
+	assert.ErrorAs(t, err, &alreadyExistsErr)
+	assert.Equal(t, tokens.Type("bar:baz"), alreadyExistsErr.ResourceType)
+	assert.Equal(t, "qux", alreadyExistsErr.ResourceName)
+	assert.ErrorContains(t, err, "provider reported a naming conflict")
+	assert.ErrorContains(t, err, "pulumi import bar:baz qux <id>")
+	assert.ErrorContains(t, err, "rename it in your program")
+}

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/codes"
@@ -47,6 +48,15 @@ func NewProviderServer(provider Provider) pulumirpc.ResourceProviderServer {
 		acceptSecrets: true, sendSecrets: true,
 		acceptResources: true, sendResources: true,
 	}
+}
+
+func marshalProviderError(err error) error {
+	var alreadyExistsErr *AlreadyExistsError
+	if errors.As(err, &alreadyExistsErr) {
+		return rpcerror.New(codes.AlreadyExists, alreadyExistsErr.baseMessage())
+	}
+
+	return err
 }
 
 func (p *providerServer) unmarshalOptions(label string, keepOutputValues bool) MarshalOptions {
@@ -566,7 +576,7 @@ func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateReques
 		ResourceStatusToken:   req.GetResourceStatusToken(),
 	})
 	if err != nil {
-		return nil, err
+		return nil, marshalProviderError(err)
 	}
 
 	rpcState, err := MarshalProperties(resp.Properties, p.marshalOptions("newState"))
@@ -625,7 +635,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 		OldViews:              oldViews,
 	})
 	if err != nil {
-		return nil, err
+		return nil, marshalProviderError(err)
 	}
 
 	rpcState, err := MarshalProperties(resp.Outputs, p.marshalOptions("newState"))
@@ -703,7 +713,7 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 		OldViews:              oldViews,
 	})
 	if err != nil {
-		return nil, err
+		return nil, marshalProviderError(err)
 	}
 
 	rpcState, err := MarshalProperties(resp.Properties, p.marshalOptions("newState"))

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -22,6 +22,8 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Validate that Configure can read inputs from variables instead of args.
@@ -59,6 +61,11 @@ func TestProviderServer_Configure_variables(t *testing.T) {
 type stubProvider struct {
 	Provider
 
+	CreateFunc func(
+		urn resource.URN,
+		inputs resource.PropertyMap,
+	) (CreateResponse, error)
+
 	ReadFunc func(
 		urn resource.URN, id resource.ID,
 		inputs, state resource.PropertyMap,
@@ -75,6 +82,14 @@ func (p *stubProvider) Configure(ctx context.Context, req ConfigureRequest) (Con
 	return p.Provider.Configure(ctx, req)
 }
 
+func (p *stubProvider) Create(ctx context.Context, req CreateRequest) (CreateResponse, error) {
+	if p.CreateFunc != nil {
+		return p.CreateFunc(req.URN, req.Properties)
+	}
+
+	return p.Provider.Create(ctx, req)
+}
+
 func (p *stubProvider) Read(ctx context.Context, req ReadRequest) (ReadResponse, error) {
 	if p.ReadFunc != nil {
 		props, status, err := p.ReadFunc(req.URN, req.ID, req.Inputs, req.State)
@@ -84,6 +99,31 @@ func (p *stubProvider) Read(ctx context.Context, req ReadRequest) (ReadResponse,
 		}, err
 	}
 	return p.Provider.Read(ctx, req)
+}
+
+func TestProviderServer_Create_mapsAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	provider := stubProvider{
+		CreateFunc: func(
+			urn resource.URN,
+			inputs resource.PropertyMap,
+		) (CreateResponse, error) {
+			return CreateResponse{}, &AlreadyExistsError{Cause: "conflicting remote resource"}
+		},
+	}
+
+	srv := NewProviderServer(&provider)
+	_, err := srv.Create(ctx, &pulumirpc.CreateRequest{
+		Urn: "urn:pulumi:dev::project::pkg:index:Thing::thing",
+	})
+	require.Error(t, err)
+
+	statusErr, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.AlreadyExists, statusErr.Code())
+	assert.Equal(t, "conflicting remote resource", statusErr.Message())
 }
 
 // When importing random passwords, the secret passed as "ID" should not leak in plain text into the final ID.


### PR DESCRIPTION
Fixes #10313

## What
- add a typed `ExistingResourceInStateError` for planned import collisions and attach a concrete `pulumi state delete <urn>` remediation hint
- recognize provider `codes.AlreadyExists` failures as `plugin.AlreadyExistsError` and enrich create failures with actionable import / rename / delete guidance
- teach the in-process provider server to preserve `AlreadyExistsError` as a semantic gRPC `AlreadyExists` response for Go providers
- add focused tests for the provider client/server path and keep the import-path change small

## Why
Previous attempts on this issue were rejected for matching arbitrary error strings in the diagnostics layer. This change avoids that by only improving two paths where the engine has structured signal:

1. planned imports that would overwrite an existing state entry
2. provider failures that are already classified as `codes.AlreadyExists`

That gives users immediate guidance in the import case today, while also improving create failures for providers that already surface semantic `AlreadyExists` errors (and for in-process Go providers that adopt `plugin.AlreadyExistsError`).

## Testing
- `cd sdk && go test ./go/common/resource/plugin -run 'TestProvider_CreateAlreadyExistsIncludesGuidance|TestProviderServer_Create_mapsAlreadyExists'`
- `cd pkg && go test ./engine/lifecycletest -run 'TestImportPlanExistingImport'`
