### PR TITLE
feat(cli/neo): declarative busy indicator and Esc to cancel

### DIFF
--- a/changelog/pending/20260417--cli-neo--declarative-busy-indicator-and-esc-to-cancel.yaml
+++ b/changelog/pending/20260417--cli-neo--declarative-busy-indicator-and-esc-to-cancel.yaml
@@ -1,0 +1,10 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    The `pulumi neo` TUI now drives its "thinking" spinner off a single declarative
+    rule (the spinner stays on until a final event — final assistant message, approval
+    request, cancellation, or error — lands), so the indicator no longer flickers off
+    when the agent hands off tool calls to the CLI or when streaming text arrives
+    between tools. Press `Esc` during a turn to ask the agent to cancel; the label
+    switches to "Cancelling..." until the backend acknowledges.

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -16,8 +16,11 @@
 // pairs with Pulumi Cloud's Neo agent when a task is created in `cli` tool execution mode.
 //
 // The wire types consumed by this loop live in sdk/go/common/apitype (see neo.go there).
-// This file only defines the string discriminator values we filter on.
+// This file defines the string discriminator values we filter on and small CLI-side
+// helpers that operate on those wire types.
 package neo
+
+import "github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 
 // Discriminator values for the AgentConsoleEvent envelope and the inner backend/user
 // events we care about.
@@ -36,12 +39,25 @@ const (
 	userEventUserMessage      = "user_message"
 	userEventUserConfirmation = "user_confirmation"
 
-	// Additional backend event types forwarded to the TUI.
+	// userEventUserCancel is the user event the CLI posts when the user asks to
+	// abort the current turn (ESC in the TUI). The agent acknowledges by emitting
+	// a cancelled backend event.
+	userEventUserCancel = "user_cancel"
+
+	// Additional backend event types forwarded to the TUI. Note that
+	// "exec_tool_call" is used both by the CLI (posted upstream, see
+	// userEventExecToolCall above) and by the service (echoed back in the event
+	// stream when a server-side tool starts running).
 	backendEventExecToolCallProgress = "exec_tool_call_progress"
+	backendEventToolResponse         = "tool_response"
 	backendEventError                = "error"
 	backendEventWarning              = "warning"
 	backendEventCancelled            = "cancelled"
 	backendEventUserApprovalRequest  = "user_approval_request"
+	backendEventAwaitingApprovals    = "awaiting_approvals"
+	backendEventContextCompression   = "context_compression_event"
+	backendEventChangeEntities       = "change_entities"
+	backendEventSetTaskName          = "set_task_name"
 
 	// approvalTypePlanExit is the approval_type value the service sets on a
 	// user_approval_request that gates an exit_plan_mode tool call. The TUI
@@ -51,3 +67,16 @@ const (
 	// tool-approval rendering path.
 	approvalTypePlanExit = "plan_exit"
 )
+
+// hasPendingCLIToolCalls reports whether any tool call in the list has
+// execution_mode=="cli", meaning the CLI must run it locally before the agent
+// turn can resume. The TUI-side busy rule uses this to keep the spinner on
+// through an is_final=true assistant_message that hands work off to the CLI.
+func hasPendingCLIToolCalls(calls []apitype.AgentBackendEventToolCall) bool {
+	for _, tc := range calls {
+		if tc.ExecutionMode == toolExecutionModeCLI {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cmd/pulumi/neo/events_test.go
+++ b/pkg/cmd/pulumi/neo/events_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// TestHasPendingCLIToolCalls is thin but explicit — the helper drives the
+// HasPendingCLIWork flag on UIAssistantMessage, which the TUI busy rule uses
+// to keep the spinner on through a CLI-work hand-off.
+func TestHasPendingCLIToolCalls(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, hasPendingCLIToolCalls(nil))
+	assert.False(t, hasPendingCLIToolCalls([]apitype.AgentBackendEventToolCall{}))
+	assert.False(t, hasPendingCLIToolCalls([]apitype.AgentBackendEventToolCall{
+		{ExecutionMode: "cloud"},
+		{ExecutionMode: ""},
+	}))
+	assert.True(t, hasPendingCLIToolCalls([]apitype.AgentBackendEventToolCall{
+		{ExecutionMode: toolExecutionModeCLI},
+	}))
+	assert.True(t, hasPendingCLIToolCalls([]apitype.AgentBackendEventToolCall{
+		{ExecutionMode: "cloud"},
+		{ExecutionMode: toolExecutionModeCLI},
+	}))
+}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -245,7 +245,11 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 		if err := json.Unmarshal(eventBody, &msg); err != nil {
 			return
 		}
-		sendUI(s.UIEvents, UIAssistantMessage{Content: msg.Content, IsFinal: msg.IsFinal})
+		sendUI(s.UIEvents, UIAssistantMessage{
+			Content:           msg.Content,
+			IsFinal:           msg.IsFinal,
+			HasPendingCLIWork: msg.IsFinal && hasPendingCLIToolCalls(msg.ToolCalls),
+		})
 	case backendEventExecToolCallProgress:
 		var p apitype.AgentBackendEventExecToolCallProgress
 		if err := json.Unmarshal(eventBody, &p); err != nil {
@@ -278,9 +282,23 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 			ApprovalType:    req.ApprovalType,
 			PlanDescription: req.Context.PlanDescription,
 		})
+	case backendEventAwaitingApprovals:
+		sendUI(s.UIEvents, UIAwaitingApprovals{})
+	case backendEventContextCompression:
+		var c apitype.AgentBackendEventContextCompression
+		if err := json.Unmarshal(eventBody, &c); err != nil {
+			return
+		}
+		sendUI(s.UIEvents, UIContextCompression{Status: c.Status})
+	case backendEventToolResponse,
+		userEventExecToolCall, // server-side echo of a tool running (same discriminator as the CLI-posted event)
+		backendEventChangeEntities,
+		backendEventSetTaskName:
+		// Intentionally ignored: the TUI has no dedicated rendering for these,
+		// and the declarative busy rule does not need a heartbeat — the spinner
+		// Tick is self-perpetuating while busy, and m.cancelling persists across
+		// events until a final one arrives.
 	}
-	// Server-side exec_tool_call and tool_response events describe tools the agent
-	// runtime executes; the CLI-run equivalents are emitted directly from runBatch.
 }
 
 // forwardUserInputToUI parses a userInput event body and sends a UIUserMessage to the TUI.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -134,6 +134,12 @@ type Model struct {
 	// pending approval (empty when none). The Enter handler checks for
 	// approvalTypePlanExit so it can auto-clear planMode on approval.
 	pendingApprovalType string
