### PR TITLE
feat(cli/neo): implement the edit filesystem tool

### DIFF
--- a/changelog/pending/20260420--cli-neo--implement-edit-filesystem-tool.yaml
+++ b/changelog/pending/20260420--cli-neo--implement-edit-filesystem-tool.yaml
@@ -1,0 +1,9 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    `pulumi neo` now executes the `edit` filesystem tool locally, matching the schema
+    and response wording of the upstream mcp-claude-code tool so the agent sees
+    identical output whether the call ran on Cloud or CLI. `edit` performs exact-string
+    replacement with occurrence-count validation, and creates a new file when the
+    target is missing and `old_string` is empty.

--- a/pkg/cmd/pulumi/neo/tools/filesystem.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem.go
@@ -23,6 +23,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/pmezard/go-difflib/difflib"
 )
 
 // Filesystem is the local handler for the Neo `filesystem` tool. Method names and argument
@@ -34,9 +37,10 @@ import (
 //	read           — args: {file_path, offset?, limit?}
 //	write          — args: {file_path, content}
 //	directory_tree — args: {path, depth?, include_filtered?}
+//	edit           — args: {file_path, old_string, new_string, expected_replacements?}
 //
-// The remaining filesystem methods (edit, multi_edit, grep, grep_ast, content_replace)
-// return a structured "not yet implemented" error so the agent can degrade gracefully.
+// The remaining filesystem methods (grep, grep_ast, content_replace) return a structured
+// "not yet implemented" error so the agent can degrade gracefully.
 //
 // All paths in incoming requests are absolute (the cloud agent assumes a sandboxed VM).
 // We resolve them and reject anything that lands outside Root, so the agent can never read
@@ -92,7 +96,13 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 			return nil, fmt.Errorf("decoding directory_tree args: %w", err)
 		}
 		return f.directoryTree(p.Path, p.Depth)
-	case "edit", "multi_edit", "grep", "grep_ast", "content_replace":
+	case "edit":
+		var p editArgs
+		if err := json.Unmarshal(args, &p); err != nil {
+			return nil, fmt.Errorf("decoding edit args: %w", err)
+		}
+		return f.edit(p)
+	case "grep", "grep_ast", "content_replace":
 		return nil, fmt.Errorf("filesystem method %q is not yet implemented in pulumi neo CLI mode", method)
 	default:
 		return nil, fmt.Errorf("unknown filesystem method %q", method)
@@ -153,6 +163,133 @@ func (f *Filesystem) write(p, content string) (any, error) {
 		return nil, err
 	}
 	return map[string]any{"bytes_written": len(content)}, nil
