### PR TITLE
Add `--changes-only` flag to `pulumi preview --json`

### DIFF
--- a/changelog/pending/20260411--cli--add-changes-only-flag-to-preview-for-minimal-json-output.yaml
+++ b/changelog/pending/20260411--cli--add-changes-only-flag-to-preview-for-minimal-json-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add a `--changes-only` flag to `pulumi preview` that, when combined with `--json`, restricts the output to only changed resources and only the properties that actually changed, producing a minimal summary suitable for bulk processing.

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -287,6 +287,15 @@ func isRootURN(urn resource.URN) bool {
 
 // shouldShow returns true if a step should show in the output.
 func shouldShow(step engine.StepEventMetadata, opts Options) bool {
+	// In changes-only mode, read and refresh operations are observations rather than changes, so we
+	// elide them from the output entirely.
+	if opts.ChangesOnly {
+		switch step.Op {
+		case deploy.OpRead, deploy.OpReadReplacement, deploy.OpReadDiscard, deploy.OpRefresh:
+			return false
+		}
+	}
+
 	// For certain operations, whether they are tracked is controlled by flags (to cut down on superfluous output).
 	if step.Op == deploy.OpSame {
 		// If the op is the same, it is possible that the resource's metadata changed.  In that case, still show it.

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -69,19 +69,44 @@ func MassageSecrets(m resource.PropertyMap, showSecrets bool) resource.PropertyM
 	return new
 }
 
-// stateForJSONOutput prepares some resource's state for JSON output. This includes filtering the output based
-// on the supplied options, in addition to massaging secret fields.
-func stateForJSONOutput(s *resource.State, opts Options) *resource.State {
+// filteredStateForJSONOutput prepares some resource's state for JSON output. When opts.ChangesOnly is set, the
+// resulting state's Inputs are filtered down to only those top-level keys that changed (for update/replace
+// operations) and Outputs are dropped entirely, so that the JSON output is a minimal summary of the actual
+// change. For creates and deletes all Inputs are kept because every property is, by definition, new or gone.
+func filteredStateForJSONOutput(
+	s *resource.State, changedKeys []resource.PropertyKey, op display.StepOp, opts Options,
+) *resource.State {
 	var inputs resource.PropertyMap
 	var outputs resource.PropertyMap
-	if !isRootURN(s.URN) || !opts.SuppressOutputs {
-		// For now, replace any secret properties as the string [secret] and then serialize what we have.
-		inputs = MassageSecrets(s.Inputs, false)
-		outputs = MassageSecrets(s.Outputs, false)
-	} else {
+	switch {
+	case isRootURN(s.URN) && opts.SuppressOutputs:
 		// If we're suppressing outputs, don't show the root stack properties.
 		inputs = resource.PropertyMap{}
 		outputs = resource.PropertyMap{}
+	case opts.ChangesOnly:
+		// In changes-only mode, we drop Outputs entirely and — for update/replace operations — restrict
+		// Inputs to only the top-level keys that the engine reported as changed.
+		outputs = resource.PropertyMap{}
+		switch op {
+		case deploy.OpUpdate, deploy.OpReplace:
+			keep := make(map[resource.PropertyKey]bool, len(changedKeys))
+			for _, k := range changedKeys {
+				keep[k] = true
+			}
+			filtered := make(resource.PropertyMap, len(keep))
+			for k, v := range s.Inputs {
+				if keep[k] {
+					filtered[k] = v
+				}
+			}
+			inputs = MassageSecrets(filtered, false)
+		default:
+			inputs = MassageSecrets(s.Inputs, false)
+		}
+	default:
+		// For now, replace any secret properties as the string [secret] and then serialize what we have.
+		inputs = MassageSecrets(s.Inputs, false)
+		outputs = MassageSecrets(s.Outputs, false)
 	}
 	return resource.NewState{
 		Type:                    s.Type,
@@ -278,7 +303,7 @@ func getPreviewMetadataStep(
 
 	ctx := context.TODO()
 	if m.Old != nil {
-		oldState := stateForJSONOutput(m.Old.State, opts)
+		oldState := filteredStateForJSONOutput(m.Old.State, m.Diffs, m.Op, opts)
 		res, err := stack.SerializeResource(ctx, oldState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.OldState = &res
@@ -287,7 +312,7 @@ func getPreviewMetadataStep(
 		}
 	}
 	if m.New != nil {
-		newState := stateForJSONOutput(m.New.State, opts)
+		newState := filteredStateForJSONOutput(m.New.State, m.Diffs, m.Op, opts)
 		res, err := stack.SerializeResource(ctx, newState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.NewState = &res

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -69,11 +69,12 @@ func MassageSecrets(m resource.PropertyMap, showSecrets bool) resource.PropertyM
 	return new
 }
 
-// filteredStateForJSONOutput prepares some resource's state for JSON output. When opts.ChangesOnly is set, the
-// resulting state's Inputs are filtered down to only those top-level keys that changed (for update/replace
-// operations) and Outputs are dropped entirely, so that the JSON output is a minimal summary of the actual
-// change. For creates and deletes all Inputs are kept because every property is, by definition, new or gone.
-func filteredStateForJSONOutput(
+// stateForJSONOutput prepares some resource's state for JSON output. This includes filtering the output based
+// on the supplied options, in addition to massaging secret fields. When opts.ChangesOnly is set, the resulting
+// state's Inputs are filtered down to only those top-level keys that changed (for update/replace operations)
+// and Outputs are dropped entirely, so that the JSON output is a minimal summary of the actual change. For
+// creates and deletes all Inputs are kept because every property is, by definition, new or gone.
+func stateForJSONOutput(
 	s *resource.State, changedKeys []resource.PropertyKey, op display.StepOp, opts Options,
 ) *resource.State {
 	var inputs resource.PropertyMap
@@ -303,7 +304,7 @@ func getPreviewMetadataStep(
 
 	ctx := context.TODO()
 	if m.Old != nil {
-		oldState := filteredStateForJSONOutput(m.Old.State, m.Diffs, m.Op, opts)
+		oldState := stateForJSONOutput(m.Old.State, m.Diffs, m.Op, opts)
 		res, err := stack.SerializeResource(ctx, oldState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.OldState = &res
@@ -312,7 +313,7 @@ func getPreviewMetadataStep(
 		}
 	}
 	if m.New != nil {
-		newState := filteredStateForJSONOutput(m.New.State, m.Diffs, m.Op, opts)
+		newState := stateForJSONOutput(m.New.State, m.Diffs, m.Op, opts)
 		res, err := stack.SerializeResource(ctx, newState, config.NewPanicCrypter(), false /* showSecrets */)
 		if err == nil {
 			step.NewState = &res

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	IsInteractive            bool                // true if we should display things interactively.
 	Type                     Type                // type of display (rich diff, progress, or query).
 	JSONDisplay              bool                // true if we should emit the entire diff as JSON.
+	ChangesOnly              bool                // true to filter JSON output down to only changed properties.
 	EventLogPath             string              // the path to the file to use for logging events, if any.
 	Debug                    bool                // true to enable debug output.
 	Stdin                    io.Reader           // the reader to use for stdin. Defaults to os.Stdin if unset.

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -270,6 +270,7 @@ func NewPreviewCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var changesOnly bool
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -318,6 +319,10 @@ func NewPreviewCmd() *cobra.Command {
 			ctx := cmd.Context()
 			ws := pkgWorkspace.Instance
 
+			if changesOnly && !jsonDisplay {
+				return errors.New("--changes-only can only be used with --json")
+			}
+
 			proj, root, err := readProjectForUpdate(ws, client)
 			if err != nil {
 				return err
@@ -353,6 +358,7 @@ func NewPreviewCmd() *cobra.Command {
 				IsInteractive:          cmdutil.Interactive(),
 				Type:                   displayType,
 				JSONDisplay:            jsonDisplay,
+				ChangesOnly:            changesOnly,
 				EventLogPath:           eventLogPath,
 				Debug:                  debug,
 			}
@@ -667,6 +673,9 @@ func NewPreviewCmd() *cobra.Command {
 		&jsonDisplay, "json", "j", false,
 		"Serialize the preview diffs, operations, and overall output as JSON."+
 			" Set PULUMI_ENABLE_STREAMING_JSON_PREVIEW to stream JSON events instead.")
+	cmd.Flags().BoolVar(
+		&changesOnly, "changes-only", false,
+		"Only include changed resources and changed properties in the output. Requires --json.")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")

--- a/tests/integration/preview_changes_only_test.go
+++ b/tests/integration/preview_changes_only_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+)
+
+// testproviderAbsPath returns the absolute path to the local testprovider directory next to this
+// test file. The Pulumi.yaml plugins.providers entry needs an absolute path because the project
+// lives in a temp directory created by ptesting.Environment.
+func testproviderAbsPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "could not determine path of preview_changes_only_test.go")
+	abs, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", "testprovider"))
+	require.NoError(t, err)
+	return abs
+}
+
+// previewChangesOnlyYAML returns a YAML pulumi program that uses three Updatable resources from the
+// testprovider. The `phase` arg controls the second deployment: keep stays the same, update has its
+// `foo` property modified, remove disappears, and added is introduced.
+func previewChangesOnlyYAML(testproviderPath, phase string) string {
+	header := `name: preview-changes-only-test
+runtime: yaml
+description: Integration test for ` + "`pulumi preview --json --changes-only`" + `
+plugins:
+  providers:
+    - name: testprovider
+      path: ` + testproviderPath + `
+resources:
+  keep:
+    type: testprovider:index:Updatable
+    properties:
+      foo: initial
+      bar: stable
+`
+	switch phase {
+	case "before":
+		return header + `  update:
+    type: testprovider:index:Updatable
+    properties:
+      foo: initial
+      bar: stable
+  remove:
+    type: testprovider:index:Updatable
+    properties:
+      foo: initial
+      bar: stable
+`
+	case "after":
+		return header + `  update:
+    type: testprovider:index:Updatable
+    properties:
+      foo: changed
+      bar: stable
+  added:
+    type: testprovider:index:Updatable
+    properties:
+      foo: brand-new
+      bar: stable
+`
+	default:
+		panic("unknown phase: " + phase)
+	}
+}
+
+// setupPreviewChangesOnlyStack bootstraps a yaml pulumi project that uses the local testprovider's
+// Updatable resource, deploys it, then rewrites the program to produce an update/create/delete mix.
+func setupPreviewChangesOnlyStack(t *testing.T, stack string) *ptesting.Environment {
+	t.Helper()
+
+	e := ptesting.NewEnvironment(t)
+	// The file backend lives entirely inside the temp dir, so dropping the env is enough; we
+	// don't run `pulumi destroy` here because it can race with the test's cancelled context.
+	t.Cleanup(e.DeleteIfNotFailed)
+
+	providerPath := testproviderAbsPath(t)
+
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.WriteTestFile("Pulumi.yaml", previewChangesOnlyYAML(providerPath, "before"))
+	e.RunCommand("pulumi", "stack", "init", stack)
+	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
+
+	// Swap the program for one that triggers an update, a create and a delete.
+	e.WriteTestFile("Pulumi.yaml", previewChangesOnlyYAML(providerPath, "after"))
+
+	return e
+}
+
+// findStep returns the first step whose URN ends with the given resource name. Returns nil if
+// no such step exists (which most tests treat as a hard failure).
+func findStep(digest *display.PreviewDigest, name string) *display.PreviewStep {
+	for _, step := range digest.Steps {
+		if strings.HasSuffix(string(step.URN), "::"+name) {
+			return step
+		}
+	}
+	return nil
+}
+
+// TestPreviewChangesOnlyRequiresJSON verifies that --changes-only is rejected without --json
+// at flag-parse time, so it fails fast and doesn't require a project on disk.
+func TestPreviewChangesOnlyRequiresJSON(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	_, stderr := e.RunCommandExpectError("pulumi", "preview", "--changes-only")
+	assert.Equal(t,
+		"error: --changes-only can only be used with --json",
+		strings.Trim(stderr, "\r\n"))
+}
+
+// TestPreviewChangesOnlyFiltersDigest runs a full preview through the CLI with --json
+// --changes-only and verifies that (a) only changed resources appear, (b) for the updated
+// resource only the changed top-level inputs are serialised, and (c) outputs are dropped.
+func TestPreviewChangesOnlyFiltersDigest(t *testing.T) {
+	t.Parallel()
+
+	e := setupPreviewChangesOnlyStack(t, "changes-only-filter")
+
+	stdout, _ := e.RunCommand("pulumi", "preview", "--json", "--changes-only")
+
+	var digest display.PreviewDigest
+	require.NoError(t, json.Unmarshal([]byte(stdout), &digest),
+		"preview --json --changes-only must emit a valid PreviewDigest; got: %s", stdout)
+
+	// --- Step filtering ---------------------------------------------------------------------
+	// "keep" is unchanged so it must not appear at all. The other three resources (update,
+	// remove, added) should be the only Updatable steps.
+	for _, step := range digest.Steps {
+		// The implicit root stack same-op step is allowed through shouldShow via the
+		// isRootStack() override; skip it here so we can make assertions on the resources.
+		if strings.Contains(string(step.URN), "::pulumi:pulumi:Stack::") {
+			continue
+		}
+		// No OpSame should ever be emitted under --changes-only for real resources.
+		assert.NotEqual(t, deploy.OpSame, step.Op,
+			"unchanged resources must be filtered out: %s", step.URN)
+		// Reads/refreshes are also suppressed.
+		assert.NotEqual(t, deploy.OpRead, step.Op, "reads must be filtered out")
+		assert.NotEqual(t, deploy.OpRefresh, step.Op, "refreshes must be filtered out")
+	}
+
+	assert.Nil(t, findStep(&digest, "keep"),
+		"unchanged resource 'keep' must not appear in --changes-only output")
+
+	// --- Update step: only changed inputs, no outputs ---------------------------------------
+	updateStep := findStep(&digest, "update")
+	require.NotNil(t, updateStep, "expected an update step for resource 'update'")
+	assert.Equal(t, deploy.OpUpdate, updateStep.Op)
+	// The provider reported `foo` as the changed key; `bar` should be filtered out of NewState
+	// and the full Outputs map should be empty.
+	require.NotNil(t, updateStep.NewState, "update step must include NewState")
+	newInputs := updateStep.NewState.Inputs
+	assert.Contains(t, newInputs, "foo", "changed key 'foo' must remain in NewState.Inputs")
+	assert.NotContains(t, newInputs, "bar",
+		"unchanged key 'bar' must be stripped from NewState.Inputs under --changes-only")
+	assert.Empty(t, updateStep.NewState.Outputs,
+		"outputs must be dropped from NewState under --changes-only")
+	// DiffReasons still carry the engine's change list, regardless of the filter.
+	assert.Contains(t, updateStep.DiffReasons, resource.PropertyKey("foo"))
+
+	// --- Delete step: OldState is still present (so consumers know what's gone) -------------
+	removeStep := findStep(&digest, "remove")
+	require.NotNil(t, removeStep, "expected a delete step for resource 'remove'")
+	assert.Equal(t, deploy.OpDelete, removeStep.Op)
+	require.NotNil(t, removeStep.OldState, "delete step must include OldState")
+	// For deletes all old inputs are preserved (there's no "changed subset" for a delete).
+	assert.Contains(t, removeStep.OldState.Inputs, "foo")
+	assert.Contains(t, removeStep.OldState.Inputs, "bar")
+	assert.Empty(t, removeStep.OldState.Outputs, "delete step Outputs must also be stripped")
+
+	// --- Create step: NewState has full inputs, no outputs ----------------------------------
+	addedStep := findStep(&digest, "added")
+	require.NotNil(t, addedStep, "expected a create step for resource 'added'")
+	assert.Equal(t, deploy.OpCreate, addedStep.Op)
+	require.NotNil(t, addedStep.NewState, "create step must include NewState")
+	assert.Contains(t, addedStep.NewState.Inputs, "foo")
+	assert.Contains(t, addedStep.NewState.Inputs, "bar")
+	assert.Empty(t, addedStep.NewState.Outputs, "create step Outputs must be stripped")
+
+	// --- ChangeSummary is untouched: still reports the full counts --------------------------
+	assert.Equal(t, 1, digest.ChangeSummary[deploy.OpCreate])
+	assert.Equal(t, 1, digest.ChangeSummary[deploy.OpUpdate])
+	assert.Equal(t, 1, digest.ChangeSummary[deploy.OpDelete])
+}
+
+// TestPreviewChangesOnlyVsPlain compares --json and --json --changes-only on the exact same
+// stack state. This nails down that --changes-only is a filter over the existing --json output:
+// for an update step, full inputs are present in the plain digest but absent in the filtered one.
+func TestPreviewChangesOnlyVsPlain(t *testing.T) {
+	t.Parallel()
+
+	e := setupPreviewChangesOnlyStack(t, "changes-only-compare")
+
+	plainStdout, _ := e.RunCommand("pulumi", "preview", "--json")
+	var plain display.PreviewDigest
+	require.NoError(t, json.Unmarshal([]byte(plainStdout), &plain))
+
+	filteredStdout, _ := e.RunCommand("pulumi", "preview", "--json", "--changes-only")
+	var filtered display.PreviewDigest
+	require.NoError(t, json.Unmarshal([]byte(filteredStdout), &filtered))
+
+	// Both digests agree on the aggregate change summary.
+	assert.Equal(t, plain.ChangeSummary, filtered.ChangeSummary)
+
+	// The plain output includes the full input map for the updated resource...
+	plainUpdate := findStep(&plain, "update")
+	require.NotNil(t, plainUpdate)
+	require.NotNil(t, plainUpdate.NewState)
+	assert.Contains(t, plainUpdate.NewState.Inputs, "bar",
+		"plain --json output should retain all inputs, including unchanged ones")
+
+	// ...while the filtered output strips unchanged inputs.
+	filteredUpdate := findStep(&filtered, "update")
+	require.NotNil(t, filteredUpdate)
+	require.NotNil(t, filteredUpdate.NewState)
+	assert.NotContains(t, filteredUpdate.NewState.Inputs, "bar")
+}

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -87,6 +87,7 @@ var testProviders = func() map[string]testProvider {
 		"testprovider:index:FailsOnCreate":     &failsOnCreateProvider{},
 		"testprovider:index:FlakyCreate":       &flakyCreateProvider{},
 		"testprovider:index:Named":             &namedProvider{},
+		"testprovider:index:Updatable":         &updatableProvider{},
 	}
 	return testProviders
 }()

--- a/tests/testprovider/updatable.go
+++ b/tests/testprovider/updatable.go
@@ -1,0 +1,142 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !all
+// +build !all
+
+package main
+
+import (
+	"context"
+	"strconv"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func init() {
+	providerSchema.Resources["testprovider:index:Updatable"] = pschema.ResourceSpec{
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			Description: "A test resource that supports updates and reports changed property keys.",
+			Properties: map[string]pschema.PropertySpec{
+				"foo": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"bar": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			},
+			Type: "object",
+		},
+		InputProperties: map[string]pschema.PropertySpec{
+			"foo": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			"bar": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+		},
+	}
+}
+
+type updatableProvider struct {
+	id int
+}
+
+func (p *updatableProvider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	return &rpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
+}
+
+// Diff compares old and new inputs and reports changed top-level keys via the proto `diffs` field.
+// This is what `pulumi preview --json --changes-only` relies on to know which inputs to surface.
+func (p *updatableProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+
+	d := olds.Diff(news)
+	changes := rpc.DiffResponse_DIFF_NONE
+	var diffs []string
+	if d != nil {
+		for _, k := range d.ChangedKeys() {
+			diffs = append(diffs, string(k))
+		}
+		if len(diffs) > 0 {
+			changes = rpc.DiffResponse_DIFF_SOME
+		}
+	}
+
+	return &rpc.DiffResponse{
+		Changes: changes,
+		Diffs:   diffs,
+	}, nil
+}
+
+func (p *updatableProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{
+		KeepUnknowns: true,
+		SkipNulls:    true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	outputProperties, err := plugin.MarshalProperties(
+		inputs,
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	p.id++
+	return &rpc.CreateResponse{
+		Id:         strconv.Itoa(p.id),
+		Properties: outputProperties,
+	}, nil
+}
+
+func (p *updatableProvider) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+	return &rpc.ReadResponse{
+		Id:         req.Id,
+		Properties: req.Properties,
+	}, nil
+}
+
+func (p *updatableProvider) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
+		KeepUnknowns: true,
+		SkipNulls:    true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	outputProperties, err := plugin.MarshalProperties(
+		news,
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &rpc.UpdateResponse{Properties: outputProperties}, nil
+}
+
+func (p *updatableProvider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (p *updatableProvider) Invoke(ctx context.Context, req *rpc.InvokeRequest) (*rpc.InvokeResponse, error) {
+	panic("Invoke not implemented")
+}
+
+func (p *updatableProvider) Call(ctx context.Context, req *rpc.CallRequest) (*rpc.CallResponse, error) {
+	panic("Call not implemented")
+}


### PR DESCRIPTION
## Summary

- Adds a `--changes-only` flag to `pulumi preview` that, when combined with `--json`, filters the output down to only changed resources and only the properties that actually changed
- For update/replace steps, `NewState.Inputs` and `OldState.Inputs` are restricted to only the top-level keys the provider reported as changed; `Outputs` are dropped entirely
- Read/refresh operations are suppressed from the output
- Using `--changes-only` without `--json` is a hard error at flag-parse time
- Adds `testprovider:index:Updatable` — a new testprovider resource that supports updates with per-key diff reporting via the gRPC `diffs` field

Closes #22068

## Test plan

- [x] `TestPreviewChangesOnlyRequiresJSON` — verifies `--changes-only` without `--json` returns error
- [x] `TestPreviewChangesOnlyFiltersDigest` — full end-to-end: deploys 3 resources via YAML + testprovider, rewrites program to trigger update/create/delete, runs `pulumi preview --json --changes-only`, parses `PreviewDigest` JSON and asserts:
  - Unchanged resource `keep` is absent
  - Updated resource only has changed key `foo` in `NewState.Inputs` (unchanged `bar` stripped)
  - Outputs are empty across all steps
  - Deleted resource retains full `OldState.Inputs`
  - Created resource retains full `NewState.Inputs`
  - `ChangeSummary` is correct (1 create / 1 update / 1 delete)
  - `DiffReasons` preserved
- [x] `TestPreviewChangesOnlyVsPlain` — runs both `--json` and `--json --changes-only` on same state, verifies the latter is a strict filter over the former
- [x] `make lint` passes (0 issues across all modules)
- [x] `make format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)