### PR TITLE
Remove orphan RunPlugin2 stub from PCL language host

### DIFF
--- a/changelog/pending/20260416--pcl--remove-orphan-runplugin2-stub-from-pcl-language-host.yaml
+++ b/changelog/pending/20260416--pcl--remove-orphan-runplugin2-stub-from-pcl-language-host.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: pcl
+  description: Remove orphan RunPlugin2 stub from the PCL language host

--- a/sdk/pcl/cmd/pulumi-language-pcl/main.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/main.go
@@ -530,12 +530,6 @@ func (host *pclLanguageHost) RunPlugin(
 	return errors.New("not implemented")
 }
 
-func (host *pclLanguageHost) RunPlugin2(
-	server grpc.BidiStreamingServer[pulumirpc.RunPlugin2Request, pulumirpc.RunPluginResponse],
-) error {
-	return errors.New("not implemented")
-}
-
 func (host *pclLanguageHost) GenerateProject(
 	ctx context.Context, req *pulumirpc.GenerateProjectRequest,
 ) (*pulumirpc.GenerateProjectResponse, error) {


### PR DESCRIPTION
## Summary
- The `RunPlugin2` RPC was removed from the `LanguageRuntime` proto, but the PCL language host still carried an unimplemented stub for it.
- The stub references `grpc.BidiStreamingServer[pulumirpc.RunPlugin2Request, pulumirpc.RunPluginResponse]`, types that no longer exist in the generated code.
- This change drops the dead method.

## Test plan
- [x] `go build ./...` in `sdk/pcl`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)