### PR TITLE
Python Automation API Codegen: use TypedDict for option types

### DIFF
--- a/sdk/python/tools/automation/boilerplate/standard.py
+++ b/sdk/python/tools/automation/boilerplate/standard.py
@@ -14,16 +14,16 @@
 
 import os
 from collections.abc import Callable, Mapping
-from typing import Any, Optional
+from typing import Any, TypedDict
 
 from pulumi.automation._cmd import CommandResult, PulumiCommand
 
 
-class BaseOptions:
-    cwd: Optional[str]
-    additional_env: Optional[Mapping[str, str]]
-    on_output: Optional[Callable[[str], Any]]
-    on_error: Optional[Callable[[str], Any]]
+class BaseOptions(TypedDict, total=False):
+    cwd: str
+    additional_env: Mapping[str, str]
+    on_output: Callable[[str], Any]
+    on_error: Callable[[str], Any]
 
 
 class API:
@@ -35,8 +35,8 @@ class API:
     def _run(self, options: BaseOptions, args: list[str]) -> CommandResult:
         return self._command.run(
             args,
-            options.cwd if getattr(options, "cwd", None) is not None else os.getcwd(),
-            getattr(options, "additional_env", None) or {},
-            getattr(options, "on_output", None),
-            getattr(options, "on_error", None),
+            options.get("cwd") or os.getcwd(),
+            options.get("additional_env") or {},
+            options.get("on_output"),
+            options.get("on_error"),
         )

--- a/sdk/python/tools/automation/boilerplate/testing.py
+++ b/sdk/python/tools/automation/boilerplate/testing.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, TypedDict
 
 
-class BaseOptions:
+class BaseOptions(TypedDict, total=False):
     pass
 
 
 class API:
-    def _run(self, options: object, args: List[str]) -> str:
+    def _run(self, options: BaseOptions, args: List[str]) -> str:
         return "pulumi " + " ".join(args)

