### PR TITLE
Auto-detect Mercurial VCS metadata for updates

### DIFF
--- a/changelog/pending/20260415--cli--auto-detect-mercurial-vcs-metadata-for-updates.yaml
+++ b/changelog/pending/20260415--cli--auto-detect-mercurial-vcs-metadata-for-updates.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Auto-detect Mercurial repository metadata for `pulumi up` / `pulumi preview` updates, mirroring existing Git support

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	declared "github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/hgutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -53,8 +54,8 @@ func GetPolicyPublishMetadata(root string) map[string]string {
 		Environment: make(map[string]string),
 	}
 
-	if err := addGitMetadata(root, m); err != nil {
-		logging.V(3).Infof("errors detecting git metadata: %s", err)
+	if err := addVCSMetadata(root, m); err != nil {
+		logging.V(3).Infof("errors detecting VCS metadata: %s", err)
 	}
 
 	addCIMetadataToEnvironment(m.Environment)
@@ -115,8 +116,8 @@ func GetUpdateMetadata(
 
 	addPulumiCLIMetadataToEnvironment(m.Environment, flags, os.Environ)
 
-	if err := addGitMetadata(root, m); err != nil {
-		logging.V(3).Infof("errors detecting git metadata: %s", err)
+	if err := addVCSMetadata(root, m); err != nil {
+		logging.V(3).Infof("errors detecting VCS metadata: %s", err)
 	}
 
 	addCIMetadataToEnvironment(m.Environment)
@@ -310,32 +311,48 @@ func addEscMetadataToEnvironment(env map[string]string, escEnvironments []string
 	env[backend.StackEnvironments] = string(jsonData)
 }
 
-// addGitMetadata populate's the environment metadata bag with Git-related values.
-func addGitMetadata(projectRoot string, m *backend.UpdateMetadata) error {
+// addVCSMetadata populates the environment metadata bag with VCS-related
+// values. It prefers Git when a `.git` directory is found walking up from
+// projectRoot, falls back to Mercurial when a `.hg` directory is found, and
+// finally falls back to explicit environment variables when no repository is
+// detected. Mercurial metadata is written to the same git.* / vcs.* keys as
+// Git so that downstream consumers (the Pulumi service, stack tags, the UI)
+// don't need to special-case it.
+func addVCSMetadata(projectRoot string, m *backend.UpdateMetadata) error {
 	var allErrors *multierror.Error
 
 	// Gather git-related data as appropriate. (Returns nil, nil if no repo found.)
-	repo, err := gitutil.GetGitRepository(projectRoot)
+	gitRepo, err := gitutil.GetGitRepository(projectRoot)
 	if err != nil {
 		return fmt.Errorf("detecting Git repository: %w", err)
 	}
-	if repo == nil {
-		// If we couldn't find a repository, see if explicit environment variables have been set to provide us with
-		// metadata.
-		addGitMetadataFromEnvironment(m)
-
-		return nil
+	if gitRepo != nil {
+		if err := addGitRemoteMetadataToMap(gitRepo, projectRoot, m.Environment); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+		if err := addGitCommitMetadata(gitRepo, projectRoot, m); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+		return allErrors.ErrorOrNil()
 	}
 
-	if err := addGitRemoteMetadataToMap(repo, projectRoot, m.Environment); err != nil {
-		allErrors = multierror.Append(allErrors, err)
+	hgRepo, err := hgutil.FindRepository(projectRoot)
+	if err != nil {
+		return fmt.Errorf("detecting Mercurial repository: %w", err)
+	}
+	if hgRepo != nil {
+		if err := addHgRemoteMetadataToMap(hgRepo, projectRoot, m.Environment); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+		if err := addHgCommitMetadata(hgRepo, m); err != nil {
+			allErrors = multierror.Append(allErrors, err)
+		}
+		return allErrors.ErrorOrNil()
 	}
 
-	if err := addGitCommitMetadata(repo, projectRoot, m); err != nil {
-		allErrors = multierror.Append(allErrors, err)
-	}
-
-	return allErrors.ErrorOrNil()
+	// No repository found — fall back to explicit environment variables.
+	addGitMetadataFromEnvironment(m)
+	return nil
 }
 
 // addGitMetadataFromEnvironment retrieves Git-related metadata from environment variables in the case that a Git
@@ -540,4 +557,81 @@ func (w *anyWriter) Write(d []byte) (int, error) {
 		*w = true
 	}
 	return len(d), nil
+}
+
+// addHgRemoteMetadataToMap reads the given hg repo's default path and
+// populates the vcs.* keys. Shape mirrors addGitRemoteMetadataToMap.
+func addHgRemoteMetadataToMap(repo *hgutil.Repository, projectRoot string, env map[string]string) error {
+	var allErrors *multierror.Error
+
+	remoteURL, err := repo.GetRemoteURL()
+	if err != nil {
+		return fmt.Errorf("detecting hg remote URL: %w", err)
+	}
+
+	if remoteURL != "" {
+		// hg URL shapes overlap with git's for the common hosts we care about
+		// (Bitbucket/Heptapod HTTPS, ssh://). Delegate parsing to hgutil.
+		vcsInfo, err := hgutil.TryGetVCSInfo(remoteURL)
+		if err != nil {
+			allErrors = multierror.Append(allErrors, fmt.Errorf("detecting VCS project information: %w", err))
+		} else {
+			env[backend.VCSRepoOwner] = vcsInfo.Owner
+			env[backend.VCSRepoName] = vcsInfo.Repo
+			env[backend.VCSRepoKind] = vcsInfo.Kind
+		}
+	}
+
+	// Add the repository root path.
+	rel, err := filepath.Rel(repo.Root, projectRoot)
+	if err != nil {
+		allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
+	} else if !strings.HasPrefix(rel, "..") {
+		env[backend.VCSRepoRoot] = filepath.ToSlash(rel)
+	}
+
+	return allErrors.ErrorOrNil()
+}
+
+// addHgCommitMetadata populates git.* commit keys from the hg working
+// directory parent. Mercurial has no separate committer/author concept, so
+// only git.author / git.author.email are set (matching what the pulumi-service
+// deployment executor writes via PULUMI_ENV for hg sources).
+func addHgCommitMetadata(repo *hgutil.Repository, m *backend.UpdateMetadata) error {
+	ciVars := ciutil.DetectVars()
+
+	info, err := repo.GetHeadCommit()
+	if err != nil {
+		return fmt.Errorf("getting hg HEAD commit info: %w", err)
+	}
+
+	m.Environment[backend.GitHead] = info.Hash
+
+	// Mercurial always reports a branch (defaulting to "default"), unlike git
+	// which reports "HEAD" when detached. CI vars override when available.
+	branch := info.Branch
+	if ciVars.BranchName != "" {
+		branch = ciVars.BranchName
+	}
+	if branch != "" {
+		m.Environment[backend.GitHeadName] = branch
+	}
+
+	msg := strings.TrimSpace(info.Message)
+	if msg == "" && ciVars.CommitMessage != "" {
+		msg = ciVars.CommitMessage
+	}
+	if m.Message == "" {
+		m.Message = gitCommitTitle(msg)
+	}
+
+	if info.Author != "" {
+		m.Environment[backend.GitAuthor] = info.Author
+	}
+	if info.AuthorEmail != "" {
+		m.Environment[backend.GitAuthorEmail] = info.AuthorEmail
+	}
+
+	m.Environment[backend.GitDirty] = strconv.FormatBool(info.Dirty)
+	return nil
 }

--- a/pkg/cmd/pulumi/metadata/metadata_test.go
+++ b/pkg/cmd/pulumi/metadata/metadata_test.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -55,7 +56,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 
 		assert.Equal(t, test.Message, "message for commit alpha")
 		assert.Contains(t, test.Environment, backend.GitHead, "Expected to find Git SHA in update environment map")
@@ -79,7 +80,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 
 		assert.Equal(t, "message for commit beta", test.Message)
 		assert.Contains(t, test.Environment, backend.GitHead, "Expected to find Git SHA in update environment map")
@@ -98,7 +99,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 
 		assert.Equal(t, "message for commit beta", test.Message)
 		featureBranch2SHA := test.Environment[backend.GitHead]
@@ -113,7 +114,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 
 		assert.Equal(t, "message for commit alpha", test.Message) // The prior commit
 		assert.Contains(t, test.Environment, backend.GitHead, "Expected to find Git SHA in update environment map")
@@ -129,7 +130,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 		// Ref is still branch2, since `git tag` didn't change anything.
 		assertEnvValue(t, test, backend.GitHeadName, "refs/heads/feature/branch2")
 	}
@@ -142,7 +143,7 @@ func TestReadingGitRepo(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 		assert.NotContains(t, test.Environment, backend.GitHeadName,
 			"Expected no 'git.headName' key, since in detached head state.")
 	}
@@ -160,10 +161,115 @@ func TestReadingGitRepo(t *testing.T) {
 			Environment: make(map[string]string),
 		}
 
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 		name, ok := test.Environment[backend.GitHeadName]
 		assert.True(t, ok, "Expected 'git.headName' key, from CI util.")
 		assert.Equal(t, "branch-from-ci", name)
+	}
+}
+
+// TestReadingHgRepo tests that metadata for a local Mercurial repository is
+// populated into the same git.* / vcs.* keys as a Git repository.
+func TestReadingHgRepo(t *testing.T) {
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg binary not found on PATH; skipping")
+	}
+
+	// Disable CI/CD detection so running this in CI doesn't perturb the expected values.
+	t.Setenv("PULUMI_DISABLE_CI_DETECTION", "1")
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	// Isolate hg from the user's ~/.hgrc. Keep the config file outside the repo
+	// so it doesn't show up in `hg status` as an untracked file.
+	hgrc := filepath.Join(t.TempDir(), "hgrc")
+	require.NoError(t, os.WriteFile(hgrc, []byte(
+		"[ui]\nusername = test <test@test.org>\n",
+	), 0o600))
+	t.Setenv("HGRCPATH", hgrc)
+
+	e.RunCommand("hg", "init")
+	// Configure default remote path.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(e.RootPath, ".hg", "hgrc"),
+		[]byte("[paths]\ndefault = https://bitbucket.org/owner-name/repo-name\n"),
+		0o600,
+	))
+	// Ignore any scaffolding files ptesting drops in RootPath (e.g. .yarnrc)
+	// so they don't pollute `hg status` and cause false "dirty" readings.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(e.RootPath, ".hgignore"),
+		[]byte("syntax: glob\n.yarnrc\n.hgignore\n"),
+		0o600,
+	))
+
+	// First commit on the default branch.
+	e.WriteTestFile("alpha.txt", "")
+	e.RunCommand("hg", "add", "alpha.txt")
+	e.RunCommand("hg", "commit", "-m", "message for commit alpha\n\nDescription for commit alpha")
+
+	// State of the world from a clean hg repo on the default branch.
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
+
+		assert.Equal(t, "message for commit alpha", test.Message)
+		assert.Contains(t, test.Environment, backend.GitHead, "Expected to find hg node hash in update environment map")
+		require.Len(t, test.Environment[backend.GitHead], 40, "Expected full 40-char hg node hash")
+
+		// Mercurial always reports a branch; on a fresh repo that's "default".
+		assertEnvValue(t, test, backend.GitHeadName, "default")
+		assertEnvValue(t, test, backend.GitDirty, "false")
+
+		assertEnvValue(t, test, backend.GitAuthor, "test")
+		assertEnvValue(t, test, backend.GitAuthorEmail, "test@test.org")
+
+		// Mercurial has no committer/author split; committer keys are not set.
+		assert.NotContains(t, test.Environment, backend.GitCommitter)
+		assert.NotContains(t, test.Environment, backend.GitCommitterEmail)
+
+		assertEnvValue(t, test, backend.VCSRepoOwner, "owner-name")
+		assertEnvValue(t, test, backend.VCSRepoName, "repo-name")
+		assertEnvValue(t, test, backend.VCSRepoKind, "bitbucket.org")
+		assertEnvValue(t, test, backend.VCSRepoRoot, ".")
+	}
+
+	// Switch to a named branch; hg.headName is now reported.
+	e.RunCommand("hg", "branch", "feature/branch1")
+	e.WriteTestFile("beta.txt", "")
+	e.RunCommand("hg", "add", "beta.txt")
+	e.RunCommand("hg", "commit", "-m", "message for commit beta")
+	// Untracked file forces dirty.
+	e.WriteTestFile("beta-unsubmitted.txt", "")
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
+
+		assert.Equal(t, "message for commit beta", test.Message)
+		assertEnvValue(t, test, backend.GitHeadName, "feature/branch1")
+		assertEnvValue(t, test, backend.GitDirty, "true")
+	}
+
+	// CI-driven branch name should be adopted when on the default branch.
+	e.RunCommand("hg", "update", "default")
+
+	os.Unsetenv("PULUMI_DISABLE_CI_DETECTION")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("TRAVIS", "1")
+	t.Setenv("TRAVIS_BRANCH", "branch-from-ci")
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
+		assertEnvValue(t, test, backend.GitHeadName, "branch-from-ci")
 	}
 }
 
