### PR TITLE
[registry] Add pulumi package readme, nav, and docs commands

### DIFF
--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -72,6 +72,24 @@ func (r registryClient) GetTemplate(
 	return meta, err
 }
 
+func (r registryClient) GetPackageReadmeMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.c.GetPackageReadmeMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r registryClient) GetPackageNavMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.c.GetPackageNavMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r registryClient) GetPackageDocsMarkdown(
+	ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.c.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
+}
+
 func (r registryClient) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
 	bytes, err := r.c.DownloadTemplate(ctx, downloadURL)
 	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2031,6 +2031,61 @@ func (pc *Client) GetPackage(
 	return resp, err
 }
 
+func (pc *Client) GetPackageReadmeMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	path := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s/readme", source, publisher, name, version)
+	format := "markdown"
+	query := struct {
+		Format *string `url:"format"`
+		Lang   *string `url:"lang,omitempty"`
+		OS     *string `url:"os,omitempty"`
+	}{Format: &format, Lang: optStr(opts.Lang), OS: optStr(opts.OS)}
+	return pc.getTextBody(ctx, path, query)
+}
+
+func (pc *Client) GetPackageNavMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	path := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s/nav", source, publisher, name, version)
+	format := "markdown"
+	query := struct {
+		Format *string `url:"format"`
+		Lang   *string `url:"lang,omitempty"`
+		Q      *string `url:"q,omitempty"`
+	}{Format: &format, Lang: optStr(opts.Lang), Q: optStr(opts.Query)}
+	return pc.getTextBody(ctx, path, query)
+}
+
+func (pc *Client) GetPackageDocsMarkdown(
+	ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	path := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s/docs/%s",
+		source, publisher, name, version, url.PathEscape(token))
+	format := "markdown"
+	query := struct {
+		Format *string `url:"format"`
+		Lang   *string `url:"lang,omitempty"`
+		OS     *string `url:"os,omitempty"`
+	}{Format: &format, Lang: optStr(opts.Lang), OS: optStr(opts.OS)}
+	return pc.getTextBody(ctx, path, query)
+}
+
+func (pc *Client) getTextBody(ctx context.Context, path string, query any) (string, error) {
+	var body []byte
+	if err := pc.restCall(ctx, "GET", path, query, nil, &body); err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
 // DeletePackageVersion deletes a specific version of a package from the registry.
 func (pc *Client) DeletePackageVersion(
 	ctx context.Context, source, publisher, name string, version semver.Version,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1093,3 +1093,92 @@ func TestStreamNeoTaskEvents(t *testing.T) {
 		}
 	})
 }
