### PR TITLE
Add hidden `pulumi events filter` command with `--changes-only`

### DIFF
--- a/changelog/pending/20260421--cli--add-hidden-pulumi-events-passthrough-command.yaml
+++ b/changelog/pending/20260421--cli--add-hidden-pulumi-events-passthrough-command.yaml
@@ -1,7 +1,0 @@
-changes:
-- type: feat
-  scope: cli
-  description: |
-    Add an experimental `pulumi events` command that reads an engine event stream
-    from stdin and writes it to stdout. This is the first iteration; the command
-    is hidden from `--help` while the interface is being developed.

--- a/changelog/pending/20260421--cli--add-hidden-pulumi-events-passthrough-command.yaml
+++ b/changelog/pending/20260421--cli--add-hidden-pulumi-events-passthrough-command.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    Add an experimental `pulumi events` command that reads an engine event stream
+    from stdin and writes it to stdout. This is the first iteration; the command
+    is hidden from `--help` while the interface is being developed.

--- a/pkg/cmd/pulumi/events/changes_only.go
+++ b/pkg/cmd/pulumi/events/changes_only.go
@@ -58,17 +58,11 @@ func runChangesOnly(in io.Reader, out io.Writer) error {
 //   - Resource events whose op is `same` are dropped: `same` is the engine's explicit marker that
 //     nothing changed. Every other op (create, update, replace, delete, read, refresh,
 //     read-replacement, read-discard) represents a real observable change and is kept.
-//   - For kept resource events, if the provider reported a non-empty `Diffs` list, the same set
-//     of top-level keys is used to restrict both `Inputs` and `Outputs` on `Old` and `New`. For
-//     ops that typically have no diffs (e.g. create and delete, where every property is new or
-//     gone) both maps are kept in full.
-//
-// Using the input-level `Diffs` to narrow `Outputs` is deliberately pragmatic: the engine only
-// exposes input-side diffs, and in practice Pulumi providers export outputs whose keys mirror
-// inputs, so filtering by `Diffs` keeps the properties a reader of a changes-only stream actually
-// cares about while dropping stable derived outputs (ids, arns, ...). Output keys that don't
-// overlap with `Diffs` are dropped — consumers that need the full post-state can work from the
-// unfiltered stream.
+//   - For kept resource events, if the provider reported a non-empty `Diffs` list, `Old.Inputs`
+//     and `New.Inputs` are restricted to those top-level keys. For ops that typically have no
+//     diffs (e.g. create and delete, where every property is new or gone) inputs are kept in full.
+//   - `Outputs` are preserved: consumers that render these events still want to see the resulting
+//     state.
 //
 // The input event is never mutated; every pointer returned references freshly-allocated structs so
 // callers can safely keep and modify the result.
@@ -92,8 +86,8 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	}
 
 	filteredMd := *md
-	filteredMd.Old = restrictToDiffs(md.Old, md.Diffs)
-	filteredMd.New = restrictToDiffs(md.New, md.Diffs)
+	filteredMd.Old = restrictInputsToDiffs(md.Old, md.Diffs)
+	filteredMd.New = restrictInputsToDiffs(md.New, md.Diffs)
 
 	out := apitype.EngineEvent{Sequence: evt.Sequence, Timestamp: evt.Timestamp}
 	switch {
@@ -113,11 +107,11 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	return &out
 }
 
