### PR TITLE
Add `--changes-only` filter to `pulumi events`

### DIFF
--- a/pkg/cmd/pulumi/events/changes_only.go
+++ b/pkg/cmd/pulumi/events/changes_only.go
@@ -1,0 +1,108 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// filterChangesOnly applies the `--changes-only` transform to a single engine event, returning nil
+// if the event should be dropped from the stream or a freshly-constructed, filtered copy otherwise.
+//
+// The filter matches the behaviour of `pulumi preview --json --changes-only` (see pulumi/pulumi
+// #22068): only resource-lifecycle events for real changes are kept, and their state metadata is
+// restricted to the properties that actually changed.
+//
+//   - Events that aren't resource-lifecycle events (stdout, diagnostic, prelude, progress, policy,
+//     summary, ...) are dropped entirely.
+//   - Resource events whose op is `same`, `read`, `read-replacement`, `discard`, or `refresh` are
+//     dropped: these are observations, not changes.
+//   - For `update` and `replace` ops the `Inputs` map on `Old` and `New` is restricted to the top
+//     level keys the provider reported via `Diffs`. For creates, deletes, and other ops every
+//     property is, by definition, new or gone so inputs are kept in full.
+//   - `Outputs` are dropped from `Old` and `New` for every kept event: they describe post-state,
+//     not the change itself.
+//
+// The input event is never mutated; every pointer returned references freshly-allocated structs so
+// callers can safely keep and modify the result.
+func filterChangesOnly(evt apitype.EngineEvent) *apitype.EngineEvent {
+	var md *apitype.StepEventMetadata
+	switch {
+	case evt.ResourcePreEvent != nil:
+		md = &evt.ResourcePreEvent.Metadata
+	case evt.ResOutputsEvent != nil:
+		md = &evt.ResOutputsEvent.Metadata
+	case evt.ResOpFailedEvent != nil:
+		md = &evt.ResOpFailedEvent.Metadata
+	default:
+		return nil
+	}
+
+	//exhaustive:ignore
+	switch md.Op {
+	case apitype.OpSame, apitype.OpRead, apitype.OpReadReplacement, apitype.OpReadDiscard, apitype.OpRefresh:
+		return nil
+	}
+
+	filteredMd := *md
+	filteredMd.Old = filterStateChangesOnly(md.Old, md.Op, md.Diffs)
+	filteredMd.New = filterStateChangesOnly(md.New, md.Op, md.Diffs)
+
+	out := apitype.EngineEvent{Sequence: evt.Sequence, Timestamp: evt.Timestamp}
+	switch {
+	case evt.ResourcePreEvent != nil:
+		cp := *evt.ResourcePreEvent
+		cp.Metadata = filteredMd
+		out.ResourcePreEvent = &cp
+	case evt.ResOutputsEvent != nil:
+		cp := *evt.ResOutputsEvent
+		cp.Metadata = filteredMd
+		out.ResOutputsEvent = &cp
+	case evt.ResOpFailedEvent != nil:
+		cp := *evt.ResOpFailedEvent
+		cp.Metadata = filteredMd
+		out.ResOpFailedEvent = &cp
+	}
+	return &out
+}
+
+// filterStateChangesOnly returns a filtered copy of s suitable for `--changes-only` output.
+// Outputs are always dropped; inputs are kept in full for every op except update and replace, where
+// they are restricted to the top-level keys in diffs.
+func filterStateChangesOnly(
+	s *apitype.StepEventStateMetadata, op apitype.OpType, diffs []string,
+) *apitype.StepEventStateMetadata {
+	if s == nil {
+		return nil
+	}
+	out := *s
+	out.Outputs = map[string]any{}
+	//exhaustive:ignore
+	switch op {
+	case apitype.OpUpdate, apitype.OpReplace:
+		keep := make(map[string]bool, len(diffs))
+		for _, k := range diffs {
+			keep[k] = true
+		}
+		filtered := make(map[string]any, len(keep))
+		for k, v := range s.Inputs {
+			if keep[k] {
+				filtered[k] = v
+			}
+		}
+		out.Inputs = filtered
+	}
+	return &out
+}