+
+func TestGetPackageReadmeMarkdown(t *testing.T) {
+	t.Parallel()
+
+	expectedMarkdown := "# My Package\n\nThis is the readme."
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, "/api/registry/packages/pulumi/pulumi/random/versions/4.19.1/readme", req.URL.Path)
+		assert.Equal(t, "markdown", req.URL.Query().Get("format"))
+		assert.Equal(t, "python", req.URL.Query().Get("lang"))
+		assert.Equal(t, "linux", req.URL.Query().Get("os"))
+		return expectedMarkdown
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	result, err := client.GetPackageReadmeMarkdown(t.Context(), "pulumi", "pulumi", "random", "4.19.1",
+		apitype.PackageDocsOptions{Lang: "python", OS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t, expectedMarkdown, result)
+}
+
+func TestGetPackageNavMarkdown(t *testing.T) {
+	t.Parallel()
+
+	expectedMarkdown := "# random v4.19.1\n\n## index/\n\n- RandomPassword"
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, "/api/registry/packages/pulumi/pulumi/random/versions/4.19.1/nav", req.URL.Path)
+		assert.Equal(t, "markdown", req.URL.Query().Get("format"))
+		assert.Equal(t, "go", req.URL.Query().Get("lang"))
+		assert.Equal(t, "Password", req.URL.Query().Get("q"))
+		return expectedMarkdown
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	result, err := client.GetPackageNavMarkdown(t.Context(), "pulumi", "pulumi", "random", "4.19.1",
+		apitype.PackageDocsOptions{Lang: "go", Query: "Password"})
+	require.NoError(t, err)
+	assert.Equal(t, expectedMarkdown, result)
+}
+
+func TestGetPackageDocsMarkdown(t *testing.T) {
+	t.Parallel()
+
+	expectedMarkdown := "# RandomPassword\n\n## Inputs\n\n| Name | Type |"
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "GET", req.Method)
+		// url.PathEscape encodes slashes but not colons (valid in path segments).
+		assert.Equal(t,
+			"/api/registry/packages/pulumi/pulumi/random/versions/4.19.1/docs/random:index%2FrandomPassword:RandomPassword",
+			req.URL.RawPath)
+		assert.Equal(t, "markdown", req.URL.Query().Get("format"))
+		assert.Equal(t, "python", req.URL.Query().Get("lang"))
+		assert.Equal(t, "linux", req.URL.Query().Get("os"))
+		return expectedMarkdown
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	result, err := client.GetPackageDocsMarkdown(t.Context(), "pulumi", "pulumi", "random", "4.19.1",
+		"random:index/randomPassword:RandomPassword",
+		apitype.PackageDocsOptions{Lang: "python", OS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t, expectedMarkdown, result)
+}
+
+func TestGetPackageDocsMarkdown_OmitsEmptyQueryParams(t *testing.T) {
+	t.Parallel()
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "markdown", req.URL.Query().Get("format"))
+		// These should be absent, not empty strings.
+		assert.Empty(t, req.URL.Query().Get("lang"))
+		assert.Empty(t, req.URL.Query().Get("os"))
+		return "content"
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	_, err := client.GetPackageDocsMarkdown(t.Context(), "pulumi", "pulumi", "random", "4.19.1",
+		"random:index/randomPassword:RandomPassword",
+		apitype.PackageDocsOptions{})
+	require.NoError(t, err)
+}

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -85,6 +85,24 @@ func (r *cloudRegistry) DownloadTemplate(ctx ctx.Context, downloadURL string) (i
 	return r.cl.DownloadTemplate(ctx, downloadURL)
 }
 
