### PR TITLE
fix(cli/neo): wrap warnings and user messages to terminal width

### DIFF
--- a/changelog/pending/20260416--cli--wrap-pulumi-neo-warnings-and-user-messages-to-terminal-width.yaml
+++ b/changelog/pending/20260416--cli--wrap-pulumi-neo-warnings-and-user-messages-to-terminal-width.yaml
@@ -1,0 +1,9 @@
+changes:
+- type: fix
+  scope: cli
+  description: |
+    Wrap warnings, errors, and user-message bubbles to the terminal width in the
+    `pulumi neo` TUI. Previously these blocks rendered as single long lines that
+    were clipped at the right edge of the viewport. On resize, all width-dependent
+    transcript blocks (user messages, warnings, errors, assistant messages) now
+    reflow to the new terminal width.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -43,18 +43,25 @@ const (
 	blockWarning
 	blockCancelled
 	blockUserMessage
-	blockApproval
+	blockApprovalPlan
+	blockApprovalGeneral
+	blockApprovalChoice
 )
 
-// block is a single rendered item in the TUI output log.
 type block struct {
-	kind blockKind
-	// rendered is the cached rendered string for non-busy kinds.
+	kind     blockKind
 	rendered string
-	// label is the text shown after the spinner for blockBusy only.
-	label string
-	// shimmer selects how label is animated; only meaningful for blockBusy.
+	// raw is the source content for width-dependent kinds. renderBlock
+	// recomputes rendered from raw on every WindowSizeMsg so the block
+	// reflows to the new width. blockBusy and blockToolComplete leave raw
+	// empty; blockApprovalChoice carries its verdict in approved below so
+	// renderBlock still runs when raw is empty.
+	raw string
+	// label and shimmer apply to blockBusy only.
+	label   string
 	shimmer shimmerKind
+	// approved applies to blockApprovalChoice only.
+	approved bool
 }
 
 // ModelConfig holds the parameters needed to create a TUI Model.
@@ -145,6 +152,16 @@ var (
 	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 )
 