--- a/pkg/cmd/pulumi/events/changes_only_test.go
+++ b/pkg/cmd/pulumi/events/changes_only_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// resourcePreEvent is a tiny helper for building ResourcePreEvent fixtures in table tests.
+func resourcePreEvent(op apitype.OpType, diffs []string, oldIn, newIn map[string]any) apitype.EngineEvent {
+	return apitype.EngineEvent{
+		Sequence:  7,
+		Timestamp: 42,
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    op,
+				URN:   "urn:pulumi:stack::proj::pkg:index:Res::r",
+				Type:  "pkg:index:Res",
+				Diffs: diffs,
+				Old:   &apitype.StepEventStateMetadata{URN: "urn:old", Inputs: oldIn, Outputs: map[string]any{"o": 1}},
+				New:   &apitype.StepEventStateMetadata{URN: "urn:new", Inputs: newIn, Outputs: map[string]any{"o": 2}},
+			},
+		},
+	}
+}
+
+func TestFilterChangesOnly_DropsNonResourceEvents(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		event apitype.EngineEvent
+	}{
+		{"cancel", apitype.EngineEvent{CancelEvent: &apitype.CancelEvent{}}},
+		{"stdout", apitype.EngineEvent{StdoutEvent: &apitype.StdoutEngineEvent{Message: "hi"}}},
+		{"diagnostic", apitype.EngineEvent{DiagnosticEvent: &apitype.DiagnosticEvent{Message: "warn"}}},
+		{"prelude", apitype.EngineEvent{PreludeEvent: &apitype.PreludeEvent{}}},
+		{"summary", apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{}}},
+		{"policy", apitype.EngineEvent{PolicyEvent: &apitype.PolicyEvent{}}},
+		{"policy-remediation", apitype.EngineEvent{PolicyRemediationEvent: &apitype.PolicyRemediationEvent{}}},
+		{"policy-load", apitype.EngineEvent{PolicyLoadEvent: &apitype.PolicyLoadEvent{}}},
+		{"progress", apitype.EngineEvent{ProgressEvent: &apitype.ProgressEvent{}}},
+		{"start-debugging", apitype.EngineEvent{StartDebuggingEvent: &apitype.StartDebuggingEvent{}}},
+		{"error", apitype.EngineEvent{ErrorEvent: &apitype.ErrorEvent{}}},
+		{"empty", apitype.EngineEvent{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, filterChangesOnly(c.event), "%s events must be dropped under --changes-only", c.name)
+		})
+	}
+}
+
+func TestFilterChangesOnly_DropsNonChangeOps(t *testing.T) {
+	t.Parallel()
+
+	ops := []apitype.OpType{
+		apitype.OpSame,
+		apitype.OpRead,
+		apitype.OpReadReplacement,
+		apitype.OpReadDiscard,
+		apitype.OpRefresh,
+	}
+	for _, op := range ops {
+		t.Run(string(op), func(t *testing.T) {
+			t.Parallel()
+			evt := resourcePreEvent(op, nil, map[string]any{"foo": "a"}, map[string]any{"foo": "b"})
+			assert.Nil(t, filterChangesOnly(evt),
+				"op %q is an observation, not a change, and must be dropped", op)
+		})
+	}
+}
+
+func TestFilterChangesOnly_UpdateRestrictsInputsToDiffs(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable", "baz": "also-stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable", "baz": "also-stable"}
+	evt := resourcePreEvent(apitype.OpUpdate, []string{"foo"}, oldIn, newIn)
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got, "update event should survive the filter")
+	require.NotNil(t, got.ResourcePreEvent)
+
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, apitype.OpUpdate, md.Op)
+	// Sequence/timestamp are passed through unchanged.
+	assert.Equal(t, 7, got.Sequence)
+	assert.Equal(t, 42, got.Timestamp)
+
+	require.NotNil(t, md.Old)
+	require.NotNil(t, md.New)
+	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs,
+		"Old.Inputs must contain only changed keys")
+	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs,
+		"New.Inputs must contain only changed keys")
+	assert.Empty(t, md.Old.Outputs, "Old.Outputs must be dropped")
+	assert.Empty(t, md.New.Outputs, "New.Outputs must be dropped")
+}
+
+func TestFilterChangesOnly_ReplaceRestrictsInputsToDiffs(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable"}
+	evt := resourcePreEvent(apitype.OpReplace, []string{"foo"}, oldIn, newIn)
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, map[string]any{"foo": "old"}, md.Old.Inputs)
+	assert.Equal(t, map[string]any{"foo": "new"}, md.New.Inputs)
+}
+
+func TestFilterChangesOnly_CreateKeepsAllInputs(t *testing.T) {
+	t.Parallel()
+
+	// Creates have no "Old" state; the engine typically sets Old to nil.
+	evt := apitype.EngineEvent{
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpCreate,
+				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
+				New: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "a", "bar": "b"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Nil(t, md.Old)
+	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.New.Inputs,
+		"create events keep all inputs — every property is new")
+	assert.Empty(t, md.New.Outputs, "outputs are still stripped")
+}
+
+func TestFilterChangesOnly_DeleteKeepsAllOldInputs(t *testing.T) {
+	t.Parallel()
+
+	evt := apitype.EngineEvent{
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpDelete,
+				URN: "urn:pulumi:stack::proj::pkg:index:Res::r",
+				Old: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "a", "bar": "b"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+
+	got := filterChangesOnly(evt)
+	require.NotNil(t, got)
+	md := got.ResourcePreEvent.Metadata
+	assert.Equal(t, map[string]any{"foo": "a", "bar": "b"}, md.Old.Inputs,
+		"delete events keep all old inputs — consumers need to know what's gone")
+	assert.Empty(t, md.Old.Outputs)
+	assert.Nil(t, md.New)
+}
+
+func TestFilterChangesOnly_KeepsResOutputsAndResOpFailed(t *testing.T) {
+	t.Parallel()
+
+	// ResOutputsEvent with an update op.
+	outputs := apitype.EngineEvent{
+		ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    apitype.OpUpdate,
+				URN:   "urn",
+				Diffs: []string{"foo"},
+				New: &apitype.StepEventStateMetadata{
+					Inputs:  map[string]any{"foo": "n", "bar": "s"},
+					Outputs: map[string]any{"o": 1},
+				},
+			},
+		},
+	}
+	gotOut := filterChangesOnly(outputs)
+	require.NotNil(t, gotOut)
+	require.NotNil(t, gotOut.ResOutputsEvent)
+	assert.Equal(t, map[string]any{"foo": "n"}, gotOut.ResOutputsEvent.Metadata.New.Inputs)
+
+	// ResOpFailedEvent with a create op retains Status/Steps on the copy.
+	failed := apitype.EngineEvent{
+		ResOpFailedEvent: &apitype.ResOpFailedEvent{
+			Status: 3,
+			Steps:  5,
+			Metadata: apitype.StepEventMetadata{
+				Op:  apitype.OpCreate,
+				URN: "urn",
+				New: &apitype.StepEventStateMetadata{
+					Inputs: map[string]any{"foo": "a"},
+				},
+			},
+		},
+	}
+	gotFail := filterChangesOnly(failed)
+	require.NotNil(t, gotFail)
+	require.NotNil(t, gotFail.ResOpFailedEvent)
+	assert.Equal(t, 3, gotFail.ResOpFailedEvent.Status)
+	assert.Equal(t, 5, gotFail.ResOpFailedEvent.Steps)
+}
+
+func TestFilterChangesOnly_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	oldIn := map[string]any{"foo": "old", "bar": "stable"}
+	newIn := map[string]any{"foo": "new", "bar": "stable"}
+	originalOldOutputs := map[string]any{"o": 1}
+	originalNewOutputs := map[string]any{"o": 2}
+
+	evt := apitype.EngineEvent{
+		Sequence:  1,
+		Timestamp: 2,
+		ResourcePreEvent: &apitype.ResourcePreEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:    apitype.OpUpdate,
+				URN:   "urn",
+				Diffs: []string{"foo"},
+				Old:   &apitype.StepEventStateMetadata{Inputs: oldIn, Outputs: originalOldOutputs},
+				New:   &apitype.StepEventStateMetadata{Inputs: newIn, Outputs: originalNewOutputs},
+			},
+		},
+	}
+
+	_ = filterChangesOnly(evt)
+
+	// The originals must be untouched: filter callers expect a pure function.
+	assert.Equal(t, map[string]any{"foo": "old", "bar": "stable"}, oldIn)
+	assert.Equal(t, map[string]any{"foo": "new", "bar": "stable"}, newIn)
+	assert.Equal(t, map[string]any{"o": 1}, originalOldOutputs)
+	assert.Equal(t, map[string]any{"o": 2}, originalNewOutputs)
+	assert.Equal(t, oldIn, evt.ResourcePreEvent.Metadata.Old.Inputs)
+	assert.Equal(t, newIn, evt.ResourcePreEvent.Metadata.New.Inputs)
+}
+
+func TestRunChangesOnly_FiltersJSONLStream(t *testing.T) {
+	t.Parallel()
+
+	// Build an input stream that mixes events that should be dropped with one real update.
+	events := []apitype.EngineEvent{
+		{StdoutEvent: &apitype.StdoutEngineEvent{Message: "boot"}},
+		resourcePreEvent(apitype.OpSame, nil, map[string]any{"x": 1}, map[string]any{"x": 1}),
+		resourcePreEvent(apitype.OpUpdate, []string{"foo"},
+			map[string]any{"foo": "old", "bar": "s"},
+			map[string]any{"foo": "new", "bar": "s"}),
+		{SummaryEvent: &apitype.SummaryEvent{}},
+	}
+
+	var input bytes.Buffer
+	enc := json.NewEncoder(&input)
+	for _, e := range events {
+		require.NoError(t, enc.Encode(e))
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runChangesOnly(&input, &out))
+
+	// Only the update event should survive.
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, 1, "expected one surviving event, got: %s", out.String())
+
+	var got apitype.EngineEvent
+	require.NoError(t, json.Unmarshal([]byte(lines[0]), &got))
+	require.NotNil(t, got.ResourcePreEvent)
+	assert.Equal(t, apitype.OpUpdate, got.ResourcePreEvent.Metadata.Op)
+	assert.Equal(t, map[string]any{"foo": "old"}, got.ResourcePreEvent.Metadata.Old.Inputs)
+	assert.Equal(t, map[string]any{"foo": "new"}, got.ResourcePreEvent.Metadata.New.Inputs)
+}
+
+func TestRunChangesOnly_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	require.NoError(t, runChangesOnly(strings.NewReader(""), &out))
+	assert.Empty(t, out.String())
+}
+
+func TestRunChangesOnly_MalformedJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := runChangesOnly(strings.NewReader("{not json}\n"), &out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding event")
+}

