### PR TITLE
move to non-preview routes for registry

### DIFF
--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -139,8 +139,8 @@ func init() {
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources/parse", "getSearchResourcesParse")
 
 	// APIs for interacting with the Package Registry
-	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")
-	addEndpoint("POST", "/api/preview/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
+	addEndpoint("POST", "/api/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")
+	addEndpoint("POST", "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}/complete", "completePackagePublish")
 	addEndpoint("DELETE", "/api/registry/packages/{source}/{publisher}/{name}/versions/{version}", "deletePackageVersion")
 
 	// APIs for interacting with the Template Registry

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -288,11 +288,11 @@ func getUpdatePath(update UpdateIdentifier, components ...string) string {
 }
 
 func publishPackagePath(source, publisher, name string) string {
-	return fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions", source, publisher, name)
+	return fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions", source, publisher, name)
 }
 
 func completePackagePublishPath(source, publisher, name, version string) string {
-	return fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
+	return fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s/complete", source, publisher, name, version)
 }
 
 func deletePackageVersionPath(source, publisher, name, version string) string {
@@ -1889,7 +1889,7 @@ func (pc *Client) GetPackage(
 	if version != nil {
 		v = version.String()
 	}
-	url := fmt.Sprintf("/api/preview/registry/packages/%s/%s/%s/versions/%s", source, publisher, name, v)
+	url := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s", source, publisher, name, v)
 	var resp apitype.PackageMetadata
 	err := pc.restCall(ctx, "GET", url, nil, nil, &resp)
 	return resp, err
@@ -1972,7 +1972,7 @@ func (pc *Client) downloadWithRawClient(ctx context.Context, downloadURL string)
 }
 
 func (pc *Client) ListPackages(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
-	url := "/api/preview/registry/packages?limit=499"
+	url := "/api/registry/packages?limit=499"
 	if name != nil {
 		url += "&name=" + *name
 	}

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -67,7 +67,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -82,7 +82,7 @@ func TestPublishPackage(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -97,7 +97,7 @@ func TestPublishPackage(t *testing.T) {
 			},
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions" {
+					if r.URL.Path == "/api/registry/packages/pulumi/test-publisher/test-package/versions" {
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Internal Server Error"))
 						require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -153,7 +153,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -186,7 +186,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -215,7 +215,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -229,7 +229,7 @@ func TestPublishPackage(t *testing.T) {
 							},
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusInternalServerError)
 						_, err := w.Write([]byte("Failed to complete"))
 						require.NoError(t, err)
@@ -253,7 +253,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -268,7 +268,7 @@ func TestPublishPackage(t *testing.T) {
 						}
 						require.NoError(t, json.NewEncoder(w).Encode(response))
 
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions/1.0.0/complete":
 						w.WriteHeader(http.StatusCreated)
 					}
 				}))
@@ -301,7 +301,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",
@@ -342,7 +342,7 @@ func TestPublishPackage(t *testing.T) {
 			setupServer: func(blobStorage *httptest.Server) *httptest.Server {
 				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
-					case "/api/preview/registry/packages/pulumi/test-publisher/test-package/versions":
+					case "/api/registry/packages/pulumi/test-publisher/test-package/versions":
 						w.WriteHeader(http.StatusAccepted)
 						response := apitype.StartPackagePublishResponse{
 							OperationID: "test-operation-id",

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -620,7 +620,7 @@ func TestListPackages(t *testing.T) {
 
 		// Set up mock server
 		mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
-			assert.Contains(t, req.URL.String(), "/api/preview/registry/packages?limit=499")
+			assert.Contains(t, req.URL.String(), "/api/registry/packages?limit=499")
 			assert.Equal(t, "GET", req.Method)
 
 			data, err := json.Marshal(mockResponse)
@@ -691,7 +691,7 @@ func TestListPackages(t *testing.T) {
 
 			switch requestCount {
 			case 0:
-				assert.Equal(t, "/api/preview/registry/packages?limit=499&name=my-package", req.URL.String())
+				assert.Equal(t, "/api/registry/packages?limit=499&name=my-package", req.URL.String())
 				assert.NotContains(t, "continuationToken", req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
@@ -701,7 +701,7 @@ func TestListPackages(t *testing.T) {
 				require.NoError(t, err)
 			case 1:
 				assert.Equal(t,
-					"/api/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-1",
+					"/api/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-1",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{
@@ -711,7 +711,7 @@ func TestListPackages(t *testing.T) {
 				require.NoError(t, err)
 			case 2:
 				assert.Equal(t,
-					"/api/preview/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-2",
+					"/api/registry/packages?limit=499&name=my-package&continuationToken=next-page-token-2",
 					req.URL.String())
 
 				responseData, err = json.Marshal(apitype.ListPackagesResponse{


### PR DESCRIPTION
We're currently using preview routes for the registry.  We have a stable route for this now, which is the same as the preview route (with a couple of additions that we're not using here).  So we can safely replace the preview api with the stable api.

Note that this command is still experimental, and we're planning to turn off the preview APIs in a few months, this is in preparation for this turning off.

See also https://pulumi.slack.com/archives/C07CT414N9W/p1776088894220109 internally.

xref https://github.com/pulumi/pulumi-service/issues/32468