+}
+
+// editArgs is the JSON shape for the `edit` tool. ExpectedReplacements is a pointer so
+// "omitted" (defaults to 1) is distinguishable from an explicit 0 — the latter is a
+// validation error rather than "replace nothing".
+type editArgs struct {
+	FilePath             string `json:"file_path"`
+	OldString            string `json:"old_string"`
+	NewString            string `json:"new_string"`
+	ExpectedReplacements *int   `json:"expected_replacements,omitempty"`
+}
+
+// edit performs a single exact-string replacement. The response string and error wording
+// are deliberately kept byte-identical to the upstream mcp-claude-code `edit` tool so the
+// agent sees the same output whether the call ran on Cloud or CLI.
+func (f *Filesystem) edit(p editArgs) (any, error) {
+	abs, err := f.resolve(p.FilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	expected := 1
+	if p.ExpectedReplacements != nil {
+		expected = *p.ExpectedReplacements
+	}
+	if expected < 0 {
+		return "Error: Parameter 'expected_replacements' must be a non-negative number", nil
+	}
+
+	info, statErr := os.Stat(abs)
+	fileExists := statErr == nil
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return nil, statErr
+	}
+
+	// Creation mode: file doesn't exist and old_string is empty.
+	if !fileExists && p.OldString == "" {
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(abs, []byte(p.NewString), 0o600); err != nil {
+			return nil, err
+		}
+		return fmt.Sprintf("Successfully created file: %s (%d bytes)", p.FilePath, len(p.NewString)), nil
+	}
+
+	if !fileExists {
+		return nil, statErr
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("path %q is a directory, not a file", p.FilePath)
+	}
+
+	// Whitespace-only old_string on an existing file is ambiguous — reject it rather
+	// than silently matching every run of whitespace in the file.
+	if strings.TrimSpace(p.OldString) == "" {
+		return "Error: Parameter 'old_string' cannot be empty for existing files", nil
+	}
+
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, err
+	}
+	if !utf8.Valid(raw) {
+		return "Error: Cannot edit binary file: " + p.FilePath, nil
+	}
+	original := string(raw)
+
+	occurrences := strings.Count(original, p.OldString)
+	if occurrences == 0 {
+		return "Error: The specified old_string was not found in the file content. " +
+			"Please check that it matches exactly, including all whitespace and indentation.", nil
+	}
+	if occurrences != expected {
+		return fmt.Sprintf(
+			"Error: Found %d occurrences of the specified old_string, but expected %d. "+
+				"Change your old_string to uniquely identify the target text, "+
+				"or set expected_replacements=%d to replace all occurrences.",
+			occurrences, expected, occurrences), nil
+	}
+
+	modified := strings.ReplaceAll(original, p.OldString, p.NewString)
+
+	diff, err := renderUnifiedDiff(p.FilePath, original, modified)
+	if err != nil {
+		return nil, err
+	}
+	if diff == "" {
+		return "No changes made to file: " + p.FilePath, nil
+	}
+
+	if err := os.WriteFile(abs, []byte(modified), 0o600); err != nil {
+		return nil, err
+	}
+	return fmt.Sprintf(
+		"Successfully edited file: %s (%d replacements applied)\n\n%s",
+		p.FilePath, expected, diff,
+	), nil
+}
+
+// renderUnifiedDiff produces a unified diff formatted the same way as the upstream Python
+// tool: `--- <path> (original)` / `+++ <path> (modified)` headers, 3 lines of context,
+// and the body fenced with the smallest backtick run that doesn't collide with the diff
+// contents. Returns an empty string when the two inputs are identical.
+func renderUnifiedDiff(path, original, modified string) (string, error) {
+	if original == modified {
+		return "", nil
+	}
+	body, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(original),
+		B:        difflib.SplitLines(modified),
+		FromFile: path + " (original)",
+		ToFile:   path + " (modified)",
+		Context:  3,
+	})
+	if err != nil {
+		return "", err
+	}
+	if body == "" {
+		return "", nil
+	}
+	ticks := 3
+	for strings.Contains(body, strings.Repeat("`", ticks)) {
+		ticks++
+	}
+	fence := strings.Repeat("`", ticks)
+	return fmt.Sprintf("%sdiff\n%s%s\n", fence, body, fence), nil
 }
 
 // directoryTree returns a flat listing of the directory at p, optionally bounded by depth.

