### PR TITLE
Drop "With" prefix from generated option helpers

### DIFF
--- a/changelog/pending/20260422--auto-go--drop-the-with-prefix-from-generated-option-helpers.yaml
+++ b/changelog/pending/20260422--auto-go--drop-the-with-prefix-from-generated-option-helpers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: auto/go
+  description: Drop the "With" prefix from generated option helpers so they match the naming of the existing optXxx packages

--- a/sdk/go/tools/automation/main.go
+++ b/sdk/go/tools/automation/main.go
@@ -418,7 +418,11 @@ func buildOptionHelpers(typeName, command string, fields []optionField) []ast.De
 		return nil
 	}
 
-	// All helpers in a package share the simple names Option / With<Field>.
+	// All helpers in a package share the simple names Option / <Field>. The
+	// helpers intentionally carry no prefix so they match the naming used by
+	// the existing hand-written optXxx packages (for example optup.Stack,
+	// optup.ContinueOnError). The integration PR can then replace those
+	// packages with the generated ones without churning call sites.
 	optionTypeName := "Option"
 
 	decls := make([]ast.Decl, 0, 1+len(fields))
@@ -447,11 +451,11 @@ func buildOptionHelpers(typeName, command string, fields []optionField) []ast.De
 		Specs: []ast.Spec{optionType},
 	})
 
-	// One With* helper per field.
+	// One helper per field, named after the field itself.
 	for _, f := range fields {
-		funcName := "With" + f.name
+		funcName := f.name
 
-		// func With<Field>(v <T>) Option
+		// func <Field>(v <T>) Option
 		fn := &ast.FuncDecl{
 			Doc: &ast.CommentGroup{
 				List: []*ast.Comment{{

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -85,12 +85,12 @@ func TestCancel_WithStackName(t *testing.T) {
 func TestCancel_WithStackFlag(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(context.Background(), nil, optcancel.WithStack("dev"))
+		r, err := api.Cancel(context.Background(), nil, optcancel.Stack("dev"))
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes --stack dev"
 	if got != want {
-		t.Fatalf("Cancel(WithStack=dev) = %q, want %q", got, want)
+		t.Fatalf("Cancel(Stack=dev) = %q, want %q", got, want)
 	}
 }
 
@@ -135,7 +135,7 @@ func TestOrgSearch_RepeatableQuery(t *testing.T) {
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearch(
 			context.Background(),
-			optorgsearch.WithQuery([]string{"foo", "bar"}),
+			optorgsearch.Query([]string{"foo", "bar"}),
 		)
 		return r.Stdout, err
 	})
@@ -150,7 +150,7 @@ func TestOrgSearchAi_SingleQuery(t *testing.T) {
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearchAi(
 			context.Background(),
-			optorgsearchai.WithQuery("hello"),
+			optorgsearchai.Query("hello"),
 		)
 		return r.Stdout, err
 	})
@@ -190,7 +190,7 @@ func TestStateMove_WithBooleanFlag(t *testing.T) {
 		r, err := api.StateMove(
 			context.Background(),
 			[]string{"urn:1"},
-			optstatemove.WithIncludeParents(true),
+			optstatemove.IncludeParents(true),
 		)
 		return r.Stdout, err
 	})
@@ -206,8 +206,8 @@ func TestStateMove_WithSourceAndDest(t *testing.T) {
 		r, err := api.StateMove(
 			context.Background(),
 			[]string{"urn:1"},
-			optstatemove.WithSource("dev"),
-			optstatemove.WithDest("prod"),
+			optstatemove.Source("dev"),
+			optstatemove.Dest("prod"),
 		)
 		return r.Stdout, err
 	})


### PR DESCRIPTION
## Summary

Follow-up to #22061 and #22612. Renames the generated per-command option
helpers from `WithX(v T) Option` to just `X(v T) Option`, so they match
the naming convention already used by the hand-written `optXxx` packages
in `sdk/go/auto` (e.g. `optup.Stack`, `optup.ContinueOnError`,
`optpreview.Target`).

Doing this now means the integration PR (tracked by #22166) can
replace a hand-written `optXxx` package with its generated counterpart
without churning every call site in `sdk/go/auto` and downstream users.

## What changes

`sdk/go/tools/automation/main.go`: one line — the funcName builder in
`buildOptionHelpers` drops the `With` prefix. The surrounding comment
now records why the prefix is absent so the next reader can find the
reasoning without digging through git history.

Before:

```go
// WithStack returns an Option that sets Stack.
func WithStack(v string) Option {
    return func(o *Options) { o.Stack = v }
}
```

After:

```go
// Stack returns an Option that sets Stack.
func Stack(v string) Option {
    return func(o *Options) { o.Stack = v }
}
```

The `Options` struct and `Option` function type keep the same names; no
collision because `Options` (type) and `Stack` (func) live in different
Go namespaces.

`sdk/go/tools/automation/tests/runtime/commands_test.go`: six call
sites updated to the new names (`optcancel.Stack`, `optorgsearch.Query`,
`optorgsearchai.Query`, `optstatemove.IncludeParents`,
`optstatemove.Source`, `optstatemove.Dest`). Test function names like
`TestCancel_WithStackFlag` are left alone — there the word "With" is
the English preposition, not a reference to the helper prefix.

## Non-goals / follow-ups

- **Name-collision guardrails.** Today's fixture doesn't contain a flag
  named `options`, `option`, `new`, or any of the `BaseOptions` fields
  (`cwd`, `stdout`, `stderr`, `stdin`, `additional-env`). If a future
  CLI flag lands with one of those names it will either shadow an
  embedded field silently or produce a duplicate-identifier error at
  `go build` time. Worth a dedicated follow-up that teaches
  `buildOptionHelpers` to detect and suffix.
- **`BaseOptions` helpers.** The follow-up flagged in #22612 to emit
  `Cwd`, `Stdout`, `Stderr`, `Stdin`, `AdditionalEnv` helpers in every
  `optXxx` package is still open; it is a separate PR.

## Test plan

- [x] `mise exec -- go test -count=1 ./tools/automation/...` — all three
  outer tests (determinism, compile, runtime subprocess) and twelve
  runtime assertions pass.
- [x] `mise exec -- golangci-lint run ./tools/automation/...` — 0 issues.
- [x] Eyeballed a regenerated `output/optcancel/options.go`: helpers are
  `Color`, `Stack`, `Verbose` (no prefix), type `Option` and struct
  `Options` still present, and the `base.BaseOptions` embedding is
  unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)