+	// cancelling is true from the moment the user presses ESC (the TUI posts an
+	// AgentUserEventCancel upstream) until the next final event arrives. While
+	// it is true the busy label is overridden to "Cancelling..." so the user
+	// can see their request is being acted on even if the agent is still
+	// mid-tool.
+	cancelling bool
 }
 
 var (
@@ -271,6 +277,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// ESC asks the agent to abort the current turn. Posts user_cancel
+		// upstream and flips the local cancelling flag so the spinner label
+		// switches to "Cancelling..." until the backend acknowledges via
+		// cancelled / error / a new final assistant_message. Ignored when the
+		// TUI isn't busy or is already waiting on an approval (where the
+		// agent is paused for us anyway).
+		if msg.Type == tea.KeyEsc {
+			if m.busy && !m.pendingApproval && !m.cancelling {
+				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
+				m.cancelling = true
+				cmd := m.showBusy("Cancelling...", shimmerVerb)
+				m.rebuildContent()
+				return m, cmd
+			}
+			return m, nil
+		}
+
 		// Handled before the busy check because the agent is intentionally
 		// paused here waiting for the user.
 		if m.pendingApproval {
@@ -282,20 +305,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					denialMsg = text
 				}
 				wasPlanApproval := m.pendingApprovalType == approvalTypePlanExit
-				if m.outCh != nil {
-					select {
-					case m.outCh <- outboundEvent{
-						event: apitype.AgentUserEventUserConfirmation{
-							Type:       userEventUserConfirmation,
-							ApprovalID: m.pendingApprovalID,
-							Approved:   approved,
-							Message:    denialMsg,
-						},
-						planMode: m.planMode,
-					}:
-					default:
-					}
-				}
+				m.sendOut(outboundEvent{
+					event: apitype.AgentUserEventUserConfirmation{
+						Type:       userEventUserConfirmation,
+						ApprovalID: m.pendingApprovalID,
+						Approved:   approved,
+						Message:    denialMsg,
+					},
+					planMode: m.planMode,
+				})
 				m.pendingApproval = false
 				m.pendingApprovalID = ""
 				m.pendingApprovalType = ""
@@ -337,28 +355,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			text := strings.TrimSpace(m.textInput.Value())
 			if text != "" {
 				m.textInput.Reset()
-				if m.outCh != nil {
-					select {
-					case m.outCh <- outboundEvent{
-						event: apitype.AgentUserEventUserMessage{
-							Type:    userEventUserMessage,
-							Content: text,
-						},
-						planMode: m.planMode,
-					}:
-						// Render optimistically so the user sees their message in
-						// the transcript before the server echoes it back. The
-						// echo is reconciled against pendingUserEchoes in the
-						// UIUserMessage handler to avoid duplicates.
-						m.appendUserMessageBlock(text)
-						m.pendingUserEchoes = append(m.pendingUserEchoes, text)
-						// Freeze the plan-mode affordance: planMode has now been
-						// committed to the dispatcher and any later Shift+Tab
-						// would be a no-op on the server.
-						m.messageSent = true
-						return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
-					default:
-					}
+				sent := m.sendOut(outboundEvent{
+					event: apitype.AgentUserEventUserMessage{
+						Type:    userEventUserMessage,
+						Content: text,
+					},
+					planMode: m.planMode,
+				})
+				if sent {
+					// Render optimistically so the user sees their message in
+					// the transcript before the server echoes it back. The
+					// echo is reconciled against pendingUserEchoes in the
+					// UIUserMessage handler to avoid duplicates.
+					m.appendUserMessageBlock(text)
+					m.pendingUserEchoes = append(m.pendingUserEchoes, text)
+					// Freeze the plan-mode affordance: planMode has now been
+					// committed to the dispatcher and any later Shift+Tab
+					// would be a no-op on the server.
+					m.messageSent = true
+					return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
 				}
 			}
 			return m, nil
@@ -393,30 +408,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case UIAssistantMessage:
-		m.removeBlockKind(blockBusy)
-		if msg.IsFinal {
+		// A truly-final message closes out any in-flight streaming block. The
+		// final-marker append is guarded because IsFinal=true can arrive with
+		// empty content (e.g. a hand-off that became final once the server
+		// reconciled pending tool calls) and we don't want a phantom marker.
+		if msg.IsFinal && !msg.HasPendingCLIWork {
 			m.removeBlockKind(blockAssistantStreaming)
-			m.appendRenderedBlock(block{kind: blockAssistantFinal, raw: msg.Content})
-		} else if idx := m.findBlockKind(blockAssistantStreaming); idx >= 0 {
-			m.blocks[idx].raw = msg.Content
-			m.renderBlock(&m.blocks[idx])
-		} else {
-			m.appendRenderedBlock(block{kind: blockAssistantStreaming, raw: msg.Content})
+			if msg.Content != "" {
+				m.appendRenderedBlock(block{kind: blockAssistantFinal, raw: msg.Content})
+			}
+		} else if msg.Content != "" {
+			if idx := m.findBlockKind(blockAssistantStreaming); idx >= 0 {
+				m.blocks[idx].raw = msg.Content
+				m.renderBlock(&m.blocks[idx])
+			} else {
+				m.appendRenderedBlock(block{kind: blockAssistantStreaming, raw: msg.Content})
+			}
 		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolStarted:
-		if cmd := m.showBusy(toolLabel(msg.Name, msg.Args)+" ...", shimmerWave); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolProgress:
-		if cmd := m.showBusy(toolLabel(msg.Name, nil)+": "+truncate(msg.Message, 60), shimmerWave); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -431,35 +450,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 		// Keep the busy block alive across the inter-tool gap so the spinner
 		// stays visible while the agent decides its next move.
-		if cmd := m.showBusy(pickThinkingVerb()+"...", shimmerVerb); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIError:
-		m.endBusy()
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.appendRenderedBlock(block{kind: blockError, raw: msg.Message})
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIWarning:
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.appendWarningBlock(msg.Message)
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UICancelled:
-		m.endBusy()
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.appendRenderedBlock(block{kind: blockCancelled, raw: "Session cancelled."})
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UITaskIdle:
-		m.endBusy()
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UISessionURL:
+		// Informational metadata for the welcome box — has no opinion on busy state.
 		m.welcome.consoleURL = msg.URL
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
@@ -473,12 +492,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pendingUserEchoes = m.pendingUserEchoes[1:]
 		} else {
 			m.appendUserMessageBlock(msg.Content)
-			m.rebuildContent()
 		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIAwaitingApprovals:
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIContextCompression:
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIApprovalRequest:
-		m.endBusy()
+		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.pendingApproval = true
 		m.pendingApprovalID = msg.ApprovalID
 		m.pendingApprovalType = msg.ApprovalType
@@ -552,6 +582,66 @@ func (m *Model) rebuildContent() {
 	}
 }
 
+// applyBusyForEvent is the single point that decides whether the busy
+// indicator should be visible after a UIEvent arrives, mirroring the web
+// console's "is the last event in the stream final?" rule. Final events hide
+// the spinner and re-enable input; non-final events keep it on, with a label
+// chosen by labelForUIEvent (or "Cancelling..." overriding everything while
+// the user's cancel request is in flight).
+func (m *Model) applyBusyForEvent(ev UIEvent) tea.Cmd {
+	if isFinalUIEvent(ev) {
+		m.cancelling = false
+		m.endBusy()
+		return nil
+	}
+	if m.cancelling {
+		return m.showBusy("Cancelling...", shimmerVerb)
+	}
+	label, shim, set := m.labelForUIEvent(ev)
+	if !set {
+		// Non-opinionated event (warning, foreign user message, session URL,
+		// non-final tick): leave the busy state exactly as it is.
+		return nil
+	}
+	return m.showBusy(label, shim)
+}
+
+// isFinalUIEvent reports whether ev closes the agent's turn. See
+// applyBusyForEvent for the full rule and the CLI-work exception.
+func isFinalUIEvent(ev UIEvent) bool {
+	switch e := ev.(type) {
+	case UIAssistantMessage:
+		return e.IsFinal && !e.HasPendingCLIWork
+	case UIApprovalRequest, UICancelled, UIError, UITaskIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+// labelForUIEvent picks the busy-indicator label for a non-final UIEvent. The
+// third return value is false when the event has no opinion on the label — in
+// that case the caller leaves the current label alone.
+func (m *Model) labelForUIEvent(ev UIEvent) (string, shimmerKind, bool) {
+	switch e := ev.(type) {
+	case UIToolStarted:
+		return toolLabel(e.Name, e.Args) + " ...", shimmerWave, true
+	case UIToolProgress:
+		return toolLabel(e.Name, nil) + ": " + truncate(e.Message, 60), shimmerWave, true
+	case UIToolCompleted:
+		return pickThinkingVerb() + "...", shimmerVerb, true
+	case UIAssistantMessage:
+		// Only reached when non-final (streaming) or when IsFinal=true with
+		// pending CLI work — i.e. the agent is still working.
+		return pickThinkingVerb() + "...", shimmerVerb, true
+	case UIAwaitingApprovals:
+		return "Awaiting approvals...", shimmerVerb, true
+	case UIContextCompression:
+		return "Compressing context...", shimmerVerb, true
+	}
+	return "", 0, false
+}
+
 // showBusy ensures the busy indicator is the last block, with the given
 // label and shimmer style, and the spinner is ticking. Always remove-then-
 // append so blockBusy is guaranteed to be at the bottom regardless of prior
@@ -583,6 +673,18 @@ func (m *Model) appendBlock(b block) {
 		return
 	}
 	m.blocks = append(m.blocks, b)
+}
+
+// sendOut is a non-blocking send on the outbound channel. Returns true on
+// success. Safe when m.outCh is nil: select with default falls through,
+// since sending on a nil channel blocks forever.
+func (m *Model) sendOut(e outboundEvent) bool {
+	select {
+	case m.outCh <- e:
+		return true
+	default:
+		return false
+	}
 }
 
 // endBusy clears the busy flag (the spinner drops its next tick) and

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -1,0 +1,247 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// TestIsFinalUIEvent_MirrorsBackendRule — the TUI-side classifier needs to
+// stay in lockstep with isFinalBackendEvent, including the CLI-tool-calls
+// exception.
+func TestIsFinalUIEvent_MirrorsBackendRule(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ev   UIEvent
+		want bool
+	}{
+		{"assistant_message_streaming", UIAssistantMessage{IsFinal: false}, false},
+		{"assistant_message_final_no_cli_work", UIAssistantMessage{IsFinal: true}, true},
+		{"assistant_message_final_with_cli_work", UIAssistantMessage{IsFinal: true, HasPendingCLIWork: true}, false},
+		{"approval_request_final", UIApprovalRequest{}, true},
+		{"cancelled_final", UICancelled{}, true},
+		{"error_final", UIError{}, true},
+		{"task_idle_final", UITaskIdle{}, true},
+		{"tool_started_non_final", UIToolStarted{Name: "x__y"}, false},
+		{"tool_progress_non_final", UIToolProgress{Name: "x__y"}, false},
+		{"tool_completed_non_final", UIToolCompleted{Name: "x__y"}, false},
+		{"warning_non_final", UIWarning{Message: "careful"}, false},
+		{"user_message_non_final", UIUserMessage{Content: "hi"}, false},
+		{"awaiting_approvals_non_final", UIAwaitingApprovals{}, false},
+		{"context_compression_non_final", UIContextCompression{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isFinalUIEvent(tc.ev))
+		})
+	}
+}
+
+// TestBusy_NoFlickerOnCLIToolHandoff is the key regression test the declarative
+// busy rule was written to pass. Under the old imperative rule, an
+// assistant_message with is_final=true and queued CLI tool calls hid the
+// spinner before the first UIToolStarted arrived. Walk the full golden
+// sequence (submit → hand-off → tool × 2 → truly-final) and assert the
+// spinner stays on throughout, only flipping off at the end.
+func TestBusy_NoFlickerOnCLIToolHandoff(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 16)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, Busy: true}))
+	require.True(t, model.(Model).busy, "NewModel with Busy:true must seed busy state")
+
+	// Step 1: the agent's first message is the CLI-work hand-off. is_final is
+	// true but there's a queued CLI tool call — spinner must stay on.
+	model, _ = model.Update(UIAssistantMessage{IsFinal: true, HasPendingCLIWork: true, Content: ""})
+	assert.True(t, model.(Model).busy, "hand-off assistant_message with pending CLI work must leave spinner on")
+
+	// Step 2: session starts running the first tool. Label switches to a tool label.
+	model, _ = model.Update(UIToolStarted{Name: "filesystem__read", Args: json.RawMessage(`{"file_path":"/x"}`)})
+	assert.True(t, model.(Model).busy)
+
+	// Step 3: progress update from the tool.
+	model, _ = model.Update(UIToolProgress{Name: "filesystem__read", Message: "reading"})
+	assert.True(t, model.(Model).busy)
+
+	// Step 4: first tool completes; inter-tool gap uses a thinking verb.
+	model, _ = model.Update(UIToolCompleted{Name: "filesystem__read", Args: json.RawMessage(`{"file_path":"/x"}`)})
+	assert.True(t, model.(Model).busy)
+
+	// Step 5: agent decides to run a second tool — another hand-off arrives first.
+	model, _ = model.Update(UIAssistantMessage{IsFinal: true, HasPendingCLIWork: true, Content: ""})
+	assert.True(t, model.(Model).busy, "second hand-off must not clear busy either")
+
+	model, _ = model.Update(UIToolStarted{Name: "filesystem__write", Args: json.RawMessage(`{"file_path":"/y"}`)})
+	assert.True(t, model.(Model).busy)
+
+	model, _ = model.Update(UIToolCompleted{Name: "filesystem__write", Args: json.RawMessage(`{"file_path":"/y"}`)})
+	assert.True(t, model.(Model).busy)
+
+	// Step 6: agent's truly-final message — no pending CLI work. Spinner drops.
+	model, _ = model.Update(UIAssistantMessage{IsFinal: true, HasPendingCLIWork: false, Content: "done"})
+	m := model.(Model)
+	assert.False(t, m.busy, "truly-final assistant_message clears busy")
+	assert.Equal(t, -1, m.findBlockKind(blockBusy))
+	assert.GreaterOrEqual(t, m.findBlockKind(blockAssistantFinal), 0)
+}
+
+// TestBusy_NonFinalStreamingKeepsSpinnerOn — under the old rule, a non-final
+// assistant_message explicitly removed the busy block. The declarative rule
+// keeps the spinner on throughout streaming so there is no gap before the
+// next tool or the truly-final message.
+func TestBusy_NonFinalStreamingKeepsSpinnerOn(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, Busy: true}))
+
+	model, _ = model.Update(UIAssistantMessage{Content: "thinking...", IsFinal: false})
+	assert.True(t, model.(Model).busy, "non-final assistant_message must leave spinner on")
+	m := model.(Model)
+	assert.GreaterOrEqual(t, m.findBlockKind(blockAssistantStreaming), 0, "streaming content renders as a streaming block")
+	assert.GreaterOrEqual(t, m.findBlockKind(blockBusy), 0, "spinner block is still present")
+
+	// More streaming text — still non-final, still busy.
+	model, _ = model.Update(UIAssistantMessage{Content: "thinking harder", IsFinal: false})
+	assert.True(t, model.(Model).busy)
+
+	// Truly final — spinner off.
+	model, _ = model.Update(UIAssistantMessage{Content: "thinking harder. Done.", IsFinal: true})
+	assert.False(t, model.(Model).busy)
+}
+
+// TestBusy_CancellingSubstate — pressing ESC while busy posts user_cancel
+// upstream, sets the cancelling flag, and rewrites the busy label to
+// "Cancelling...". The flag clears on the next final event (here:
+// UICancelled).
+func TestBusy_CancellingSubstate(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	outCh := make(chan outboundEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
+
+	// Press ESC mid-turn.
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m := model.(Model)
+	assert.True(t, m.cancelling, "ESC must set the cancelling flag")
+	assert.True(t, m.busy, "spinner stays on while we wait for the backend to confirm")
+
+	// user_cancel was posted upstream.
+	select {
+	case ev := <-outCh:
+		c, ok := ev.event.(apitype.AgentUserEventCancel)
+		require.True(t, ok, "ESC must post an AgentUserEventCancel")
+		assert.Equal(t, userEventUserCancel, c.Type)
+	default:
+		t.Fatal("ESC did not post any user event")
+	}
+
+	// Busy block's label reflects the cancelling state.
+	idx := m.findBlockKind(blockBusy)
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, "Cancelling...", m.blocks[idx].label)
+
+	// Any non-final event while cancelling keeps the cancelling label, not a
+	// fresh thinking verb or tool label.
+	model, _ = model.Update(UIToolStarted{Name: "filesystem__read"})
+	m = model.(Model)
+	idx = m.findBlockKind(blockBusy)
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, "Cancelling...", m.blocks[idx].label, "cancelling overrides tool labels too")
+	assert.True(t, m.cancelling, "still cancelling until a final event arrives")
+
+	// Backend acknowledges the cancel → spinner off, cancelling flag clears.
+	model, _ = model.Update(UICancelled{})
+	m = model.(Model)
+	assert.False(t, m.busy)
+	assert.False(t, m.cancelling, "cancelling must clear on the final event")
+	assert.Equal(t, -1, m.findBlockKind(blockBusy))
+}
+
+// TestBusy_EscIgnoredWhenIdle — ESC while the TUI is idle is a no-op. We
+// don't want to post a spurious user_cancel.
+func TestBusy_EscIgnoredWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	outCh := make(chan outboundEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh}))
+	assert.False(t, model.(Model).busy)
+
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m := model.(Model)
+	assert.False(t, m.cancelling)
+	assert.False(t, m.busy)
+
+	select {
+	case <-outCh:
+		t.Fatal("ESC when idle must not post a user event")
+	default:
+	}
+}
+
+// TestBusy_EscIgnoredWhileApprovalPending — the agent is already paused
+// waiting for us during an approval; ESC should be a no-op here.
+func TestBusy_EscIgnoredWhileApprovalPending(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	outCh := make(chan outboundEvent, 4)
+	model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: true}))
+
+	// Simulate an approval request arriving.
+	model, _ = model.Update(UIApprovalRequest{ApprovalID: "a1", Message: "ok?"})
+	require.True(t, model.(Model).pendingApproval)
+
+	// ESC must not post anything.
+	model, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	assert.False(t, model.(Model).cancelling)
+	select {
+	case <-outCh:
+		t.Fatal("ESC during pending approval must not post a user event")
+	default:
+	}
+}
+
+// TestBusy_UnopinionatedEventsWhenIdle — warnings, session URLs, foreign
+// user messages arriving while the TUI is idle must NOT spin up the
+// indicator. These events fall through labelForUIEvent's default branch;
+// under an earlier draft of the rule they would have triggered a
+// "Thinking..." spin, which is wrong when no task is running.
+func TestBusy_UnopinionatedEventsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	for _, ev := range []UIEvent{
+		UIWarning{Message: "careful"},
+		UISessionURL{URL: "https://example.invalid"},
+		UIUserMessage{Content: "from another client"},
+	} {
+		ch := make(chan UIEvent, 4)
+		model := tea.Model(NewModel(ModelConfig{EventCh: ch}))
+		model, _ = model.Update(ev)
+		assert.False(t, model.(Model).busy, "event %T must not start the spinner when idle", ev)
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -26,6 +26,13 @@ type UIEvent interface {
 type UIAssistantMessage struct {
 	Content string
 	IsFinal bool
+	// HasPendingCLIWork is true when IsFinal is true AND the original
+	// assistant_message backend event had at least one tool_call with
+	// execution_mode=="cli". In that case the agent is paused handing control to
+	// the CLI to run those tools locally; the declarative busy rule treats the
+	// event as non-final and keeps the spinner on until the CLI has replied and
+	// the agent emits a truly-final message.
+	HasPendingCLIWork bool
 }
 
 func (UIAssistantMessage) uiEvent() {}
@@ -109,3 +116,19 @@ type UIApprovalRequest struct {
 }
 
 func (UIApprovalRequest) uiEvent() {}
+
+// UIAwaitingApprovals is an interim backend signal that the agent is pausing before
+// it will emit a UIApprovalRequest. The declarative busy rule treats it as non-final
+// and shows an "Awaiting approvals" label until the approval request arrives.
+type UIAwaitingApprovals struct{}
+
+func (UIAwaitingApprovals) uiEvent() {}
+
+// UIContextCompression signals that the agent is compressing its context window.
+// Non-final; the TUI surfaces it as a "Compressing context" label on the busy
+// indicator and otherwise doesn't render anything.
+type UIContextCompression struct {
+	Status string
+}
+
+func (UIContextCompression) uiEvent() {}

--- a/sdk/go/common/apitype/neo.go
+++ b/sdk/go/common/apitype/neo.go
@@ -171,6 +171,15 @@ type AgentBackendEventCancelled struct {
 	Type string `json:"type"` // always "cancelled"
 }
 
+// AgentBackendEventContextCompression is a backend event signalling that the agent is
+// compressing its context window. Non-final; the CLI surfaces it as a "Compressing
+// context" label on the busy indicator. Status carries a short human-readable label
+// such as "compressing".
+type AgentBackendEventContextCompression struct {
+	Type   string `json:"type"` // always "context_compression_event"
+	Status string `json:"status,omitempty"`
+}
+
 // AgentUserEventUserConfirmation is the user event a CLI client posts in response to a
 // user_approval_request backend event, approving or denying the requested operation.
 type AgentUserEventUserConfirmation struct {
@@ -181,3 +190,13 @@ type AgentUserEventUserConfirmation struct {
 }
 
 func (AgentUserEventUserConfirmation) isAgentUserEvent() {}
+
+// AgentUserEventCancel is the user event a CLI client posts to ask the agent to abort
+// the current turn. The agent acknowledges by emitting a cancelled backend event. Until
+// that acknowledgement arrives the TUI keeps the busy indicator on with a "Cancelling"
+// label.
+type AgentUserEventCancel struct {
+	Type string `json:"type"` // always "user_cancel"
+}
+
+func (AgentUserEventCancel) isAgentUserEvent() {}


### PR DESCRIPTION
Drive the thinking spinner off a single last-event-final? rule instead of
scattered showBusy/endBusy calls. Keeps the spinner on through CLI tool
hand-offs (assistant_message with is_final=true + queued CLI tool_calls)
and through non-final assistant streaming. Press Esc to post a
user_cancel upstream; the label switches to "Cancelling..." until the
backend acknowledges.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

Fixes pulumi/pulumi-service#41454

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
