### PR TITLE
feat(cli/neo): add plan-mode toggle to the pulumi neo TUI

### DIFF
--- a/changelog/pending/20260416--cli--add-plan-mode-toggle-to-pulumi-neo.yaml
+++ b/changelog/pending/20260416--cli--add-plan-mode-toggle-to-pulumi-neo.yaml
@@ -1,0 +1,10 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    Add a plan-mode toggle to the `pulumi neo` TUI, bound to Shift+Tab. When
+    plan mode is on, Neo explores and asks questions without writing files,
+    running `pulumi up`, or opening PRs, and surfaces an approved plan via a
+    dedicated approval gate. The toggle must be set before the first message
+    (plan mode is task-level on the wire); approving the proposed plan exits
+    plan mode automatically.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1531,7 +1531,8 @@ func (b *cloudBackend) createNeoTaskOnError(
 		"Help me debug the following Pulumi error for project %s and stack %s:\n\n%s",
 		stackID.Project, stackID.Stack.String(), pulumiOutput)
 
-	return b.client.CreateNeoTask(ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, "", "", false)
+	return b.client.CreateNeoTask(
+		ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, client.CreateNeoTaskOptions{})
 }
 
 type updateMetadata struct {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1531,7 +1531,7 @@ func (b *cloudBackend) createNeoTaskOnError(
 		"Help me debug the following Pulumi error for project %s and stack %s:\n\n%s",
 		stackID.Project, stackID.Stack.String(), pulumiOutput)
 
-	return b.client.CreateNeoTask(ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, "", "")
+	return b.client.CreateNeoTask(ctx, stackID.Owner, content, stackID.Stack.String(), stackID.Project, "", "", false)
 }
 
 type updateMetadata struct {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -79,6 +79,11 @@ type NeoTaskRequest struct {
 	// ApprovalMode controls whether the agent requires user approval before executing tools.
 	// JSON tag is camelCase to match apitype.CreateAgentTaskRequest from pulumi-service.
 	ApprovalMode NeoApprovalMode `json:"approvalMode,omitempty"`
+	// PlanMode, when true, creates the task in plan mode: the agent explores and asks
+	// questions but must not write files, run `pulumi up`, or open PRs. The server enforces
+	// this by activating PlanModeTracker for the task and gating the exit on an approved
+	// exit_plan_mode call. JSON tag is camelCase to match the service IDL.
+	PlanMode bool `json:"planMode,omitempty"`
 }
 
 // NeoTaskMessage represents the message content for a Neo task.
@@ -1688,6 +1693,7 @@ func (pc *Client) ExplainPreviewWithNeo(
 // "cli" to have the cloud agent emit CliToolRequest events for the local-tool subset
 // (filesystem, shell) instead of running them itself. Pass an approvalMode of "manual"
 // to require user approval before each tool call; empty uses the server default.
+// Pass planMode = true to create the task in plan mode (explore/ask only, no writes).
 func (pc *Client) CreateNeoTask(
 	ctx context.Context,
 	orgName string,
@@ -1696,6 +1702,7 @@ func (pc *Client) CreateNeoTask(
 	projectName string,
 	toolExecutionMode string,
 	approvalMode NeoApprovalMode,
+	planMode bool,
 ) (*NeoTaskResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
 	defer cancel()
@@ -1708,6 +1715,7 @@ func (pc *Client) CreateNeoTask(
 		},
 		ToolExecutionMode: toolExecutionMode,
 		ApprovalMode:      approvalMode,
+		PlanMode:          planMode,
 	}
 	// Only attach a stack entity when we actually have one — the backend rejects
 	// entity_diff entries with empty name/project as "unable to access stack".

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1688,21 +1688,25 @@ func (pc *Client) ExplainPreviewWithNeo(
 	return pc.callCopilot(ctx, request)
 }
 
-// CreateNeoTask creates a new Neo agent task via the Neo Tasks API. Pass an empty
-// toolExecutionMode for the default (cloud) mode used by `--neo-task-on-failure`; pass
-// "cli" to have the cloud agent emit CliToolRequest events for the local-tool subset
-// (filesystem, shell) instead of running them itself. Pass an approvalMode of "manual"
-// to require user approval before each tool call; empty uses the server default.
-// Pass planMode = true to create the task in plan mode (explore/ask only, no writes).
+// CreateNeoTaskOptions bundles the optional knobs on CreateNeoTask. The zero value
+// corresponds to the defaults used by `--neo-task-on-failure`: cloud tool execution,
+// server-default approval policy, and plan mode off.
+type CreateNeoTaskOptions struct {
+	ToolExecutionMode string
+	ApprovalMode      NeoApprovalMode
+	PlanMode          bool
+}
+
+// CreateNeoTask creates a new Neo agent task via the Neo Tasks API. See
+// CreateNeoTaskOptions for the available knobs; pass a zero-value struct to accept
+// server defaults (the `--neo-task-on-failure` path).
 func (pc *Client) CreateNeoTask(
 	ctx context.Context,
 	orgName string,
 	content string,
 	stackName string,
 	projectName string,
-	toolExecutionMode string,
-	approvalMode NeoApprovalMode,
-	planMode bool,
+	opts CreateNeoTaskOptions,
 ) (*NeoTaskResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
 	defer cancel()
@@ -1713,9 +1717,9 @@ func (pc *Client) CreateNeoTask(
 			Content:   content,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
-		ToolExecutionMode: toolExecutionMode,
-		ApprovalMode:      approvalMode,
-		PlanMode:          planMode,
+		ToolExecutionMode: opts.ToolExecutionMode,
+		ApprovalMode:      opts.ApprovalMode,
+		PlanMode:          opts.PlanMode,
 	}
 	// Only attach a stack entity when we actually have one — the backend rejects
 	// entity_diff entries with empty name/project as "unable to access stack".

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -868,7 +868,7 @@ func TestCreateNeoTask(t *testing.T) {
 
 		client := newMockClient(successServer)
 		resp, err := client.CreateNeoTask(
-			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", CreateNeoTaskOptions{})
 
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -883,7 +883,7 @@ func TestCreateNeoTask(t *testing.T) {
 
 		client := newMockClient(errorServer)
 		resp, err := client.CreateNeoTask(
-			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", CreateNeoTaskOptions{})
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -898,7 +898,7 @@ func TestCreateNeoTask(t *testing.T) {
 
 		client := newMockClient(unauthorizedServer)
 		resp, err := client.CreateNeoTask(
-			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", CreateNeoTaskOptions{})
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -925,7 +925,9 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", "cli", "", false)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode: "cli",
+		})
 		require.NoError(t, err)
 
 		assert.Equal(t, http.MethodPost, gotMethod)
@@ -965,8 +967,10 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(
-			t.Context(), "my-org", "hi", "stack", "proj", "cli", NeoApprovalModeManual)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "stack", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode: "cli",
+			ApprovalMode:      NeoApprovalModeManual,
+		})
 		require.NoError(t, err)
 
 		assert.Equal(t, "manual", gotBody["approvalMode"])
@@ -986,7 +990,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "", false)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", CreateNeoTaskOptions{})
 		require.NoError(t, err)
 
 		message, _ := gotBody["message"].(map[string]any)
@@ -1009,7 +1013,10 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "plan this", "", "proj", "cli", "", true)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "plan this", "", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode: "cli",
+			PlanMode:          true,
+		})
 		require.NoError(t, err)
 
 		assert.Equal(t, true, gotBody["planMode"], "planMode=true must be sent as planMode:true")
@@ -1027,7 +1034,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "", false)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", CreateNeoTaskOptions{})
 		require.NoError(t, err)
 
 		assert.NotContains(t, gotBody, "planMode", "planMode must be omitted when false")

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -867,7 +867,8 @@ func TestCreateNeoTask(t *testing.T) {
 		defer successServer.Close()
 
 		client := newMockClient(successServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
+		resp, err := client.CreateNeoTask(
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
 
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -881,7 +882,8 @@ func TestCreateNeoTask(t *testing.T) {
 		defer errorServer.Close()
 
 		client := newMockClient(errorServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
+		resp, err := client.CreateNeoTask(
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -895,7 +897,8 @@ func TestCreateNeoTask(t *testing.T) {
 		defer unauthorizedServer.Close()
 
 		client := newMockClient(unauthorizedServer)
-		resp, err := client.CreateNeoTask(t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "")
+		resp, err := client.CreateNeoTask(
+			t.Context(), "my-org", "Help me debug this error", "my-stack", "my-project", "", "", false)
 
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -922,7 +925,7 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", "cli", "")
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hello", "stack", "proj", "cli", "", false)
 		require.NoError(t, err)
 
 		assert.Equal(t, http.MethodPost, gotMethod)
@@ -983,12 +986,51 @@ func TestCreateNeoTask(t *testing.T) {
 		defer server.Close()
 
 		client := newMockClient(server)
-		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "")
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "", false)
 		require.NoError(t, err)
 
 		message, _ := gotBody["message"].(map[string]any)
 		require.NotNil(t, message)
 		assert.NotContains(t, message, "entity_diff")
+	})
+
+	t.Run("PlanModeInRequestBody", func(t *testing.T) {
+		t.Parallel()
+
+		// planMode is a per-task feature flag plumbed on CreateAgentTaskRequest; the
+		// JSON tag must be camelCase planMode, and an omitted (false) value must not
+		// leak into the request so unrelated callers aren't implicitly opted in.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_3"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "plan this", "", "proj", "cli", "", true)
+		require.NoError(t, err)
+
+		assert.Equal(t, true, gotBody["planMode"], "planMode=true must be sent as planMode:true")
+	})
+
+	t.Run("PlanModeOmittedWhenFalse", func(t *testing.T) {
+		t.Parallel()
+
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_4"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", "", "", false)
+		require.NoError(t, err)
+
+		assert.NotContains(t, gotBody, "planMode", "planMode must be omitted when false")
 	})
 }
 

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -16,8 +16,7 @@
 // pairs with Pulumi Cloud's Neo agent when a task is created in `cli` tool execution mode.
 //
 // The wire types consumed by this loop live in sdk/go/common/apitype (see neo.go there).
-// This file only defines the string discriminator values we filter on and the local-only
-// helper shapes the TUI uses to peek at backend events.
+// This file only defines the string discriminator values we filter on.
 package neo
 
 // Discriminator values for the AgentConsoleEvent envelope and the inner backend/user
@@ -48,4 +47,12 @@ const (
 	backendEventWarning              = "warning"
 	backendEventCancelled            = "cancelled"
 	backendEventUserApprovalRequest  = "user_approval_request"
+
+	// approvalTypePlanExit is the approval_type value the service sets on a
+	// user_approval_request that gates an exit_plan_mode tool call. The TUI
+	// renders context.plan_description with markdown and, on user approval,
+	// auto-clears the local plan-mode indicator (the server-side PlanModeTracker
+	// exits in lockstep). Any other value (today: "general") takes the regular
+	// tool-approval rendering path.
+	approvalTypePlanExit = "plan_exit"
 )

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -33,12 +33,7 @@ const (
 	// handled by the agent runtime and must not be touched by the CLI.
 	toolExecutionModeCLI = "cli"
 
-	// userEventUserMessage is the user event the CLI posts when the user types a chat
-	// message into the TUI.
-	userEventUserMessage = "user_message"
-
-	// userEventUserConfirmation is the user event the CLI posts in response to a
-	// user_approval_request backend event, approving or denying the operation.
+	userEventUserMessage      = "user_message"
 	userEventUserConfirmation = "user_confirmation"
 
 	// Additional backend event types forwarded to the TUI.

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"sync/atomic"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -40,20 +39,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// sessionConfig is the per-session mutable state shared between the bubbletea TUI
-// (which owns the toggle affordance) and the background dispatcher that calls
-// CreateNeoTask (which needs to read the final planMode value at task-creation time).
-// Both fields are atomic so the TUI can flip them from inside Update without
-// synchronising against the dispatcher goroutine.
-type sessionConfig struct {
-	// planMode reflects the user's current choice, toggled via Shift+Tab. Read once
-	// by the dispatcher when CreateNeoTask is invoked for the first user message;
-	// may be cleared by the TUI when the user approves an exit_plan_mode request.
-	planMode atomic.Bool
-	// taskCreated is set by the dispatcher after CreateNeoTask returns successfully.
-	// The TUI reads it to decide whether Shift+Tab should toggle (pre-task, effective)
-	// or emit a one-shot warning (post-task, ineffective because planMode is task-level).
-	taskCreated atomic.Bool
+// outboundEvent is the local envelope the TUI uses to dispatch user events to
+// runNeo's dispatcher loop. It wraps the wire-level AgentUserEvent and tacks on
+// planMode, which is only meaningful for the first user_message (the one that
+// triggers CreateNeoTask). Wrapping keeps planMode out of apitype and avoids a
+// second channel for a value that's always produced alongside a message.
+type outboundEvent struct {
+	event    apitype.AgentUserEvent
+	planMode bool
 }
 
 // NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
@@ -146,10 +139,11 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
-		// Plan mode is only reachable via the TTY's Shift+Tab toggle today; scripted
-		// invocations are never started in plan mode.
 		resp, err := pc.CreateNeoTask(
-			ctx, orgName, prompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual, false)
+			ctx, orgName, prompt, stackRefName, projectName, client.CreateNeoTaskOptions{
+				ToolExecutionMode: "cli",
+				ApprovalMode:      client.NeoApprovalModeManual,
+			})
 		if err != nil {
 			return err
 		}
@@ -170,14 +164,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	}
 
 	uiCh := make(chan UIEvent, 64)
-	outCh := make(chan apitype.AgentUserEvent, 8)
+	outCh := make(chan outboundEvent, 8)
 
-	// Resolve the username for the welcome greeting.
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
-
-	// Shared state between the TUI (toggle source) and the dispatcher (reader at
-	// CreateNeoTask time). Allocated here so both halves observe the same atomics.
-	sessionCfg := &sessionConfig{}
 
 	model := NewModel(ModelConfig{
 		Org:           orgName,
@@ -187,7 +176,6 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		OutCh:         outCh,
 		Busy:          prompt != "",
 		InitialPrompt: prompt,
-		Config:        sessionCfg,
 	})
 
 	p := tea.NewProgram(model,
@@ -206,14 +194,15 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	// createTask creates the Neo task with the given prompt and starts the session.
 	// Called immediately if a prompt was provided, or on the first user message.
-	createTask := func(initialPrompt string) error {
-		// Snapshot planMode at task-creation time. The toggle is task-level on the
-		// wire, so late flips (e.g. a racing Shift+Tab while we're in flight) don't
-		// retroactively change the task's configuration.
-		planMode := sessionCfg.planMode.Load()
+	// planMode is the value the TUI captured at the moment the first message was
+	// sent; the CLI-prompt path always passes false.
+	createTask := func(initialPrompt string, planMode bool) error {
 		resp, err := pc.CreateNeoTask(
-			gctx, orgName, initialPrompt, stackRefName, projectName, "cli",
-			client.NeoApprovalModeManual, planMode)
+			gctx, orgName, initialPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
+				ToolExecutionMode: "cli",
+				ApprovalMode:      client.NeoApprovalModeManual,
+				PlanMode:          planMode,
+			})
 		if err != nil {
 			return err
 		}
@@ -221,9 +210,6 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		ts.mu.Lock()
 		ts.taskID = resp.TaskID
 		ts.mu.Unlock()
-		// Mark the task as created so the TUI's Shift+Tab handler switches from
-		// "toggle the atomic" to "emit a one-shot warning".
-		sessionCfg.taskCreated.Store(true)
 
 		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
 		if consoleURL != "" {
@@ -241,8 +227,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	}
 
 	if prompt != "" {
+		// The command-line prompt path always passes false for planMode.
 		g.Go(func() error {
-			return createTask(prompt)
+			return createTask(prompt, false)
 		})
 	}
 
@@ -260,14 +247,15 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 			select {
 			case <-gctx.Done():
 				return nil
-			case evt, ok := <-outCh:
+			case ob, ok := <-outCh:
 				if !ok {
 					return nil
 				}
-				if msg, isMsg := evt.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
+				if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
 					taskCreated = true
+					planMode := ob.planMode
 					g.Go(func() error {
-						return createTask(msg.Content)
+						return createTask(msg.Content, planMode)
 					})
 					continue
 				}
@@ -282,7 +270,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 					sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
 					continue
 				}
-				if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, evt); err != nil {
+				if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, ob.event); err != nil {
 					sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
 				}
 			}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -38,6 +39,22 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+// sessionConfig is the per-session mutable state shared between the bubbletea TUI
+// (which owns the toggle affordance) and the background dispatcher that calls
+// CreateNeoTask (which needs to read the final planMode value at task-creation time).
+// Both fields are atomic so the TUI can flip them from inside Update without
+// synchronising against the dispatcher goroutine.
+type sessionConfig struct {
+	// planMode reflects the user's current choice, toggled via Shift+Tab. Read once
+	// by the dispatcher when CreateNeoTask is invoked for the first user message;
+	// may be cleared by the TUI when the user approves an exit_plan_mode request.
+	planMode atomic.Bool
+	// taskCreated is set by the dispatcher after CreateNeoTask returns successfully.
+	// The TUI reads it to decide whether Shift+Tab should toggle (pre-task, effective)
+	// or emit a one-shot warning (post-task, ineffective because planMode is task-level).
+	taskCreated atomic.Bool
+}
 
 // NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
 // Neo task in `cli` tool execution mode, prints a console URL the user can open in a
@@ -129,7 +146,10 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
-		resp, err := pc.CreateNeoTask(ctx, orgName, prompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
+		// Plan mode is only reachable via the TTY's Shift+Tab toggle today; scripted
+		// invocations are never started in plan mode.
+		resp, err := pc.CreateNeoTask(
+			ctx, orgName, prompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual, false)
 		if err != nil {
 			return err
 		}
@@ -155,6 +175,10 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// Resolve the username for the welcome greeting.
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
+	// Shared state between the TUI (toggle source) and the dispatcher (reader at
+	// CreateNeoTask time). Allocated here so both halves observe the same atomics.
+	sessionCfg := &sessionConfig{}
+
 	model := NewModel(ModelConfig{
 		Org:           orgName,
 		WorkDir:       cwdFlag,
@@ -163,6 +187,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		OutCh:         outCh,
 		Busy:          prompt != "",
 		InitialPrompt: prompt,
+		Config:        sessionCfg,
 	})
 
 	p := tea.NewProgram(model,
@@ -182,8 +207,13 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// createTask creates the Neo task with the given prompt and starts the session.
 	// Called immediately if a prompt was provided, or on the first user message.
 	createTask := func(initialPrompt string) error {
+		// Snapshot planMode at task-creation time. The toggle is task-level on the
+		// wire, so late flips (e.g. a racing Shift+Tab while we're in flight) don't
+		// retroactively change the task's configuration.
+		planMode := sessionCfg.planMode.Load()
 		resp, err := pc.CreateNeoTask(
-			gctx, orgName, initialPrompt, stackRefName, projectName, "cli", client.NeoApprovalModeManual)
+			gctx, orgName, initialPrompt, stackRefName, projectName, "cli",
+			client.NeoApprovalModeManual, planMode)
 		if err != nil {
 			return err
 		}
@@ -191,6 +221,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		ts.mu.Lock()
 		ts.taskID = resp.TaskID
 		ts.mu.Unlock()
+		// Mark the task as created so the TUI's Shift+Tab handler switches from
+		// "toggle the atomic" to "emit a one-shot warning".
+		sessionCfg.taskCreated.Store(true)
 
 		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
 		if consoleURL != "" {

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -272,9 +272,11 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 			return
 		}
 		sendUI(s.UIEvents, UIApprovalRequest{
-			ApprovalID:  a.ID,
-			Message:     a.Message,
-			Sensitivity: a.Sensitivity,
+			ApprovalID:      a.ID,
+			Message:         a.Message,
+			Sensitivity:     a.Sensitivity,
+			ApprovalType:    a.ApprovalType,
+			PlanDescription: a.Context.PlanDescription,
 		})
 	}
 	// Server-side exec_tool_call and tool_response events describe tools the agent

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -267,16 +267,16 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 	case backendEventCancelled:
 		sendUI(s.UIEvents, UICancelled{})
 	case backendEventUserApprovalRequest:
-		var a apitype.AgentBackendEventUserApprovalRequest
-		if err := json.Unmarshal(eventBody, &a); err != nil {
+		var req apitype.AgentBackendEventUserApprovalRequest
+		if err := json.Unmarshal(eventBody, &req); err != nil {
 			return
 		}
 		sendUI(s.UIEvents, UIApprovalRequest{
-			ApprovalID:      a.ID,
-			Message:         a.Message,
-			Sensitivity:     a.Sensitivity,
-			ApprovalType:    a.ApprovalType,
-			PlanDescription: a.Context.PlanDescription,
+			ApprovalID:      req.ApprovalID,
+			Message:         req.Message,
+			Sensitivity:     req.Sensitivity,
+			ApprovalType:    req.ApprovalType,
+			PlanDescription: req.Context.PlanDescription,
 		})
 	}
 	// Server-side exec_tool_call and tool_response events describe tools the agent

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -77,6 +77,11 @@ type ModelConfig struct {
 	// which is sent to the backend via CreateNeoTask rather than outCh and
 	// would otherwise only appear once the SSE stream echoes it back.
 	InitialPrompt string
+	// Config is the shared session state the TUI and the dispatcher both
+	// read/write — today just the plan-mode toggle and a "task created" flag.
+	// NewModel allocates a zero-value sessionConfig if this is nil so tests
+	// can construct a Model without plumbing the shared state through.
+	Config *sessionConfig
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
@@ -109,6 +114,15 @@ type Model struct {
 	// Non-matching UIUserMessage events still render — they originated
 	// from another client (e.g. the web UI).
 	pendingUserEchoes []string
+	// config is shared with the dispatcher goroutine in runNeo. Owned via a
+	// pointer so Shift+Tab / plan-approval handlers can mutate the atomics
+	// that the dispatcher reads at CreateNeoTask time. Always non-nil after
+	// NewModel — the constructor allocates a fresh one if the caller passed nil.
+	config *sessionConfig
+	// pendingApprovalIsPlan is true when the currently pending approval is an
+	// exit_plan_mode gate, so the Enter handler knows to auto-clear planMode on
+	// approval.
+	pendingApprovalIsPlan bool
 }
 
 var (
@@ -122,6 +136,10 @@ var (
 	toolErrMarker  = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
 	finalMarker    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Render("⏺")
 	userMsgBubble  = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("8"))
+	// planModeIndicatorStyle is a distinct cyan+bold so the footer banner is
+	// visible at a glance; it contrasts against the faint, neutral hint line.
+	planModeIndicatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	planBlockHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 )
 
 // NewModel creates a new TUI Model.
@@ -140,6 +158,11 @@ func NewModel(cfg ModelConfig) Model {
 		spinner.WithStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("6"))),
 	)
 
+	sc := cfg.Config
+	if sc == nil {
+		sc = &sessionConfig{}
+	}
+
 	m := Model{
 		welcome: welcomeModel{
 			org:       cfg.Org,
@@ -156,6 +179,7 @@ func NewModel(cfg ModelConfig) Model {
 		spinner:   sp,
 		width:     80,
 		height:    24,
+		config:    sc,
 	}
 	m.viewport.SetContent(m.welcome.View())
 	if cfg.InitialPrompt != "" {
@@ -212,6 +236,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 
+		// Shift+Tab toggles plan mode. The toggle must run before the approval
+		// and busy guards so users can flip the indicator at any point in the
+		// pre-task window, even while the startup spinner is up. It also has to
+		// intercept the key before textinput.Update sees it, since textinput
+		// otherwise treats Shift+Tab as a keypress with no visible effect.
+		if msg.Type == tea.KeyShiftTab {
+			if m.config.taskCreated.Load() {
+				// Plan mode is task-level on the wire. Toggling post-creation
+				// would be misleading — the server's state is already fixed.
+				m.appendBlock(block{
+					kind: blockWarning,
+					rendered: "  " + warningStyle.Render(
+						"⚠ Plan mode is task-level — start a new `pulumi neo` session to change it."),
+				})
+				m.rebuildContent()
+				return m, nil
+			}
+			// Flip the atomic. The dispatcher reads it lazily at CreateNeoTask
+			// time, so this write doesn't need ordering with task creation.
+			m.config.planMode.Store(!m.config.planMode.Load())
+			m.rebuildContent()
+			return m, nil
+		}
+
 		// Handled before the busy check because the agent is intentionally
 		// paused here waiting for the user.
 		if m.pendingApproval {
@@ -222,6 +270,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if !approved {
 					denialMsg = text
 				}
+				wasPlanApproval := m.pendingApprovalIsPlan
 				if m.outCh != nil {
 					select {
 					case m.outCh <- apitype.AgentUserEventUserConfirmation{
@@ -235,6 +284,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.pendingApproval = false
 				m.pendingApprovalID = ""
+				m.pendingApprovalIsPlan = false
+				// Approving a plan exits plan mode server-side (the PlanModeTracker
+				// stops gating writes), so mirror that locally. Denial leaves the
+				// mode on — the agent will re-plan and gate-out again on the next
+				// exit_plan_mode call.
+				if wasPlanApproval && approved && m.config != nil {
+					m.config.planMode.Store(false)
+				}
 				m.textInput.Prompt = "❯ "
 				m.textInput.PromptStyle = promptStyle
 				m.textInput.Placeholder = "Send a message..."
@@ -419,14 +476,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case UIApprovalRequest:
 		m.endBusy()
-		warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
-		m.appendBlock(block{
-			kind:     blockApproval,
-			rendered: "  " + warnStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
-		})
 		m.pendingApproval = true
 		m.pendingApprovalID = msg.ApprovalID
-		m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
+		m.pendingApprovalIsPlan = msg.ApprovalType == approvalTypePlanExit
+		if m.pendingApprovalIsPlan {
+			// Plan bodies are authored as markdown — headings, bullet lists, code
+			// blocks. Route through the same glamour renderer used for final
+			// assistant messages so the approval reads as a proper plan document
+			// rather than a single-line warning. The approval event's `message`
+			// field holds a generic intro ("I've finished exploring..."); the
+			// actual plan is in `context.plan_description`.
+			header := "  " + planBlockHeaderStyle.Render("⏺ Proposed plan")
+			body := m.renderMarkdown(msg.PlanDescription)
+			indentedBody := lipgloss.NewStyle().MarginLeft(4).Render(strings.TrimRight(body, "\n"))
+			m.appendBlock(block{
+				kind:     blockApproval,
+				rendered: lipgloss.JoinVertical(lipgloss.Left, header, indentedBody),
+			})
+			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
+		} else {
+			warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+			m.appendBlock(block{
+				kind:     blockApproval,
+				rendered: "  " + warnStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
+			})
+			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
+		}
 		m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		m.textInput.Placeholder = ""
 		m.textInput.Reset()
@@ -446,11 +521,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View returns the rendered TUI: viewport on top, input bar at the bottom.
 func (m Model) View() string {
 	sep := inputSepStyle.Render(strings.Repeat("─", m.width))
-	hintText := "  enter to send · ctrl+c to quit"
-	if m.busy {
-		hintText = "  agent is working · enter disabled · ctrl+c to quit"
+	// The hint stays on a single line to keep inputBarHeight constant; the
+	// plan-mode indicator is prepended inline when active so the viewport sizing
+	// code doesn't need to track hint-line count.
+	planPrefix := ""
+	if m.config != nil && m.config.planMode.Load() {
+		planPrefix = planModeIndicatorStyle.Render("⏸ plan mode") + inputHintStyle.Render(" · ")
 	}
-	hint := inputHintStyle.Render(hintText)
+	hintText := "enter to send · shift+tab to toggle plan mode · ctrl+c to quit"
+	if m.busy {
+		hintText = "agent is working · enter disabled · ctrl+c to quit"
+	}
+	hint := "  " + planPrefix + inputHintStyle.Render(hintText)
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		m.viewport.View(),

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -64,9 +64,10 @@ type ModelConfig struct {
 	Username string
 	EventCh  <-chan UIEvent
 	// OutCh carries every TUI-originated user event (chat messages, approval
-	// answers, …) to the dispatcher in runNeo. A single typed channel keeps
-	// Session focused on SSE intake and tool dispatch.
-	OutCh chan<- apitype.AgentUserEvent
+	// answers, …) to the dispatcher in runNeo. Each send also carries the
+	// TUI's current planMode, which the dispatcher reads on the first
+	// user_message to configure CreateNeoTask.
+	OutCh chan<- outboundEvent
 	// Busy seeds the input-gating state. True when the caller has already
 	// handed a prompt to the backend — the TUI starts with Enter disabled
 	// until the first UITaskIdle.
@@ -77,11 +78,10 @@ type ModelConfig struct {
 	// which is sent to the backend via CreateNeoTask rather than outCh and
 	// would otherwise only appear once the SSE stream echoes it back.
 	InitialPrompt string
-	// Config is the shared session state the TUI and the dispatcher both
-	// read/write — today just the plan-mode toggle and a "task created" flag.
-	// NewModel allocates a zero-value sessionConfig if this is nil so tests
-	// can construct a Model without plumbing the shared state through.
-	Config *sessionConfig
+	// MessageSent seeds the post-first-message gate. Set it to true in tests
+	// that want to exercise the Shift+Tab post-send warning path without
+	// having to simulate a full Enter-driven send first.
+	MessageSent bool
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
@@ -91,7 +91,7 @@ type Model struct {
 	textInput textinput.Model
 	blocks    []block
 	eventCh   <-chan UIEvent
-	outCh     chan<- apitype.AgentUserEvent
+	outCh     chan<- outboundEvent
 	// busy is true from the moment the user sends a message (or a prompt was
 	// provided up front) until the session emits UITaskIdle / UICancelled /
 	// UIError. While busy, Enter is swallowed so the user can't talk over
@@ -114,15 +114,19 @@ type Model struct {
 	// Non-matching UIUserMessage events still render — they originated
 	// from another client (e.g. the web UI).
 	pendingUserEchoes []string
-	// config is shared with the dispatcher goroutine in runNeo. Owned via a
-	// pointer so Shift+Tab / plan-approval handlers can mutate the atomics
-	// that the dispatcher reads at CreateNeoTask time. Always non-nil after
-	// NewModel — the constructor allocates a fresh one if the caller passed nil.
-	config *sessionConfig
-	// pendingApprovalIsPlan is true when the currently pending approval is an
-	// exit_plan_mode gate, so the Enter handler knows to auto-clear planMode on
-	// approval.
-	pendingApprovalIsPlan bool
+	// planMode is the user's current plan-mode choice, toggled via Shift+Tab.
+	// Pre-first-message this is the live affordance; once messageSent flips
+	// true, Shift+Tab stops toggling and planMode is effectively frozen
+	// (further changes happen only via plan-approval auto-clear below).
+	planMode bool
+	// messageSent flips to true when the TUI successfully dispatches its
+	// first user_message on outCh. From that point on, Shift+Tab emits the
+	// "plan mode is task-level" warning instead of toggling.
+	messageSent bool
+	// pendingApprovalType is the raw wire approval_type for the currently
+	// pending approval (empty when none). The Enter handler checks for
+	// approvalTypePlanExit so it can auto-clear planMode on approval.
+	pendingApprovalType string
 }
 
 var (
@@ -136,10 +140,9 @@ var (
 	toolErrMarker  = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
 	finalMarker    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Render("⏺")
 	userMsgBubble  = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("8"))
-	// planModeIndicatorStyle is a distinct cyan+bold so the footer banner is
-	// visible at a glance; it contrasts against the faint, neutral hint line.
-	planModeIndicatorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
-	planBlockHeaderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	// planAccentStyle is a distinct cyan+bold used for both the footer banner
+	// and the "Proposed plan" block header so they read as the same visual cue.
+	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 )
 
 // NewModel creates a new TUI Model.
@@ -158,11 +161,6 @@ func NewModel(cfg ModelConfig) Model {
 		spinner.WithStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("6"))),
 	)
 
-	sc := cfg.Config
-	if sc == nil {
-		sc = &sessionConfig{}
-	}
-
 	m := Model{
 		welcome: welcomeModel{
 			org:       cfg.Org,
@@ -171,15 +169,15 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		viewport:  vp,
-		textInput: ti,
-		eventCh:   cfg.EventCh,
-		outCh:     cfg.OutCh,
-		busy:      cfg.Busy,
-		spinner:   sp,
-		width:     80,
-		height:    24,
-		config:    sc,
+		viewport:    vp,
+		textInput:   ti,
+		eventCh:     cfg.EventCh,
+		outCh:       cfg.OutCh,
+		busy:        cfg.Busy,
+		spinner:     sp,
+		width:       80,
+		height:      24,
+		messageSent: cfg.MessageSent,
 	}
 	m.viewport.SetContent(m.welcome.View())
 	if cfg.InitialPrompt != "" {
@@ -242,20 +240,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// intercept the key before textinput.Update sees it, since textinput
 		// otherwise treats Shift+Tab as a keypress with no visible effect.
 		if msg.Type == tea.KeyShiftTab {
-			if m.config.taskCreated.Load() {
-				// Plan mode is task-level on the wire. Toggling post-creation
-				// would be misleading — the server's state is already fixed.
-				m.appendBlock(block{
-					kind: blockWarning,
-					rendered: "  " + warningStyle.Render(
-						"⚠ Plan mode is task-level — start a new `pulumi neo` session to change it."),
-				})
+			if m.messageSent {
+				// Plan mode is task-level on the wire and gets snapshotted at
+				// the moment the first message is sent. A post-send toggle
+				// would be misleading — it could not affect the task.
+				m.appendWarningBlock(
+					"Plan mode is task-level — start a new `pulumi neo` session to change it.")
 				m.rebuildContent()
 				return m, nil
 			}
-			// Flip the atomic. The dispatcher reads it lazily at CreateNeoTask
-			// time, so this write doesn't need ordering with task creation.
-			m.config.planMode.Store(!m.config.planMode.Load())
+			m.planMode = !m.planMode
 			m.rebuildContent()
 			return m, nil
 		}
@@ -270,27 +264,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if !approved {
 					denialMsg = text
 				}
-				wasPlanApproval := m.pendingApprovalIsPlan
+				wasPlanApproval := m.pendingApprovalType == approvalTypePlanExit
 				if m.outCh != nil {
 					select {
-					case m.outCh <- apitype.AgentUserEventUserConfirmation{
-						Type:       userEventUserConfirmation,
-						ApprovalID: m.pendingApprovalID,
-						Approved:   approved,
-						Message:    denialMsg,
+					case m.outCh <- outboundEvent{
+						event: apitype.AgentUserEventUserConfirmation{
+							Type:       userEventUserConfirmation,
+							ApprovalID: m.pendingApprovalID,
+							Approved:   approved,
+							Message:    denialMsg,
+						},
+						planMode: m.planMode,
 					}:
 					default:
 					}
 				}
 				m.pendingApproval = false
 				m.pendingApprovalID = ""
-				m.pendingApprovalIsPlan = false
+				m.pendingApprovalType = ""
 				// Approving a plan exits plan mode server-side (the PlanModeTracker
 				// stops gating writes), so mirror that locally. Denial leaves the
 				// mode on — the agent will re-plan and gate-out again on the next
 				// exit_plan_mode call.
-				if wasPlanApproval && approved && m.config != nil {
-					m.config.planMode.Store(false)
+				if wasPlanApproval && approved {
+					m.planMode = false
 				}
 				m.textInput.Prompt = "❯ "
 				m.textInput.PromptStyle = promptStyle
@@ -328,9 +325,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.Reset()
 				if m.outCh != nil {
 					select {
-					case m.outCh <- apitype.AgentUserEventUserMessage{
-						Type:    userEventUserMessage,
-						Content: text,
+					case m.outCh <- outboundEvent{
+						event: apitype.AgentUserEventUserMessage{
+							Type:    userEventUserMessage,
+							Content: text,
+						},
+						planMode: m.planMode,
 					}:
 						// Render optimistically so the user sees their message in
 						// the transcript before the server echoes it back. The
@@ -338,6 +338,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						// UIUserMessage handler to avoid duplicates.
 						m.appendUserMessageBlock(text)
 						m.pendingUserEchoes = append(m.pendingUserEchoes, text)
+						// Freeze the plan-mode affordance: planMode has now been
+						// committed to the dispatcher and any later Shift+Tab
+						// would be a no-op on the server.
+						m.messageSent = true
 						return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
 					default:
 					}
@@ -435,10 +439,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIWarning:
-		m.appendBlock(block{
-			kind:     blockWarning,
-			rendered: "  " + warningStyle.Render("⚠ "+msg.Message),
-		})
+		m.appendWarningBlock(msg.Message)
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -478,27 +479,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.endBusy()
 		m.pendingApproval = true
 		m.pendingApprovalID = msg.ApprovalID
-		m.pendingApprovalIsPlan = msg.ApprovalType == approvalTypePlanExit
-		if m.pendingApprovalIsPlan {
+		m.pendingApprovalType = msg.ApprovalType
+		if m.pendingApprovalType == approvalTypePlanExit {
 			// Plan bodies are authored as markdown — headings, bullet lists, code
 			// blocks. Route through the same glamour renderer used for final
 			// assistant messages so the approval reads as a proper plan document
 			// rather than a single-line warning. The approval event's `message`
 			// field holds a generic intro ("I've finished exploring..."); the
 			// actual plan is in `context.plan_description`.
-			header := "  " + planBlockHeaderStyle.Render("⏺ Proposed plan")
+			header := planAccentStyle.Render("⏺ Proposed plan")
 			body := m.renderMarkdown(msg.PlanDescription)
-			indentedBody := lipgloss.NewStyle().MarginLeft(4).Render(strings.TrimRight(body, "\n"))
 			m.appendBlock(block{
 				kind:     blockApproval,
-				rendered: lipgloss.JoinVertical(lipgloss.Left, header, indentedBody),
+				rendered: renderHeaderedBlock(header, body),
 			})
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
 		} else {
-			warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 			m.appendBlock(block{
 				kind:     blockApproval,
-				rendered: "  " + warnStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
+				rendered: "  " + warningStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
 			})
 			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
 		}
@@ -524,15 +523,16 @@ func (m Model) View() string {
 	// The hint stays on a single line to keep inputBarHeight constant; the
 	// plan-mode indicator is prepended inline when active so the viewport sizing
 	// code doesn't need to track hint-line count.
-	planPrefix := ""
-	if m.config != nil && m.config.planMode.Load() {
-		planPrefix = planModeIndicatorStyle.Render("⏸ plan mode") + inputHintStyle.Render(" · ")
-	}
 	hintText := "enter to send · shift+tab to toggle plan mode · ctrl+c to quit"
 	if m.busy {
 		hintText = "agent is working · enter disabled · ctrl+c to quit"
 	}
-	hint := "  " + planPrefix + inputHintStyle.Render(hintText)
+	hint := "  "
+	if m.planMode {
+		hint += planAccentStyle.Render("⏸ plan mode")
+		hintText = " · " + hintText
+	}
+	hint += inputHintStyle.Render(hintText)
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		m.viewport.View(),
@@ -575,6 +575,16 @@ func (m *Model) showBusy(label string, shimmer shimmerKind) tea.Cmd {
 	}
 	m.busy = true
 	return m.spinner.Tick
+}
+
+// appendWarningBlock appends a standard "⚠ msg" warning block to the transcript.
+// Used by UIWarning and by local-only warnings (e.g. the Shift+Tab post-send
+// warning) so both paths share the same rendering.
+func (m *Model) appendWarningBlock(msg string) {
+	m.appendBlock(block{
+		kind:     blockWarning,
+		rendered: "  " + warningStyle.Render("⚠ "+msg),
+	})
 }
 
 // appendUserMessageBlock renders a user's chat message as a styled bubble and
@@ -638,6 +648,19 @@ func (m *Model) renderMarkdown(text string) string {
 	return strings.TrimRight(rendered, "\n")
 }
 
+// renderHeaderedBlock renders "  header" followed by body indented by 4 spaces,
+// matching the visual style of tool/assistant/plan blocks in the transcript. If
+// body is empty only the header line is returned, so callers can pass the split
+// first line of some content as the header and the remainder as the body.
+func renderHeaderedBlock(header, body string) string {
+	first := "  " + header
+	if strings.TrimSpace(body) == "" {
+		return first
+	}
+	indented := lipgloss.NewStyle().MarginLeft(4).Render(strings.TrimRight(body, "\n"))
+	return lipgloss.JoinVertical(lipgloss.Left, first, indented)
+}
+
 // renderAssistantFinal renders a final assistant message with a white circle marker.
 func renderAssistantFinal(rendered string) string {
 	trimmed := strings.TrimLeft(rendered, "\n ")
@@ -645,12 +668,7 @@ func renderAssistantFinal(rendered string) string {
 		return ""
 	}
 	firstLine, rest, _ := strings.Cut(trimmed, "\n")
-	first := "  " + finalMarker + " " + firstLine
-	if rest == "" {
-		return first
-	}
-	indented := lipgloss.NewStyle().MarginLeft(4).Render(strings.TrimRight(rest, "\n"))
-	return lipgloss.JoinVertical(lipgloss.Left, first, indented)
+	return renderHeaderedBlock(finalMarker+" "+firstLine, rest)
 }
 
 // renderAssistantStreaming renders streaming text with a dim indicator.

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -98,6 +98,14 @@ type UIApprovalRequest struct {
 	ApprovalID  string
 	Message     string
 	Sensitivity string
+	// ApprovalType is the wire discriminator that tells the TUI which rendering
+	// path to use. "plan_exit" triggers the plan rendering (markdown body, plan
+	// header, auto-exit on approval); any other value (today: "general") uses
+	// the regular tool-approval rendering.
+	ApprovalType string
+	// PlanDescription is the markdown plan body, populated only for plan_exit
+	// approvals. The TUI renders it through the glamour markdown renderer.
+	PlanDescription string
 }
 
 func (UIApprovalRequest) uiEvent() {}

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -322,7 +322,7 @@ func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {
 
 	// Enter while busy must be a no-op: the typed text stays in the input
 	// (user can retry after UITaskIdle) and no value is posted to outCh.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
 	m.textInput.SetValue("queued")
 
@@ -341,7 +341,7 @@ func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {
 func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 	t.Parallel()
 
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := NewModel(ModelConfig{OutCh: outCh})
 	m.textInput.SetValue("hello")
 
@@ -350,8 +350,8 @@ func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 
 	select {
 	case got := <-outCh:
-		msg, ok := got.(apitype.AgentUserEventUserMessage)
-		require.True(t, ok, "Enter must post a UserMessage event")
+		msg, ok := got.event.(apitype.AgentUserEventUserMessage)
+		require.True(t, ok, "Enter must post a UserMessage event, got %T", got.event)
 		assert.Equal(t, "hello", msg.Content)
 	default:
 		t.Fatal("Enter must post the input to outCh")
@@ -374,7 +374,7 @@ func TestModel_Update_KeyEnter_Idle_SendsAndClearsInput(t *testing.T) {
 func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 	t.Parallel()
 
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := NewModel(ModelConfig{OutCh: outCh})
 	// input left empty
 
@@ -398,7 +398,7 @@ func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 // request — busy is cleared, pendingApproval is true, and the prompt has been
 // swapped to the approval prompt. Mirrors the state UIApprovalRequest leaves
 // behind so each Enter test can start from a known point.
-func newApprovalPendingModel(t *testing.T, outCh chan apitype.AgentUserEvent) Model {
+func newApprovalPendingModel(t *testing.T, outCh chan outboundEvent) Model {
 	t.Helper()
 	m := NewModel(ModelConfig{OutCh: outCh, EventCh: make(chan UIEvent, 4), Busy: true})
 	updated, _ := m.Update(UIApprovalRequest{
@@ -415,7 +415,7 @@ func TestModel_Update_UIApprovalRequest_ShowsPromptAndPausesAgent(t *testing.T) 
 	// The approval request must clear busy (the agent is intentionally paused),
 	// append a visible approval block, and swap the input prompt so the user
 	// knows Enter now answers the approval rather than sending a chat message.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := newApprovalPendingModel(t, outCh)
 
 	assert.False(t, m.busy, "approval request must end busy so the user can answer")
@@ -432,7 +432,7 @@ func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
-			outCh := make(chan apitype.AgentUserEvent, 1)
+			outCh := make(chan outboundEvent, 1)
 			m := newApprovalPendingModel(t, outCh)
 			m.textInput.SetValue(in)
 
@@ -442,8 +442,8 @@ func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 			// Must post a confirmation event with Approved=true and no instructions.
 			select {
 			case got := <-outCh:
-				conf, ok := got.(apitype.AgentUserEventUserConfirmation)
-				require.True(t, ok, "expected UserConfirmation, got %T", got)
+				conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+				require.True(t, ok, "expected UserConfirmation, got %T", got.event)
 				assert.True(t, conf.Approved, "%q must be parsed as approval", in)
 				assert.Equal(t, "appr_1", conf.ApprovalID, "must echo the request id")
 				assert.Empty(t, conf.Message, "approval must not carry instructions")
@@ -469,7 +469,7 @@ func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 
 	// Anything that isn't "y"/"yes" is treated as a denial; the typed text becomes
 	// the instructions field so the agent can act on the user's reasoning.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := newApprovalPendingModel(t, outCh)
 	m.textInput.SetValue("not on prod")
 
@@ -478,8 +478,8 @@ func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 
 	select {
 	case got := <-outCh:
-		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
-		require.True(t, ok, "expected UserConfirmation, got %T", got)
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got.event)
 		assert.False(t, conf.Approved)
 		assert.Equal(t, "appr_1", conf.ApprovalID)
 		assert.Equal(t, "not on prod", conf.Message, "denial must forward the typed reason")
@@ -497,7 +497,7 @@ func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {
 
 	// An empty input is a denial with no instructions. Same outcome as a reasoned
 	// denial wire-wise (Approved=false), with an empty Message field.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := newApprovalPendingModel(t, outCh)
 	// input left empty
 
@@ -506,8 +506,8 @@ func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {
 
 	select {
 	case got := <-outCh:
-		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
-		require.True(t, ok, "expected UserConfirmation, got %T", got)
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got.event)
 		assert.False(t, conf.Approved)
 		assert.Empty(t, conf.Message)
 	default:
@@ -522,7 +522,7 @@ func TestModel_Update_Approval_NonEnterKey_ForwardsToTextInput(t *testing.T) {
 	// While waiting for approval, non-Enter keys must still type into the input
 	// (so the user can compose a denial reason). The approval state must NOT
 	// clear and no event may be posted.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := newApprovalPendingModel(t, outCh)
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
@@ -544,7 +544,7 @@ func TestModel_Update_KeyEnter_Approval_NotGatedByBusy(t *testing.T) {
 	// is intentionally paused waiting for the user. Even if busy somehow stayed
 	// true (e.g. a stray TickMsg arrived between UIApprovalRequest and Enter),
 	// Enter must still answer the approval rather than be swallowed.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	m := newApprovalPendingModel(t, outCh)
 	m.busy = true // simulate a stale busy state
 	m.textInput.SetValue("y")
@@ -552,7 +552,7 @@ func TestModel_Update_KeyEnter_Approval_NotGatedByBusy(t *testing.T) {
 	_, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	select {
 	case got := <-outCh:
-		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
 		require.True(t, ok)
 		assert.True(t, conf.Approved)
 	default:
@@ -767,7 +767,7 @@ func TestModel_Update_UIUserMessage_SelfEchoIsSuppressed(t *testing.T) {
 	// for suppression. When the server echoes that same message back, the
 	// queue entry is popped and the redundant render is skipped — so the
 	// transcript contains exactly one user block.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	evCh := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
 	m.textInput.SetValue("hi")
@@ -796,7 +796,7 @@ func TestModel_Update_UIUserMessage_ForeignEchoStillRenders(t *testing.T) {
 	// A user message that didn't originate from this TUI (for example, the
 	// user typing in the web UI for the same task) must still render. The
 	// dedup queue only suppresses echoes that match what this TUI submitted.
-	outCh := make(chan apitype.AgentUserEvent, 1)
+	outCh := make(chan outboundEvent, 1)
 	evCh := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
 	m.textInput.SetValue("from cli")
@@ -857,45 +857,76 @@ func TestModel_View_ShowsHintBasedOnBusy(t *testing.T) {
 // Plan mode
 // -----------------------------------------------------------------------------
 
-func TestModel_Update_ShiftTab_TogglesPlanModeBeforeTaskCreation(t *testing.T) {
+func TestModel_Update_ShiftTab_TogglesPlanModeBeforeFirstMessage(t *testing.T) {
 	t.Parallel()
 
-	// Shift+Tab before the task is created is the user's affordance to opt
-	// into plan mode. The toggle is reflected in the footer hint so the user
-	// gets immediate feedback without waiting for any server round trip.
-	cfg := &sessionConfig{}
-	m := NewModel(ModelConfig{Config: cfg})
+	// Shift+Tab before the first message is sent is the user's affordance to
+	// opt into plan mode. The toggle is reflected in the footer hint so the
+	// user gets immediate feedback without waiting for any server round trip.
+	m := NewModel(ModelConfig{})
 	assert.NotContains(t, m.View(), "plan mode on")
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	m = updated.(Model)
-	assert.True(t, cfg.planMode.Load(), "Shift+Tab must flip planMode on")
+	assert.True(t, m.planMode, "Shift+Tab must flip planMode on")
 	assert.Contains(t, m.View(), "plan mode", "hint must show the plan-mode indicator")
 
 	// Second press toggles back off — same affordance, symmetric behaviour.
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	m = updated.(Model)
-	assert.False(t, cfg.planMode.Load(), "second Shift+Tab must flip planMode off")
+	assert.False(t, m.planMode, "second Shift+Tab must flip planMode off")
 	assert.NotContains(t, m.View(), "plan mode on")
 }
 
-func TestModel_Update_ShiftTab_AfterTaskCreation_WarnsAndDoesNotToggle(t *testing.T) {
+func TestModel_Update_ShiftTab_AfterFirstMessage_WarnsAndDoesNotToggle(t *testing.T) {
 	t.Parallel()
 
-	// Plan mode is task-level on the wire, so a post-creation toggle would be
-	// misleading: the server's state is fixed. The TUI must surface a warning
-	// and leave the atomic alone.
-	cfg := &sessionConfig{}
-	cfg.taskCreated.Store(true)
-	m := NewModel(ModelConfig{Config: cfg})
+	// Plan mode is task-level on the wire and is snapshotted the moment the
+	// first message is dispatched. A post-send toggle would be misleading —
+	// the dispatcher has already captured planMode for CreateNeoTask, so any
+	// later flip could not affect the task.
+	m := NewModel(ModelConfig{MessageSent: true})
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	m = updated.(Model)
 
-	assert.False(t, cfg.planMode.Load(), "post-creation Shift+Tab must not toggle planMode")
+	assert.False(t, m.planMode, "post-send Shift+Tab must not toggle planMode")
 	idx := m.findBlockKind(blockWarning)
-	require.NotEqual(t, -1, idx, "post-creation Shift+Tab must append a warning block")
+	require.NotEqual(t, -1, idx, "post-send Shift+Tab must append a warning block")
 	assert.Contains(t, m.blocks[idx].rendered, "task-level")
+}
+
+func TestModel_Update_KeyEnter_SendingFirstMessageFreezesPlanMode(t *testing.T) {
+	t.Parallel()
+
+	// Sending the first user message both (a) carries the current planMode
+	// across to the dispatcher and (b) flips messageSent so any subsequent
+	// Shift+Tab is a no-op. This is the moment the TUI commits planMode.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m.planMode = true
+	m.textInput.SetValue("kick off")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+
+	select {
+	case got := <-outCh:
+		msg, ok := got.event.(apitype.AgentUserEventUserMessage)
+		require.True(t, ok, "expected AgentUserEventUserMessage, got %T", got.event)
+		assert.Equal(t, "kick off", msg.Content)
+		assert.True(t, got.planMode, "outbound envelope must carry the TUI's planMode")
+	default:
+		t.Fatal("Enter must post the input to outCh")
+	}
+
+	assert.True(t, m.messageSent, "first send must freeze the plan-mode affordance")
+
+	// Shift+Tab after send must warn, not toggle.
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated2.(Model)
+	assert.True(t, m.planMode, "post-send Shift+Tab must leave planMode untouched")
+	assert.NotEqual(t, -1, m.findBlockKind(blockWarning), "post-send Shift+Tab must warn")
 }
 
 func TestModel_Update_UIApprovalRequest_PlanCategory_RendersPlanHeaderAndMarkdown(t *testing.T) {
@@ -907,9 +938,8 @@ func TestModel_Update_UIApprovalRequest_PlanCategory_RendersPlanHeaderAndMarkdow
 	// rather than raw asterisks. The distinct "Proposed plan" header tells
 	// the user this isn't a regular tool approval.
 	ch := make(chan UIEvent, 4)
-	cfg := &sessionConfig{}
-	cfg.planMode.Store(true)
-	m := NewModel(ModelConfig{EventCh: ch, Config: cfg})
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.planMode = true
 	// Initialize the markdown renderer (built on WindowSize).
 	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = updated0.(Model)
@@ -923,7 +953,8 @@ func TestModel_Update_UIApprovalRequest_PlanCategory_RendersPlanHeaderAndMarkdow
 	um := updated.(Model)
 
 	assert.True(t, um.pendingApproval, "plan approval must enter the pending state")
-	assert.True(t, um.pendingApprovalIsPlan, "plan approval must be flagged as a plan")
+	assert.Equal(t, approvalTypePlanExit, um.pendingApprovalType,
+		"plan approval must record its wire approval_type")
 	idx := um.findBlockKind(blockApproval)
 	require.NotEqual(t, -1, idx)
 	assert.Contains(t, um.blocks[idx].rendered, "Proposed plan")
@@ -952,7 +983,8 @@ func TestModel_Update_UIApprovalRequest_General_UsesExistingApprovalRendering(t 
 	})
 	um := updated.(Model)
 
-	assert.False(t, um.pendingApprovalIsPlan)
+	assert.NotEqual(t, approvalTypePlanExit, um.pendingApprovalType,
+		"general approval must not be flagged as a plan")
 	idx := um.findBlockKind(blockApproval)
 	require.NotEqual(t, -1, idx)
 	assert.Contains(t, um.blocks[idx].rendered, "Approval required")
@@ -966,10 +998,9 @@ func TestModel_Update_ApprovePlan_ClearsPlanMode(t *testing.T) {
 	// Approving the plan exits plan mode server-side (PlanModeTracker stops
 	// gating writes); the local indicator must mirror that immediately so the
 	// footer doesn't misrepresent the effective state.
-	outCh := make(chan apitype.AgentUserEvent, 1)
-	cfg := &sessionConfig{}
-	cfg.planMode.Store(true)
-	m := NewModel(ModelConfig{OutCh: outCh, Config: cfg})
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m.planMode = true
 
 	// Simulate receiving the plan approval request.
 	updated, _ := m.Update(UIApprovalRequest{
@@ -986,17 +1017,17 @@ func TestModel_Update_ApprovePlan_ClearsPlanMode(t *testing.T) {
 
 	select {
 	case got := <-outCh:
-		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
-		require.True(t, ok, "expected AgentUserEventUserConfirmation, got %T", got)
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected AgentUserEventUserConfirmation, got %T", got.event)
 		assert.True(t, conf.Approved)
 		assert.Equal(t, "appr_3", conf.ApprovalID)
 	default:
 		t.Fatal("approving plan must post a confirmation event")
 	}
 
-	assert.False(t, cfg.planMode.Load(), "approved plan must auto-clear planMode")
+	assert.False(t, m.planMode, "approved plan must auto-clear planMode")
 	assert.False(t, m.pendingApproval)
-	assert.False(t, m.pendingApprovalIsPlan)
+	assert.Empty(t, m.pendingApprovalType, "approval type must be cleared after response")
 }
 
 func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
@@ -1004,10 +1035,9 @@ func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
 
 	// Denying the plan means the user wants the agent to re-plan — plan mode
 	// must stay on so writes remain gated while the agent iterates.
-	outCh := make(chan apitype.AgentUserEvent, 1)
-	cfg := &sessionConfig{}
-	cfg.planMode.Store(true)
-	m := NewModel(ModelConfig{OutCh: outCh, Config: cfg})
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m.planMode = true
 
 	updated, _ := m.Update(UIApprovalRequest{
 		ApprovalID:      "appr_4",
@@ -1023,7 +1053,7 @@ func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
 
 	select {
 	case got := <-outCh:
-		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
 		require.True(t, ok)
 		assert.False(t, conf.Approved)
 		assert.Equal(t, "cover error handling too", conf.Message, "denial text becomes the re-plan instructions")
@@ -1031,7 +1061,7 @@ func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
 		t.Fatal("denying plan must post a confirmation event")
 	}
 
-	assert.True(t, cfg.planMode.Load(), "denied plan must leave planMode on")
+	assert.True(t, m.planMode, "denied plan must leave planMode on")
 }
 
 func TestModel_RenderMarkdown_FallsBackWhenRendererNil(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -853,6 +853,187 @@ func TestModel_View_ShowsHintBasedOnBusy(t *testing.T) {
 	assert.Contains(t, busy.View(), "enter disabled")
 }
 
+// -----------------------------------------------------------------------------
+// Plan mode
+// -----------------------------------------------------------------------------
+
+func TestModel_Update_ShiftTab_TogglesPlanModeBeforeTaskCreation(t *testing.T) {
+	t.Parallel()
+
+	// Shift+Tab before the task is created is the user's affordance to opt
+	// into plan mode. The toggle is reflected in the footer hint so the user
+	// gets immediate feedback without waiting for any server round trip.
+	cfg := &sessionConfig{}
+	m := NewModel(ModelConfig{Config: cfg})
+	assert.NotContains(t, m.View(), "plan mode on")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated.(Model)
+	assert.True(t, cfg.planMode.Load(), "Shift+Tab must flip planMode on")
+	assert.Contains(t, m.View(), "plan mode", "hint must show the plan-mode indicator")
+
+	// Second press toggles back off — same affordance, symmetric behaviour.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated.(Model)
+	assert.False(t, cfg.planMode.Load(), "second Shift+Tab must flip planMode off")
+	assert.NotContains(t, m.View(), "plan mode on")
+}
+
+func TestModel_Update_ShiftTab_AfterTaskCreation_WarnsAndDoesNotToggle(t *testing.T) {
+	t.Parallel()
+
+	// Plan mode is task-level on the wire, so a post-creation toggle would be
+	// misleading: the server's state is fixed. The TUI must surface a warning
+	// and leave the atomic alone.
+	cfg := &sessionConfig{}
+	cfg.taskCreated.Store(true)
+	m := NewModel(ModelConfig{Config: cfg})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	m = updated.(Model)
+
+	assert.False(t, cfg.planMode.Load(), "post-creation Shift+Tab must not toggle planMode")
+	idx := m.findBlockKind(blockWarning)
+	require.NotEqual(t, -1, idx, "post-creation Shift+Tab must append a warning block")
+	assert.Contains(t, m.blocks[idx].rendered, "task-level")
+}
+
+func TestModel_Update_UIApprovalRequest_PlanCategory_RendersPlanHeaderAndMarkdown(t *testing.T) {
+	t.Parallel()
+
+	// A plan-category approval signals that the agent is ready to exit plan
+	// mode with its proposed plan. The body comes in as markdown and must be
+	// routed through the model's renderer so the user sees a formatted plan
+	// rather than raw asterisks. The distinct "Proposed plan" header tells
+	// the user this isn't a regular tool approval.
+	ch := make(chan UIEvent, 4)
+	cfg := &sessionConfig{}
+	cfg.planMode.Store(true)
+	m := NewModel(ModelConfig{EventCh: ch, Config: cfg})
+	// Initialize the markdown renderer (built on WindowSize).
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_1",
+		Message:         "I've finished exploring and have a plan ready for your review.",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\n- step one\n- step two",
+	})
+	um := updated.(Model)
+
+	assert.True(t, um.pendingApproval, "plan approval must enter the pending state")
+	assert.True(t, um.pendingApprovalIsPlan, "plan approval must be flagged as a plan")
+	idx := um.findBlockKind(blockApproval)
+	require.NotEqual(t, -1, idx)
+	assert.Contains(t, um.blocks[idx].rendered, "Proposed plan")
+	// Glamour wraps each word in its own ANSI escape run; assert on word
+	// fragments that the renderer never splits ("step" shows up verbatim).
+	assert.Contains(t, um.blocks[idx].rendered, "step", "rendered plan must include the plan body")
+	assert.Contains(t, um.blocks[idx].rendered, "Plan", "rendered plan must include the heading")
+	assert.Contains(t, um.textInput.Prompt, "Approve plan",
+		"prompt must indicate this is a plan approval")
+}
+
+func TestModel_Update_UIApprovalRequest_General_UsesExistingApprovalRendering(t *testing.T) {
+	t.Parallel()
+
+	// Regular (non-plan) tool approvals keep the existing "⚠ Approval required"
+	// rendering and generic prompt. The plan path must not leak into them — they
+	// share the same wire event type (user_approval_request) and only diverge on
+	// ApprovalType.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_2",
+		Message:      "run pulumi up",
+		ApprovalType: "general",
+	})
+	um := updated.(Model)
+
+	assert.False(t, um.pendingApprovalIsPlan)
+	idx := um.findBlockKind(blockApproval)
+	require.NotEqual(t, -1, idx)
+	assert.Contains(t, um.blocks[idx].rendered, "Approval required")
+	assert.Contains(t, um.textInput.Prompt, "Approve?")
+	assert.NotContains(t, um.textInput.Prompt, "plan")
+}
+
+func TestModel_Update_ApprovePlan_ClearsPlanMode(t *testing.T) {
+	t.Parallel()
+
+	// Approving the plan exits plan mode server-side (PlanModeTracker stops
+	// gating writes); the local indicator must mirror that immediately so the
+	// footer doesn't misrepresent the effective state.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	cfg := &sessionConfig{}
+	cfg.planMode.Store(true)
+	m := NewModel(ModelConfig{OutCh: outCh, Config: cfg})
+
+	// Simulate receiving the plan approval request.
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_3",
+		Message:         "I've finished exploring.",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\n- step one\n- step two",
+	})
+	m = updated.(Model)
+	m.textInput.SetValue("y")
+
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated2.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected AgentUserEventUserConfirmation, got %T", got)
+		assert.True(t, conf.Approved)
+		assert.Equal(t, "appr_3", conf.ApprovalID)
+	default:
+		t.Fatal("approving plan must post a confirmation event")
+	}
+
+	assert.False(t, cfg.planMode.Load(), "approved plan must auto-clear planMode")
+	assert.False(t, m.pendingApproval)
+	assert.False(t, m.pendingApprovalIsPlan)
+}
+
+func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
+	t.Parallel()
+
+	// Denying the plan means the user wants the agent to re-plan — plan mode
+	// must stay on so writes remain gated while the agent iterates.
+	outCh := make(chan apitype.AgentUserEvent, 1)
+	cfg := &sessionConfig{}
+	cfg.planMode.Store(true)
+	m := NewModel(ModelConfig{OutCh: outCh, Config: cfg})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_4",
+		Message:         "I've finished exploring.",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\n- step one\n- step two",
+	})
+	m = updated.(Model)
+	m.textInput.SetValue("cover error handling too")
+
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated2.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok)
+		assert.False(t, conf.Approved)
+		assert.Equal(t, "cover error handling too", conf.Message, "denial text becomes the re-plan instructions")
+	default:
+		t.Fatal("denying plan must post a confirmation event")
+	}
+
+	assert.True(t, cfg.planMode.Load(), "denied plan must leave planMode on")
+}
+
 func TestModel_RenderMarkdown_FallsBackWhenRendererNil(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_tools.go
+++ b/pkg/cmd/pulumi/neo/tui_tools.go
@@ -51,6 +51,11 @@ func toolLabelParts(toolName string, args json.RawMessage) (funcName, arg string
 			return "Edit", p
 		}
 		return "Edit", ""
+	case "multi_edit":
+		if p := extractFilePathArg(args); p != "" {
+			return "MultiEdit", p
+		}
+		return "MultiEdit", ""
 	case "content_replace":
 		if p := extractArg(args, "pattern"); p != "" {
 			return "Replace", p

--- a/pkg/cmd/pulumi/neo/tui_tools_test.go
+++ b/pkg/cmd/pulumi/neo/tui_tools_test.go
@@ -47,6 +47,8 @@ func TestToolLabelParts(t *testing.T) {
 		{"write_short", "write", nil, "Write", ""},
 		{"edit_with_path", "edit", json.RawMessage(`{"file_path":"/x"}`), "Edit", "/x"},
 		{"edit_no_path", "edit", json.RawMessage(`{}`), "Edit", ""},
+		{"multi_edit_with_path", "multi_edit", json.RawMessage(`{"file_path":"/x"}`), "MultiEdit", "/x"},
+		{"multi_edit_no_path", "multi_edit", json.RawMessage(`{}`), "MultiEdit", ""},
 		{"content_replace_with_pattern", "content_replace", json.RawMessage(`{"pattern":"needle"}`), "Replace", "needle"},
 		{"content_replace_no_pattern", "content_replace", nil, "Replace", ""},
 		{"execute_command_short", "execute_command", json.RawMessage(`{"command":"ls -la"}`), "Bash", "ls -la"},

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -152,6 +152,25 @@ type AgentBackendEventUserApprovalRequest struct {
 	ID          string `json:"id,omitempty"`
 	Message     string `json:"message,omitempty"`
 	Sensitivity string `json:"sensitivity,omitempty"`
+	// ApprovalType discriminates the rendering path. "plan_exit" is the gate fired
+	// for the exit_plan_mode tool — the CLI reads the plan body out of
+	// Context.PlanDescription and renders it as markdown. Any other value (today:
+	// "general") takes the regular tool-approval rendering path.
+	ApprovalType string `json:"approval_type,omitempty"`
+	// Context carries approval-type-specific payload. For "plan_exit" the relevant
+	// field is PlanDescription; for "general" approvals only ToolCallID / ToolName
+	// are set.
+	Context AgentBackendEventUserApprovalRequestContext `json:"context,omitzero"`
+}
+
+// AgentBackendEventUserApprovalRequestContext is the nested payload on
+// user_approval_request events.
+type AgentBackendEventUserApprovalRequestContext struct {
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	ToolName   string `json:"tool_name,omitempty"`
+	// PlanDescription is the markdown plan body the agent is asking the user to
+	// approve. Populated only when ApprovalType == "plan_exit".
+	PlanDescription string `json:"plan_description,omitempty"`
 }
 
 // AgentUserEventUserConfirmation is the user event a CLI client posts in response to a

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -70,6 +70,33 @@ type AgentBackendEventToolCall struct {
 	ExecutionMode string `json:"execution_mode,omitempty"`
 }
 
+// AgentBackendEventUserApprovalRequest is the backend event the agent emits to gate an
+// operation on human approval. CLI clients reply with an AgentUserEventUserConfirmation
+// referencing the same ApprovalID.
+type AgentBackendEventUserApprovalRequest struct {
+	Type string `json:"type"` // always "user_approval_request"
+	// ApprovalID is the correlation id echoed back on the user_confirmation reply. The
+	// wire field is "id" because the service reuses the generic event id here.
+	ApprovalID  string `json:"id,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Sensitivity string `json:"sensitivity,omitempty"`
+	// ApprovalType discriminates the rendering path. "plan_exit" gates the
+	// exit_plan_mode tool — the CLI reads the plan body out of Context.PlanDescription
+	// and renders it with markdown. "general" covers regular tool approvals.
+	ApprovalType string                               `json:"approval_type,omitempty"`
+	Context      AgentBackendEventUserApprovalContext `json:"context"`
+}
+
+// AgentBackendEventUserApprovalContext is the nested payload on an
+// AgentBackendEventUserApprovalRequest.
+type AgentBackendEventUserApprovalContext struct {
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	ToolName   string `json:"tool_name,omitempty"`
+	// PlanDescription is the markdown plan body the agent is asking the user to
+	// approve. Populated only when ApprovalType == "plan_exit".
+	PlanDescription string `json:"plan_description,omitempty"`
+}
+
 // AgentUserEventToolResult is the user event a CLI client posts to resume an agent turn
 // after executing one or more cli-marked tool calls.
 type AgentUserEventToolResult struct {
@@ -142,35 +169,6 @@ type AgentBackendEventWarning struct {
 // the current turn (e.g. the user interrupted it).
 type AgentBackendEventCancelled struct {
 	Type string `json:"type"` // always "cancelled"
-}
-
-// AgentBackendEventUserApprovalRequest is a backend event asking the user to approve or
-// deny a potentially-sensitive operation before the agent proceeds. The CLI replies with
-// a user_confirmation user event echoing the ID.
-type AgentBackendEventUserApprovalRequest struct {
-	Type        string `json:"type"` // always "user_approval_request"
-	ID          string `json:"id,omitempty"`
-	Message     string `json:"message,omitempty"`
-	Sensitivity string `json:"sensitivity,omitempty"`
-	// ApprovalType discriminates the rendering path. "plan_exit" is the gate fired
-	// for the exit_plan_mode tool — the CLI reads the plan body out of
-	// Context.PlanDescription and renders it as markdown. Any other value (today:
-	// "general") takes the regular tool-approval rendering path.
-	ApprovalType string `json:"approval_type,omitempty"`
-	// Context carries approval-type-specific payload. For "plan_exit" the relevant
-	// field is PlanDescription; for "general" approvals only ToolCallID / ToolName
-	// are set.
-	Context AgentBackendEventUserApprovalRequestContext `json:"context,omitzero"`
-}
-
-// AgentBackendEventUserApprovalRequestContext is the nested payload on
-// user_approval_request events.
-type AgentBackendEventUserApprovalRequestContext struct {
-	ToolCallID string `json:"tool_call_id,omitempty"`
-	ToolName   string `json:"tool_name,omitempty"`
-	// PlanDescription is the markdown plan body the agent is asking the user to
-	// approve. Populated only when ApprovalType == "plan_exit".
-	PlanDescription string `json:"plan_description,omitempty"`
 }
 
 // AgentUserEventUserConfirmation is the user event a CLI client posts in response to a


### PR DESCRIPTION
Add a plan-mode toggle to the `pulumi neo` TUI, bound to Shift+Tab. When
plan mode is on, Neo explores and asks questions without writing files,
running `pulumi up`, or opening PRs, and surfaces an approved plan via
a dedicated approval gate. The toggle must be set before the first
message (plan mode is task-level on the wire).

The CLI plumbs a planMode bool through CreateNeoTask so the server can
activate PlanModeTracker for the task, and renders exit_plan_mode
approval requests (approval_type=plan_exit) with the plan body rendered
as markdown.

Fixes pulumi/pulumi-service#41314

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->

https://asciinema.org/a/xFfBGELcXLjrefFl