--- a/sdk/python/tools/automation/main.py
+++ b/sdk/python/tools/automation/main.py
@@ -164,7 +164,9 @@ def _generate_options_types(
             ast.ClassDef(
                 name=class_name,
                 bases=[ast.Name(id="BaseOptions", ctx=ast.Load())],
-                keywords=[],
+                keywords=[
+                    ast.keyword(arg="total", value=ast.Constant(value=False)),
+                ],
                 body=class_body,
                 decorator_list=[],
             )
@@ -489,18 +491,18 @@ def _emit_preset_flag(body: List[ast.stmt], flag: Mapping[str, Any]) -> None:
         return
 
     if not is_omitted:
-        # Wrap in: if getattr(options, "<opt_name>", None) is None:
+        # Wrap in: if options.get("<opt_name>") is None:
         opt_name = _snake_case(flag_name)
         body.append(
             ast.If(
                 test=ast.Compare(
                     left=ast.Call(
-                        func=ast.Name(id="getattr", ctx=ast.Load()),
-                        args=[
-                            ast.Name(id="options", ctx=ast.Load()),
-                            ast.Constant(value=opt_name),
-                            ast.Constant(value=None),
-                        ],
+                        func=ast.Attribute(
+                            value=ast.Name(id="options", ctx=ast.Load()),
+                            attr="get",
+                            ctx=ast.Load(),
+                        ),
+                        args=[ast.Constant(value=opt_name)],
                         keywords=[],
                     ),
                     ops=[ast.Is()],
@@ -522,20 +524,20 @@ def _emit_option_flag(body: List[ast.stmt], flag: Mapping[str, Any]) -> None:
     required = flag.get("required", False)
     opt_name = _snake_case(flag_name)
 
-    # Access: getattr(options, "opt_name", None)
+    # Access: options.get("opt_name")
     def _opt_access() -> ast.Call:
         return ast.Call(
-            func=ast.Name(id="getattr", ctx=ast.Load()),
-            args=[
-                ast.Name(id="options", ctx=ast.Load()),
-                ast.Constant(value=opt_name),
-                ast.Constant(value=None),
-            ],
+            func=ast.Attribute(
+                value=ast.Name(id="options", ctx=ast.Load()),
+                attr="get",
+                ctx=ast.Load(),
+            ),
+            args=[ast.Constant(value=opt_name)],
             keywords=[],
         )
 
     if repeatable:
-        # for __item in getattr(options, "x", None) or []:
+        # for __item in options.get("x") or []:
         inner: List[ast.stmt]
         if flag_type == "boolean":
             inner = [
@@ -593,7 +595,7 @@ def _emit_option_flag(body: List[ast.stmt], flag: Mapping[str, Any]) -> None:
             )
         )
     elif flag_type == "boolean":
-        # if getattr(options, "x", None): __flags.append("--flag")
+        # if options.get("x"): __flags.append("--flag")
         body.append(
             ast.If(
                 test=_opt_access(),
@@ -614,7 +616,7 @@ def _emit_option_flag(body: List[ast.stmt], flag: Mapping[str, Any]) -> None:
             )
         )
     elif required:
-        # __flags.extend(["--flag", str(getattr(options, "x", None))])
+        # __flags.extend(["--flag", str(options.get("x"))])
         body.append(
             ast.Expr(
                 value=ast.Call(
@@ -641,7 +643,7 @@ def _emit_option_flag(body: List[ast.stmt], flag: Mapping[str, Any]) -> None:
             )
         )
     else:
-        # if getattr(options, "x", None) is not None: __flags.extend(["--flag", str(...)])
+        # if options.get("x") is not None: __flags.extend(["--flag", str(...)])
         body.append(
             ast.If(
                 test=ast.Compare(

--- a/sdk/python/tools/automation/tests/test_commands.py
+++ b/sdk/python/tools/automation/tests/test_commands.py
@@ -58,8 +58,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(command, "pulumi cancel --yes")
 
     def test_cancel_with_option(self) -> None:
-        options = self.mod.PulumiCancelOptions()
-        options.stack = "dev"
+        options = self.mod.PulumiCancelOptions(stack="dev")
         command = self.api.cancel(options)
         self.assertEqual(command, "pulumi cancel --yes --stack dev")
 
@@ -74,10 +73,11 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(command, "pulumi org set-default -- my-org")
 
     def test_org_search_with_query_flags(self) -> None:
-        options = self.mod.PulumiOrgSearchOptions()
-        options.org = "my-org"
-        options.query = ["type:aws:s3/bucketv2:BucketV2", "modified:>=2023-09-01"]
-        options.output = "json"
+        options = self.mod.PulumiOrgSearchOptions(
+            org="my-org",
+            query=["type:aws:s3/bucketv2:BucketV2", "modified:>=2023-09-01"],
+            output="json",
+        )
         command = self.api.org_search(options)
         self.assertEqual(
             command,
@@ -86,9 +86,10 @@ class TestCommands(unittest.TestCase):
         )
 
     def test_org_search_ai(self) -> None:
-        options = self.mod.PulumiOrgSearchAiOptions()
-        options.org = "my-org"
-        options.query = "find all S3 buckets"
+        options = self.mod.PulumiOrgSearchAiOptions(
+            org="my-org",
+            query="find all S3 buckets",
+        )
         command = self.api.org_search_ai(options)
         self.assertEqual(
             command,
@@ -101,9 +102,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(command, "pulumi org")
 
     def test_state_move_variadic(self) -> None:
-        options = self.mod.PulumiStateMoveOptions()
-        options.dest = "prod"
-        options.source = "dev"
+        options = self.mod.PulumiStateMoveOptions(dest="prod", source="dev")
         command = self.api.state_move(options, "urn:1", "urn:2")
         self.assertEqual(
             command,
@@ -116,8 +115,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(command, "pulumi state move --yes")
 
     def test_state_move_boolean_flag(self) -> None:
-        options = self.mod.PulumiStateMoveOptions()
-        options.include_parents = True
+        options = self.mod.PulumiStateMoveOptions(include_parents=True)
         command = self.api.state_move(options, "urn:1")
         self.assertEqual(
             command,


### PR DESCRIPTION
## Summary

Follow-up to #22490. Switch the Python automation API code generator to emit `TypedDict` subclasses for the per-command option types (and the shared `BaseOptions` in both boilerplates) instead of plain classes with annotated attributes.

This aligns with:
- The `TypedDict` pattern already used in the existing automation API (e.g. `ImportResource` in `sdk/python/lib/pulumi/automation/_stack.py`).
- The structural shape of the TypeScript `type` declarations emitted by the NodeJS generator (#21762).

### Changes

- `boilerplate/standard.py`: `BaseOptions` is now `TypedDict(total=False)`. `API._run` reads options via `options.get(...)` instead of `getattr(options, ..., None)`.
- `boilerplate/testing.py`: `BaseOptions` is now an empty `TypedDict(total=False)` for consistency.
- `main.py`: generated option classes pass `total=False`, and all `getattr(options, "x", None)` accesses in the generated command bodies become `options.get("x")`.
- `tests/test_commands.py`: use keyword-argument construction (`PulumiCancelOptions(stack="dev")`) instead of attribute assignment, since `TypedDict` instances are plain dicts at runtime.

### Why `total=False`

Almost every CLI flag is optional, and `TypedDict(total=False)` keeps the generator trivial. If we later want to honour the `required: true` flag from the spec precisely, we can migrate individual fields to `typing.NotRequired[T]` without further churn.

## Test plan

- [x] `python -m unittest tests.test_commands` — all 11 tests pass
- [x] Regenerated against `tests/fixture.json` and inspected the output: option classes now declare `class PulumiXOptions(BaseOptions, total=False):` and command bodies use `options.get(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)