### PR TITLE
neo preview and up tools

### DIFF
--- a/changelog/pending/20260422--cli--add-pulumi-preview-and-up-tools-to-pulumi-neo.yaml
+++ b/changelog/pending/20260422--cli--add-pulumi-preview-and-up-tools-to-pulumi-neo.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: feat
+  scope: cli
+  description: |
+    Add `pulumi_preview` and `pulumi_up` as local tools for the experimental `pulumi neo`
+    agent. The Neo TUI renders a persistent bordered block for each operation that
+    streams changed resources and diagnostics as the engine runs and finalizes with a
+    summary of the op counts. Hidden behind PULUMI_EXPERIMENTAL.

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -175,22 +175,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	uiCh := make(chan UIEvent, 64)
 	outCh := make(chan outboundEvent, 8)
 
-	// Translate each PulumiSink callback into the matching UIEvent on uiCh. The
-	// TUI builds a persistent preview/up block from these events.
-	pu.Sink = &tools.PulumiSink{
-		OnStart: func(toolName, stackName string, isPreview bool) {
-			sendUI(uiCh, UIPulumiStart{ToolName: toolName, StackName: stackName, IsPreview: isPreview})
-		},
-		OnResource: func(toolName string, op displaytypes.StepOp, urn, typ, status string) {
-			sendUI(uiCh, UIPulumiResource{ToolName: toolName, Op: op, URN: urn, Type: typ, Status: status})
-		},
-		OnDiag: func(toolName, severity, message, urn string) {
-			sendUI(uiCh, UIPulumiDiag{ToolName: toolName, Severity: severity, Message: message, URN: urn})
-		},
-		OnEnd: func(toolName, errStr string, counts displaytypes.ResourceChanges, elapsed string) {
-			sendUI(uiCh, UIPulumiEnd{ToolName: toolName, Err: errStr, Counts: counts, Elapsed: elapsed})
-		},
-	}
+	pu.Sink = newPulumiSinkForUI(uiCh)
 
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
@@ -345,4 +330,24 @@ func resolveTaskTarget(
 		return "", "", "", errors.New("could not determine an organization for the Neo task; pass --org")
 	}
 	return org, projectName, stack, nil
+}
+
+// newPulumiSinkForUI builds a tools.PulumiSink whose callbacks translate each
+// progress signal into the matching UIEvent on uiCh. Pure mechanical
+// translation
+func newPulumiSinkForUI(uiCh chan<- UIEvent) *tools.PulumiSink {
+	return &tools.PulumiSink{
+		OnStart: func(toolName, stackName string, isPreview bool) {
+			sendUI(uiCh, UIPulumiStart{ToolName: toolName, StackName: stackName, IsPreview: isPreview})
+		},
+		OnResource: func(toolName string, op displaytypes.StepOp, urn, typ, status string) {
+			sendUI(uiCh, UIPulumiResource{ToolName: toolName, Op: op, URN: urn, Type: typ, Status: status})
+		},
+		OnDiag: func(toolName, severity, message, urn string) {
+			sendUI(uiCh, UIPulumiDiag{ToolName: toolName, Severity: severity, Message: message, URN: urn})
+		},
+		OnEnd: func(toolName, errStr string, counts displaytypes.ResourceChanges, elapsed string) {
+			sendUI(uiCh, UIPulumiEnd{ToolName: toolName, Err: errStr, Counts: counts, Elapsed: elapsed})
+		},
+	}
 }

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -134,6 +134,14 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		"shell":      sh,
 	}
 
