### PR TITLE
encryptedlog: don't base64 encode session key

### DIFF
--- a/pkg/engine/encryptedlog/encrypted_log_test.go
+++ b/pkg/engine/encryptedlog/encrypted_log_test.go
@@ -405,9 +405,9 @@ func TestV1GoldenData(t *testing.T) {
 	// the plaintext "Hello, PLOG v1!\n". If the format ever changes, this test
 	// will catch it.
 	golden, err := base64.StdEncoding.DecodeString(
-		"UExPRwEAPFNrcG9TRGRNY0RJclpDOUVTR1E1WmpGVU0wdDBjMnBFVUROV2JTOVNiVGx2WVdwT1dt" +
-			"RnVNbUZqY3owPQAAAEQAAAAAAAAAAAAAAAHQ5ZUrfOfE0r/+aPKp7NRX2gpCrBGIJgj3Pl2Ztxn3" +
-			"tLKmracwfcAaqfmwsL4mbrKen2vYLziniQ==")
+		"UExPRwEALEVuUFF2TW9oQnBGaml2RTlCUVVBQjdJS2V5aTJtb3FIMUFicytHcUJrUzQ9" +
+			"AAAARAAAAAAAAAAAAAAAAQ9Y92bKmK4Mp6thx3VtOQbvn9h3fHYSaV2eSh0ur4CwxiTa" +
+			"jiDxfppi7qb+7j0uo0Zt9emP3Zd6")
 	require.NoError(t, err)
 
 	ctx := t.Context()

--- a/pkg/engine/encryptedlog/format.go
+++ b/pkg/engine/encryptedlog/format.go
@@ -20,7 +20,7 @@
 //   - Magic (4 bytes): the ASCII string "PLOG"
 //   - Version (1 byte): the format version (currently 0x01)
 //   - Key length (2 bytes, big-endian uint16): the length of the encrypted session key
-//   - Encrypted session key (variable length): the base64-encoded session key, encrypted with the configured encrypter
+//   - Encrypted session key (variable length): the raw session key, encrypted with the configured encrypter
 //
 // After the header, the file contains a sequence of encrypted chunks. Each chunk has the following format:
 //

--- a/pkg/engine/encryptedlog/reader.go
+++ b/pkg/engine/encryptedlog/reader.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
-	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -69,14 +68,11 @@ func NewReader(
 		return nil, fmt.Errorf("encryptedlog: reading encrypted key: %w", err)
 	}
 
-	encodedKey, err := dec.DecryptValue(ctx, string(encryptedKeyBytes))
+	decryptedKey, err := dec.DecryptValue(ctx, string(encryptedKeyBytes))
 	if err != nil {
 		return nil, fmt.Errorf("encryptedlog: decrypting session key: %w", err)
 	}
-	sessionKey, err := base64.StdEncoding.DecodeString(encodedKey)
-	if err != nil {
-		return nil, fmt.Errorf("encryptedlog: decoding session key: %w", err)
-	}
+	sessionKey := []byte(decryptedKey)
 	if len(sessionKey) != keySize {
 		return nil, fmt.Errorf("encryptedlog: invalid session key size %d", len(sessionKey))
 	}

--- a/pkg/engine/encryptedlog/writer.go
+++ b/pkg/engine/encryptedlog/writer.go
@@ -21,7 +21,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -55,9 +54,8 @@ func NewWriter(
 		return nil, fmt.Errorf("encryptedlog: generating session key: %w", err)
 	}
 
-	// Encrypt the base64-encoded session key via the caller's secrets provider.
-	encodedKey := base64.StdEncoding.EncodeToString(sessionKey[:])
-	encryptedKey, err := enc.EncryptValue(ctx, encodedKey)
+	// Encrypt the raw session key via the caller's secrets provider.
+	encryptedKey, err := enc.EncryptValue(ctx, string(sessionKey[:]))
 	if err != nil {
 		return nil, fmt.Errorf("encryptedlog: encrypting session key: %w", err)
 	}


### PR DESCRIPTION
In an internal doc it was pointed out that base64 encoding the session key is not necessary.  This library is unused as of yet, so we can still make the change, and avoid base64 encoding the session key, and just use the raw bytes instead.

Co-authored-by: Claude

/cc @Frassle 