### PR TITLE
Deduplicate X-Pulumi-Warning headers across API calls

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -258,7 +258,7 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 func pulumiAPICall(ctx context.Context,
 	requestSpan opentracing.Span,
 	d diag.Sink, client httpClient, cloudAPI, method, path string, body []byte,
-	tok accessToken, opts httpCallOptions,
+	tok accessToken, opts httpCallOptions, seenWarnings map[string]bool,
 ) (string, *http.Response, error) {
 	// Normalize URL components
 	cloudAPI = strings.TrimSuffix(cloudAPI, "/")
@@ -356,6 +356,12 @@ func pulumiAPICall(ctx context.Context,
 
 	if warningHeader, ok := resp.Header["X-Pulumi-Warning"]; ok {
 		for _, warning := range warningHeader {
+			if seenWarnings[warning] {
+				continue
+			}
+			if seenWarnings != nil {
+				seenWarnings[warning] = true
+			}
 			d.Warningf(diag.RawMessage("", warning))
 		}
 	}
@@ -437,7 +443,8 @@ type restClient interface {
 
 // defaultRESTClient is the default implementation for calling the Pulumi REST API.
 type defaultRESTClient struct {
-	client httpClient
+	client       httpClient
+	seenWarnings map[string]bool
 }
 
 // HTTPClient returns the HTTP client for this REST client.
@@ -500,7 +507,7 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 
 	// Make API call
 	url, resp, err := pulumiAPICall(
-		ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
+		ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts, c.seenWarnings)
 	if err != nil {
 		otelSpan.RecordError(err)
 		otelSpan.SetStatus(codes.Error, err.Error())

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -182,7 +182,7 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 			t.Context(), opentracing.NoopTracer{}.StartSpan("test"),
 			diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
 			httpClient, "https://api.pulumi.com", "GET", "/api/test", nil,
-			apiAccessToken("some-token"), httpCallOptions{},
+			apiAccessToken("some-token"), httpCallOptions{}, nil,
 		)
 
 		var loginErr backenderr.LoginRequiredError
@@ -226,7 +226,7 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 				t.Context(), opentracing.NoopTracer{}.StartSpan("test"),
 				diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
 				httpClient, "https://api.pulumi.com", "GET", "/api/test", nil,
-				apiAccessToken("some-token"), httpCallOptions{},
+				apiAccessToken("some-token"), httpCallOptions{}, nil,
 			)
 
 			var loginErr backenderr.LoginRequiredError
@@ -258,7 +258,7 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 			t.Context(), opentracing.NoopTracer{}.StartSpan("test"),
 			diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
 			httpClient, "https://api.pulumi.com", "GET", "/api/test", nil,
-			apiAccessToken(""), httpCallOptions{},
+			apiAccessToken(""), httpCallOptions{}, nil,
 		)
 
 		assert.True(t, errors.Is(err, backenderr.LoginRequiredError{}))

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -156,6 +156,7 @@ var newClient = func(apiURL, apiToken string, insecure bool, d diag.Sink) *Clien
 			client: &defaultHTTPClient{
 				client: httpClient,
 			},
+			seenWarnings: make(map[string]bool),
 		},
 	}
 }
@@ -177,6 +178,7 @@ func (pc *Client) WithHTTPClient(httpClient *http.Client) *Client {
 		client: &defaultHTTPClient{
 			client: httpClient,
 		},
+		seenWarnings: make(map[string]bool),
 	}
 	return pc
 }


### PR DESCRIPTION
## Summary
- Add a `seenWarnings` map to `defaultRESTClient` that persists across all API calls within a CLI session
- Pass it through to `pulumiAPICall` so duplicate `X-Pulumi-Warning` response headers are skipped after the first occurrence
- Each unique warning string is displayed exactly once per CLI invocation

## Motivation
The service sends `X-Pulumi-Warning` headers on every org-scoped API response (e.g. expired trial warnings). A single CLI command like `pulumi up` makes multiple API calls, causing the same warning to print repeatedly. This change deduplicates them.

## Test plan
- [x] Existing `TestPulumiAPICall_401_LoginRequired` tests pass (updated to pass `nil` for `seenWarnings`)
- [ ] Manual test: run a CLI command against an org with an expired trial, verify the warning prints once

🤖 Generated with [Claude Code](https://claude.com/claude-code)