+	// In non-interactive mode the sink stays nil and live events are dropped; the
+	// interactive path below sets pu.Sink to push UIEvents onto uiCh.
+	pu, err := tools.NewPulumi(cwdFlag, ws, cloudBe, nil)
+	if err != nil {
+		return err
+	}
+	handlers["pulumi"] = pu
+
 	// Non-interactive mode requires a prompt — there's no input mechanism.
 	if !cmdutil.Interactive() {
 		if prompt == "" {
@@ -165,6 +173,23 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	uiCh := make(chan UIEvent, 64)
 	outCh := make(chan outboundEvent, 8)
+
+	// Translate each PulumiSink callback into the matching UIEvent on uiCh. The
+	// TUI builds a persistent preview/up block from these events.
+	pu.Sink = &tools.PulumiSink{
+		OnStart: func(toolName, stackName string, isPreview bool) {
+			sendUI(uiCh, UIPulumiStart{ToolName: toolName, StackName: stackName, IsPreview: isPreview})
+		},
+		OnResource: func(toolName, op, urn, typ, status string) {
+			sendUI(uiCh, UIPulumiResource{ToolName: toolName, Op: op, URN: urn, Type: typ, Status: status})
+		},
+		OnDiag: func(toolName, severity, message, urn string) {
+			sendUI(uiCh, UIPulumiDiag{ToolName: toolName, Severity: severity, Message: message, URN: urn})
+		},
+		OnEnd: func(toolName, errStr string, counts map[string]int, elapsed string) {
+			sendUI(uiCh, UIPulumiEnd{ToolName: toolName, Err: errStr, Counts: counts, Elapsed: elapsed})
+		},
+	}
 
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
+	displaytypes "github.com/pulumi/pulumi/pkg/v3/display"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -180,13 +181,13 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		OnStart: func(toolName, stackName string, isPreview bool) {
 			sendUI(uiCh, UIPulumiStart{ToolName: toolName, StackName: stackName, IsPreview: isPreview})
 		},
-		OnResource: func(toolName, op, urn, typ, status string) {
+		OnResource: func(toolName string, op displaytypes.StepOp, urn, typ, status string) {
 			sendUI(uiCh, UIPulumiResource{ToolName: toolName, Op: op, URN: urn, Type: typ, Status: status})
 		},
 		OnDiag: func(toolName, severity, message, urn string) {
 			sendUI(uiCh, UIPulumiDiag{ToolName: toolName, Severity: severity, Message: message, URN: urn})
 		},
-		OnEnd: func(toolName, errStr string, counts map[string]int, elapsed string) {
+		OnEnd: func(toolName, errStr string, counts displaytypes.ResourceChanges, elapsed string) {
 			sendUI(uiCh, UIPulumiEnd{ToolName: toolName, Err: errStr, Counts: counts, Elapsed: elapsed})
 		},
 	}

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	displaytypes "github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -243,4 +245,102 @@ func TestNewNeoCmd_HiddenWhenNotExperimental(t *testing.T) {
 	t.Setenv("PULUMI_EXPERIMENTAL", "")
 	cmd := NewNeoCmd()
 	assert.True(t, cmd.Hidden, "without PULUMI_EXPERIMENTAL the command must be hidden")
+}
+
+// -----------------------------------------------------------------------------
+// newPulumiSinkForUI
+//
+// The sink is a thin translation layer between tools.PulumiSink callbacks and
+// the UIEvent channel that drives the TUI. Each callback maps to one UIEvent
+// variant; these tests exercise that mapping in isolation so the runNeo
+// errgroup plumbing doesn't have to be staged for a unit test.
+// -----------------------------------------------------------------------------
+
+func TestNewPulumiSinkForUI_OnStart(t *testing.T) {
+	t.Parallel()
+
+	uiCh := make(chan UIEvent, 1)
+	sink := newPulumiSinkForUI(uiCh)
+	require.NotNil(t, sink.OnStart)
+
+	sink.OnStart("pulumi__pulumi_preview", "dev", true)
+
+	got := <-uiCh
+	start, ok := got.(UIPulumiStart)
+	require.True(t, ok, "OnStart must emit UIPulumiStart, got %T", got)
+	assert.Equal(t, "pulumi__pulumi_preview", start.ToolName)
+	assert.Equal(t, "dev", start.StackName)
+	assert.True(t, start.IsPreview)
+}
+
+func TestNewPulumiSinkForUI_OnResource(t *testing.T) {
+	t.Parallel()
+
+	uiCh := make(chan UIEvent, 1)
+	sink := newPulumiSinkForUI(uiCh)
+	require.NotNil(t, sink.OnResource)
+
+	sink.OnResource("pulumi__pulumi_up", deploy.OpCreate,
+		"urn:pulumi:dev::p::aws:s3/Bucket::b", "aws:s3/Bucket", "running")
+
+	got := <-uiCh
+	res, ok := got.(UIPulumiResource)
+	require.True(t, ok, "OnResource must emit UIPulumiResource, got %T", got)
+	assert.Equal(t, "pulumi__pulumi_up", res.ToolName)
+	assert.Equal(t, deploy.OpCreate, res.Op)
+	assert.Equal(t, "urn:pulumi:dev::p::aws:s3/Bucket::b", res.URN)
+	assert.Equal(t, "aws:s3/Bucket", res.Type)
+	assert.Equal(t, "running", res.Status)
+}
+
+func TestNewPulumiSinkForUI_OnDiag(t *testing.T) {
+	t.Parallel()
+
+	uiCh := make(chan UIEvent, 1)
+	sink := newPulumiSinkForUI(uiCh)
+	require.NotNil(t, sink.OnDiag)
+
+	sink.OnDiag("pulumi__pulumi_up", "warning", "deprecated foo", "urn:x")
+
+	got := <-uiCh
+	d, ok := got.(UIPulumiDiag)
+	require.True(t, ok, "OnDiag must emit UIPulumiDiag, got %T", got)
+	assert.Equal(t, "pulumi__pulumi_up", d.ToolName)
+	assert.Equal(t, "warning", d.Severity)
+	assert.Equal(t, "deprecated foo", d.Message)
+	assert.Equal(t, "urn:x", d.URN)
+}
+
+func TestNewPulumiSinkForUI_OnEnd(t *testing.T) {
+	t.Parallel()
+
+	uiCh := make(chan UIEvent, 1)
+	sink := newPulumiSinkForUI(uiCh)
+	require.NotNil(t, sink.OnEnd)
+
+	counts := displaytypes.ResourceChanges{deploy.OpCreate: 2}
+	sink.OnEnd("pulumi__pulumi_up", "boom", counts, "5s")
+
+	got := <-uiCh
+	e, ok := got.(UIPulumiEnd)
+	require.True(t, ok, "OnEnd must emit UIPulumiEnd, got %T", got)
+	assert.Equal(t, "pulumi__pulumi_up", e.ToolName)
+	assert.Equal(t, "boom", e.Err)
+	assert.Equal(t, counts, e.Counts)
+	assert.Equal(t, "5s", e.Elapsed)
+}
+
+func TestNewPulumiSinkForUI_NonBlockingOnFullChannel(t *testing.T) {
+	t.Parallel()
+
+	// sendUI is a non-blocking send (buffered + default branch), so a full
+	// channel must drop the event rather than deadlock the engine drain
+	// goroutine. Verify by overflowing a 1-buffered channel.
+	uiCh := make(chan UIEvent, 1)
+	uiCh <- UIWarning{Message: "filler"}
+
+	sink := newPulumiSinkForUI(uiCh)
+	require.NotPanics(t, func() {
+		sink.OnStart("pulumi__pulumi_preview", "dev", true)
+	}, "OnStart must not block when the UI channel is full")
 }

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -1,0 +1,673 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	backendDisplay "github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/autonaming"
+	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/util/cancel"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Pulumi is the local handler for the Neo `pulumi` tool. It implements the two tool
+// methods exposed by the cloud agent's pulumi_mcp server:
+//
+//	pulumi_preview — runs `pulumi preview` against the selected stack
+//	pulumi_up      — runs `pulumi up` against the selected stack (mutating)
+//
+// The argument and return shapes mirror the upstream definitions in
+// pulumi-service:cmd/agents/src/agents_py/mcp/pulumi_mcp.py. The upstream tool was
+// designed for the cloud-run Deployment path; when running under Neo CLI mode we
+// return empty strings for `deployment_id` and `branch_name` (there is no Deployment
+// and no git branch is created), and populate `events_file` with a temp NDJSON file
+// of engine events for the agent to read via the filesystem tool.
+//
+// Mutation safety: `pulumi_up` is gated upstream via NeoApprovalModeManual — the
+// Neo service sends a user_approval_request before dispatching the tool, and the
+// TUI renders it via UIApprovalRequest. This handler does no local pre-flight
+// confirmation; it expects the approval contract to be honored upstream.
+type Pulumi struct {
+	// Cwd is the canonical sandbox root. LocalPulumiDir in args must resolve under it.
+	Cwd string
+	// Workspace is used to read the project file from the working directory.
+	Workspace pkgWorkspace.Context
+	// Backend is the (cloud) backend used to resolve stacks and execute operations.
+	Backend backend.Backend
+	// Sink, when non-nil, receives structured events that power the Neo TUI's
+	// live preview/up block. See PulumiSink for the callback surface. All
+	// fields are optional: a nil callback on any one method is silently skipped.
+	Sink *PulumiSink
+}
+
+// PulumiSink is the structured callback surface for live preview/up progress.
+// The neo package wires each callback to a matching UIEvent so the TUI can
+// build a persistent block with resources and diagnostics. The callbacks run on
+// the drain goroutine, so implementations must not block.
+//
+// toolName is the full wire name ("pulumi__pulumi_preview" / "pulumi__pulumi_up")
+// used by the TUI to correlate events to the active block. Secret values from
+// `environment_variables` never flow into any callback argument.
+type PulumiSink struct {
+	// OnStart opens a new block when the tool call starts. stackName is the
+	// short stack name from args; isPreview differentiates preview from up.
+	OnStart func(toolName, stackName string, isPreview bool)
+	// OnResource reports one resource the engine touched. status is one of
+	// "planned" (preview), "running" (up, pre-event), "done" (up, outputs),
+	// or "failed" (up, operation-failed). Duplicate URNs are accepted — the
+	// TUI dedupes and upgrades status in place.
+	OnResource func(toolName, op, urn, typ, status string)
+	// OnDiag reports one engine diagnostic. urn may be empty for stack-level
+	// diagnostics.
+	OnDiag func(toolName, severity, message, urn string)
+	// OnEnd finalizes the block. err is empty on success, otherwise the
+	// wrapped engine error string. counts is the display.ResourceChanges map
+	// flattened to string keys.
+	OnEnd func(toolName, err string, counts map[string]int, elapsed string)
+}
+
+// NewPulumi creates a Pulumi handler sandboxed under cwd. The workspace and backend
+// are captured at construction so tests can inject fakes. Sink may be nil when
+// running outside the interactive TUI (non-interactive mode); in that case progress
+// is silently dropped and the final result is still returned to the caller.
+func NewPulumi(cwd string, ws pkgWorkspace.Context, be backend.Backend,
+	sink *PulumiSink,
+) (*Pulumi, error) {
+	if ws == nil {
+		return nil, errors.New("workspace is required")
+	}
+	if be == nil {
+		return nil, errors.New("backend is required")
+	}
+	abs, err := canonicalRoot(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("resolving pulumi cwd: %w", err)
+	}
+	return &Pulumi{Cwd: abs, Workspace: ws, Backend: be, Sink: sink}, nil
+}
+
+// pulumiArgs matches pulumi-service:cmd/agents/src/agents_py/mcp/pulumi_mcp.py's
+// pulumi_preview/pulumi_up parameters.
+type pulumiArgs struct {
+	ProjectName          string            `json:"project_name"`
+	StackName            string            `json:"stack_name"`
+	LocalPulumiDir       string            `json:"local_pulumi_dir"`
+	EnvironmentVariables map[string]envVal `json:"environment_variables,omitempty"`
+}
+
+// envVal decodes the dict value type `str | SecretValue` used by the upstream schema.
+// Plain and Secret are mutually exclusive; the Value() accessor returns whichever is set.
+// Secret values must never be echoed into logs, progress messages, or the events file.
+type envVal struct {
+	Plain  string
+	Secret string
+}
+
+func (e *envVal) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		e.Plain = s
+		return nil
+	}
+	var obj struct {
+		Secret string `json:"secret"`
+	}
+	if err := json.Unmarshal(b, &obj); err != nil {
+		return errors.New(`environment_variables value must be a string or {"secret": "..."}`)
+	}
+	if obj.Secret == "" {
+		return errors.New(`environment_variables secret form requires a non-empty "secret" field`)
+	}
+	e.Secret = obj.Secret
+	return nil
+}
+
+// Value returns the effective environment variable value regardless of form.
+func (e envVal) Value() string {
+	if e.Secret != "" {
+		return e.Secret
+	}
+	return e.Plain
+}
+
+// pulumiResult matches pulumi-service's PulumiOperationResult so tool consumers on the
+// agent side don't care whether the call ran locally or in a Deployment.
+type pulumiResult struct {
+	DeploymentID  string `json:"deployment_id"`
+	ConsoleURL    string `json:"console_url"`
+	Logs          string `json:"logs"`
+	Status        string `json:"status"`
+	BranchName    string `json:"branch_name"`
+	ProjectName   string `json:"project_name"`
+	StackName     string `json:"stack_name"`
+	UpdateSummary string `json:"update_summary,omitempty"`
+	EventsFile    string `json:"events_file,omitempty"`
+}
+
+// Invoke dispatches a single pulumi method call.
+func (p *Pulumi) Invoke(ctx context.Context, method string, args json.RawMessage) (any, error) {
+	var a pulumiArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return nil, fmt.Errorf("decoding %s args: %w", method, err)
+	}
+	switch method {
+	case "pulumi_preview":
+		return p.run(ctx, a, true)
+	case "pulumi_up":
+		return p.run(ctx, a, false)
+	default:
+		return nil, fmt.Errorf("unknown pulumi method %q", method)
+	}
+}
+
+// maxLogsBytes caps the in-memory logs buffer we return in pulumiResult.Logs. Beyond
+// this point further events still go to the events file and to UIToolProgress, but
+// they stop being appended to the returned logs string.
+const maxLogsBytes = 256 * 1024
+
+// maxSummaryLines caps the number of {op urn type} entries we return in UpdateSummary.
+const maxSummaryLines = 50
+
+func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiResult, error) {
+	if a.StackName == "" {
+		return pulumiResult{}, errors.New("stack_name is required")
+	}
+	if a.LocalPulumiDir == "" {
+		return pulumiResult{}, errors.New("local_pulumi_dir is required")
+	}
+	if !filepath.IsAbs(a.LocalPulumiDir) {
+		return pulumiResult{}, errors.New("local_pulumi_dir must be an absolute path")
+	}
+
+	// Confine local_pulumi_dir to the Session sandbox.
+	dir, err := resolveUnderRoot(p.Cwd, a.LocalPulumiDir, false)
+	if err != nil {
+		return pulumiResult{}, err
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Pulumi.yaml")); err != nil {
+		return pulumiResult{}, fmt.Errorf("local_pulumi_dir %q: Pulumi.yaml not found", a.LocalPulumiDir)
+	}
+
+	// Apply environment variables for the engine run. We snapshot and restore the
+	// values we touch so subsequent tool calls aren't affected. Secret values are
+	// unwrapped here but never flow into logs/progress/events_file.
+	restoreEnv := applyEnvVars(a.EnvironmentVariables)
+	defer restoreEnv()
+
+	// cmdStack.LoadProjectStack (called via GetStackConfiguration below) walks up
+	// from os.Getwd() to find Pulumi.<stack>.yaml, so we chdir into the project
+	// directory for the duration of the call. The engine itself derives its own
+	// working directory from op.Root and doesn't depend on cwd. Session.runBatch
+	// dispatches tool calls serially so we don't lock here, but os.Chdir is
+	// process-global — concurrent callers from outside the Session would race.
+	prevDir, err := os.Getwd()
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("recording working directory: %w", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		return pulumiResult{}, fmt.Errorf("chdir %q: %w", dir, err)
+	}
+	defer func() { _ = os.Chdir(prevDir) }()
+
+	proj, root, err := p.Workspace.ReadProject()
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("reading project: %w", err)
+	}
+
+	stackRef, err := p.Backend.ParseStackReference(a.StackName)
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("parsing stack reference: %w", err)
+	}
+	s, err := p.Backend.GetStack(ctx, stackRef)
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("getting stack: %w", err)
+	}
+	if s == nil {
+		return pulumiResult{}, fmt.Errorf("stack %q not found", a.StackName)
+	}
+
+	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
+	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("getting stack configuration: %w", err)
+	}
+
+	decrypter := sm.Decrypter()
+	encrypter := sm.Encrypter()
+	if err := workspace.ValidateStackConfigAndApplyProjectConfig(
+		ctx, s.Ref().Name().String(), proj, cfg.Environment, cfg.Config, encrypter, decrypter,
+	); err != nil {
+		return pulumiResult{}, fmt.Errorf("validating stack config: %w", err)
+	}
+
+	autonamer, err := autonaming.ParseAutonamingConfig(
+		autonamingStackContextFor(proj, s), cfg.Config, decrypter)
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("getting autonaming config: %w", err)
+	}
+
+	// Pass nil for flags: GetUpdateMetadata only uses them to record
+	// "pulumi.flag.<name>" entries, and Neo has no CLI flags to record.
+	m, err := metadata.GetUpdateMetadata("" /*message*/, root,
+		"neo" /*execKind*/, "" /*execAgent*/, false /*updatePlan*/, cfg, nil)
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("gathering metadata: %w", err)
+	}
+
+	opts := backend.UpdateOptions{
+		AutoApprove: true, // Upstream approval already gates pulumi_up before dispatch.
+		Engine: engine.UpdateOptions{
+			Experimental: true,
+			Autonamer:    autonamer,
+		},
+		Display: backendDisplay.Options{
+			// Mute the backend's own progress renderer so it doesn't fight the Neo TUI.
+			// Stdout / Stderr go to io.Discard; the Neo tool handler consumes events via
+			// the events channel instead.
+			Color:            colors.Never,
+			SuppressProgress: true,
+			SuppressOutputs:  true,
+			IsInteractive:    false,
+			Type:             backendDisplay.DisplayProgress,
+			Stdout:           io.Discard,
+			Stderr:           io.Discard,
+		},
+	}
+
+	eventsFile, err := os.CreateTemp("", "pulumi-neo-events-*.ndjson")
+	if err != nil {
+		return pulumiResult{}, fmt.Errorf("creating events file: %w", err)
+	}
+	// We deliberately do NOT delete the file on exit — the agent may read it via
+	// the filesystem tool after the handler returns. Callers accept the OS temp-dir
+	// lifecycle. This matches the upstream Pulumi Cloud behavior.
+	eventsPath := eventsFile.Name()
+
+	toolName := "pulumi__pulumi_up"
+	if isPreview {
+		toolName = "pulumi__pulumi_preview"
+	}
+
+	if p.Sink != nil && p.Sink.OnStart != nil {
+		p.Sink.OnStart(toolName, a.StackName, isPreview)
+	}
+
+	eventsCh := make(chan engine.Event, 128)
+	var drainOut drainResult
+	drainDone := make(chan struct{})
+	go func() {
+		defer close(drainDone)
+		drainOut = p.drainEvents(toolName, isPreview, eventsCh, eventsFile)
+		_ = eventsFile.Close()
+	}()
+
+	startedAt := time.Now()
+	op := backend.UpdateOperation{
+		Proj:               proj,
+		Root:               root,
+		M:                  m,
+		Opts:               opts,
+		StackConfiguration: cfg,
+		SecretsManager:     sm,
+		SecretsProvider:    secrets.DefaultProvider,
+		Scopes:             ctxOnlyCancellationSource{},
+	}
+
+	// The engine and backend print a handful of headers/messages directly to
+	// os.Stdout/os.Stderr (e.g. the "Previewing update (stack)" banner in
+	// pkg/backend/httpstate/backend.go) that bypass Display.Stdout. Under the
+	// Neo TUI this corrupts bubbletea's alt-screen, so redirect both streams to
+	// /dev/null for the duration of the backend call. bubbletea holds a
+	// captured reference to the original stdout from tea.NewProgram, so this
+	// swap doesn't disturb rendering. Deferred so a panic in the engine
+	// can't leave the CLI permanently muted.
+	restoreStd := silenceStd()
+	defer restoreStd()
+
+	var runErr error
+	var changes display.ResourceChanges
+	if isPreview {
+		_, changes, runErr = backend.PreviewStack(ctx, s, op, eventsCh)
+	} else {
+		changes, runErr = backend.UpdateStack(ctx, s, op, eventsCh)
+	}
+	// Closing eventsCh lets the drain goroutine return. The backend does not close
+	// the channel for us; once the backend call returns, no more events will arrive.
+	close(eventsCh)
+	<-drainDone
+
+	res := pulumiResult{
+		ProjectName: a.ProjectName,
+		StackName:   a.StackName,
+		EventsFile:  eventsPath,
+	}
+	if res.ProjectName == "" {
+		res.ProjectName = proj.Name.String()
+	}
+
+	switch {
+	case runErr != nil && errors.Is(ctx.Err(), context.Canceled):
+		res.Status = "cancelled"
+	case runErr != nil:
+		res.Status = "failed"
+	default:
+		res.Status = "succeeded"
+	}
+
+	elapsed := time.Since(startedAt)
+	res.Logs = drainOut.logs.String()
+	res.UpdateSummary = formatUpdateSummary(a.StackName, changes, drainOut.summary, elapsed)
+
+	if p.Sink != nil && p.Sink.OnEnd != nil {
+		errStr := ""
+		if runErr != nil {
+			errStr = runErr.Error()
+		}
+		p.Sink.OnEnd(toolName, errStr, flattenChanges(changes), elapsed.Round(time.Second).String())
+	}
+
+	if runErr != nil {
+		label := "up"
+		if isPreview {
+			label = "preview"
+		}
+		return res, fmt.Errorf("pulumi %s: %w", label, runErr)
+	}
+	return res, nil
+}
+
+// flattenChanges converts display.ResourceChanges (keyed on StepOp) to a
+// string-keyed map for transport across the tools/neo boundary.
+func flattenChanges(c display.ResourceChanges) map[string]int {
+	if len(c) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(c))
+	for op, n := range c {
+		out[string(op)] = n
+	}
+	return out
+}
+
+// drainResult is what the event-drain goroutine produces.
+type drainResult struct {
+	logs    bytes.Buffer
+	summary []changeLine
+}
+
+type changeLine struct {
+	Op   string
+	URN  string
+	Type string
+}
+
+// drainEvents consumes the engine event channel: writes each event as one NDJSON
+// line to the events file, dispatches structured sink callbacks for the TUI's
+// live preview block, and accumulates the {op urn type} summary + logs buffer
+// that are returned to the agent in pulumiResult.
+func (p *Pulumi) drainEvents(
+	toolName string, isPreview bool, events <-chan engine.Event, ndjson io.Writer,
+) drainResult {
+	var out drainResult
+	seenURN := map[string]struct{}{}
+
+	for e := range events {
+		// Best-effort: skip events that fail to convert.
+		if apiEv, err := backendDisplay.ConvertEngineEvent(e, false /*showSecrets*/); err == nil {
+			if b, err := json.Marshal(apiEv); err == nil {
+				_, _ = ndjson.Write(b)
+				_, _ = ndjson.Write([]byte("\n"))
+			}
+		}
+
+		switch payload := e.Payload().(type) {
+		case engine.ResourcePreEventPayload:
+			if payload.Internal {
+				continue
+			}
+			op := payload.Metadata.Op
+			if op == deploy.OpSame {
+				continue
+			}
+			urn := payload.Metadata.URN
+			status := "running"
+			if isPreview {
+				status = "planned"
+			}
+			if p.Sink != nil && p.Sink.OnResource != nil {
+				p.Sink.OnResource(toolName, string(op), string(urn), string(urn.Type()), status)
+			}
+			p.appendLog(fmt.Sprintf("%s %s (%s)", op, urn.Name(), urn.Type()), &out.logs)
+			if _, dup := seenURN[string(urn)]; !dup && len(out.summary) < maxSummaryLines {
+				seenURN[string(urn)] = struct{}{}
+				out.summary = append(out.summary, changeLine{
+					Op:   string(op),
+					URN:  string(urn),
+					Type: string(urn.Type()),
+				})
+			}
+		case engine.ResourceOutputsEventPayload:
+			if payload.Internal {
+				continue
+			}
+			if isPreview {
+				// In preview we don't run resources, so there's no status
+				// upgrade to do. Skip to avoid duplicating "planned" rows.
+				continue
+			}
+			if payload.Metadata.Op == deploy.OpSame {
+				continue
+			}
+			urn := payload.Metadata.URN
+			if p.Sink != nil && p.Sink.OnResource != nil {
+				p.Sink.OnResource(toolName, string(payload.Metadata.Op),
+					string(urn), string(urn.Type()), "done")
+			}
+		case engine.ResourceOperationFailedPayload:
+			urn := payload.Metadata.URN
+			if p.Sink != nil && p.Sink.OnResource != nil {
+				p.Sink.OnResource(toolName, string(payload.Metadata.Op),
+					string(urn), string(urn.Type()), "failed")
+			}
+		case engine.DiagEventPayload:
+			if payload.Ephemeral {
+				continue
+			}
+			if payload.Severity != diag.Warning && payload.Severity != diag.Error {
+				continue
+			}
+			// The engine embeds Pulumi color markers (e.g. <{%reset%}>) in
+			// diagnostic messages and expects the display layer to substitute
+			// them. Run through colors.Never to strip to plain text; the TUI
+			// paints its own severity color on the row, so we don't need ANSI.
+			msg := strings.TrimSpace(colors.Never.Colorize(payload.Message))
+			if p.Sink != nil && p.Sink.OnDiag != nil {
+				p.Sink.OnDiag(toolName, string(payload.Severity), msg, string(payload.URN))
+			}
+			p.appendLog(fmt.Sprintf("%s: %s", payload.Severity, msg), &out.logs)
+		case engine.SummaryEventPayload:
+			if counts := formatCountsFromChanges(payload.ResourceChanges); counts != "" {
+				p.appendLog("summary: "+counts, &out.logs)
+			}
+		}
+	}
+	return out
+}
+
+// appendLog grows the logs buffer up to the cap. Past the cap, writes are
+// silently dropped so the returned pulumiResult.Logs stays bounded.
+func (p *Pulumi) appendLog(msg string, logs *bytes.Buffer) {
+	if logs.Len() >= maxLogsBytes {
+		return
+	}
+	line := msg + "\n"
+	if remaining := maxLogsBytes - logs.Len(); len(line) > remaining {
+		line = line[:remaining]
+	}
+	logs.WriteString(line)
+}
+
+// formatCountsFromChanges produces a compact "3 create, 1 update" style string,
+// excluding sames. Keys are sorted for deterministic output.
+func formatCountsFromChanges(changes display.ResourceChanges) string {
+	if len(changes) == 0 {
+		return ""
+	}
+	type kv struct {
+		op string
+		n  int
+	}
+	kvs := make([]kv, 0, len(changes))
+	for op, n := range changes {
+		if op == deploy.OpSame || n == 0 {
+			continue
+		}
+		kvs = append(kvs, kv{op: string(op), n: n})
+	}
+	sort.Slice(kvs, func(i, j int) bool { return kvs[i].op < kvs[j].op })
+	parts := make([]string, 0, len(kvs))
+	for _, e := range kvs {
+		parts = append(parts, fmt.Sprintf("%d %s", e.n, e.op))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatUpdateSummary renders the human-readable summary returned in
+// pulumiResult.UpdateSummary — one header line, the op counts, and up to
+// maxSummaryLines resource lines.
+func formatUpdateSummary(stackName string, changes display.ResourceChanges,
+	summary []changeLine, elapsed time.Duration,
+) string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "stack: %s (%s)\n", stackName, elapsed.Round(time.Second))
+	if counts := formatCountsFromChanges(changes); counts != "" {
+		fmt.Fprintf(&buf, "changes: %s\n", counts)
+	} else {
+		buf.WriteString("changes: none\n")
+	}
+	if len(summary) > 0 {
+		buf.WriteString("resources:\n")
+		for _, l := range summary {
+			fmt.Fprintf(&buf, "  %s %s (%s)\n", l.Op, l.URN, l.Type)
+		}
+	}
+	return buf.String()
+}
+
+// applyEnvVars sets the given environment variables on the process, returning a
+// function that restores the prior values. Variables previously unset are unset on
+// restore. Secret values are applied normally; restoreEnv does not log or return them.
+func applyEnvVars(vars map[string]envVal) func() {
+	if len(vars) == 0 {
+		return func() {}
+	}
+	type prev struct {
+		value string
+		had   bool
+	}
+	saved := make(map[string]prev, len(vars))
+	for k, v := range vars {
+		old, ok := os.LookupEnv(k)
+		saved[k] = prev{value: old, had: ok}
+		_ = os.Setenv(k, v.Value())
+	}
+	return func() {
+		for k, pv := range saved {
+			if pv.had {
+				_ = os.Setenv(k, pv.value)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		}
+	}
+}
+
+// ctxOnlyCancellationSource is a minimal backend.CancellationScopeSource that observes
+// only the caller's context — no SIGINT/SIGTERM handler is installed. Under Neo the TUI
+// owns the terminal and posts AgentUserEventCancel on ESC; the backend's stock
+// CancellationScopes would install its own SIGINT handler and conflict with bubbletea.
+type ctxOnlyCancellationSource struct{}
+
+func (ctxOnlyCancellationSource) NewScope(
+	ctx context.Context, _ chan<- engine.Event, _ bool,
+) backend.CancellationScope {
+	cctx, src := cancel.NewContext(ctx)
+	return &ctxOnlyCancellationScope{ctx: cctx, src: src}
+}
+
+type ctxOnlyCancellationScope struct {
+	ctx *cancel.Context
+	src *cancel.Source
+}
+
+func (c *ctxOnlyCancellationScope) Context() *cancel.Context { return c.ctx }
+func (c *ctxOnlyCancellationScope) Close()                   { c.src.Cancel() }
+
+// silenceStd redirects os.Stdout and os.Stderr to /dev/null and returns a
+// restore func. Calls to fmt.Printf / fmt.Println / fmt.Print during the
+// redirection go nowhere. Safe even if opening /dev/null fails — in that case
+// the originals remain in place. bubbletea's tea.NewProgram captures a stable
+// reference to the terminal at construction, so this swap does not affect the
+// TUI's rendering; it only catches writes that look up os.Stdout dynamically.
+func silenceStd() func() {
+	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return func() {}
+	}
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = null, null
+	return func() {
+		os.Stdout, os.Stderr = origStdout, origStderr
+		_ = null.Close()
+	}
+}
+
+// autonamingStackContextFor mirrors operations.autonamingStackContext without pulling in
+// the cobra-coupled operations package.
+func autonamingStackContextFor(proj *workspace.Project, s backend.Stack) autonaming.StackContext {
+	organization := "organization"
+	if cs, ok := s.(httpstate.Stack); ok {
+		organization = cs.OrgName()
+	}
+	return autonaming.StackContext{
+		Organization: organization,
+		Project:      proj.Name.String(),
+		Stack:        s.Ref().Name().String(),
+	}
+}

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -15,7 +15,6 @@
 package tools
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -88,18 +87,19 @@ type PulumiSink struct {
 	// OnStart opens a new block when the tool call starts. stackName is the
 	// short stack name from args; isPreview differentiates preview from up.
 	OnStart func(toolName, stackName string, isPreview bool)
-	// OnResource reports one resource the engine touched. status is one of
-	// "planned" (preview), "running" (up, pre-event), "done" (up, outputs),
-	// or "failed" (up, operation-failed). Duplicate URNs are accepted — the
-	// TUI dedupes and upgrades status in place.
-	OnResource func(toolName, op, urn, typ, status string)
+	// OnResource reports one resource the engine touched. op is the typed
+	// StepOp from the engine; status is one of "planned" (preview),
+	// "running" (up, pre-event), "done" (up, outputs), or "failed" (up,
+	// operation-failed). Duplicate URNs are accepted — the TUI dedupes
+	// and upgrades status in place.
+	OnResource func(toolName string, op display.StepOp, urn, typ, status string)
 	// OnDiag reports one engine diagnostic. urn may be empty for stack-level
 	// diagnostics.
 	OnDiag func(toolName, severity, message, urn string)
 	// OnEnd finalizes the block. err is empty on success, otherwise the
-	// wrapped engine error string. counts is the display.ResourceChanges map
-	// flattened to string keys.
-	OnEnd func(toolName, err string, counts map[string]int, elapsed string)
+	// wrapped engine error string. counts is the typed ResourceChanges map
+	// from the engine.
+	OnEnd func(toolName, err string, counts display.ResourceChanges, elapsed string)
 }
 
 // NewPulumi creates a Pulumi handler sandboxed under cwd. The workspace and backend
