### PR TITLE
Support ADO, Bitbucket, and generic VCS token env vars for git auth

### DIFF
--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -360,6 +360,23 @@ func getAuthForURL(url string) (string, transport.AuthMethod, error) {
 				Username: "oauth2",
 				Password: os.Getenv("GITLAB_TOKEN"),
 			}
+		} else if (strings.Contains(endpoint, "dev.azure.com") ||
+			strings.Contains(endpoint, "visualstudio.com")) &&
+			os.Getenv("AZURE_DEV_OPS_TOKEN") != "" {
+			auth = &http.BasicAuth{
+				Username: "x-access-token",
+				Password: os.Getenv("AZURE_DEV_OPS_TOKEN"),
+			}
+		} else if strings.Contains(endpoint, "bitbucket") && os.Getenv("BITBUCKET_TOKEN") != "" {
+			auth = &http.BasicAuth{
+				Username: "x-token-auth",
+				Password: os.Getenv("BITBUCKET_TOKEN"),
+			}
+		} else if os.Getenv("GENERIC_VCS_TOKEN") != "" {
+			auth = &http.BasicAuth{
+				Username: "x-access-token",
+				Password: os.Getenv("GENERIC_VCS_TOKEN"),
+			}
 		} else if os.Getenv("GIT_USERNAME") != "" || os.Getenv("GIT_PASSWORD") != "" {
 			auth = &http.BasicAuth{
 				Username: os.Getenv("GIT_USERNAME"),

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -458,6 +458,9 @@ func TestParseAuthURL(t *testing.T) {
 	t.Run("with no auth", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
 		t.Setenv("GITLAB_TOKEN", "")
+		t.Setenv("AZURE_DEV_OPS_TOKEN", "")
+		t.Setenv("BITBUCKET_TOKEN", "")
+		t.Setenv("GENERIC_VCS_TOKEN", "")
 
 		_, auth, err := getAuthForURL("http://github.com/pulumi/templates")
 		require.NoError(t, err)
@@ -511,6 +514,58 @@ func TestParseAuthURL(t *testing.T) {
 		_, auth, err = getAuthForURL("http://github.com/pulumi/templates")
 		require.NoError(t, err)
 		assert.Nil(t, auth)
+	})
+
+	t.Run("with AZURE_DEV_OPS_TOKEN set in environment", func(t *testing.T) {
+		t.Setenv("AZURE_DEV_OPS_TOKEN", "token-1")
+		t.Setenv("GITHUB_TOKEN", "")
+		_, auth, err := getAuthForURL("http://dev.azure.com/org/project/_git/repo")
+		require.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "token-1"}, auth)
+
+		// Also works with legacy visualstudio.com URLs.
+		_, auth, err = getAuthForURL("http://org.visualstudio.com/project/_git/repo")
+		require.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "token-1"}, auth)
+
+		// Does not leak to non-ADO URLs.
+		_, auth, err = getAuthForURL("http://github.com/pulumi/templates")
+		require.NoError(t, err)
+		assert.Nil(t, auth)
+	})
+
+	t.Run("with BITBUCKET_TOKEN set in environment", func(t *testing.T) {
+		t.Setenv("BITBUCKET_TOKEN", "token-1")
+		t.Setenv("GITHUB_TOKEN", "")
+		_, auth, err := getAuthForURL("http://bitbucket.org/team/repo")
+		require.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-token-auth", Password: "token-1"}, auth)
+
+		// Does not leak to non-Bitbucket URLs.
+		_, auth, err = getAuthForURL("http://github.com/pulumi/templates")
+		require.NoError(t, err)
+		assert.Nil(t, auth)
+	})
+
+	t.Run("with GENERIC_VCS_TOKEN set in environment", func(t *testing.T) {
+		t.Setenv("GENERIC_VCS_TOKEN", "token-1")
+		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GITLAB_TOKEN", "")
+		t.Setenv("AZURE_DEV_OPS_TOKEN", "")
+		t.Setenv("BITBUCKET_TOKEN", "")
+
+		// Generic token is used as a fallback for unknown hosts.
+		_, auth, err := getAuthForURL("http://git.example.com/org/repo")
+		require.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "token-1"}, auth)
+	})
+
+	t.Run("provider-specific token takes precedence over GENERIC_VCS_TOKEN", func(t *testing.T) {
+		t.Setenv("GENERIC_VCS_TOKEN", "generic")
+		t.Setenv("GITHUB_TOKEN", "github")
+		_, auth, err := getAuthForURL("http://github.com/pulumi/templates")
+		require.NoError(t, err)
+		assert.Equal(t, &http.BasicAuth{Username: "x-access-token", Password: "github"}, auth)
 	})
 
 	t.Run("with GIT_USERNAME/GIT_PASSWORD set in environment", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds environment variable-based git authentication for Azure DevOps, Bitbucket, and generic VCS providers, extending the existing `GITHUB_TOKEN` and `GITLAB_TOKEN` support
- Enables `pulumi install` to authenticate when fetching private git-hosted dependencies from non-GitHub/GitLab providers during Pulumi Deployments
- Companion PR in pulumi-service sets these env vars based on the VCS provider: pulumi/pulumi-service#41402

## Context

The Pulumi CLI's `getAuthForURL()` function in `sdk/go/common/util/gitutil/git.go` provides a fallback authentication chain for git operations. It checks for provider-specific environment variables (`GITHUB_TOKEN`, `GITLAB_TOKEN`) and uses them as HTTP basic auth credentials with the correct username for each provider.

During Pulumi Deployments, the service sets these env vars so that `pulumi install` can authenticate when fetching private component packages. However, only GitHub and GitLab were supported, leaving Azure DevOps, Bitbucket, and generic VCS providers unable to authenticate during dependency downloads.

## Changes

**`sdk/go/common/util/gitutil/git.go`** — added three new env var checks in the `getAuthForURL` fallback chain:

| Env var | URL match | Auth username | Rationale |
|---|---|---|---|
| `AZURE_DEV_OPS_TOKEN` | `dev.azure.com`, `visualstudio.com` | `x-access-token` | ADO accepts any non-empty username with PAT as password |
| `BITBUCKET_TOKEN` | `bitbucket` | `x-token-auth` | Bitbucket workspace/repo access token convention |
| `GENERIC_VCS_TOKEN` | any (last-resort fallback) | `x-access-token` | Catch-all for unknown/generic VCS providers |

Precedence order: provider-specific tokens > `GENERIC_VCS_TOKEN` > `GIT_USERNAME`/`GIT_PASSWORD`.

The username conventions match those used in `pulumi-service/cmd/agents/src/agents_py/git_utils.py:PROVIDER_USERNAMES` and `pulumi-service/cmd/service/vcs/bitbucket/provider.go`.

**`sdk/go/common/util/gitutil/git_test.go`** — added tests for:
- `AZURE_DEV_OPS_TOKEN` with `dev.azure.com` and `visualstudio.com` URLs, plus cross-provider isolation
- `BITBUCKET_TOKEN` with `bitbucket.org` URLs, plus cross-provider isolation
- `GENERIC_VCS_TOKEN` as fallback for unknown hosts
- Provider-specific tokens taking precedence over `GENERIC_VCS_TOKEN`
- Updated "no auth" test to clear new env vars

## Test plan

- [x] `TestParseAuthURL` passes with all new and existing subtests
- [ ] Manual test with Pulumi Deployment using GitLab private dependency (reproduces pulumi/pulumi-service#41356)

🤖 Generated with [Claude Code](https://claude.com/claude-code)