### PR TITLE
Fix flaky `TestDAG_Walk_ErrorPropogation`

### DIFF
--- a/pkg/util/pdag/pdag.go
+++ b/pkg/util/pdag/pdag.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"golang.org/x/sync/errgroup"
@@ -297,13 +298,26 @@ func (g *DAG[T]) Walk(ctx context.Context, process func(context.Context, T) erro
 		value any
 		stack []byte
 	}
+
+	// We can't use the wg to prevent walks from racing against errors since the `done` returned from `g.Drain` runs
+	// before `wg.Go` registers that an error was returned. Instead we manually track errors and then block until
+	// `wg` registers the error before discarding the run.
+	//
+	// We block to prevent multiple threads from being spawned and then discarded.
+	var failed atomic.Bool
+
 	for node, done := range g.Drain(ctx) {
 		if err := ctx.Err(); err != nil {
 			cancelError = err
 			break
 		}
 		wg.Go(func() (err error) {
-			defer done()
+			defer func() {
+				if err != nil {
+					failed.Store(true)
+				}
+				done()
+			}()
 			defer func() {
 				p := recover()
 				if p == nil {
@@ -317,6 +331,10 @@ func (g *DAG[T]) Walk(ctx context.Context, process func(context.Context, T) erro
 				panicMu.Unlock()
 				err = errors.Join(err, errProcessPanicked)
 			}()
+			if failed.Load() {
+				<-ctx.Done()
+				return nil
+			}
 			return process(ctx, node)
 		})
 	}

--- a/pkg/util/pdag/pdag_test.go
+++ b/pkg/util/pdag/pdag_test.go
@@ -261,20 +261,19 @@ func TestDAG_Walk_ErrorPropogation(t *testing.T) {
 	require.NoError(t, dag.NewEdge(h1, h2))
 
 	var completed atomic.Int32
-	expectedErr := errors.New("processing error")
 
 	err := dag.Walk(t.Context(), func(ctx context.Context, v int) error {
 		completed.Add(1)
 		if v == 1 {
 			// Error on the middle node after the first node has completed
-			return expectedErr
+			return assert.AnError
 		}
 		return nil
 	})
 
-	assert.ErrorIs(t, err, expectedErr)
+	assert.ErrorIs(t, err, assert.AnError)
 	// Node 0 should have completed, node 1 errored (but was added), node 2 should not run
-	assert.Equal(t, int(completed.Load()), 2)
+	assert.Equal(t, 2, int(completed.Load()))
 }
 
 // TestDAG_Walk_MaxProcs checks that we saturate up to the maximum allows procs, but no


### PR DESCRIPTION
We can't use the wg to prevent walks from racing against errors, even for the
simple case of linear dependencies (see
https://github.com/pulumi/pulumi/actions/runs/24716266210/job/72293890384?pr=21648). This
is because the `defer done()` unblocks the next return from drain. The bad
order, occurring maybe 5/1M times is:

Setup: nodes n1, n2, n3, edges n1->n2, n2->n3 with processing process(n2) erroring

- process(n2) errors
- the function in wg.Go calls done, freeing up the next return value from g.Drain
- g.Drain yields the next value and it's enqueued onto the wg
- the new function runs
- the error returned from process(n2) cancels the wg
- process(n3) runs

The fix is to independently ensure that if a node has failed, we wait for the
`wg` to catch up.