### PR TITLE
skip signal cancellation tests

### DIFF
--- a/tests/integration/signal_cancellation/signal_cancellation_test.go
+++ b/tests/integration/signal_cancellation/signal_cancellation_test.go
@@ -34,6 +34,8 @@ func TestSignalCancellation(t *testing.T) {
 		t.Skip("Sending SIGINT to a process is not supported on Windows")
 	}
 	t.Parallel()
+	// TODO[pulumi/pulumi#22683]: Re-enable when we fix the underlying issue
+	t.Skip("flaky test, see pulumi/pulumi#22683")
 	for _, lang := range []string{"go", "python", "nodejs"} {
 		t.Run(lang, func(t *testing.T) {
 			t.Parallel()
@@ -87,6 +89,8 @@ func TestSignalCancellationForceKill(t *testing.T) {
 		t.Skip("Sending SIGINT to a process is not supported on Windows")
 	}
 	t.Parallel()
+	// TODO[pulumi/pulumi#22683]: Re-enable when we fix the underlying issue
+	t.Skip("flaky test, see pulumi/pulumi#22683")
 	for _, lang := range []string{"go_ignore", "python_ignore", "nodejs_ignore"} {
 		t.Run(lang, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
These tests are very flaky in CI.  Skip them until we find a solution to fix them and unflake them.

/xref #22683 