@@ -193,7 +299,7 @@ func TestReadingGitLabMetadata(t *testing.T) {
 		test := &backend.UpdateMetadata{
 			Environment: make(map[string]string),
 		}
-		require.NoError(t, addGitMetadata(e.RootPath, test))
+		require.NoError(t, addVCSMetadata(e.RootPath, test))
 
 		assert.Contains(t, test.Environment, backend.GitHead, "Expected to find Git SHA in update environment map")
 
@@ -416,7 +522,7 @@ func TestGitMetadataIsReadFromEnvironmentWhenNoRepo(t *testing.T) {
 	}
 
 	// Act.
-	err := addGitMetadata(e.RootPath, test)
+	err := addVCSMetadata(e.RootPath, test)
 
 	// Assert.
 	require.NoError(t, err)
@@ -475,7 +581,7 @@ func TestGitMetadataIsNotReadFromEnvironmentWhenRepo(t *testing.T) {
 	}
 
 	// Act.
-	err := addGitMetadata(subDir, test)
+	err := addVCSMetadata(subDir, test)
 
 	// Assert.
 	require.NoError(t, err)

--- a/sdk/go/common/util/hgutil/hg.go
+++ b/sdk/go/common/util/hgutil/hg.go
@@ -1,0 +1,221 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hgutil provides a minimal wrapper around the `hg` (Mercurial) binary for
+// detecting a local repository and extracting metadata that Pulumi attaches to
+// stack updates.
+//
+// There is no pure-Go Mercurial library, so every operation shells out to the
+// `hg` binary. If `hg` is not available on PATH, discovery returns (nil, nil)
+// so that callers degrade silently to other VCS detection (for example Git)
+// or to environment-variable fallbacks.
+package hgutil
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/mail"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
+)
+
+// Repository is an opaque handle to a Mercurial checkout. Root is the absolute
+// path of the directory that contains the `.hg` metadata directory.
+type Repository struct {
+	Root string
+}
+
+// CommitInfo describes a Mercurial commit.
+type CommitInfo struct {
+	Hash        string
+	Branch      string
+	Author      string
+	AuthorEmail string
+	Message     string
+	Dirty       bool
+}
+
+// hgBin locates the `hg` binary. Returns "" (no error) when not installed, so
+// callers can treat missing Mercurial as "no repo" rather than a failure.
+func hgBin() string {
+	path, err := exec.LookPath("hg")
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+// FindRepository walks up from `dir` looking for a `.hg` directory. Returns
+// (nil, nil) if no repository is found, or if the `hg` binary is not on PATH.
+// This mirrors the contract of gitutil.GetGitRepository.
+func FindRepository(dir string) (*Repository, error) {
+	if hgBin() == "" {
+		return nil, nil
+	}
+
+	hgRoot, err := fsutil.WalkUp(dir, func(s string) bool {
+		return filepath.Base(s) == ".hg"
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("searching for hg repository from %v: %w", dir, err)
+	}
+	if hgRoot == "" {
+		return nil, nil
+	}
+
+	// WalkUp returned the path of the `.hg` directory itself; the repository
+	// root is its parent.
+	return &Repository{Root: filepath.Dir(hgRoot)}, nil
+}
+
+// runHg runs `hg <args...>` in repo.Root and returns trimmed stdout.
+func (r *Repository) runHg(args ...string) (string, error) {
+	bin := hgBin()
+	if bin == "" {
+		return "", errors.New("hg binary not found on PATH")
+	}
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = r.Root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("'hg %s' failed: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// GetRemoteURL returns the URL configured as the default push/pull path, or
+// "" if no default path is configured.
+func (r *Repository) GetRemoteURL() (string, error) {
+	bin := hgBin()
+	if bin == "" {
+		return "", nil
+	}
+	cmd := exec.Command(bin, "paths", "default")
+	cmd.Dir = r.Root
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		// `hg paths default` exits non-zero when no default is configured;
+		// treat that as "no remote" rather than an error.
+		stderrStr := stderr.String()
+		if strings.Contains(stderrStr, "not found") || strings.Contains(stderrStr, "no such path") {
+			return "", nil
+		}
+		return "", fmt.Errorf("'hg paths default' failed: %w: %s", err, strings.TrimSpace(stderrStr))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// Unit separator used to delimit fields in `hg log --template` output. Chosen
+// so multi-line commit messages survive parsing.
+const logFieldSep = "\x1f"
+
+// GetHeadCommit returns information about the commit at `.` (working
+// directory parent) plus the dirty state of the working copy.
+func (r *Repository) GetHeadCommit() (*CommitInfo, error) {
+	// Template emits: hash\x1fbranch\x1fauthor\x1fdesc
+	template := strings.Join([]string{"{node}", "{branch}", "{author}", "{desc}"}, logFieldSep)
+	out, err := r.runHg("log", "-r", ".", "--template", template)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.SplitN(out, logFieldSep, 4)
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("unexpected 'hg log' output: %q", out)
+	}
+
+	author, authorEmail := splitAuthor(parts[2])
+	info := &CommitInfo{
+		Hash:        parts[0],
+		Branch:      parts[1],
+		Author:      author,
+		AuthorEmail: authorEmail,
+		Message:     parts[3],
+	}
+
+	dirty, err := r.isDirty()
+	if err != nil {
+		return nil, err
+	}
+	info.Dirty = dirty
+	return info, nil
+}
+
+// splitAuthor parses an hg author string into name and email. Mercurial's
+// {author} template is typically "Name <email>" but doesn't enforce it.
+func splitAuthor(author string) (name, email string) {
+	author = strings.TrimSpace(author)
+	if author == "" {
+		return "", ""
+	}
+	if addr, err := mail.ParseAddress(author); err == nil {
+		return addr.Name, addr.Address
+	}
+	return author, ""
+}
+
+// isDirty reports whether the working copy has any uncommitted changes or
+// untracked files.
+func (r *Repository) isDirty() (bool, error) {
+	out, err := r.runHg("status")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// TryGetVCSInfo extracts owner / repo / kind information from a Mercurial
+// remote URL. HTTP(S) remotes and the common `ssh://user@host/owner/repo`
+// shape are supported. For other shapes, it delegates to gitutil.TryGetVCSInfo.
+func TryGetVCSInfo(remoteURL string) (*gitutil.VCSInfo, error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if strings.HasPrefix(remoteURL, "ssh://") {
+		return parseSSHRemote(remoteURL)
+	}
+	return gitutil.TryGetVCSInfo(remoteURL)
+}
+
+func parseSSHRemote(remoteURL string) (*gitutil.VCSInfo, error) {
+	u, err := url.Parse(remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing hg ssh remote %q: %w", remoteURL, err)
+	}
+	host := u.Hostname()
+	path := strings.TrimPrefix(u.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	if host == "" || path == "" {
+		return nil, fmt.Errorf("hg ssh remote %q missing host or path", remoteURL)
+	}
+	split := strings.SplitN(path, "/", 2)
+	if len(split) != 2 {
+		return nil, fmt.Errorf("hg ssh remote %q path must include '/'", remoteURL)
+	}
+	return &gitutil.VCSInfo{
+		Owner: split[0],
+		Repo:  split[1],
+		Kind:  host,
+	}, nil
+}

--- a/sdk/go/common/util/hgutil/hg_test.go
+++ b/sdk/go/common/util/hgutil/hg_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hgutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// requireHg skips the test if the `hg` binary is not available on PATH.
+func requireHg(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("hg"); err != nil {
+		t.Skip("hg binary not found on PATH; skipping")
+	}
+}
+
+// initHgRepo creates a new hg repository rooted at a temporary directory and
+// isolates the test from the user's real ~/.hgrc by setting HGRCPATH to a
+// minimal config.
+func initHgRepo(t *testing.T) string {
+	t.Helper()
+	parent := t.TempDir()
+
+	// Isolated hgrc with just enough config for commits to succeed. Keep this
+	// outside the repo so it doesn't show up in `hg status`.
+	hgrc := filepath.Join(parent, "hgrc")
+	require.NoError(t, os.WriteFile(hgrc, []byte(
+		"[ui]\nusername = Test User <test@test.org>\n",
+	), 0o600))
+	t.Setenv("HGRCPATH", hgrc)
+
+	root := filepath.Join(parent, "repo")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	run(t, root, "init")
+	return root
+}
+
+// run executes `hg <args...>` in dir and fails the test if it errors.
+func run(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("hg", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "hg %v failed: %s", args, string(out))
+	return string(out)
+}
+
+//nolint:paralleltest // t.Setenv("HGRCPATH") is incompatible with t.Parallel.
+func TestFindRepository_NoRepo(t *testing.T) {
+	requireHg(t)
+	dir := t.TempDir()
+	repo, err := FindRepository(dir)
+	require.NoError(t, err)
+	assert.Nil(t, repo)
+}
+
+//nolint:paralleltest // t.Setenv("HGRCPATH") is incompatible with t.Parallel.
+func TestFindRepository_FindsWalkingUp(t *testing.T) {
+	requireHg(t)
+	root := initHgRepo(t)
+	sub := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	repo, err := FindRepository(sub)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	// hg/symlink-aware equality: resolve both sides.
+	wantRoot, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+	gotRoot, err := filepath.EvalSymlinks(repo.Root)
+	require.NoError(t, err)
+	assert.Equal(t, wantRoot, gotRoot)
+}
+
+//nolint:paralleltest // t.Setenv("HGRCPATH") is incompatible with t.Parallel.
+func TestGetHeadCommit(t *testing.T) {
+	requireHg(t)
+	root := initHgRepo(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "alpha.txt"), []byte("hi"), 0o600))
+	run(t, root, "add", "alpha.txt")
+	run(t, root, "commit", "-m", "first commit\n\nbody line")
+
+	repo, err := FindRepository(root)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	info, err := repo.GetHeadCommit()
+	require.NoError(t, err)
+
+	require.Len(t, info.Hash, 40, "expected full 40-char hg node hash")
+	assert.Equal(t, "default", info.Branch)
+	assert.Equal(t, "Test User", info.Author)
+	assert.Equal(t, "test@test.org", info.AuthorEmail)
+	assert.Equal(t, "first commit\n\nbody line", info.Message)
+	assert.False(t, info.Dirty)
+
+	// Untracked file makes the tree dirty.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "beta.txt"), []byte(""), 0o600))
+	info2, err := repo.GetHeadCommit()
+	require.NoError(t, err)
+	assert.True(t, info2.Dirty)
+}
+
+//nolint:paralleltest // t.Setenv("HGRCPATH") is incompatible with t.Parallel.
+func TestGetHeadCommit_NamedBranch(t *testing.T) {
+	requireHg(t)
+	root := initHgRepo(t)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "alpha.txt"), []byte("hi"), 0o600))
+	run(t, root, "add", "alpha.txt")
+	run(t, root, "commit", "-m", "first")
+
+	run(t, root, "branch", "feature/x")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "beta.txt"), []byte("hi"), 0o600))
+	run(t, root, "add", "beta.txt")
+	run(t, root, "commit", "-m", "second")
+
+	repo, err := FindRepository(root)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	info, err := repo.GetHeadCommit()
+	require.NoError(t, err)
+	assert.Equal(t, "feature/x", info.Branch)
+}
+
+//nolint:paralleltest // t.Setenv("HGRCPATH") is incompatible with t.Parallel.
+func TestGetRemoteURL(t *testing.T) {
+	requireHg(t)
+	root := initHgRepo(t)
+
+	// No default path configured yet.
+	repo, err := FindRepository(root)
+	require.NoError(t, err)
+	url, err := repo.GetRemoteURL()
+	require.NoError(t, err)
+	assert.Empty(t, url)
+
+	// Configure a default path via the repo-local hgrc.
+	hgrc := filepath.Join(root, ".hg", "hgrc")
+	require.NoError(t, os.WriteFile(hgrc, []byte(
+		"[paths]\ndefault = https://bitbucket.org/owner-name/repo-name\n",
+	), 0o600))
+
+	url, err = repo.GetRemoteURL()
+	require.NoError(t, err)
+	assert.Equal(t, "https://bitbucket.org/owner-name/repo-name", url)
+}
+
+func TestSplitAuthor(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, name, email string
+	}{
+		{"Test User <test@test.org>", "Test User", "test@test.org"},
+		{"test@test.org", "", "test@test.org"},
+		{"plain name", "plain name", ""},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			t.Parallel()
+			name, email := splitAuthor(c.in)
+			assert.Equal(t, c.name, name)
+			assert.Equal(t, c.email, email)
+		})
+	}
+}
+
+func TestTryGetVCSInfo_HTTPS(t *testing.T) {
+	t.Parallel()
+	info, err := TryGetVCSInfo("https://bitbucket.org/owner-name/repo-name")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "owner-name", info.Owner)
+	assert.Equal(t, "repo-name", info.Repo)
+	assert.Equal(t, "bitbucket.org", info.Kind)
+}
+
+func TestTryGetVCSInfo_SSH(t *testing.T) {
+	t.Parallel()
+	info, err := TryGetVCSInfo("ssh://hg@hg.example.com/owner-name/repo-name")
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, "owner-name", info.Owner)
+	assert.Equal(t, "repo-name", info.Repo)
+	assert.Equal(t, "hg.example.com", info.Kind)
+}