-// restrictToDiffs returns a shallow copy of s with `Inputs` and `Outputs` narrowed to the
-// top-level keys in diffs. If diffs is empty the full `Inputs` and `Outputs` maps are preserved
-// (every property is, by the engine's own report, either unchanged or — for creates and deletes —
-// entirely new or gone).
-func restrictToDiffs(
+// restrictInputsToDiffs returns a shallow copy of s with `Inputs` narrowed to the top-level keys
+// in diffs. If diffs is empty the full `Inputs` map is preserved (every property is, by the
+// engine's own report, either unchanged or — for creates and deletes — entirely new or gone).
+// `Outputs` are carried over unchanged.
+func restrictInputsToDiffs(
 	s *apitype.StepEventStateMetadata, diffs []string,
 ) *apitype.StepEventStateMetadata {
 	if s == nil {
@@ -129,23 +123,13 @@ func restrictToDiffs(
 		for _, k := range diffs {
 			keep[k] = true
 		}
-		out.Inputs = pickKeys(s.Inputs, keep)
-		out.Outputs = pickKeys(s.Outputs, keep)
+		filtered := make(map[string]any, len(keep))
+		for k, v := range s.Inputs {
+			if keep[k] {
+				filtered[k] = v
+			}
+		}
+		out.Inputs = filtered
 	}
 	return &out
-}
-
-// pickKeys returns a fresh map containing only the entries of m whose keys are present in keep.
-// A nil input yields a nil output.
-func pickKeys(m map[string]any, keep map[string]bool) map[string]any {
-	if m == nil {
-		return nil
-	}
-	out := make(map[string]any, len(keep))
-	for k, v := range m {
-		if keep[k] {
-			out[k] = v
-		}
-	}
-	return out
 }

--- a/pkg/cmd/pulumi/events/changes_only.go
+++ b/pkg/cmd/pulumi/events/changes_only.go
@@ -58,11 +58,17 @@ func runChangesOnly(in io.Reader, out io.Writer) error {
 //   - Resource events whose op is `same` are dropped: `same` is the engine's explicit marker that
 //     nothing changed. Every other op (create, update, replace, delete, read, refresh,
 //     read-replacement, read-discard) represents a real observable change and is kept.
-//   - For kept resource events, if the provider reported a non-empty `Diffs` list, `Old.Inputs`
-//     and `New.Inputs` are restricted to those top-level keys. For ops that typically have no
-//     diffs (e.g. create and delete, where every property is new or gone) inputs are kept in full.
-//   - `Outputs` are preserved: consumers that render these events still want to see the resulting
-//     state.
+//   - For kept resource events, if the provider reported a non-empty `Diffs` list, the same set
+//     of top-level keys is used to restrict both `Inputs` and `Outputs` on `Old` and `New`. For
+//     ops that typically have no diffs (e.g. create and delete, where every property is new or
+//     gone) both maps are kept in full.
+//
+// Using the input-level `Diffs` to narrow `Outputs` is deliberately pragmatic: the engine only
+// exposes input-side diffs, and in practice Pulumi providers export outputs whose keys mirror
+// inputs, so filtering by `Diffs` keeps the properties a reader of a changes-only stream actually
+// cares about while dropping stable derived outputs (ids, arns, ...). Output keys that don't
+// overlap with `Diffs` are dropped — consumers that need the full post-state can work from the
+// unfiltered stream.
 //
 // The input event is never mutated; every pointer returned references freshly-allocated structs so
 // callers can safely keep and modify the result.
@@ -86,8 +92,8 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	}
 
 	filteredMd := *md
-	filteredMd.Old = restrictInputsToDiffs(md.Old, md.Diffs)
-	filteredMd.New = restrictInputsToDiffs(md.New, md.Diffs)
+	filteredMd.Old = restrictToDiffs(md.Old, md.Diffs)
+	filteredMd.New = restrictToDiffs(md.New, md.Diffs)
 
 	out := apitype.EngineEvent{Sequence: evt.Sequence, Timestamp: evt.Timestamp}
 	switch {
@@ -107,11 +113,11 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	return &out
 }
 
-// restrictInputsToDiffs returns a shallow copy of s with `Inputs` narrowed to the top-level keys
-// in diffs. If diffs is empty the full `Inputs` map is preserved (every property is, by the
-// engine's own report, either unchanged or — for creates and deletes — entirely new or gone).
-// `Outputs` are carried over unchanged.
-func restrictInputsToDiffs(
+// restrictToDiffs returns a shallow copy of s with `Inputs` and `Outputs` narrowed to the
+// top-level keys in diffs. If diffs is empty the full `Inputs` and `Outputs` maps are preserved
+// (every property is, by the engine's own report, either unchanged or — for creates and deletes —
+// entirely new or gone).
+func restrictToDiffs(
 	s *apitype.StepEventStateMetadata, diffs []string,
 ) *apitype.StepEventStateMetadata {
 	if s == nil {
@@ -123,13 +129,23 @@ func restrictInputsToDiffs(
 		for _, k := range diffs {
 			keep[k] = true
 		}
-		filtered := make(map[string]any, len(keep))
-		for k, v := range s.Inputs {
-			if keep[k] {
-				filtered[k] = v
-			}
-		}
-		out.Inputs = filtered
+		out.Inputs = pickKeys(s.Inputs, keep)
+		out.Outputs = pickKeys(s.Outputs, keep)
 	}
 	return &out
+}
+
+// pickKeys returns a fresh map containing only the entries of m whose keys are present in keep.
+// A nil input yields a nil output.
+func pickKeys(m map[string]any, keep map[string]bool) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(keep))
+	for k, v := range m {
+		if keep[k] {
+			out[k] = v
+		}
+	}
+	return out
 }

--- a/pkg/cmd/pulumi/events/changes_only.go
+++ b/pkg/cmd/pulumi/events/changes_only.go
@@ -50,19 +50,19 @@ func runChangesOnly(in io.Reader, out io.Writer) error {
 // filterChangesOnly applies the `--changes-only` transform to a single engine event, returning nil
 // if the event should be dropped from the stream or a freshly-constructed, filtered copy otherwise.
 //
-// The filter matches the behaviour of `pulumi preview --json --changes-only` (see pulumi/pulumi
-// #22068): only resource-lifecycle events for real changes are kept, and their state metadata is
-// restricted to the properties that actually changed.
+// Rules:
 //
-//   - Events that aren't resource-lifecycle events (stdout, diagnostic, prelude, progress, policy,
-//     summary, ...) are dropped entirely.
-//   - Resource events whose op is `same`, `read`, `read-replacement`, `discard`, or `refresh` are
-//     dropped: these are observations, not changes.
-//   - For `update` and `replace` ops the `Inputs` map on `Old` and `New` is restricted to the top
-//     level keys the provider reported via `Diffs`. For creates, deletes, and other ops every
-//     property is, by definition, new or gone so inputs are kept in full.
-//   - `Outputs` are dropped from `Old` and `New` for every kept event: they describe post-state,
-//     not the change itself.
+//   - Non-resource events (stdout, diagnostic, prelude, summary, policy, progress, cancel, ...)
+//     are passed through unchanged — they carry context the consumer may care about regardless of
+//     whether any resource changed.
+//   - Resource events whose op is `same` are dropped: `same` is the engine's explicit marker that
+//     nothing changed. Every other op (create, update, replace, delete, read, refresh,
+//     read-replacement, read-discard) represents a real observable change and is kept.
+//   - For kept resource events, if the provider reported a non-empty `Diffs` list, `Old.Inputs`
+//     and `New.Inputs` are restricted to those top-level keys. For ops that typically have no
+//     diffs (e.g. create and delete, where every property is new or gone) inputs are kept in full.
+//   - `Outputs` are preserved: consumers that render these events still want to see the resulting
+//     state.
 //
 // The input event is never mutated; every pointer returned references freshly-allocated structs so
 // callers can safely keep and modify the result.
@@ -76,18 +76,18 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	case evt.ResOpFailedEvent != nil:
 		md = &evt.ResOpFailedEvent.Metadata
 	default:
-		return nil
+		// Non-resource event: pass through a shallow copy so callers still own a fresh pointer.
+		cp := evt
+		return &cp
 	}
 
-	//exhaustive:ignore
-	switch md.Op {
-	case apitype.OpSame, apitype.OpRead, apitype.OpReadReplacement, apitype.OpReadDiscard, apitype.OpRefresh:
+	if md.Op == apitype.OpSame {
 		return nil
 	}
 
 	filteredMd := *md
-	filteredMd.Old = filterStateChangesOnly(md.Old, md.Op, md.Diffs)
-	filteredMd.New = filterStateChangesOnly(md.New, md.Op, md.Diffs)
+	filteredMd.Old = restrictInputsToDiffs(md.Old, md.Diffs)
+	filteredMd.New = restrictInputsToDiffs(md.New, md.Diffs)
 
 	out := apitype.EngineEvent{Sequence: evt.Sequence, Timestamp: evt.Timestamp}
 	switch {
@@ -107,20 +107,18 @@ func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
 	return &out
 }
 
-// filterStateChangesOnly returns a filtered copy of s suitable for `--changes-only` output.
-// Outputs are always dropped; inputs are kept in full for every op except update and replace, where
-// they are restricted to the top-level keys in diffs.
-func filterStateChangesOnly(
-	s *apitype.StepEventStateMetadata, op apitype.OpType, diffs []string,
+// restrictInputsToDiffs returns a shallow copy of s with `Inputs` narrowed to the top-level keys
+// in diffs. If diffs is empty the full `Inputs` map is preserved (every property is, by the
+// engine's own report, either unchanged or — for creates and deletes — entirely new or gone).
+// `Outputs` are carried over unchanged.
+func restrictInputsToDiffs(
+	s *apitype.StepEventStateMetadata, diffs []string,
 ) *apitype.StepEventStateMetadata {
 	if s == nil {
 		return nil
 	}
 	out := *s
-	out.Outputs = map[string]any{}
-	//exhaustive:ignore
-	switch op {
-	case apitype.OpUpdate, apitype.OpReplace:
+	if len(diffs) > 0 {
 		keep := make(map[string]bool, len(diffs))
 		for _, k := range diffs {
 			keep[k] = true

--- a/pkg/cmd/pulumi/events/changes_only.go
+++ b/pkg/cmd/pulumi/events/changes_only.go
@@ -1,0 +1,137 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// runChangesOnly reads a JSONL engine event stream from in, applies the `--changes-only` filter
+// to each event, and writes the surviving events back as JSONL to out. Decoding errors are
+// surfaced to the caller so that malformed input fails fast rather than silently dropping events.
+func runChangesOnly(in io.Reader, out io.Writer) error {
+	dec := json.NewDecoder(in)
+	enc := json.NewEncoder(out)
+	for {
+		var evt apitype.EngineEvent
+		if err := dec.Decode(&evt); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("decoding event: %w", err)
+		}
+		filtered := filterChangesOnly(evt)
+		if filtered == nil {
+			continue
+		}
+		if err := enc.Encode(filtered); err != nil {
+			return fmt.Errorf("encoding event: %w", err)
+		}
+	}
+}
+
+// filterChangesOnly applies the `--changes-only` transform to a single engine event, returning nil
+// if the event should be dropped from the stream or a freshly-constructed, filtered copy otherwise.
+//
+// The filter matches the behaviour of `pulumi preview --json --changes-only` (see pulumi/pulumi
+// #22068): only resource-lifecycle events for real changes are kept, and their state metadata is
+// restricted to the properties that actually changed.
+//
+//   - Events that aren't resource-lifecycle events (stdout, diagnostic, prelude, progress, policy,
+//     summary, ...) are dropped entirely.
+//   - Resource events whose op is `same`, `read`, `read-replacement`, `discard`, or `refresh` are
+//     dropped: these are observations, not changes.
+//   - For `update` and `replace` ops the `Inputs` map on `Old` and `New` is restricted to the top
+//     level keys the provider reported via `Diffs`. For creates, deletes, and other ops every
+//     property is, by definition, new or gone so inputs are kept in full.
+//   - `Outputs` are dropped from `Old` and `New` for every kept event: they describe post-state,
+//     not the change itself.
+//
+// The input event is never mutated; every pointer returned references freshly-allocated structs so
+// callers can safely keep and modify the result.
+func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
+	var md *apitype.StepEventMetadata
+	switch {
+	case evt.ResourcePreEvent != nil:
+		md = &evt.ResourcePreEvent.Metadata
+	case evt.ResOutputsEvent != nil:
+		md = &evt.ResOutputsEvent.Metadata
+	case evt.ResOpFailedEvent != nil:
+		md = &evt.ResOpFailedEvent.Metadata
+	default:
+		return nil
+	}
+
+	//exhaustive:ignore
+	switch md.Op {
+	case apitype.OpSame, apitype.OpRead, apitype.OpReadReplacement, apitype.OpReadDiscard, apitype.OpRefresh:
+		return nil
+	}
+
+	filteredMd := *md
+	filteredMd.Old = filterStateChangesOnly(md.Old, md.Op, md.Diffs)
+	filteredMd.New = filterStateChangesOnly(md.New, md.Op, md.Diffs)
+
+	out := apitype.EngineEvent{Sequence: evt.Sequence, Timestamp: evt.Timestamp}
+	switch {
+	case evt.ResourcePreEvent != nil:
+		cp := *evt.ResourcePreEvent
+		cp.Metadata = filteredMd
+		out.ResourcePreEvent = &cp
+	case evt.ResOutputsEvent != nil:
+		cp := *evt.ResOutputsEvent
+		cp.Metadata = filteredMd
+		out.ResOutputsEvent = &cp
+	case evt.ResOpFailedEvent != nil:
+		cp := *evt.ResOpFailedEvent
+		cp.Metadata = filteredMd
+		out.ResOpFailedEvent = &cp
+	}
+	return &out
+}
+
+// filterStateChangesOnly returns a filtered copy of s suitable for `--changes-only` output.
+// Outputs are always dropped; inputs are kept in full for every op except update and replace, where
+// they are restricted to the top-level keys in diffs.
+func filterStateChangesOnly(
+	s *apitype.StepEventStateMetadata, op apitype.OpType, diffs []string,
+) *apitype.StepEventStateMetadata {
+	if s == nil {
+		return nil
+	}
+	out := *s
+	out.Outputs = map[string]any{}
+	//exhaustive:ignore
+	switch op {
+	case apitype.OpUpdate, apitype.OpReplace:
+		keep := make(map[string]bool, len(diffs))
+		for _, k := range diffs {
+			keep[k] = true
+		}
+		filtered := make(map[string]any, len(keep))
+		for k, v := range s.Inputs {
+			if keep[k] {
+				filtered[k] = v
+			}
+		}
+		out.Inputs = filtered
+	}
+	return &out
+}

--- a/pkg/cmd/pulumi/events/changes_only_test.go
+++ b/pkg/cmd/pulumi/events/changes_only_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// resourcePreEvent is a tiny helper for building ResourcePreEvent fixtures in table tests.
+func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string]any) apitype.EngineEvent {
+	return apitype.EngineEvent{
+		Sequence:  7,
+		Timestamp: 42,
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    op,
+				URN:   "urn:pulumi:stack::proj::pkg:index:Res::r",
+				Type:  "pkg:index:Res",
+				Diffs: diffs,
+				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: map[string]any{"o": 1}},
+				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: map[string]any{"o": 2}},
+			},
+		},
+	}
+}
+
+func TestFilterChangesOnly_DropsNonResourceEvents(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		event apitype.EngineEvent
+	}{
+		{"cancel", apitype.EngineEvent{CancelEvent: &apitype.CancelEvent{}}},
+		{"stdout", apitype.EngineEvent{StdoutEvent: &apitype.StdoutEngineEvent{Message: "hi"}}},
+		{"diagnostic", apitype.EngineEvent{DiagnosticEvent: &apitype.DiagnosticEvent{Message: "warn"}}},
+		{"prelude", apitype.EngineEvent{PreludeEvent: &apitype.PreludeEvent{}}},
+		{"summary", apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{}}},
+		{"policy", apitype.EngineEvent{PolicyEvent: &apitype.PolicyEvent{}}},
+		{"policy-remediation", apitype.EngineEvent{PolicyRemediationEvent: &apitype.PolicyRemediationEvent{}}},
+		{"policy-load", apitype.EngineEvent{PolicyLoadEvent: &apitype.PolicyLoadEvent{}}},
+		{"progress", apitype.EngineEvent{ProgressEvent: &apitype.ProgressEvent{}}},
+		{"start-debugging", apitype.EngineEvent{StartDebuggingEvent: &apitype.StartDebuggingEvent{}}},
+		{"error", apitype.EngineEvent{ErrorEvent: &apitype.ErrorEvent{}}},
+		{"empty", apitype.EngineEvent{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, filterChangesOnly(c.event), "%s events must be dropped under --changes-only", c.name)
+		})
+	}
+}
+
+func TestFilterChangesOnly_DropsNonChangeOps(t *testing.T) {
+	t.Parallel()
+
+	ops := []apitype.OpType{
+		apitype.OpSame,
+		apitype.OpRead,
+		apitype.OpReadReplacement,
+		apitype.OpReadDiscard,
+		apitype.OpRefresh,
+	}
+	for _, op := range ops {
+		t.Run(string(op), func(t *testing.T) {
+			t.Parallel()
+			evt := resourcePreEvent(op, nil, map[string]any{"foo": "a"}, map[string]any{"foo": "b"})
+			assert.Nil(t, filterChangesOnly(evt),
+				"op %q is an observation, not a change, and must be dropped", op)
+		})
+	}
+}
+
+func TestFilterChangesOnly_UpdateRestrictsInputsToDiffs(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable", "baz": "also-stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable", "baz": "also-stable"}
+	evt := resourcePreEvent(apitype.OpUpdate, []string{"foo"}, oldIn, newIn)
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got, "update event should survive the filter")
+	require.NotNil(t, got.ResourcePreEvent)
+
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, apitype.OpUpdate, md.Op)
+	// Sequence/timestamp are passed through unchanged.
+	assert.Equal(t, 7, got.Sequence)
+	assert.Equal(t, 42, got.Timestamp)
+
+	require.NotNil(t, md.Old)
+	require.NotNil(t, md.New)
+	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs,
+		"Old.Inputs must contain only changed keys")
+	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs,
+		"New.Inputs must contain only changed keys")
+	assert.Empty(t, md.Old.Outputs, "Old.Outputs must be dropped")
+	assert.Empty(t, md.New.Outputs, "New.Outputs must be dropped")
+}
+
+func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable"}
+	evt := resourcePreEvent(apitype.OpReplace, []string{"foo"}, oldIn, newIn)
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
+	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
+}
+
+func TestFilterChangesOnly_CreateKeepsAllInputs(t *testing.T) {
+	t.Parallel()
+
+	// Creates have no "Old" state; the engine typically sets Old to nil.
+	evt := apitype.EngineEvent{
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpCreate,
+				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
+				New: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "a", "bar": "b"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Nil(t, md.Old)
+	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.New.Inputs,
+		"create events keep all inputs — every property is new")
+	assert.Empty(t, md.New.Outputs, "outputs are still stripped")
+}
+
+func TestFilterChangesOnly_DeleteKeepsAllOldInputs(t *testing.T) {
+	t.Parallel()
+
+	evt := apitype.EngineEvent{
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpDelete,
+				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
+				Old: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "a", "bar": "b"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.Old.Inputs,
+		"delete events keep all old inputs — consumers need to know what's gone")
+	assert.Empty(t, md.Old.Outputs)
+	assert.Nil(t, md.New)
+}
+
+func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
+	t.Parallel()
+
+	// ResOutputsEvent with an update op.
+	outputs := apitype.EngineEvent{
+		ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    apitype.OpUpdate,
+				URN:   "urn",
+				Diffs: []string{"foo"},
+				New: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "n", "bar": "s"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+	gotOut := filterChangesOnly(outputs)
+	require.NotNil(t, gotOut)
+	require.NotNil(t, gotOut.ResOutputsEvent)
+	assert.Equal(t, map[string]any{"foo": "n"}, gotOut.ResOutputsEvent.Metadata.New.Inputs)
+
+	// ResOpFailedEvent with a create op retains Status/Steps on the copy.
+	failed := apitype.EngineEvent{
+		ResOpFailedEvent: &apitype.ResOpFailedEvent{
+			Status: 3,
+			Steps:  5,
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpCreate,
+				URN: "urn",
+				New: &apitype.StepEventStateMetadata{
+					Inputs: map[string]any{"foo": "a"},
+				},
+			},
+		},
+	}
+	gotFail := filterChangesOnly(failed)
+	require.NotNil(t, gotFail)
+	require.NotNil(t, gotFail.ResOpFailedEvent)
+	assert.Equal(t, 3, gotFail.ResOpFailedEvent.Status)
+	assert.Equal(t, 5, gotFail.ResOpFailedEvent.Steps)
+}
+
+func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable"}
+	originalOldOutputs := map[string]any{"o": 1}
+	originalNewOutputs := map[string]any{"o": 2}
+
+	evt := apitype.EngineEvent{
+		Sequence:  1,
+		Timestamp: 2,
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    apitype.OpUpdate,
+				URN:   "urn",
+				Diffs: []string{"foo"},
+				Old:   &apitype.StepEventStateMetadata{Inputs: oldIn, Outputs: originalOldOutputs},
+				New:   &apitype.StepEventStateMetadata{Inputs: newIn, Outputs: originalNewOutputs},
+			},
+		},
+	}
+
+	_ = filterChangesOnly(evt)
+
+	// The originals must be untouched: filter callers expect a pure function.
+	assert.Equal(t, map[string]any{"foo": "old", "bar": "stable"}, oldIn)
+	assert.Equal(t, map[string]any{"foo": "new", "bar": "stable"}, newIn)
+	assert.Equal(t, map[string]any{"o": 1}, originalOldOutputs)
+	assert.Equal(t, map[string]any{"o": 2}, originalNewOutputs)
+	assert.Equal(t, oldIn, evt.ResourcePreEvent.Metadata.Old.Inputs)
+	assert.Equal(t, newIn, evt.ResourcePreEvent.Metadata.New.Inputs)
+}
+
+func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
+	t.Parallel()
+
+	// Build an input stream that mixes events that should be dropped with one real update.
+	events := []apitype.EngineEvent{
+		{StdoutEvent: &apitype.StdoutEngineEvent{Message: "boot"}},
+		resourcePreEvent(apitype.OpSame, nil, map[string]any{"x": 1}, map[string]any{"x": 1}),
+		resourcePreEvent(apitype.OpUpdate, []string{"foo"},
+			map[string]any{"foo": "old", "bar": "s"},
+			map[string]any{"foo": "new", "bar": "s"}),
+		{SummaryEvent: &apitype.SummaryEvent{}},
+	}
+
+	var input bytes.Buffer
+	enc := json.NewEncoder(&input)
+	for _, e := range events {
+		require.NoError(t, enc.Encode(e))
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runChangesOnly(&input, &out))
+
+	// Only the update event should survive.
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, 1, "expected one surviving event, got: %s", out.String())
+
+	var got apitype.EngineEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &got))
+	require.NotNil(t, got.ResourcePreEvent)
+	assert.Equal(t, apitype.OpUpdate, got.ResourcePreEvent.Metadata.Op)
+	assert.Equal(t, map[string]any{"foo": "old"}, got.ResourcePreEvent.Metadata.Old.Inputs)
+	assert.Equal(t, map[string]any{"foo": "new"}, got.ResourcePreEvent.Metadata.New.Inputs)
+}
+
+func TestRunChangesOnly_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	require.NoError(t, runChangesOnly(strings.NewReader(""), &out))
+	assert.Empty(t, out.String())
+}
+
+func TestRunChangesOnly_MalformedJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := runChangesOnly(strings.NewReader("{not json}\n"), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding event")
+}

