### PR TITLE
List and Tuple indices are ints, not numbers

### DIFF
--- a/changelog/pending/20260413--pcl--type-list-and-tuple-indices-as-integers-not-numbers.yaml
+++ b/changelog/pending/20260413--pcl--type-list-and-tuple-indices-as-integers-not-numbers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pcl
+  description: Type list and tuple indices as integers not numbers

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -68,11 +68,11 @@ func GetCollectionTypes(collectionType Type, rng hcl.Range, strict bool) (Type, 
 	unwrappedCollectionType := unwrapIterableSourceType(collectionType)
 	switch collectionType := unwrappedCollectionType.(type) {
 	case *ListType:
-		keyType, valueType = NumberType, collectionType.ElementType
+		keyType, valueType = IntType, collectionType.ElementType
 	case *MapType:
 		keyType, valueType = StringType, collectionType.ElementType
 	case *TupleType:
-		keyType = NumberType
+		keyType = IntType
 		valueType, _ = UnifyTypes(collectionType.ElementTypes...)
 	case *ObjectType:
 		keyType = StringType


### PR DESCRIPTION
Hit this when I started adding conversion support for python, that is make the codegen emit cast operators to match the target type. All the lists accesses ended up as `list[float(n)]` because PCL was telling the generator that indices are numbers not ints.