### PR TITLE
Lookup policy packs by default-org not username

### DIFF
--- a/changelog/pending/20260420--cli-policy--fix-policy-ls-to-use-the-default-org-name-not-username.yaml
+++ b/changelog/pending/20260420--cli-policy--fix-policy-ls-to-use-the-default-org-name-not-username.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/policy
+  description: Fix `policy ls` to use the default org name, not username

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -69,6 +69,8 @@ type MockBackend struct {
 	RemoveStackF func(context.Context, Stack, bool, bool) (bool, error)
 	ListStacksF  func(context.Context, ListStacksFilter, ContinuationToken) (
 		[]StackSummary, ContinuationToken, error)
+	ListPolicyPacksF func(context.Context, string, ContinuationToken) (
+		apitype.ListPolicyPacksResponse, ContinuationToken, error)
 	ListStackNamesF func(context.Context, ListStackNamesFilter, ContinuationToken) (
 		[]StackReference, ContinuationToken, error)
 	RenameStackF                          func(context.Context, Stack, tokens.QName) (StackReference, error)
@@ -143,9 +145,12 @@ func (be *MockBackend) ListPolicyGroups(context.Context, string, ContinuationTok
 	panic("not implemented")
 }
 
-func (be *MockBackend) ListPolicyPacks(context.Context, string, ContinuationToken) (
+func (be *MockBackend) ListPolicyPacks(ctx context.Context, orgName string, inContToken ContinuationToken) (
 	apitype.ListPolicyPacksResponse, ContinuationToken, error,
 ) {
+	if be.ListPolicyPacksF != nil {
+		return be.ListPolicyPacksF(ctx, orgName, inContToken)
+	}
 	panic("not implemented")
 }
 

--- a/pkg/cmd/pulumi/policy/policy.go
+++ b/pkg/cmd/pulumi/policy/policy.go
@@ -37,7 +37,7 @@ func NewPolicyCmd() *cobra.Command {
 	cmd.AddCommand(newPolicyEnableCmd())
 	cmd.AddCommand(newPolicyGroupCmd())
 	cmd.AddCommand(newPolicyInstallCmd())
-	cmd.AddCommand(newPolicyLsCmd())
+	cmd.AddCommand(newPolicyLsCmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager))
 	cmd.AddCommand(newPolicyNewCmd())
 	cmd.AddCommand(newPolicyPublishCmd())
 	cmd.AddCommand(newPolicyRmCmd())

--- a/pkg/cmd/pulumi/policy/policy_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_ls.go
@@ -33,7 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPolicyLsCmd() *cobra.Command {
+func newPolicyLsCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
@@ -44,7 +44,6 @@ func newPolicyLsCmd() *cobra.Command {
 			ctx := cmd.Context()
 
 			// Try to read the current project
-			ws := pkgWorkspace.Instance
 			project, _, err := ws.ReadProject()
 			if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 				return err
@@ -52,7 +51,7 @@ func newPolicyLsCmd() *cobra.Command {
 
 			// Get backend.
 			b, err := cmdBackend.CurrentBackend(
-				ctx, ws, cmdBackend.DefaultLoginManager, project,
+				ctx, ws, lm, project,
 				display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return err
@@ -63,7 +62,7 @@ func newPolicyLsCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				orgName = cliArgs[0]
 			} else {
-				orgName, _, _, err = b.CurrentUser()
+				orgName, err = backend.GetDefaultOrg(ctx, b, project)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/policy/policy_ls_test.go
+++ b/pkg/cmd/pulumi/policy/policy_ls_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+//nolint:paralleltest // uses t.Setenv
+func TestPolicyLsCmd_QueriesPolicyPacksByOrgNameNotUserName(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	var queriedOrgName string
+	be := &backend.MockBackend{
+		GetDefaultOrgF: func(context.Context) (string, error) {
+			return "default-org", nil
+		},
+		CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+			t.Fatal("CurrentUser should not be called when resolving org for policy ls")
+			return "", nil, nil, nil
+		},
+		ListPolicyPacksF: func(
+			_ context.Context, orgName string, _ backend.ContinuationToken,
+		) (apitype.ListPolicyPacksResponse, backend.ContinuationToken, error) {
+			queriedOrgName = orgName
+			return apitype.ListPolicyPacksResponse{}, nil, nil
+		},
+	}
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return nil, "", workspace.ErrProjectNotFound
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	cmd := newPolicyLsCmd(ws, lm)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "default-org", queriedOrgName)
+}
+
+//nolint:paralleltest // uses t.Setenv
+func TestPolicyLsCmd_RespectsLocalDefaultOrgSetting(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	t.Setenv("PULUMI_BACKEND_URL", "https://api.pulumi.com")
+	require.NoError(t, workspace.SetBackendConfigDefaultOrg("https://api.pulumi.com", "local-default-org"))
+
+	var queriedOrgName string
+	be := &backend.MockBackend{
+		GetDefaultOrgF: func(context.Context) (string, error) {
+			t.Fatal("GetDefaultOrg should not be called when local default org is configured")
+			return "", nil
+		},
+		ListPolicyPacksF: func(
+			_ context.Context, orgName string, _ backend.ContinuationToken,
+		) (apitype.ListPolicyPacksResponse, backend.ContinuationToken, error) {
+			queriedOrgName = orgName
+			return apitype.ListPolicyPacksResponse{}, nil, nil
+		},
+	}
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return nil, "", workspace.ErrProjectNotFound
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		LoginF: func(
+			context.Context, pkgWorkspace.Context, diag.Sink,
+			string, *workspace.Project, bool, bool, colors.Colorization,
+		) (backend.Backend, error) {
+			return be, nil
+		},
+	}
+
+	cmd := newPolicyLsCmd(ws, lm)
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "local-default-org", queriedOrgName)
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/22646

Use `GetDefaultOrg` instead of username to decide the string value to pass to `ListPolicyPacks`.