### PR TITLE
try to stop pkg 7/7 from flaking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
             --version-set current \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
             --partition-package github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language \
-                pkg/testing/pulumi-test-language 1 \
+                pkg/testing/pulumi-test-language 2 \
             --partition-module sdk 1 \
             --partition-module sdk/go/pulumi-language-go 1 \
             --partition-module tests 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
             --platform "${INTEGRATION_PLATFORMS[@]}" "${ACCEPTANCE_PLATFORMS[@]}" \
             --version-set current \
             --partition-module pkg "$PKG_UNIT_TEST_PARTITIONS" \
+            --partition-package github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language \
+                pkg/testing/pulumi-test-language 1 \
             --partition-module sdk 1 \
             --partition-module sdk/go/pulumi-language-go 1 \
             --partition-module tests 8


### PR DESCRIPTION
I noticed that `pkg` recently often seems to be flaky, getting killed by the runner (exit 143 == SIGTERM). Likely this is because of memory usage, since it's not running long enough for it to be a timeout.

Claude claims the likely culprit is
https://github.com/pulumi/pulumi/pull/21805.  Both codegen/batchyaml and testing/pulumi-test-language have fairly heavy memory usage, and when they end up being tested in the same runner, this can cause us to go over the limit for it, and the tests get terminated unceremoniously.

Split the pulumi-test-language package into its own test partition, to hopefully avoid this.

Note that I didn't double check yet whether this helps, but realistically it can't really hurt either, so I think it's worth a try.