### PR TITLE
Warn when non-ComponentResource passed to component provider host

### DIFF
--- a/changelog/pending/20260415--sdk-nodejs--warn-when-non-componentresource-is-passed-to-componentproviderhost.yaml
+++ b/changelog/pending/20260415--sdk-nodejs--warn-when-non-componentresource-is-passed-to-componentproviderhost.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk-nodejs
+  description: Warn when a non-ComponentResource class is passed in the explicit `components` list to `componentProviderHost`

--- a/changelog/pending/20260415--sdk-python--warn-when-non-componentresource-is-passed-to-component-provider-host.yaml
+++ b/changelog/pending/20260415--sdk-python--warn-when-non-componentresource-is-passed-to-component-provider-host.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk-python
+  description: Warn when a non-ComponentResource class is passed in the explicit `components` list to `component_provider_host`

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -42,6 +42,8 @@ export type ComponentResourceConstructor = {
 /**
  * Returns true if the given value is a constructor whose prototype chain
  * includes ComponentResource.
+ *
+ * @internal exported for testing
  */
 export function isComponentResourceConstructor(value: any): value is ComponentResourceConstructor {
     if (typeof value !== "function" || !value.prototype) {

--- a/sdk/nodejs/provider/experimental/provider.ts
+++ b/sdk/nodejs/provider/experimental/provider.ts
@@ -40,6 +40,61 @@ export type ComponentResourceConstructor = {
 };
 
 /**
+ * Returns true if the given value is a constructor whose prototype chain
+ * includes ComponentResource.
+ */
+export function isComponentResourceConstructor(value: any): value is ComponentResourceConstructor {
+    if (typeof value !== "function" || !value.prototype) {
+        return false;
+    }
+    let proto = value.prototype;
+    while (proto?.__proto__) {
+        proto = proto.__proto__;
+        if (
+            proto.constructor &&
+            (proto.constructor.name === "ComponentResource" || proto.constructor.__pulumiComponentResource === true)
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Filter the explicit `components` array passed to `componentProviderHost`,
+ * emitting a warning via the supplied `warn` callback for any entry that is
+ * not a `ComponentResource` subclass.
+ *
+ * Source-based component plugins only support classes that extend
+ * `ComponentResource`. Anything else (e.g. a `CustomResource` subclass, a
+ * plain class, or a non-class value) is silently dropped from the generated
+ * schema/SDK, which is a footgun. This helper surfaces a clear diagnostic
+ * naming the offending value while still allowing the host to run with the
+ * valid components.
+ *
+ * @internal exported for testing
+ */
+export function validateExplicitComponents(
+    components: any[],
+    warn: (msg: string) => void = console.warn,
+): ComponentResourceConstructor[] {
+    const valid: ComponentResourceConstructor[] = [];
+    for (const c of components) {
+        if (isComponentResourceConstructor(c)) {
+            valid.push(c);
+        } else {
+            const label = (typeof c === "function" && (c as any).name) || String(c);
+            warn(
+                `componentProviderHost: '${label}' is not a ComponentResource subclass and will be ` +
+                    `excluded from the generated schema/SDK. Source-based component plugins only ` +
+                    `support classes that extend ComponentResource.`,
+            );
+        }
+    }
+    return valid;
+}
+
+/**
  * Get all Pulumi Component constructors from a module's exports.
  * @param moduleExports The exports object of the module to check.
  * @returns Array of Pulumi Component constructors found in the exports.
@@ -216,6 +271,8 @@ export function componentProviderHost(options: ComponentProviderOptions): Promis
         return Promise.resolve();
     }
     isHosting = true;
+
+    options.components = validateExplicitComponents(options.components);
 
     const args = process.argv.slice(2);
     // If dirname is not provided, get it from the call stack

--- a/sdk/nodejs/tests/provider/experimental/provider.spec.ts
+++ b/sdk/nodejs/tests/provider/experimental/provider.spec.ts
@@ -14,7 +14,13 @@
 
 import * as assert from "assert";
 import * as path from "node:path";
-import { ComponentProvider, getPulumiComponents } from "../../../provider/experimental/provider";
+import {
+    ComponentProvider,
+    getPulumiComponents,
+    isComponentResourceConstructor,
+    validateExplicitComponents,
+} from "../../../provider/experimental/provider";
+import { CustomResource } from "../../../resource";
 import { ComponentResource, ComponentResourceOptions } from "../../../resource";
 import { Output, Input } from "../../../output";
 
@@ -301,6 +307,16 @@ describe("getPulumiComponents", () => {
         assert.deepStrictEqual(getPulumiComponents(new Set()), []);
     });
 
+    it("isComponentResourceConstructor distinguishes ComponentResource subclasses", () => {
+        class NotAComponent {}
+        assert.strictEqual(isComponentResourceConstructor(TestComponent1), true);
+        assert.strictEqual(isComponentResourceConstructor(NotAComponent), false);
+        assert.strictEqual(isComponentResourceConstructor(null), false);
+        assert.strictEqual(isComponentResourceConstructor(undefined), false);
+        assert.strictEqual(isComponentResourceConstructor("string"), false);
+        assert.strictEqual(isComponentResourceConstructor({}), false);
+    });
+
     it("deduplicates repeated components", () => {
         const exports = {
             first: TestComponent1,
@@ -314,5 +330,79 @@ describe("getPulumiComponents", () => {
         const result = getPulumiComponents(exports);
         assert.strictEqual(result.length, 1);
         assert.strictEqual(result[0], TestComponent1);
+    });
+});
+
+describe("validateExplicitComponents", () => {
+    class CompA extends ComponentResource {
+        constructor(name: string, args: any, opts: any) {
+            super("test:index:CompA", name, args, opts);
+        }
+    }
+    class CompB extends ComponentResource {
+        constructor(name: string, args: any, opts: any) {
+            super("test:index:CompB", name, args, opts);
+        }
+    }
+    class CompASub extends CompA {}
+    class MyCustom extends CustomResource {
+        constructor(name: string) {
+            super("test:index:MyCustom", name);
+        }
+    }
+    class PlainClass {}
+
+    it("does not warn for an empty list", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, []);
+        assert.deepStrictEqual(warnings, []);
+    });
+
+    it("does not warn for valid component classes", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([CompA, CompB], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, [CompA, CompB]);
+        assert.deepStrictEqual(warnings, []);
+    });
+
+    it("does not warn for subclasses of components", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([CompASub], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, [CompASub]);
+        assert.deepStrictEqual(warnings, []);
+    });
+
+    it("warns and drops a CustomResource subclass", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([MyCustom], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(warnings.length, 1);
+        assert.match(warnings[0], /MyCustom/);
+        assert.match(warnings[0], /ComponentResource/);
+    });
+
+    it("warns and drops a plain class", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([PlainClass], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(warnings.length, 1);
+        assert.match(warnings[0], /PlainClass/);
+    });
+
+    it("warns once per non-component, dropping each", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([null, undefined, 42, "str", {}, () => 1], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, []);
+        assert.strictEqual(warnings.length, 6);
+    });
+
+    it("keeps valid components while warning about invalid ones", () => {
+        const warnings: string[] = [];
+        const result = validateExplicitComponents([CompA, MyCustom, CompB, PlainClass], (m) => warnings.push(m));
+        assert.deepStrictEqual(result, [CompA, CompB]);
+        assert.strictEqual(warnings.length, 2);
+        assert.ok(warnings.some((w) => /MyCustom/.test(w)));
+        assert.ok(warnings.some((w) => /PlainClass/.test(w)));
     });
 });

--- a/sdk/python/lib/pulumi/provider/experimental/host.py
+++ b/sdk/python/lib/pulumi/provider/experimental/host.py
@@ -14,6 +14,7 @@
 
 from inspect import isclass
 import sys
+import warnings
 from types import ModuleType
 from typing import Optional
 
@@ -47,6 +48,8 @@ def component_provider_host(
         return
     is_hosting = True
 
+    components = _validate_explicit_components(components)
+
     # When the languge runtime runs the plugin, the first argument is the path
     # to the plugin's installation directory. This is followed by the engine
     # address and other optional arguments flags, like `--logtostderr`.
@@ -56,6 +59,35 @@ def component_provider_host(
     if version is None:
         version = "0.0.0"
     main(ComponentProvider(components, name, namespace, version), args)
+
+
+def _validate_explicit_components(
+    components: list[type[ComponentResource]],
+) -> list[type[ComponentResource]]:
+    """
+    Filter the explicit `components` list passed to `component_provider_host`,
+    emitting a warning for each entry that is not a `ComponentResource` subclass.
+
+    Source-based component plugins only support classes that extend
+    `ComponentResource`. Anything else (e.g. a `CustomResource` subclass, a plain
+    class, or a non-class value) is silently dropped from the generated
+    schema/SDK, which is a footgun. This helper surfaces a clear diagnostic
+    naming the offending value while still allowing the host to run with the
+    valid components.
+    """
+    valid: list[type[ComponentResource]] = []
+    for c in components:
+        if isclass(c) and issubclass(c, ComponentResource):
+            valid.append(c)
+        else:
+            label = getattr(c, "__name__", repr(c))
+            warnings.warn(
+                f"component_provider_host: '{label}' is not a ComponentResource subclass and "
+                f"will be excluded from the generated schema/SDK. Source-based component plugins "
+                f"only support classes that extend ComponentResource.",
+                stacklevel=3,
+            )
+    return valid
 
 
 def components_from_module(mod: ModuleType) -> list[type[ComponentResource]]:

--- a/sdk/python/lib/test/provider/experimental/test_host.py
+++ b/sdk/python/lib/test/provider/experimental/test_host.py
@@ -84,7 +84,9 @@ def test_warns_for_non_class_values():
 def test_keeps_valid_warns_for_invalid_mixed():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        result = _validate_explicit_components([MyComponent, MyCustom, MyOtherComponent, NotAResource])  # type: ignore[list-item]
+        result = _validate_explicit_components(
+            [MyComponent, MyCustom, MyOtherComponent, NotAResource]
+        )  # type: ignore[list-item]
     assert result == [MyComponent, MyOtherComponent]
     assert len(w) == 2
     messages = [str(x.message) for x in w]

--- a/sdk/python/lib/test/provider/experimental/test_host.py
+++ b/sdk/python/lib/test/provider/experimental/test_host.py
@@ -1,0 +1,103 @@
+# Copyright 2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+from pulumi.provider.experimental.host import _validate_explicit_components
+from pulumi.resource import ComponentResource, CustomResource
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, args=None, opts=None):
+        super().__init__("test:index:MyComponent", name, {}, opts)
+
+
+class MyOtherComponent(ComponentResource):
+    def __init__(self, name, args=None, opts=None):
+        super().__init__("test:index:MyOtherComponent", name, {}, opts)
+
+
+class MyCustom(CustomResource):
+    pass
+
+
+class NotAResource:
+    pass
+
+
+def test_no_warning_for_valid_components():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([MyComponent, MyOtherComponent])
+    assert result == [MyComponent, MyOtherComponent]
+    assert w == []
+
+
+def test_no_warning_for_empty_list():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([])
+    assert result == []
+    assert w == []
+
+
+def test_warns_for_customresource_subclass():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([MyCustom])
+    assert result == []
+    assert len(w) == 1
+    msg = str(w[0].message)
+    assert "MyCustom" in msg
+    assert "ComponentResource" in msg
+
+
+def test_warns_for_plain_class():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([NotAResource])
+    assert result == []
+    assert len(w) == 1
+    assert "NotAResource" in str(w[0].message)
+
+
+def test_warns_for_non_class_values():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components(["MyComponent", None, 42, lambda: None])  # type: ignore[list-item]
+    # All four should warn, none are valid components
+    assert result == []
+    assert len(w) == 4
+
+
+def test_keeps_valid_warns_for_invalid_mixed():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([MyComponent, MyCustom, MyOtherComponent, NotAResource])  # type: ignore[list-item]
+    assert result == [MyComponent, MyOtherComponent]
+    assert len(w) == 2
+    messages = [str(x.message) for x in w]
+    assert any("MyCustom" in m for m in messages)
+    assert any("NotAResource" in m for m in messages)
+
+
+def test_subclass_of_component_is_accepted():
+    class Sub(MyComponent):
+        pass
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _validate_explicit_components([Sub])
+    assert result == [Sub]
+    assert w == []


### PR DESCRIPTION
## Summary

Fixes #22616 and #22617.

The Node.js `componentProviderHost` and Python `component_provider_host` silently filtered out anything that wasn't a `ComponentResource` subclass from their explicit `components` argument. Users who passed a `CustomResource` subclass or a plain class expecting it to appear in the generated schema/SDK got no diagnostic.

- An explicit non-`ComponentResource` entry now produces a clear warning naming the offending class, and the host continues with the valid components.
- Auto-discovery paths (`getPulumiComponents` walking module exports, `components_from_module`) are unchanged — module exports legitimately include many non-component values.

## Test plan

- [x] Node.js: 8 new tests (`validateExplicitComponents` + `isComponentResourceConstructor`) covering empty list, valid components, subclasses, `CustomResource` subclass, plain class, assorted non-class values, and mixed valid+invalid.
- [x] Python: 7 new tests (`test_host.py`) with the same coverage including subclass-of-component acceptance.
- [x] All 27 tests in `provider.spec.ts` and 7 tests in `test_host.py` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)