+func (r *cloudRegistry) GetPackageReadmeMarkdown(
+	ctx ctx.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.cl.GetPackageReadmeMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r *cloudRegistry) GetPackageNavMarkdown(
+	ctx ctx.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.cl.GetPackageNavMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r *cloudRegistry) GetPackageDocsMarkdown(
+	ctx ctx.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	return r.cl.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
+}
+
 func (r *cloudRegistry) DeletePackageVersion(
 	ctx ctx.Context, source, publisher, name string, version semver.Version,
 ) error {

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -40,6 +40,9 @@ Install and configure Pulumi packages and their plugins and SDKs.`,
 		newPackagePublishCmd(),
 		newPackageDeleteCmd(),
 		newPackageInfoCmd(),
+		newPackageReadmeCmd(),
+		newPackageNavCmd(),
+		newPackageDocsCmd(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_docs.go
+++ b/pkg/cmd/pulumi/packagecmd/package_docs.go
@@ -1,0 +1,80 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/spf13/cobra"
+)
+
+func newPackageDocsCmd() *cobra.Command {
+	var lang string
+	var os string
+
+	cmd := &cobra.Command{
+		Use:   "docs <package>[@<version>] <token>",
+		Short: "Display documentation for a registry package resource or function",
+		Long: `Display documentation for a specific resource or function in a registry package.
+
+The package argument accepts the same formats as 'pulumi package add':
+  aws, pulumi/pulumi/aws, aws@7.20.0
+
+The token argument is a Pulumi type token, e.g.:
+  random:index/randomPassword:RandomPassword
+  aws:s3/bucket:Bucket
+
+Use 'pulumi package nav' to discover available tokens.
+
+If --lang is not specified, the language is inferred from the current
+Pulumi project's runtime (Pulumi.yaml).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			pkg, err := parseAndResolvePackage(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			token := args[1]
+
+			reg := registryForContext(ctx)
+			md, err := reg.GetPackageDocsMarkdown(
+				ctx, pkg.Source, pkg.Publisher, pkg.Name, pkg.Version, token,
+				docsOpts(lang, os, ""),
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), md)
+			return nil
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package", Usage: "<package>[@<version>]"},
+			{Name: "token", Usage: "<token>"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&lang, "lang", "", "Language for code examples and type names (typescript, python, go, csharp, yaml, java)")
+	cmd.Flags().StringVar(&os, "os", "", "OS for platform-specific content (linux, macos, windows)")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/packagecmd/package_docs_common.go
+++ b/pkg/cmd/pulumi/packagecmd/package_docs_common.go
@@ -1,0 +1,116 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/blang/semver"
+
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// resolvedPackage holds the coordinates of a resolved registry package.
+type resolvedPackage struct {
+	Source    string
+	Publisher string
+	Name      string
+	Version   string
+}
+
+// parseAndResolvePackage parses a user-provided package argument (e.g. "aws",
+// "aws@7.20.0", "pulumi/pulumi/aws") and resolves it via the registry.
+func parseAndResolvePackage(ctx context.Context, pkg string) (resolvedPackage, error) {
+	name, versionStr, _ := strings.Cut(pkg, "@")
+
+	var version *semver.Version
+	if versionStr != "" {
+		v, err := semver.Parse(versionStr)
+		if err != nil {
+			return resolvedPackage{}, err
+		}
+		version = &v
+	}
+
+	reg := cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
+	meta, err := registry.ResolvePackageFromName(ctx, reg, name, version)
+	if err != nil {
+		return resolvedPackage{}, err
+	}
+
+	return resolvedPackage{
+		Source:    meta.Source,
+		Publisher: meta.Publisher,
+		Name:      meta.Name,
+		Version:   meta.Version.String(),
+	}, nil
+}
+
+// registryForContext returns a registry suitable for making doc API calls.
+func registryForContext(ctx context.Context) registry.Registry {
+	return cmdCmd.NewDefaultRegistry(ctx, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
+}
+
+var runtimeToLang = map[string]string{
+	"nodejs": "typescript",
+	"dotnet": "csharp",
+	"go":     "go",
+	"python": "python",
+	"yaml":   "yaml",
+	"java":   "java",
+}
+
+// detectLang returns the docs language inferred from the current Pulumi
+// project's runtime, or empty string if detection fails.
+func detectLang() string {
+	proj, err := workspace.DetectProject()
+	if err != nil {
+		return ""
+	}
+	if lang, ok := runtimeToLang[proj.Runtime.Name()]; ok {
+		return lang
+	}
+	return ""
+}
+
+const defaultLang = "go"
+
+// effectiveLang returns the explicitly provided language flag, falling back
+// to project detection, then to "go" (matching the server-side default).
+func effectiveLang(flag string) string {
+	if flag != "" {
+		return flag
+	}
+	if detected := detectLang(); detected != "" {
+		return detected
+	}
+	return defaultLang
+}
+
+// docsOpts builds a PackageDocsOptions from common flag values.
+func docsOpts(lang, os, query string) apitype.PackageDocsOptions {
+	return apitype.PackageDocsOptions{
+		Lang:  effectiveLang(lang),
+		OS:    os,
+		Query: query,
+	}
+}

--- a/pkg/cmd/pulumi/packagecmd/package_docs_common_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_docs_common_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests mutate the process working directory, so they must not run in parallel.
+func TestEffectiveLang(t *testing.T) {
+	t.Run("explicit flag wins", func(t *testing.T) {
+		assert.Equal(t, "python", effectiveLang("python"))
+	})
+
+	t.Run("defaults to go outside a project", func(t *testing.T) {
+		tmp := t.TempDir()
+		orig, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmp))
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+		assert.Equal(t, "go", effectiveLang(""))
+	})
+
+	t.Run("detects language from Pulumi.yaml", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmp, "Pulumi.yaml"),
+			[]byte("name: test\nruntime: python\n"),
+			0o644,
+		))
+		orig, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmp))
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+		assert.Equal(t, "python", effectiveLang(""))
+	})
+
+	t.Run("explicit flag overrides Pulumi.yaml", func(t *testing.T) {
+		tmp := t.TempDir()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(tmp, "Pulumi.yaml"),
+			[]byte("name: test\nruntime: python\n"),
+			0o644,
+		))
+		orig, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmp))
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+		assert.Equal(t, "java", effectiveLang("java"))
+	})
+}
+
+func TestRuntimeToLang(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		runtime  string
+		expected string
+	}{
+		{"nodejs", "typescript"},
+		{"dotnet", "csharp"},
+		{"go", "go"},
+		{"python", "python"},
+		{"yaml", "yaml"},
+		{"java", "java"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.runtime, func(t *testing.T) {
+			t.Parallel()
+			lang, ok := runtimeToLang[tt.runtime]
+			assert.True(t, ok, "runtime %q should be in runtimeToLang", tt.runtime)
+			assert.Equal(t, tt.expected, lang)
+		})
+	}
+
+	t.Run("unknown runtime not in map", func(t *testing.T) {
+		t.Parallel()
+		_, ok := runtimeToLang["rust"]
+		assert.False(t, ok)
+	})
+}
+
+func TestDocsOpts(t *testing.T) {
+	t.Run("with explicit lang", func(t *testing.T) {
+		t.Parallel()
+		opts := docsOpts("python", "linux", "Bucket")
+		assert.Equal(t, "python", opts.Lang)
+		assert.Equal(t, "linux", opts.OS)
+		assert.Equal(t, "Bucket", opts.Query)
+	})
+
+	t.Run("lang is never empty", func(t *testing.T) {
+		tmp := t.TempDir()
+		orig, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmp))
+		t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+		opts := docsOpts("", "", "")
+		assert.Equal(t, "go", opts.Lang, "lang should default to 'go' outside a project")
+	})
+}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -37,6 +37,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TODO: discuss whether this command can be replaced by `pulumi package nav` and
+// `pulumi package docs`, which use the registry API and return processed docs
+// (lang spans resolved, Hugo shortcodes expanded) without requiring a local plugin.
 func newPackageInfoCmd() *cobra.Command {
 	var module string
 	var resource string

--- a/pkg/cmd/pulumi/packagecmd/package_nav.go
+++ b/pkg/cmd/pulumi/packagecmd/package_nav.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/spf13/cobra"
+)
+
+func newPackageNavCmd() *cobra.Command {
+	var lang string
+	var search string
+
+	cmd := &cobra.Command{
+		Use:   "nav <package>[@<version>]",
+		Short: "Browse a registry package's modules, resources, and functions",
+		Long: `Browse a registry package's modules, resources, and functions.
+
+The package argument accepts the same formats as 'pulumi package add':
+  aws, pulumi/pulumi/aws, aws@7.20.0
+
+If --lang is not specified, the language is inferred from the current
+Pulumi project's runtime (Pulumi.yaml).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			pkg, err := parseAndResolvePackage(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			reg := registryForContext(ctx)
+			md, err := reg.GetPackageNavMarkdown(
+				ctx, pkg.Source, pkg.Publisher, pkg.Name, pkg.Version,
+				docsOpts(lang, "", search),
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), md)
+			return nil
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package", Usage: "<package>[@<version>]"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&lang, "lang", "", "Language for display names (typescript, python, go, csharp, yaml, java)")
+	cmd.Flags().StringVar(&search, "search", "", "Filter items by name (case-insensitive substring)")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/packagecmd/package_readme.go
+++ b/pkg/cmd/pulumi/packagecmd/package_readme.go
@@ -1,0 +1,74 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/spf13/cobra"
+)
+
+func newPackageReadmeCmd() *cobra.Command {
+	var lang string
+	var os string
+
+	cmd := &cobra.Command{
+		Use:   "readme <package>[@<version>]",
+		Short: "Display the README for a registry package",
+		Long: `Display the README for a registry package.
+
+The package argument accepts the same formats as 'pulumi package add':
+  aws, pulumi/pulumi/aws, aws@7.20.0
+
+Content is fetched from the Pulumi Registry API with language spans,
+Hugo shortcodes, and code choosers resolved server-side.
+
+If --lang is not specified, the language is inferred from the current
+Pulumi project's runtime (Pulumi.yaml).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			pkg, err := parseAndResolvePackage(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			reg := registryForContext(ctx)
+			md, err := reg.GetPackageReadmeMarkdown(
+				ctx, pkg.Source, pkg.Publisher, pkg.Name, pkg.Version,
+				docsOpts(lang, os, ""),
+			)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), md)
+			return nil
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package", Usage: "<package>[@<version>]"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&lang, "lang", "", "Language for code examples (typescript, python, go, csharp, yaml, java)")
+	cmd.Flags().StringVar(&os, "os", "", "OS for platform-specific content (linux, macos, windows)")
+
+	return cmd
+}