+// renderIndented word-wraps content (ANSI-safe) to termWidth minus the
+// 2-space transcript gutter, or returns un-wrapped if the width is too
+// small to wrap into.
+func renderIndented(style lipgloss.Style, termWidth int, content string) string {
+	if termWidth <= 4 {
+		return "  " + style.Render(content)
+	}
+	return "  " + style.Width(termWidth-2).Render(content)
+}
+
 // NewModel creates a new TUI Model.
 func NewModel(cfg ModelConfig) Model {
 	ti := textinput.New()
@@ -212,20 +229,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.welcome.termWidth = msg.Width
 
-		vpHeight := msg.Height - inputBarHeight
-		if vpHeight < 1 {
-			vpHeight = 1
-		}
+		vpHeight := max(msg.Height-inputBarHeight, 1)
 		m.viewport.Width = msg.Width
 		m.viewport.Height = vpHeight
 		m.textInput.Width = msg.Width - lipgloss.Width(m.textInput.Prompt) - 1
 
-		// (Re)initialize the glamour renderer with the actual terminal width.
+		// Glamour's wrap width is baked in at construction, so rebuild on resize.
 		if r, err := glamour.NewTermRenderer(
 			glamour.WithStylePath("dark"),
 			glamour.WithWordWrap(msg.Width-4),
 		); err == nil {
 			m.mdRenderer = r
+		}
+		for i := range m.blocks {
+			m.renderBlock(&m.blocks[i])
 		}
 		m.rebuildContent()
 
@@ -293,14 +310,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.PromptStyle = promptStyle
 				m.textInput.Placeholder = "Send a message..."
 				m.textInput.Reset()
-				choice := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("✓ Approved")
-				if !approved {
-					choice = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("✗ Denied")
-					if denialMsg != "" {
-						choice += " — " + denialMsg
-					}
-				}
-				m.appendBlock(block{kind: blockUserMessage, rendered: "  " + choice})
+				m.appendRenderedBlock(block{
+					kind:     blockApprovalChoice,
+					approved: approved,
+					raw:      denialMsg,
+				})
 				if approved {
 					cmd := m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
 					m.rebuildContent()
@@ -382,18 +396,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.removeBlockKind(blockBusy)
 		if msg.IsFinal {
 			m.removeBlockKind(blockAssistantStreaming)
-			rendered := m.renderMarkdown(msg.Content)
-			m.appendBlock(block{
-				kind:     blockAssistantFinal,
-				rendered: renderAssistantFinal(rendered),
-			})
+			m.appendRenderedBlock(block{kind: blockAssistantFinal, raw: msg.Content})
 		} else if idx := m.findBlockKind(blockAssistantStreaming); idx >= 0 {
-			m.blocks[idx].rendered = renderAssistantStreaming(msg.Content)
+			m.blocks[idx].raw = msg.Content
+			m.renderBlock(&m.blocks[idx])
 		} else {
-			m.appendBlock(block{
-				kind:     blockAssistantStreaming,
-				rendered: renderAssistantStreaming(msg.Content),
-			})
+			m.appendRenderedBlock(block{kind: blockAssistantStreaming, raw: msg.Content})
 		}
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
@@ -431,10 +439,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case UIError:
 		m.endBusy()
-		m.appendBlock(block{
-			kind:     blockError,
-			rendered: "  " + errorStyle.Render("✗ Error: "+msg.Message),
-		})
+		m.appendRenderedBlock(block{kind: blockError, raw: msg.Message})
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -445,10 +450,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case UICancelled:
 		m.endBusy()
-		m.appendBlock(block{
-			kind:     blockCancelled,
-			rendered: "  " + cancelledStyle.Render("Session cancelled."),
-		})
+		m.appendRenderedBlock(block{kind: blockCancelled, raw: "Session cancelled."})
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -481,24 +483,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingApprovalID = msg.ApprovalID
 		m.pendingApprovalType = msg.ApprovalType
 		if m.pendingApprovalType == approvalTypePlanExit {
-			// Plan bodies are authored as markdown — headings, bullet lists, code
-			// blocks. Route through the same glamour renderer used for final
-			// assistant messages so the approval reads as a proper plan document
-			// rather than a single-line warning. The approval event's `message`
-			// field holds a generic intro ("I've finished exploring..."); the
-			// actual plan is in `context.plan_description`.
-			header := planAccentStyle.Render("⏺ Proposed plan")
-			body := m.renderMarkdown(msg.PlanDescription)
-			m.appendBlock(block{
-				kind:     blockApproval,
-				rendered: renderHeaderedBlock(header, body),
-			})
+			// The plan body is authored as markdown and lives in
+			// PlanDescription; msg.Message is just a generic intro.
+			m.appendRenderedBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription})
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
 		} else {
-			m.appendBlock(block{
-				kind:     blockApproval,
-				rendered: "  " + warningStyle.Render("⚠ Approval required") + "\n    " + msg.Message,
-			})
+			m.appendRenderedBlock(block{kind: blockApprovalGeneral, raw: msg.Message})
 			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
 		}
 		m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
@@ -577,24 +567,12 @@ func (m *Model) showBusy(label string, shimmer shimmerKind) tea.Cmd {
 	return m.spinner.Tick
 }
 
-// appendWarningBlock appends a standard "⚠ msg" warning block to the transcript.
-// Used by UIWarning and by local-only warnings (e.g. the Shift+Tab post-send
-// warning) so both paths share the same rendering.
 func (m *Model) appendWarningBlock(msg string) {
-	m.appendBlock(block{
-		kind:     blockWarning,
-		rendered: "  " + warningStyle.Render("⚠ "+msg),
-	})
+	m.appendRenderedBlock(block{kind: blockWarning, raw: msg})
 }
 
-// appendUserMessageBlock renders a user's chat message as a styled bubble and
-// appends it to the transcript. Used both for optimistic rendering on submit
-// and for echoes that originated outside this TUI.
 func (m *Model) appendUserMessageBlock(content string) {
-	m.appendBlock(block{
-		kind:     blockUserMessage,
-		rendered: promptStyle.Render("❯") + " " + userMsgBubble.Render(" "+content+" "),
-	})
+	m.appendRenderedBlock(block{kind: blockUserMessage, raw: content})
 }
 
 // appendBlock appends a non-busy block, keeping any existing blockBusy
@@ -634,6 +612,84 @@ func (m *Model) findBlockKind(kind blockKind) int {
 		}
 	}
 	return -1
