### PR TITLE
Encapsulate Resource.Token

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -886,7 +886,8 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*pcl.Resource); isResource {
 			pcl.FixupPulumiPackageTokens(r)
-			pkg, mod, name, _ := r.DecomposeToken()
+			token, tokenRange := r.GetToken()
+			pkg, mod, name, _ := pcl.DecomposeToken(token, tokenRange)
 			if pkg == "pulumi" {
 				if mod == "providers" {
 					pkg = name
@@ -895,7 +896,7 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 					continue
 				}
 			} else {
-				mod = g.resolveModule(r.Token)
+				mod = g.resolveModule(token)
 			}
 			vPath, err := g.getVersionPath(program, pkg)
 			if err != nil {
@@ -941,8 +942,9 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 					if objectType, ok := call.Args[0].Type().(*model.ObjectType); ok {
 						if annotation, ok := model.GetObjectTypeAnnotation[*pcl.ResourceAnnotation](objectType); ok {
 							res := annotation.Node
-							resPkg, _, resName, _ := res.DecomposeToken()
-							resMod := g.resolveModule(res.Token)
+							token, tokenRange := res.GetToken()
+							resPkg, _, resName, _ := pcl.DecomposeToken(token, tokenRange)
+							resMod := g.resolveModule(token)
 							vPath, err := g.getVersionPath(program, resPkg)
 							if err != nil {
 								panic(err)
@@ -1495,8 +1497,9 @@ func (g *generator) genResourceOptions(w io.Writer, block *model.Block) {
 
 func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 	resName, resNameVar := r.LogicalName(), g.nodeName(r.Name())
-	pkg, _, typ, _ := r.DecomposeToken()
-	mod := g.resolveModule(r.Token)
+	token, tokenRange := r.GetToken()
+	pkg, _, typ, _ := pcl.DecomposeToken(token, tokenRange)
+	mod := g.resolveModule(token)
 	originalMod := mod
 	if pkg == "pulumi" && mod == "providers" {
 		pkg = typ
@@ -1525,8 +1528,9 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 			input.Value = expr
 			g.genTemps(w, temps)
 		}
-		pkg, _, _, _ := r.DecomposeToken()
-		mod := g.resolveModule(r.Token)
+		token, tokenRange := r.GetToken()
+		pkg, _, _, _ := pcl.DecomposeToken(token, tokenRange)
+		mod := g.resolveModule(token)
 		if pkgCtx := g.contexts[pkg][mod]; pkgCtx != nil {
 			typ = disambiguatedResourceName(r.Schema, pkgCtx)
 		}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -533,8 +533,9 @@ func (g *generator) genMethodCall(w io.Writer, expr *model.FunctionCallExpressio
 	res := annotation.Node
 
 	// Get the disambiguated resource name and module alias.
-	pkg, _, _, _ := res.DecomposeToken()
-	mod := g.resolveModule(res.Token)
+	token, tokenRange := res.GetToken()
+	pkg, _, _, _ := pcl.DecomposeToken(token, tokenRange)
+	mod := g.resolveModule(token)
 	originalMod := mod
 	if mod == "" || strings.HasPrefix(mod, "/") || mod == IndexToken {
 		originalMod = mod
@@ -548,7 +549,7 @@ func (g *generator) genMethodCall(w io.Writer, expr *model.FunctionCallExpressio
 			resourceName = rawResourceName(res.Schema)
 		}
 	} else {
-		resourceName = tokenToName(res.Token)
+		resourceName = tokenToName(token)
 	}
 	modOrAlias := g.getModOrAlias(pkg, mod, originalMod)
 

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -603,7 +603,7 @@ func (g *generator) collectProgramImports(program *pcl.Program) programImports {
 	for _, n := range program.Nodes {
 		switch n := n.(type) {
 		case *pcl.Resource:
-			pkg, _, _, _ := n.DecomposeToken()
+			pkg, _, _, _ := pcl.DecomposeToken(n.GetToken())
 			var packageRef schema.PackageReference
 			if n.Schema != nil && n.Schema.PackageReference != nil {
 				packageRef = n.Schema.PackageReference
@@ -1022,7 +1022,7 @@ func outputRequiresAsyncMain(ov *pcl.OutputVariable) bool {
 func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
 	pcl.FixupPulumiPackageTokens(r)
-	pkg, module, member, diagnostics := r.DecomposeToken()
+	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
 
 	if r.Schema != nil {
 		module = moduleName(module, r.Schema.PackageReference)

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -32,10 +32,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func getResourceToken(node *Resource) (string, hcl.Range) {
-	return node.syntax.Labels[1], node.syntax.LabelRanges[1]
-}
-
 func (b *binder) bindResource(ctx context.Context, node *Resource) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 
@@ -272,7 +268,7 @@ func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diag
 	node.InputType, node.OutputType = model.DynamicType, model.DynamicType
 
 	// Find the resource's schema.
-	token, tokenRange := getResourceToken(node)
+	token, tokenRange := node.GetToken()
 	pkg, module, name, diagnostics := DecomposeToken(token, tokenRange)
 	if diagnostics.HasErrors() {
 		return diagnostics
@@ -280,7 +276,7 @@ func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diag
 
 	makeResourceDynamic := func() {
 		// make the inputs and outputs of the resource dynamic
-		node.Token = token
+		node.token = token
 		node.OutputType = model.DynamicType
 		inferredInputProperties := map[string]model.Type{}
 		for _, attr := range node.Inputs {
@@ -352,7 +348,7 @@ func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diag
 	}
 	node.Schema = res
 	inputProperties, properties = res.InputProperties, res.Properties
-	node.Token = token
+	node.token = token
 
 	// Create input and output types for the schema.
 	// first reduce property types which are unions of objects into just an object when possible
@@ -778,7 +774,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 							Detail: fmt.Sprintf("Cannot assign value %s to attribute of type %q for resource %q",
 								attr.Value.Type().Pretty().String(),
 								propertyType.String(),
-								node.Token),
+								node.token),
 						})
 					}
 				}

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -282,7 +282,7 @@ func (b *binder) loadReferencedPackageSchemas(ctx context.Context, n Node) error
 	packageNames := codegen.StringSet{}
 
 	if r, ok := n.(*Resource); ok {
-		token, tokenRange := getResourceToken(r)
+		token, tokenRange := r.GetToken()
 		packageName, mod, name, _ := DecomposeToken(token, tokenRange)
 		if mod == "providers" {
 			packageNames.Add(name)

--- a/pkg/codegen/pcl/call.go
+++ b/pkg/codegen/pcl/call.go
@@ -94,7 +94,7 @@ func (b *binder) bindCallSignature(args []model.Expression) (model.StaticFunctio
 	if method == nil {
 		return b.zeroCallSignature(), hcl.Diagnostics{errorf(
 			args[1].SyntaxNode().Range(),
-			"resource type %q has no method %q", selfRes.Token, methodName,
+			"resource type %q has no method %q", selfRes.token, methodName,
 		)}
 	}
 

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -100,7 +100,7 @@ type Resource struct {
 	LenientTraversal bool
 
 	// Token is the type token for this resource.
-	Token string
+	token string
 
 	// Schema is the schema definition for this resource, if any.
 	Schema *schema.Resource
@@ -118,6 +118,16 @@ type Resource struct {
 
 	// The resource's options, if any.
 	Options *ResourceOptions
+}
+
+// GetToken returns the resource's token and its source range. If the resource has been successfully bound, the token is
+// canonical, else it's what was parsed from the source code.
+func (r *Resource) GetToken() (string, hcl.Range) {
+	token := r.token
+	if token == "" {
+		token = r.syntax.Labels[1]
+	}
+	return token, r.syntax.LabelRanges[1]
 }
 
 // SyntaxNode returns the syntax node associated with the resource.
@@ -168,13 +178,6 @@ func (r *Resource) LogicalName() string {
 	}
 
 	return r.Name()
-}
-
-// DecomposeToken attempts to decompose the resource's type token into its package, module, and type. If decomposition
-// fails, a description of the failure is returned in the diagnostics.
-func (r *Resource) DecomposeToken() (string, string, string, hcl.Diagnostics) {
-	_, tokenRange := getResourceToken(r)
-	return DecomposeToken(r.Token, tokenRange)
 }
 
 // ResourceProperty represents a resource property.

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -228,19 +228,19 @@ func Linearize(p *Program) []Node {
 func MapProvidersAsResources(p *Program) {
 	for _, n := range p.Nodes {
 		if r, ok := n.(*Resource); ok && r.Schema != nil {
-			pkg, mod, name, _ := r.DecomposeToken()
+			pkg, mod, name, _ := DecomposeToken(r.GetToken())
 			if r.Schema.IsProvider && pkg == "pulumi" && mod == "providers" {
 				// the binder emits tokens like this when the module is "index"
-				r.Token = name + "::Provider"
+				r.token = name + "::Provider"
 			}
 		}
 	}
 }
 
 func FixupPulumiPackageTokens(r *Resource) {
-	pkg, mod, name, _ := r.DecomposeToken()
+	pkg, mod, name, _ := DecomposeToken(r.GetToken())
 	if pkg == "pulumi" && mod == "pulumi" {
-		r.Token = "pulumi::" + name
+		r.token = "pulumi::" + name
 	}
 }
 

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -629,7 +629,7 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*pcl.Resource); isResource {
 			pcl.FixupPulumiPackageTokens(r)
-			pkg, _, _, _ := r.DecomposeToken()
+			pkg, _, _, _ := pcl.DecomposeToken(r.GetToken())
 			if pkg == "pulumi" {
 				continue
 			}
@@ -766,7 +766,7 @@ func tokenToQualifiedName(pkgAlias, module, member string) string {
 // resourceTypeName computes the qualified name of a python resource.
 func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
-	pkg, module, member, diagnostics := r.DecomposeToken()
+	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
 	pcl.FixupPulumiPackageTokens(r)
 
 	// Normalize module.

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -628,7 +628,7 @@ func TestProgramCodegen(
 func collectExtraPulumiPackages(program *pcl.Program, extraPulumiPackages codegen.StringSet) {
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*pcl.Resource); isResource {
-			pkg, _, _, _ := r.DecomposeToken()
+			pkg, _, _, _ := pcl.DecomposeToken(r.GetToken())
 			if pkg != "pulumi" {
 				extraPulumiPackages.Add(pkg)
 			}


### PR DESCRIPTION
This encapsulates the current `Resource.Token` field into a `GetToken` method. This consistently returns either the source parsed token, if the resource is not yet bound, or the canonical token. Either way it returns the source range associated with the token.

This allows a small clean up of:
a) No longer needing the `getResourceToken` helper function
b) No longer needing `DecomposeToken` on `Resource` (it's simple enough to just call `pcl.DecomposeToken(r.GetToken())` now)
c) Clearer boundary that `Token` is not for external manipulation and is just read-only data outside the binding package.