--- a/pkg/cmd/pulumi/neo/tools/filesystem_test.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,7 +136,7 @@ func TestFilesystem_UnimplementedMethodsReturnClearError(t *testing.T) {
 	fs, err := NewFilesystem(t.TempDir())
 	require.NoError(t, err)
 
-	for _, method := range []string{"edit", "multi_edit", "grep", "grep_ast", "content_replace"} {
+	for _, method := range []string{"grep", "grep_ast", "content_replace"} {
 		_, err := fs.Invoke(t.Context(), method, json.RawMessage(`{}`))
 		require.Error(t, err, method)
 		assert.Contains(t, err.Error(), "not yet implemented", method)
@@ -179,7 +180,7 @@ func TestFilesystem_InvokeRejectsMalformedArgs(t *testing.T) {
 	fs, err := NewFilesystem(t.TempDir())
 	require.NoError(t, err)
 
-	for _, method := range []string{"read", "write", "directory_tree"} {
+	for _, method := range []string{"read", "write", "directory_tree", "edit"} {
 		_, err := fs.Invoke(t.Context(), method, json.RawMessage(`{`))
 		require.Error(t, err, method)
 		assert.Contains(t, err.Error(), "decoding", method)
@@ -321,4 +322,239 @@ func TestFilesystem_WriteRelativePathResolvesAgainstRoot(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(root, "nested", "child.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, "hi", string(got))
+}
+
+// editResult wraps the result returned by an edit invocation so tests can assert against
+// the human-readable response string the agent receives.
+func editResult(t *testing.T, fs *Filesystem, method string, args string) string {
+	t.Helper()
+	res, err := fs.Invoke(t.Context(), method, json.RawMessage(args))
+	require.NoError(t, err)
+	s, ok := res.(string)
+	require.True(t, ok, "expected string result, got %T", res)
+	return s
+}
+
+func TestFilesystem_EditReplaceSingleMatch(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "hello.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hello world\n"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"world","new_string":"there"}`, target))
+	assert.Contains(t, res, "Successfully edited file")
+	assert.Contains(t, res, "1 replacements applied")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "hello there\n", string(got))
+}
+
+func TestFilesystem_EditReplaceAllWithExplicitCount(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "triples.txt")
+	require.NoError(t, os.WriteFile(target, []byte("a\na\na\n"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"a","new_string":"b","expected_replacements":3}`, target))
+	assert.Contains(t, res, "3 replacements applied")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "b\nb\nb\n", string(got))
+}
+
+func TestFilesystem_EditOccurrenceMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Two occurrences, agent expected one. The error must surface both counts plus the
+	// "set expected_replacements=<actual>" suggestion so the agent can self-correct.
+	root := t.TempDir()
+	target := filepath.Join(root, "doubles.txt")
+	require.NoError(t, os.WriteFile(target, []byte("x x"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"x","new_string":"y"}`, target))
+	assert.Contains(t, res, "Found 2 occurrences")
+	assert.Contains(t, res, "expected 1")
+	assert.Contains(t, res, "expected_replacements=2")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "x x", string(got), "mismatched edit must not write the file")
+}
+
+func TestFilesystem_EditOldStringNotFound(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(target, []byte("nothing here"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"missing","new_string":"x"}`, target))
+	assert.Contains(t, res, "was not found in the file content")
+}
+
+func TestFilesystem_EditEmptyOldStringOnExistingFile(t *testing.T) {
+	t.Parallel()
+
+	// A whitespace-only old_string against an existing file would match every run of
+	// whitespace, which is almost never what the agent intends — reject it.
+	root := t.TempDir()
+	target := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hi"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	for _, old := range []string{"", "   ", "\t\n"} {
+		res := editResult(t, fs, "edit", fmt.Sprintf(
+			`{"file_path":%q,"old_string":%q,"new_string":"x"}`, target, old))
+		assert.Contains(t, res, "cannot be empty for existing files")
+	}
+}
+
+func TestFilesystem_EditNegativeExpectedReplacements(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hi"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"h","new_string":"j","expected_replacements":-1}`, target))
+	assert.Contains(t, res, "non-negative")
+}
+
+func TestFilesystem_EditCreatesFileWhenMissingAndOldEmpty(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "nested", "new.txt")
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"","new_string":"seeded"}`, target))
+	assert.Contains(t, res, "Successfully created file")
+
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "seeded", string(got))
+}
+
+func TestFilesystem_EditMissingFileWithNonEmptyOldString(t *testing.T) {
+	t.Parallel()
+
+	// old_string != "" + file missing must be an error, not silent creation.
+	root := t.TempDir()
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	_, err = fs.Invoke(t.Context(), "edit", json.RawMessage(fmt.Sprintf(
+		`{"file_path":%q,"old_string":"x","new_string":"y"}`,
+		filepath.Join(root, "nope.txt"))))
+	require.Error(t, err)
+}
+
+func TestFilesystem_EditRejectsBinaryFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "bin.dat")
+	require.NoError(t, os.WriteFile(target, []byte{0xff, 0xfe, 0x00, 0x01}, 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"x","new_string":"y"}`, target))
+	assert.Contains(t, res, "Cannot edit binary file")
+}
+
+func TestFilesystem_EditNoOpReturnsNoChanges(t *testing.T) {
+	t.Parallel()
+
+	// old == new is a legal no-op (matches upstream semantics). The file's mtime must
+	// not change because the guard skips the write entirely when the diff is empty.
+	root := t.TempDir()
+	target := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(target, []byte("hello"), 0o600))
+
+	before, err := os.Stat(target)
+	require.NoError(t, err)
+
+	// Roll mtime back so even a same-second rewrite would be detectable.
+	oldTime := before.ModTime().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(target, oldTime, oldTime))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"hello","new_string":"hello"}`, target))
+	assert.Contains(t, res, "No changes made")
+
+	after, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, oldTime.Unix(), after.ModTime().Unix(), "no-op edit must not rewrite the file")
+}
+
+func TestFilesystem_EditRejectsPathOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	fs, err := NewFilesystem(t.TempDir())
+	require.NoError(t, err)
+
+	outside := filepath.Join(t.TempDir(), "evil.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("x"), 0o600))
+
+	_, err = fs.Invoke(t.Context(), "edit", json.RawMessage(fmt.Sprintf(
+		`{"file_path":%q,"old_string":"x","new_string":"y"}`, outside)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside the working directory")
+
+	// Sanity-check the untouched file so we know the sandbox caught it before the write.
+	got, err := os.ReadFile(outside)
+	require.NoError(t, err)
+	assert.Equal(t, "x", string(got))
+}
+
+func TestFilesystem_EditReturnsUnifiedDiff(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "a.txt")
+	require.NoError(t, os.WriteFile(target, []byte("alpha\nbeta\ngamma\n"), 0o600))
+
+	fs, err := NewFilesystem(root)
+	require.NoError(t, err)
+
+	res := editResult(t, fs, "edit", fmt.Sprintf(
+		`{"file_path":%q,"old_string":"beta","new_string":"BETA"}`, target))
+	assert.Contains(t, res, "--- "+target+" (original)")
+	assert.Contains(t, res, "+++ "+target+" (modified)")
+	assert.Contains(t, res, "@@")
+	assert.Contains(t, res, "```diff")
 }