@@ -195,14 +195,6 @@ func (p *Pulumi) Invoke(ctx context.Context, method string, args json.RawMessage
 		return nil, fmt.Errorf("unknown pulumi method %q", method)
 	}
 }
-
-// maxLogsBytes caps the in-memory logs buffer we return in pulumiResult.Logs. Beyond
-// this point further events still go to the events file and to UIToolProgress, but
-// they stop being appended to the returned logs string.
-const maxLogsBytes = 256 * 1024
-
-// maxSummaryLines caps the number of {op urn type} entries we return in UpdateSummary.
-const maxSummaryLines = 50
 
 func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiResult, error) {
 	if a.StackName == "" {
@@ -329,11 +321,11 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 
 	eventsCh := make(chan engine.Event, 128)
-	var drainOut drainResult
+	var diagLines []string
 	drainDone := make(chan struct{})
 	go func() {
 		defer close(drainDone)
-		drainOut = p.drainEvents(toolName, isPreview, eventsCh, eventsFile)
+		diagLines = p.drainEvents(toolName, isPreview, eventsCh, eventsFile)
 		_ = eventsFile.Close()
 	}()
 
@@ -391,15 +383,15 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 
 	elapsed := time.Since(startedAt)
-	res.Logs = drainOut.logs.String()
-	res.UpdateSummary = formatUpdateSummary(a.StackName, changes, drainOut.summary, elapsed)
+	res.Logs = formatLogs(changes, diagLines)
+	res.UpdateSummary = formatUpdateSummary(a.StackName, changes, elapsed)
 
 	if p.Sink != nil && p.Sink.OnEnd != nil {
 		errStr := ""
 		if runErr != nil {
 			errStr = runErr.Error()
 		}
-		p.Sink.OnEnd(toolName, errStr, flattenChanges(changes), elapsed.Round(time.Second).String())
+		p.Sink.OnEnd(toolName, errStr, changes, elapsed.Round(time.Second).String())
 	}
 
 	if runErr != nil {
@@ -412,40 +404,70 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	return res, nil
 }
 
-// flattenChanges converts display.ResourceChanges (keyed on StepOp) to a
-// string-keyed map for transport across the tools/neo boundary.
-func flattenChanges(c display.ResourceChanges) map[string]int {
-	if len(c) == 0 {
-		return nil
+// OpSortRank orders StepOps for human-readable output: creates first, then
+// updates, replaces, deletes, reads, refreshes, imports, then everything else.
+// Exported so the TUI side can sort UI-counts the same way the agent-facing
+// summary does.
+func OpSortRank(op display.StepOp) int {
+	switch op {
+	case deploy.OpCreate, deploy.OpCreateReplacement:
+		return 0
+	case deploy.OpUpdate:
+		return 1
+	case deploy.OpReplace:
+		return 2
+	case deploy.OpDelete, deploy.OpDeleteReplaced:
+		return 3
+	case deploy.OpRead, deploy.OpReadReplacement:
+		return 4
+	case deploy.OpRefresh:
+		return 5
+	case deploy.OpImport, deploy.OpImportReplacement:
+		return 6
+	case deploy.OpSame:
+		return 9
+	default:
+		return 7
 	}
-	out := make(map[string]int, len(c))
-	for op, n := range c {
-		out[string(op)] = n
+}
+
+// FormatChangeCounts produces a "3 create<joiner>1 update" string from a
+// ResourceChanges map. OpSame and zero entries are filtered. Returns "" when
+// no non-trivial changes remain.
+func FormatChangeCounts(changes display.ResourceChanges, joiner string) string {
+	if len(changes) == 0 {
+		return ""
 	}
-	return out
+	type kv struct {
+		op display.StepOp
+		n  int
+	}
+	kvs := make([]kv, 0, len(changes))
+	for op, n := range changes {
+		if op == deploy.OpSame || n == 0 {
+			continue
+		}
+		kvs = append(kvs, kv{op: op, n: n})
+	}
+	sort.Slice(kvs, func(i, j int) bool { return OpSortRank(kvs[i].op) < OpSortRank(kvs[j].op) })
+	parts := make([]string, 0, len(kvs))
+	for _, e := range kvs {
+		parts = append(parts, fmt.Sprintf("%d %s", e.n, e.op))
+	}
+	return strings.Join(parts, joiner)
 }
 
-// drainResult is what the event-drain goroutine produces.
-type drainResult struct {
-	logs    bytes.Buffer
-	summary []changeLine
-}
-
-type changeLine struct {
-	Op   string
-	URN  string
-	Type string
-}
-
-// drainEvents consumes the engine event channel: writes each event as one NDJSON
-// line to the events file, dispatches structured sink callbacks for the TUI's
-// live preview block, and accumulates the {op urn type} summary + logs buffer
-// that are returned to the agent in pulumiResult.
+// drainEvents consumes the engine event channel: writes each event as one
+// NDJSON line to the events file (the canonical record the agent reads via
+// the filesystem tool) and dispatches structured sink callbacks for the
+// TUI's live preview block. It returns the accumulated diagnostic lines so
+// they can be folded into pulumiResult.Logs at the end of the run; per-resource
+// lines are intentionally not duplicated in memory because the events file
+// already holds them.
 func (p *Pulumi) drainEvents(
 	toolName string, isPreview bool, events <-chan engine.Event, ndjson io.Writer,
-) drainResult {
-	var out drainResult
-	seenURN := map[string]struct{}{}
+) []string {
+	var diags []string
 
 	for e := range events {
 		// Best-effort: skip events that fail to convert.
@@ -471,16 +493,7 @@ func (p *Pulumi) drainEvents(
 				status = "planned"
 			}
 			if p.Sink != nil && p.Sink.OnResource != nil {
-				p.Sink.OnResource(toolName, string(op), string(urn), string(urn.Type()), status)
-			}
-			p.appendLog(fmt.Sprintf("%s %s (%s)", op, urn.Name(), urn.Type()), &out.logs)
-			if _, dup := seenURN[string(urn)]; !dup && len(out.summary) < maxSummaryLines {
-				seenURN[string(urn)] = struct{}{}
-				out.summary = append(out.summary, changeLine{
-					Op:   string(op),
-					URN:  string(urn),
-					Type: string(urn.Type()),
-				})
+				p.Sink.OnResource(toolName, op, string(urn), string(urn.Type()), status)
 			}
 		case engine.ResourceOutputsEventPayload:
 			if payload.Internal {
@@ -496,13 +509,13 @@ func (p *Pulumi) drainEvents(
 			}
 			urn := payload.Metadata.URN
 			if p.Sink != nil && p.Sink.OnResource != nil {
-				p.Sink.OnResource(toolName, string(payload.Metadata.Op),
+				p.Sink.OnResource(toolName, payload.Metadata.Op,
 					string(urn), string(urn.Type()), "done")
 			}
 		case engine.ResourceOperationFailedPayload:
 			urn := payload.Metadata.URN
 			if p.Sink != nil && p.Sink.OnResource != nil {
-				p.Sink.OnResource(toolName, string(payload.Metadata.Op),
+				p.Sink.OnResource(toolName, payload.Metadata.Op,
 					string(urn), string(urn.Type()), "failed")
 			}
 		case engine.DiagEventPayload:
@@ -520,72 +533,38 @@ func (p *Pulumi) drainEvents(
 			if p.Sink != nil && p.Sink.OnDiag != nil {
 				p.Sink.OnDiag(toolName, string(payload.Severity), msg, string(payload.URN))
 			}
-			p.appendLog(fmt.Sprintf("%s: %s", payload.Severity, msg), &out.logs)
-		case engine.SummaryEventPayload:
-			if counts := formatCountsFromChanges(payload.ResourceChanges); counts != "" {
-				p.appendLog("summary: "+counts, &out.logs)
-			}
+			diags = append(diags, fmt.Sprintf("%s: %s", payload.Severity, msg))
 		}
 	}
-	return out
+	return diags
 }
 
-// appendLog grows the logs buffer up to the cap. Past the cap, writes are
-// silently dropped so the returned pulumiResult.Logs stays bounded.
-func (p *Pulumi) appendLog(msg string, logs *bytes.Buffer) {
-	if logs.Len() >= maxLogsBytes {
-		return
+// formatLogs builds the agent-facing pulumiResult.Logs string: a counts line
+// followed by any non-ephemeral diagnostics. Full per-resource detail lives in
+// EventsFile.
+func formatLogs(changes display.ResourceChanges, diags []string) string {
+	var buf strings.Builder
+	if counts := FormatChangeCounts(changes, ", "); counts != "" {
+		buf.WriteString("summary: " + counts + "\n")
 	}
-	line := msg + "\n"
-	if remaining := maxLogsBytes - logs.Len(); len(line) > remaining {
-		line = line[:remaining]
+	for _, d := range diags {
+		buf.WriteString(d + "\n")
 	}
-	logs.WriteString(line)
-}
-
-// formatCountsFromChanges produces a compact "3 create, 1 update" style string,
-// excluding sames. Keys are sorted for deterministic output.
-func formatCountsFromChanges(changes display.ResourceChanges) string {
-	if len(changes) == 0 {
-		return ""
-	}
-	type kv struct {
-		op string
-		n  int
-	}
-	kvs := make([]kv, 0, len(changes))
-	for op, n := range changes {
-		if op == deploy.OpSame || n == 0 {
-			continue
-		}
-		kvs = append(kvs, kv{op: string(op), n: n})
-	}
-	sort.Slice(kvs, func(i, j int) bool { return kvs[i].op < kvs[j].op })
-	parts := make([]string, 0, len(kvs))
-	for _, e := range kvs {
-		parts = append(parts, fmt.Sprintf("%d %s", e.n, e.op))
-	}
-	return strings.Join(parts, ", ")
+	return buf.String()
 }
 
 // formatUpdateSummary renders the human-readable summary returned in
-// pulumiResult.UpdateSummary — one header line, the op counts, and up to
-// maxSummaryLines resource lines.
+// pulumiResult.UpdateSummary: stack + elapsed header followed by the op counts.
+// Per-resource detail is in EventsFile so we don't duplicate it here.
 func formatUpdateSummary(stackName string, changes display.ResourceChanges,
-	summary []changeLine, elapsed time.Duration,
+	elapsed time.Duration,
 ) string {
 	var buf strings.Builder
 	fmt.Fprintf(&buf, "stack: %s (%s)\n", stackName, elapsed.Round(time.Second))
-	if counts := formatCountsFromChanges(changes); counts != "" {
+	if counts := FormatChangeCounts(changes, ", "); counts != "" {
 		fmt.Fprintf(&buf, "changes: %s\n", counts)
 	} else {
 		buf.WriteString("changes: none\n")
-	}
-	if len(summary) > 0 {
-		buf.WriteString("resources:\n")
-		for _, l := range summary {
-			fmt.Fprintf(&buf, "  %s %s (%s)\n", l.Op, l.URN, l.Type)
-		}
 	}
 	return buf.String()
 }

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"testing"
@@ -23,8 +24,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestPulumi_NewPulumiRejectsMissingDependencies(t *testing.T) {
@@ -33,6 +44,40 @@ func TestPulumi_NewPulumiRejectsMissingDependencies(t *testing.T) {
 	_, err := NewPulumi(t.TempDir(), nil, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workspace")
+}
+
+func TestPulumi_NewPulumiRejectsNilBackend(t *testing.T) {
+	t.Parallel()
+
+	// Workspace present, backend nil — covers the second guard distinct from
+	// the workspace-only case above.
+	_, err := NewPulumi(t.TempDir(), &pkgWorkspace.MockContext{}, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend")
+}
+
+func TestPulumi_NewPulumiHappyPath(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	ws := &pkgWorkspace.MockContext{}
+	be := newFakePulumiBackend()
+	sink := &PulumiSink{}
+
+	pu, err := NewPulumi(cwd, ws, be, sink)
+	require.NoError(t, err)
+	require.NotNil(t, pu)
+
+	// Cwd is canonicalized; on macOS /var → /private/var via symlink, so we
+	// can't compare the raw input. Instead require the result is absolute and
+	// resolves the same as canonicalRoot would on the same input.
+	want, err := canonicalRoot(cwd)
+	require.NoError(t, err)
+	assert.Equal(t, want, pu.Cwd)
+
+	assert.Same(t, ws, pu.Workspace)
+	assert.Same(t, be, pu.Backend)
+	assert.Same(t, sink, pu.Sink)
 }
 
 func TestPulumi_InvokeUnknownMethod(t *testing.T) {
@@ -270,3 +315,464 @@ func TestOpSortRank(t *testing.T) {
 	assert.Less(t, OpSortRank(deploy.OpRefresh), OpSortRank("bogus"))
 	assert.Less(t, OpSortRank("bogus"), OpSortRank(deploy.OpSame))
 }
+
+// TestPulumi_InvokeRoutesPreviewAndUp confirms the method dispatch in Invoke
+// reaches both run() entry points. Both methods get past JSON decoding and
+// hit the same arg-validation rule (`local_pulumi_dir is required`) — the
+// fact that both succeed at decoding and produce that same downstream error
+// proves the switch wires both arms, not a single method via a fallthrough.
+func TestPulumi_InvokeRoutesPreviewAndUp(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range []string{"pulumi_preview", "pulumi_up"} {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+			p := &Pulumi{Cwd: t.TempDir()}
+			_, err := p.Invoke(t.Context(), method,
+				json.RawMessage(`{"project_name":"p","stack_name":"dev"}`))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "local_pulumi_dir is required")
+		})
+	}
+}
+
+// recorder collects invocations into the PulumiSink so tests can assert which
+// callbacks fired and with what arguments. It's a struct of slices rather than
+// counters so the test can inspect the exact event order.
+type sinkRecorder struct {
+	starts    []recordedStart
+	resources []recordedResource
+	diags     []recordedDiag
+	ends      []recordedEnd
+}
+
+type recordedStart struct {
+	toolName, stack string
+	isPreview       bool
+}
+
+type recordedResource struct {
+	toolName, urn, typ, status string
+	op                         display.StepOp
+}
+
+type recordedDiag struct {
+	toolName, severity, message, urn string
+}
+
+type recordedEnd struct {
+	toolName, err, elapsed string
+	counts                 display.ResourceChanges
+}
+
+func (r *sinkRecorder) sink() *PulumiSink {
+	return &PulumiSink{
+		OnStart: func(tn, sn string, p bool) {
+			r.starts = append(r.starts, recordedStart{toolName: tn, stack: sn, isPreview: p})
+		},
+		OnResource: func(tn string, op display.StepOp, urn, typ, status string) {
+			r.resources = append(r.resources, recordedResource{
+				toolName: tn, op: op, urn: urn, typ: typ, status: status,
+			})
+		},
+		OnDiag: func(tn, sev, msg, urn string) {
+			r.diags = append(r.diags, recordedDiag{toolName: tn, severity: sev, message: msg, urn: urn})
+		},
+		OnEnd: func(tn, e string, c display.ResourceChanges, el string) {
+			r.ends = append(r.ends, recordedEnd{toolName: tn, err: e, counts: c, elapsed: el})
+		},
+	}
+}
+
+// testURN constructs a syntactically-valid resource URN for fixture events.
+// drainEvents reads URN.Type() and stringifies the URN; both paths require a
+// well-formed URN.
+func testURN(name string) resource.URN {
+	return resource.NewURN(
+		tokens.QName("dev"), tokens.PackageName("p"),
+		"" /*parentType*/, tokens.Type("aws:s3/Bucket:Bucket"), name,
+	)
+}
+
+func TestPulumi_DrainEvents_ResourcePre_PreviewMode(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+	urn := testURN("my-bucket")
+
+	ev := engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpCreate, URN: urn, Type: tokens.Type("aws:s3/Bucket:Bucket"),
+		},
+	})
+
+	ch := make(chan engine.Event, 1)
+	ch <- ev
+	close(ch)
+
+	var buf bytes.Buffer
+	diags := p.drainEvents("pulumi__pulumi_preview", true, ch, &buf)
+
+	assert.Empty(t, diags, "preview-mode pre-event must not produce diag lines")
+	require.Len(t, rec.resources, 1)
+	got := rec.resources[0]
+	assert.Equal(t, "pulumi__pulumi_preview", got.toolName)
+	assert.Equal(t, deploy.OpCreate, got.op)
+	assert.Equal(t, string(urn), got.urn)
+	assert.Equal(t, "aws:s3/Bucket:Bucket", got.typ)
+	assert.Equal(t, "planned", got.status, "preview-mode status must be planned")
+
+	// NDJSON line is produced for the event.
+	assert.NotEmpty(t, buf.String(), "events file must receive a line for the event")
+	assert.True(t, json.Valid(bytes.TrimSpace(buf.Bytes())),
+		"NDJSON line must be valid JSON")
+}
+
+func TestPulumi_DrainEvents_ResourcePre_UpMode(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ev := engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpCreate, URN: testURN("b"), Type: tokens.Type("aws:s3/Bucket:Bucket"),
+		},
+	})
+	ch := make(chan engine.Event, 1)
+	ch <- ev
+	close(ch)
+
+	var buf bytes.Buffer
+	_ = p.drainEvents("pulumi__pulumi_up", false, ch, &buf)
+
+	require.Len(t, rec.resources, 1)
+	assert.Equal(t, "running", rec.resources[0].status,
+		"up-mode pre-event must use 'running' status, not 'planned'")
+}
+
+func TestPulumi_DrainEvents_ResourcePre_FiltersInternalAndSame(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 2)
+	// Internal events are engine-private and must not surface to the user.
+	ch <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpCreate, URN: testURN("internal"),
+		},
+		Internal: true,
+	})
+	// OpSame is the no-op step; the live block only shows actual changes.
+	ch <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpSame, URN: testURN("same"),
+		},
+	})
+	close(ch)
+
+	_ = p.drainEvents("pulumi__pulumi_preview", true, ch, &bytes.Buffer{})
+	assert.Empty(t, rec.resources, "Internal and OpSame must not invoke OnResource")
+}
+
+func TestPulumi_DrainEvents_ResourceOutputs_UpMarksDone(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 1)
+	ch <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpUpdate, URN: testURN("u"), Type: tokens.Type("aws:s3/Bucket:Bucket"),
+		},
+	})
+	close(ch)
+
+	_ = p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	require.Len(t, rec.resources, 1)
+	assert.Equal(t, "done", rec.resources[0].status)
+	assert.Equal(t, deploy.OpUpdate, rec.resources[0].op)
+}
+
+func TestPulumi_DrainEvents_ResourceOutputs_PreviewSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Preview never runs resources, so an outputs event there would only
+	// duplicate the row already emitted by ResourcePre. Skip silently.
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 1)
+	ch <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpCreate, URN: testURN("c")},
+	})
+	close(ch)
+
+	_ = p.drainEvents("pulumi__pulumi_preview", true, ch, &bytes.Buffer{})
+	assert.Empty(t, rec.resources, "outputs in preview mode must not invoke OnResource")
+}
+
+func TestPulumi_DrainEvents_ResourceOutputs_FiltersInternalAndSame(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 2)
+	ch <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpUpdate, URN: testURN("i")},
+		Internal: true,
+	})
+	ch <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpSame, URN: testURN("s")},
+	})
+	close(ch)
+
+	_ = p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	assert.Empty(t, rec.resources)
+}
+
+func TestPulumi_DrainEvents_ResourceFailed_MarksFailed(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 1)
+	ch <- engine.NewEvent(engine.ResourceOperationFailedPayload{
+		Metadata: engine.StepEventMetadata{
+			Op: deploy.OpCreate, URN: testURN("f"), Type: tokens.Type("aws:s3/Bucket:Bucket"),
+		},
+	})
+	close(ch)
+
+	_ = p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	require.Len(t, rec.resources, 1)
+	assert.Equal(t, "failed", rec.resources[0].status)
+}
+
+func TestPulumi_DrainEvents_Diag_WarningAndError(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 2)
+	// Color markers (<{%fg%}>) are stripped by colors.Never before the
+	// callback fires — the TUI paints its own row colour.
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Warning,
+		URN:      testURN("w"),
+		Message:  "<{%fg 3%}>deprecated foo<{%reset%}>",
+	})
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Error,
+		Message:  "config invalid",
+	})
+	close(ch)
+
+	diags := p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	require.Len(t, rec.diags, 2)
+	assert.Equal(t, "warning", rec.diags[0].severity)
+	assert.Equal(t, "deprecated foo", rec.diags[0].message,
+		"color markers must be stripped from the message")
+	assert.NotEmpty(t, rec.diags[0].urn, "resource-scoped warning must carry the URN")
+	assert.Equal(t, "error", rec.diags[1].severity)
+	assert.Empty(t, rec.diags[1].urn, "stack-level diag has empty URN")
+
+	// Returned diags slice mirrors what's threaded into Logs.
+	require.Len(t, diags, 2)
+	assert.Contains(t, diags[0], "deprecated foo")
+	assert.Contains(t, diags[1], "config invalid")
+}
+
+func TestPulumi_DrainEvents_Diag_FiltersEphemeralAndInfo(t *testing.T) {
+	t.Parallel()
+
+	rec := &sinkRecorder{}
+	p := &Pulumi{Sink: rec.sink()}
+
+	ch := make(chan engine.Event, 2)
+	// Ephemeral: progress chatter the engine emits while a resource is
+	// running. Skipping these matches the rest of the CLI's display.
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Warning, Message: "tick", Ephemeral: true,
+	})
+	// Info severity isn't surfaced to the user — only Warning/Error gate the
+	// Neo block from getting noisy.
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Info, Message: "fyi",
+	})
+	close(ch)
+
+	diags := p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	assert.Empty(t, rec.diags)
+	assert.Empty(t, diags)
+}
+
+func TestPulumi_DrainEvents_NilSinkSafe(t *testing.T) {
+	t.Parallel()
+
+	// drainEvents must tolerate p.Sink == nil (non-interactive mode) without
+	// panicking; events still need to land in the NDJSON file because the
+	// agent reads it via the filesystem tool regardless of TUI state.
+	p := &Pulumi{Sink: nil}
+
+	ch := make(chan engine.Event, 4)
+	ch <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpCreate, URN: testURN("a")},
+	})
+	ch <- engine.NewEvent(engine.ResourceOutputsEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpCreate, URN: testURN("a")},
+	})
+	ch <- engine.NewEvent(engine.ResourceOperationFailedPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpCreate, URN: testURN("b")},
+	})
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Warning, Message: "warn",
+	})
+	close(ch)
+
+	var buf bytes.Buffer
+	require.NotPanics(t, func() {
+		_ = p.drainEvents("pulumi__pulumi_up", false, ch, &buf)
+	})
+	assert.NotEmpty(t, buf.String(), "NDJSON output must still be written when sink is nil")
+}
+
+func TestPulumi_DrainEvents_PartialSinkSafe(t *testing.T) {
+	t.Parallel()
+
+	// A PulumiSink with a nil OnResource (caller only wired diags, say) must
+	// not panic when a resource event arrives — every callback is independently
+	// guarded.
+	calledDiag := 0
+	p := &Pulumi{Sink: &PulumiSink{
+		OnDiag: func(_, _, _, _ string) { calledDiag++ },
+		// OnStart, OnResource, OnEnd intentionally nil.
+	}}
+
+	ch := make(chan engine.Event, 2)
+	ch <- engine.NewEvent(engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{Op: deploy.OpCreate, URN: testURN("a")},
+	})
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Warning, Message: "w",
+	})
+	close(ch)
+
+	require.NotPanics(t, func() {
+		_ = p.drainEvents("pulumi__pulumi_up", false, ch, &bytes.Buffer{})
+	})
+	assert.Equal(t, 1, calledDiag, "OnDiag must still fire when other callbacks are nil")
+}
+
+func TestPulumi_DrainEvents_NDJSONIsValidEngineEvent(t *testing.T) {
+	t.Parallel()
+
+	// The NDJSON file is what the agent reads via the filesystem tool — each
+	// line must round-trip through apitype.EngineEvent so downstream consumers
+	// can re-hydrate it. Verify with a representative diag event.
+	p := &Pulumi{}
+
+	ch := make(chan engine.Event, 1)
+	ch <- engine.NewEvent(engine.DiagEventPayload{
+		Severity: diag.Warning,
+		URN:      testURN("d"),
+		Message:  "deprecated",
+	})
+	close(ch)
+
+	var buf bytes.Buffer
+	_ = p.drainEvents("pulumi__pulumi_up", false, ch, &buf)
+
+	line := bytes.TrimSpace(buf.Bytes())
+	require.NotEmpty(t, line)
+	var apiEv apitype.EngineEvent
+	require.NoError(t, json.Unmarshal(line, &apiEv))
+	require.NotNil(t, apiEv.DiagnosticEvent, "NDJSON must carry the DiagnosticEvent payload")
+	assert.Equal(t, "warning", apiEv.DiagnosticEvent.Severity)
+}
+
+func TestAutonamingStackContextFor_NonHTTPStateStack(t *testing.T) {
+	t.Parallel()
+
+	// A plain backend.Stack (not the cloud httpstate.Stack) cannot supply an
+	// org name — autonamingStackContextFor must fall back to the placeholder
+	// "organization" so autonaming config still loads.
+	proj := &workspace.Project{Name: tokens.PackageName("my-proj")}
+	stk := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+		},
+	}
+
+	got := autonamingStackContextFor(proj, stk)
+	assert.Equal(t, "organization", got.Organization)
+	assert.Equal(t, "my-proj", got.Project)
+	assert.Equal(t, "dev", got.Stack)
+}
+
+func TestAutonamingStackContextFor_HTTPStateStackUsesOrgName(t *testing.T) {
+	t.Parallel()
+
+	// httpstate.Stack callers expose the real organization via OrgName(); that
+	// value must propagate into the autonaming context.
+	proj := &workspace.Project{Name: tokens.PackageName("my-proj")}
+	stk := &fakeHTTPStack{
+		MockStack: &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{NameV: tokens.MustParseStackName("prod")}
+			},
+		},
+		orgName: "my-org",
+	}
+
+	got := autonamingStackContextFor(proj, stk)
+	assert.Equal(t, "my-org", got.Organization)
+	assert.Equal(t, "my-proj", got.Project)
+	assert.Equal(t, "prod", got.Stack)
+}
+
+// fakeHTTPStack satisfies httpstate.Stack so tests can exercise the
+// type-assertion branch in autonamingStackContextFor. Methods other than the
+// two cloud-only ones delegate to the embedded MockStack.
+type fakeHTTPStack struct {
+	*backend.MockStack
+	orgName string
+}
+
+func (f *fakeHTTPStack) OrgName() string {
+	return f.orgName
+}
+
+func (f *fakeHTTPStack) CurrentOperation() *apitype.OperationStatus {
+	return nil
+}
+
+func (f *fakeHTTPStack) StackIdentifier() client.StackIdentifier {
+	return client.StackIdentifier{}
+}
+
+// fakePulumiBackend is a backend.Backend used by NewPulumi happy-path test.
+// All cloud-specific calls are no-ops because NewPulumi only stores the
+// reference — it never dispatches anything against it at construction time.
+type fakePulumiBackend struct {
+	*backend.MockBackend
+}
+
+func newFakePulumiBackend() *fakePulumiBackend {
+	return &fakePulumiBackend{MockBackend: &backend.MockBackend{}}
+}
+
+// Compile-time assertions: fakeHTTPStack must satisfy httpstate.Stack so the
+// type assertion in autonamingStackContextFor succeeds. fakePulumiBackend
+// must satisfy backend.Backend.
+var (
+	_ httpstate.Stack = (*fakeHTTPStack)(nil)
+	_ backend.Backend = (*fakePulumiBackend)(nil)
+)

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -15,7 +15,6 @@
 package tools
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"testing"
@@ -195,24 +194,34 @@ func TestApplyEnvVarsNoopOnEmpty(t *testing.T) {
 	restore()
 }
 