### PR DESCRIPTION
## Summary

Adds Mercurial auto-detection to the Pulumi CLI's update metadata pipeline, so `pulumi up` / `pulumi preview` run from a local `.hg` checkout report the same commit, branch, author, remote, and dirty-state metadata as a git checkout does today. Part of the Generic VCS initiative (Phase C) — the service + deployment executor side already landed in `pulumi-service#41015`.

- New `sdk/go/common/util/hgutil` package. Shells out to the `hg` binary (no pure-Go Mercurial library exists); returns `(nil, nil)` from discovery when `hg` is not installed, mirroring `gitutil.GetGitRepository`'s contract.
- Refactors `addGitMetadata` → `addVCSMetadata` in `pkg/cmd/pulumi/metadata/metadata.go`: try git first, then hg, then fall back to `PULUMI_GIT_*` / `PULUMI_VCS_*` env vars. Git is never perturbed.
- Reuses the existing `git.*` / `vcs.*` keys in `backend.UpdateMetadata.Environment` — no new keys, no new env vars. This matches what the pulumi-service deployment executor already populates for hg sources, so nothing on the service side needs to change.

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in \`pkg/engine/lifecycletest\` - For all engine/protocol changes
- [ ] Added a conformance test in \`pkg/testing/pulumi-test-language\` - For language protocol changes
- [ ] Added a golden test in \`pkg/backend/display\` - For changes to the output renderers

New unit coverage:
- \`sdk/go/common/util/hgutil/hg_test.go\` — discovery walk-up, missing repo, head commit (hash/branch/author/email), dirty state, \`hg paths default\` parsing, HTTPS + SSH URL → owner/repo/kind, author-splitting edge cases.
- \`pkg/cmd/pulumi/metadata/metadata_test.go\` — new \`TestReadingHgRepo\` covering default branch, named branch, dirty state, CI branch-name override; existing git tests continue to pass through the renamed entry point.

Manually verified: \`pulumi preview\` in a local hg repo now populates \`git.head\`, \`git.headName\`, \`git.author\`, \`git.author.email\`, \`git.dirty\`, and \`vcs.owner/repo/kind/root\`.

## Validation

- [x] \`make lint\` — clean
- [x] \`make test_fast\` — clean
- [x] \`make tidy_fix\` — clean
- [x] \`make format_fix\` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] \`make check_proto\` — clean (if proto changes) — no proto changes

## Changelog

- [x] Changelog entry added.

## Risk

Low. The git detection path is untouched — git repos continue to be detected first and go through the existing code unchanged. Hg detection is only attempted when no \`.git\` is found walking up. If \`hg\` is not installed, discovery silently returns \`nil\` and we fall through to the env-var path (same as before this PR for non-git directories). No public SDK or CLI surface changes. Mercurial metadata is written to the existing \`git.*\` / \`vcs.*\` keys, so the Pulumi service, stack tags, and UI require no changes.