### PR TITLE
Display backend messages on stack creation

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1088,24 +1088,7 @@ func (b *cloudBackend) CreateStack(
 	}
 
 	// Display messages from the backend if present.
-	if len(details.Messages) > 0 {
-		for _, msg := range details.Messages {
-			m := diag.RawMessage("", msg.Message)
-			switch msg.Severity {
-			case apitype.MessageSeverityError:
-				cmdutil.Diag().Errorf(m)
-			case apitype.MessageSeverityWarning:
-				cmdutil.Diag().Warningf(m)
-			case apitype.MessageSeverityInfo:
-				cmdutil.Diag().Infof(m)
-			default:
-				// Fallback on Info if we don't recognize the severity.
-				cmdutil.Diag().Infof(m)
-				logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
-			}
-		}
-		fmt.Print("\n")
-	}
+	displayBackendMessages(details.Messages)
 
 	stack, err := newStack(ctx, apistack, b)
 	if err != nil {
@@ -1721,24 +1704,7 @@ func (b *cloudBackend) apply(
 	}
 
 	// Display messages from the backend if present.
-	if len(updateMeta.messages) > 0 {
-		for _, msg := range updateMeta.messages {
-			m := diag.RawMessage("", msg.Message)
-			switch msg.Severity {
-			case apitype.MessageSeverityError:
-				cmdutil.Diag().Errorf(m)
-			case apitype.MessageSeverityWarning:
-				cmdutil.Diag().Warningf(m)
-			case apitype.MessageSeverityInfo:
-				cmdutil.Diag().Infof(m)
-			default:
-				// Fallback on Info if we don't recognize the severity.
-				cmdutil.Diag().Infof(m)
-				logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
-			}
-		}
-		fmt.Print("\n")
-	}
+	displayBackendMessages(updateMeta.messages)
 
 	permalink := b.getPermalink(update, updateMeta.version, opts.DryRun)
 	return b.runEngineAction(
@@ -2750,4 +2716,30 @@ func (b *cloudBackend) downgradeUntypedDeploymentVersionIfNeeded(
 		deployment.Version, deployment.Features = b.downgradeDeploymentVersionIfNeeded(
 			ctx, deployment.Version, deployment.Features)
 	}
+}
+
+// displayBackendMessages renders backend-vended messages to the user via the default
+// diagnostic sink, mapping each message's severity to the appropriate log level. A trailing
+// blank line is printed when any messages are displayed, to separate them from subsequent
+// output. If messages is empty, this is a no-op.
+func displayBackendMessages(messages []apitype.Message) {
+	if len(messages) == 0 {
+		return
+	}
+	for _, msg := range messages {
+		m := diag.RawMessage("", msg.Message)
+		switch msg.Severity {
+		case apitype.MessageSeverityError:
+			cmdutil.Diag().Errorf(m)
+		case apitype.MessageSeverityWarning:
+			cmdutil.Diag().Warningf(m)
+		case apitype.MessageSeverityInfo:
+			cmdutil.Diag().Infof(m)
+		default:
+			// Fallback on Info if we don't recognize the severity.
+			cmdutil.Diag().Infof(m)
+			logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
+		}
+	}
+	fmt.Print("\n")
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1071,7 +1071,7 @@ func (b *cloudBackend) CreateStack(
 
 	b.downgradeUntypedDeploymentVersionIfNeeded(ctx, initialState)
 
-	apistack, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState, opts.Config)
+	apistack, messages, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState, opts.Config)
 	if err != nil {
 		// Wire through well-known error types.
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusConflict {
@@ -1085,6 +1085,23 @@ func (b *cloudBackend) CreateStack(
 			}
 		}
 		return nil, err
+	}
+
+	// Display messages from the backend if present (e.g. subscription warnings).
+	for _, msg := range messages {
+		m := diag.RawMessage("", msg.Message)
+		switch msg.Severity {
+		case apitype.MessageSeverityError:
+			cmdutil.Diag().Errorf(m)
+		case apitype.MessageSeverityWarning:
+			cmdutil.Diag().Warningf(m)
+		case apitype.MessageSeverityInfo:
+			cmdutil.Diag().Infof(m)
+		default:
+			// Fallback on Info if we don't recognize the severity.
+			cmdutil.Diag().Infof(m)
+			logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
+		}
 	}
 
 	stack, err := newStack(ctx, apistack, b)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1071,7 +1071,7 @@ func (b *cloudBackend) CreateStack(
 
 	b.downgradeUntypedDeploymentVersionIfNeeded(ctx, initialState)
 
-	apistack, messages, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState, opts.Config)
+	apistack, details, err := b.client.CreateStack(ctx, stackID, tags, opts.Teams, initialState, opts.Config)
 	if err != nil {
 		// Wire through well-known error types.
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == http.StatusConflict {
@@ -1087,21 +1087,24 @@ func (b *cloudBackend) CreateStack(
 		return nil, err
 	}
 
-	// Display messages from the backend if present (e.g. subscription warnings).
-	for _, msg := range messages {
-		m := diag.RawMessage("", msg.Message)
-		switch msg.Severity {
-		case apitype.MessageSeverityError:
-			cmdutil.Diag().Errorf(m)
-		case apitype.MessageSeverityWarning:
-			cmdutil.Diag().Warningf(m)
-		case apitype.MessageSeverityInfo:
-			cmdutil.Diag().Infof(m)
-		default:
-			// Fallback on Info if we don't recognize the severity.
-			cmdutil.Diag().Infof(m)
-			logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
+	// Display messages from the backend if present.
+	if len(details.Messages) > 0 {
+		for _, msg := range details.Messages {
+			m := diag.RawMessage("", msg.Message)
+			switch msg.Severity {
+			case apitype.MessageSeverityError:
+				cmdutil.Diag().Errorf(m)
+			case apitype.MessageSeverityWarning:
+				cmdutil.Diag().Warningf(m)
+			case apitype.MessageSeverityInfo:
+				cmdutil.Diag().Infof(m)
+			default:
+				// Fallback on Info if we don't recognize the severity.
+				cmdutil.Diag().Infof(m)
+				logging.V(7).Infof("Unknown message severity: %s", msg.Severity)
+			}
 		}
+		fmt.Print("\n")
 	}
 
 	stack, err := newStack(ctx, apistack, b)

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -800,6 +800,75 @@ func TestCreateStackDeploymentSchemaVersion(t *testing.T) {
 	assert.Equal(t, []string{"refreshBeforeUpdate"}, lastUntypedDeployment.Features)
 }
 
+// TestCreateStackDisplaysBackendMessages verifies that backend-vended messages on the
+// CreateStackResponse (e.g. an expired trial warning) flow through the client into the
+// cloudBackend without breaking stack creation, and that displayBackendMessages renders
+// them via the diag sink.
+func TestCreateStackDisplaysBackendMessages(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	const trialWarning = "Your organization's trial has expired. " +
+		"Please contact sales@pulumi.com to upgrade."
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/capabilities":
+			err := json.NewEncoder(rw).Encode(apitype.CapabilitiesResponse{})
+			require.NoError(t, err)
+		case "/api/user":
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "test-user",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		case "/api/user/organizations/default":
+			err := json.NewEncoder(rw).Encode(apitype.GetDefaultOrganizationResponse{
+				GitHubLogin: "owner",
+			})
+			require.NoError(t, err)
+		case "/api/stacks/owner/project":
+			rw.WriteHeader(http.StatusOK)
+			err := json.NewEncoder(rw).Encode(apitype.CreateStackResponse{
+				Messages: []apitype.Message{{
+					Severity: apitype.MessageSeverityWarning,
+					Message:  trialWarning,
+				}},
+			})
+			require.NoError(t, err)
+		default:
+			panic(fmt.Sprintf("Path not supported: %v", req.URL.Path))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	b, err := New(ctx, nil, server.URL, nil, false)
+	require.NoError(t, err)
+
+	ref, err := b.ParseStackReference("owner/project/stack")
+	require.NoError(t, err)
+
+	// CreateStack should succeed and the warning message should not interfere with
+	// stack creation; it is rendered via cmdutil.Diag() as a side effect.
+	s, err := b.CreateStack(ctx, ref, "", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	// Exercise displayBackendMessages directly with each severity, including an
+	// unknown one, so the helper's switch arms are all covered. The expired-trial
+	// warning is the primary case driving this test.
+	displayBackendMessages([]apitype.Message{
+		{Severity: apitype.MessageSeverityWarning, Message: trialWarning},
+		{Severity: apitype.MessageSeverityError, Message: "test error"},
+		{Severity: apitype.MessageSeverityInfo, Message: "test info"},
+		{Severity: "mystery", Message: "unknown severity"},
+	})
+
+	// Empty input is a no-op and must not panic.
+	displayBackendMessages(nil)
+}
+
 func TestImportDeploymentSchemaVersion(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -653,9 +653,15 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 	return stack, nil
 }
 
-// CreateStack creates a stack with the given cloud and stack name in the scope of the indicated project.
-// It returns the created stack along with any messages the backend wants displayed to the user (e.g.
-// warnings about the organization's subscription status).
+// CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
+// created, beyond the stack itself.
+type CreateStackDetails struct {
+	Messages []apitype.Message
+}
+
+// CreateStack creates a stack with the given cloud and stack name in the scope of the indicated
+// project. It returns the created stack along with any side information the backend wants the CLI
+// to act on (e.g. messages to display to the user).
 func (pc *Client) CreateStack(
 	ctx context.Context,
 	stackID StackIdentifier,
@@ -663,10 +669,10 @@ func (pc *Client) CreateStack(
 	teams []string,
 	state *apitype.UntypedDeployment,
 	config *apitype.StackConfig,
-) (apitype.Stack, []apitype.Message, error) {
+) (apitype.Stack, CreateStackDetails, error) {
 	// Validate names and tags.
 	if err := validation.ValidateStackTags(tags); err != nil {
-		return apitype.Stack{}, nil, fmt.Errorf("validating stack properties: %w", err)
+		return apitype.Stack{}, CreateStackDetails{}, fmt.Errorf("validating stack properties: %w", err)
 	}
 
 	stack := apitype.Stack{
@@ -687,10 +693,12 @@ func (pc *Client) CreateStack(
 	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)
 	if err := pc.restCall(
 		ctx, "POST", endpoint, nil, &createStackReq, &createStackResp); err != nil {
-		return apitype.Stack{}, nil, err
+		return apitype.Stack{}, CreateStackDetails{}, err
 	}
 
-	return stack, createStackResp.Messages, nil
+	return stack, CreateStackDetails{
+		Messages: createStackResp.Messages,
+	}, nil
 }
 
 // DeleteStack deletes the indicated stack. If force is true, the stack is deleted even if it contains resources.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -654,6 +654,8 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 }
 
 // CreateStack creates a stack with the given cloud and stack name in the scope of the indicated project.
+// It returns the created stack along with any messages the backend wants displayed to the user (e.g.
+// warnings about the organization's subscription status).
 func (pc *Client) CreateStack(
 	ctx context.Context,
 	stackID StackIdentifier,
@@ -661,10 +663,10 @@ func (pc *Client) CreateStack(
 	teams []string,
 	state *apitype.UntypedDeployment,
 	config *apitype.StackConfig,
-) (apitype.Stack, error) {
+) (apitype.Stack, []apitype.Message, error) {
 	// Validate names and tags.
 	if err := validation.ValidateStackTags(tags); err != nil {
-		return apitype.Stack{}, fmt.Errorf("validating stack properties: %w", err)
+		return apitype.Stack{}, nil, fmt.Errorf("validating stack properties: %w", err)
 	}
 
 	stack := apitype.Stack{
@@ -681,13 +683,14 @@ func (pc *Client) CreateStack(
 		Config:    config,
 	}
 
+	var createStackResp apitype.CreateStackResponse
 	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)
 	if err := pc.restCall(
-		ctx, "POST", endpoint, nil, &createStackReq, nil); err != nil {
-		return apitype.Stack{}, err
+		ctx, "POST", endpoint, nil, &createStackReq, &createStackResp); err != nil {
+		return apitype.Stack{}, nil, err
 	}
 
-	return stack, nil
+	return stack, createStackResp.Messages, nil
 }
 
 // DeleteStack deletes the indicated stack. If force is true, the stack is deleted even if it contains resources.

--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -71,7 +71,10 @@ type CreateStackRequest struct {
 }
 
 // CreateStackResponse is the response from a create Stack request.
-type CreateStackResponse struct{}
+type CreateStackResponse struct {
+	// Messages is a list of messages that should be displayed to the user.
+	Messages []Message `json:"messages,omitempty"`
+}
 
 // EncryptValueRequest defines the request body for encrypting a value.
 type EncryptValueRequest struct {


### PR DESCRIPTION
## Context

Today, the update stack paths on `pulumi up/destroy/refresh/preview` produce a warning in the CLI output if the requesting org is on an expired trial or a cancelled subscription. This is done via a `Message` field that gets included in the API response body.

We want to extend this behavior to `pulumi new` since it also is a path that users will most likely see the warning. We want to follow the existing architecture to populate a `Message` field containing the expired trial/cancelled subscription warning.

## Summary
- Adds `Messages []Message` to `apitype.CreateStackResponse`, mirroring the existing `UpdateProgramResponse.Messages` pattern used for `pulumi up`/`preview`/`destroy`.
- `Client.CreateStack` now parses the response body and returns any messages alongside the created stack.
- `cloudBackend.CreateStack` renders the messages using the same severity-aware `cmdutil.Diag()` calls as the update flow, so users see subscription warnings (e.g. expired trials) during `pulumi new` before they invest time configuring a new stack.

This is an additive, backwards-compatible change: older Pulumi Service builds that don't populate `Messages` simply produce an empty list and no output. The companion service-side change is in pulumi-service.

## Test plan
- [x] `go build ./backend/httpstate/...`
- [x] `go vet ./backend/httpstate/...`
- [x] `go test -run TestCreateStack ./backend/httpstate/...`
- [ ] End-to-end: once the service-side PR lands, run `pulumi new` against an org with an expired trial and confirm the warning prints between the project prompts and config prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)