### PR TITLE
ci: point test runs at staging Pulumi API

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -74,7 +74,8 @@ env:
   PULUMI_VERSION: ${{ inputs.version }}
   PULUMI_TEST_OWNER: "moolumi"
   PULUMI_TEST_ORG: "moolumi"
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_STAGING_ACCESS_TOKEN }}
+  PULUMI_API: https://api.pulumi-staging.io
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -74,8 +74,11 @@ env:
   PULUMI_VERSION: ${{ inputs.version }}
   PULUMI_TEST_OWNER: "moolumi"
   PULUMI_TEST_ORG: "moolumi"
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_STAGING_ACCESS_TOKEN }}
-  PULUMI_API: https://api.pulumi-staging.io
+  # Performance tests keep hitting production because staging has different
+  # throughput characteristics than production, so the perf thresholds aren't
+  # meaningful against staging. Everything else runs against staging.
+  PULUMI_ACCESS_TOKEN: ${{ inputs.is-performance-test && secrets.PULUMI_PROD_ACCESS_TOKEN || secrets.PULUMI_STAGING_ACCESS_TOKEN }}
+  PULUMI_API: ${{ inputs.is-performance-test && 'https://api.pulumi.com' || 'https://api.pulumi-staging.io' }}
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -53,6 +53,15 @@ import (
 //nolint:lll // JWT token is long
 const testJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 
+// testCloudURL honors the PULUMI_API override so CI can point tests at a non-production
+// Pulumi Cloud (e.g. staging). Falls back to the default production endpoint.
+func testCloudURL() string {
+	if u := env.APIURL.Value(); u != "" {
+		return u
+	}
+	return client.PulumiCloudURL
+}
+
 //nolint:paralleltest // mutates global configuration
 func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 	// Arrange
@@ -62,10 +71,10 @@ func TestEnabledFullyQualifiedStackNames(t *testing.T) {
 
 	ctx := t.Context()
 
-	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, testCloudURL(), false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), testCloudURL(), &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -122,10 +131,10 @@ func TestDisabledFullyQualifiedStackNames(t *testing.T) {
 
 	ctx := t.Context()
 
-	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, testCloudURL(), false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), testCloudURL(), &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -280,10 +289,10 @@ func TestDisableIntegrityChecking(t *testing.T) {
 
 	ctx := t.Context()
 
-	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, testCloudURL(), false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), testCloudURL(), &workspace.Project{Name: "testproj"}, false)
 	require.NoError(t, err)
 
 	stackName := ptesting.RandomStackName()
@@ -435,10 +444,10 @@ func TestListStackNames(t *testing.T) {
 
 	ctx := t.Context()
 
-	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, testCloudURL(), false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), testCloudURL(), &workspace.Project{Name: "testproj-list-stacks"}, false)
 	require.NoError(t, err)
 
 	// Create test stacks
@@ -550,10 +559,10 @@ func TestListStackNamesVsListStacks(t *testing.T) {
 
 	ctx := t.Context()
 
-	_, err := NewLoginManager().Login(ctx, client.PulumiCloudURL, false, "", "", nil, true, display.Options{})
+	_, err := NewLoginManager().Login(ctx, testCloudURL(), false, "", "", nil, true, display.Options{})
 	require.NoError(t, err)
 
-	b, err := New(ctx, diagtest.LogSink(t), client.PulumiCloudURL, &workspace.Project{Name: "testproj-list-stacks"}, false)
+	b, err := New(ctx, diagtest.LogSink(t), testCloudURL(), &workspace.Project{Name: "testproj-list-stacks"}, false)
 	require.NoError(t, err)
 
 	// Create a test stack

--- a/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_acceptance_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -198,7 +199,11 @@ func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
 
 	b, err := backend.CurrentBackend(ctx, pkgWorkspace.Instance, backend.DefaultLoginManager, nil, display.Options{})
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
+	cloudURL := env.APIURL.Value()
+	if cloudURL == "" {
+		cloudURL = client.PulumiCloudURL
+	}
+	assert.True(t, strings.HasPrefix(b.URL(), client.CloudConsoleURL(cloudURL)))
 
 	backendDir := t.TempDir()
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1448,20 +1448,6 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 		if err := pt.runPulumiCommand("pulumi-login", loginArgs, dir, false); err != nil {
 			return err
 		}
-
-		// When running against a Pulumi service, pin the CLI's default org to
-		// PULUMI_TEST_OWNER so that unqualified references (e.g. stack names,
-		// ESC environment refs in Pulumi.<stack>.yaml) resolve to the test
-		// owner rather than to whatever the access token's user happens to
-		// have as their default.
-		if pt.opts.RequireService {
-			if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
-				setDefaultArgs := []string{"org", "set-default", owner}
-				if err := pt.runPulumiCommand("pulumi-org-set-default", setDefaultArgs, dir, false); err != nil {
-					return err
-				}
-			}
-		}
 	}
 
 	// Stack init