--- a/sdk/go/common/apitype/registry_docs.go
+++ b/sdk/go/common/apitype/registry_docs.go
@@ -1,0 +1,24 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// PackageDocsOptions holds optional query parameters for the registry
+// documentation endpoints. All three endpoints share this struct; each
+// endpoint ignores fields that don't apply to it.
+type PackageDocsOptions struct {
+	Lang  string
+	OS    string
+	Query string
+}

--- a/sdk/go/common/registry/mock.go
+++ b/sdk/go/common/registry/mock.go
@@ -40,6 +40,16 @@ type Mock struct {
 	ListTemplatesF func(ctx context.Context, name *string) iter.Seq2[apitype.TemplateMetadata, error]
 
 	DownloadTemplateF func(ctx context.Context, downloadURL string) (io.ReadCloser, error)
+
+	GetPackageReadmeMarkdownF func(
+		ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+	) (string, error)
+	GetPackageNavMarkdownF func(
+		ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+	) (string, error)
+	GetPackageDocsMarkdownF func(
+		ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+	) (string, error)
 }
 
 func (m Mock) GetPackage(
@@ -75,8 +85,35 @@ func (m Mock) ListTemplates(ctx context.Context, name *string) iter.Seq2[apitype
 }
 
 func (m Mock) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
-	if m.ListTemplatesF == nil {
+	if m.DownloadTemplateF == nil {
 		panic("registry.Mock.DownloadTemplateF not implemented")
 	}
 	return m.DownloadTemplateF(ctx, downloadURL)
+}
+
+func (m Mock) GetPackageReadmeMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	if m.GetPackageReadmeMarkdownF == nil {
+		panic("registry.Mock.GetPackageReadmeMarkdownF not implemented")
+	}
+	return m.GetPackageReadmeMarkdownF(ctx, source, publisher, name, version, opts)
+}
+
+func (m Mock) GetPackageNavMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	if m.GetPackageNavMarkdownF == nil {
+		panic("registry.Mock.GetPackageNavMarkdownF not implemented")
+	}
+	return m.GetPackageNavMarkdownF(ctx, source, publisher, name, version, opts)
+}
+
+func (m Mock) GetPackageDocsMarkdown(
+	ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	if m.GetPackageDocsMarkdownF == nil {
+		panic("registry.Mock.GetPackageDocsMarkdownF not implemented")
+	}
+	return m.GetPackageDocsMarkdownF(ctx, source, publisher, name, version, token, opts)
 }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -59,6 +59,21 @@ type Registry interface {
 	// DownloadTemplate downloads a template given the value of
 	// [apitype.TemplateMetadata].DownloadURL.
 	DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error)
