### PR TITLE
fix: redact creds in the backend url when printing lock errors (#22698)

### DIFF
--- a/changelog/pending/20260422--backend-diy--redact-credentials-in-backend-url-when-printing-lock-errors.yaml
+++ b/changelog/pending/20260422--backend-diy--redact-credentials-in-backend-url-when-printing-lock-errors.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: backend/diy
-  description: when using a backend url containing creds (e.g. PostgreSQL conn string), user:pass are now masked as in lock-related error messages
+  description: When using a backend url containing creds (e.g. PostgreSQL conn string), mask user:pass as in lock-related error messages

--- a/changelog/pending/20260422--backend-diy--redact-credentials-in-backend-url-when-printing-lock-errors.yaml
+++ b/changelog/pending/20260422--backend-diy--redact-credentials-in-backend-url-when-printing-lock-errors.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: backend/diy
+  description: when using a backend url containing creds (e.g. PostgreSQL conn string), user:pass are now masked as in lock-related error messages

--- a/pkg/backend/diy/lock.go
+++ b/pkg/backend/diy/lock.go
@@ -114,8 +114,13 @@ func (b *diyBackend) checkForLock(ctx context.Context, stackRef backend.StackRef
 // lockURLForError returns a URL that can be used in error messages to help users find the lock file.
 func (b *diyBackend) lockURLForError(lockPath string) string {
 	if parsedURL, err := url.Parse(b.url); err == nil {
+		if parsedURL.User != nil {
+			parsedURL.User = url.UserPassword("****", "****")
+		}
 		parsedURL.Path = path.Join(parsedURL.Path, lockPath)
-		return parsedURL.String()
+		// Go's URL encoder percent-encodes '*' as '%2A'; replace back so the
+		// redaction placeholder is human-readable in error messages.
+		return strings.ReplaceAll(parsedURL.String(), "%2A", "*")
 	}
 	// If we couldn't parse the URL, we'll just return a naive concatenation,
 	// which is what we used to do before we started using URL parsing.
@@ -153,7 +158,7 @@ func (b *diyBackend) Unlock(ctx context.Context, stackRef backend.StackReference
 	if err != nil {
 		b.d.Errorf(
 			diag.Message("", "there was a problem deleting the lock at %v, manual clean up may be required: %v"),
-			path.Join(b.url, b.lockPath(stackRef)),
+			b.lockURLForError(b.lockPath(stackRef)),
 			err)
 	}
 }

--- a/pkg/backend/diy/lock_test.go
+++ b/pkg/backend/diy/lock_test.go
@@ -73,7 +73,8 @@ func TestLockURLForError(t *testing.T) {
 			name:     "URL with password",
 			baseURL:  "https://user:password@example.com",
 			lockPath: "/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
-			expected: "https://****:****@example.com/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
+			expected: "https://****:****@example.com/.pulumi/locks/organization/proj/stack/" +
+				"18262c43-124d-4f19-b90f-24db3c0a22a3.json",
 		},
 		{
 			name:     "URL without password",

--- a/pkg/backend/diy/lock_test.go
+++ b/pkg/backend/diy/lock_test.go
@@ -69,6 +69,18 @@ func TestLockURLForError(t *testing.T) {
 			lockPath: "lock/file",
 			expected: ":bad:url/lock/file",
 		},
+		{
+			name:     "URL with password",
+			baseURL:  "https://user:password@example.com",
+			lockPath: "/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
+			expected: "https://****:****@example.com/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
+		},
+		{
+			name:     "URL without password",
+			baseURL:  "https://example.com",
+			lockPath: "/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
+			expected: "https://example.com/.pulumi/locks/organization/proj/stack/18262c43-124d-4f19-b90f-24db3c0a22a3.json",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Issue Fixes #22698 
When Pulumi uses a backend URL that contains credentials (e.g. a PostgreSQL connection string like `postgres://user:pass@host:5432/db`), the full URL including the plaintext password was appearing in lock error messages and unlock failure diagnostics. This is a problem in CI/CD environments where logs are collected and retained.

Two leak points in `pkg/backend/diy/lock.go`:
- `lockURLForError` parsed the URL but never stripped credentials before returning it
- `Unlock` used a raw `path.Join(b.url, ...)` that bypassed URL parsing entirely
Both now redact the `userinfo` section to `****:****` so the URL in error output makes clear that auth was present without exposing the actual credentials.

## Test plan

- [x] Added appropriate unit tests by extending `TestLockURLForError` in `lock_test.go` with cases for URLs with and without credentials

## Validation

- [x] `make lint` - clean
- [x] `make test_fast` - all pass
- [x] `make format` - clean

## Changelog
- [x] Changelog entry added (`changelog/pending/20260422--backend-diy--redact-credentials-in-backend-url-when-printing-lock-errors.yaml`)

## Risk
Low. Only affects the string returned by `lockURLForError`, which is used exclusively in error messages. No behavior change for users without credentials in their backend URL.

<!--
NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.
-->