--- a/pkg/cmd/pulumi/events/events.go
+++ b/pkg/cmd/pulumi/events/events.go
@@ -15,26 +15,65 @@
 package events
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func NewEventsCmd() *cobra.Command {
+	var changesOnly bool
+
 	cmd := &cobra.Command{
 		Use:   "events",
 		Short: "Operate on engine event streams",
 		Long: "Operate on engine event streams.\n" +
 			"\n" +
-			"Reads an engine event stream from stdin and writes it to stdout.\n",
+			"Reads an engine event stream from stdin and writes it to stdout.\n" +
+			"\n" +
+			"With --changes-only, events are filtered down to only resource changes, and\n" +
+			"each event's state metadata is restricted to the properties that changed.\n",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())
-			return err
+			if !changesOnly {
+				_, err := io.Copy(cmd.OutOrStdout(), cmd.InOrStdin())
+				return err
+			}
+			return runChangesOnly(cmd.InOrStdin(), cmd.OutOrStdout())
 		},
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	cmd.Flags().BoolVar(
+		&changesOnly, "changes-only", false,
+		"Keep only resource-change events and strip each event down to the properties that changed.")
 	return cmd
+}
+
+// runChangesOnly reads a JSONL engine event stream from in, applies the `--changes-only` filter
+// to each event, and writes the surviving events back as JSONL to out. Decoding errors are
+// surfaced to the caller so that malformed input fails fast rather than silently dropping events.
+func runChangesOnly(in io.Reader, out io.Writer) error {
+	dec := json.NewDecoder(in)
+	enc := json.NewEncoder(out)
+	for {
+		var evt apitype.EngineEvent
+		if err := dec.Decode(&evt); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("decoding event: %w", err)
+		}
+		filtered := filterChangesOnly(evt)
+		if filtered == nil {
+			continue
+		}
+		if err := enc.Encode(filtered); err != nil {
+			return fmt.Errorf("encoding event: %w", err)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Second iteration of `pulumi events` (stacked on #22669). Adds a `--changes-only` flag that filters the event stream down to only real resource changes, and restricts each event's state metadata to the properties that actually changed.

Closes one of the open discussion threads in the [design doc](https://www.notion.so/pulumi-events-344fdbdf1cce803b92edd4b16bb4f3b7): `changes-only` lands as a flag on `pulumi events`, not as a separate subcommand. This leaves room for a future `filter` subcommand if the need arises — `--changes-only` is the first concrete filter.

Mirrors the behaviour proposed for `pulumi preview --json --changes-only` in #22585 (closed), moved to the event-stream layer so it composes with any source of engine events — pipes, files, or the future Pulumi Cloud fetch subcommand.

## Filter behaviour

- **Non-resource-lifecycle events are dropped entirely**: stdout, diagnostic, prelude, summary, policy, progress, cancel, start-debugging, error.
- **Resource events whose op is an observation are dropped**: `same`, `read`, `read-replacement`, `discard`, `refresh`.
- **For `update` and `replace`**, `Old.Inputs` and `New.Inputs` are restricted to the top-level keys the provider reported via `Diffs`. For creates and deletes, inputs are kept in full (every property is, by definition, new or gone).
- **`Outputs` are stripped from every kept event** — they describe post-state, not the change itself.

The filter is a pure function on `apitype.EngineEvent`: it never mutates the input and returns a freshly-allocated event pointer (or nil to drop).

## Composition

Because the filter operates on the event stream, it chains with any producer of JSONL events:

```sh
pulumi up --json | pulumi events --changes-only                # live stream, filtered
cat event-log.jsonl | pulumi events --changes-only             # replay from disk
pulumi events --changes-only < event-log.jsonl | jq .          # inspect with jq
```

The flag lives alongside the `events` command itself — both are hidden from `--help` while the interface is still being shaped. No changelog entry for that reason.

## Test plan

- [x] Unit tests in [`changes_only_test.go`](pkg/cmd/pulumi/events/changes_only_test.go):
  - Non-resource events (12 types) → dropped
  - Resource events with non-change ops (same/read/read-replacement/discard/refresh) → dropped
  - `OpUpdate` → inputs restricted to `Diffs`, outputs empty
  - `OpReplace` → same treatment as `OpUpdate`
  - `OpCreate` → full inputs, outputs empty
  - `OpDelete` → full old inputs, outputs empty
  - `ResOutputsEvent` and `ResOpFailedEvent` follow the same rules as `ResourcePreEvent`; `Status`/`Steps` preserved on failure events
  - Filter does not mutate the input event
  - JSONL stream round-trip: mixed events in → only the surviving update event out
  - Empty stream → empty output
  - Malformed JSON → error surfaced
- [x] `mise exec -- go test ./cmd/pulumi/events/...` — all pass
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/events/...` — 0 issues
- [x] Manual smoke test: piping a synthetic JSONL stream through `pulumi events --changes-only` drops the expected events and filters inputs as expected; passthrough (no flag) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)