### PR TITLE
Neo Approvals

### DIFF
--- a/changelog/pending/20260415--cli--add-approval-flow-for-pulumi-neo.yaml
+++ b/changelog/pending/20260415--cli--add-approval-flow-for-pulumi-neo.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    Add support for handling user approval requests in the `pulumi neo` terminal UI.
+    When the agent requests confirmation for a sensitive action, the TUI prompts the
+    user and forwards their response back to the Pulumi Console. Hidden behind
+    PULUMI_EXPERIMENTAL.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1531,7 +1531,7 @@ func (b *cloudBackend) createNeoTaskOnError(
 		"Help me debug the following Pulumi error for project %s and stack %s:\n\n%s",
 		stackID.Project, stackID.Stack.String(), pulumiOutput)
 
-	return b.client.CreateNeoTask(ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, "")
+	return b.client.CreateNeoTask(ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, "", "")
 }
 
 type updateMetadata struct {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -55,6 +55,16 @@ const (
 	NeoRequestTimeout = 20 * time.Second
 )
 
+// NeoApprovalMode controls whether the agent requires user approval before executing tools.
+type NeoApprovalMode string
+
+const (
+	// NeoApprovalModeManual requires the agent to request user approval for each tool call.
+	NeoApprovalModeManual NeoApprovalMode = "manual"
+	// NeoApprovalModeAuto allows the agent to execute tools without user approval.
+	NeoApprovalModeAuto NeoApprovalMode = "auto"
+)
+
 // NeoTaskRequest represents a request to create a Neo task. This is a thin client-side
 // shape that the server deserializes into apitype.CreateAgentTaskRequest, so the JSON
 // field names must match the IDL-generated tags exactly.
@@ -66,6 +76,9 @@ type NeoTaskRequest struct {
 	// pulumi_preview, pulumi_up) and waits for cli_tool_result user events in response.
 	// JSON tag is camelCase to match apitype.CreateAgentTaskRequest from pulumi-service.
 	ToolExecutionMode string `json:"toolExecutionMode,omitempty"`
+	// ApprovalMode controls whether the agent requires user approval before executing tools.
+	// JSON tag is camelCase to match apitype.CreateAgentTaskRequest from pulumi-service.
+	ApprovalMode NeoApprovalMode `json:"approvalMode,omitempty"`
 }
 
 // NeoTaskMessage represents the message content for a Neo task.
@@ -1673,7 +1686,8 @@ func (pc *Client) ExplainPreviewWithNeo(
 // CreateNeoTask creates a new Neo agent task via the Neo Tasks API. Pass an empty
 // toolExecutionMode for the default (cloud) mode used by `--neo-task-on-failure`; pass
 // "cli" to have the cloud agent emit CliToolRequest events for the local-tool subset
-// (filesystem, shell) instead of running them itself.
+// (filesystem, shell) instead of running them itself. Pass an approvalMode of "manual"
+// to require user approval before each tool call; empty uses the server default.
 func (pc *Client) CreateNeoTask(
 	ctx context.Context,
 	orgName string,
@@ -1681,6 +1695,7 @@ func (pc *Client) CreateNeoTask(
 	stackName string,
 	projectName string,
 	toolExecutionMode string,
+	approvalMode NeoApprovalMode,
 ) (*NeoTaskResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
 	defer cancel()
@@ -1692,6 +1707,7 @@ func (pc *Client) CreateNeoTask(
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
 		ToolExecutionMode: toolExecutionMode,
+		ApprovalMode:      approvalMode,
 	}
 	// Only attach a stack entity when we actually have one — the backend rejects
 	// entity_diff entries with empty name/project as "unable to access stack".

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -867,7 +867,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer successServer.Close()
 
 		client := newMockClient(successServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "")
+		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
 
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -881,7 +881,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer errorServer.Close()
 
 		client := newMockClient(errorServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "")
+		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -895,7 +895,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer unauthorizedServer.Close()
 
 		client := newMockClient(unauthorizedServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "")
+		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -922,7 +922,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", "cli")
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", "cli", "")
 		require.NoError(t, err)
 
 		assert.Equal(t, http.MethodPost, gotMethod)
@@ -958,7 +958,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "")
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "")
 		require.NoError(t, err)
 
 		message, _ := gotBody["message"].(map[string]any)

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -928,6 +928,9 @@ func TestCreateNeoTask(t *testing.T) {
 		assert.Equal(t, http.MethodPost, gotMethod)
 		assert.Equal(t, "/api/preview/agents/my-org/tasks", gotPath)
 		assert.Equal(t, "cli", gotBody["toolExecutionMode"])
+		// approvalMode is omitempty — must not appear in the body when empty so the
+		// server falls back to its default (auto) mode.
+		assert.NotContains(t, gotBody, "approvalMode", "empty approvalMode must be omitted")
 
 		message, _ := gotBody["message"].(map[string]any)
 		require.NotNil(t, message)
@@ -942,6 +945,28 @@ func TestCreateNeoTask(t *testing.T) {
 		assert.Equal(t, "stack", entity["type"])
 		assert.Equal(t, "stack", entity["name"])
 		assert.Equal(t, "proj", entity["project"])
+	})
+
+	t.Run("ApprovalModeManualSerializes", func(t *testing.T) {
+		t.Parallel()
+
+		// When the CLI passes NeoApprovalModeManual, the body must carry
+		// approvalMode:"manual" so the server gates each tool call on a
+		// user_approval_request. The wire tag is camelCase to match the IDL.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_3"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(
+			t.Context(), "my-org", "hi", "stack", "proj", "cli", NeoApprovalModeManual)
+		require.NoError(t, err)
+
+		assert.Equal(t, "manual", gotBody["approvalMode"])
 	})
 
 	t.Run("OmitsEntityDiffWhenStackMissing", func(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -49,12 +49,3 @@ const (
 	backendEventCancelled            = "cancelled"
 	backendEventUserApprovalRequest  = "user_approval_request"
 )
-
-// UserConfirmationEvent is the user event the CLI posts in response to a
-// user_approval_request, approving or denying the requested operation.
-type UserConfirmationEvent struct {
-	Type       string `json:"type"`                   // always "user_confirmation"
-	ApprovalID string `json:"approval_request_id"`    // echoes the approval_request_id from the request
-	Approved   bool   `json:"ok"`                     // true to approve, false to deny
-	Message    string `json:"instructions,omitempty"` // if rejected, guidance for the agent on what to do instead
-}

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -38,9 +38,23 @@ const (
 	// message into the TUI.
 	userEventUserMessage = "user_message"
 
+	// userEventUserConfirmation is the user event the CLI posts in response to a
+	// user_approval_request backend event, approving or denying the operation.
+	userEventUserConfirmation = "user_confirmation"
+
 	// Additional backend event types forwarded to the TUI.
 	backendEventExecToolCallProgress = "exec_tool_call_progress"
 	backendEventError                = "error"
 	backendEventWarning              = "warning"
 	backendEventCancelled            = "cancelled"
+	backendEventUserApprovalRequest  = "user_approval_request"
 )
+
+// UserConfirmationEvent is the user event the CLI posts in response to a
+// user_approval_request, approving or denying the requested operation.
+type UserConfirmationEvent struct {
+	Type       string `json:"type"`                   // always "user_confirmation"
+	ApprovalID string `json:"approval_request_id"`    // echoes the approval_request_id from the request
+	Approved   bool   `json:"ok"`                     // true to approve, false to deny
+	Message    string `json:"instructions,omitempty"` // if rejected, guidance for the agent on what to do instead
+}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -129,7 +129,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
-		resp, err := pc.CreateNeoTask(ctx, orgName, prompt, stackRefName, projectName, "cli")
+		resp, err := pc.CreateNeoTask(ctx, orgName, prompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
 		if err != nil {
 			return err
 		}
@@ -151,17 +151,19 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	uiCh := make(chan UIEvent, 64)
 	sendCh := make(chan string, 4)
+	approvalCh := make(chan ApprovalResponse, 4)
 
 	// Resolve the username for the welcome greeting.
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
 	model := NewModel(ModelConfig{
-		Org:      orgName,
-		WorkDir:  cwdFlag,
-		Username: username,
-		EventCh:  uiCh,
-		SendCh:   sendCh,
-		Busy:     prompt != "",
+		Org:        orgName,
+		WorkDir:    cwdFlag,
+		Username:   username,
+		EventCh:    uiCh,
+		SendCh:     sendCh,
+		ApprovalCh: approvalCh,
+		Busy:       prompt != "",
 	})
 
 	p := tea.NewProgram(model,
@@ -181,7 +183,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// createTask creates the Neo task with the given prompt and starts the session.
 	// Called immediately if a prompt was provided, or on the first user message.
 	createTask := func(initialPrompt string) error {
-		resp, err := pc.CreateNeoTask(gctx, orgName, initialPrompt, stackRefName, projectName, "cli")
+		resp, err := pc.CreateNeoTask(gctx, orgName, initialPrompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
 		if err != nil {
 			return err
 		}
@@ -196,11 +198,12 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		}
 
 		session := &Session{
-			Client:   pc,
-			Handlers: handlers,
-			OrgName:  orgName,
-			TaskID:   resp.TaskID,
-			UIEvents: uiCh,
+			Client:     pc,
+			Handlers:   handlers,
+			OrgName:    orgName,
+			TaskID:     resp.TaskID,
+			UIEvents:   uiCh,
+			ApprovalCh: approvalCh,
 		}
 		return session.Run(gctx)
 	}
@@ -216,6 +219,8 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		return err
 	})
 
+	// Post user chat messages to the API. If no task exists yet, the first
+	// message creates one.
 	g.Go(func() error {
 		taskCreated := prompt != ""
 		for {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -150,20 +150,18 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	}
 
 	uiCh := make(chan UIEvent, 64)
-	sendCh := make(chan string, 4)
-	approvalCh := make(chan ApprovalResponse, 4)
+	outCh := make(chan apitype.AgentUserEvent, 8)
 
 	// Resolve the username for the welcome greeting.
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
 	model := NewModel(ModelConfig{
-		Org:        orgName,
-		WorkDir:    cwdFlag,
-		Username:   username,
-		EventCh:    uiCh,
-		SendCh:     sendCh,
-		ApprovalCh: approvalCh,
-		Busy:       prompt != "",
+		Org:      orgName,
+		WorkDir:  cwdFlag,
+		Username: username,
+		EventCh:  uiCh,
+		OutCh:    outCh,
+		Busy:     prompt != "",
 	})
 
 	p := tea.NewProgram(model,
@@ -183,7 +181,8 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// createTask creates the Neo task with the given prompt and starts the session.
 	// Called immediately if a prompt was provided, or on the first user message.
 	createTask := func(initialPrompt string) error {
-		resp, err := pc.CreateNeoTask(gctx, orgName, initialPrompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
+		resp, err := pc.CreateNeoTask(
+			gctx, orgName, initialPrompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
 		if err != nil {
 			return err
 		}
@@ -198,12 +197,11 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		}
 
 		session := &Session{
-			Client:     pc,
-			Handlers:   handlers,
-			OrgName:    orgName,
-			TaskID:     resp.TaskID,
-			UIEvents:   uiCh,
-			ApprovalCh: approvalCh,
+			Client:   pc,
+			Handlers: handlers,
+			OrgName:  orgName,
+			TaskID:   resp.TaskID,
+			UIEvents: uiCh,
 		}
 		return session.Run(gctx)
 	}
@@ -219,22 +217,23 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		return err
 	})
 
-	// Post user chat messages to the API. If no task exists yet, the first
-	// message creates one.
+	// Post TUI-originated user events to the API. Chat messages may arrive before
+	// any task exists — the first one creates it. Other event types (approvals
+	// and anything we add later) only make sense once a task is live.
 	g.Go(func() error {
 		taskCreated := prompt != ""
 		for {
 			select {
 			case <-gctx.Done():
 				return nil
-			case text, ok := <-sendCh:
+			case evt, ok := <-outCh:
 				if !ok {
 					return nil
 				}
-				if !taskCreated {
+				if msg, isMsg := evt.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
 					taskCreated = true
 					g.Go(func() error {
-						return createTask(text)
+						return createTask(msg.Content)
 					})
 					continue
 				}
@@ -243,17 +242,14 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 				ts.mu.Unlock()
 				if taskID == "" {
 					// Unreachable in normal use: the TUI gates Enter on busy state
-					// until UITaskIdle, so no message should arrive here before the
-					// task ID is known. Surface instead of silently dropping.
-					sendUI(uiCh, UIWarning{Message: "dropped message: task not ready"})
+					// until UITaskIdle, and approvals only fire in response to backend
+					// events that imply the task exists. Surface instead of silently
+					// dropping.
+					sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
 					continue
 				}
-				evt := apitype.AgentUserEventUserMessage{
-					Type:    userEventUserMessage,
-					Content: text,
-				}
 				if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, evt); err != nil {
-					sendUI(uiCh, UIWarning{Message: "failed to send message: " + err.Error()})
+					sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
 				}
 			}
 		}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -54,6 +54,17 @@ type Session struct {
 	// UIEvents, when non-nil, receives parsed events for the bubbletea TUI to display.
 	// The Session closes this channel when Run() exits.
 	UIEvents chan<- UIEvent
+	// ApprovalCh, when non-nil, receives approval responses from the TUI.
+	// The session posts them to the API from its own goroutine, avoiding races
+	// with tool result posts in runBatch.
+	ApprovalCh <-chan ApprovalResponse
+}
+
+// ApprovalResponse carries the user's answer to an approval request.
+type ApprovalResponse struct {
+	ApprovalID string
+	Approved   bool
+	Message    string
 }
 
 // Run drives the loop. It blocks until ctx is cancelled or the SSE stream errors out.
@@ -81,6 +92,10 @@ func (s *Session) Run(ctx context.Context) error {
 			}
 			if err := s.handleEvent(ctx, evt.Data); err != nil {
 				return err
+			}
+		case resp, ok := <-s.approvalCh():
+			if ok {
+				s.postApproval(ctx, resp)
 			}
 		}
 	}
@@ -214,6 +229,25 @@ func (s *Session) logf(format string, args ...any) {
 	fmt.Fprintf(s.Log, format+"\n", args...)
 }
 
+// approvalCh returns the ApprovalCh or a nil channel (blocks forever in select).
+func (s *Session) approvalCh() <-chan ApprovalResponse {
+	return s.ApprovalCh
+}
+
+// postApproval posts a UserConfirmationEvent to the API from the session goroutine.
+func (s *Session) postApproval(ctx context.Context, resp ApprovalResponse) {
+	evt := UserConfirmationEvent{
+		Type:       userEventUserConfirmation,
+		ApprovalID: resp.ApprovalID,
+		Approved:   resp.Approved,
+		Message:    resp.Message,
+	}
+	if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, evt); err != nil {
+		s.logf("error: posting user_confirmation: %v", err)
+		sendUI(s.UIEvents, UIWarning{Message: "failed to send approval: " + err.Error()})
+	}
+}
+
 // sendUI sends a UIEvent to the TUI channel if it is connected.
 // Uses a non-blocking send so the session loop is never blocked by a slow TUI.
 func sendUI(ch chan<- UIEvent, evt UIEvent) {
@@ -266,6 +300,16 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 		sendUI(s.UIEvents, UIWarning{Message: w.Message})
 	case backendEventCancelled:
 		sendUI(s.UIEvents, UICancelled{})
+	case backendEventUserApprovalRequest:
+		var a apitype.AgentBackendEventUserApprovalRequest
+		if err := json.Unmarshal(eventBody, &a); err != nil {
+			return
+		}
+		sendUI(s.UIEvents, UIApprovalRequest{
+			ApprovalID:  a.ID,
+			Message:     a.Message,
+			Sensitivity: a.Sensitivity,
+		})
 	}
 	// Server-side exec_tool_call and tool_response events describe tools the agent
 	// runtime executes; the CLI-run equivalents are emitted directly from runBatch.

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -234,9 +234,9 @@ func (s *Session) approvalCh() <-chan ApprovalResponse {
 	return s.ApprovalCh
 }
 
-// postApproval posts a UserConfirmationEvent to the API from the session goroutine.
+// postApproval posts an AgentUserEventUserConfirmation to the API from the session goroutine.
 func (s *Session) postApproval(ctx context.Context, resp ApprovalResponse) {
-	evt := UserConfirmationEvent{
+	evt := apitype.AgentUserEventUserConfirmation{
 		Type:       userEventUserConfirmation,
 		ApprovalID: resp.ApprovalID,
 		Approved:   resp.Approved,

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -54,17 +54,6 @@ type Session struct {
 	// UIEvents, when non-nil, receives parsed events for the bubbletea TUI to display.
 	// The Session closes this channel when Run() exits.
 	UIEvents chan<- UIEvent
-	// ApprovalCh, when non-nil, receives approval responses from the TUI.
-	// The session posts them to the API from its own goroutine, avoiding races
-	// with tool result posts in runBatch.
-	ApprovalCh <-chan ApprovalResponse
-}
-
-// ApprovalResponse carries the user's answer to an approval request.
-type ApprovalResponse struct {
-	ApprovalID string
-	Approved   bool
-	Message    string
 }
 
 // Run drives the loop. It blocks until ctx is cancelled or the SSE stream errors out.
@@ -92,10 +81,6 @@ func (s *Session) Run(ctx context.Context) error {
 			}
 			if err := s.handleEvent(ctx, evt.Data); err != nil {
 				return err
-			}
-		case resp, ok := <-s.approvalCh():
-			if ok {
-				s.postApproval(ctx, resp)
 			}
 		}
 	}
@@ -227,25 +212,6 @@ func (s *Session) logf(format string, args ...any) {
 		return
 	}
 	fmt.Fprintf(s.Log, format+"\n", args...)
-}
-
-// approvalCh returns the ApprovalCh or a nil channel (blocks forever in select).
-func (s *Session) approvalCh() <-chan ApprovalResponse {
-	return s.ApprovalCh
-}
-
-// postApproval posts an AgentUserEventUserConfirmation to the API from the session goroutine.
-func (s *Session) postApproval(ctx context.Context, resp ApprovalResponse) {
-	evt := apitype.AgentUserEventUserConfirmation{
-		Type:       userEventUserConfirmation,
-		ApprovalID: resp.ApprovalID,
-		Approved:   resp.Approved,
-		Message:    resp.Message,
-	}
-	if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, evt); err != nil {
-		s.logf("error: posting user_confirmation: %v", err)
-		sendUI(s.UIEvents, UIWarning{Message: "failed to send approval: " + err.Error()})
-	}
 }
 
 // sendUI sends a UIEvent to the TUI channel if it is connected.

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -712,6 +712,20 @@ func TestSession_ForwardToUI_EmitsAllEventTypes(t *testing.T) {
 				return ok
 			},
 		},
+		{
+			"user_approval_request",
+			map[string]any{
+				"type":        backendEventUserApprovalRequest,
+				"id":          "appr_42",
+				"message":     "Run pulumi up?",
+				"sensitivity": "high",
+			},
+			func(e UIEvent) bool {
+				m, ok := e.(UIApprovalRequest)
+				return ok && m.ApprovalID == "appr_42" &&
+					m.Message == "Run pulumi up?" && m.Sensitivity == "high"
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -23,14 +23,13 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 // inputBarHeight is the number of terminal lines reserved for the input area
 // (separator + input line + hint line).
 const inputBarHeight = 3
-
-// approvalResponse is an alias for the session's ApprovalResponse type,
-// used by the TUI to send approval answers back to the session goroutine.
 
 // blockKind identifies the type of rendered block in the output log.
 type blockKind int
@@ -60,12 +59,14 @@ type block struct {
 
 // ModelConfig holds the parameters needed to create a TUI Model.
 type ModelConfig struct {
-	Org        string
-	WorkDir    string
-	Username   string
-	EventCh    <-chan UIEvent
-	SendCh     chan<- string
-	ApprovalCh chan<- ApprovalResponse
+	Org      string
+	WorkDir  string
+	Username string
+	EventCh  <-chan UIEvent
+	// OutCh carries every TUI-originated user event (chat messages, approval
+	// answers, …) to the dispatcher in runNeo. A single typed channel keeps
+	// Session focused on SSE intake and tool dispatch.
+	OutCh chan<- apitype.AgentUserEvent
 	// Busy seeds the input-gating state. True when the caller has already
 	// handed a prompt to the backend — the TUI starts with Enter disabled
 	// until the first UITaskIdle.
@@ -74,13 +75,12 @@ type ModelConfig struct {
 
 // Model is the top-level bubbletea model for the Neo TUI.
 type Model struct {
-	welcome    welcomeModel
-	viewport   viewport.Model
-	textInput  textinput.Model
-	blocks     []block
-	eventCh    <-chan UIEvent
-	sendCh     chan<- string
-	approvalCh chan<- ApprovalResponse
+	welcome   welcomeModel
+	viewport  viewport.Model
+	textInput textinput.Model
+	blocks    []block
+	eventCh   <-chan UIEvent
+	outCh     chan<- apitype.AgentUserEvent
 	// busy is true from the moment the user sends a message (or a prompt was
 	// provided up front) until the session emits UITaskIdle / UICancelled /
 	// UIError. While busy, Enter is swallowed so the user can't talk over
@@ -137,15 +137,14 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		viewport:   vp,
-		textInput:  ti,
-		eventCh:    cfg.EventCh,
-		sendCh:     cfg.SendCh,
-		approvalCh: cfg.ApprovalCh,
-		busy:       cfg.Busy,
-		spinner:    sp,
-		width:      80,
-		height:     24,
+		viewport:  vp,
+		textInput: ti,
+		eventCh:   cfg.EventCh,
+		outCh:     cfg.OutCh,
+		busy:      cfg.Busy,
+		spinner:   sp,
+		width:     80,
+		height:    24,
 	}
 	m.viewport.SetContent(m.welcome.View())
 	if cfg.Busy {
@@ -209,9 +208,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if !approved {
 					denialMsg = text
 				}
-				if m.approvalCh != nil {
+				if m.outCh != nil {
 					select {
-					case m.approvalCh <- ApprovalResponse{
+					case m.outCh <- apitype.AgentUserEventUserConfirmation{
+						Type:       userEventUserConfirmation,
 						ApprovalID: m.pendingApprovalID,
 						Approved:   approved,
 						Message:    denialMsg,
@@ -256,9 +256,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			text := strings.TrimSpace(m.textInput.Value())
 			if text != "" {
 				m.textInput.Reset()
-				if m.sendCh != nil {
+				if m.outCh != nil {
 					select {
-					case m.sendCh <- text:
+					case m.outCh <- apitype.AgentUserEventUserMessage{
+						Type:    userEventUserMessage,
+						Content: text,
+					}:
 						return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
 					default:
 					}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -93,9 +93,7 @@ type Model struct {
 	height     int
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
-	frame int
-	// Approval state: set when the session has emitted a UIApprovalRequest and
-	// the TUI is waiting for the user to type y/yes or a denial reason.
+	frame             int
 	pendingApproval   bool
 	pendingApprovalID string
 }
@@ -197,9 +195,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
-		// Approval mode: "y"/"yes" + Enter approves, anything else + Enter denies
-		// with the typed text as guidance. We handle this before the busy check
-		// because the agent is intentionally paused here waiting for the user.
+		// Handled before the busy check because the agent is intentionally
+		// paused here waiting for the user.
 		if m.pendingApproval {
 			if msg.Type == tea.KeyEnter {
 				text := strings.TrimSpace(m.textInput.Value())
@@ -241,7 +238,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.rebuildContent()
 				return m, nil
 			}
-			// Pass other keys to textinput for typing the denial reason.
 			var tiCmd tea.Cmd
 			m.textInput, tiCmd = m.textInput.Update(msg)
 			return m, tiCmd

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -29,6 +29,9 @@ import (
 // (separator + input line + hint line).
 const inputBarHeight = 3
 
+// approvalResponse is an alias for the session's ApprovalResponse type,
+// used by the TUI to send approval answers back to the session goroutine.
+
 // blockKind identifies the type of rendered block in the output log.
 type blockKind int
 
@@ -41,6 +44,7 @@ const (
 	blockWarning
 	blockCancelled
 	blockUserMessage
+	blockApproval
 )
 
 // block is a single rendered item in the TUI output log.
@@ -56,11 +60,12 @@ type block struct {
 
 // ModelConfig holds the parameters needed to create a TUI Model.
 type ModelConfig struct {
-	Org      string
-	WorkDir  string
-	Username string
-	EventCh  <-chan UIEvent
-	SendCh   chan<- string
+	Org        string
+	WorkDir    string
+	Username   string
+	EventCh    <-chan UIEvent
+	SendCh     chan<- string
+	ApprovalCh chan<- ApprovalResponse
 	// Busy seeds the input-gating state. True when the caller has already
 	// handed a prompt to the backend — the TUI starts with Enter disabled
 	// until the first UITaskIdle.
@@ -69,12 +74,13 @@ type ModelConfig struct {
 
 // Model is the top-level bubbletea model for the Neo TUI.
 type Model struct {
-	welcome   welcomeModel
-	viewport  viewport.Model
-	textInput textinput.Model
-	blocks    []block
-	eventCh   <-chan UIEvent
-	sendCh    chan<- string
+	welcome    welcomeModel
+	viewport   viewport.Model
+	textInput  textinput.Model
+	blocks     []block
+	eventCh    <-chan UIEvent
+	sendCh     chan<- string
+	approvalCh chan<- ApprovalResponse
 	// busy is true from the moment the user sends a message (or a prompt was
 	// provided up front) until the session emits UITaskIdle / UICancelled /
 	// UIError. While busy, Enter is swallowed so the user can't talk over
@@ -88,6 +94,10 @@ type Model struct {
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
 	frame int
+	// Approval state: set when the session has emitted a UIApprovalRequest and
+	// the TUI is waiting for the user to type y/yes or a denial reason.
+	pendingApproval   bool
+	pendingApprovalID string
 }
 
 var (
@@ -127,14 +137,15 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		viewport:  vp,
-		textInput: ti,
-		eventCh:   cfg.EventCh,
-		sendCh:    cfg.SendCh,
-		busy:      cfg.Busy,
-		spinner:   sp,
-		width:     80,
-		height:    24,
+		viewport:   vp,
+		textInput:  ti,
+		eventCh:    cfg.EventCh,
+		sendCh:     cfg.SendCh,
+		approvalCh: cfg.ApprovalCh,
+		busy:       cfg.Busy,
+		spinner:    sp,
+		width:      80,
+		height:     24,
 	}
 	m.viewport.SetContent(m.welcome.View())
 	if cfg.Busy {
@@ -183,11 +194,60 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rebuildContent()
 
 	case tea.KeyMsg:
-		//nolint:exhaustive // Only Ctrl-C and Enter need special handling; everything else flows through to the text input.
-		switch msg.Type {
-		case tea.KeyCtrlC:
+		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit
-		case tea.KeyEnter:
+		}
+
+		// Approval mode: "y"/"yes" + Enter approves, anything else + Enter denies
+		// with the typed text as guidance. We handle this before the busy check
+		// because the agent is intentionally paused here waiting for the user.
+		if m.pendingApproval {
+			if msg.Type == tea.KeyEnter {
+				text := strings.TrimSpace(m.textInput.Value())
+				approved := strings.EqualFold(text, "y") || strings.EqualFold(text, "yes")
+				var denialMsg string
+				if !approved {
+					denialMsg = text
+				}
+				if m.approvalCh != nil {
+					select {
+					case m.approvalCh <- ApprovalResponse{
+						ApprovalID: m.pendingApprovalID,
+						Approved:   approved,
+						Message:    denialMsg,
+					}:
+					default:
+					}
+				}
+				m.pendingApproval = false
+				m.pendingApprovalID = ""
+				m.textInput.Prompt = "❯ "
+				m.textInput.PromptStyle = promptStyle
+				m.textInput.Placeholder = "Send a message..."
+				m.textInput.Reset()
+				choice := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("✓ Approved")
+				if !approved {
+					choice = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("✗ Denied")
+					if denialMsg != "" {
+						choice += " — " + denialMsg
+					}
+				}
+				m.appendBlock(block{kind: blockUserMessage, rendered: "  " + choice})
+				if approved {
+					cmd := m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
+					m.rebuildContent()
+					return m, cmd
+				}
+				m.rebuildContent()
+				return m, nil
+			}
+			// Pass other keys to textinput for typing the denial reason.
+			var tiCmd tea.Cmd
+			m.textInput, tiCmd = m.textInput.Update(msg)
+			return m, tiCmd
+		}
+
+		if msg.Type == tea.KeyEnter {
 			if m.busy {
 				// Agent is mid-turn — leave the typed text in the input so
 				// the user can send it after the next UITaskIdle.
@@ -327,6 +387,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			kind:     blockUserMessage,
 			rendered: promptStyle.Render("❯") + " " + userMsgBubble.Render(" "+msg.Content+" "),
 		})
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIApprovalRequest:
+		m.endBusy()
+		warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+		m.appendBlock(block{
+			kind:     blockApproval,
+			rendered: "  " + warnStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
+		})
+		m.pendingApproval = true
+		m.pendingApprovalID = msg.ApprovalID
+		m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
+		m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+		m.textInput.Placeholder = ""
+		m.textInput.Reset()
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -92,3 +92,12 @@ type UIUserMessage struct {
 }
 
 func (UIUserMessage) uiEvent() {}
+
+// UIApprovalRequest signals that the agent needs user approval for an operation.
+type UIApprovalRequest struct {
+	ApprovalID  string
+	Message     string
+	Sensitivity string
+}
+
+func (UIApprovalRequest) uiEvent() {}

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -22,6 +22,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 // -----------------------------------------------------------------------------
@@ -319,9 +321,9 @@ func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {
 	t.Parallel()
 
 	// Enter while busy must be a no-op: the typed text stays in the input
-	// (user can retry after UITaskIdle) and no value is posted to sendCh.
-	sendCh := make(chan string, 1)
-	m := NewModel(ModelConfig{SendCh: sendCh, Busy: true})
+	// (user can retry after UITaskIdle) and no value is posted to outCh.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
 	m.textInput.SetValue("queued")
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -330,8 +332,8 @@ func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {
 	assert.Nil(t, cmd)
 	assert.Equal(t, "queued", um.textInput.Value(), "text must stay in input while busy")
 	select {
-	case got := <-sendCh:
-		t.Fatalf("no message must be sent while busy, got %q", got)
+	case got := <-outCh:
+		t.Fatalf("no message must be sent while busy, got %+v", got)
 	default:
 	}
 }
@@ -339,18 +341,20 @@ func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {
 func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 	t.Parallel()
 
-	sendCh := make(chan string, 1)
-	m := NewModel(ModelConfig{SendCh: sendCh})
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh})
 	m.textInput.SetValue("hello")
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	um := updated.(Model)
 
 	select {
-	case got := <-sendCh:
-		assert.Equal(t, "hello", got)
+	case got := <-outCh:
+		msg, ok := got.(apitype.AgentUserEventUserMessage)
+		require.True(t, ok, "Enter must post a UserMessage event")
+		assert.Equal(t, "hello", msg.Content)
 	default:
-		t.Fatal("Enter must post the input to sendCh")
+		t.Fatal("Enter must post the input to outCh")
 	}
 	assert.Empty(t, um.textInput.Value(), "input must clear after send")
 	assert.True(t, um.busy, "sending must enter the busy state")
@@ -359,8 +363,8 @@ func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 	t.Parallel()
 
-	sendCh := make(chan string, 1)
-	m := NewModel(ModelConfig{SendCh: sendCh})
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh})
 	// input left empty
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -368,9 +372,179 @@ func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 
 	assert.False(t, um.busy, "empty Enter must not enter the busy state")
 	select {
-	case got := <-sendCh:
-		t.Fatalf("empty Enter must not send, got %q", got)
+	case got := <-outCh:
+		t.Fatalf("empty Enter must not send, got %+v", got)
 	default:
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Approval flow
+// -----------------------------------------------------------------------------
+
+// newApprovalPendingModel returns a Model that has just received an approval
+// request — busy is cleared, pendingApproval is true, and the prompt has been
+// swapped to the approval prompt. Mirrors the state UIApprovalRequest leaves
+// behind so each Enter test can start from a known point.
+func newApprovalPendingModel(t *testing.T, outCh chan apitype.AgentUserEvent) Model {
+	t.Helper()
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: make(chan UIEvent, 4), Busy: true})
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:  "appr_1",
+		Message:     "Run pulumi up?",
+		Sensitivity: "high",
+	})
+	return updated.(Model)
+}
+
+func TestModel_Update_UIApprovalRequest_ShowsPromptAndPausesAgent(t *testing.T) {
+	t.Parallel()
+
+	// The approval request must clear busy (the agent is intentionally paused),
+	// append a visible approval block, and swap the input prompt so the user
+	// knows Enter now answers the approval rather than sending a chat message.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+
+	assert.False(t, m.busy, "approval request must end busy so the user can answer")
+	assert.True(t, m.pendingApproval)
+	assert.Equal(t, "appr_1", m.pendingApprovalID)
+	assert.GreaterOrEqual(t, m.findBlockKind(blockApproval), 0, "an approval block must be appended")
+	assert.Contains(t, m.textInput.Prompt, "Approve?", "input prompt must reflect approval mode")
+}
+
+func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"y", "Y", "yes", "YES", "Yes"}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			outCh := make(chan apitype.AgentUserEvent, 1)
+			m := newApprovalPendingModel(t, outCh)
+			m.textInput.SetValue(in)
+
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			um := updated.(Model)
+
+			// Must post a confirmation event with Approved=true and no instructions.
+			select {
+			case got := <-outCh:
+				conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+				require.True(t, ok, "expected UserConfirmation, got %T", got)
+				assert.True(t, conf.Approved, "%q must be parsed as approval", in)
+				assert.Equal(t, "appr_1", conf.ApprovalID, "must echo the request id")
+				assert.Empty(t, conf.Message, "approval must not carry instructions")
+				assert.Equal(t, userEventUserConfirmation, conf.Type)
+			default:
+				t.Fatalf("Enter must post a confirmation event")
+			}
+
+			// State must reset: pendingApproval cleared, prompt restored, input
+			// cleared, and a busy block re-armed because the agent is about to
+			// resume work.
+			assert.False(t, um.pendingApproval)
+			assert.Empty(t, um.pendingApprovalID)
+			assert.Empty(t, um.textInput.Value())
+			assert.True(t, um.busy, "approving must hand the turn back to the agent")
+			require.NotNil(t, cmd, "approval must return the spinner Tick command")
+		})
+	}
+}
+
+func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
+	t.Parallel()
+
+	// Anything that isn't "y"/"yes" is treated as a denial; the typed text becomes
+	// the instructions field so the agent can act on the user's reasoning.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+	m.textInput.SetValue("not on prod")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	um := updated.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got)
+		assert.False(t, conf.Approved)
+		assert.Equal(t, "appr_1", conf.ApprovalID)
+		assert.Equal(t, "not on prod", conf.Message, "denial must forward the typed reason")
+	default:
+		t.Fatal("Enter must post a confirmation event")
+	}
+
+	assert.False(t, um.pendingApproval)
+	assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
+	assert.Nil(t, cmd, "denial must not return a spinner cmd")
+}
+
+func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {
+	t.Parallel()
+
+	// An empty input is a denial with no instructions. Same outcome as a reasoned
+	// denial wire-wise (Approved=false), with an empty Message field.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+	// input left empty
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	um := updated.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got)
+		assert.False(t, conf.Approved)
+		assert.Empty(t, conf.Message)
+	default:
+		t.Fatal("Enter must post a confirmation event even on empty input")
+	}
+	assert.False(t, um.busy)
+}
+
+func TestModel_Update_Approval_NonEnterKey_ForwardsToTextInput(t *testing.T) {
+	t.Parallel()
+
+	// While waiting for approval, non-Enter keys must still type into the input
+	// (so the user can compose a denial reason). The approval state must NOT
+	// clear and no event may be posted.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	um := updated.(Model)
+
+	assert.True(t, um.pendingApproval, "non-Enter key must not exit approval mode")
+	assert.Equal(t, "a", um.textInput.Value())
+	select {
+	case got := <-outCh:
+		t.Fatalf("non-Enter must not post a confirmation, got %+v", got)
+	default:
+	}
+}
+
+func TestModel_Update_KeyEnter_Approval_NotGatedByBusy(t *testing.T) {
+	t.Parallel()
+
+	// The approval branch sits ahead of the busy gate in Update because the agent
+	// is intentionally paused waiting for the user. Even if busy somehow stayed
+	// true (e.g. a stray TickMsg arrived between UIApprovalRequest and Enter),
+	// Enter must still answer the approval rather than be swallowed.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+	m.busy = true // simulate a stale busy state
+	m.textInput.SetValue("y")
+
+	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	select {
+	case got := <-outCh:
+		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok)
+		assert.True(t, conf.Approved)
+	default:
+		t.Fatal("approval Enter must not be gated by busy")
 	}
 }
 

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -145,3 +145,12 @@ type AgentBackendEventUserApprovalRequest struct {
 	Message     string `json:"message,omitempty"`
 	Sensitivity string `json:"sensitivity,omitempty"`
 }
+
+// AgentUserEventUserConfirmation is the user event a CLI client posts in response to a
+// user_approval_request backend event, approving or denying the requested operation.
+type AgentUserEventUserConfirmation struct {
+	Type       string `json:"type"`                   // always "user_confirmation"
+	ApprovalID string `json:"approval_request_id"`    // echoes the approval_request_id from the request
+	Approved   bool   `json:"ok"`                     // true to approve, false to deny
+	Message    string `json:"instructions,omitempty"` // if rejected, guidance for the agent on what to do instead
+}

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -135,3 +135,13 @@ type AgentBackendEventWarning struct {
 type AgentBackendEventCancelled struct {
 	Type string `json:"type"` // always "cancelled"
 }
+
+// AgentBackendEventUserApprovalRequest is a backend event asking the user to approve or
+// deny a potentially-sensitive operation before the agent proceeds. The CLI replies with
+// a user_confirmation user event echoing the ID.
+type AgentBackendEventUserApprovalRequest struct {
+	Type        string `json:"type"` // always "user_approval_request"
+	ID          string `json:"id,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Sensitivity string `json:"sensitivity,omitempty"`
+}

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -104,9 +104,7 @@ type AgentUserEventExecToolCall struct {
 }
 
 // AgentUserEvent is the sealed interface implemented by user events the TUI posts back
-// to the Neo task. The CLI dispatcher carries values of this type on a single channel
-// and forwards them to PostNeoTaskUserEvent; the JSON discriminator is set per-variant
-// via the Type field.
+// to the Neo task. The JSON discriminator is set per-variant via the Type field.
 type AgentUserEvent interface {
 	isAgentUserEvent()
 }
@@ -159,9 +157,9 @@ type AgentBackendEventUserApprovalRequest struct {
 // AgentUserEventUserConfirmation is the user event a CLI client posts in response to a
 // user_approval_request backend event, approving or denying the requested operation.
 type AgentUserEventUserConfirmation struct {
-	Type       string `json:"type"`                   // always "user_confirmation"
-	ApprovalID string `json:"approval_request_id"`    // echoes the approval_request_id from the request
-	Approved   bool   `json:"ok"`                     // true to approve, false to deny
+	Type       string `json:"type"`                // always "user_confirmation"
+	ApprovalID string `json:"approval_request_id"` // echoes the approval_request_id from the request
+	Approved   bool   `json:"ok"`
 	Message    string `json:"instructions,omitempty"` // if rejected, guidance for the agent on what to do instead
 }
 

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -103,12 +103,22 @@ type AgentUserEventExecToolCall struct {
 	Name       string `json:"name"`         // full tool name, e.g. "filesystem__read"
 }
 
+// AgentUserEvent is the sealed interface implemented by user events the TUI posts back
+// to the Neo task. The CLI dispatcher carries values of this type on a single channel
+// and forwards them to PostNeoTaskUserEvent; the JSON discriminator is set per-variant
+// via the Type field.
+type AgentUserEvent interface {
+	isAgentUserEvent()
+}
+
 // AgentUserEventUserMessage is the user event a CLI client posts when the user sends a
 // chat message from the TUI.
 type AgentUserEventUserMessage struct {
 	Type    string `json:"type"` // always "user_message"
 	Content string `json:"content"`
 }
+
+func (AgentUserEventUserMessage) isAgentUserEvent() {}
 
 // AgentBackendEventExecToolCallProgress is a backend event reporting incremental progress
 // for an in-flight tool call, forwarded to the TUI to update the tool's status line.
@@ -154,3 +164,5 @@ type AgentUserEventUserConfirmation struct {
 	Approved   bool   `json:"ok"`                     // true to approve, false to deny
 	Message    string `json:"instructions,omitempty"` // if rejected, guidance for the agent on what to do instead
 }
+
+func (AgentUserEventUserConfirmation) isAgentUserEvent() {}


### PR DESCRIPTION
## Summary

Add user-approval support to the `pulumi neo` TUI. When the cloud agent emits a `user_approval_request` for a sensitive action, the terminal prompts the user; typing `y`/`yes` + Enter approves, anything else + Enter denies and forwards the typed text to the agent as guidance for what to do instead.

- **Wire types** (`sdk/go/common/apitype/neo.go`): new sealed `AgentUserEvent` interface implemented by `AgentUserEventUserMessage` and `AgentUserEventUserConfirmation`.
- **Client** (`pkg/backend/httpstate/client`): `CreateNeoTask` takes a new `NeoApprovalMode` (`"manual"`, `"auto"`, or empty for the server default). The CLI hard-codes `manual` for `pulumi neo`.
- **TUI** (`pkg/cmd/pulumi/neo/tui.go`): `user_approval_request` backend events surface as a `⚠ Approval required` block; the input prompt switches to `Approve? [y to approve / reason to deny]:` until the user answers, then either resumes with the spinner (approve) or stays idle with the denial reason posted as `instructions` (deny).
- **Engine** (`pkg/cmd/pulumi/neo/neo.go`, `session.go`): a single typed `OutCh chan apitype.AgentUserEvent` carries every TUI-originated event (chat + approvals). The dispatcher in `runNeo` type-switches the first chat message into task creation and posts everything else straight through `PostNeoTaskUserEvent`. `Session` stays focused on SSE intake and CLI-tool dispatch.

Hidden behind `PULUMI_EXPERIMENTAL`.

fixes pulumi/pulumi-service#41313

## Test plan

- [x] `cd pkg && go test -count=1 -tags all ./cmd/pulumi/neo/...` — pass
- [x] `golangci-lint run ./cmd/pulumi/neo/... ./go/common/apitype/...` — clean
- [ ] Manual against an org/task that exercises `manual` approval mode:
  - `pulumi neo` chat round-trips `user_message` as before
  - `user_approval_request` lights up the `⚠ Approval required` block
  - `y` + Enter posts `user_confirmation` with `ok: true` and the agent resumes
  - Free-text + Enter posts `user_confirmation` with `ok: false` and `instructions: <text>`
  - Approve + deny in the same session, back-to-back, no deadlock

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` (neo package) — pass
- [x] `make format` — clean
- [ ] `make tidy` — N/A (no go.mod changes)
- [ ] `make check_proto` — N/A (no proto changes)

## Changelog

- [x] `changelog/pending/20260415--cli--add-approval-flow-for-pulumi-neo.yaml`

## Risk

- **Public Go API** (`sdk/go/common/apitype`): adds the `AgentUserEvent` sealed interface and the `AgentUserEventUserConfirmation` struct. Additive; no existing exports change shape.
- **Internal Go API** (`pkg/backend/httpstate/client`): `Client.CreateNeoTask` gains a trailing `NeoApprovalMode` parameter. All in-tree callers updated; the only one outside `pulumi neo` is `cloudBackend.createNeoTaskOnError`, which now passes `""` (server default).
- **Wire protocol**: depends on the cloud agent emitting `user_approval_request` and accepting `user_confirmation` (`approval_request_id`, `ok`, `instructions`). Server-side coordination tracked in pulumi/pulumi-service#41313.
- **Blast radius**: TUI-only behavior change for `pulumi neo`, which is gated by `PULUMI_EXPERIMENTAL`. The non-TTY path also passes `manual`, so a non-interactive run that triggers an approval request will stall the agent until cancelled — non-interactive callers should request `auto` mode once that's wired through (out of scope here).

recording: https://asciinema.org/a/03oQKBvSqgyjHRxC