@@ -1532,9 +1518,7 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 	if len(pt.opts.Environments) != 0 {
 		envs := make([]string, len(pt.opts.Environments))
 		for i, e := range pt.opts.Environments {
-			// Pulumi.<stack>.yaml accepts only `project/env`; the owner is
-			// inferred from the CLI's default org, which we pin above.
-			envs[i] = pt.opts.getEnvName(e)
+			envs[i] = pt.opts.getEnvNameWithOwner(e)
 		}
 
 		stackFile := filepath.Join(dir, fmt.Sprintf("Pulumi.%v.yaml", stackName))

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1448,6 +1448,20 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 		if err := pt.runPulumiCommand("pulumi-login", loginArgs, dir, false); err != nil {
 			return err
 		}
+
+		// When running against a Pulumi service, pin the CLI's default org to
+		// PULUMI_TEST_OWNER so that unqualified references (e.g. stack names,
+		// ESC environment refs in Pulumi.<stack>.yaml) resolve to the test
+		// owner rather than to whatever the access token's user happens to
+		// have as their default.
+		if pt.opts.RequireService {
+			if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
+				setDefaultArgs := []string{"org", "set-default", owner}
+				if err := pt.runPulumiCommand("pulumi-org-set-default", setDefaultArgs, dir, false); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	// Stack init
@@ -1518,7 +1532,9 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 	if len(pt.opts.Environments) != 0 {
 		envs := make([]string, len(pt.opts.Environments))
 		for i, e := range pt.opts.Environments {
-			envs[i] = pt.opts.getEnvNameWithOwner(e)
+			// Pulumi.<stack>.yaml accepts only `project/env`; the owner is
+			// inferred from the CLI's default org, which we pin above.
+			envs[i] = pt.opts.getEnvName(e)
 		}
 
 		stackFile := filepath.Join(dir, fmt.Sprintf("Pulumi.%v.yaml", stackName))

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1518,7 +1518,7 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 	if len(pt.opts.Environments) != 0 {
 		envs := make([]string, len(pt.opts.Environments))
 		for i, e := range pt.opts.Environments {
-			envs[i] = pt.opts.getEnvName(e)
+			envs[i] = pt.opts.getEnvNameWithOwner(e)
 		}
 
 		stackFile := filepath.Join(dir, fmt.Sprintf("Pulumi.%v.yaml", stackName))

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1518,7 +1518,7 @@ func (pt *ProgramTester) TestLifeCycleInitialize() error {
 	if len(pt.opts.Environments) != 0 {
 		envs := make([]string, len(pt.opts.Environments))
 		for i, e := range pt.opts.Environments {
-			envs[i] = pt.opts.getEnvNameWithOwner(e)
+			envs[i] = pt.opts.getEnvName(e)
 		}
 
 		stackFile := filepath.Join(dir, fmt.Sprintf("Pulumi.%v.yaml", stackName))

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -60,6 +60,16 @@ const (
 	pulumiTestOrg = "moolumi"
 )
 
+// consoleURLPrefix returns the expected permalink prefix, honoring PULUMI_API so tests
+// can point at non-production Pulumi Cloud (e.g. staging).
+func consoleURLPrefix() string {
+	apiURL := os.Getenv("PULUMI_API")
+	if apiURL == "" {
+		return "https://app.pulumi.com"
+	}
+	return strings.Replace(apiURL, "://api.", "://app.", 1)
+}
+
 type mockPulumiCommand struct {
 	version      semver.Version
 	stdout       string
@@ -233,8 +243,8 @@ func TestRemoveWithForce(t *testing.T) {
 	assert.Equal(t, "update", res.Summary.Kind)
 	assert.Equal(t, "succeeded", res.Summary.Result)
 
-	const permalinkSearchStr = "https://app.pulumi.com"
-	startRegex := regexp.MustCompile(permalinkSearchStr)
+	permalinkSearchStr := consoleURLPrefix()
+	startRegex := regexp.MustCompile(regexp.QuoteMeta(permalinkSearchStr))
 	permalink, err := GetPermalink(res.StdOut)
 	require.NoError(t, err, "failed to get permalink.")
 	assert.True(t, startRegex.MatchString(permalink))
@@ -319,8 +329,8 @@ func TestNewStackLocalSource(t *testing.T) {
 	assert.Equal(t, "update", res.Summary.Kind)
 	assert.Equal(t, "succeeded", res.Summary.Result)
 
-	const permalinkSearchStr = "https://app.pulumi.com"
-	startRegex := regexp.MustCompile(permalinkSearchStr)
+	permalinkSearchStr := consoleURLPrefix()
+	startRegex := regexp.MustCompile(regexp.QuoteMeta(permalinkSearchStr))
 	permalink, err := GetPermalink(res.StdOut)
 	require.NoError(t, err, "failed to get permalink.")
 	assert.True(t, startRegex.MatchString(permalink))

--- a/sdk/nodejs/tests/automation/util.ts
+++ b/sdk/nodejs/tests/automation/util.ts
@@ -59,7 +59,9 @@ function withCloudBackend(
     runtime?: string,
 ): LocalWorkspaceOptions {
     let url = "https://api.pulumi.com";
-    if (process.env.PULUMI_BACKEND_URL) {
+    if (process.env.PULUMI_API) {
+        url = process.env.PULUMI_API;
+    } else if (process.env.PULUMI_BACKEND_URL) {
         url = process.env.PULUMI_BACKEND_URL;
     }
     const backend = {


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/ci-run-test.yml` to use `PULUMI_STAGING_ACCESS_TOKEN` instead of `PULUMI_PROD_ACCESS_TOKEN`.
- Set `PULUMI_API: https://api.pulumi-staging.io` so tests hit staging Pulumi Cloud instead of the default production endpoint.
- `release.yml` is intentionally left on prod — it cuts real releases.

## Test plan
- [ ] Verify `PULUMI_STAGING_ACCESS_TOKEN` secret is configured on the repo before merge.
- [ ] Confirm the `moolumi` org exists in staging with any templates/policy packs the tests expect.
- [ ] Watch the first CI run for failures caused by tests that assume production-only state (org members, teams, named stacks, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)