+
+	// GetPackageReadmeMarkdown retrieves the processed README as markdown.
+	GetPackageReadmeMarkdown(
+		ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+	) (string, error)
+
+	// GetPackageNavMarkdown retrieves the navigation tree as markdown.
+	GetPackageNavMarkdown(
+		ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+	) (string, error)
+
+	// GetPackageDocsMarkdown retrieves documentation for a resource or function as markdown.
+	GetPackageDocsMarkdown(
+		ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+	) (string, error)
 }
 
 type registryKey struct{}
@@ -136,4 +151,34 @@ func (r *onDemandRegistry) DownloadTemplate(
 		return nil, err
 	}
 	return impl.DownloadTemplate(ctx, downloadURL)
+}
+
+func (r *onDemandRegistry) GetPackageReadmeMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return "", err
+	}
+	return impl.GetPackageReadmeMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r *onDemandRegistry) GetPackageNavMarkdown(
+	ctx context.Context, source, publisher, name, version string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return "", err
+	}
+	return impl.GetPackageNavMarkdown(ctx, source, publisher, name, version, opts)
+}
+
+func (r *onDemandRegistry) GetPackageDocsMarkdown(
+	ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
+) (string, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return "", err
+	}
+	return impl.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
 }

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -66,6 +66,24 @@ func (r mockRegistry) DownloadTemplate(ctx context.Context, downloadURL string) 
 	return r.downloadTemplate(ctx, downloadURL)
 }
 
