### PR TITLE
Remove FixupPulumiPackageTokens

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -885,7 +885,6 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 	// Accumulate import statements for the various providers
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*pcl.Resource); isResource {
-			pcl.FixupPulumiPackageTokens(r)
 			token, tokenRange := r.GetToken()
 			pkg, mod, name, _ := pcl.DecomposeToken(token, tokenRange)
 			if pkg == "pulumi" {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1021,7 +1021,6 @@ func outputRequiresAsyncMain(ov *pcl.OutputVariable) bool {
 // resourceTypeName computes the NodeJS package, module, and type name for the given resource.
 func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
-	pcl.FixupPulumiPackageTokens(r)
 	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
 
 	if r.Schema != nil {

--- a/pkg/codegen/pcl/utilities.go
+++ b/pkg/codegen/pcl/utilities.go
@@ -237,13 +237,6 @@ func MapProvidersAsResources(p *Program) {
 	}
 }
 
-func FixupPulumiPackageTokens(r *Resource) {
-	pkg, mod, name, _ := DecomposeToken(r.GetToken())
-	if pkg == "pulumi" && mod == "pulumi" {
-		r.token = "pulumi::" + name
-	}
-}
-
 // SortedFunctionParameters returns a list of properties of the input type from the schema
 // for an invoke function call which has multi argument inputs. We assume here
 // that the expression is an invoke which has it's args (2nd parameter) annotated

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -628,7 +628,6 @@ func (g *generator) genPreamble(w io.Writer, program *pcl.Program, preambleHelpe
 
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*pcl.Resource); isResource {
-			pcl.FixupPulumiPackageTokens(r)
 			pkg, _, _, _ := pcl.DecomposeToken(r.GetToken())
 			if pkg == "pulumi" {
 				continue
@@ -767,7 +766,6 @@ func tokenToQualifiedName(pkgAlias, module, member string) string {
 func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
-	pcl.FixupPulumiPackageTokens(r)
 
 	// Normalize module.
 	if r.Schema != nil {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -913,21 +913,20 @@ func (pkg *Package) TokenToModule(tok string) string {
 		return ""
 	}
 
-	switch components[1] {
-	case "providers":
+	if components[0] == "pulumi" && (components[1] == "pulumi" || components[1] == "providers") {
 		return ""
-	default:
-		format := pkg.moduleFormat
-		if format == nil {
-			format = defaultModuleFormat
-		}
-
-		matches := format.FindStringSubmatch(components[1])
-		if len(matches) < 2 || matches[1] == "index" {
-			return ""
-		}
-		return matches[1]
 	}
+
+	format := pkg.moduleFormat
+	if format == nil {
+		format = defaultModuleFormat
+	}
+
+	matches := format.FindStringSubmatch(components[1])
+	if len(matches) < 2 || matches[1] == "index" {
+		return ""
+	}
+	return matches[1]
 }
 
 func TokenToRuntimeModule(tok string) string {


### PR DESCRIPTION
This was a really odd function that mutated resource nodes so that "pulumi:pulumi:typ" became "pulumi::typ". This is so that stack references which are tokenized as "pulumi:pulumi:StackReference" would show up in the root pulumi package. 

Really _they_ should have been tokenized as "pulumi:index:StackReference" (like we have now done for Stash), but alas changing that now is probably tricky (maybe doable with aliases over time?). So we have to keep working around this, but we can do this in the `TokenToModule` function where we already special case that "pulumi:providers:X" are treated as the index module as well.