### PR TITLE
fix(cli/neo): render user messages optimistically in the TUI

### DIFF
--- a/changelog/pending/20260416--cli--render-neo-user-messages-optimistically.yaml
+++ b/changelog/pending/20260416--cli--render-neo-user-messages-optimistically.yaml
@@ -1,0 +1,10 @@
+changes:
+- type: fix
+  scope: cli
+  description: |
+    Render user messages in the `pulumi neo` TUI as soon as they're submitted
+    instead of waiting for the Pulumi Cloud event stream to echo them back.
+    The initial prompt passed on the command line also appears in the
+    transcript at startup. Self-echoes from the server are de-duplicated;
+    user input that originated from another client (e.g. the web UI on the
+    same task) still renders.

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -156,12 +156,13 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
 	model := NewModel(ModelConfig{
-		Org:      orgName,
-		WorkDir:  cwdFlag,
-		Username: username,
-		EventCh:  uiCh,
-		OutCh:    outCh,
-		Busy:     prompt != "",
+		Org:           orgName,
+		WorkDir:       cwdFlag,
+		Username:      username,
+		EventCh:       uiCh,
+		OutCh:         outCh,
+		Busy:          prompt != "",
+		InitialPrompt: prompt,
 	})
 
 	p := tea.NewProgram(model,

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -71,6 +71,12 @@ type ModelConfig struct {
 	// handed a prompt to the backend — the TUI starts with Enter disabled
 	// until the first UITaskIdle.
 	Busy bool
+	// InitialPrompt, when non-empty, is rendered as the first user message
+	// in the transcript and seeds the self-echo suppression queue. Use this
+	// for the prompt passed on the command line (e.g. `pulumi neo "..."`)
+	// which is sent to the backend via CreateNeoTask rather than outCh and
+	// would otherwise only appear once the SSE stream echoes it back.
+	InitialPrompt string
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
@@ -96,6 +102,13 @@ type Model struct {
 	frame             int
 	pendingApproval   bool
 	pendingApprovalID string
+	// pendingUserEchoes is a FIFO of user-message contents the TUI has
+	// already rendered optimistically on submit. When a UIUserMessage
+	// arrives (the server's echo of our own input) and the front of the
+	// queue matches, it is popped and the redundant render is skipped.
+	// Non-matching UIUserMessage events still render — they originated
+	// from another client (e.g. the web UI).
+	pendingUserEchoes []string
 }
 
 var (
@@ -145,6 +158,10 @@ func NewModel(cfg ModelConfig) Model {
 		height:    24,
 	}
 	m.viewport.SetContent(m.welcome.View())
+	if cfg.InitialPrompt != "" {
+		m.appendUserMessageBlock(cfg.InitialPrompt)
+		m.pendingUserEchoes = append(m.pendingUserEchoes, cfg.InitialPrompt)
+	}
 	if cfg.Busy {
 		m.blocks = append(m.blocks, block{
 			kind:    blockBusy,
@@ -258,6 +275,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Type:    userEventUserMessage,
 						Content: text,
 					}:
+						// Render optimistically so the user sees their message in
+						// the transcript before the server echoes it back. The
+						// echo is reconciled against pendingUserEchoes in the
+						// UIUserMessage handler to avoid duplicates.
+						m.appendUserMessageBlock(text)
+						m.pendingUserEchoes = append(m.pendingUserEchoes, text)
 						return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
 					default:
 					}
@@ -382,11 +405,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIUserMessage:
-		m.appendBlock(block{
-			kind:     blockUserMessage,
-			rendered: promptStyle.Render("❯") + " " + userMsgBubble.Render(" "+msg.Content+" "),
-		})
-		m.rebuildContent()
+		// If the queue's front matches, this is the server echoing a message
+		// we already rendered optimistically on submit — pop and skip.
+		// Otherwise it came from another client (e.g. the web UI) and we
+		// render it normally.
+		if len(m.pendingUserEchoes) > 0 && m.pendingUserEchoes[0] == msg.Content {
+			m.pendingUserEchoes = m.pendingUserEchoes[1:]
+		} else {
+			m.appendUserMessageBlock(msg.Content)
+			m.rebuildContent()
+		}
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIApprovalRequest:
@@ -465,6 +493,16 @@ func (m *Model) showBusy(label string, shimmer shimmerKind) tea.Cmd {
 	}
 	m.busy = true
 	return m.spinner.Tick
+}
+
+// appendUserMessageBlock renders a user's chat message as a styled bubble and
+// appends it to the transcript. Used both for optimistic rendering on submit
+// and for echoes that originated outside this TUI.
+func (m *Model) appendUserMessageBlock(content string) {
+	m.appendBlock(block{
+		kind:     blockUserMessage,
+		rendered: promptStyle.Render("❯") + " " + userMsgBubble.Render(" "+content+" "),
+	})
 }
 
 // appendBlock appends a non-busy block, keeping any existing blockBusy

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -358,6 +358,17 @@ func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 	}
 	assert.Empty(t, um.textInput.Value(), "input must clear after send")
 	assert.True(t, um.busy, "sending must enter the busy state")
+
+	// Optimistic render: the user's message must appear in the transcript
+	// as soon as Enter is handled, before any server echo arrives.
+	idx := um.findBlockKind(blockUserMessage)
+	require.NotEqual(t, -1, idx, "Enter must render the user message immediately")
+	assert.Contains(t, um.blocks[idx].rendered, "hello")
+
+	// The content is queued for echo suppression so the server's replay
+	// doesn't duplicate the block.
+	require.Len(t, um.pendingUserEchoes, 1)
+	assert.Equal(t, "hello", um.pendingUserEchoes[0])
 }
 
 func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
@@ -371,6 +382,7 @@ func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 	um := updated.(Model)
 
 	assert.False(t, um.busy, "empty Enter must not enter the busy state")
+	assert.Equal(t, -1, um.findBlockKind(blockUserMessage), "empty Enter must not render a user block")
 	select {
 	case got := <-outCh:
 		t.Fatalf("empty Enter must not send, got %+v", got)
@@ -736,6 +748,8 @@ func TestModel_Update_UISessionURL_UpdatesWelcomeConsoleURL(t *testing.T) {
 func TestModel_Update_UIUserMessage_AppendsUserBlock(t *testing.T) {
 	t.Parallel()
 
+	// With an empty pending queue the echo comes from outside this TUI
+	// (e.g. the web UI on the same task) and must render as a user block.
 	ch := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{EventCh: ch})
 	updated, _ := m.Update(UIUserMessage{Content: "hi there"})
@@ -744,6 +758,86 @@ func TestModel_Update_UIUserMessage_AppendsUserBlock(t *testing.T) {
 	idx := um.findBlockKind(blockUserMessage)
 	require.NotEqual(t, -1, idx)
 	assert.Contains(t, um.blocks[idx].rendered, "hi there")
+}
+
+func TestModel_Update_UIUserMessage_SelfEchoIsSuppressed(t *testing.T) {
+	t.Parallel()
+
+	// Submitting "hi" renders a block optimistically and queues the content
+	// for suppression. When the server echoes that same message back, the
+	// queue entry is popped and the redundant render is skipped — so the
+	// transcript contains exactly one user block.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	evCh := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
+	m.textInput.SetValue("hi")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	<-outCh // drain the submitted event so outCh doesn't leak
+	require.Len(t, m.pendingUserEchoes, 1)
+
+	updated2, _ := m.Update(UIUserMessage{Content: "hi"})
+	m = updated2.(Model)
+
+	count := 0
+	for _, b := range m.blocks {
+		if b.kind == blockUserMessage {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "self-echo must not double-render the user message")
+	assert.Empty(t, m.pendingUserEchoes, "matching echo must pop the queue entry")
+}
+
+func TestModel_Update_UIUserMessage_ForeignEchoStillRenders(t *testing.T) {
+	t.Parallel()
+
+	// A user message that didn't originate from this TUI (for example, the
+	// user typing in the web UI for the same task) must still render. The
+	// dedup queue only suppresses echoes that match what this TUI submitted.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	evCh := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
+	m.textInput.SetValue("from cli")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	<-outCh
+
+	updated2, _ := m.Update(UIUserMessage{Content: "from web"})
+	m = updated2.(Model)
+
+	count := 0
+	for _, b := range m.blocks {
+		if b.kind == blockUserMessage {
+			count++
+		}
+	}
+	assert.Equal(t, 2, count, "non-matching echo must still render as a user block")
+	require.Len(t, m.pendingUserEchoes, 1, "non-matching echo must not pop the queue")
+	assert.Equal(t, "from cli", m.pendingUserEchoes[0])
+}
+
+func TestNewModel_InitialPromptRendersUserBlock(t *testing.T) {
+	t.Parallel()
+
+	// `pulumi neo "my prompt"` sends the prompt via CreateNeoTask rather
+	// than outCh, so the TUI only learns about it through ModelConfig.
+	// NewModel must render it as a user block and seed the echo queue so
+	// the server's replay doesn't duplicate it.
+	m := NewModel(ModelConfig{InitialPrompt: "kick off", Busy: true})
+
+	idx := m.findBlockKind(blockUserMessage)
+	require.NotEqual(t, -1, idx, "initial prompt must appear as a user block at startup")
+	assert.Contains(t, m.blocks[idx].rendered, "kick off")
+
+	require.Len(t, m.pendingUserEchoes, 1)
+	assert.Equal(t, "kick off", m.pendingUserEchoes[0])
+
+	// The busy block still sits at the bottom so the spinner is visible
+	// while the agent starts its first turn.
+	assert.Equal(t, blockBusy, m.blocks[len(m.blocks)-1].kind)
 }
 
 func TestModel_View_ShowsHintBasedOnBusy(t *testing.T) {


### PR DESCRIPTION
User messages typed into the pulumi neo TUI were not appearing in the
transcript until the Pulumi Cloud event stream echoed them back. The
initial prompt passed on the command line had the same issue. This introduced a noticeable delay in the UI.

Render user messages locally as soon as the CLI learns about them
(Enter submit, and the initial prompt from ModelConfig). Track rendered
contents in a FIFO queue so matching server echoes are suppressed;
non-matching echoes (e.g. from the web UI on the same task) still
render as user blocks.

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->


Recording: https://asciinema.org/a/CZXbg1ZPhPT8bMvv

fixes https://github.com/pulumi/pulumi-service/issues/41317