### PR TITLE
Error on 'id' in state inputs

### DIFF
--- a/changelog/pending/20260416--sdkgen--error-on-id-in-state-inputs.yaml
+++ b/changelog/pending/20260416--sdkgen--error-on-id-in-state-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen
+  description: Error on 'id' in state inputs

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -1676,6 +1676,14 @@ func (t *types) bindResourceDetails(
 
 	var stateInputs *ObjectType
 	if spec.StateInputs != nil {
+		for name := range spec.StateInputs.Properties {
+			if isReservedStateInputPropertyKey(name) {
+				diags = diags.Append(errorf(
+					path+"/stateInputs/properties/"+name,
+					"%s is a reserved property name for stateInputs", name))
+			}
+		}
+
 		si, stateDiags, err := t.bindAnonymousObjectType(path+"/stateInputs", token+"Args", *spec.StateInputs, options)
 		diags = diags.Extend(stateDiags)
 		if err != nil {

--- a/pkg/codegen/schema/reserved_keywords.go
+++ b/pkg/codegen/schema/reserved_keywords.go
@@ -41,5 +41,9 @@ func isReservedComponentResourcePropertyKey(name string) bool {
 }
 
 func isReservedCustomResourcePropertyKey(name string) bool {
-	return slices.Contains(reservedNonComponentPropertyKeys, name)
+	return slices.Contains(reservedNonComponentPropertyKeys, name) || isReservedKeyword(name)
+}
+
+func isReservedStateInputPropertyKey(name string) bool {
+	return slices.Contains(reservedNonComponentPropertyKeys, name) || isReservedKeyword(name)
 }

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1185,8 +1185,8 @@ func TestUsingIdInStateInputsIsAnError(t *testing.T) {
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
-	assert.NoError(t, err)
-	assert.NotNil(t, pkg)
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
 	require.True(t, diags.HasErrors())
 	assert.Contains(t, diags.Error(), "id is a reserved property name for stateInputs")
 }

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1150,6 +1150,47 @@ func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 	assert.Contains(t, diags[0].Summary, "id is a reserved property name")
 }
 
+func TestUsingIdInStateInputsIsAnError(t *testing.T) {
+	t.Parallel()
+	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	pkgSpec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]ResourceSpec{
+			"test:index:TestResource": {
+				ObjectTypeSpec: ObjectTypeSpec{
+					Properties: map[string]PropertySpec{
+						"value": {
+							TypeSpec: TypeSpec{Type: "string"},
+						},
+					},
+				},
+				InputProperties: map[string]PropertySpec{
+					"value": {
+						TypeSpec: TypeSpec{Type: "string"},
+					},
+				},
+				StateInputs: &ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]PropertySpec{
+						"id": {
+							TypeSpec: TypeSpec{Type: "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
+		AllowDanglingReferences: true,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, pkg)
+	require.True(t, diags.HasErrors())
+	assert.Contains(t, diags.Error(), "id is a reserved property name for stateInputs")
+}
+
 func TestOmittingVersionWhenSupportsPackEnabledGivesError(t *testing.T) {
 	t.Parallel()
 	loader := NewPluginLoader(utils.NewHost(testdataPath))


### PR DESCRIPTION
In preparation for `read` blocks that need to take an "id" input we want to ensure no provider tries to also use this as a state input property. It doesn't look like any provider currently does this, so this should be safe to start limiting now.

Also made `isReservedCustomResourcePropertyKey` consistent about checking `isReservedKeyword`, no path can be changed by this today, but looked like something that might trip us up later.