### PR TITLE
Cancel providers before closing them

### DIFF
--- a/changelog/pending/20260422--engine--signal-providers-to-cancel-before-closing-them-during-replacement.yaml
+++ b/changelog/pending/20260422--engine--signal-providers-to-cancel-before-closing-them-during-replacement.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Signal providers to cancel before closing them during replacement

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
@@ -501,6 +502,14 @@ func (r *Registry) setProviderLocked(ref providers.Reference, provider plugin.Pr
 	}
 }
 
+func (r *Registry) cancelAndCloseProvider(provider plugin.Provider) {
+	cancelCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	contract.IgnoreError(provider.SignalCancellation(cancelCtx))
+	contract.IgnoreClose(provider)
+}
+
 // setProviderAndCloseOld sets the provider at ref and closes any previously registered provider at that ref.
 // This should be used when overwriting is expected (e.g., Update) to avoid leaking the old provider instance.
 func (r *Registry) setProviderAndCloseOld(ref providers.Reference, provider plugin.Provider) {
@@ -511,7 +520,7 @@ func (r *Registry) setProviderAndCloseOld(ref providers.Reference, provider plug
 
 	if hadOld && oldProvider != provider {
 		logging.V(7).Infof("setProviderAndCloseOld(%v): closing old provider", ref)
-		contract.IgnoreClose(oldProvider)
+		r.cancelAndCloseProvider(oldProvider)
 	}
 }
 
@@ -680,7 +689,7 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 		AllowUnknowns: true,
 	})
 	if len(resp.Failures) != 0 || err != nil {
-		contract.IgnoreClose(provider)
+		r.cancelAndCloseProvider(provider)
 		return plugin.CheckResponse{Failures: resp.Failures}, err
 	}
 
@@ -774,7 +783,7 @@ func (r *Registry) Diff(ctx context.Context, req plugin.DiffRequest) (plugin.Dif
 
 	// If the diff requires replacement, unload the provider: the engine will reload it during its replacememnt Check.
 	if diff.Replace() {
-		contract.IgnoreClose(provider)
+		r.cancelAndCloseProvider(provider)
 	}
 
 	logging.V(7).Infof("%s: executed (%#v, %#v)", label, diff.Changes, diff.ReplaceKeys)
@@ -869,7 +878,7 @@ func (r *Registry) Same(ctx context.Context, res *resource.State, fromCheck bool
 		ID:     &res.ID,
 		Inputs: FilterProviderConfig(res.Inputs),
 	}); err != nil {
-		contract.IgnoreClose(provider)
+		r.cancelAndCloseProvider(provider)
 		return fmt.Errorf("configure provider '%v': %w", urn, err)
 	}
 
@@ -883,7 +892,7 @@ func (r *Registry) Same(ctx context.Context, res *resource.State, fromCheck bool
 	} else {
 		if !r.setProviderIfNotExists(ref, provider) {
 			// A provider was already registered (likely by a concurrent Update). Close ours to avoid leaks.
-			contract.IgnoreClose(provider)
+			r.cancelAndCloseProvider(provider)
 		}
 	}
 
@@ -1028,7 +1037,7 @@ func (r *Registry) Delete(_ context.Context, req plugin.DeleteRequest) (plugin.D
 		return plugin.DeleteResponse{}, nil
 	}
 
-	contract.IgnoreClose(provider)
+	r.cancelAndCloseProvider(provider)
 	return plugin.DeleteResponse{}, nil
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -133,6 +133,22 @@ type testProvider struct {
 	config     func(resource.PropertyMap) error
 }
 
+type lifecycleTrackingProvider struct {
+	*testProvider
+	closeCalls  int
+	cancelCalls int
+}
+
+func (p *lifecycleTrackingProvider) Close() error {
+	p.closeCalls++
+	return nil
+}
+
+func (p *lifecycleTrackingProvider) SignalCancellation(context.Context) error {
+	p.cancelCalls++
+	return nil
+}
+
 func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
@@ -699,6 +715,57 @@ func TestCRUDNoProviders(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, check.Failures)
 	assert.Nil(t, check.Properties)
+}
+
+func TestDiffReplaceSignalsCancellationBeforeClose(t *testing.T) {
+	t.Parallel()
+
+	var tracked *lifecycleTrackingProvider
+	loader := newLoader(t, "pkgA", "1.0.0", func(pkg tokens.Package, ver semver.Version) (plugin.Provider, error) {
+		tracked = &lifecycleTrackingProvider{
+			testProvider: &testProvider{
+				pkg:     pkg,
+				version: ver,
+				checkConfig: func(
+					_ resource.URN, _ resource.PropertyMap, news resource.PropertyMap, _ bool,
+				) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					return news, nil, nil
+				},
+				diffConfig: func(
+					_ resource.URN, _ resource.PropertyMap, _ resource.PropertyMap, _ bool, _ []string,
+				) (plugin.DiffResult, error) {
+					return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"id"}}, nil
+				},
+				config: func(resource.PropertyMap) error { return nil },
+			},
+		}
+		return tracked, nil
+	})
+
+	r := NewRegistry(newPluginHost(t, []*providerLoader{loader}), false, nil)
+	typ := providers.MakeProviderType("pkgA")
+	urn := resource.NewURN("test", "test", "", typ, "a")
+
+	_, err := r.Check(t.Context(), plugin.CheckRequest{
+		URN:  urn,
+		Olds: resource.PropertyMap{},
+		News: resource.PropertyMap{"version": resource.NewProperty("1.0.0")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tracked)
+
+	diff, err := r.Diff(t.Context(), plugin.DiffRequest{
+		URN:        urn,
+		ID:         resource.ID("existing"),
+		OldOutputs: resource.PropertyMap{},
+		NewInputs:  resource.PropertyMap{"version": resource.NewProperty("1.0.0")},
+	})
+	require.NoError(t, err)
+	require.True(t, diff.Replace())
+
+	// Registry should signal cancellation before closing on replace.
+	assert.Equal(t, 1, tracked.closeCalls)
+	assert.Equal(t, 1, tracked.cancelCalls)
 }
 
 func TestCRUDWrongPackage(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/22662

In https://github.com/pulumi/pulumi/pull/22569 we started tracking if providers were expected to be terminated differently. This worked well for providers that we called Cancel against, which is most of the time. But if we ever killed a provider we didn't set the "expect shutdown" flag and would later print an error saying it had shutdown unexpectedly. 
This used to only fire if our health check against the provider suggested it was dead.

Turns out a load of registry paths did exactly this, Close without Cancel, and so we ended up printing out loads of errors that providers had shutdown unexpectedly.

This adds a test to the registry to check that we call Cancel before Close in a replace diff, and fixes all the `IgnoreClose(provider)` call sites to instead call a helper that calls Cancel then Close.