+func (r mockRegistry) GetPackageReadmeMarkdown(
+	_ context.Context, _, _, _, _ string, _ apitype.PackageDocsOptions,
+) (string, error) {
+	panic("not implemented in mock")
+}
+
+func (r mockRegistry) GetPackageNavMarkdown(
+	_ context.Context, _, _, _, _ string, _ apitype.PackageDocsOptions,
+) (string, error) {
+	panic("not implemented in mock")
+}
+
+func (r mockRegistry) GetPackageDocsMarkdown(
+	_ context.Context, _, _, _, _, _ string, _ apitype.PackageDocsOptions,
+) (string, error) {
+	panic("not implemented in mock")
+}
+
 func TestOnDemandRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Three new subcommands that fetch package documentation from the Pulumi
Cloud registry API and print the response verbatim. The commands always
request `?format=markdown` and print the API's markdown body as-is,
avoiding any commitment to a structured output contract.

- `pulumi package readme <pkg>[@Version]` -- package README
- `pulumi package nav <pkg>[@Version]` -- module/resource/function tree
- `pulumi package docs <pkg>[@Version] <token>` -- single resource or
  function documentation with properties, types, and examples

All three accept `--lang` to select a language for code examples and
type names. When omitted, the language is inferred from the nearest
Pulumi.yaml runtime field, falling back to Go. Package resolution
uses the same path as `pulumi package add` (short names, version
pinning, private package lookup via existing auth).

The registry interface gains three `*Markdown` methods that return
`(string, error)`, leaving room for `*JSON` variants later without
a breaking change.

Sample runs:

```
$ pulumi package readme random
## Installation

The Random provider is available as a package in all Pulumi languages:
[...]
```

```
$ pulumi package nav random
# random v4.19.1

## (root)

### Resources

- `Provider` -- pulumi:providers:random
- `RandomBytes` -- random:index/randomBytes:RandomBytes
- `RandomId` -- random:index/randomId:RandomId
[...]
```

```
$ pulumi package docs random random:index/randomPassword:RandomPassword --lang python
# RandomPassword

resource `random:index/randomPassword:RandomPassword`

## Example Usage

import pulumi
import pulumi_random as random

password = random.RandomPassword("password",
    length=16,
    special=True,
    override_special="!#$%&*()-_=+[]{}<>:?")
[...]

## Inputs

| Name | Type | Required | Description |
|------|------|----------|-------------|
| `keepers` | `Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]` | no | Arbitrary map of values [...] |
| `length` | `pulumi.Input[int]` | yes | The length of the string desired. [...] |
[...]
```

## Test plan

- Client tests verify URL construction, query param serialization
  (format always set, optional params omitted when empty), and token
  path-escaping
- Common helper tests verify language detection from Pulumi.yaml,
  fallback to Go outside a project, and flag precedence
- Manual end-to-end testing against a review stack (the registry
  documentation API is not on production yet)