### PR TITLE
Clarify docs on `remote` parameter of ComponentResource

### DIFF
--- a/changelog/pending/20260414--sdk--clarify-remote-parameter-docs-on-componentresource.yaml
+++ b/changelog/pending/20260414--sdk--clarify-remote-parameter-docs-on-componentresource.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk
+  description: Clarify docs on the `remote` parameter of `ComponentResource` / `Resource` in the Node and Python SDKs

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -430,7 +430,12 @@ export abstract class Resource {
      * @param opts
      *  A bag of options that control this resource's behavior.
      * @param remote
-     *  True if this is a remote component resource.
+     *  This parameter is intended for use by code-generated component SDKs;
+     *  end users authoring their own {@link ComponentResource} subclasses
+     *  should leave this at its default (`false`). When `true`, the
+     *  component's children are constructed by the engine rather than in
+     *  this process, and the constructor skips local child registration
+     *  accordingly.
      * @param dependency
      *  True if this is a synthetic resource used internally for dependency tracking.
      */
@@ -1536,7 +1541,12 @@ export class ComponentResource<TData = any> extends Resource {
      * @param opts
      *  A bag of options that control this resource's behavior.
      * @param remote
-     *  True if this is a remote component resource.
+     *  This parameter is intended for use by code-generated component SDKs;
+     *  end users authoring their own {@link ComponentResource} subclasses
+     *  should leave this at its default (`false`). When `true`, the
+     *  component's children are constructed by the engine rather than in
+     *  this process, and the constructor skips local child registration
+     *  accordingly.
      */
     constructor(
         type: string,

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -893,7 +893,11 @@ class Resource:
                and `translate_output_property` methods.
         :param Optional[ResourceOptions] opts: Optional set of :class:`pulumi.ResourceOptions` to use for this
                resource.
-        :param bool remote: True if this is a remote component resource.
+        :param bool remote: This parameter is intended for use by code-generated component SDKs;
+               end users authoring their own :class:`ComponentResource` subclasses should leave this at
+               its default (``False``). When ``True``, the component's children are constructed by the
+               engine rather than in this process, and the constructor skips local child registration
+               accordingly.
         :param bool dependency: True if this is a synthetic resource used internally for dependency tracking.
         :param Optional[Awaitable[Optional[str]]] package_ref: The package reference for this resource.
         """
@@ -1232,7 +1236,11 @@ class ComponentResource(Resource):
         :param Optional[dict] props: An optional list of input properties to use as inputs for the resource.
         :param Optional[ResourceOptions] opts: Optional set of :class:`pulumi.ResourceOptions` to use for this
                resource.
-        :param bool remote: True if this is a remote component resource.
+        :param bool remote: This parameter is intended for use by code-generated component SDKs;
+               end users authoring their own :class:`ComponentResource` subclasses should leave this at
+               its default (``False``). When ``True``, the component's children are constructed by the
+               engine rather than in this process, and the constructor skips local child registration
+               accordingly.
         :param Optional[Awaitable[Optional[str]]] package_ref: The package reference for this resource.
         """
         Resource.__init__(self, t, name, False, props, opts, remote, False, package_ref)


### PR DESCRIPTION
## Summary
- The `remote` parameter on `Resource` / `ComponentResource` constructors in the Node and Python SDKs is intended for use by code-generated component SDKs, not by end users.
- Previous docs ("True if this is a remote component resource.") were circular and gave no guidance. Expanded to tell end users to leave the default and describe what changes when it is true.

Fixes #21377

## Test plan
- [x] `make format` + `make lint` in `sdk/nodejs`
- [x] `make lint` in `sdk/python`
- Docs-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)