### PR TITLE
Log serialisation errors when marshalling outputs to wire protocol

### DIFF
--- a/changelog/pending/20260413--sdk-nodejs--log-serialisation-errors.yaml
+++ b/changelog/pending/20260413--sdk-nodejs--log-serialisation-errors.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
-  scope: sdk/nodejs
+  scope: sdk/nodejs,python,go
   description: Log serialisation errors at error level when marshalling outputs to the wire protocol

--- a/changelog/pending/20260413--sdk-nodejs--log-serialisation-errors.yaml
+++ b/changelog/pending/20260413--sdk-nodejs--log-serialisation-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk/nodejs
+  description: Log serialisation errors at error level when marshalling outputs to the wire protocol

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1422,6 +1422,7 @@ func (ctx *Context) readPackageResource(
 		// Prepare the inputs for an impending operation.
 		inputs, err = ctx.prepareResourceInputs(resource, props, t, options, res, false /* remote */, true /* custom */)
 		if err != nil {
+			contract.IgnoreError(ctx.Log.Error(fmt.Sprintf("ReadResource(%s, %s): error marshaling properties: %v", t, name, err), nil))
 			return
 		}
 
@@ -1816,6 +1817,7 @@ func (ctx *Context) registerResource(
 		// Prepare the inputs for an impending operation.
 		inputs, err = ctx.prepareResourceInputs(resource, props, t, options, resState, remote, custom)
 		if err != nil {
+			contract.IgnoreError(ctx.Log.Error(fmt.Sprintf("RegisterResource(%s, %s): error marshaling properties: %v", t, name, err), nil))
 			return
 		}
 

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -166,6 +166,20 @@ func TestWaitingCausesNoPanics(t *testing.T) {
 	}
 }
 
+func TestRegisterResourceMarshalError(t *testing.T) {
+	t.Parallel()
+
+	mocks := &testMonitor{}
+	err := RunErr(func(ctx *Context) error {
+		out, _, rejectOut := ctx.NewOutput()
+		rejectOut(fmt.Errorf("intentional marshaling error"))
+		var res struct{ CustomResourceState }
+		return ctx.RegisterResource("test:index:res", "test", Map{"badProp": out}, &res)
+	}, WithMocks("project", "stack", mocks))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "marshaling properties")
+}
+
 func TestCollapseAliases(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -112,6 +112,9 @@ export function invokeOutput<T>(
             resolve(<T>result, isKnown, containsSecrets, dependencies, undefined);
         })
         .catch((err) => {
+            log.error(
+                `Invoke RPC failed: tok=${tok}, err=${err instanceof Error ? err.stack || err.message : String(err)}`,
+            );
             resolve(<any>undefined, true, false, [], err);
         });
 
@@ -164,6 +167,9 @@ export function invokeSingleOutput<T>(
             resolve(<T>value, isKnown, containsSecrets, dependencies, undefined);
         })
         .catch((err) => {
+            log.error(
+                `Invoke RPC failed: tok=${tok}, err=${err instanceof Error ? err.stack || err.message : String(err)}`,
+            );
             resolve(<any>undefined, true, false, [], err);
         });
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -313,6 +313,10 @@ export function getResource(
                 });
             })
             .catch((err) => {
+                log.error(
+                    `GetResource RPC failed: urn=${urn}, err=${err instanceof Error ? err.stack || err.message : String(err)}`,
+                    res,
+                );
                 done();
                 throw err;
             }),
@@ -450,6 +454,10 @@ export function readResource(
                 });
             })
             .catch((err) => {
+                log.error(
+                    `ReadResource RPC failed: t=${t}, name=${name}, err=${err instanceof Error ? err.stack || err.message : String(err)}`,
+                    res,
+                );
                 done();
                 throw err;
             }),
