### PR TITLE
Gitignore `.claude/scheduled_tasks.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ yarn-error.log
 # Local environment settings
 .env
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Local mise.toml
 .mise.local.toml


### PR DESCRIPTION
## Summary

Adds `.claude/scheduled_tasks.lock` to `.gitignore` so the lock file stays out of future commits.

Extracted from #22638 to land independently.

## Test plan

- [x] `git status` no longer reports the lock file as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)