--- a/pkg/cmd/pulumi/events/changes_only_test.go
+++ b/pkg/cmd/pulumi/events/changes_only_test.go
@@ -26,19 +26,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// resourcePreEvent builds a ResourcePreEvent fixture. Outputs share the input keys (mirroring what
-// most Pulumi providers do: outputs include every input plus derived fields) and add a derived
-// `id` key, so tests can observe how the --changes-only filter narrows both `Inputs` and
-// `Outputs` using the same `Diffs` list.
+// resourcePreEvent is a tiny helper for building ResourcePreEvent fixtures in table tests.
 func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string]any) apitype.EngineEvent {
-	oldOut := map[string]any{"id": "id-old"}
-	for k := range oldIn {
-		oldOut[k] = "out-old-" + k
-	}
-	newOut := map[string]any{"id": "id-new"}
-	for k := range newIn {
-		newOut[k] = "out-new-" + k
-	}
 	return apitype.EngineEvent{
 		Sequence:  7,
 		Timestamp: 42,
@@ -48,8 +37,8 @@ func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string
 				URN:   "urn:pulumi:stack::proj::pkg:index:Res::r",
 				Type:  "pkg:index:Res",
 				Diffs: diffs,
-				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: oldOut},
-				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: newOut},
+				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: map[string]any{"o": 1}},
+				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: map[string]any{"o": 2}},
 			},
 		},
 	}