-func TestFormatCountsFromChanges(t *testing.T) {
+func TestFormatChangeCounts(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "", formatCountsFromChanges(nil))
+	assert.Equal(t, "", FormatChangeCounts(nil, ", "))
 
 	// Same-only counts produce an empty summary.
-	assert.Equal(t, "", formatCountsFromChanges(display.ResourceChanges{
+	assert.Equal(t, "", FormatChangeCounts(display.ResourceChanges{
 		deploy.OpSame: 5,
-	}))
+	}, ", "))
 
-	// Zero-count ops are filtered; keys sort alphabetically.
-	got := formatCountsFromChanges(display.ResourceChanges{
-		deploy.OpUpdate: 2,
-		deploy.OpCreate: 3,
-		deploy.OpDelete: 0,
-		deploy.OpSame:   5,
-	})
-	assert.Equal(t, "3 create, 2 update", got)
+	// Zero-count ops are filtered; ordering is semantic (creates first, then
+	// updates, replaces, deletes…).
+	got := FormatChangeCounts(display.ResourceChanges{
+		deploy.OpUpdate:  2,
+		deploy.OpCreate:  3,
+		deploy.OpDelete:  0,
+		deploy.OpReplace: 1,
+		deploy.OpSame:    5,
+	}, ", ")
+	assert.Equal(t, "3 create, 2 update, 1 replace", got)
+
+	// Joiner is configurable so the TUI can use " · " and the agent-facing
+	// summary can use ", ".
+	dot := FormatChangeCounts(display.ResourceChanges{
+		deploy.OpCreate: 1,
+		deploy.OpDelete: 1,
+	}, " · ")
+	assert.Equal(t, "1 create · 1 delete", dot)
 }
 
 func TestFormatUpdateSummary(t *testing.T) {
@@ -221,46 +230,43 @@ func TestFormatUpdateSummary(t *testing.T) {
 	out := formatUpdateSummary(
 		"dev",
 		display.ResourceChanges{deploy.OpCreate: 1},
-		[]changeLine{{Op: "create", URN: "urn:a", Type: "aws:s3/Bucket:Bucket"}},
 		3*time.Second,
 	)
 	assert.Contains(t, out, "stack: dev (3s)")
 	assert.Contains(t, out, "changes: 1 create")
-	assert.Contains(t, out, "resources:")
-	assert.Contains(t, out, "create urn:a (aws:s3/Bucket:Bucket)")
 }
 
 func TestFormatUpdateSummaryNoChanges(t *testing.T) {
 	t.Parallel()
 
-	out := formatUpdateSummary("dev", nil, nil, time.Second)
+	out := formatUpdateSummary("dev", nil, time.Second)
 	assert.Contains(t, out, "changes: none")
-	assert.NotContains(t, out, "resources:")
 }
 
-func TestAppendLogRespectsCap(t *testing.T) {
+func TestFormatLogs(t *testing.T) {
 	t.Parallel()
 
-	p := &Pulumi{}
-	var logs bytes.Buffer
-	p.appendLog("hello", &logs)
-	assert.Equal(t, "hello\n", logs.String())
+	// Empty inputs produce an empty string.
+	assert.Equal(t, "", formatLogs(nil, nil))
 
-	// Fill the buffer to just under the cap, then ensure further writes cannot
-	// exceed the cap.
-	logs.Reset()
-	logs.WriteString(string(make([]byte, maxLogsBytes-1)))
-	p.appendLog("extra-that-wont-fit", &logs)
-	assert.LessOrEqual(t, logs.Len(), maxLogsBytes)
+	// Counts and diags compose; counts come first.
+	got := formatLogs(
+		display.ResourceChanges{deploy.OpCreate: 2, deploy.OpUpdate: 1},
+		[]string{"warning: deprecated foo", "error: bad config"},
+	)
+	assert.Equal(t,
+		"summary: 2 create, 1 update\nwarning: deprecated foo\nerror: bad config\n",
+		got)
 }
 
-func TestFlattenChanges(t *testing.T) {
+func TestOpSortRank(t *testing.T) {
 	t.Parallel()
 
-	assert.Nil(t, flattenChanges(nil))
-	got := flattenChanges(display.ResourceChanges{
-		deploy.OpCreate: 2,
-		deploy.OpDelete: 1,
-	})
-	assert.Equal(t, map[string]int{"create": 2, "delete": 1}, got)
+	// Creates sort before updates, replaces before deletes.
+	assert.Less(t, OpSortRank(deploy.OpCreate), OpSortRank(deploy.OpUpdate))
+	assert.Less(t, OpSortRank(deploy.OpReplace), OpSortRank(deploy.OpDelete))
+	// Same lands at the bottom; an unknown StepOp sits between the known set
+	// and same so the ordering stays stable when the engine adds new ops.
+	assert.Less(t, OpSortRank(deploy.OpRefresh), OpSortRank("bogus"))
+	assert.Less(t, OpSortRank("bogus"), OpSortRank(deploy.OpSame))
 }

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+)
+
+func TestPulumi_NewPulumiRejectsMissingDependencies(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewPulumi(t.TempDir(), nil, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace")
+}
+
+func TestPulumi_InvokeUnknownMethod(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{Cwd: t.TempDir()}
+	_, err := p.Invoke(t.Context(), "pulumi_destroy", json.RawMessage(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown pulumi method")
+}
+
+func TestPulumi_InvokeRejectsBadJSON(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{Cwd: t.TempDir()}
+	_, err := p.Invoke(t.Context(), "pulumi_preview", json.RawMessage(`not json`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding")
+}
+
+func TestPulumi_RunRejectsMissingStackName(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{Cwd: t.TempDir()}
+	_, err := p.Invoke(t.Context(), "pulumi_preview",
+		json.RawMessage(`{"project_name":"p","local_pulumi_dir":"/tmp"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stack_name is required")
+}
+
+func TestPulumi_RunRejectsMissingLocalDir(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{Cwd: t.TempDir()}
+	_, err := p.Invoke(t.Context(), "pulumi_preview",
+		json.RawMessage(`{"project_name":"p","stack_name":"dev"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local_pulumi_dir is required")
+}
+
+func TestPulumi_RunRejectsRelativeLocalDir(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{Cwd: t.TempDir()}
+	_, err := p.Invoke(t.Context(), "pulumi_preview",
+		json.RawMessage(`{"project_name":"p","stack_name":"dev","local_pulumi_dir":"relative/path"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an absolute path")
+}
+
+func TestPulumi_RunRejectsEscapingLocalDir(t *testing.T) {
+	t.Parallel()
+
+	sandbox, err := canonicalRoot(t.TempDir())
+	require.NoError(t, err)
+
+	outside, err := canonicalRoot(t.TempDir())
+	require.NoError(t, err)
+
+	p := &Pulumi{Cwd: sandbox}
+	args, err := json.Marshal(map[string]any{
+		"project_name":     "p",
+		"stack_name":       "dev",
+		"local_pulumi_dir": outside,
+	})
+	require.NoError(t, err)
+	_, err = p.Invoke(t.Context(), "pulumi_preview", args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside")
+}
+
+func TestPulumi_RunRejectsMissingPulumiYaml(t *testing.T) {
+	t.Parallel()
+
+	root, err := canonicalRoot(t.TempDir())
+	require.NoError(t, err)
+
+	p := &Pulumi{Cwd: root}
+	args, err := json.Marshal(map[string]any{
+		"project_name":     "p",
+		"stack_name":       "dev",
+		"local_pulumi_dir": root,
+	})
+	require.NoError(t, err)
+	_, err = p.Invoke(t.Context(), "pulumi_preview", args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pulumi.yaml not found")
+}
+
+func TestEnvValUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    envVal
+		wantErr bool
+	}{
+		{name: "plain", input: `"hello"`, want: envVal{Plain: "hello"}},
+		{name: "secret", input: `{"secret":"shh"}`, want: envVal{Secret: "shh"}},
+		{name: "empty_secret", input: `{"secret":""}`, wantErr: true},
+		{name: "number", input: `42`, wantErr: true},
+		{name: "object_no_secret", input: `{"foo":"bar"}`, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got envVal
+			err := json.Unmarshal([]byte(tc.input), &got)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEnvValValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "plain", envVal{Plain: "plain"}.Value())
+	assert.Equal(t, "secret", envVal{Secret: "secret"}.Value())
+	// Secret takes precedence over Plain.
+	assert.Equal(t, "secret", envVal{Plain: "plain", Secret: "secret"}.Value())
+}
+
+func TestApplyEnvVarsSetsAndRestores(t *testing.T) {
+	// t.Setenv precludes t.Parallel, which is what we want here — the test mutates
+	// process-global state.
+	const presentKey = "PULUMI_NEO_TEST_PRESENT"
+	const absentKey = "PULUMI_NEO_TEST_ABSENT"
+
+	t.Setenv(presentKey, "original")
+	require.NoError(t, os.Unsetenv(absentKey))
+	t.Cleanup(func() { _ = os.Unsetenv(absentKey) })
+
+	restore := applyEnvVars(map[string]envVal{
+		presentKey: {Plain: "modified"},
+		absentKey:  {Secret: "secret-val"},
+	})
+
+	assert.Equal(t, "modified", os.Getenv(presentKey))
+	assert.Equal(t, "secret-val", os.Getenv(absentKey))
+
+	restore()
+
+	assert.Equal(t, "original", os.Getenv(presentKey))
+	_, absentStillSet := os.LookupEnv(absentKey)
+	assert.False(t, absentStillSet, "absent key should be cleared after restore")
+}
+
+func TestApplyEnvVarsNoopOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	restore := applyEnvVars(nil)
+	require.NotNil(t, restore)
+	restore()
+}
+
+func TestFormatCountsFromChanges(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", formatCountsFromChanges(nil))
+
+	// Same-only counts produce an empty summary.
+	assert.Equal(t, "", formatCountsFromChanges(display.ResourceChanges{
+		deploy.OpSame: 5,
+	}))
+
+	// Zero-count ops are filtered; keys sort alphabetically.
+	got := formatCountsFromChanges(display.ResourceChanges{
+		deploy.OpUpdate: 2,
+		deploy.OpCreate: 3,
+		deploy.OpDelete: 0,
+		deploy.OpSame:   5,
+	})
+	assert.Equal(t, "3 create, 2 update", got)
+}
+
+func TestFormatUpdateSummary(t *testing.T) {
+	t.Parallel()
+
+	out := formatUpdateSummary(
+		"dev",
+		display.ResourceChanges{deploy.OpCreate: 1},
+		[]changeLine{{Op: "create", URN: "urn:a", Type: "aws:s3/Bucket:Bucket"}},
+		3*time.Second,
+	)
+	assert.Contains(t, out, "stack: dev (3s)")
+	assert.Contains(t, out, "changes: 1 create")
+	assert.Contains(t, out, "resources:")
+	assert.Contains(t, out, "create urn:a (aws:s3/Bucket:Bucket)")
+}
+
+func TestFormatUpdateSummaryNoChanges(t *testing.T) {
+	t.Parallel()
+
+	out := formatUpdateSummary("dev", nil, nil, time.Second)
+	assert.Contains(t, out, "changes: none")
+	assert.NotContains(t, out, "resources:")
+}
+
+func TestAppendLogRespectsCap(t *testing.T) {
+	t.Parallel()
+
+	p := &Pulumi{}
+	var logs bytes.Buffer
+	p.appendLog("hello", &logs)
+	assert.Equal(t, "hello\n", logs.String())
+
+	// Fill the buffer to just under the cap, then ensure further writes cannot
+	// exceed the cap.
+	logs.Reset()
+	logs.WriteString(string(make([]byte, maxLogsBytes-1)))
+	p.appendLog("extra-that-wont-fit", &logs)
+	assert.LessOrEqual(t, logs.Len(), maxLogsBytes)
+}
+
+func TestFlattenChanges(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, flattenChanges(nil))
+	got := flattenChanges(display.ResourceChanges{
+		deploy.OpCreate: 2,
+		deploy.OpDelete: 1,
+	})
+	assert.Equal(t, map[string]int{"create": 2, "delete": 1}, got)
+}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -25,6 +25,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -82,14 +83,14 @@ type pulumiBlockState struct {
 	resources     []pulumiResourceRow
 	resourceByURN map[string]int
 	diags         []pulumiDiagRow
-	counts        map[string]int
+	counts        display.ResourceChanges
 	elapsed       string
 	err           string
 	done          bool
 }
 
 type pulumiResourceRow struct {
-	op     string
+	op     display.StepOp
 	urn    string
 	typ    string
 	status string

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -47,6 +47,7 @@ const (
 	blockApprovalPlan
 	blockApprovalGeneral
 	blockApprovalChoice
+	blockPulumiOp
 )
 
 type block struct {
@@ -63,6 +64,41 @@ type block struct {
 	shimmer shimmerKind
 	// approved applies to blockApprovalChoice only.
 	approved bool
+	// pulumi carries per-block state for blockPulumiOp. It is mutated in place
+	// as UIPulumiResource / UIPulumiDiag / UIPulumiEnd events arrive, then
+	// re-rendered by renderBlock on every update.
+	pulumi *pulumiBlockState
+}
+
+// pulumiBlockState accumulates the live state of a blockPulumiOp. Resources are
+// deduped by URN (the index into resources is stored in resourceByURN so late
+// events like ResourceOutputs can upgrade the status of an earlier
+// ResourcePre). Diags are append-only because they carry their own severity
+// and messages aren't keyed.
+type pulumiBlockState struct {
+	toolName      string
+	stackName     string
+	isPreview     bool
+	resources     []pulumiResourceRow
+	resourceByURN map[string]int
+	diags         []pulumiDiagRow
+	counts        map[string]int
+	elapsed       string
+	err           string
+	done          bool
+}
+
+type pulumiResourceRow struct {
+	op     string
+	urn    string
+	typ    string
+	status string
+}
+
+type pulumiDiagRow struct {
+	severity string
+	message  string
+	urn      string
 }
 
 // ModelConfig holds the parameters needed to create a TUI Model.
@@ -516,6 +552,70 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
+	case UIPulumiStart:
+		// Reuse an existing open block for the same tool name if one is present
+		// (shouldn't happen in practice — each tool call is serialized — but it
+		// guards against a stale block if the agent retries). An open block has
+		// done==false. On reuse we reset state so the new run starts clean.
+		idx := m.findOpenPulumiBlock(msg.ToolName)
+		if idx < 0 {
+			b := block{kind: blockPulumiOp, pulumi: &pulumiBlockState{
+				toolName:      msg.ToolName,
+				stackName:     msg.StackName,
+				isPreview:     msg.IsPreview,
+				resourceByURN: map[string]int{},
+			}}
+			m.renderBlock(&b)
+			m.appendBlock(b)
+		} else {
+			m.blocks[idx].pulumi = &pulumiBlockState{
+				toolName:      msg.ToolName,
+				stackName:     msg.StackName,
+				isPreview:     msg.IsPreview,
+				resourceByURN: map[string]int{},
+			}
+			m.renderBlock(&m.blocks[idx])
+		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIPulumiResource:
+		if idx := m.findOpenPulumiBlock(msg.ToolName); idx >= 0 {
+			m.blocks[idx].pulumi.addResource(msg.Op, msg.URN, msg.Type, msg.Status)
+			m.renderBlock(&m.blocks[idx])
+		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIPulumiDiag:
+		if idx := m.findOpenPulumiBlock(msg.ToolName); idx >= 0 {
+			st := m.blocks[idx].pulumi
+			st.diags = append(st.diags, pulumiDiagRow{
+				severity: msg.Severity,
+				message:  msg.Message,
+				urn:      msg.URN,
+			})
+			m.renderBlock(&m.blocks[idx])
+		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
+	case UIPulumiEnd:
+		if idx := m.findOpenPulumiBlock(msg.ToolName); idx >= 0 {
+			st := m.blocks[idx].pulumi
+			st.counts = msg.Counts
+			st.elapsed = msg.Elapsed
+			st.err = msg.Err
+			st.done = true
+			m.renderBlock(&m.blocks[idx])
+		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		m.rebuildContent()
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
 	case UIApprovalRequest:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.pendingApproval = true
@@ -733,6 +833,10 @@ func (m *Model) renderBlock(b *block) {
 		m.renderApprovalChoice(b)
 		return
 	}
+	if b.kind == blockPulumiOp {
+		b.rendered = m.renderPulumiBlock(b.pulumi)
+		return
+	}
 	if b.raw == "" {
 		return
 	}
@@ -758,8 +862,8 @@ func (m *Model) renderBlock(b *block) {
 	case blockBusy, blockToolComplete:
 		// No raw: blockBusy renders live from label, blockToolComplete is
 		// pre-styled at event time.
-	case blockApprovalChoice:
-		// Unreachable; kept for exhaustive lint.
+	case blockApprovalChoice, blockPulumiOp:
+		// Unreachable: both are handled by early returns above.
 	}
 }
 

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -132,3 +132,64 @@ type UIContextCompression struct {
 }
 
 func (UIContextCompression) uiEvent() {}
+
+// UIPulumiStart opens a persistent preview/up block in the TUI for a pulumi tool
+// call. The block accumulates resource and diagnostic rows as they stream in,
+// and is finalized by UIPulumiEnd.
+//
+// The open block is keyed on ToolName: subsequent UIPulumi{Resource,Diag,End}
+// events for the in-flight call update the same block. Once UIPulumiEnd fires
+// the block is finalized; the next UIPulumiStart with the same ToolName starts
+// a fresh block. Relies on Session.runBatch dispatching tool calls serially —
+// concurrent calls would clobber each other.
+type UIPulumiStart struct {
+	ToolName  string
+	StackName string
+	// IsPreview is true for pulumi_preview, false for pulumi_up. Used by the
+	// renderer to title the block (PulumiPreview vs PulumiUp) and to pick the
+	// "planned changes" vs "applied changes" wording.
+	IsPreview bool
+}
+
+func (UIPulumiStart) uiEvent() {}
+
+// UIPulumiResource reports one resource the engine is acting on. URN is used
+// as the dedup key — duplicate events for the same URN update the row in place
+// (e.g. status transitions from "planned" to "running" to "done").
+type UIPulumiResource struct {
+	ToolName string
+	// Op is the StepOp string: create, update, delete, replace, read, refresh, etc.
+	Op   string
+	URN  string
+	Type string
+	// Status is "planned" (preview only), "running" (up, pre-event), "done"
+	// (up, outputs-event), or "failed" (up, operation-failed event).
+	Status string
+}
+
+func (UIPulumiResource) uiEvent() {}
+
+// UIPulumiDiag appends one diagnostic row to the open pulumi block. URN may be
+// empty for stack-level diagnostics.
+type UIPulumiDiag struct {
+	ToolName string
+	Severity string
+	Message  string
+	URN      string
+}
+
+func (UIPulumiDiag) uiEvent() {}
+
+// UIPulumiEnd finalizes the open pulumi block. Err is empty on success. Counts
+// is the display.ResourceChanges map already flattened to string keys for
+// render-time transport without pulling display into this package.
+type UIPulumiEnd struct {
+	ToolName string
+	Err      string
+	Counts   map[string]int
+	// Elapsed is the duration the backend call took, pre-formatted so the TUI
+	// doesn't need to care about time types.
+	Elapsed string
+}
+
+func (UIPulumiEnd) uiEvent() {}

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -14,7 +14,11 @@
 
 package neo
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+)
 
 // UIEvent is the sealed interface for events sent from the Session event loop to the
 // bubbletea TUI. Each variant carries just enough information for the TUI to render.
@@ -158,8 +162,9 @@ func (UIPulumiStart) uiEvent() {}
 // (e.g. status transitions from "planned" to "running" to "done").
 type UIPulumiResource struct {
 	ToolName string
-	// Op is the StepOp string: create, update, delete, replace, read, refresh, etc.
-	Op   string
+	// Op is the typed StepOp from the engine: create, update, delete,
+	// replace, read, refresh, etc.
+	Op   display.StepOp
 	URN  string
 	Type string
 	// Status is "planned" (preview only), "running" (up, pre-event), "done"
@@ -181,12 +186,12 @@ type UIPulumiDiag struct {
 func (UIPulumiDiag) uiEvent() {}
 
 // UIPulumiEnd finalizes the open pulumi block. Err is empty on success. Counts
-// is the display.ResourceChanges map already flattened to string keys for
-// render-time transport without pulling display into this package.
+// is the engine's ResourceChanges map; the TUI consumes it as-is so we don't
+// pay a flatten/unflatten round-trip just to cross the package boundary.
 type UIPulumiEnd struct {
 	ToolName string
 	Err      string
-	Counts   map[string]int
+	Counts   display.ResourceChanges
 	// Elapsed is the duration the backend call took, pre-formatted so the TUI
 	// doesn't need to care about time types.
 	Elapsed string

--- a/pkg/cmd/pulumi/neo/tui_events_test.go
+++ b/pkg/cmd/pulumi/neo/tui_events_test.go
@@ -40,6 +40,13 @@ func TestUIEventSealedInterface(t *testing.T) {
 		UITaskIdle{},
 		UISessionURL{URL: "https://example"},
 		UIUserMessage{Content: "hello"},
+		UIApprovalRequest{ApprovalID: "appr_1"},
+		UIAwaitingApprovals{},
+		UIContextCompression{},
+		UIPulumiStart{ToolName: "pulumi__pulumi_preview"},
+		UIPulumiResource{ToolName: "pulumi__pulumi_preview"},
+		UIPulumiDiag{ToolName: "pulumi__pulumi_preview"},
+		UIPulumiEnd{ToolName: "pulumi__pulumi_preview"},
 	}
 
 	// Calling uiEvent() through the interface dispatches to each concrete impl —
@@ -47,5 +54,5 @@ func TestUIEventSealedInterface(t *testing.T) {
 	for _, e := range events {
 		e.uiEvent()
 	}
-	require.Len(t, events, 10, "bumped this when adding a new UIEvent variant")
+	require.Len(t, events, 17, "bumped this when adding a new UIEvent variant")
 }

--- a/pkg/cmd/pulumi/neo/tui_pulumi.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi.go
@@ -20,6 +20,10 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 )
 
 // Pulumi block styling. Colors follow the CLI's preview output: green for
@@ -60,7 +64,7 @@ var (
 // a URN is seen again, the op stays from the first event (the ResourcePre
 // that established what the engine is doing) and only the status is upgraded
 // in place — later events like ResourceOutputs may carry only a status change.
-func (s *pulumiBlockState) addResource(op, urn, typ, status string) {
+func (s *pulumiBlockState) addResource(op display.StepOp, urn, typ, status string) {
 	if existing, ok := s.resourceByURN[urn]; ok {
 		if status != "" {
 			s.resources[existing].status = status
@@ -130,7 +134,7 @@ func (m *Model) renderPulumiBlock(st *pulumiBlockState) string {
 		// so streaming doesn't shuffle earlier lines.
 		rows := append([]pulumiResourceRow(nil), st.resources...)
 		sort.SliceStable(rows, func(i, j int) bool {
-			return opSortRank(rows[i].op) < opSortRank(rows[j].op)
+			return tools.OpSortRank(rows[i].op) < tools.OpSortRank(rows[j].op)
 		})
 		for _, r := range rows {
 			body.WriteString(renderPulumiResourceLine(r) + "\n")
@@ -220,77 +224,36 @@ func renderPulumiDiagLine(d pulumiDiagRow) string {
 }
 
 // renderPulumiCounts prints a compact "3 create · 1 update" counts line with
-// deterministic ordering. Empty / all-same maps render as "no changes".
-func renderPulumiCounts(counts map[string]int) string {
-	if len(counts) == 0 {
+// deterministic ordering. Empty / all-same maps render as "no changes". The
+// underlying ordering and filtering live in tools.FormatChangeCounts so the
+// agent-facing UpdateSummary text and the live TUI footer stay in sync.
+func renderPulumiCounts(counts display.ResourceChanges) string {
+	out := tools.FormatChangeCounts(counts, " · ")
+	if out == "" {
 		return "no changes"
 	}
-	type kv struct {
-		op string
-		n  int
-	}
-	filtered := make([]kv, 0, len(counts))
-	for op, n := range counts {
-		if op == "same" || n == 0 {
-			continue
-		}
-		filtered = append(filtered, kv{op: op, n: n})
-	}
-	if len(filtered) == 0 {
-		return "no changes"
-	}
-	sort.Slice(filtered, func(i, j int) bool {
-		return opSortRank(filtered[i].op) < opSortRank(filtered[j].op)
-	})
-	parts := make([]string, 0, len(filtered))
-	for _, e := range filtered {
-		parts = append(parts, fmt.Sprintf("%d %s", e.n, e.op))
-	}
-	return strings.Join(parts, " · ")
-}
-
-// opSortRank orders operations in the output so related changes cluster: creates
-// first, then updates, replaces, deletes, reads, refreshes, and everything else.
-func opSortRank(op string) int {
-	switch op {
-	case "create", "create-replacement":
-		return 0
-	case "update":
-		return 1
-	case "replace":
-		return 2
-	case "delete", "delete-replaced":
-		return 3
-	case "read", "read-replacement":
-		return 4
-	case "refresh":
-		return 5
-	case "import", "import-replacement":
-		return 6
-	case "same":
-		return 9
-	default:
-		return 7
-	}
+	return out
 }
 
 // pulumiOpGlyph picks the symbol and color for each StepOp. Mirrors the Pulumi
-// CLI's diff display: + creates, - deletes, ~ updates, +- replaces.
-func pulumiOpGlyph(op string) (string, lipgloss.Style) {
+// CLI's diff display: + creates, - deletes, ~ updates, +- replaces. Uses the
+// typed StepOp constants from pkg/resource/deploy so adding a new op causes a
+// compiler-visible miss in the switch (it falls through to the "·" default).
+func pulumiOpGlyph(op display.StepOp) (string, lipgloss.Style) {
 	switch op {
-	case "create", "create-replacement":
+	case deploy.OpCreate, deploy.OpCreateReplacement:
 		return "+", pulumiOpCreate
-	case "update":
+	case deploy.OpUpdate:
 		return "~", pulumiOpUpdate
-	case "delete", "delete-replaced":
+	case deploy.OpDelete, deploy.OpDeleteReplaced:
 		return "-", pulumiOpDelete
-	case "replace":
+	case deploy.OpReplace:
 		return "+-", pulumiOpReplace
-	case "read", "read-replacement":
+	case deploy.OpRead, deploy.OpReadReplacement:
 		return "→", pulumiOpRead
-	case "refresh":
+	case deploy.OpRefresh:
 		return "↻", pulumiOpRefresh
-	case "import", "import-replacement":
+	case deploy.OpImport, deploy.OpImportReplacement:
 		return "⇒", pulumiOpCreate
 	default:
 		return "·", pulumiOpUnknown

--- a/pkg/cmd/pulumi/neo/tui_pulumi.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi.go
@@ -1,0 +1,298 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Pulumi block styling. Colors follow the CLI's preview output: green for
+// create, yellow for update and replace, red for delete, blue for read/refresh.
+// Diagnostics reuse the existing warning/error styles for consistency with the
+// rest of the TUI's event feed.
+var (
+	pulumiBorderOpen = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("8")).
+				Padding(0, 1)
+	pulumiBorderDone = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("6")).
+				Padding(0, 1)
+	pulumiBorderErr = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("1")).
+			Padding(0, 1)
+	pulumiHeaderStyle  = lipgloss.NewStyle().Bold(true)
+	pulumiSubHeader    = lipgloss.NewStyle().Faint(true)
+	pulumiMetaStyle    = lipgloss.NewStyle().Faint(true)
+	pulumiOpCreate     = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	pulumiOpUpdate     = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	pulumiOpDelete     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	pulumiOpReplace    = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+	pulumiOpRead       = lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+	pulumiOpRefresh    = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	pulumiOpUnknown    = lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
+	pulumiDiagWarning  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	pulumiDiagError    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	pulumiStatusDim    = lipgloss.NewStyle().Faint(true)
+	pulumiStatusDone   = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	pulumiStatusFailed = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+)
+
+// addResource records a resource event on the block, deduping by URN. When
+// a URN is seen again, the op stays from the first event (the ResourcePre
+// that established what the engine is doing) and only the status is upgraded
+// in place — later events like ResourceOutputs may carry only a status change.
+func (s *pulumiBlockState) addResource(op, urn, typ, status string) {
+	if existing, ok := s.resourceByURN[urn]; ok {
+		if status != "" {
+			s.resources[existing].status = status
+		}
+		return
+	}
+	s.resourceByURN[urn] = len(s.resources)
+	s.resources = append(s.resources, pulumiResourceRow{op: op, urn: urn, typ: typ, status: status})
+}
+
+// findOpenPulumiBlock returns the index of the most recently added, still-open
+// blockPulumiOp for the given tool name. An "open" block is one that hasn't
+// received UIPulumiEnd yet (state.done == false). Returns -1 if none.
+func (m *Model) findOpenPulumiBlock(toolName string) int {
+	for i := len(m.blocks) - 1; i >= 0; i-- {
+		b := m.blocks[i]
+		if b.kind != blockPulumiOp || b.pulumi == nil {
+			continue
+		}
+		if b.pulumi.toolName == toolName && !b.pulumi.done {
+			return i
+		}
+	}
+	return -1
+}
+
+// renderPulumiBlock produces the rendered string for a blockPulumiOp from its
+// accumulated state. Called from renderBlock on every update and on resize.
+func (m *Model) renderPulumiBlock(st *pulumiBlockState) string {
+	if st == nil {
+		return ""
+	}
+
+	title := "PulumiPreview"
+	if !st.isPreview {
+		title = "PulumiUp"
+	}
+	if st.stackName != "" {
+		title = fmt.Sprintf("%s · %s", title, st.stackName)
+	}
+	header := pulumiHeaderStyle.Render(title)
+	var status string
+	switch {
+	case !st.done:
+		status = pulumiMetaStyle.Render(" · running")
+	case st.err != "":
+		status = pulumiStatusFailed.Render(" · failed")
+	default:
+		status = pulumiStatusDone.Render(" · done")
+	}
+	if st.elapsed != "" {
+		status += pulumiMetaStyle.Render(" · " + st.elapsed)
+	}
+
+	var body strings.Builder
+	body.WriteString(header + status + "\n")
+
+	if len(st.resources) > 0 {
+		resourcesHeader := "Planned changes"
+		if !st.isPreview {
+			resourcesHeader = "Changes"
+		}
+		body.WriteString("\n")
+		body.WriteString(pulumiSubHeader.Render(resourcesHeader) + "\n")
+		// Sort resources: group by op so the block reads top-down as "creates,
+		// updates, replaces, deletes, …". Within each op, keep insertion order
+		// so streaming doesn't shuffle earlier lines.
+		rows := append([]pulumiResourceRow(nil), st.resources...)
+		sort.SliceStable(rows, func(i, j int) bool {
+			return opSortRank(rows[i].op) < opSortRank(rows[j].op)
+		})
+		for _, r := range rows {
+			body.WriteString(renderPulumiResourceLine(r) + "\n")
+		}
+	}
+
+	if len(st.diags) > 0 {
+		body.WriteString("\n")
+		body.WriteString(pulumiSubHeader.Render("Diagnostics") + "\n")
+		for _, d := range st.diags {
+			body.WriteString(renderPulumiDiagLine(d) + "\n")
+		}
+	}
+
+	if len(st.counts) > 0 || st.done {
+		body.WriteString("\n")
+		body.WriteString(pulumiMetaStyle.Render(renderPulumiCounts(st.counts)) + "\n")
+	}
+	if st.err != "" {
+		body.WriteString("\n")
+		body.WriteString(pulumiStatusFailed.Render("error: "+st.err) + "\n")
+	}
+
+	// Choose the border color based on terminal state. Pad the box to fit
+	// comfortably in the viewport — subtract 4 for the border+padding glyphs.
+	style := pulumiBorderOpen
+	switch {
+	case st.err != "":
+		style = pulumiBorderErr
+	case st.done:
+		style = pulumiBorderDone
+	}
+	width := max(m.width-4, 20)
+	return style.Width(width).Render(strings.TrimRight(body.String(), "\n"))
+}
+
+// renderPulumiResourceLine renders one resource row with an op-colored symbol,
+// a short name, the fully-qualified type (dimmed), and a status suffix when
+// relevant (e.g. "running", "done", "failed" for live up operations).
+func renderPulumiResourceLine(r pulumiResourceRow) string {
+	sym, colored := pulumiOpGlyph(r.op)
+	// Extract the short name from the URN (the last `::`-delimited segment).
+	name := r.urn
+	if i := strings.LastIndex(name, "::"); i >= 0 {
+		name = name[i+2:]
+	}
+	line := fmt.Sprintf("  %s %s", colored.Render(sym), name)
+	if r.typ != "" {
+		line += " " + pulumiStatusDim.Render("("+r.typ+")")
+	}
+	switch r.status {
+	case "running":
+		line += " " + pulumiMetaStyle.Render("…")
+	case "done":
+		line += " " + pulumiStatusDone.Render("✓")
+	case "failed":
+		line += " " + pulumiStatusFailed.Render("✗")
+	}
+	return line
+}
+
+// renderPulumiDiagLine renders one diagnostic, trimming excessive whitespace so
+// multi-line messages render as one line in the block. If the URN is present,
+// it's appended as a dim suffix so errors can be associated with resources
+// without visually dominating the row.
+func renderPulumiDiagLine(d pulumiDiagRow) string {
+	glyph := "⚠"
+	style := pulumiDiagWarning
+	switch strings.ToLower(d.severity) {
+	case "error", "fatal":
+		glyph = "✗"
+		style = pulumiDiagError
+	case "info", "debug":
+		glyph = "ℹ"
+		style = pulumiStatusDim
+	}
+	msg := strings.TrimSpace(strings.ReplaceAll(d.message, "\n", " "))
+	line := fmt.Sprintf("  %s %s", style.Render(glyph), msg)
+	if d.urn != "" {
+		short := d.urn
+		if i := strings.LastIndex(short, "::"); i >= 0 {
+			short = short[i+2:]
+		}
+		line += " " + pulumiStatusDim.Render("("+short+")")
+	}
+	return line
+}
+
+// renderPulumiCounts prints a compact "3 create · 1 update" counts line with
+// deterministic ordering. Empty / all-same maps render as "no changes".
+func renderPulumiCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return "no changes"
+	}
+	type kv struct {
+		op string
+		n  int
+	}
+	filtered := make([]kv, 0, len(counts))
+	for op, n := range counts {
+		if op == "same" || n == 0 {
+			continue
+		}
+		filtered = append(filtered, kv{op: op, n: n})
+	}
+	if len(filtered) == 0 {
+		return "no changes"
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return opSortRank(filtered[i].op) < opSortRank(filtered[j].op)
+	})
+	parts := make([]string, 0, len(filtered))
+	for _, e := range filtered {
+		parts = append(parts, fmt.Sprintf("%d %s", e.n, e.op))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// opSortRank orders operations in the output so related changes cluster: creates
+// first, then updates, replaces, deletes, reads, refreshes, and everything else.
+func opSortRank(op string) int {
+	switch op {
+	case "create", "create-replacement":
+		return 0
+	case "update":
+		return 1
+	case "replace":
+		return 2
+	case "delete", "delete-replaced":
+		return 3
+	case "read", "read-replacement":
+		return 4
+	case "refresh":
+		return 5
+	case "import", "import-replacement":
+		return 6
+	case "same":
+		return 9
+	default:
+		return 7
+	}
+}
+
+// pulumiOpGlyph picks the symbol and color for each StepOp. Mirrors the Pulumi
+// CLI's diff display: + creates, - deletes, ~ updates, +- replaces.
+func pulumiOpGlyph(op string) (string, lipgloss.Style) {
+	switch op {
+	case "create", "create-replacement":
+		return "+", pulumiOpCreate
+	case "update":
+		return "~", pulumiOpUpdate
+	case "delete", "delete-replaced":
+		return "-", pulumiOpDelete
+	case "replace":
+		return "+-", pulumiOpReplace
+	case "read", "read-replacement":
+		return "→", pulumiOpRead
+	case "refresh":
+		return "↻", pulumiOpRefresh
+	case "import", "import-replacement":
+		return "⇒", pulumiOpCreate
+	default:
+		return "·", pulumiOpUnknown
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui_pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestModel returns a Model wide enough that the pulumi block's border
+// doesn't force weird word wrapping, without spinning up a full NewModel (which
+// pulls in glamour and textinput setup that aren't needed for block rendering).
+func newTestModel() *Model {
+	return &Model{width: 100, height: 40}
+}
+
+func TestFindOpenPulumiBlock(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	assert.Equal(t, -1, m.findOpenPulumiBlock("pulumi__pulumi_preview"))
+
+	m.blocks = []block{
+		{kind: blockAssistantFinal, raw: "hi"},
+		{kind: blockPulumiOp, pulumi: &pulumiBlockState{toolName: "pulumi__pulumi_preview"}},
+	}
+	assert.Equal(t, 1, m.findOpenPulumiBlock("pulumi__pulumi_preview"))
+
+	// A finalized block is not "open" — subsequent lookups for the same name
+	// should return -1 so UIPulumiStart for a new run opens a fresh block.
+	m.blocks[1].pulumi.done = true
+	assert.Equal(t, -1, m.findOpenPulumiBlock("pulumi__pulumi_preview"))
+
+	// Different tool name doesn't match.
+	m.blocks[1].pulumi.done = false
+	assert.Equal(t, -1, m.findOpenPulumiBlock("pulumi__pulumi_up"))
+}
+
+func TestRenderPulumiBlockEmpty(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_preview",
+		stackName:     "dev",
+		isPreview:     true,
+		resourceByURN: map[string]int{},
+	}
+	out := m.renderPulumiBlock(st)
+	assert.Contains(t, out, "PulumiPreview")
+	assert.Contains(t, out, "dev")
+	assert.Contains(t, out, "running")
+}
+
+func TestRenderPulumiBlockWithResources(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_preview",
+		stackName:     "dev",
+		isPreview:     true,
+		resourceByURN: map[string]int{},
+		resources: []pulumiResourceRow{
+			{
+				op: "create", urn: "urn:pulumi:dev::p::aws:s3/Bucket:Bucket::my-bucket",
+				typ: "aws:s3/Bucket:Bucket", status: "planned",
+			},
+			{
+				op: "update", urn: "urn:pulumi:dev::p::aws:dynamodb/Table::my-table",
+				typ: "aws:dynamodb/Table", status: "planned",
+			},
+			{
+				op: "delete", urn: "urn:pulumi:dev::p::aws:lambda/Function::old-fn",
+				typ: "aws:lambda/Function", status: "planned",
+			},
+		},
+	}
+	out := m.renderPulumiBlock(st)
+	assert.Contains(t, out, "Planned changes")
+	assert.Contains(t, out, "my-bucket")
+	assert.Contains(t, out, "my-table")
+	assert.Contains(t, out, "old-fn")
+	// Short-name extraction: the URN's last `::` segment must appear.
+	assert.NotContains(t, out, "urn:pulumi:dev::")
+}
+
+func TestRenderPulumiBlockWithDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_up",
+		stackName:     "prod",
+		isPreview:     false,
+		resourceByURN: map[string]int{},
+		diags: []pulumiDiagRow{
+			{severity: "warning", message: "deprecated foo", urn: "urn:pulumi:prod::p::aws:s3/Bucket::b"},
+			{severity: "error", message: "bad config", urn: ""},
+		},
+	}
+	out := m.renderPulumiBlock(st)
+	assert.Contains(t, out, "Diagnostics")
+	assert.Contains(t, out, "deprecated foo")
+	assert.Contains(t, out, "bad config")
+	// The resource URN suffix is shown for resource-level diagnostics.
+	assert.Contains(t, out, "b")
+}
+
+func TestRenderPulumiBlockFinalState(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_preview",
+		stackName:     "dev",
+		isPreview:     true,
+		resourceByURN: map[string]int{},
+		counts:        map[string]int{"create": 3, "update": 1, "same": 7},
+		elapsed:       "3s",
+		done:          true,
+	}
+	out := m.renderPulumiBlock(st)
+	assert.Contains(t, out, "done")
+	assert.Contains(t, out, "3s")
+	assert.Contains(t, out, "3 create")
+	assert.Contains(t, out, "1 update")
+	// Same-ops are filtered from the counts footer.
+	assert.NotContains(t, out, "7 same")
+}
+
+func TestRenderPulumiBlockFailed(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModel()
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_up",
+		stackName:     "prod",
+		isPreview:     false,
+		resourceByURN: map[string]int{},
+		err:           "engine crash",
+		done:          true,
+	}
+	out := m.renderPulumiBlock(st)
+	assert.Contains(t, out, "failed")
+	assert.Contains(t, out, "engine crash")
+}
+
+func TestRenderPulumiCounts(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "no changes", renderPulumiCounts(nil))
+	assert.Equal(t, "no changes", renderPulumiCounts(map[string]int{"same": 5}))
+	assert.Equal(t, "2 create · 1 update",
+		renderPulumiCounts(map[string]int{"update": 1, "create": 2, "same": 10}))
+	// Zero-count entries are filtered.
+	assert.Equal(t, "1 create",
+		renderPulumiCounts(map[string]int{"create": 1, "update": 0}))
+}
+
+func TestPulumiOpGlyph(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"create":  "+",
+		"update":  "~",
+		"delete":  "-",
+		"replace": "+-",
+		"read":    "→",
+		"refresh": "↻",
+		"bogus":   "·",
+	}
+	for op, want := range cases {
+		got, _ := pulumiOpGlyph(op)
+		assert.Equal(t, want, got, "op=%s", op)
+	}
+}
+
+func TestPulumiStateDedupesURN(t *testing.T) {
+	t.Parallel()
+
+	// During a pulumi up the engine fires ResourcePre ("running") and then
+	// ResourceOutputs ("done") for the same URN. addResource must dedupe by
+	// URN and upgrade status in place.
+	st := &pulumiBlockState{resourceByURN: map[string]int{}}
+	st.addResource("create", "urn:1", "aws:s3/Bucket", "running")
+	st.addResource("create", "urn:1", "aws:s3/Bucket", "done")
+
+	require.Len(t, st.resources, 1)
+	assert.Equal(t, "done", st.resources[0].status)
+}
+
+func TestRenderPulumiBlockNarrowWidth(t *testing.T) {
+	t.Parallel()
+
+	// Tiny terminal. Box width is clamped to a floor so lipgloss doesn't blow up.
+	m := &Model{width: 10, height: 20}
+	st := &pulumiBlockState{
+		toolName:      "pulumi__pulumi_preview",
+		stackName:     "dev",
+		isPreview:     true,
+		resourceByURN: map[string]int{},
+	}
+	out := m.renderPulumiBlock(st)
+	// The output must be non-empty and not panic; exact visual layout at
+	// width=10 isn't interesting to assert.
+	require.NotEmpty(t, out)
+	assert.Contains(t, strings.ToLower(out), "pulumipreview")
+}

--- a/pkg/cmd/pulumi/neo/tui_pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi_test.go
@@ -225,3 +225,247 @@ func TestRenderPulumiBlockNarrowWidth(t *testing.T) {
 	require.NotEmpty(t, out)
 	assert.Contains(t, strings.ToLower(out), "pulumipreview")
 }
+
+// -----------------------------------------------------------------------------
+// Model.Update tests for the UIPulumi* events. These exercise the four event
+// handlers added to tui.go in this PR. Pattern matches the other UI* Update
+// tests in tui_test.go (e.g. TestModel_Update_UIToolStarted_ShowsBusyBlock).
+// -----------------------------------------------------------------------------
+
+func TestModel_Update_UIPulumiStart_OpensBlock(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "dev", IsPreview: true,
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks, 1, "Start opens exactly one block")
+	got := um.blocks[0]
+	assert.Equal(t, blockPulumiOp, got.kind)
+	require.NotNil(t, got.pulumi)
+	assert.Equal(t, "pulumi__pulumi_preview", got.pulumi.toolName)
+	assert.Equal(t, "dev", got.pulumi.stackName)
+	assert.True(t, got.pulumi.isPreview)
+	assert.False(t, got.pulumi.done, "block must start in the open state")
+	assert.NotEmpty(t, got.rendered, "Start must render the block immediately")
+}
+
+func TestModel_Update_UIPulumiStart_ReusesOpenBlock(t *testing.T) {
+	t.Parallel()
+
+	// Defensive: if a UIPulumiStart arrives while another block for the same
+	// tool name is still open (e.g. agent retry), the existing block is
+	// reset rather than a duplicate appearing in the transcript.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.blocks = []block{{
+		kind: blockPulumiOp,
+		pulumi: &pulumiBlockState{
+			toolName:      "pulumi__pulumi_preview",
+			stackName:     "stale",
+			resourceByURN: map[string]int{"urn:x": 0},
+			resources:     []pulumiResourceRow{{urn: "urn:x"}},
+		},
+	}}
+
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "fresh", IsPreview: true,
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks, 1, "must not append a second block for the same open tool")
+	st := um.blocks[0].pulumi
+	assert.Equal(t, "fresh", st.stackName, "state must be replaced, not merged")
+	assert.Empty(t, st.resources, "resources from the prior run must be cleared")
+	require.NotNil(t, st.resourceByURN)
+	assert.Empty(t, st.resourceByURN)
+}
+
+func TestModel_Update_UIPulumiStart_StartsFreshAfterDone(t *testing.T) {
+	t.Parallel()
+
+	// A finalized block (done=true) is no longer "open"; a subsequent Start
+	// for the same tool name must append a new block, not overwrite history.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.blocks = []block{{
+		kind: blockPulumiOp,
+		pulumi: &pulumiBlockState{
+			toolName:      "pulumi__pulumi_preview",
+			done:          true,
+			resourceByURN: map[string]int{},
+		},
+	}}
+
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "second", IsPreview: true,
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks, 2, "a fresh Start after done must append a new block")
+	assert.True(t, um.blocks[0].pulumi.done, "old block stays finalized")
+	assert.False(t, um.blocks[1].pulumi.done, "new block is open")
+	assert.Equal(t, "second", um.blocks[1].pulumi.stackName)
+}
+
+func TestModel_Update_UIPulumiResource_AppendsRow(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "dev", IsPreview: true,
+	})
+	updated, _ = updated.(Model).Update(UIPulumiResource{
+		ToolName: "pulumi__pulumi_preview",
+		Op:       deploy.OpCreate,
+		URN:      "urn:pulumi:dev::p::aws:s3/Bucket::b",
+		Type:     "aws:s3/Bucket",
+		Status:   "planned",
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks, 1)
+	require.Len(t, um.blocks[0].pulumi.resources, 1)
+	row := um.blocks[0].pulumi.resources[0]
+	assert.Equal(t, deploy.OpCreate, row.op)
+	assert.Equal(t, "planned", row.status)
+}
+
+func TestModel_Update_UIPulumiResource_NoBlockIsDefensiveNoOp(t *testing.T) {
+	t.Parallel()
+
+	// If a Resource event arrives without a preceding Start (e.g. event
+	// reordering on the wire), the handler must not panic and must not
+	// fabricate a block out of thin air.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	require.NotPanics(t, func() {
+		_, _ = m.Update(UIPulumiResource{
+			ToolName: "pulumi__pulumi_preview",
+			Op:       deploy.OpCreate,
+			URN:      "urn:x",
+		})
+	})
+	updated, _ := m.Update(UIPulumiResource{
+		ToolName: "pulumi__pulumi_preview", Op: deploy.OpCreate, URN: "urn:x",
+	})
+	um := updated.(Model)
+	assert.Empty(t, um.blocks, "no block must be created without a Start")
+}
+
+func TestModel_Update_UIPulumiDiag_AppendsRow(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_up", StackName: "prod", IsPreview: false,
+	})
+	updated, _ = updated.(Model).Update(UIPulumiDiag{
+		ToolName: "pulumi__pulumi_up",
+		Severity: "warning",
+		Message:  "deprecated foo",
+		URN:      "urn:pulumi:prod::p::aws:s3/Bucket::b",
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks[0].pulumi.diags, 1)
+	d := um.blocks[0].pulumi.diags[0]
+	assert.Equal(t, "warning", d.severity)
+	assert.Equal(t, "deprecated foo", d.message)
+}
+
+func TestModel_Update_UIPulumiDiag_NoBlockIsDefensiveNoOp(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	require.NotPanics(t, func() {
+		_, _ = m.Update(UIPulumiDiag{
+			ToolName: "pulumi__pulumi_up", Severity: "error", Message: "x",
+		})
+	})
+}
+
+func TestModel_Update_UIPulumiEnd_FinalizesBlock(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "dev", IsPreview: true,
+	})
+	updated, _ = updated.(Model).Update(UIPulumiEnd{
+		ToolName: "pulumi__pulumi_preview",
+		Counts:   display.ResourceChanges{deploy.OpCreate: 2, deploy.OpUpdate: 1},
+		Elapsed:  "5s",
+	})
+	um := updated.(Model)
+
+	require.Len(t, um.blocks, 1)
+	st := um.blocks[0].pulumi
+	assert.True(t, st.done, "End must mark the block done")
+	assert.Equal(t, "5s", st.elapsed)
+	assert.Equal(t, display.ResourceChanges{deploy.OpCreate: 2, deploy.OpUpdate: 1}, st.counts)
+	assert.Empty(t, st.err)
+
+	// A subsequent Start for the same tool name must open a new block, not
+	// reopen this one — proves done-flag gating works end-to-end.
+	updated, _ = um.Update(UIPulumiStart{ToolName: "pulumi__pulumi_preview"})
+	require.Len(t, updated.(Model).blocks, 2)
+}
+
+func TestModel_Update_UIPulumiEnd_CarriesError(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated, _ := m.Update(UIPulumiStart{ToolName: "pulumi__pulumi_up"})
+	updated, _ = updated.(Model).Update(UIPulumiEnd{
+		ToolName: "pulumi__pulumi_up",
+		Err:      "engine crash",
+		Elapsed:  "3s",
+	})
+	um := updated.(Model)
+
+	st := um.blocks[0].pulumi
+	assert.True(t, st.done)
+	assert.Equal(t, "engine crash", st.err)
+}
+
+func TestModel_Update_UIPulumiEnd_NoBlockIsDefensiveNoOp(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	require.NotPanics(t, func() {
+		_, _ = m.Update(UIPulumiEnd{ToolName: "pulumi__pulumi_up"})
+	})
+}
+
+func TestModel_Update_UIPulumi_LeavesBusyAlone(t *testing.T) {
+	t.Parallel()
+
+	// UIPulumi* are progress events for an in-flight tool call; they must
+	// neither end the busy state (the agent is still working through the
+	// tool) nor change the busy *label* (the parent UIToolStarted set
+	// "PulumiPreview ..." and that's the right label to keep showing).
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch, Busy: true})
+	require.True(t, m.busy)
+
+	for _, ev := range []UIEvent{
+		UIPulumiStart{ToolName: "pulumi__pulumi_preview", IsPreview: true},
+		UIPulumiResource{ToolName: "pulumi__pulumi_preview", Op: deploy.OpCreate, URN: "urn:x"},
+		UIPulumiDiag{ToolName: "pulumi__pulumi_preview", Severity: "warning", Message: "w"},
+		UIPulumiEnd{ToolName: "pulumi__pulumi_preview", Elapsed: "1s"},
+	} {
+		updated, _ := m.Update(ev)
+		m = updated.(Model)
+		assert.True(t, m.busy, "event %T must not end the busy state", ev)
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui_pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi_test.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 )
 
 // newTestModel returns a Model wide enough that the pulumi block's border
@@ -78,15 +81,15 @@ func TestRenderPulumiBlockWithResources(t *testing.T) {
 		resourceByURN: map[string]int{},
 		resources: []pulumiResourceRow{
 			{
-				op: "create", urn: "urn:pulumi:dev::p::aws:s3/Bucket:Bucket::my-bucket",
+				op: deploy.OpCreate, urn: "urn:pulumi:dev::p::aws:s3/Bucket:Bucket::my-bucket",
 				typ: "aws:s3/Bucket:Bucket", status: "planned",
 			},
 			{
-				op: "update", urn: "urn:pulumi:dev::p::aws:dynamodb/Table::my-table",
+				op: deploy.OpUpdate, urn: "urn:pulumi:dev::p::aws:dynamodb/Table::my-table",
 				typ: "aws:dynamodb/Table", status: "planned",
 			},
 			{
-				op: "delete", urn: "urn:pulumi:dev::p::aws:lambda/Function::old-fn",
+				op: deploy.OpDelete, urn: "urn:pulumi:dev::p::aws:lambda/Function::old-fn",
 				typ: "aws:lambda/Function", status: "planned",
 			},
 		},
@@ -131,7 +134,7 @@ func TestRenderPulumiBlockFinalState(t *testing.T) {
 		stackName:     "dev",
 		isPreview:     true,
 		resourceByURN: map[string]int{},
-		counts:        map[string]int{"create": 3, "update": 1, "same": 7},
+		counts:        display.ResourceChanges{deploy.OpCreate: 3, deploy.OpUpdate: 1, deploy.OpSame: 7},
 		elapsed:       "3s",
 		done:          true,
 	}
@@ -165,25 +168,25 @@ func TestRenderPulumiCounts(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "no changes", renderPulumiCounts(nil))
-	assert.Equal(t, "no changes", renderPulumiCounts(map[string]int{"same": 5}))
+	assert.Equal(t, "no changes", renderPulumiCounts(display.ResourceChanges{deploy.OpSame: 5}))
 	assert.Equal(t, "2 create · 1 update",
-		renderPulumiCounts(map[string]int{"update": 1, "create": 2, "same": 10}))
+		renderPulumiCounts(display.ResourceChanges{deploy.OpUpdate: 1, deploy.OpCreate: 2, deploy.OpSame: 10}))
 	// Zero-count entries are filtered.
 	assert.Equal(t, "1 create",
-		renderPulumiCounts(map[string]int{"create": 1, "update": 0}))
+		renderPulumiCounts(display.ResourceChanges{deploy.OpCreate: 1, deploy.OpUpdate: 0}))
 }
 
 func TestPulumiOpGlyph(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]string{
-		"create":  "+",
-		"update":  "~",
-		"delete":  "-",
-		"replace": "+-",
-		"read":    "→",
-		"refresh": "↻",
-		"bogus":   "·",
+	cases := map[display.StepOp]string{
+		deploy.OpCreate:  "+",
+		deploy.OpUpdate:  "~",
+		deploy.OpDelete:  "-",
+		deploy.OpReplace: "+-",
+		deploy.OpRead:    "→",
+		deploy.OpRefresh: "↻",
+		"bogus":          "·",
 	}
 	for op, want := range cases {
 		got, _ := pulumiOpGlyph(op)
@@ -198,8 +201,8 @@ func TestPulumiStateDedupesURN(t *testing.T) {
 	// ResourceOutputs ("done") for the same URN. addResource must dedupe by
 	// URN and upgrade status in place.
 	st := &pulumiBlockState{resourceByURN: map[string]int{}}
-	st.addResource("create", "urn:1", "aws:s3/Bucket", "running")
-	st.addResource("create", "urn:1", "aws:s3/Bucket", "done")
+	st.addResource(deploy.OpCreate, "urn:1", "aws:s3/Bucket", "running")
+	st.addResource(deploy.OpCreate, "urn:1", "aws:s3/Bucket", "done")
 
 	require.Len(t, st.resources, 1)
 	assert.Equal(t, "done", st.resources[0].status)


### PR DESCRIPTION
## Summary

Adds `pulumi_preview` and `pulumi_up` as Neo CLI tools with a rich TUI presentation.

- New `Pulumi` tool handler in `pkg/cmd/pulumi/neo/tools/pulumi.go` that wraps `backend.PreviewStack` / `backend.UpdateStack`. JSON argument and result shapes match the upstream MCP tool definitions in `pulumi-service:cmd/agents/src/agents_py/mcp/pulumi_mcp.py` (`project_name`, `stack_name`, `local_pulumi_dir`, `environment_variables`; returns a `PulumiOperationResult`), so the agent sees the same shape whether a call ran locally or via a Pulumi Cloud Deployment.
- Secret-typed env vars (`{"secret": "..."}`) are unwrapped and applied for the engine run but never flow into progress messages, the returned logs, or the NDJSON events file.
- Engine events stream into a persistent, bordered preview/up block in the Neo TUI: resources grouped by op with colored glyphs (`+` / `~` / `-` / `+-` / `→` / `↻`), a diagnostics section, and a `2 create · 1 update` counts footer. The block shows as "running" while the operation is live and flips to "done" / "failed" on completion.
- Approval is delegated to the existing server-side flow (`NeoApprovalModeManual` + `UIApprovalRequest`); no local pre-flight confirmation.
- `os.Stdout` / `os.Stderr` are redirected to `/dev/null` for the duration of the backend call so stray `fmt.Printf` banners (e.g. the `"Previewing update (stack)"` line in `pkg/backend/httpstate/backend.go:1662`) can't corrupt bubbletea's alt-screen. bubbletea captures its terminal reference at `tea.NewProgram`, so the TUI keeps rendering through the swap.

Fixes pulumi/pulumi-service#41315.

[![asciicast](https://asciinema.org/a/IVckQzWqBaLCRoM5.svg)](https://asciinema.org/a/IVckQzWqBaLCRoM5)

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [x] `make lint` — clean on the touched tree (`golangci-lint run ./cmd/pulumi/neo/...` → 0 issues)
- [x] `make format` — clean
- [x] `go test ./cmd/pulumi/neo/...` — all pass
- [ ] `make test_fast` — not run
- [ ] `make tidy_fix` — not run
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply the `impact/no-changelog-required` label.

## Risk

- The new command is gated on experimental mode (`pulumi neo` stays hidden unless `PULUMI_EXPERIMENTAL=1`); no public SDK or CLI surface changes.
- `silenceStd` swaps `os.Stdout` / `os.Stderr` for the duration of each pulumi tool call. bubbletea holds a captured terminal reference from `tea.NewProgram`, so rendering is unaffected, and `defer` restores the originals even on panic. Plugin subprocesses inherit the original fd 1 at the OS level, not the Go variable — their output still flows through the engine's gRPC event stream.
- Engine `UpdateOptions` are built inline (~40 lines duplicated from `operations/up.go`). Follow-up to extract shared `operations.RunPreview` / `operations.RunUpdate` helpers once this path is stable.