### PR TITLE
[registry] Add pulumi package ls and versions commands

### DIFF
--- a/pkg/backend/diy/unauthenticatedregistry/package_registry.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry.go
@@ -90,6 +90,18 @@ func (r registryClient) GetPackageDocsMarkdown(
 	return r.c.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
 }
 
+func (r registryClient) SearchPackages(
+	ctx context.Context, opts apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	return r.c.SearchPackages(ctx, opts)
+}
+
+func (r registryClient) ListPackageVersions(
+	ctx context.Context, source, publisher, name string, limit int,
+) ([]apitype.PackageMetadata, error) {
+	return r.c.ListPackageVersions(ctx, source, publisher, name, limit)
+}
+
 func (r registryClient) DownloadTemplate(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
 	bytes, err := r.c.DownloadTemplate(ctx, downloadURL)
 	if apiErr := (&apitype.ErrorResponse{}); errors.As(err, &apiErr) && apiErr.Code == http.StatusNotFound {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2086,6 +2086,52 @@ func optStr(s string) *string {
 	return &s
 }
 
+func (pc *Client) SearchPackages(
+	ctx context.Context, opts apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	query := struct {
+		OrgLogin *string `url:"orgLogin,omitempty"`
+		Search   *string `url:"search,omitempty"`
+		Name     *string `url:"name,omitempty"`
+		Type     *string `url:"type,omitempty"`
+		Sort     *string `url:"sort,omitempty"`
+		Asc      *bool   `url:"asc,omitempty"`
+		Limit    *int    `url:"limit,omitempty"`
+	}{
+		OrgLogin: optStr(opts.OrgName),
+		Search:   optStr(opts.Search),
+		Name:     optStr(opts.Name),
+		Type:     optStr(opts.Type),
+		Sort:     optStr(opts.Sort),
+		Asc:      opts.Asc,
+	}
+	if opts.Limit > 0 {
+		query.Limit = &opts.Limit
+	}
+	var resp apitype.ListPackagesResponse
+	if err := pc.restCall(ctx, "GET", "/api/registry/packages", query, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Packages, nil
+}
+
+func (pc *Client) ListPackageVersions(
+	ctx context.Context, source, publisher, name string, limit int,
+) ([]apitype.PackageMetadata, error) {
+	path := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions", source, publisher, name)
+	query := struct {
+		Limit *int `url:"limit,omitempty"`
+	}{}
+	if limit > 0 {
+		query.Limit = &limit
+	}
+	var resp apitype.ListPackagesResponse
+	if err := pc.restCall(ctx, "GET", path, query, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Packages, nil
+}
+
 // DeletePackageVersion deletes a specific version of a package from the registry.
 func (pc *Client) DeletePackageVersion(
 	ctx context.Context, source, publisher, name string, version semver.Version,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1182,3 +1182,60 @@ func TestGetPackageDocsMarkdown_OmitsEmptyQueryParams(t *testing.T) {
 		apitype.PackageDocsOptions{})
 	require.NoError(t, err)
 }
+
+func TestSearchPackages(t *testing.T) {
+	t.Parallel()
+
+	expected := []apitype.PackageMetadata{
+		{Name: "random", Publisher: "pulumi", Source: "pulumi", Version: semver.Version{Major: 4, Minor: 19, Patch: 1}, PackageStatus: apitype.PackageStatusGA, Visibility: apitype.VisibilityPublic},
+	}
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, "/api/registry/packages", req.URL.Path)
+		assert.Equal(t, "myorg", req.URL.Query().Get("orgLogin"))
+		assert.Equal(t, "random", req.URL.Query().Get("search"))
+		assert.Equal(t, "provider", req.URL.Query().Get("type"))
+		assert.Equal(t, "10", req.URL.Query().Get("limit"))
+
+		data, err := json.Marshal(apitype.ListPackagesResponse{Packages: expected})
+		require.NoError(t, err)
+		return string(data)
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	result, err := client.SearchPackages(t.Context(), apitype.PackageSearchOptions{
+		OrgName: "myorg",
+		Search:  "random",
+		Type:    "provider",
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestListPackageVersions(t *testing.T) {
+	t.Parallel()
+
+	expected := []apitype.PackageMetadata{
+		{Name: "random", Publisher: "pulumi", Source: "pulumi", Version: semver.Version{Major: 4, Minor: 19, Patch: 1}, PackageStatus: apitype.PackageStatusGA, Visibility: apitype.VisibilityPublic},
+		{Name: "random", Publisher: "pulumi", Source: "pulumi", Version: semver.Version{Major: 4, Minor: 19}, PackageStatus: apitype.PackageStatusGA, Visibility: apitype.VisibilityPublic},
+	}
+
+	mockServer := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, "/api/registry/packages/pulumi/pulumi/random/versions", req.URL.Path)
+		assert.Equal(t, "5", req.URL.Query().Get("limit"))
+
+		data, err := json.Marshal(apitype.ListPackagesResponse{Packages: expected})
+		require.NoError(t, err)
+		return string(data)
+	})
+	defer mockServer.Close()
+
+	client := newMockClient(mockServer)
+	result, err := client.ListPackageVersions(t.Context(), "pulumi", "pulumi", "random", 5)
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/pkg/backend/httpstate/cloud_registry.go
+++ b/pkg/backend/httpstate/cloud_registry.go
@@ -103,6 +103,18 @@ func (r *cloudRegistry) GetPackageDocsMarkdown(
 	return r.cl.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
 }
 
+func (r *cloudRegistry) SearchPackages(
+	ctx ctx.Context, opts apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	return r.cl.SearchPackages(ctx, opts)
+}
+
+func (r *cloudRegistry) ListPackageVersions(
+	ctx ctx.Context, source, publisher, name string, limit int,
+) ([]apitype.PackageMetadata, error) {
+	return r.cl.ListPackageVersions(ctx, source, publisher, name, limit)
+}
+
 func (r *cloudRegistry) DeletePackageVersion(
 	ctx ctx.Context, source, publisher, name string, version semver.Version,
 ) error {

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -40,9 +40,11 @@ Install and configure Pulumi packages and their plugins and SDKs.`,
 		newPackagePublishCmd(),
 		newPackageDeleteCmd(),
 		newPackageInfoCmd(),
+		newPackageLsCmd(),
 		newPackageReadmeCmd(),
 		newPackageNavCmd(),
 		newPackageDocsCmd(),
+		newPackageVersionsCmd(),
 	)
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_docs_common.go
+++ b/pkg/cmd/pulumi/packagecmd/package_docs_common.go
@@ -16,6 +16,7 @@ package packagecmd
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/blang/semver"
@@ -37,9 +38,21 @@ type resolvedPackage struct {
 	Version   string
 }
 
-// parseAndResolvePackage parses a user-provided package argument (e.g. "aws",
-// "aws@7.20.0", "pulumi/pulumi/aws") and resolves it via the registry.
+// TODO: the registry:// URL handling here duplicates logic in
+// cmd/pulumi/templates/cloud.go. Consider teaching ResolvePackageFromName
+// to accept registry:// URLs so all consumers get it for free.
+//
+// parseAndResolvePackage parses a user-provided package argument and resolves
+// it via the registry. Accepts:
+//   - registry://packages/source/publisher/name[@version]
+//   - source/publisher/name[@version]
+//   - publisher/name[@version]
+//   - name[@version]
 func parseAndResolvePackage(ctx context.Context, pkg string) (resolvedPackage, error) {
+	if registry.IsRegistryURL(pkg) {
+		return parseRegistryURL(pkg)
+	}
+
 	name, versionStr, _ := strings.Cut(pkg, "@")
 
 	var version *semver.Version
@@ -62,6 +75,26 @@ func parseAndResolvePackage(ctx context.Context, pkg string) (resolvedPackage, e
 		Publisher: meta.Publisher,
 		Name:      meta.Name,
 		Version:   meta.Version.String(),
+	}, nil
+}
+
+func parseRegistryURL(pkg string) (resolvedPackage, error) {
+	info, err := registry.ParseRegistryURL(pkg)
+	if err != nil {
+		return resolvedPackage{}, err
+	}
+	if info.ResourceType() != "packages" {
+		return resolvedPackage{}, fmt.Errorf("resource type %q is not valid for packages", info.ResourceType())
+	}
+	v := "latest"
+	if info.Version() != nil {
+		v = info.Version().String()
+	}
+	return resolvedPackage{
+		Source:    info.Source(),
+		Publisher: info.Publisher(),
+		Name:      info.Name(),
+		Version:   v,
 	}, nil
 }
 
@@ -104,6 +137,15 @@ func effectiveLang(flag string) string {
 		return detected
 	}
 	return defaultLang
+}
+
+const maxLimit = 500
+
+func validateLimit(limit int) error {
+	if limit < 1 || limit > maxLimit {
+		return fmt.Errorf("--limit must be between 1 and %d", maxLimit)
+	}
+	return nil
 }
 
 // docsOpts builds a PackageDocsOptions from common flag values.

--- a/pkg/cmd/pulumi/packagecmd/package_ls.go
+++ b/pkg/cmd/pulumi/packagecmd/package_ls.go
@@ -1,0 +1,140 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newPackageLsCmd() *cobra.Command {
+	var orgName string
+	var pkgType string
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "ls [query]",
+		Short: "List packages in the registry",
+		Long: `List packages in the registry.
+
+Without a query, lists all packages. With a query, searches by name.
+Use --org to scope results to an organization's packages.
+
+If --org is not specified, the default organization is resolved from
+the Pulumi configuration, then from the backend.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if err := validateLimit(limit); err != nil {
+				return err
+			}
+
+			if orgName == "" {
+				orgName = resolveDefaultOrg(ctx)
+			}
+
+			var search string
+			if len(args) > 0 {
+				search = strings.Join(args, " ")
+			}
+
+			sort, asc := defaultSort(orgName, search)
+
+			reg := registryForContext(ctx)
+			packages, err := reg.SearchPackages(ctx, apitype.PackageSearchOptions{
+				OrgName: orgName,
+				Search:  search,
+				Type:    pkgType,
+				Sort:    sort,
+				Asc:     asc,
+				Limit:   limit,
+			})
+			if err != nil {
+				return err
+			}
+
+			if len(packages) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No packages found.")
+				return nil
+			}
+
+			rows := make([]cmdutil.TableRow, len(packages))
+			for i, pkg := range packages {
+				registryURL := fmt.Sprintf("%s/%s/%s", pkg.Source, pkg.Publisher, pkg.Name)
+				pkgTypes := ""
+				if len(pkg.PackageTypes) > 0 {
+					pkgTypes = string(pkg.PackageTypes[0])
+				}
+				rows[i] = cmdutil.TableRow{
+					Columns: []string{pkg.Name, pkg.Version.String(), registryURL, pkgTypes},
+				}
+			}
+
+			ui.PrintTable(cmdutil.Table{
+				Headers: []string{"NAME", "VERSION", "REGISTRY URL", "TYPE"},
+				Rows:    rows,
+			}, nil)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&orgName, "org", "", "Organization to list packages for, including private packages (defaults to configured default org)")
+	cmd.Flags().StringVar(&pkgType, "type", "", "Filter by package type (provider, component)")
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of results (max 500)")
+
+	return cmd
+}
+
+// defaultSort returns sort field and direction based on context, matching
+// the console UI behavior: usageTotal desc when browsing an org without a
+// search query, name asc otherwise.
+func defaultSort(orgName, search string) (string, *bool) {
+	if orgName != "" && search == "" {
+		asc := false
+		return "usageTotal", &asc
+	}
+	asc := true
+	return "name", &asc
+}
+
+// resolveDefaultOrg attempts to resolve the default organization
+// non-interactively. Returns empty string if not logged in or no default set.
+func resolveDefaultOrg(ctx context.Context) string {
+	project, _, err := pkgWorkspace.Instance.ReadProject()
+	if err != nil {
+		project = nil
+	}
+	b, err := cmdBackend.NonInteractiveCurrentBackend(
+		ctx, pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, project,
+	)
+	if err != nil || b == nil {
+		return ""
+	}
+	org, err := backend.GetDefaultOrg(ctx, b, project)
+	if err != nil {
+		return ""
+	}
+	return org
+}

--- a/pkg/cmd/pulumi/packagecmd/package_versions.go
+++ b/pkg/cmd/pulumi/packagecmd/package_versions.go
@@ -1,0 +1,90 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagecmd
+
+import (
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newPackageVersionsCmd() *cobra.Command {
+	var limit int
+
+	cmd := &cobra.Command{
+		Use:   "versions <package>",
+		Short: "List version history for a registry package",
+		Long: `List version history for a registry package.
+
+The package argument accepts the same formats as 'pulumi package add':
+  aws, pulumi/pulumi/aws`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			if err := validateLimit(limit); err != nil {
+				return err
+			}
+
+			pkg, err := parseAndResolvePackage(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
+			reg := registryForContext(ctx)
+			versions, err := reg.ListPackageVersions(
+				ctx, pkg.Source, pkg.Publisher, pkg.Name, limit,
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(versions) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No versions found.")
+				return nil
+			}
+
+			rows := make([]cmdutil.TableRow, len(versions))
+			for i, v := range versions {
+				registryURL := fmt.Sprintf("%s/%s/%s@%s", v.Source, v.Publisher, v.Name, v.Version)
+				published := humanize.Time(v.CreatedAt)
+				rows[i] = cmdutil.TableRow{
+					Columns: []string{v.Version.String(), registryURL, published},
+				}
+			}
+
+			ui.PrintTable(cmdutil.Table{
+				Headers: []string{"VERSION", "REGISTRY URL", "PUBLISHED"},
+				Rows:    rows,
+			}, nil)
+
+			return nil
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "package", Usage: "<package>"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().IntVar(&limit, "limit", 20, "Maximum number of versions (max 500)")
+
+	return cmd
+}

--- a/sdk/go/common/apitype/registry_docs.go
+++ b/sdk/go/common/apitype/registry_docs.go
@@ -22,3 +22,14 @@ type PackageDocsOptions struct {
 	OS    string
 	Query string
 }
+
+// PackageSearchOptions holds query parameters for listing/searching packages.
+type PackageSearchOptions struct {
+	OrgName string
+	Search  string
+	Name    string
+	Type    string
+	Sort    string
+	Asc     *bool
+	Limit   int
+}

--- a/sdk/go/common/registry/mock.go
+++ b/sdk/go/common/registry/mock.go
@@ -50,6 +50,13 @@ type Mock struct {
 	GetPackageDocsMarkdownF func(
 		ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
 	) (string, error)
+
+	SearchPackagesF func(
+		ctx context.Context, opts apitype.PackageSearchOptions,
+	) ([]apitype.PackageMetadata, error)
+	ListPackageVersionsF func(
+		ctx context.Context, source, publisher, name string, limit int,
+	) ([]apitype.PackageMetadata, error)
 }
 
 func (m Mock) GetPackage(
@@ -116,4 +123,22 @@ func (m Mock) GetPackageDocsMarkdown(
 		panic("registry.Mock.GetPackageDocsMarkdownF not implemented")
 	}
 	return m.GetPackageDocsMarkdownF(ctx, source, publisher, name, version, token, opts)
+}
+
+func (m Mock) SearchPackages(
+	ctx context.Context, opts apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	if m.SearchPackagesF == nil {
+		panic("registry.Mock.SearchPackagesF not implemented")
+	}
+	return m.SearchPackagesF(ctx, opts)
+}
+
+func (m Mock) ListPackageVersions(
+	ctx context.Context, source, publisher, name string, limit int,
+) ([]apitype.PackageMetadata, error) {
+	if m.ListPackageVersionsF == nil {
+		panic("registry.Mock.ListPackageVersionsF not implemented")
+	}
+	return m.ListPackageVersionsF(ctx, source, publisher, name, limit)
 }

--- a/sdk/go/common/registry/registry.go
+++ b/sdk/go/common/registry/registry.go
@@ -74,6 +74,16 @@ type Registry interface {
 	GetPackageDocsMarkdown(
 		ctx context.Context, source, publisher, name, version, token string, opts apitype.PackageDocsOptions,
 	) (string, error)
+
+	// SearchPackages searches for packages with optional filters.
+	SearchPackages(
+		ctx context.Context, opts apitype.PackageSearchOptions,
+	) ([]apitype.PackageMetadata, error)
+
+	// ListPackageVersions lists all versions of a package.
+	ListPackageVersions(
+		ctx context.Context, source, publisher, name string, limit int,
+	) ([]apitype.PackageMetadata, error)
 }
 
 type registryKey struct{}
@@ -181,4 +191,24 @@ func (r *onDemandRegistry) GetPackageDocsMarkdown(
 		return "", err
 	}
 	return impl.GetPackageDocsMarkdown(ctx, source, publisher, name, version, token, opts)
+}
+
+func (r *onDemandRegistry) SearchPackages(
+	ctx context.Context, opts apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return nil, err
+	}
+	return impl.SearchPackages(ctx, opts)
+}
+
+func (r *onDemandRegistry) ListPackageVersions(
+	ctx context.Context, source, publisher, name string, limit int,
+) ([]apitype.PackageMetadata, error) {
+	impl, err := r.factory()
+	if err != nil {
+		return nil, err
+	}
+	return impl.ListPackageVersions(ctx, source, publisher, name, limit)
 }

--- a/sdk/go/common/registry/registry_test.go
+++ b/sdk/go/common/registry/registry_test.go
@@ -84,6 +84,18 @@ func (r mockRegistry) GetPackageDocsMarkdown(
 	panic("not implemented in mock")
 }
 
+func (r mockRegistry) SearchPackages(
+	_ context.Context, _ apitype.PackageSearchOptions,
+) ([]apitype.PackageMetadata, error) {
+	panic("not implemented in mock")
+}
+
+func (r mockRegistry) ListPackageVersions(
+	_ context.Context, _, _, _ string, _ int,
+) ([]apitype.PackageMetadata, error) {
+	panic("not implemented in mock")
+}
+
 func TestOnDemandRegistry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Stacked on #22642.

Two new discovery subcommands that query the registry API and render
results as tables, following the same pattern as `pulumi stack ls` and
`pulumi plugin ls`.

- `pulumi package ls [query]` -- list/search packages with `--org`,
  `--type`, `--limit`
- `pulumi package versions <package>` -- list version history with
  `--limit`

Default sort matches the console UI: `usageTotal` descending when
browsing an org without a search query, `name` ascending otherwise.
The `--org` flag resolves the default org non-interactively using the
same three-tier fallback as other commands (user config, then backend).

Both commands validate `--limit` against the server maximum of 500.

Package resolution now also accepts `registry://` URLs alongside the
existing short forms:

```
$ pulumi package versions random
$ pulumi package versions pulumi/random
$ pulumi package versions pulumi/pulumi/random
$ pulumi package versions registry://packages/pulumi/pulumi/random
VERSION  REGISTRY URL                 PUBLISHED
4.19.1   pulumi/pulumi/random@4.19.1  1 month ago
4.19.0   pulumi/pulumi/random@4.19.0  1 month ago
4.18.2   pulumi/pulumi/random@4.18.2  4 months ago
[...]
```

```
$ pulumi package ls --limit 5
NAME                     VERSION  REGISTRY URL                                  TYPE
random                   4.19.1   pulumi/pulumi/random                          bridged
random-string-component  0.1.4    private/pulumi_local/random-string-component  component
sumologic                1.0.11   pulumi/pulumi/sumologic                       bridged
google-native            0.32.0   pulumi/pulumi/google-native                   native
koyeb                    0.1.11   pulumi/koyeb/koyeb                            bridged
```

```
$ pulumi package ls aws
NAME              VERSION  REGISTRY URL                    TYPE
aws               7.20.0   pulumi/pulumi/aws               bridged
aws-apigateway    3.0.0    pulumi/pulumi/aws-apigateway    component
aws-iam           0.0.3    pulumi/pulumi/aws-iam           component
aws-k8s           0.0.21   private/pulumi_local/aws-k8s    component
[...]
```

The registry interface gains `SearchPackages` and
`ListPackageVersions` methods.

## Test plan

- Client tests verify URL construction, query param serialization
  (orgLogin, search, sort, asc, limit, type), and version list path
- Manual end-to-end testing against a review stack (the registry API
  is not on production yet)