@@ -100,8 +89,7 @@ func TestFilterChangesOnly_KeepsReadRefreshDiscardAndReplacements(t *testing.T) 
 
 	// Read, refresh, read-replacement, and read-discard all represent real observable changes:
 	// a resource was pulled in, refreshed state diverged, or a resource was dropped from state.
-	// They must survive the filter and — when `Diffs` is reported — be narrowed the same way as
-	// update/replace.
+	// They must survive the filter.
 	ops := []apitype.OpType{
 		apitype.OpRead,
 		apitype.OpReadReplacement,
@@ -119,16 +107,14 @@ func TestFilterChangesOnly_KeepsReadRefreshDiscardAndReplacements(t *testing.T) 
 			require.NotNil(t, got.ResourcePreEvent)
 			md := got.ResourcePreEvent.Metadata
 			assert.Equal(t, op, md.Op)
+			// Diffs, when present, still restrict inputs regardless of the op.
 			assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
 			assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
-			assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs,
-				"Outputs must be narrowed by the same Diffs list as inputs")
-			assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs)
 		})
 	}
 }
 
-func TestFilterChangesOnly_UpdateRestrictsInputsAndOutputsToDiffs(t *testing.T) {
+func TestFilterChangesOnly_UpdateRestrictsInputsAndKeepsOutputs(t *testing.T) {
 	t.Parallel()
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable", "baz": "also-stable"}
@@ -151,13 +137,13 @@ func TestFilterChangesOnly_UpdateRestrictsInputsAndOutputsToDiffs(t *testing.T) 
 		"Old.Inputs must contain only changed keys")
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs,
 		"New.Inputs must contain only changed keys")
-	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs,
-		"Old.Outputs must be narrowed to the same Diffs keys; the derived `id` key is dropped")
-	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs,
-		"New.Outputs must be narrowed to the same Diffs keys")
+	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs,
+		"Old.Outputs must be preserved — consumers still want to see resulting state")
+	assert.Equal(t, map[string]any{"o": 2}, md.New.Outputs,
+		"New.Outputs must be preserved")
 }
 