+}
+
+// renderBlock recomputes b.rendered from b.raw using the current terminal
+// width and markdown renderer. blockApprovalChoice is the one kind that
+// still renders when raw is empty (its verdict is carried by b.approved).
+func (m *Model) renderBlock(b *block) {
+	if b.kind == blockApprovalChoice {
+		m.renderApprovalChoice(b)
+		return
+	}
+	if b.raw == "" {
+		return
+	}
+	switch b.kind {
+	case blockWarning:
+		b.rendered = renderIndented(warningStyle, m.width, "⚠ "+b.raw)
+	case blockError:
+		b.rendered = renderIndented(errorStyle, m.width, "✗ Error: "+b.raw)
+	case blockCancelled:
+		b.rendered = renderIndented(cancelledStyle, m.width, b.raw)
+	case blockUserMessage:
+		b.rendered = m.renderUserBubble(b.raw)
+	case blockAssistantStreaming:
+		b.rendered = renderAssistantStreaming(m.wrapPlain(b.raw))
+	case blockAssistantFinal:
+		b.rendered = renderAssistantFinal(m.renderMarkdown(b.raw))
+	case blockApprovalPlan:
+		header := planAccentStyle.Render("⏺ Proposed plan")
+		b.rendered = renderHeaderedBlock(header, m.renderMarkdown(b.raw))
+	case blockApprovalGeneral:
+		header := warningStyle.Render("⚠ Approval required")
+		b.rendered = renderHeaderedBlock(header, m.wrapPlain(b.raw))
+	case blockBusy, blockToolComplete:
+		// No raw: blockBusy renders live from label, blockToolComplete is
+		// pre-styled at event time.
+	case blockApprovalChoice:
+		// Unreachable; kept for exhaustive lint.
+	}
+}
+
+func (m *Model) renderApprovalChoice(b *block) {
+	if b.approved {
+		b.rendered = "  " + lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("✓ Approved")
+		return
+	}
+	denied := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("✗ Denied")
+	if b.raw == "" {
+		b.rendered = "  " + denied
+		return
+	}
+	b.rendered = renderIndented(lipgloss.NewStyle(), m.width, denied+" — "+b.raw)
+}
+
+// renderUserBubble renders a user-chat bubble. Short messages hug their
+// content; only overflow triggers Width, which both wraps and pads so the
+// background colour fills every wrapped line evenly.
+func (m *Model) renderUserBubble(content string) string {
+	prefix := promptStyle.Render("❯") + " " // visible width 2
+	padded := " " + content + " "
+	bubbleWidth := max(m.width-2, 8)
+	style := userMsgBubble
+	if m.width > 4 && lipgloss.Width(padded) > bubbleWidth {
+		style = style.Width(bubbleWidth)
+	}
+	return prefix + style.Render(padded)
+}
+
+// wrapPlain word-wraps non-markdown text to the terminal width.
+func (m *Model) wrapPlain(text string) string {
+	if m.width <= 4 {
+		return text
+	}
+	return lipgloss.NewStyle().Width(m.width - 4).Render(text)
+}
+
+func (m *Model) appendRenderedBlock(b block) {
+	m.renderBlock(&b)
+	m.appendBlock(b)
 }
 
 // renderMarkdown renders text through glamour, falling back to plain text.

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -16,10 +16,12 @@ package neo
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -421,7 +423,7 @@ func TestModel_Update_UIApprovalRequest_ShowsPromptAndPausesAgent(t *testing.T) 
 	assert.False(t, m.busy, "approval request must end busy so the user can answer")
 	assert.True(t, m.pendingApproval)
 	assert.Equal(t, "appr_1", m.pendingApprovalID)
-	assert.GreaterOrEqual(t, m.findBlockKind(blockApproval), 0, "an approval block must be appended")
+	assert.GreaterOrEqual(t, m.findBlockKind(blockApprovalGeneral), 0, "an approval block must be appended")
 	assert.Contains(t, m.textInput.Prompt, "Approve?", "input prompt must reflect approval mode")
 }
 
@@ -955,7 +957,7 @@ func TestModel_Update_UIApprovalRequest_PlanCategory_RendersPlanHeaderAndMarkdow
 	assert.True(t, um.pendingApproval, "plan approval must enter the pending state")
 	assert.Equal(t, approvalTypePlanExit, um.pendingApprovalType,
 		"plan approval must record its wire approval_type")
-	idx := um.findBlockKind(blockApproval)
+	idx := um.findBlockKind(blockApprovalPlan)
 	require.NotEqual(t, -1, idx)
 	assert.Contains(t, um.blocks[idx].rendered, "Proposed plan")
 	// Glamour wraps each word in its own ANSI escape run; assert on word