@@ -811,7 +819,10 @@ export function registerResource(
                 });
             })
             .catch((err) => {
-                log.debug(`RegisterResource RPC failed: t=${t}, name=${name}, err=${err}`);
+                log.error(
+                    `RegisterResource RPC failed: t=${t}, name=${name}, err=${err instanceof Error ? err.stack || err.message : String(err)}`,
+                    res,
+                );
                 // If we fail to prepare the resource, we need to ensure that we still call done to prevent a hang.
                 done();
                 throw err;

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -175,10 +175,15 @@ async function serializeFilteredProperties(
         if (acceptKey(k)) {
             // We treat properties with undefined values as if they do not exist.
             const dependentResources = new Set<Resource>();
-            const v = await serializeProperty(`${label}.${k}`, props[k], dependentResources, opts);
-            if (v !== undefined) {
-                result[k] = v;
-                propertyToDependentResources.set(k, dependentResources);
+            try {
+                const v = await serializeProperty(`${label}.${k}`, props[k], dependentResources, opts);
+                if (v !== undefined) {
+                    result[k] = v;
+                    propertyToDependentResources.set(k, dependentResources);
+                }
+            } catch (err) {
+                const detail = err instanceof Error ? err.stack || err.message : String(err);
+                throw new Error(`error serializing property "${k}": ${detail}`);
             }
         }
     }

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -516,4 +516,19 @@ describe("runtime", () => {
             );
         });
     });
+
+    describe("serialization error enrichment", () => {
+        it("includes property name in error when serialization fails", async () => {
+            const rejected = Promise.reject(new Error("inner serialization error"));
+            // Suppress unhandled rejection warning - the rejection is handled via serializeProperties.
+            rejected.catch(() => {});
+
+            await assert.rejects(
+                runtime.serializeProperties("test", { problematicProp: rejected }),
+                (err: Error) => {
+                    return err.message.includes('"problematicProp"');
+                },
+            );
+        });
+    });
 });

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -610,7 +610,7 @@ def get_resource(
                 )
 
         except Exception as exn:
-            log.debug(
+            log.error(
                 f"exception when preparing or executing rpc: {traceback.format_exc()}"
             )
             rpc.resolve_outputs_due_to_exception(resolvers, exn)
@@ -887,7 +887,7 @@ def read_resource(
             )
 
         except Exception as exn:
-            log.debug(
+            log.error(
                 f"exception when preparing or executing rpc: {traceback.format_exc()}"
             )
             rpc.resolve_outputs_due_to_exception(resolvers, exn)
@@ -1177,7 +1177,7 @@ def register_resource(
                 None, wrap_with_context(do_rpc_call)
             )
         except Exception as exn:
-            log.debug(
+            log.error(
                 f"exception when preparing or executing rpc for {ty=} {name=}: {traceback.format_exc()}"
             )
             rpc.resolve_outputs_due_to_exception(resolvers, exn)

--- a/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
+++ b/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
@@ -21,6 +21,7 @@ class TestMarshalFailure(LanghostTest):
             program=path.join(self.base_path(), "marshal_failure"),
             expected_resource_count=1,
             expected_bail=True,
+            expected_log_message="exception when preparing",
         )
 
     def invoke(self, _ctx, token, args, provider, _version):


### PR DESCRIPTION
Fixes #21901

## Summary

When marshalling resource/invoke inputs from outputs to the gRPC wire protocol, any exceptions thrown in that path were either not logged at all or only logged at `debug` level, making them invisible to users.

This change logs serialisation errors at `error` level across all three language SDKs:

**Node.js**
- `rpc.ts` (`serializeFilteredProperties`): Wrap per-property `serializeProperty` calls in try/catch that enriches the error with the property key name and original stack trace — mirrors Python's context-enrichment approach
- `resource.ts`: Change `log.debug` → `log.error` (with stack trace) in `registerResource`, and add `log.error` to `getResource` and `readResource` which previously had no logging at all
- `invoke.ts`: Add `log.error` in `invokeOutput` and `invokeSingleOutput` catch handlers that were previously silently swallowing errors

**Python**
- `resource.py`: Change `log.debug` → `log.error` in the outer exception handlers of `get_resource`, `read_resource`, and `register_resource` (full traceback was already included via `traceback.format_exc()`)

**Go**
- `context.go`: Add `ctx.Log.Error()` calls in the `readResource` and `RegisterResource` goroutines when `prepareResourceInputs` (which marshals output properties) returns an error — errors were previously only propagated via output rejection with no log

## Test plan

- [ ] Verify that a program passing an unserializable property to a resource now emits a visible error log instead of a silent failure