-func TestFilterChangesOnly_ReplaceRestrictsInputsAndOutputsToDiffs(t *testing.T) {
+func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
 	t.Parallel()
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable"}
@@ -169,15 +155,13 @@ func TestFilterChangesOnly_ReplaceRestrictsInputsAndOutputsToDiffs(t *testing.T)
 	md := got.ResourcePreEvent.Metadata
 	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
-	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs)
-	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs)
 }
 
 func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 	t.Parallel()
 
 	// Creates have no "Old" state and typically no Diffs; every property is new, so the full
-	// `Inputs` and `Outputs` maps are preserved.
+	// Inputs map is preserved along with the Outputs.
 	evt := apitype.EngineEvent{
 		ResourcePreEvent: &apitype.ResourcePreEvent{
 			Metadata: apitype.StepEventMetadata{
@@ -185,7 +169,7 @@ func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
 				New: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "a", "bar": "b"},
-					Outputs: map[string]any{"id": "xyz", "foo": "a"},
+					Outputs: map[string]any{"o": 1},
 				},
 			},
 		},
@@ -197,8 +181,7 @@ func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 	assert.Nil(t, md.Old)
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.New.Inputs,
 		"create events keep all inputs — every property is new")
-	assert.Equal(t, map[string]any{"id": "xyz", "foo": "a"}, md.New.Outputs,
-		"create events keep all outputs with no Diffs to narrow by")
+	assert.Equal(t, map[string]any{"o": 1}, md.New.Outputs, "outputs must be preserved")
 }
 
 func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
@@ -211,7 +194,7 @@ func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
 				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
 				Old: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "a", "bar": "b"},
-					Outputs: map[string]any{"id": "xyz", "foo": "a"},
+					Outputs: map[string]any{"o": 1},
 				},
 			},
 		},
@@ -222,16 +205,14 @@ func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
 	md := got.ResourcePreEvent.Metadata
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.Old.Inputs,
 		"delete events keep all old inputs — consumers need to know what's gone")
-	assert.Equal(t, map[string]any{"id": "xyz", "foo": "a"}, md.Old.Outputs,
-		"delete events keep all old outputs with no Diffs to narrow by")
+	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs, "outputs must be preserved")
 	assert.Nil(t, md.New)
 }
 
 func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 	t.Parallel()
 
-	// ResOutputsEvent with an update op — outputs are narrowed by Diffs the same way as
-	// ResourcePreEvent.
+	// ResOutputsEvent with an update op.
 	outputs := apitype.EngineEvent{
 		ResOutputsEvent: &apitype.ResOutputsEvent{
 			Metadata: apitype.StepEventMetadata{
@@ -240,7 +221,7 @@ func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 				Diffs: []string{"foo"},
 				New: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "n", "bar": "s"},
-					Outputs: map[string]any{"foo": "post-n", "id": "xyz"},
+					Outputs: map[string]any{"o": 1},
 				},
 			},
 		},
@@ -249,8 +230,8 @@ func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 	require.NotNil(t, gotOut)
 	require.NotNil(t, gotOut.ResOutputsEvent)
 	assert.Equal(t, map[string]any{"foo": "n"}, gotOut.ResOutputsEvent.Metadata.New.Inputs)
-	assert.Equal(t, map[string]any{"foo": "post-n"}, gotOut.ResOutputsEvent.Metadata.New.Outputs,
-		"ResOutputsEvent outputs must be narrowed by Diffs")
+	assert.Equal(t, map[string]any{"o": 1}, gotOut.ResOutputsEvent.Metadata.New.Outputs,
+		"ResOutputsEvent outputs must be preserved")
 
 	// ResOpFailedEvent with a create op retains Status/Steps on the copy.
 	failed := apitype.EngineEvent{
@@ -278,8 +259,8 @@ func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable"}
 	newIn := map[string]any{"foo": "new", "bar": "stable"}
-	originalOldOutputs := map[string]any{"foo": "out-old", "id": "x"}
-	originalNewOutputs := map[string]any{"foo": "out-new", "id": "y"}
+	originalOldOutputs := map[string]any{"o": 1}
+	originalNewOutputs := map[string]any{"o": 2}
 
 	evt := apitype.EngineEvent{
 		Sequence:  1,
@@ -300,8 +281,8 @@ func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
 	// The originals must be untouched: filter callers expect a pure function.
 	assert.Equal(t, map[string]any{"foo": "old", "bar": "stable"}, oldIn)
 	assert.Equal(t, map[string]any{"foo": "new", "bar": "stable"}, newIn)
-	assert.Equal(t, map[string]any{"foo": "out-old", "id": "x"}, originalOldOutputs)
-	assert.Equal(t, map[string]any{"foo": "out-new", "id": "y"}, originalNewOutputs)
+	assert.Equal(t, map[string]any{"o": 1}, originalOldOutputs)
+	assert.Equal(t, map[string]any{"o": 2}, originalNewOutputs)
 	assert.Equal(t, oldIn, evt.ResourcePreEvent.Metadata.Old.Inputs)
 	assert.Equal(t, newIn, evt.ResourcePreEvent.Metadata.New.Inputs)
 }
@@ -344,8 +325,6 @@ func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
 	assert.Equal(t, apitype.OpUpdate, updateEvt.ResourcePreEvent.Metadata.Op)
 	assert.Equal(t, map[string]any{"foo": "old"}, updateEvt.ResourcePreEvent.Metadata.Old.Inputs)
 	assert.Equal(t, map[string]any{"foo": "new"}, updateEvt.ResourcePreEvent.Metadata.New.Inputs)
-	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, updateEvt.ResourcePreEvent.Metadata.Old.Outputs)
-	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, updateEvt.ResourcePreEvent.Metadata.New.Outputs)
 
 	var summaryEvt apitype.EngineEvent
 	require.NoError(t, json.Unmarshal([]byte(lines[2]), &summaryEvt))

--- a/pkg/cmd/pulumi/events/changes_only_test.go
+++ b/pkg/cmd/pulumi/events/changes_only_test.go
@@ -44,9 +44,11 @@ func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string
 	}
 }
 
-func TestFilterChangesOnly_DropsNonResourceEvents(t *testing.T) {
+func TestFilterChangesOnly_KeepsNonResourceEvents(t *testing.T) {
 	t.Parallel()
 
+	// Non-resource events carry context (stdout, diagnostics, summary, ...) that consumers of a
+	// filtered stream may still care about, so the filter passes them through unchanged.
 	cases := []struct {
 		name  string
 		event apitype.EngineEvent
@@ -67,16 +69,28 @@ func TestFilterChangesOnly_DropsNonResourceEvents(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Nil(t, filterChangesOnly(c.event), "%s events must be dropped under --changes-only", c.name)
+			got := filterChangesOnly(c.event)
+			require.NotNil(t, got, "%s events must pass through --changes-only", c.name)
+			assert.Equal(t, c.event, *got, "%s events must pass through unchanged", c.name)
 		})
 	}
 }
 
