### PR TITLE
Add ID type to PCL

### DIFF
--- a/changelog/pending/20260423--pcl--add-id-type-to-pcl.yaml
+++ b/changelog/pending/20260423--pcl--add-id-type-to-pcl.yaml
@@ -1,0 +1,4 @@
+component: programgen
+kind: improvement
+body: Add `ID` type to PCL
+time: 2026-07-22T00:00:00+00:00

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -107,6 +107,9 @@ var (
 	NumberType = NewOpaqueType("number")
 	// StringType represents the set of UTF-8 string values.
 	StringType = NewOpaqueType("string")
+	// IDType represents resource IDs. It is distinct from string in the type
+	// system but safely convertible to and from string.
+	IDType = NewOpaqueType("id")
 	// DynamicType represents the set of all values.
 	DynamicType = NewOpaqueType("dynamic")
 )

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -109,6 +109,9 @@ func (t *OpaqueType) conversionFromImpl(
 				}
 				return NoConversion, noConversionDiag
 			case StringType:
+				if src == IDType {
+					return SafeConversion, nil
+				}
 				ckb, _ := BoolType.conversionFromImpl(src, unifying, false, seen)
 				ckn, _ := NumberType.conversionFromImpl(src, unifying, false, seen)
 				if ckb == SafeConversion || ckn == SafeConversion {
@@ -116,6 +119,12 @@ func (t *OpaqueType) conversionFromImpl(
 				}
 				if ckb == UnsafeConversion || ckn == UnsafeConversion {
 					return UnsafeConversion, nil
+				}
+				return NoConversion, noConversionDiag
+			case IDType:
+				kind, _ := StringType.conversionFromImpl(src, unifying, checkUnsafe, seen)
+				if kind.Exists() {
+					return kind, nil
 				}
 				return NoConversion, noConversionDiag
 			default:
@@ -135,6 +144,7 @@ func (t *OpaqueType) conversionFrom(src Type, unifying bool, seen cycleSet) (Con
 //
 // - The dynamic type is safely convertible from any other type, and is unsafely convertible _to_ any other type
 // - The string type is safely convertible from bool, number, and int
+// - The id type is safely convertible to and from string, and otherwise behaves like string
 // - The number type is safely convertible from int and unsafely convertible from string
 // - The int type is unsafely convertible from string
 // - The bool type is unsafely convertible from string
@@ -153,6 +163,8 @@ func (t *OpaqueType) String() string {
 		return "bool"
 	case StringType:
 		return "string"
+	case IDType:
+		return "id"
 	default:
 		if hclsyntax.ValidIdentifier(string(*t)) {
 			return string(*t)
@@ -180,7 +192,7 @@ func (t *OpaqueType) string(_ map[Type]struct{}) string {
 	return t.String()
 }
 
-var opaquePrecedence = []Type{StringType, NumberType, IntType, BoolType}
+var opaquePrecedence = []Type{StringType, NumberType, IntType, BoolType, IDType}
 
 func (t *OpaqueType) unify(other Type) (Type, ConversionKind) {
 	return unify(t, other, func() (Type, ConversionKind) {

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -123,6 +123,28 @@ func TestDynamicType(t *testing.T) {
 	testTraverse(t, DynamicType, hcl.TraverseIndex{Key: encapsulateType(DynamicType)}, DynamicType, false)
 }
 
+func TestIDType(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IDType.AssignableFrom(StringType))
+	assert.False(t, StringType.AssignableFrom(IDType))
+
+	assert.Equal(t, SafeConversion, IDType.ConversionFrom(StringType))
+	assert.Equal(t, SafeConversion, StringType.ConversionFrom(IDType))
+
+	assert.Equal(t, SafeConversion, IDType.ConversionFrom(BoolType))
+	assert.Equal(t, SafeConversion, IDType.ConversionFrom(IntType))
+	assert.Equal(t, SafeConversion, IDType.ConversionFrom(NumberType))
+
+	assert.Equal(t, UnsafeConversion, BoolType.ConversionFrom(IDType))
+	assert.Equal(t, UnsafeConversion, IntType.ConversionFrom(IDType))
+	assert.Equal(t, UnsafeConversion, NumberType.ConversionFrom(IDType))
+
+	safeType, unsafeType := UnifyTypes(IDType, StringType)
+	assert.True(t, safeType.Equals(StringType))
+	assert.True(t, unsafeType.Equals(StringType))
+}
+
 func TestOptionalType(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -739,7 +739,7 @@ func componentElementType(pclType model.Type) string {
 		return "boolean"
 	case model.IntType, model.NumberType:
 		return "number"
-	case model.StringType:
+	case model.IDType, model.StringType:
 		return "string"
 	default:
 		switch pclType := pclType.(type) {
@@ -1963,7 +1963,7 @@ func (g *generator) genComponent(w io.Writer, component *pcl.Component) {
 
 func computeConfigTypeParam(configType model.Type) string {
 	switch pcl.UnwrapOption(configType) {
-	case model.StringType:
+	case model.IDType, model.StringType:
 		return "string"
 	case model.NumberType, model.IntType:
 		return "number"

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -502,7 +502,14 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				genMaybeOutputConversion(func(v string) {
 					g.Fgenf(w, `%s === "true"`, v)
 				})
-			case model.StringType.AssignableFrom(to) && !model.StringType.AssignableFrom(fromType):
+			// ids and strings are treated interchangeably in JavaScript, so if we are casting to id but
+			// already have string _or_ id that's fine. Same for casting to string.
+			case model.StringType.AssignableFrom(to) &&
+				!model.StringType.AssignableFrom(fromType) &&
+				!model.IDType.AssignableFrom(fromType),
+				model.IDType.AssignableFrom(to) &&
+					!model.StringType.AssignableFrom(fromType) &&
+					!model.IDType.AssignableFrom(fromType):
 				genMaybeOutputConversion(func(v string) {
 					g.Fgenf(w, "String(%s)", v)
 				})

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -320,7 +320,7 @@ func (s *hookScope) GetScopeForAttribute(attr *hclsyntax.Attribute) (*model.Scop
 
 		properties := map[string]model.Type{
 			"urn":        model.StringType,
-			"id":         model.StringType,
+			"id":         model.IDType,
 			"name":       model.StringType,
 			"type":       model.StringType,
 			"newInputs":  model.NewMapType(model.DynamicType),

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -164,7 +164,7 @@ func (b *binder) computeBaseResourceInputOutputTypes(
 	inputType := b.schemaTypeToType(inputObjectType)
 
 	outputProperties := map[string]model.Type{
-		"id":  model.NewOutputType(model.StringType),
+		"id":  model.NewOutputType(model.IDType),
 		"urn": model.NewOutputType(model.StringType),
 	}
 	for _, prop := range properties {

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -238,7 +238,7 @@ func canonicalizeToken(tok string, pkg schema.PackageReference) string {
 // getPkgOpts gets the package options from an unbound resource node.
 func (b *binder) getPkgOpts(node *Resource) packageOpts {
 	node.VariableType = model.NewObjectType(map[string]model.Type{
-		"id":  model.NewOutputType(model.StringType),
+		"id":  model.NewOutputType(model.IDType),
 		"urn": model.NewOutputType(model.StringType),
 	})
 	var rangeKey, rangeValue model.Type

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -506,7 +506,7 @@ output "knownId" {
 		}
 
 		if output.Name() == "knownId" {
-			assert.Equal(t, model.StringType, outputType)
+			assert.Equal(t, model.IDType, outputType)
 		}
 	}
 

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -418,7 +418,14 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				genMaybeOutputConversion(func(v string) {
 					g.Fgenf(w, `%s == "true"`, v)
 				})
-			case model.StringType.AssignableFrom(to) && !model.StringType.AssignableFrom(fromType):
+			// ids and strings are treated interchangeably in Python, so if we are casting to id but
+			// already have string _or_ id that's fine. Same for casting to string.
+			case model.StringType.AssignableFrom(to) &&
+				!model.StringType.AssignableFrom(fromType) &&
+				!model.IDType.AssignableFrom(fromType),
+				model.IDType.AssignableFrom(to) &&
+					!model.StringType.AssignableFrom(fromType) &&
+					!model.IDType.AssignableFrom(fromType):
 				genMaybeOutputConversion(func(v string) {
 					if model.BoolType.AssignableFrom(fromType) {
 						g.Fgenf(w, `"true" if %s else "false"`, v)

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-id-type/main.go
@@ -47,11 +47,11 @@ func main() {
 		}
 		_, err = primitive.NewResource(ctx, "sink1", &primitive.ResourceArgs{
 			Boolean: pulumi.Bool(false),
-			Float:   idMap["source1Token"].(string),
-			Integer: idMap["source1Token"].(string),
-			String:  idMap["source1Token"].(string),
+			Float:   idMap["source1Token"].(id),
+			Integer: idMap["source1Token"].(id),
+			String:  idMap["source1Token"].(id),
 			NumberArray: pulumi.Float64Array{
-				idMap["source1Token"].(string),
+				idMap["source1Token"].(id),
 			},
 			BooleanMap: pulumi.BoolMap{
 				"sink": pulumi.Bool(false),
@@ -61,7 +61,7 @@ func main() {
 			return err
 		}
 		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
-			Boolean: idMap["source2Token"].(string),
+			Boolean: idMap["source2Token"].(id),
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
 			String:  pulumi.String("abc"),
@@ -69,15 +69,15 @@ func main() {
 				pulumi.Float64(3),
 			},
 			BooleanMap: pulumi.BoolMap{
-				"sink": idMap["source2Token"].(string),
+				"sink": idMap["source2Token"].(id),
 			},
 		})
 		if err != nil {
 			return err
 		}
 		ctx.Export("ids", idMap)
-		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
-			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		ctx.Export("base64", sink2.ID().ApplyT(func(id id) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(pulumi.String(id)))), nil
 		}).(pulumi.StringOutput))
 		return nil
 	})

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-id-type/main.go
@@ -47,11 +47,11 @@ func main() {
 		}
 		_, err = primitive.NewResource(ctx, "sink1", &primitive.ResourceArgs{
 			Boolean: pulumi.Bool(false),
-			Float:   idMap["source1Token"].(string),
-			Integer: idMap["source1Token"].(string),
-			String:  idMap["source1Token"].(string),
+			Float:   idMap["source1Token"].(id),
+			Integer: idMap["source1Token"].(id),
+			String:  idMap["source1Token"].(id),
 			NumberArray: pulumi.Float64Array{
-				idMap["source1Token"].(string),
+				idMap["source1Token"].(id),
 			},
 			BooleanMap: pulumi.BoolMap{
 				"sink": pulumi.Bool(false),
@@ -61,7 +61,7 @@ func main() {
 			return err
 		}
 		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
-			Boolean: idMap["source2Token"].(string),
+			Boolean: idMap["source2Token"].(id),
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
 			String:  pulumi.String("abc"),
@@ -69,15 +69,15 @@ func main() {
 				pulumi.Float64(3),
 			},
 			BooleanMap: pulumi.BoolMap{
-				"sink": idMap["source2Token"].(string),
+				"sink": idMap["source2Token"].(id),
 			},
 		})
 		if err != nil {
 			return err
 		}
 		ctx.Export("ids", idMap)
-		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
-			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		ctx.Export("base64", sink2.ID().ApplyT(func(id id) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(pulumi.String(id)))), nil
 		}).(pulumi.StringOutput))
 		return nil
 	})

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
@@ -41,7 +41,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		idMap := map[string]pulumi.String{
+		idMap := map[string]id{
 			"source1Token": source1.ID(),
 			"source2Token": source2.ID(),
 		}
@@ -76,8 +76,8 @@ func main() {
 			return err
 		}
 		ctx.Export("ids", idMap)
-		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
-			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		ctx.Export("base64", sink2.ID().ApplyT(func(id id) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(pulumi.String(id)))), nil
 		}).(pulumi.StringOutput))
 		return nil
 	})


### PR DESCRIPTION
Go (and potentially other languages in the future, who knows) treat resources ID's as a separate type `ID` type, not just `string`. 

Because the PCL binder didn't do this we were relying on heuristics and guess work to find ids and for the most part didn't get it right and assumed string.

This adds `id` as a PCL type so Go can track the type better. Node and Python just handle this as no-ops in `convert`.