--- a/pkg/cmd/pulumi/neo/tui_tools.go
+++ b/pkg/cmd/pulumi/neo/tui_tools.go
@@ -51,11 +51,6 @@ func toolLabelParts(toolName string, args json.RawMessage) (funcName, arg string
 			return "Edit", p
 		}
 		return "Edit", ""
-	case "multi_edit":
-		if p := extractFilePathArg(args); p != "" {
-			return "MultiEdit", p
-		}
-		return "MultiEdit", ""
 	case "content_replace":
 		if p := extractArg(args, "pattern"); p != "" {
 			return "Replace", p

--- a/pkg/cmd/pulumi/neo/tui_tools_test.go
+++ b/pkg/cmd/pulumi/neo/tui_tools_test.go
@@ -47,8 +47,6 @@ func TestToolLabelParts(t *testing.T) {
 		{"write_short", "write", nil, "Write", ""},
 		{"edit_with_path", "edit", json.RawMessage(`{"file_path":"/x"}`), "Edit", "/x"},
 		{"edit_no_path", "edit", json.RawMessage(`{}`), "Edit", ""},
-		{"multi_edit_with_path", "multi_edit", json.RawMessage(`{"file_path":"/x"}`), "MultiEdit", "/x"},
-		{"multi_edit_no_path", "multi_edit", json.RawMessage(`{}`), "MultiEdit", ""},
 		{"content_replace_with_pattern", "content_replace", json.RawMessage(`{"pattern":"needle"}`), "Replace", "needle"},
 		{"content_replace_no_pattern", "content_replace", nil, "Replace", ""},
 		{"execute_command_short", "execute_command", json.RawMessage(`{"command":"ls -la"}`), "Bash", "ls -la"},

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/pgavlin/fx v0.1.6
 	github.com/pgavlin/fx/v2 v2.0.10
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231
 	github.com/pulumi/esc v0.17.0
 	github.com/segmentio/encoding v0.3.5
@@ -234,7 +235,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect


### PR DESCRIPTION
## Summary

Implements the local `filesystem__edit` handler for `pulumi neo` so the cloud agent's edit tool-use calls execute on the CLI side instead of failing with "not yet implemented." The schema (`file_path`, `old_string`, `new_string`, `expected_replacements`) and response wording mirror the upstream mcp-claude-code `edit` tool byte-for-byte, so the agent sees the same output whether a call ran on Cloud or CLI.

Behavior:

- Exact-string replacement with occurrence-count validation (default `expected_replacements=1`); count mismatches surface `Found N, expected M` with a `set expected_replacements=N` hint so the agent can self-correct.
- Creation mode: missing file + empty `old_string` writes `new_string` as the file contents (creating parent dirs).
- Whitespace-only `old_string` is rejected against existing files to avoid matching every run of whitespace.
- Binary files (non-UTF-8) are refused rather than corrupted.
- No-op (`old_string == new_string`) skips the write entirely — the file's mtime is preserved.
- Success response embeds a unified diff in a ` ```diff ` fenced block for the TUI to render.
- All writes go through the existing sandbox guard (`f.resolve`), so the agent can't escape the working directory.

Also drops the unused `MultiEdit` label from the TUI renderer since `multi_edit` is not being implemented on the CLI side.

## Test plan

- [x] `cd pkg && go test -count=1 ./cmd/pulumi/neo/tools/...` — 12 new tests covering single-match, explicit expected count, occurrence mismatch, not-found, whitespace-only old_string, negative expected_replacements, creation mode, missing file with non-empty old_string, binary rejection, no-op mtime preservation, sandbox escape, unified-diff shape.
- [x] `make lint` — clean.
- [x] `make format` — clean.
- [x] `make tidy` — `go-difflib` promoted from indirect to direct in `pkg/go.mod`.

https://asciinema.org/a/bBj2MS6iSv4JS9o7