-func TestFilterChangesOnly_DropsNonChangeOps(t *testing.T) {
+func TestFilterChangesOnly_DropsOpSame(t *testing.T) {
 	t.Parallel()
 
+	// OpSame is the engine's explicit "nothing changed" marker — that's the one op we drop.
+	evt := resourcePreEvent(apitype.OpSame, nil, map[string]any{"foo": "a"}, map[string]any{"foo": "a"})
+	assert.Nil(t, filterChangesOnly(evt), "OpSame resource events must be dropped")
+}
+
+func TestFilterChangesOnly_KeepsReadRefreshDiscardAndReplacements(t *testing.T) {
+	t.Parallel()
+
+	// Read, refresh, read-replacement, and read-discard all represent real observable changes:
+	// a resource was pulled in, refreshed state diverged, or a resource was dropped from state.
+	// They must survive the filter.
 	ops := []apitype.OpType{
-		apitype.OpSame,
 		apitype.OpRead,
 		apitype.OpReadReplacement,
 		apitype.OpReadDiscard,
@@ -85,14 +99,22 @@ func TestFilterChangesOnly_DropsNonChangeOps(t *testing.T) {
 	for _, op := range ops {
 		t.Run(string(op), func(t *testing.T) {
 			t.Parallel()
-			evt := resourcePreEvent(op, nil, map[string]any{"foo": "a"}, map[string]any{"foo": "b"})
-			assert.Nil(t, filterChangesOnly(evt),
-				"op %q is an observation, not a change, and must be dropped", op)
+			evt := resourcePreEvent(op, []string{"foo"},
+				map[string]any{"foo": "old", "bar": "s"},
+				map[string]any{"foo": "new", "bar": "s"})
+			got := filterChangesOnly(evt)
+			require.NotNil(t, got, "%s events must survive --changes-only", op)
+			require.NotNil(t, got.ResourcePreEvent)
+			md := got.ResourcePreEvent.Metadata
+			assert.Equal(t, op, md.Op)
+			// Diffs, when present, still restrict inputs regardless of the op.
+			assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
+			assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
 		})
 	}
 }
 
-func TestFilterChangesOnly_UpdateRestrictsInputsToDiffs(t *testing.T) {
+func TestFilterChangesOnly_UpdateRestrictsInputsAndKeepsOutputs(t *testing.T) {
 	t.Parallel()
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable", "baz": "also-stable"}
@@ -115,8 +137,10 @@ func TestFilterChangesOnly_UpdateRestrictsInputsToDiffs(t *testing.T) {
 		"Old.Inputs must contain only changed keys")
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs,
 		"New.Inputs must contain only changed keys")
-	assert.Empty(t, md.Old.Outputs, "Old.Outputs must be dropped")
-	assert.Empty(t, md.New.Outputs, "New.Outputs must be dropped")
+	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs,
+		"Old.Outputs must be preserved — consumers still want to see resulting state")
+	assert.Equal(t, map[string]any{"o": 2}, md.New.Outputs,
+		"New.Outputs must be preserved")
 }
 
 func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
@@ -133,10 +157,11 @@ func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
 }
 
-func TestFilterChangesOnly_CreateKeepsAllInputs(t *testing.T) {
+func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 	t.Parallel()
 
-	// Creates have no "Old" state; the engine typically sets Old to nil.
+	// Creates have no "Old" state and typically no Diffs; every property is new, so the full
+	// Inputs map is preserved along with the Outputs.
 	evt := apitype.EngineEvent{
 		ResourcePreEvent: &apitype.ResourcePreEvent{
 			Metadata: apitype.StepEventMetadata{
@@ -156,10 +181,10 @@ func TestFilterChangesOnly_CreateKeepsAllInputs(t *testing.T) {
 	assert.Nil(t, md.Old)
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.New.Inputs,
 		"create events keep all inputs — every property is new")
-	assert.Empty(t, md.New.Outputs, "outputs are still stripped")
+	assert.Equal(t, map[string]any{"o": 1}, md.New.Outputs, "outputs must be preserved")
 }
 
-func TestFilterChangesOnly_DeleteKeepsAllOldInputs(t *testing.T) {
+func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
 	t.Parallel()
 
 	evt := apitype.EngineEvent{
@@ -180,7 +205,7 @@ func TestFilterChangesOnly_DeleteKeepsAllOldInputs(t *testing.T) {
 	md := got.ResourcePreEvent.Metadata
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.Old.Inputs,
 		"delete events keep all old inputs — consumers need to know what's gone")
-	assert.Empty(t, md.Old.Outputs)
+	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs, "outputs must be preserved")
 	assert.Nil(t, md.New)
 }
 
@@ -205,6 +230,8 @@ func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 	require.NotNil(t, gotOut)
 	require.NotNil(t, gotOut.ResOutputsEvent)
 	assert.Equal(t, map[string]any{"foo": "n"}, gotOut.ResOutputsEvent.Metadata.New.Inputs)
+	assert.Equal(t, map[string]any{"o": 1}, gotOut.ResOutputsEvent.Metadata.New.Outputs,
+		"ResOutputsEvent outputs must be preserved")
 
 	// ResOpFailedEvent with a create op retains Status/Steps on the copy.
 	failed := apitype.EngineEvent{
@@ -263,7 +290,8 @@ func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
 func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
 	t.Parallel()
 
-	// Build an input stream that mixes events that should be dropped with one real update.
+	// Build an input stream that mixes non-resource events, a same-op resource event (the only
+	// one that should be dropped), and a real update.
 	events := []apitype.EngineEvent{
 		{StdoutEvent: &apitype.StdoutEngineEvent{Message: "boot"}},
 		resourcePreEvent(apitype.OpSame, nil, map[string]any{"x": 1}, map[string]any{"x": 1}),
@@ -282,16 +310,25 @@ func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
 	var out bytes.Buffer
 	require.NoError(t, runChangesOnly(&input, &out))
 
-	// Only the update event should survive.
+	// The stdout, update, and summary events survive; only the OpSame event is dropped.
 	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
-	require.Len(t, lines, 1, "expected one surviving event, got: %s", out.String())
+	require.Len(t, lines, 3, "expected 3 surviving events, got: %s", out.String())
 
-	var got apitype.EngineEvent
-	require.NoError(t, json.Unmarshal([]byte(lines[0]), &got))
-	require.NotNil(t, got.ResourcePreEvent)
-	assert.Equal(t, apitype.OpUpdate, got.ResourcePreEvent.Metadata.Op)
-	assert.Equal(t, map[string]any{"foo": "old"}, got.ResourcePreEvent.Metadata.Old.Inputs)
-	assert.Equal(t, map[string]any{"foo": "new"}, got.ResourcePreEvent.Metadata.New.Inputs)
+	var stdoutEvt apitype.EngineEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &stdoutEvt))
+	require.NotNil(t, stdoutEvt.StdoutEvent, "stdout event must pass through")
+	assert.Equal(t, "boot", stdoutEvt.StdoutEvent.Message)
+
+	var updateEvt apitype.EngineEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[1]), &updateEvt))
+	require.NotNil(t, updateEvt.ResourcePreEvent)
+	assert.Equal(t, apitype.OpUpdate, updateEvt.ResourcePreEvent.Metadata.Op)
+	assert.Equal(t, map[string]any{"foo": "old"}, updateEvt.ResourcePreEvent.Metadata.Old.Inputs)
+	assert.Equal(t, map[string]any{"foo": "new"}, updateEvt.ResourcePreEvent.Metadata.New.Inputs)
+
+	var summaryEvt apitype.EngineEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[2]), &summaryEvt))
+	require.NotNil(t, summaryEvt.SummaryEvent, "summary event must pass through")
 }
 
 func TestRunChangesOnly_EmptyStream(t *testing.T) {

--- a/pkg/cmd/pulumi/events/changes_only_test.go
+++ b/pkg/cmd/pulumi/events/changes_only_test.go
@@ -26,8 +26,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// resourcePreEvent is a tiny helper for building ResourcePreEvent fixtures in table tests.
+// resourcePreEvent builds a ResourcePreEvent fixture. Outputs share the input keys (mirroring what
+// most Pulumi providers do: outputs include every input plus derived fields) and add a derived
+// `id` key, so tests can observe how the --changes-only filter narrows both `Inputs` and
+// `Outputs` using the same `Diffs` list.
 func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string]any) apitype.EngineEvent {
+	oldOut := map[string]any{"id": "id-old"}
+	for k := range oldIn {
+		oldOut[k] = "out-old-" + k
+	}
+	newOut := map[string]any{"id": "id-new"}
+	for k := range newIn {
+		newOut[k] = "out-new-" + k
+	}
 	return apitype.EngineEvent{
 		Sequence:  7,
 		Timestamp: 42,
@@ -37,8 +48,8 @@ func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string
 				URN:   "urn:pulumi:stack::proj::pkg:index:Res::r",
 				Type:  "pkg:index:Res",
 				Diffs: diffs,
-				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: map[string]any{"o": 1}},
-				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: map[string]any{"o": 2}},
+				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: oldOut},
+				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: newOut},
 			},
 		},
 	}
