### PR TITLE
python/test_named_config: use unique stack names

### DIFF
--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -570,31 +570,31 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = fully_qualified_stack_name(get_test_org(), project_name, "dev")
         project_dir = get_test_path("data", project_name)
         stack = create_or_select_stack(stack_name, work_dir=project_dir)
-        with stack_cleanup(stack, destroy=False):
-            all_config = stack.get_all_config()
-            outer_val = all_config["nested_config:outer"]
-            self.assertFalse(outer_val.secret)
-            self.assertEqual(
-                outer_val.value, '{"inner":"my_value","other":"something_else"}'
-            )
 
-            list_val = all_config["nested_config:myList"]
-            self.assertFalse(list_val.secret)
-            self.assertEqual(list_val.value, '["one","two","three"]')
+        all_config = stack.get_all_config()
+        outer_val = all_config["nested_config:outer"]
+        self.assertFalse(outer_val.secret)
+        self.assertEqual(
+            outer_val.value, '{"inner":"my_value","other":"something_else"}'
+        )
 
-            outer = stack.get_config("outer")
-            self.assertFalse(outer.secret)
-            self.assertEqual(
-                outer_val.value, '{"inner":"my_value","other":"something_else"}'
-            )
+        list_val = all_config["nested_config:myList"]
+        self.assertFalse(list_val.secret)
+        self.assertEqual(list_val.value, '["one","two","three"]')
 
-            arr = stack.get_config("myList")
-            self.assertFalse(arr.secret)
-            self.assertEqual(arr.value, '["one","two","three"]')
+        outer = stack.get_config("outer")
+        self.assertFalse(outer.secret)
+        self.assertEqual(
+            outer_val.value, '{"inner":"my_value","other":"something_else"}'
+        )
 
-            # We're intentionally skipping removing this particular stack at the end of the test,
-            # because it requires the Pulumi.dev.yaml file to be present, and we'll re-use this stack
-            # name in other tests.
+        arr = stack.get_config("myList")
+        self.assertFalse(arr.secret)
+        self.assertEqual(arr.value, '["one","two","three"]')
+
+        # We're intentionally skipping removing this particular stack at the end of the test,
+        # because it requires the Pulumi.dev.yaml file to be present, and we'll re-use this stack
+        # name in other tests.
 
     def test_tag_methods(self):
         if os.getenv("PULUMI_ACCESS_TOKEN") is None:

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -592,6 +592,10 @@ class TestLocalWorkspace(unittest.TestCase):
             self.assertFalse(arr.secret)
             self.assertEqual(arr.value, '["one","two","three"]')
 
+            # We're intentionally skipping removing this particular stack at the end of the test,
+            # because it requires the Pulumi.dev.yaml file to be present, and we'll re-use this stack
+            # name in other tests.
+
     def test_tag_methods(self):
         if os.getenv("PULUMI_ACCESS_TOKEN") is None:
             self.skipTest(


### PR DESCRIPTION
`test_named_config` uses a static stack name for testing.  This used to work fine until https://github.com/pulumi/pulumi/pull/22564, where we started cleaning stacks up.  This cleanup means that now other processes can interfere with the test and delete the stack while the test is in progress, making the test fail.

Since we require a `Pulumi.dev.yaml` for this test, we can't simply change the stackname to be unique.  The comment on top of the test already mentions we don't want to remove the stack because of that, so this PR changes things to not remove the stack again (there's not going to be stacks accumulating, since it's just the one), and add a comment to that extent.

Fixes https://github.com/pulumi/pulumi/issues/22606