### PR TITLE
engine: return clear error for provider name conflicts instead of panicking

### DIFF
--- a/changelog/pending/20260422--engine--return-clear-error-for-provider-name-conflict-instead-of-panicking.yaml
+++ b/changelog/pending/20260422--engine--return-clear-error-for-provider-name-conflict-instead-of-panicking.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Return a clear error when two installed plugins claim the same default provider package name (for example, a native `scaleway` provider alongside a `terraform-provider` bridge parameterized as `scaleway`) instead of panicking with "Should not have seen an older plugin if sorting is correct!"

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -667,14 +667,14 @@ func describePluginSource(p workspace.PackageDescriptor) string {
 	return fmt.Sprintf("plugin %q%s", p.Name, pluginVer)
 }
 
-// ambigiousPluginSourceError is returned when two distinct plugins both claim
+// ambiguousPluginSourceError is returned when two distinct plugins both claim
 // to provide the same default provider package name.
-type ambigiousPluginSourceError struct {
+type ambiguousPluginSourceError struct {
 	pkg  tokens.Package
 	a, b workspace.PackageDescriptor
 }
 
-func (err ambigiousPluginSourceError) Error() string {
+func (err ambiguousPluginSourceError) Error() string {
 	return fmt.Sprintf(
 		"package %q is provided by more than one plugin:\n"+
 			"  %s\n"+
@@ -751,7 +751,7 @@ func computeDefaultProviderPackages(
 
 		if seenPlugin, has := defaultProviderPlugins[name]; has {
 			if !samePluginSource(seenPlugin, p) {
-				return nil, ambigiousPluginSourceError{name, seenPlugin, p}
+				return nil, ambiguousPluginSourceError{name, seenPlugin, p}
 			}
 
 			if seenPlugin.Version == nil {

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -659,10 +659,46 @@ func installPlugin(
 // that the engine uses to determine which version of a particular provider to load.
 //
 // Note: it is critical that this function be 100% deterministic.
+// samePluginSource reports whether two PackageDescriptors refer to the same
+// underlying plugin (matching binary Name and matching parameterization
+// origin). Two descriptors that differ only in version are the same source;
+// two descriptors with different plugin Names (for example, a native
+// "scaleway" provider and a "terraform-provider" bridge parameterized as
+// "scaleway") are not.
+func samePluginSource(a, b workspace.PackageDescriptor) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if (a.Parameterization == nil) != (b.Parameterization == nil) {
+		return false
+	}
+	if a.Parameterization != nil && a.Parameterization.Name != b.Parameterization.Name {
+		return false
+	}
+	return true
+}
+
+// describePluginSource returns a human-readable description of a plugin that
+// distinguishes bridged (parameterized) packages from native ones. The output
+// of PackageDescriptor.String is insufficient here because it collapses both
+// forms onto the parameterized name, which hides the distinction users need
+// to resolve a conflict.
+func describePluginSource(p workspace.PackageDescriptor) string {
+	var pluginVer string
+	if p.Version != nil {
+		pluginVer = " v" + p.Version.String()
+	}
+	if p.Parameterization != nil {
+		return fmt.Sprintf("plugin %q%s parameterized as %q v%s",
+			p.Name, pluginVer, p.Parameterization.Name, p.Parameterization.Version.String())
+	}
+	return fmt.Sprintf("plugin %q%s", p.Name, pluginVer)
+}
+
 func computeDefaultProviderPackages(
 	languagePackages PackageSet,
 	allPackages PackageSet,
-) map[tokens.Package]workspace.PackageDescriptor {
+) (map[tokens.Package]workspace.PackageDescriptor, error) {
 	// Language hosts are not required to specify the full set of plugins they depend on. If the set of plugins received
 	// from the language host does not include any resource providers, fall back to the full set of plugins.
 	languageReportedProviderPlugins := false
@@ -704,6 +740,23 @@ func computeDefaultProviderPackages(
 		name := tokens.Package(p.PackageName())
 
 		if seenPlugin, has := defaultProviderPlugins[name]; has {
+			// Two different underlying plugins cannot both provide the same default
+			// provider package name. This happens, for example, when a project
+			// installs both a native Pulumi provider named "scaleway" and a bridged
+			// Terraform provider added via `pulumi package add terraform-provider
+			// scaleway/scaleway`, which parameterizes the bridge as "scaleway".
+			// Return a clear error so the user can uninstall one or disambiguate
+			// with an explicit `provider` option on each resource.
+			if !samePluginSource(seenPlugin, p) {
+				return nil, fmt.Errorf(
+					"package %q is provided by more than one plugin:\n"+
+						"  %s\n"+
+						"  %s\n"+
+						"Remove one of the packages, or pass an explicit `provider` "+
+						"option on each resource to disambiguate.",
+					name, describePluginSource(seenPlugin), describePluginSource(p))
+			}
+
 			if seenPlugin.Version == nil {
 				logging.V(preparePluginLog).Infof(
 					"computeDefaultProviderPlugins(): plugin %s selected for package %s (override, previous was nil)",
@@ -743,5 +796,5 @@ func computeDefaultProviderPackages(
 		defaultProviderInfo[name] = plugin
 	}
 
-	return defaultProviderInfo
+	return defaultProviderInfo, nil
 }

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -741,13 +741,7 @@ func computeDefaultProviderPackages(
 			// Return a clear error so the user can uninstall one or disambiguate
 			// with an explicit `provider` option on each resource.
 			if !samePluginSource(seenPlugin, p) {
-				return nil, fmt.Errorf(
-					"package %q is provided by more than one plugin:\n"+
-						"  %s\n"+
-						"  %s\n"+
-						"Remove one of the packages, or pass an explicit `provider` "+
-						"option on each resource to disambiguate.",
-					name, describePluginSource(seenPlugin), describePluginSource(p))
+				return nil, ambigiousPluginSourceError{name, seenPlugin, p}
 			}
 
 			if seenPlugin.Version == nil {

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -638,27 +638,6 @@ func installPlugin(
 	return nil
 }
 
-// computeDefaultProviderPackages computes, for every package, a mapping from packages to semver versions reflecting the
-// version of a provider that should be used as the "default" resource when registering resources. This function takes
-// two sets of packages:
-//
-// - a set given to us from the language host; and
-// - the full set of packages.
-//
-// If the language host has sent us a non-empty set of packages, we will use those exclusively to service default
-// provider requests. Otherwise, we will use the full set of packages, which is the existing behavior today.
-//
-// The justification for favoring the language host is that, ultimately, it is the language host that produces resource
-// registrations and therefore it is the language host that should dictate exactly what package to use to satisfy a
-// resource registration. SDKs have the opportunity to specify what plugin (pluginDownloadURL and version) they want to
-// use in RegisterResource. If the plugin is left unspecified, we make a best-guess effort to infer the version and URL
-// that the language host actually wants.
-//
-// Whenever a resource arrives via RegisterResource and does not explicitly specify which provider to use, the engine
-// injects a "default" provider resource that will serve as that resource's provider. This function computes the map
-// that the engine uses to determine which version of a particular provider to load.
-//
-// Note: it is critical that this function be 100% deterministic.
 // samePluginSource reports whether two PackageDescriptors refer to the same
 // underlying plugin (matching binary Name and matching parameterization
 // origin). Two descriptors that differ only in version are the same source;
@@ -666,7 +645,7 @@ func installPlugin(
 // "scaleway" provider and a "terraform-provider" bridge parameterized as
 // "scaleway") are not.
 func samePluginSource(a, b workspace.PackageDescriptor) bool {
-	return a.Name == b.Name && 
+	return a.Name == b.Name &&
 		(a.Parameterization == nil) == (b.Parameterization == nil) &&
 		(a.Parameterization == nil || a.Parameterization.Name == b.Parameterization.Name)
 }
@@ -688,6 +667,44 @@ func describePluginSource(p workspace.PackageDescriptor) string {
 	return fmt.Sprintf("plugin %q%s", p.Name, pluginVer)
 }
 
+// ambigiousPluginSourceError is returned when two distinct plugins both claim
+// to provide the same default provider package name.
+type ambigiousPluginSourceError struct {
+	pkg  tokens.Package
+	a, b workspace.PackageDescriptor
+}
+
+func (err ambigiousPluginSourceError) Error() string {
+	return fmt.Sprintf(
+		"package %q is provided by more than one plugin:\n"+
+			"  %s\n"+
+			"  %s\n"+
+			"Remove one of the packages, or pass an explicit `provider` "+
+			"option on each resource to disambiguate.",
+		err.pkg, describePluginSource(err.a), describePluginSource(err.b))
+}
+
+// computeDefaultProviderPackages computes, for every package, a mapping from packages to semver versions reflecting the
+// version of a provider that should be used as the "default" resource when registering resources. This function takes
+// two sets of packages:
+//
+// - a set given to us from the language host; and
+// - the full set of packages.
+//
+// If the language host has sent us a non-empty set of packages, we will use those exclusively to service default
+// provider requests. Otherwise, we will use the full set of packages, which is the existing behavior today.
+//
+// The justification for favoring the language host is that, ultimately, it is the language host that produces resource
+// registrations and therefore it is the language host that should dictate exactly what package to use to satisfy a
+// resource registration. SDKs have the opportunity to specify what plugin (pluginDownloadURL and version) they want to
+// use in RegisterResource. If the plugin is left unspecified, we make a best-guess effort to infer the version and URL
+// that the language host actually wants.
+//
+// Whenever a resource arrives via RegisterResource and does not explicitly specify which provider to use, the engine
+// injects a "default" provider resource that will serve as that resource's provider. This function computes the map
+// that the engine uses to determine which version of a particular provider to load.
+//
+// Note: it is critical that this function be 100% deterministic.
 func computeDefaultProviderPackages(
 	languagePackages PackageSet,
 	allPackages PackageSet,
@@ -733,13 +750,6 @@ func computeDefaultProviderPackages(
 		name := tokens.Package(p.PackageName())
 
 		if seenPlugin, has := defaultProviderPlugins[name]; has {
-			// Two different underlying plugins cannot both provide the same default
-			// provider package name. This happens, for example, when a project
-			// installs both a native Pulumi provider named "scaleway" and a bridged
-			// Terraform provider added via `pulumi package add terraform-provider
-			// scaleway/scaleway`, which parameterizes the bridge as "scaleway".
-			// Return a clear error so the user can uninstall one or disambiguate
-			// with an explicit `provider` option on each resource.
 			if !samePluginSource(seenPlugin, p) {
 				return nil, ambigiousPluginSourceError{name, seenPlugin, p}
 			}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -666,16 +666,9 @@ func installPlugin(
 // "scaleway" provider and a "terraform-provider" bridge parameterized as
 // "scaleway") are not.
 func samePluginSource(a, b workspace.PackageDescriptor) bool {
-	if a.Name != b.Name {
-		return false
-	}
-	if (a.Parameterization == nil) != (b.Parameterization == nil) {
-		return false
-	}
-	if a.Parameterization != nil && a.Parameterization.Name != b.Parameterization.Name {
-		return false
-	}
-	return true
+	return a.Name == b.Name && 
+		(a.Parameterization == nil) == (b.Parameterization == nil) &&
+		(a.Parameterization == nil || a.Parameterization.Name == b.Parameterization.Name)
 }
 
 // describePluginSource returns a human-readable description of a plugin that

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -720,9 +720,9 @@ func TestAmbigiousPluginSourceErrorMessage(t *testing.T) {
 
 	err := ambigiousPluginSourceError{"target", target, parameterized}
 	assert.Equal(t,
-		`package "target" is provided by more than one plugin:`+"\n"+
-			`  plugin "target" v1.47.0`+"\n"+
-			`  plugin "parameterize-base" v1.1.1 parameterized as "target" v2.73.0`+"\n"+
-			"Remove one of the packages, or pass an explicit `provider` option on each resource to disambiguate.",
+		`package "target" is provided by more than one plugin:
+  plugin "target" v1.47.0
+  plugin "parameterize-base" v1.1.1 parameterized as "target" v2.73.0
+Remove one of the packages, or pass an explicit `+"`provider`"+` option on each resource to disambiguate.`,
 		err.Error())
 }

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -653,9 +653,9 @@ func TestDefaultProvidersConflictAcrossDifferentPlugins(t *testing.T) {
 	plugins := NewPackageSet(target, parameterized)
 	_, err := computeDefaultProviderPackages(plugins, plugins)
 
-	var actualErr ambigiousPluginSourceError
+	var actualErr ambiguousPluginSourceError
 	require.ErrorAs(t, err, &actualErr)
-	assert.Equal(t, ambigiousPluginSourceError{"target", target, parameterized}, actualErr)
+	assert.Equal(t, ambiguousPluginSourceError{"target", target, parameterized}, actualErr)
 }
 
 func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {
@@ -696,7 +696,7 @@ func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {
 	}, result)
 }
 
-func TestAmbigiousPluginSourceErrorMessage(t *testing.T) {
+func TestAmbiguousPluginSourceErrorMessage(t *testing.T) {
 	t.Parallel()
 
 	target := workspace.PackageDescriptor{
@@ -718,7 +718,7 @@ func TestAmbigiousPluginSourceErrorMessage(t *testing.T) {
 		},
 	}
 
-	err := ambigiousPluginSourceError{"target", target, parameterized}
+	err := ambiguousPluginSourceError{"target", target, parameterized}
 	assert.Equal(t,
 		`package "target" is provided by more than one plugin:
   plugin "target" v1.47.0

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -652,10 +652,9 @@ func TestDefaultProvidersConflictAcrossDifferentPlugins(t *testing.T) {
 
 	plugins := NewPackageSet(native, bridged)
 	result, err := computeDefaultProviderPackages(plugins, plugins)
-	require.Error(t, err)
-	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "\"scaleway\"")
-	assert.Contains(t, err.Error(), "terraform-provider")
+	var actualErr ambigiousPluginSourceError
+	require.ErrorAs(t, err, &actualErr)
+	assert.Equal(t, ambigiousPluginSourceError{"scaleway", native, bridged})
 }
 
 func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -626,63 +626,64 @@ func TestDefaultProviderPluginsSorting(t *testing.T) {
 func TestDefaultProvidersConflictAcrossDifferentPlugins(t *testing.T) {
 	t.Parallel()
 
-	// Two distinct plugins both claim to provide the Pulumi package name
-	// "scaleway": a native plugin named "scaleway" and a bridged Terraform
-	// provider parameterized as "scaleway". The engine must return a clear
-	// error instead of panicking or silently picking a winner. Regression
-	// test for https://github.com/pulumi/pulumi/issues/22678.
-	native := workspace.PackageDescriptor{
+	// Two distinct plugins both claim to provide the same Pulumi package name
+	// "target": one native plugin named "target" and one bridge plugin
+	// ("parameterize-base") parameterized as "target". The engine must return
+	// a clear error instead of panicking or silently picking a winner.
+	// Regression test for https://github.com/pulumi/pulumi/issues/22678.
+	target := workspace.PackageDescriptor{
 		PluginDescriptor: workspace.PluginDescriptor{
-			Name:    "scaleway",
+			Name:    "target",
 			Version: mustMakeVersion("1.47.0"),
 			Kind:    apitype.ResourcePlugin,
 		},
 	}
-	bridged := workspace.PackageDescriptor{
+	parameterized := workspace.PackageDescriptor{
 		PluginDescriptor: workspace.PluginDescriptor{
-			Name:    "terraform-provider",
+			Name:    "parameterize-base",
 			Version: mustMakeVersion("1.1.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 		Parameterization: &workspace.Parameterization{
-			Name:    "scaleway",
+			Name:    "target",
 			Version: semver.MustParse("2.73.0"),
 		},
 	}
 
-	plugins := NewPackageSet(native, bridged)
-	result, err := computeDefaultProviderPackages(plugins, plugins)
+	plugins := NewPackageSet(target, parameterized)
+	_, err := computeDefaultProviderPackages(plugins, plugins)
+
 	var actualErr ambigiousPluginSourceError
 	require.ErrorAs(t, err, &actualErr)
-	assert.Equal(t, ambigiousPluginSourceError{"scaleway", native, bridged})
+	assert.Equal(t, ambigiousPluginSourceError{"target", target, parameterized}, actualErr)
 }
 
 func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {
 	t.Parallel()
 
-	// Two PackageDescriptors from the same bridge plugin ("terraform-provider")
-	// with the same parameterization name ("scaleway") but different
+	// Two PackageDescriptors from the same bridge plugin ("parameterize-base")
+	// with the same parameterization name ("target") but different
 	// parameterization versions should be treated as "same source, different
 	// versions" and resolve cleanly to the newer one, not as a conflict.
 	older := workspace.PackageDescriptor{
 		PluginDescriptor: workspace.PluginDescriptor{
-			Name:    "terraform-provider",
+			Name:    "parameterize-base",
 			Version: mustMakeVersion("1.1.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 		Parameterization: &workspace.Parameterization{
-			Name:    "scaleway",
+			Name:    "target",
 			Version: semver.MustParse("2.72.0"),
 		},
 	}
 	newer := workspace.PackageDescriptor{
 		PluginDescriptor: workspace.PluginDescriptor{
-			Name:    "terraform-provider",
+			Name:    "parameterize-base",
 			Version: mustMakeVersion("1.1.1"),
 			Kind:    apitype.ResourcePlugin,
 		},
 		Parameterization: &workspace.Parameterization{
-			Name:    "scaleway",
+			Name:    "target",
 			Version: semver.MustParse("2.73.0"),
 		},
 	}
@@ -690,9 +691,38 @@ func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {
 	plugins := NewPackageSet(older, newer)
 	result, err := computeDefaultProviderPackages(plugins, plugins)
 	require.NoError(t, err)
-	require.NotNil(t, result)
-	got, ok := result[tokens.Package("scaleway")]
-	require.True(t, ok)
-	require.NotNil(t, got.Parameterization)
-	assert.Equal(t, "2.73.0", got.Parameterization.Version.String())
+	assert.Equal(t, map[tokens.Package]workspace.PackageDescriptor{
+		"target": newer,
+	}, result)
+}
+
+func TestAmbigiousPluginSourceErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	target := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "target",
+			Version: mustMakeVersion("1.47.0"),
+			Kind:    apitype.ResourcePlugin,
+		},
+	}
+	parameterized := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "parameterize-base",
+			Version: mustMakeVersion("1.1.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
+		Parameterization: &workspace.Parameterization{
+			Name:    "target",
+			Version: semver.MustParse("2.73.0"),
+		},
+	}
+
+	err := ambigiousPluginSourceError{"target", target, parameterized}
+	assert.Equal(t,
+		`package "target" is provided by more than one plugin:`+"\n"+
+			`  plugin "target" v1.47.0`+"\n"+
+			`  plugin "parameterize-base" v1.1.1 parameterized as "target" v2.73.0`+"\n"+
+			"Remove one of the packages, or pass an explicit `provider` option on each resource to disambiguate.",
+		err.Error())
 }

--- a/pkg/engine/plugins_test.go
+++ b/pkg/engine/plugins_test.go
@@ -52,7 +52,8 @@ func TestDefaultProvidersSingle(t *testing.T) {
 		},
 	})
 
-	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	defaultProviders, err := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	require.NoError(t, err)
 	require.NotNil(t, defaultProviders)
 
 	aws, ok := defaultProviders[tokens.Package("aws")]
@@ -88,7 +89,8 @@ func TestDefaultProvidersOverrideNoVersion(t *testing.T) {
 		},
 	})
 
-	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	defaultProviders, err := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	require.NoError(t, err)
 	require.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -123,7 +125,8 @@ func TestDefaultProvidersOverrideNewerVersion(t *testing.T) {
 		},
 	})
 
-	defaultProviders := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	defaultProviders, err := computeDefaultProviderPackages(languagePlugins, NewPackageSet())
+	require.NoError(t, err)
 	require.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -151,7 +154,8 @@ func TestDefaultProvidersSnapshotOverrides(t *testing.T) {
 		},
 	})
 
-	defaultProviders := computeDefaultProviderPackages(languagePlugins, snapshotPlugins)
+	defaultProviders, err := computeDefaultProviderPackages(languagePlugins, snapshotPlugins)
+	require.NoError(t, err)
 	require.NotNil(t, defaultProviders)
 	aws, ok := defaultProviders[tokens.Package("aws")]
 	assert.True(t, ok)
@@ -612,8 +616,84 @@ func TestDefaultProviderPluginsSorting(t *testing.T) {
 		},
 	}
 	plugins := NewPackageSet(p1, p2)
-	result := computeDefaultProviderPackages(plugins, plugins)
+	result, err := computeDefaultProviderPackages(plugins, plugins)
+	require.NoError(t, err)
 	assert.Equal(t, map[tokens.Package]workspace.PackageDescriptor{
 		"foo": p2,
 	}, result)
+}
+
+func TestDefaultProvidersConflictAcrossDifferentPlugins(t *testing.T) {
+	t.Parallel()
+
+	// Two distinct plugins both claim to provide the Pulumi package name
+	// "scaleway": a native plugin named "scaleway" and a bridged Terraform
+	// provider parameterized as "scaleway". The engine must return a clear
+	// error instead of panicking or silently picking a winner. Regression
+	// test for https://github.com/pulumi/pulumi/issues/22678.
+	native := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "scaleway",
+			Version: mustMakeVersion("1.47.0"),
+			Kind:    apitype.ResourcePlugin,
+		},
+	}
+	bridged := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "terraform-provider",
+			Version: mustMakeVersion("1.1.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
+		Parameterization: &workspace.Parameterization{
+			Name:    "scaleway",
+			Version: semver.MustParse("2.73.0"),
+		},
+	}
+
+	plugins := NewPackageSet(native, bridged)
+	result, err := computeDefaultProviderPackages(plugins, plugins)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "\"scaleway\"")
+	assert.Contains(t, err.Error(), "terraform-provider")
+}
+
+func TestDefaultProvidersSameBridgeDifferentVersions(t *testing.T) {
+	t.Parallel()
+
+	// Two PackageDescriptors from the same bridge plugin ("terraform-provider")
+	// with the same parameterization name ("scaleway") but different
+	// parameterization versions should be treated as "same source, different
+	// versions" and resolve cleanly to the newer one, not as a conflict.
+	older := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "terraform-provider",
+			Version: mustMakeVersion("1.1.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
+		Parameterization: &workspace.Parameterization{
+			Name:    "scaleway",
+			Version: semver.MustParse("2.72.0"),
+		},
+	}
+	newer := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "terraform-provider",
+			Version: mustMakeVersion("1.1.1"),
+			Kind:    apitype.ResourcePlugin,
+		},
+		Parameterization: &workspace.Parameterization{
+			Name:    "scaleway",
+			Version: semver.MustParse("2.73.0"),
+		},
+	}
+
+	plugins := NewPackageSet(older, newer)
+	result, err := computeDefaultProviderPackages(plugins, plugins)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	got, ok := result[tokens.Package("scaleway")]
+	require.True(t, ok)
+	require.NotNil(t, got.Parameterization)
+	assert.Equal(t, "2.73.0", got.Parameterization.Version.String())
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -534,7 +534,10 @@ func installPlugins(
 	}
 
 	// Collect the version information for default providers.
-	defaultProviderVersions := computeDefaultProviderPackages(languagePackages, allPackages)
+	defaultProviderVersions, err := computeDefaultProviderPackages(languagePackages, allPackages)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return allPlugins, defaultProviderVersions, nil
 }


### PR DESCRIPTION
## Summary

Fixes #22678.

When two installed plugins resolve to the same Pulumi provider package name (for example, a native `scaleway` provider alongside a `terraform-provider` bridge parameterized as `scaleway`), `computeDefaultProviderPackages` used to panic via `contract.Failf` with:

```
Panic: fatal: A failure has occurred: Should not have seen an older plugin if sorting is correct!
  terraform-provider-1.1.1
  scaleway-1.47.0
```

That message is misleading: the two descriptors are not older/newer versions of the same plugin, they are two distinct plugins claiming the same package name. The sort invariant was never applicable.

This PR detects the case explicitly and returns a descriptive error naming both conflicting plugins:

```
error: package "scaleway" is provided by more than one plugin:
  plugin "scaleway" v1.47.0
  plugin "terraform-provider" v1.1.1 parameterized as "scaleway" v2.73.0
Remove one of the packages, or pass an explicit `provider` option on each resource to disambiguate.
```

## Approach

- Added a small `samePluginSource` helper that treats two `PackageDescriptor`s as the same source when they share the plugin binary `Name` and the same parameterization origin (both nil, or both set with the same `Parameterization.Name`). Different versions of the same source remain "same source".
- Added a `describePluginSource` helper that formats a descriptor distinguishing native from bridged (parameterized) packages, which `PackageDescriptor.String` alone does not.
- Changed `computeDefaultProviderPackages` to return `(map, error)`. Single caller in `pkg/engine/update.go` propagates the error up the existing `(allPlugins, defaultProviderVersions, error)` return.
- Updated the five existing tests to handle the new return signature.

## Test plan

- [x] `go test ./engine/ -run TestDefaultProvider` - 7 passed, 0 failed
- [x] New test `TestDefaultProvidersConflictAcrossDifferentPlugins` asserts an error naming both plugins when a native `scaleway` and a `terraform-provider`-bridged `scaleway` collide
- [x] New test `TestDefaultProvidersSameBridgeDifferentVersions` asserts that two descriptors from the same bridge plugin with the same parameterization name and different parameterization versions still resolve cleanly to the newer one
- [x] Built `pulumi` from this branch, ran it against the repro project at https://github.com/wlami/pulumi-provider-name-conflict-repro - the panic is replaced with the descriptive error above, exit code non-zero, no stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)