@@ -89,7 +100,8 @@ func TestFilterChangesOnly_KeepsReadRefreshDiscardAndReplacements(t *testing.T) 
 
 	// Read, refresh, read-replacement, and read-discard all represent real observable changes:
 	// a resource was pulled in, refreshed state diverged, or a resource was dropped from state.
-	// They must survive the filter.
+	// They must survive the filter and — when `Diffs` is reported — be narrowed the same way as
+	// update/replace.
 	ops := []apitype.OpType{
 		apitype.OpRead,
 		apitype.OpReadReplacement,
@@ -107,14 +119,16 @@ func TestFilterChangesOnly_KeepsReadRefreshDiscardAndReplacements(t *testing.T) 
 			require.NotNil(t, got.ResourcePreEvent)
 			md := got.ResourcePreEvent.Metadata
 			assert.Equal(t, op, md.Op)
-			// Diffs, when present, still restrict inputs regardless of the op.
 			assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
 			assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
+			assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs,
+				"Outputs must be narrowed by the same Diffs list as inputs")
+			assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs)
 		})
 	}
 }
 
-func TestFilterChangesOnly_UpdateRestrictsInputsAndKeepsOutputs(t *testing.T) {
+func TestFilterChangesOnly_UpdateRestrictsInputsAndOutputsToDiffs(t *testing.T) {
 	t.Parallel()
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable", "baz": "also-stable"}
@@ -137,13 +151,13 @@ func TestFilterChangesOnly_UpdateRestrictsInputsAndKeepsOutputs(t *testing.T) {
 		"Old.Inputs must contain only changed keys")
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs,
 		"New.Inputs must contain only changed keys")
-	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs,
-		"Old.Outputs must be preserved — consumers still want to see resulting state")
-	assert.Equal(t, map[string]any{"o": 2}, md.New.Outputs,
-		"New.Outputs must be preserved")
+	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs,
+		"Old.Outputs must be narrowed to the same Diffs keys; the derived `id` key is dropped")
+	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs,
+		"New.Outputs must be narrowed to the same Diffs keys")
 }
 
-func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
+func TestFilterChangesOnly_ReplaceRestrictsInputsAndOutputsToDiffs(t *testing.T) {
 	t.Parallel()
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable"}
@@ -155,13 +169,15 @@ func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
 	md := got.ResourcePreEvent.Metadata
 	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
 	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
+	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, md.Old.Outputs)
+	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, md.New.Outputs)
 }
 
 func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 	t.Parallel()
 
 	// Creates have no "Old" state and typically no Diffs; every property is new, so the full
-	// Inputs map is preserved along with the Outputs.
+	// `Inputs` and `Outputs` maps are preserved.
 	evt := apitype.EngineEvent{
 		ResourcePreEvent: &apitype.ResourcePreEvent{
 			Metadata: apitype.StepEventMetadata{
@@ -169,7 +185,7 @@ func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
 				New: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "a", "bar": "b"},
-					Outputs: map[string]any{"o": 1},
+					Outputs: map[string]any{"id": "xyz", "foo": "a"},
 				},
 			},
 		},
@@ -181,7 +197,8 @@ func TestFilterChangesOnly_CreateKeepsAllInputsAndOutputs(t *testing.T) {
 	assert.Nil(t, md.Old)
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.New.Inputs,
 		"create events keep all inputs — every property is new")
-	assert.Equal(t, map[string]any{"o": 1}, md.New.Outputs, "outputs must be preserved")
+	assert.Equal(t, map[string]any{"id": "xyz", "foo": "a"}, md.New.Outputs,
+		"create events keep all outputs with no Diffs to narrow by")
 }
 
 func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
@@ -194,7 +211,7 @@ func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
 				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
 				Old: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "a", "bar": "b"},
-					Outputs: map[string]any{"o": 1},
+					Outputs: map[string]any{"id": "xyz", "foo": "a"},
 				},
 			},
 		},
@@ -205,14 +222,16 @@ func TestFilterChangesOnly_DeleteKeepsAllOldInputsAndOutputs(t *testing.T) {
 	md := got.ResourcePreEvent.Metadata
 	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.Old.Inputs,
 		"delete events keep all old inputs — consumers need to know what's gone")
-	assert.Equal(t, map[string]any{"o": 1}, md.Old.Outputs, "outputs must be preserved")
+	assert.Equal(t, map[string]any{"id": "xyz", "foo": "a"}, md.Old.Outputs,
+		"delete events keep all old outputs with no Diffs to narrow by")
 	assert.Nil(t, md.New)
 }
 
 func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 	t.Parallel()
 
