### PR TITLE
Fix element and range to use ints

### DIFF
--- a/changelog/pending/20260414--pcl--builtin-functions-element-and-range-take-int-parameters-not-numbers.yaml
+++ b/changelog/pending/20260414--pcl--builtin-functions-element-and-range-take-int-parameters-not-numbers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pcl
+  description: Builtin functions element and range take int parameters not numbers

--- a/pkg/codegen/pcl/functions.go
+++ b/pkg/codegen/pcl/functions.go
@@ -97,7 +97,7 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 						},
 						{
 							Name: "index",
-							Type: model.NumberType,
+							Type: model.IntType,
 						},
 					},
 					ReturnType: returnType,
@@ -254,11 +254,11 @@ func pulumiBuiltins(options bindOptions) map[string]*model.Function {
 			Parameters: []model.Parameter{
 				{
 					Name: "fromOrTo",
-					Type: model.NumberType,
+					Type: model.IntType,
 				},
 				{
 					Name: "to",
-					Type: model.NewOptionalType(model.NumberType),
+					Type: model.NewOptionalType(model.IntType),
 				},
 			},
 			ReturnType: model.NewListType(model.IntType),


### PR DESCRIPTION
These two functions work with integer values, not float numbers. Found while trying to get python codegen to add primitive conversions in the right places, it kept trying to cast to float for `element` calls which then resulted in python code like `list[float(x)]` from `element(list, x)`.