### PR TITLE
Accept explicit SecretValue object form on unmarshal

### DIFF
--- a/changelog/pending/20260422--sdk-go--accept-explicit-secretvalue-object-wire-form-on-unmarshal.yaml
+++ b/changelog/pending/20260422--sdk-go--accept-explicit-secretvalue-object-wire-form-on-unmarshal.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/go
+  description: Accept the new explicit `{"isSecret": bool, "value": "..."}` object form when unmarshaling `apitype.SecretValue` from JSON or YAML. The existing legacy forms (bare string for non-secret values, `{"secret": "..."}` for secrets) are unchanged, and `MarshalJSON` still emits the legacy forms. This is a forward-compat step so CLI installations can read a future Pulumi Service wire format where the `isSecret` bit is an explicit field rather than encoded structurally.

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -356,26 +356,40 @@ type SecretValue struct {
 	Secret     bool
 }
 
-type secretWorkflowValue struct {
+// secretWireValue is the on-the-wire representation of a SecretValue. It covers two shapes:
+//
+//   - The legacy shape, where the secret-ness of a value is encoded structurally: a bare string
+//     is a non-secret plaintext value, and any object is a secret whose plaintext lives in the
+//     Secret field (or whose ciphertext lives in Ciphertext). Written by MarshalJSON today.
+//   - The explicit shape, where IsSecret is a present boolean and the plaintext lives in Value.
+//     Not written today, but accepted on unmarshal so CLI installs become new-format-tolerant
+//     before any server starts emitting it.
+//
+// Exactly one of Value or Secret should be set; senders should not populate both.
+type secretWireValue struct {
+	// Legacy fields.
 	Secret     string `json:"secret,omitempty" yaml:"secret,omitempty"`
 	Ciphertext string `json:"ciphertext,omitempty" yaml:"ciphertext,omitempty"`
+	// Explicit-form fields. IsSecret is a pointer so its presence distinguishes the two shapes.
+	IsSecret *bool  `json:"isSecret,omitempty" yaml:"isSecret,omitempty"`
+	Value    string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 func (v SecretValue) MarshalJSON() ([]byte, error) {
 	switch {
 	case len(v.Ciphertext) != 0:
-		return json.Marshal(secretWorkflowValue{Ciphertext: v.Ciphertext})
+		return json.Marshal(secretWireValue{Ciphertext: v.Ciphertext})
 	case v.Secret:
-		return json.Marshal(secretWorkflowValue{Secret: v.Value})
+		return json.Marshal(secretWireValue{Secret: v.Value})
 	default:
 		return json.Marshal(v.Value)
 	}
 }
 
 func (v *SecretValue) UnmarshalJSON(bytes []byte) error {
-	var secret secretWorkflowValue
-	if err := json.Unmarshal(bytes, &secret); err == nil {
-		v.Value, v.Ciphertext, v.Secret = secret.Secret, secret.Ciphertext, true
+	var w secretWireValue
+	if err := json.Unmarshal(bytes, &w); err == nil {
+		v.fromWire(w)
 		return nil
 	}
 
@@ -390,18 +404,18 @@ func (v *SecretValue) UnmarshalJSON(bytes []byte) error {
 func (v SecretValue) MarshalYAML() (any, error) {
 	switch {
 	case len(v.Ciphertext) != 0:
-		return secretWorkflowValue{Ciphertext: v.Ciphertext}, nil
+		return secretWireValue{Ciphertext: v.Ciphertext}, nil
 	case v.Secret:
-		return secretWorkflowValue{Secret: v.Value}, nil
+		return secretWireValue{Secret: v.Value}, nil
 	default:
 		return v.Value, nil
 	}
 }
 
 func (v *SecretValue) UnmarshalYAML(node *yaml.Node) error {
-	var secret secretWorkflowValue
-	if err := node.Decode(&secret); err == nil {
-		v.Value, v.Ciphertext, v.Secret = secret.Secret, secret.Ciphertext, true
+	var w secretWireValue
+	if err := node.Decode(&w); err == nil {
+		v.fromWire(w)
 		return nil
 	}
 
@@ -411,6 +425,18 @@ func (v *SecretValue) UnmarshalYAML(node *yaml.Node) error {
 	}
 	v.Value, v.Secret = plaintext, false
 	return nil
+}
+
+// fromWire populates v from a decoded secretWireValue. If IsSecret is present the wire is in the
+// new explicit form and Value carries the plaintext; otherwise the legacy form is assumed and any
+// object is treated as a secret.
+func (v *SecretValue) fromWire(w secretWireValue) {
+	v.Ciphertext = w.Ciphertext
+	if w.IsSecret != nil {
+		v.Value, v.Secret = w.Value, *w.IsSecret
+		return
+	}
+	v.Value, v.Secret = w.Secret, true
 }
 
 type GetDeploymentUpdatesUpdateInfo struct {

--- a/sdk/go/common/apitype/deployments_test.go
+++ b/sdk/go/common/apitype/deployments_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSecretValueUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  SecretValue
+	}{
+		{
+			name:  "legacy plaintext string",
+			input: `"plain"`,
+			want:  SecretValue{Value: "plain", Secret: false},
+		},
+		{
+			name:  "legacy empty string",
+			input: `""`,
+			want:  SecretValue{Value: "", Secret: false},
+		},
+		{
+			name:  "legacy secret object",
+			input: `{"secret":"plain"}`,
+			want:  SecretValue{Value: "plain", Secret: true},
+		},
+		{
+			name:  "legacy ciphertext object",
+			input: `{"ciphertext":"encrypted"}`,
+			want:  SecretValue{Ciphertext: "encrypted", Secret: true},
+		},
+		{
+			name:  "legacy secret + ciphertext",
+			input: `{"secret":"plain","ciphertext":"encrypted"}`,
+			want:  SecretValue{Value: "plain", Ciphertext: "encrypted", Secret: true},
+		},
+		{
+			name:  "new form explicit non-secret",
+			input: `{"isSecret":false,"value":"plain"}`,
+			want:  SecretValue{Value: "plain", Secret: false},
+		},
+		{
+			name:  "new form explicit secret with plaintext",
+			input: `{"isSecret":true,"value":"plain"}`,
+			want:  SecretValue{Value: "plain", Secret: true},
+		},
+		{
+			name:  "new form explicit secret with ciphertext",
+			input: `{"isSecret":true,"ciphertext":"encrypted"}`,
+			want:  SecretValue{Ciphertext: "encrypted", Secret: true},
+		},
+		{
+			name:  "new form explicit non-secret with empty value",
+			input: `{"isSecret":false}`,
+			want:  SecretValue{Value: "", Secret: false},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got SecretValue
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSecretValueUnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  SecretValue
+	}{
+		{
+			name:  "legacy plaintext string",
+			input: `plain`,
+			want:  SecretValue{Value: "plain", Secret: false},
+		},
+		{
+			name:  "legacy secret object",
+			input: `secret: plain`,
+			want:  SecretValue{Value: "plain", Secret: true},
+		},
+		{
+			name:  "legacy ciphertext object",
+			input: `ciphertext: encrypted`,
+			want:  SecretValue{Ciphertext: "encrypted", Secret: true},
+		},
+		{
+			name:  "new form explicit non-secret",
+			input: "isSecret: false\nvalue: plain",
+			want:  SecretValue{Value: "plain", Secret: false},
+		},
+		{
+			name:  "new form explicit secret with plaintext",
+			input: "isSecret: true\nvalue: plain",
+			want:  SecretValue{Value: "plain", Secret: true},
+		},
+		{
+			name:  "new form explicit secret with ciphertext",
+			input: "isSecret: true\nciphertext: encrypted",
+			want:  SecretValue{Ciphertext: "encrypted", Secret: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got SecretValue
+			require.NoError(t, yaml.Unmarshal([]byte(tc.input), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSecretValueUnmarshalJSONError covers inputs that are valid JSON but cannot decode as
+// either the object form (bare string, legacy, or new explicit shape) or the fallback string
+// form. UnmarshalJSON should surface the string-decode error to the caller.
+func TestSecretValueUnmarshalJSONError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "bare number", input: `42`},
+		{name: "bare bool", input: `true`},
+		{name: "array", input: `[1,2,3]`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got SecretValue
+			assert.Error(t, json.Unmarshal([]byte(tc.input), &got))
+		})
+	}
+}
+
+// TestSecretValueUnmarshalYAMLError covers inputs that are valid YAML but cannot decode as
+// either the object form or the fallback string form. UnmarshalYAML should surface the
+// string-decode error to the caller.
+func TestSecretValueUnmarshalYAMLError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "sequence", input: "- 1\n- 2\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got SecretValue
+			assert.Error(t, yaml.Unmarshal([]byte(tc.input), &got))
+		})
+	}
+}
+
+// TestSecretValueMarshalJSONUnchanged locks down the write-side wire format. The staged
+// rollout keeps MarshalJSON emitting the legacy heterogeneous form until adoption of the
+// new UnmarshalJSON reaches high coverage; this test fails loudly if that changes.
+func TestSecretValueMarshalJSONUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   SecretValue
+		want string
+	}{
+		{
+			name: "non-secret plaintext emits bare string",
+			in:   SecretValue{Value: "plain", Secret: false},
+			want: `"plain"`,
+		},
+		{
+			name: "secret plaintext emits legacy object",
+			in:   SecretValue{Value: "plain", Secret: true},
+			want: `{"secret":"plain"}`,
+		},
+		{
+			name: "ciphertext emits legacy object",
+			in:   SecretValue{Ciphertext: "encrypted", Secret: true},
+			want: `{"ciphertext":"encrypted"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestSecretValueMarshalYAMLUnchanged locks down the on-disk YAML format written by
+// `pulumi deployment settings pull` into the user-facing `Pulumi.stack.deploy.yaml` file.
+// That file is source-controlled; its schema is a user-facing UX commitment. Even when the
+// service eventually flips its JSON wire format to an explicit object form, the CLI's
+// MarshalYAML must continue to emit the compact heterogeneous form: a bare string for
+// non-secret values, a `{secret: ...}` object for secrets, and a `{ciphertext: ...}` object
+// for encrypted secrets. This test fails loudly if that promise is broken.
+func TestSecretValueMarshalYAMLUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   SecretValue
+		want string
+	}{
+		{
+			name: "non-secret plaintext emits bare string",
+			in:   SecretValue{Value: "plain", Secret: false},
+			want: "plain\n",
+		},
+		{
+			name: "secret plaintext emits legacy object",
+			in:   SecretValue{Value: "plain", Secret: true},
+			want: "secret: plain\n",
+		},
+		{
+			name: "ciphertext emits legacy object",
+			in:   SecretValue{Ciphertext: "encrypted", Secret: true},
+			want: "ciphertext: encrypted\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := yaml.Marshal(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestSecretValueRoundTripJSON verifies that values produced by MarshalJSON are read back
+// to structurally-equivalent SecretValues. The legacy forms should round-trip exactly; the
+// new explicit form isn't emitted yet but is parsed, so we round-trip it manually.
+func TestSecretValueRoundTripJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("legacy writer", func(t *testing.T) {
+		t.Parallel()
+		inputs := []SecretValue{
+			{Value: "plain", Secret: false},
+			{Value: "plain", Secret: true},
+			{Ciphertext: "encrypted", Secret: true},
+		}
+		for _, in := range inputs {
+			bytes, err := json.Marshal(in)
+			require.NoError(t, err)
+			var out SecretValue
+			require.NoError(t, json.Unmarshal(bytes, &out))
+			assert.Equal(t, in, out)
+		}
+	})
+
+	t.Run("new form parses", func(t *testing.T) {
+		t.Parallel()
+		// Future senders will emit the explicit form. These fixtures cover the cases the
+		// CLI must be tolerant of once the service side flips.
+		cases := []struct {
+			wire string
+			want SecretValue
+		}{
+			{`{"isSecret":false,"value":"plain"}`, SecretValue{Value: "plain", Secret: false}},
+			{`{"isSecret":true,"value":"plain"}`, SecretValue{Value: "plain", Secret: true}},
+			{`{"isSecret":true,"ciphertext":"encrypted"}`, SecretValue{Ciphertext: "encrypted", Secret: true}},
+		}
+		for _, tc := range cases {
+			var got SecretValue
+			require.NoError(t, json.Unmarshal([]byte(tc.wire), &got))
+			assert.Equal(t, tc.want, got)
+		}
+	})
+}
+
+// DockerImage shares SecretValue's heterogeneous wire-format anti-pattern: MarshalJSON
+// emits a bare string when only Reference is set and an object otherwise. The same
+// staged convergence is planned (see pulumi/pulumi-service TYPE_MIGRATION_PLAN.md
+// Phase 1a). Unlike SecretValue, DockerImage's UnmarshalJSON already accepts both
+// forms, so no compat-read code change is needed in the CLI — but we lock in the
+// current MarshalJSON output and the dual-form UnmarshalJSON behavior so a future
+// flip is intentional and reviewable.
+
+// TestDockerImageMarshalJSONUnchanged locks down the current heterogeneous JSON output:
+// a bare string when only Reference is set, an object when Credentials is also present.
+// When the Pulumi Service flips its DockerImage MarshalJSON to always emit object form
+// (Phase 1a Stage 2), this test will fail and prompt a coordinated update.
+func TestDockerImageMarshalJSONUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   DockerImage
+		want string
+	}{
+		{
+			name: "reference only emits bare string",
+			in:   DockerImage{Reference: "alpine:latest"},
+			want: `"alpine:latest"`,
+		},
+		{
+			name: "reference + credentials emits object",
+			in: DockerImage{
+				Reference: "alpine:latest",
+				Credentials: &DockerImageCredentials{
+					Username: "user",
+					Password: SecretValue{Value: "pw", Secret: true},
+				},
+			},
+			want: `{"reference":"alpine:latest","credentials":{"username":"user","password":{"secret":"pw"}}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(&tc.in)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+// TestDockerImageUnmarshalJSON verifies that DockerImage's existing UnmarshalJSON accepts
+// both the bare-string and object wire forms. This is regression coverage: when the
+// service eventually starts emitting only the object form (Phase 1a Stage 2), bare-string
+// support must remain so older saved data continues to parse.
+func TestDockerImageUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  DockerImage
+	}{
+		{
+			name:  "bare string",
+			input: `"alpine:latest"`,
+			want:  DockerImage{Reference: "alpine:latest"},
+		},
+		{
+			name:  "object with reference only",
+			input: `{"reference":"alpine:latest"}`,
+			want:  DockerImage{Reference: "alpine:latest"},
+		},
+		{
+			name:  "object with credentials",
+			input: `{"reference":"alpine:latest","credentials":{"username":"user","password":{"secret":"pw"}}}`,
+			want: DockerImage{
+				Reference: "alpine:latest",
+				Credentials: &DockerImageCredentials{
+					Username: "user",
+					Password: SecretValue{Value: "pw", Secret: true},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var got DockerImage
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &got))
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Extends `SecretValue.UnmarshalJSON` and `UnmarshalYAML` in `sdk/go/common/apitype/deployments.go` to accept a new explicit object form — `{"isSecret": bool, "value": "..."}` — in addition to the existing legacy forms (bare string for non-secret values, `{"secret": "..."}` for secrets). No `MarshalJSON`/`MarshalYAML` changes — the CLI continues to emit the legacy heterogeneous form. Existing write-side behavior (both for `SecretValue` and for `DockerImage`, which shares the same heterogeneous wire pattern) is locked down with golden tests so a future flip of the write side is intentional and reviewable.

### Why

This is Stage 1 of a staged wire-format convergence tracked in `pulumi/pulumi-service` → `cmd/console2/TYPE_MIGRATION_PLAN.md` (Phase 1a). The Pulumi Service's `SecretValue` wire format today is heterogeneous: a bare string `"value"` means "not secret", and an object means "secret". The Java IDL and generated TypeScript can only model the object shape, so the frontend keeps a hand-maintained `{[k]: string | SecretValue}` type for deployment environment variables. To converge the IDL, OpenAPI spec, and TypeScript on a single source of truth, we want the service to flip `MarshalJSON` to always emit the object form with an explicit `isSecret` field.

Doing that flip safely requires every live CLI to already tolerate the new form before the service starts emitting it. This PR is that tolerance step — it's purely read-side, so shipping it now has no behavior impact but ensures future CLI installs can parse the new form once the service cuts over (target: ~3–6 months out, after adoption of this release).

`DockerImage` in the same file shares the anti-pattern (bare string when only `Reference` is set, object otherwise). Its `UnmarshalJSON` already accepts both forms, so no compat-read change is needed there — but we lock in the current `MarshalJSON` output and dual-form `UnmarshalJSON` behavior so a future Stage-2 flip on the service side is visible as an intentional test update.

### Scope

- `SecretValue.UnmarshalJSON` / `UnmarshalYAML`: accept three forms (bare string, legacy `{"secret"}` object, new `{"isSecret", "value"}` object). Disambiguation is by the presence of `isSecret`. The object/string decode logic is factored into a small `fromWire` helper shared by both.
- `SecretValue.MarshalJSON` / `MarshalYAML`: **unchanged**. Golden tests (`TestSecretValueMarshalJSONUnchanged`, `TestSecretValueMarshalYAMLUnchanged`) lock down the current output. The YAML lockdown matters because `Pulumi.stack.deploy.yaml` is source-controlled — its schema is a user-facing UX commitment that must not flip even when the service-side JSON eventually does.
- `DockerImage.MarshalJSON`: **unchanged**. `TestDockerImageMarshalJSONUnchanged` locks down the current heterogeneous output, and `TestDockerImageUnmarshalJSON` is regression coverage for the existing dual-form read path.
- Tests cover every form (legacy bare string, legacy secret/ciphertext objects, new explicit form for secret and non-secret with plaintext and ciphertext), round-trip via the legacy writer, and error paths (malformed JSON/YAML that decodes as neither object nor bare string).

### Test plan

- [x] `go test ./sdk/go/common/apitype/...` passes
- [x] `go test ./pkg/cmd/pulumi/deployment/...` passes (primary internal consumer)
- [x] `go build ./...` in both `sdk/` and `pkg/` modules
- [x] `golangci-lint` clean on `sdk/go/common/apitype`
- [x] Local `go tool cover` shows 100% coverage of every modified function (`MarshalJSON`, `UnmarshalJSON`, `MarshalYAML`, `UnmarshalYAML`, `fromWire`)
- [x] CI green except `codecov/patch` (see note below)

> **Codecov note:** `codecov/patch` reports 68% (threshold 80%). Local `go tool cover` shows the new code is 100% covered. The codecov report marks pre-existing `MarshalJSON` lines as newly uncovered on head even though they were covered on base — appears to be a codecov aggregation issue with the repo's `-coverpkg` multi-entry output, not a real gap.