@@ -985,7 +987,7 @@ func TestModel_Update_UIApprovalRequest_General_UsesExistingApprovalRendering(t 
 
 	assert.NotEqual(t, approvalTypePlanExit, um.pendingApprovalType,
 		"general approval must not be flagged as a plan")
-	idx := um.findBlockKind(blockApproval)
+	idx := um.findBlockKind(blockApprovalGeneral)
 	require.NotEqual(t, -1, idx)
 	assert.Contains(t, um.blocks[idx].rendered, "Approval required")
 	assert.Contains(t, um.textInput.Prompt, "Approve?")
@@ -1090,6 +1092,106 @@ func TestModel_RenderMarkdown_UsesRendererAfterWindowSize(t *testing.T) {
 	assert.Contains(t, got, "hello")
 }
 
+// -----------------------------------------------------------------------------
+// Text reflow: wrapping and resize re-render
+// -----------------------------------------------------------------------------
+
+// visibleLines returns each line's ANSI-stripped visible width.
+func visibleLines(rendered string) []int {
+	lines := strings.Split(rendered, "\n")
+	widths := make([]int, len(lines))
+	for i, l := range lines {
+		widths[i] = lipgloss.Width(l)
+	}
+	return widths
+}
+
+func TestWarningWrapsToTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	// Long warning must wrap rather than clip at the viewport edge.
+	msg := "this is an intentionally long warning message that must span multiple lines when the terminal is narrow"
+	got := renderIndented(warningStyle, 40, "⚠ "+msg)
+
+	widths := visibleLines(got)
+	require.Greater(t, len(widths), 1, "long warning must wrap to multiple lines; got: %q", got)
+	for i, w := range widths {
+		assert.LessOrEqual(t, w, 40, "line %d exceeds terminal width: width=%d", i, w)
+	}
+	assert.Contains(t, got, "warning", "wrapped output must still contain the message body")
+}
+
+func TestUserBubbleWrapsToTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	m := &Model{width: 40}
+	long := strings.Repeat("word ", 25) // ~125 chars
+	got := m.renderUserBubble(long)
+
+	require.Contains(t, got, "\n", "long bubble must contain a newline (wrapped): %q", got)
+	for i, w := range visibleLines(got) {
+		assert.LessOrEqual(t, w, 40, "bubble line %d exceeds terminal width: width=%d", i, w)
+	}
+}
+
+func TestUserBubbleDoesNotPadShortMessages(t *testing.T) {
+	t.Parallel()
+
+	// Short messages hug content so the bubble looks like a chat bubble,
+	// not a full-width card.
+	m := &Model{width: 80}
+	got := m.renderUserBubble("hi")
+
+	widths := visibleLines(got)
+	require.Len(t, widths, 1, "short bubble should render on a single line: %q", got)
+	assert.Less(t, widths[0], 20, "short bubble line should hug content, not fill terminal; got width=%d", widths[0])
+}
+
+func TestResizeReRendersWidthDependentBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Blocks cached at event time must re-wrap on resize, not stay at the
+	// old width forever.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	long := strings.Repeat("word ", 25)
+	updated1, _ := m.Update(UIWarning{Message: long})
+	m = updated1.(Model)
+
+	idx := m.findBlockKind(blockWarning)
+	require.NotEqual(t, -1, idx)
+	widthsAt80 := visibleLines(m.blocks[idx].rendered)
+	for i, w := range widthsAt80 {
+		assert.LessOrEqual(t, w, 80, "line %d at width 80 exceeds: width=%d", i, w)
+	}
+
+	updated2, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated2.(Model)
+
+	widthsAt40 := visibleLines(m.blocks[idx].rendered)
+	assert.Greater(t, len(widthsAt40), len(widthsAt80),
+		"resize to 40 cols must produce more lines than the 80-col render; 80=%d lines, 40=%d lines",
+		len(widthsAt80), len(widthsAt40))
+	for i, w := range widthsAt40 {
+		assert.LessOrEqual(t, w, 40, "line %d at width 40 exceeds: width=%d", i, w)
+	}
+}
+
+func TestRenderBlock_SkipsWidthIndependentBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Empty-raw kinds (blockBusy, blockToolComplete) keep their pre-styled
+	// rendered string untouched on resize.
+	m := &Model{width: 40}
+	b := block{kind: blockToolComplete, rendered: "  ⏺ Read(\"/x\")"}
+	m.renderBlock(&b)
+	assert.Equal(t, "  ⏺ Read(\"/x\")", b.rendered, "empty raw must be a no-op")
+}
+
 func TestModel_RebuildContent_HandlesMixedBlocksWithoutPanic(t *testing.T) {
 	t.Parallel()
 
@@ -1113,4 +1215,109 @@ func TestModel_RebuildContent_HandlesMixedBlocksWithoutPanic(t *testing.T) {
 	// panic is enough — we don't reach into the viewport internals here.
 	require.NotPanics(t, func() { m.rebuildContent() })
 	require.Len(t, m.blocks, 5, "blocks slice must be untouched")
+}
+
+func TestApprovalGeneralWrapsToTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	// Long approval message wraps rather than clipping at the viewport edge.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated0.(Model)
+
+	long := strings.Repeat("word ", 25) // ~125 chars
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr",
+		Message:      long,
+		ApprovalType: "general",
+	})
+	um := updated.(Model)
+
+	idx := um.findBlockKind(blockApprovalGeneral)
+	require.NotEqual(t, -1, idx)
+	widths := visibleLines(um.blocks[idx].rendered)
+	require.Greater(t, len(widths), 1,
+		"long approval body must wrap to multiple lines; got: %q", um.blocks[idx].rendered)
+	for i, w := range widths {
+		assert.LessOrEqual(t, w, 40, "line %d exceeds terminal width: width=%d", i, w)
+	}
+}
+
+func TestApprovalPlanReflowsOnResize(t *testing.T) {
+	t.Parallel()
+
+	// Plan markdown must re-render through glamour on resize instead of
+	// staying pinned to the width it arrived at.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	longParagraph := strings.Repeat("alpha ", 30) // ~180 chars, glamour-wrappable
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr",
+		Message:         "intro",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\n" + longParagraph,
+	})
+	m = updated.(Model)
+
+	idx := m.findBlockKind(blockApprovalPlan)
+	require.NotEqual(t, -1, idx)
+	linesAt80 := len(visibleLines(m.blocks[idx].rendered))
+
+	updated2, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated2.(Model)
+
+	linesAt40 := len(visibleLines(m.blocks[idx].rendered))
+	assert.Greater(t, linesAt40, linesAt80,
+		"resize to 40 cols must produce more wrapped lines than the 80-col render; 80=%d lines, 40=%d lines",
+		linesAt80, linesAt40)
+}
+
+func TestApprovalChoiceDenialWrapsToTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	// Denial text can be up to textinput's 4096-char limit; must wrap.
+	outCh := make(chan outboundEvent, 1)
+	evCh := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated0.(Model)
+
+	updated1, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr",
+		Message:      "run something",
+		ApprovalType: "general",
+	})
+	m = updated1.(Model)
+	m.textInput.SetValue(strings.Repeat("because ", 20)) // ~160 chars of denial text
+
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated2.(Model)
+	<-outCh
+
+	idx := m.findBlockKind(blockApprovalChoice)
+	require.NotEqual(t, -1, idx)
+	widths := visibleLines(m.blocks[idx].rendered)
+	require.Greater(t, len(widths), 1,
+		"long denial must wrap to multiple lines; got: %q", m.blocks[idx].rendered)
+	for i, w := range widths {
+		assert.LessOrEqual(t, w, 40, "line %d exceeds terminal width: width=%d", i, w)
+	}
+}
+
+func TestApprovalChoiceApprovedStaysSingleLine(t *testing.T) {
+	t.Parallel()
+
+	// Approved carries its verdict in block.approved, not raw — the raw==""
+	// early-exit must not short-circuit this kind.
+	m := &Model{width: 80}
+	b := block{kind: blockApprovalChoice, approved: true}
+	m.renderBlock(&b)
+
+	widths := visibleLines(b.rendered)
+	require.Len(t, widths, 1, "approved verdict must render on a single line: %q", b.rendered)
+	assert.Contains(t, b.rendered, "Approved")
 }


### PR DESCRIPTION
Warnings, errors, and user-message bubbles in the pulumi neo TUI used to
render as single long lines that got clipped at the viewport edge because
they went through lipgloss.Style.Render with no width constraint — unlike
assistant messages, which wrap via glamour's WithWordWrap.

Route width-dependent blocks (user, warning, error, cancelled, assistant
streaming and final) through a renderBlock helper that stores the source
text on block.raw and reflows from it on every WindowSizeMsg, so the whole
transcript re-wraps when the terminal is resized.

Fixes pulumi/pulumi-service#41444

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
