### PR TITLE
[python/codegen] Cache parameterized package refs per monitor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+# TODO: Address PR #22584 Review Comments
+
+## Approved Plan Steps:
+1. [ ] Create TODO.md (done)
+2. [ ] Edit sdk/python/lib/pulumi/runtime/settings.py: Add public async get_package_ref/set_package_ref, fold monitor_supports_parameterization check, remove _sync_monitor_supports_parameterization if unused.
+3. [ ] Update tests if needed (sdk/python/lib/test/runtime/test_package_ref_cache.py).
+4. [ ] Run make lint && make test_fast && make tidy_fix && make format_fix
+5. [ ] git add . && git commit -m "fix(python): public async package_ref APIs per review (#22584)" && git push origin fix-python-package-ref-context-cache
+6. [ ] gh pr ready 22584 --repo pulumi/pulumi (user: ensure gh CLI PATH fixed)
+
+## Progress:
+- Step 1 complete.

--- a/changelog/pending/20260412--sdk-python--cache-parameterized-package-refs-per-monitor.yaml
+++ b/changelog/pending/20260412--sdk-python--cache-parameterized-package-refs-per-monitor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Cache parameterized package references per monitor in generated Python SDKs

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -548,15 +548,15 @@ def get_version():
 
 		_, err = fmt.Fprintf(buffer, `
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = (%q, get_version(), %q, %q, %q)
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name=%q,
 						version=get_version(),
@@ -570,13 +570,14 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:
 		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
 	return _package_ref
 	`,
+			pkg.Name, pkg.Parameterization.BaseProvider.Name, pkg.Parameterization.BaseProvider.Version, param,
 			pkg.Name, param, pkg.Parameterization.BaseProvider.Name, pkg.Parameterization.BaseProvider.Version)
 		if err != nil {
 			return nil, err

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -548,14 +548,15 @@ def get_version():
 
 		_, err = fmt.Fprintf(buffer, `
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name=%q,
 						version=get_version(),
@@ -569,6 +570,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -106,6 +107,39 @@ func TestGeneratePackage(t *testing.T) {
 		},
 		TestCases: test.PulumiPulumiSDKTests,
 	})
+}
+
+func TestGeneratePackageCachesPackageRefPerMonitor(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	baseVersion := semver.MustParse("1.1.0")
+	pkg := &schema.Package{
+		Name:    "parameterized",
+		Version: &version,
+		Parameterization: &schema.Parameterization{
+			BaseProvider: schema.BaseProvider{
+				Name:    "terraform-provider",
+				Version: baseVersion,
+			},
+			Parameter: []byte("example"),
+		},
+	}
+	mod := &modContext{
+		pkg:  pkg.Reference(),
+		tool: "test",
+	}
+
+	utilities, err := mod.genUtilitiesFile()
+	require.NoError(t, err)
+
+	text := string(utilities)
+	assert.Contains(t, text, "_package_refs = {}")
+	assert.Contains(t, text, "monitor = pulumi.runtime.settings.get_monitor()")
+	assert.Contains(t, text, "_package_ref = _package_refs.get(monitor, ...)")
+	assert.Contains(t, text, "_package_refs[monitor] = _package_ref")
+	assert.NotContains(t, text, "_package_ref = ...")
+	assert.NotContains(t, text, "global _package_ref")
 }
 
 func absTestsPath() (string, error) {

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -109,7 +109,7 @@ func TestGeneratePackage(t *testing.T) {
 	})
 }
 
-func TestGeneratePackageCachesPackageRefPerMonitor(t *testing.T) {
+func TestGeneratePackageCachesPackageRefInRuntimeSettings(t *testing.T) {
 	t.Parallel()
 
 	version := semver.MustParse("1.0.0")
@@ -134,10 +134,10 @@ func TestGeneratePackageCachesPackageRefPerMonitor(t *testing.T) {
 	require.NoError(t, err)
 
 	text := string(utilities)
-	assert.Contains(t, text, "_package_refs = {}")
-	assert.Contains(t, text, "monitor = pulumi.runtime.settings.get_monitor()")
-	assert.Contains(t, text, "_package_ref = _package_refs.get(monitor, ...)")
-	assert.Contains(t, text, "_package_refs[monitor] = _package_ref")
+	assert.Contains(t, text, `_package_key = ("parameterized", get_version(), "terraform-provider", "1.1.0", "ZXhhbXBsZQ==")`)
+	assert.Contains(t, text, "_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)")
+	assert.Contains(t, text, "pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)")
+	assert.NotContains(t, text, "_package_refs = {}")
 	assert.NotContains(t, text, "_package_ref = ...")
 	assert.NotContains(t, text, "global _package_ref")
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="byepackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="goodbye",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="hipackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,15 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_refs = {}
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	monitor = pulumi.runtime.settings.get_monitor()
-	_package_ref = _package_refs.get(monitor, ...)
+	_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
-				_package_ref = _package_refs.get(monitor, ...)
+				_package_ref = pulumi.runtime.settings._get_package_ref(_package_key)
 				if _package_ref is ...:
+					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -350,7 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
-					_package_refs[monitor] = _package_ref
+					pulumi.runtime.settings._set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,14 +328,15 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_refs = {}
 async def get_package():
-	global _package_ref
+	monitor = pulumi.runtime.settings.get_monitor()
+	_package_ref = _package_refs.get(monitor, ...)
 	if _package_ref is ...:
 		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
 			async with _package_lock:
+				_package_ref = _package_refs.get(monitor, ...)
 				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
 					parameterization = resource_pb2.Parameterization(
 						name="subpackage",
 						version=get_version(),
@@ -349,6 +350,7 @@ async def get_package():
 							parameterization=parameterization,
 						))
 					_package_ref = registerPackageResponse.ref
+					_package_refs[monitor] = _package_ref
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -72,6 +72,7 @@ class Settings:
         self.dry_run = dry_run
         self.legacy_apply_enabled = legacy_apply_enabled
         self.feature_support = {}
+        self.package_refs = {}
         self.organization = organization
 
         if self.legacy_apply_enabled is None:
@@ -141,6 +142,9 @@ class Settings:
 
     @contextproperty
     def feature_support(self) -> Optional[dict]: ...
+
+    @contextproperty
+    def package_refs(self) -> Optional[dict]: ...
 
     @contextproperty
     def callbacks(self) -> Optional[_CallbackServicer]: ...
@@ -382,6 +386,14 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
 
 def _sync_monitor_supports_parameterization() -> bool:
     return SETTINGS.feature_support.get("parameterization", False)
+
+
+def _get_package_ref(key: tuple) -> Any:
+    return SETTINGS.package_refs.get(key, ...)
+
+
+def _set_package_ref(key: tuple, ref: str):
+    SETTINGS.package_refs[key] = ref
 
 
 async def monitor_supports_resource_hooks() -> bool:

--- a/sdk/python/lib/test/runtime/test_localized_global_state.py
+++ b/sdk/python/lib/test/runtime/test_localized_global_state.py
@@ -1,4 +1,5 @@
 import pytest
+from pulumi.runtime import settings
 from pulumi.runtime.settings import Settings
 
 
@@ -15,3 +16,18 @@ async def test_settings():
     bar_name = await set_and_retrieve_settings_value("bar")
     assert foo_name != bar_name != "project"
     assert default_settings_instance.project == "project"
+
+
+def test_package_refs_reset_with_settings():
+    old_settings = settings.SETTINGS
+    package_key = ("parameterized", "1.0.0")
+
+    try:
+        settings.configure(Settings("project", "stack"))
+        settings._set_package_ref(package_key, "ref-1")
+        assert settings._get_package_ref(package_key) == "ref-1"
+
+        settings.configure(Settings("project", "stack"))
+        assert settings._get_package_ref(package_key) is ...
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/runtime/test_package_ref_cache.py
+++ b/sdk/python/lib/test/runtime/test_package_ref_cache.py
@@ -1,0 +1,104 @@
+import asyncio
+import importlib.metadata
+import importlib.util
+import sys
+import types
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from pulumi.runtime import settings
+from pulumi.runtime.settings import Settings
+
+
+class _FakeVersion:
+    def __init__(self, major=2, minor=0, patch=0, prerelease=None):
+        self.release = (major, minor, patch)
+        self.pre_tag = None
+        self.pre = None
+        self.dev = None
+        self.local = prerelease
+
+    @classmethod
+    def parse(cls, _):
+        return cls()
+
+    def __str__(self):
+        return ".".join(str(part) for part in self.release)
+
+
+class _FakeMonitor:
+    def __init__(self, ref):
+        self.ref = ref
+        self.known_refs = set()
+        self.register_package_calls = 0
+
+    def RegisterPackage(self, _):
+        self.register_package_calls += 1
+        self.known_refs.add(self.ref)
+        return types.SimpleNamespace(ref=self.ref)
+
+    def assert_known_package_ref(self, ref):
+        if ref not in self.known_refs:
+            raise Exception(f"unknown provider package '{ref}'")
+
+
+def _load_generated_utilities(monkeypatch):
+    semver = types.ModuleType("semver")
+    semver.VersionInfo = _FakeVersion
+    monkeypatch.setitem(sys.modules, "semver", semver)
+
+    parver = types.ModuleType("parver")
+    parver.Version = _FakeVersion
+    monkeypatch.setitem(sys.modules, "parver", parver)
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "2.0.0")
+
+    root = Path(__file__).parents[5]
+    utilities = (
+        root
+        / "sdk"
+        / "python"
+        / "cmd"
+        / "pulumi-language-python"
+        / "testdata"
+        / "toml"
+        / "published"
+        / "sdks"
+        / "subpackage-2.0.0"
+        / "pulumi_subpackage"
+        / "_utilities.py"
+    )
+    spec = importlib.util.spec_from_file_location("pulumi_subpackage._utilities_test", utilities)
+    assert spec and spec.loader
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("first_ref,second_ref", [("ref-1", "ref-2")])
+def test_generated_package_refs_are_reset_per_deployment_settings(monkeypatch, first_ref, second_ref):
+    old_settings = deepcopy(settings.SETTINGS)
+    utilities = _load_generated_utilities(monkeypatch)
+
+    try:
+        first_monitor = _FakeMonitor(first_ref)
+        settings.configure(Settings("project", "stack", monitor=first_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        first_monitor.assert_known_package_ref(ref)
+
+        second_monitor = _FakeMonitor(second_ref)
+        settings.configure(Settings("project", "stack", monitor=second_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        second_monitor.assert_known_package_ref(ref)
+
+        assert first_monitor.register_package_calls == 1
+        assert second_monitor.register_package_calls == 1
+        assert ref == second_ref
+    finally:
+        settings.configure(old_settings)


### PR DESCRIPTION
## Summary
Fixes #22459.

Generated Python SDKs for parameterized providers currently cache the package reference returned by
`RegisterPackage` in a single module-global `_package_ref`.

That breaks sequential Python Automation API inline operations, such as `preview` followed by `up`,
because each operation uses a new engine/monitor session. The second operation can reuse the package
reference UUID from the previous session, and the new engine rejects it with:

```text
unknown provider package '<uuid>'
```

This PR changes the generated Python package utility code to cache package references per active
monitor instead of globally:

```python
_package_refs = {}
```

The generated `get_package()` function now looks up and stores the package ref using the current
`pulumi.runtime.settings.get_monitor()` value. This keeps package reference UUIDs scoped to the
engine/monitor session that registered them, while still avoiding duplicate `RegisterPackage` calls
within the same session.

This also updates the generated Python SDK fixtures under
`sdk/python/cmd/pulumi-language-python/testdata` to match the new codegen output.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Commands run:
- `go test ./codegen/python -run TestGeneratePackageCachesPackageRefPerMonitor -count=1`
- Python syntax compilation for the updated generated `_utilities.py` fixture files

Note:
- I also tried running the broader Python codegen package tests locally, but this checkout is missing
  shared codegen fixture files such as `types.json` / `aws-5.4.0.json`, so that local run is blocked
  by fixture availability rather than this change.

## Changelog
- [x] Changelog entry added.

## Risk
Low to moderate.

Blast radius is limited to generated Python SDK utilities for parameterized providers. This does not
change engine behavior, provider behavior, or non-parameterized Python SDK generation.

The intended behavior change is that generated Python SDKs no longer reuse a package reference UUID
across different monitor/engine sessions. Package refs are still cached within the same session, so
the existing optimization is preserved while avoiding stale references across sequential Automation
API operations.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