-	// ResOutputsEvent with an update op.
+	// ResOutputsEvent with an update op — outputs are narrowed by Diffs the same way as
+	// ResourcePreEvent.
 	outputs := apitype.EngineEvent{
 		ResOutputsEvent: &apitype.ResOutputsEvent{
 			Metadata: apitype.StepEventMetadata{
@@ -221,7 +240,7 @@ func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 				Diffs: []string{"foo"},
 				New: &apitype.StepEventStateMetadata{
 					Inputs:  map[string]any{"foo": "n", "bar": "s"},
-					Outputs: map[string]any{"o": 1},
+					Outputs: map[string]any{"foo": "post-n", "id": "xyz"},
 				},
 			},
 		},
@@ -230,8 +249,8 @@ func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
 	require.NotNil(t, gotOut)
 	require.NotNil(t, gotOut.ResOutputsEvent)
 	assert.Equal(t, map[string]any{"foo": "n"}, gotOut.ResOutputsEvent.Metadata.New.Inputs)
-	assert.Equal(t, map[string]any{"o": 1}, gotOut.ResOutputsEvent.Metadata.New.Outputs,
-		"ResOutputsEvent outputs must be preserved")
+	assert.Equal(t, map[string]any{"foo": "post-n"}, gotOut.ResOutputsEvent.Metadata.New.Outputs,
+		"ResOutputsEvent outputs must be narrowed by Diffs")
 
 	// ResOpFailedEvent with a create op retains Status/Steps on the copy.
 	failed := apitype.EngineEvent{
@@ -259,8 +278,8 @@ func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
 
 	oldIn := map[string]any{"foo": "old", "bar": "stable"}
 	newIn := map[string]any{"foo": "new", "bar": "stable"}
-	originalOldOutputs := map[string]any{"o": 1}
-	originalNewOutputs := map[string]any{"o": 2}
+	originalOldOutputs := map[string]any{"foo": "out-old", "id": "x"}
+	originalNewOutputs := map[string]any{"foo": "out-new", "id": "y"}
 
 	evt := apitype.EngineEvent{
 		Sequence:  1,
@@ -281,8 +300,8 @@ func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
 	// The originals must be untouched: filter callers expect a pure function.
 	assert.Equal(t, map[string]any{"foo": "old", "bar": "stable"}, oldIn)
 	assert.Equal(t, map[string]any{"foo": "new", "bar": "stable"}, newIn)
-	assert.Equal(t, map[string]any{"o": 1}, originalOldOutputs)
-	assert.Equal(t, map[string]any{"o": 2}, originalNewOutputs)
+	assert.Equal(t, map[string]any{"foo": "out-old", "id": "x"}, originalOldOutputs)
+	assert.Equal(t, map[string]any{"foo": "out-new", "id": "y"}, originalNewOutputs)
 	assert.Equal(t, oldIn, evt.ResourcePreEvent.Metadata.Old.Inputs)
 	assert.Equal(t, newIn, evt.ResourcePreEvent.Metadata.New.Inputs)
 }
@@ -325,6 +344,8 @@ func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
 	assert.Equal(t, apitype.OpUpdate, updateEvt.ResourcePreEvent.Metadata.Op)
 	assert.Equal(t, map[string]any{"foo": "old"}, updateEvt.ResourcePreEvent.Metadata.Old.Inputs)
 	assert.Equal(t, map[string]any{"foo": "new"}, updateEvt.ResourcePreEvent.Metadata.New.Inputs)
+	assert.Equal(t, map[string]any{"foo": "out-old-foo"}, updateEvt.ResourcePreEvent.Metadata.Old.Outputs)
+	assert.Equal(t, map[string]any{"foo": "out-new-foo"}, updateEvt.ResourcePreEvent.Metadata.New.Outputs)
 
 	var summaryEvt apitype.EngineEvent
 	require.NoError(t, json.Unmarshal([]byte(lines[2]), &summaryEvt))

--- a/pkg/cmd/pulumi/events/events.go
+++ b/pkg/cmd/pulumi/events/events.go
@@ -27,12 +27,9 @@ import (
 // Hidden from `--help` while the interface is being developed.
 func NewEventsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "events",
-		Short: "Operate on engine event streams",
-		Long: "Operate on engine event streams.\n" +
-			"\n" +
-			"Subcommands ingest an engine event stream (typically piped from `pulumi up --json`\n" +
-			"or similar) and produce a transformed stream on stdout.\n",
+		Use:    "events",
+		Short:  "Work with engine event streams",
+		Long:   "Commands for working with Pulumi engine event streams.\n",
 		Hidden: true,
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)

--- a/pkg/cmd/pulumi/events/events.go
+++ b/pkg/cmd/pulumi/events/events.go
@@ -15,26 +15,27 @@
 package events
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// NewEventsCmd is the parent of the `pulumi events` subcommand tree. It does not perform any
+// work on its own — running `pulumi events` without a subcommand prints the command's help text.
+// Behaviour lives on the subcommands (currently `filter`).
+//
+// Hidden from `--help` while the interface is being developed.
 func NewEventsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "events",
 		Short: "Operate on engine event streams",
 		Long: "Operate on engine event streams.\n" +
 			"\n" +
-			"Reads an engine event stream from stdin and writes it to stdout.\n",
+			"Subcommands ingest an engine event stream (typically piped from `pulumi up --json`\n" +
+			"or similar) and produce a transformed stream on stdout.\n",
 		Hidden: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())
-			return err
-		},
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	cmd.AddCommand(NewFilterCmd())
 	return cmd
 }

--- a/pkg/cmd/pulumi/events/events.go
+++ b/pkg/cmd/pulumi/events/events.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func NewEventsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "events",
+		Short: "Operate on engine event streams",
+		Long: "Operate on engine event streams.\n" +
+			"\n" +
+			"Reads an engine event stream from stdin and writes it to stdout.\n",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())
+			return err
+		},
+	}
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	return cmd
+}

--- a/pkg/cmd/pulumi/events/filter.go
+++ b/pkg/cmd/pulumi/events/filter.go
@@ -38,6 +38,7 @@ func NewFilterCmd() *cobra.Command {
 			"\n" +
 			"With --changes-only, events are filtered down to only resource changes, and\n" +
 			"each event's state metadata is restricted to the properties that changed.\n",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !changesOnly {
 				_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())

--- a/pkg/cmd/pulumi/events/filter.go
+++ b/pkg/cmd/pulumi/events/filter.go
@@ -1,0 +1,54 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+// NewFilterCmd builds the `pulumi events filter` command. With no flags it is effectively `cat`:
+// it reads a JSONL engine event stream from stdin and writes it back to stdout unchanged. Flags
+// select concrete filters — currently `--changes-only`.
+func NewFilterCmd() *cobra.Command {
+	var changesOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "filter",
+		Short: "Filter an engine event stream",
+		Long: "Filter an engine event stream.\n" +
+			"\n" +
+			"Reads an engine event stream from stdin and writes it to stdout. With no flags\n" +
+			"the stream is passed through unchanged.\n" +
+			"\n" +
+			"With --changes-only, events are filtered down to only resource changes, and\n" +
+			"each event's state metadata is restricted to the properties that changed.\n",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !changesOnly {
+				_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())
+				return err
+			}
+			return runChangesOnly(cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	cmd.Flags().BoolVar(
+		&changesOnly, "changes-only", false,
+		"Keep only resource-change events and strip each event down to the properties that changed.")
+	return cmd
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -507,6 +507,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				trace.NewViewTraceCmd(),
 				trace.NewConvertTraceCmd(),
 				events.NewReplayEventsCmd(),
+				events.NewEventsCmd(),
 				clispec.NewGenCLISpecCmd(cmd),
 			},
 		},


### PR DESCRIPTION
## Summary

First iteration of the `pulumi events` command from the [design doc](https://www.notion.so/pulumi-events-344fdbdf1cce803b92edd4b16bb4f3b7). Absorbs #22670.

The tree is rooted so further subcommands (`fetch`, `summary`, ...) can be added without overloading `events` itself:

- `pulumi events` — parent command; `pulumi events` with no args just prints help.
- `pulumi events filter` — reads JSONL events from stdin and writes to stdout. With no flags it is `cat`.
- `pulumi events filter --changes-only` — drops resource events with `OpSame` (the engine's explicit "nothing changed" marker) and, for kept events, restricts `Inputs` to the top-level keys the provider reported via `Diffs`. Every other event — non-resource events (stdout, diagnostic, summary, prelude, ...) and resource events with any other op (create, update, replace, delete, read, refresh, read-replacement, read-discard) — is kept. Outputs are preserved.

Both the parent command and `filter` are `Hidden: true` while the interface is being shaped. No changelog entry for that reason.

## `--changes-only` semantics

| Event                                             | Behaviour                                                   |
| ------------------------------------------------- | ----------------------------------------------------------- |
| Non-resource (stdout, diagnostic, summary, ...)   | Pass through unchanged                                      |
| Resource, `op = same`                             | Drop                                                        |
| Resource, other op, `Diffs` non-empty             | Keep; restrict `Old.Inputs` / `New.Inputs` to those keys    |
| Resource, other op, empty `Diffs` (create/delete) | Keep; full inputs preserved                                 |
| Any kept event                                    | `Outputs` preserved                                         |

## Composition

```sh
pulumi up --json | pulumi events filter --changes-only           # live stream, filtered
cat event-log.jsonl | pulumi events filter --changes-only        # replay from disk
pulumi events filter --changes-only < event-log.jsonl | jq .     # inspect with jq
```

## Test plan

- [x] `pulumi --help` does not show `events`.
- [x] `pulumi events` prints help (no action).
- [x] `pulumi events filter` is `cat` for a JSONL stream.
- [x] `pulumi events filter --changes-only`:
  - keeps non-resource events (stdout, summary, diagnostic, ...)
  - drops `OpSame`
  - keeps `OpRead`, `OpRefresh`, `OpReadDiscard`, `OpReadReplacement` with `Diffs`-restricted inputs
  - restricts `Inputs` to `Diffs` on `OpUpdate` / `OpReplace`
  - keeps full inputs on `OpCreate` / `OpDelete`
  - preserves `Outputs` on every kept event
  - covers `ResOutputsEvent` and `ResOpFailedEvent` the same way
  - does not mutate the input event
  - handles empty and malformed streams
- [x] `mise exec -- go test ./cmd/pulumi/events/...` — pass.
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/events/...` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)