### PR TITLE
Add a public export map accessor for unit testing (Python)

### DIFF
--- a/changelog/pending/20260412--sdk-python--the-current-exports-map-is-now-available-for-unit-testing-through-get-current-export-map.yaml
+++ b/changelog/pending/20260412--sdk-python--the-current-exports-map-is-now-available-for-unit-testing-through-get-current-export-map.yaml
@@ -1,0 +1,6 @@
+component: sdk/python
+kind: feat
+body: The current exports map is now available for unit testing through `get_current_export_map`
+time: 2026-06-10T11:44:00.000000+00:00
+custom:
+    PR: "22586"

--- a/changelog/pending/20260412--sdk-python--the-current-exports-map-is-now-available-for-unit-testing-through-get-current-export-map.yaml
+++ b/changelog/pending/20260412--sdk-python--the-current-exports-map-is-now-available-for-unit-testing-through-get-current-export-map.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/python
+  description: The current exports map is now available for unit testing through `get_current_export_map`

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -109,6 +109,8 @@ from .resource_hooks import (
     error_hook,
 )
 
+from .runtime.stack import get_current_export_map
+
 from .log import (
     debug,
     info,
@@ -182,6 +184,7 @@ __all__ = [
     "ResourceOptions",
     "create_urn",
     "export",
+    "get_current_export_map",
     "ROOT_STACK_RESOURCE",
     "ResourceTransformation",
     "ResourceTransformationArgs",

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -22,8 +22,6 @@ resources.
 # The instrumentation works by monkey-patching grpc, which must happen before it's loaded.
 from .runtime import _instrumentation  # noqa: F401 - imported for side effects
 
-from .runtime.stack import get_current_export_map
-
 # Make all module members inside of this package available as package members.
 from .asset import (
     Asset,
@@ -110,6 +108,8 @@ from .resource_hooks import (
     resource_hook,
     error_hook,
 )
+
+from .runtime.stack import get_current_export_map
 
 from .log import (
     debug,

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -22,6 +22,8 @@ resources.
 # The instrumentation works by monkey-patching grpc, which must happen before it's loaded.
 from .runtime import _instrumentation  # noqa: F401 - imported for side effects
 
+from .runtime.stack import get_current_export_map
+
 # Make all module members inside of this package available as package members.
 from .asset import (
     Asset,
@@ -182,6 +184,7 @@ __all__ = [
     "ResourceOptions",
     "create_urn",
     "export",
+    "get_current_export_map",
     "ROOT_STACK_RESOURCE",
     "ResourceTransformation",
     "ResourceTransformationArgs",

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -46,6 +46,7 @@ from .settings import (
 
 from .stack import (
     run_in_stack,
+    get_current_export_map,
     register_stack_transformation,
     register_stack_transform,
     register_resource_transform,
@@ -98,6 +99,7 @@ __all__ = [
     "require_pulumi_version",
     # stack
     "run_in_stack",
+    "get_current_export_map",
     "register_stack_transformation",
     "register_stack_transform",
     "register_resource_transform",

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -227,6 +227,14 @@ class Stack(ComponentResource):
         self.outputs[name] = value
 
 
+def get_current_export_map() -> dict[str, Any]:
+    """Get a copy of the current export map. Primarily useful for testing."""
+    root = get_root_resource()
+    if root is not None and isinstance(root, Stack):
+        return dict(root.outputs)
+    return {}
+
+
 # Note: we use a List here instead of a set as many objects are unhashable.  This is inefficient,
 # but python seems to offer no alternative.
 def massage(attr: Any, seen: list[Any]):

--- a/sdk/python/lib/test/test_export_map.py
+++ b/sdk/python/lib/test/test_export_map.py
@@ -1,0 +1,98 @@
+# Copyright 2026, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for get_current_export_map, which exposes stack exports for
+unit testing assertions."""
+
+from copy import deepcopy
+
+from pulumi.runtime.stack import Stack
+from pulumi.runtime import settings, mocks
+import pulumi
+
+
+class MyMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        raise Exception("call")
+
+
+def _setup_mocks():
+    """Reset options with proper project/stack names and configure a mock
+    monitor so that Stack URNs are well-formed, without auto-creating a
+    root Stack (which ``set_mocks`` would do)."""
+    old_settings = deepcopy(settings.SETTINGS)
+    mm = MyMocks()
+    settings.reset_options(project="test", stack="test")
+    settings.configure(
+        mocks.MockSettings(
+            monitor=mocks.MockMonitor(mm),
+            engine=mocks.MockEngine(None),
+            project="test",
+            stack="test",
+            dry_run=False,
+        )
+    )
+    return old_settings
+
+
+def test_get_current_export_map():
+    old_settings = _setup_mocks()
+
+    def program():
+        pulumi.export("fruit", "banana")
+        pulumi.export("color", "yellow")
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        assert export_map == {"fruit": "banana", "color": "yellow"}
+    finally:
+        settings.configure(old_settings)
+
+
+def test_get_current_export_map_returns_copy():
+    old_settings = _setup_mocks()
+
+    def program():
+        pulumi.export("key", "value")
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        export_map["key"] = "modified"
+
+        # The original should be unaffected.
+        assert pulumi.get_current_export_map() == {"key": "value"}
+    finally:
+        settings.configure(old_settings)
+
+
+def test_get_current_export_map_empty():
+    old_settings = _setup_mocks()
+
+    def program():
+        pass
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        assert export_map == {}
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/test_export_map.py
+++ b/sdk/python/lib/test/test_export_map.py
@@ -1,0 +1,85 @@
+# Copyright 2016, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for get_current_export_map, which exposes stack exports for
+unit testing assertions.
+
+Part of https://github.com/pulumi/pulumi/issues/6113
+"""
+
+from copy import deepcopy
+
+from pulumi.runtime.stack import Stack
+from pulumi.runtime import settings
+import pulumi
+
+
+class MyMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        raise Exception("call")
+
+
+def test_get_current_export_map():
+    settings.reset_options()
+    old_settings = deepcopy(settings.SETTINGS)
+
+    def program():
+        pulumi.export("fruit", "banana")
+        pulumi.export("color", "yellow")
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        assert export_map == {"fruit": "banana", "color": "yellow"}
+    finally:
+        settings.configure(old_settings)
+
+
+def test_get_current_export_map_returns_copy():
+    settings.reset_options()
+    old_settings = deepcopy(settings.SETTINGS)
+
+    def program():
+        pulumi.export("key", "value")
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        export_map["key"] = "modified"
+
+        # The original should be unaffected.
+        assert pulumi.get_current_export_map() == {"key": "value"}
+    finally:
+        settings.configure(old_settings)
+
+
+def test_get_current_export_map_empty():
+    settings.reset_options()
+    old_settings = deepcopy(settings.SETTINGS)
+
+    def program():
+        pass
+
+    try:
+        Stack(program)
+
+        export_map = pulumi.get_current_export_map()
+        assert export_map == {}
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/test_export_map.py
+++ b/sdk/python/lib/test/test_export_map.py
@@ -21,7 +21,7 @@ Part of https://github.com/pulumi/pulumi/issues/6113
 from copy import deepcopy
 
 from pulumi.runtime.stack import Stack
-from pulumi.runtime import settings
+from pulumi.runtime import settings, mocks
 import pulumi
 
 
@@ -33,9 +33,27 @@ class MyMocks(pulumi.runtime.Mocks):
         raise Exception("call")
 
 
-def test_get_current_export_map():
-    settings.reset_options()
+def _setup_mocks():
+    """Reset options with proper project/stack names and configure a mock
+    monitor so that Stack URNs are well-formed, without auto-creating a
+    root Stack (which ``set_mocks`` would do)."""
     old_settings = deepcopy(settings.SETTINGS)
+    mm = MyMocks()
+    settings.reset_options(project="test", stack="test")
+    settings.configure(
+        mocks.MockSettings(
+            monitor=mocks.MockMonitor(mm),
+            engine=mocks.MockEngine(None),
+            project="test",
+            stack="test",
+            dry_run=False,
+        )
+    )
+    return old_settings
+
+
+def test_get_current_export_map():
+    old_settings = _setup_mocks()
 
     def program():
         pulumi.export("fruit", "banana")
@@ -51,8 +69,7 @@ def test_get_current_export_map():
 
 
 def test_get_current_export_map_returns_copy():
-    settings.reset_options()
-    old_settings = deepcopy(settings.SETTINGS)
+    old_settings = _setup_mocks()
 
     def program():
         pulumi.export("key", "value")
@@ -70,8 +87,7 @@ def test_get_current_export_map_returns_copy():
 
 
 def test_get_current_export_map_empty():
-    settings.reset_options()
-    old_settings = deepcopy(settings.SETTINGS)
+    old_settings = _setup_mocks()
 
     def program():
         pass


### PR DESCRIPTION
Continuation of #20471 for #6113.

Long-time listeners may remember this PR from before, and our conversations to avoid it using the event stream. While I still think that's a better fix, this issue needs closing, and the code already exists in Go, so we should probably just add this for now and deprecate it when we have a better solution.