### PR TITLE
Expand `l1-stack-reference` test with secret handling check

### DIFF
--- a/pkg/testing/pulumi-test-language/tests/l1_stack_reference.go
+++ b/pkg/testing/pulumi-test-language/tests/l1_stack_reference.go
@@ -43,9 +43,10 @@ func init() {
 
 					outputs := stack.Outputs
 
-					require.Len(l, outputs, 2, "expected 2 outputs")
+					require.Len(l, outputs, 3, "expected 3 outputs")
 					AssertPropertyMapMember(l, outputs, "plain", resource.NewProperty("plain"))
 					AssertPropertyMapMember(l, outputs, "secret", resource.MakeSecret(resource.NewProperty("secret")))
+					AssertPropertyMapMember(l, outputs, "secret_unsecret", resource.NewProperty("secret"))
 				},
 			},
 		},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l1-stack-reference/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l1-stack-reference/main.pp
@@ -9,3 +9,7 @@ output "plain" {
 output "secret" {
     value = getOutput(ref, "secret")
 }
+
+output "secret_unsecret" {
+    value = unsecret(getOutput(ref, "secret"))
+}

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-stack-reference/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l1-stack-reference/main.go
@@ -14,6 +14,7 @@ func main() {
 		}
 		ctx.Export("plain", ref.GetOutput(pulumi.String("plain")))
 		ctx.Export("secret", ref.GetOutput(pulumi.String("secret")))
+		ctx.Export("secret_unsecret", pulumi.Unsecret(ref.GetOutput(pulumi.String("secret"))).(pulumi.AnyOutput))
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l1-stack-reference/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l1-stack-reference/main.go
@@ -14,6 +14,7 @@ func main() {
 		}
 		ctx.Export("plain", ref.GetOutput(pulumi.String("plain")))
 		ctx.Export("secret", ref.GetOutput(pulumi.String("secret")))
+		ctx.Export("secret_unsecret", pulumi.Unsecret(ref.GetOutput(pulumi.String("secret"))).(pulumi.AnyOutput))
 		return nil
 	})
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-stack-reference/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l1-stack-reference/index.ts
@@ -3,3 +3,4 @@ import * as pulumi from "@pulumi/pulumi";
 const ref = new pulumi.StackReference("ref", {name: "organization/other/dev"});
 export const plain = ref.getOutput("plain");
 export const secret = ref.getOutput("secret");
+export const secret_unsecret = pulumi.unsecret(ref.getOutput("secret"));

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-stack-reference/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l1-stack-reference/index.ts
@@ -3,3 +3,4 @@ import * as pulumi from "@pulumi/pulumi";
 const ref = new pulumi.StackReference("ref", {name: "organization/other/dev"});
 export const plain = ref.getOutput("plain");
 export const secret = ref.getOutput("secret");
+export const secret_unsecret = pulumi.unsecret(ref.getOutput("secret"));

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-stack-reference/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l1-stack-reference/index.ts
@@ -3,3 +3,4 @@ import * as pulumi from "@pulumi/pulumi";
 const ref = new pulumi.StackReference("ref", {name: "organization/other/dev"});
 export const plain = ref.getOutput("plain");
 export const secret = ref.getOutput("secret");
+export const secret_unsecret = pulumi.unsecret(ref.getOutput("secret"));

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-stack-reference/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-stack-reference/main.pp
@@ -9,3 +9,7 @@ output "plain" {
 output "secret" {
     value = getOutput(ref, "secret")
 }
+
+output "secret_unsecret" {
+    value = unsecret(getOutput(ref, "secret"))
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-stack-reference/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-stack-reference/main.pp
@@ -9,3 +9,7 @@ output "plain" {
 output "secret" {
     value = getOutput(ref, "secret")
 }
+
+output "secret_unsecret" {
+    value = unsecret(getOutput(ref, "secret"))
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-stack-reference/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-stack-reference/main.pp
@@ -9,3 +9,7 @@ output "plain" {
 output "secret" {
     value = getOutput(ref, "secret")
 }
+
+output "secret_unsecret" {
+    value = unsecret(getOutput(ref, "secret"))
+}

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l1-stack-reference/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l1-stack-reference/__main__.py
@@ -3,3 +3,4 @@ import pulumi
 ref = pulumi.StackReference("ref", stack_name="organization/other/dev")
 pulumi.export("plain", ref.get_output("plain"))
 pulumi.export("secret", ref.get_output("secret"))
+pulumi.export("secret_unsecret", pulumi.Output.unsecret(ref.get_output("secret")))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l1-stack-reference/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l1-stack-reference/__main__.py
@@ -3,3 +3,4 @@ import pulumi
 ref = pulumi.StackReference("ref", stack_name="organization/other/dev")
 pulumi.export("plain", ref.get_output("plain"))
 pulumi.export("secret", ref.get_output("secret"))
+pulumi.export("secret_unsecret", pulumi.Output.unsecret(ref.get_output("secret")))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l1-stack-reference/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l1-stack-reference/__main__.py
@@ -3,3 +3,4 @@ import pulumi
 ref = pulumi.StackReference("ref", stack_name="organization/other/dev")
 pulumi.export("plain", ref.get_output("plain"))
 pulumi.export("secret", ref.get_output("secret"))
+pulumi.export("secret_unsecret", pulumi.Output.unsecret(ref.get_output("secret")))


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

Slack thread: https://pulumi-community.slack.com/archives/CB81H6DG9/p1776905216407519

Non-conforming implementation may treat `secret` reference value as non-Secret with value

```json
{
  "4dabf18193072939515e22adb298388d" : "1b47061264138c4ac30d75fd1eb44270",
  "value": "secret"
}
```

instead of Secret with value

```json
"secret"
```

Current test does not verify it, because both serialize to same value.

My addition forces the implementation to strip "secretness" from secret. If it's stripped - that means that implementation properly detected that the value was secret in the first place.


## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [X] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)
- [X] `./scripts/run-conformance.sh "l1-stack-reference"`

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
