### PR TITLE
Bump CLI Accept header to application/vnd.pulumi+9

### DIFF
--- a/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
+++ b/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: backend/service
-  description: Bump the CLI's outbound `Accept` header to `application/vnd.pulumi+9` to advertise tolerance of the explicit SecretValue wire form. Adds a version-history docblock and named constants in `pkg/backend/httpstate/client/api.go` to make the CLI/service version contract explicit. No user-visible behavior change.
+  description: Bump the CLI's outbound `Accept` header to `application/vnd.pulumi+9`.

--- a/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
+++ b/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: backend/service
-  description: Advertise tolerance of the explicit SecretValue wire form via Accept header `application/vnd.pulumi+9`. No visible behavior change; lets the service use a self-attested capability signal before flipping its SecretValue output format.
+  description: Bump the CLI's outbound `Accept` header to `application/vnd.pulumi+9` to advertise tolerance of the explicit SecretValue wire form. Adds a version-history docblock and named constants in `pkg/backend/httpstate/client/api.go` to make the CLI/service version contract explicit. No user-visible behavior change.

--- a/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
+++ b/changelog/pending/20260423--backend-service--advertise-secretvalue-tolerance-via-accept-api-v9.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: backend/service
+  description: Advertise tolerance of the explicit SecretValue wire form via Accept header `application/vnd.pulumi+9`. No visible behavior change; lets the service use a self-attested capability signal before flipping its SecretValue output format.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -51,6 +51,49 @@ const (
 	apiRequestDetailLogLevel = 11 // log level for logging extra details about API requests and responses
 )
 
+// Pulumi service Accept header version history.
+//
+// The CLI advertises its API capabilities to the service by setting the
+// `Accept: application/vnd.pulumi+N` header on every request. Each increment
+// reflects a CLI capability the service can rely on, gating response shape or
+// behavior accordingly. Keep this table in sync with the matching version block
+// in pulumi-service `cmd/service/api/rest/request.go` — the integers are a
+// shared contract across both repos.
+//
+// To add a new capability: append a row, define a named constant for it, and
+// point `currentAPIVersion` at the new constant.
+//
+// CLI Ver. API Ver. Description
+// -------- -------- -----------
+//
+//	pre-1.0     0    Initial API version.
+//	  v15.3     1    New /user/stacks response type.
+//	 v16.07     2    CLI sends "rich update events" during an update.
+//	v0.16.2     3    /user/stacks returns project name; /stacks routes accept project name.
+//	 v1.1.1     4    Policy as Code support.
+//	 v1.5.0     5    renew_lease takes the update token instead of the user access token.
+//	v1.13.1     6    PAC config support.
+//	 v3.3.2     7    CLI sets required headers when uploading policy packs via pre-signed URL.
+//	 v3.9.0     8    CLI handles paginated /user/stacks responses.
+//	 v3.233     9    SecretValue tolerance: CLI decodes the explicit
+//	                 {"isSecret": bool, "value": "..."} object form in addition
+//	                 to the legacy heterogeneous form (bare string when not
+//	                 secret, {"secret": "..."} when secret). Tolerant decoder
+//	                 added in https://github.com/pulumi/pulumi/pull/22699.
+const (
+	// apiVersionExplicitSecretValueObjectForm: CLI decodes the explicit
+	// {"isSecret", "value"} SecretValue form. See row 9 in the table above.
+	apiVersionExplicitSecretValueObjectForm = 9
+
+	// currentAPIVersion is the value this CLI sends in the `Accept` header.
+	// Bump (and add a row to the table above) when introducing a new capability.
+	currentAPIVersion = apiVersionExplicitSecretValueObjectForm
+)
+
+// acceptAPIVersionHeader is the rendered `Accept` header value sent on every
+// request to the Pulumi service. See `currentAPIVersion`.
+var acceptAPIVersionHeader = fmt.Sprintf("application/vnd.pulumi+%d", currentAPIVersion)
+
 func UserAgent() string {
 	return fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 }
@@ -306,15 +349,9 @@ func pulumiAPICall(ctx context.Context,
 		req.Header[k] = v
 	}
 
-	// Specify the specific API version we accept.
-	//
-	// v9 advertises that this client tolerates the explicit
-	// {"isSecret": bool, "value": "..."} form of SecretValue in addition to the legacy
-	// heterogeneous form (bare string when not secret, {"secret": "..."} when secret).
-	// The tolerant decoder was added in https://github.com/pulumi/pulumi/pull/22699;
-	// this header lets the service use Accept as a self-attested capability signal
-	// before it flips SecretValue.MarshalJSON server-side.
-	req.Header.Add("Accept", "application/vnd.pulumi+9")
+	// Advertise the API capabilities this CLI supports. See the version-history
+	// table above `currentAPIVersion`.
+	req.Header.Add("Accept", acceptAPIVersionHeader)
 
 	// Apply credentials if provided.
 	creds, err := tok.Get(ctx)

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -307,7 +307,14 @@ func pulumiAPICall(ctx context.Context,
 	}
 
 	// Specify the specific API version we accept.
-	req.Header.Add("Accept", "application/vnd.pulumi+8")
+	//
+	// v9 advertises that this client tolerates the explicit
+	// {"isSecret": bool, "value": "..."} form of SecretValue in addition to the legacy
+	// heterogeneous form (bare string when not secret, {"secret": "..."} when secret).
+	// The tolerant decoder was added in https://github.com/pulumi/pulumi/pull/22699;
+	// this header lets the service use Accept as a self-attested capability signal
+	// before it flips SecretValue.MarshalJSON server-side.
+	req.Header.Add("Accept", "application/vnd.pulumi+9")
 
 	// Apply credentials if provided.
 	creds, err := tok.Get(ctx)

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -60,8 +60,8 @@ const (
 // in pulumi-service `cmd/service/api/rest/request.go` — the integers are a
 // shared contract across both repos.
 //
-// To add a new capability: append a row, define a named constant for it, and
-// point `currentAPIVersion` at the new constant.
+// To add a new capability: bump `currentAPIVersion` and append a row to the
+// table below.
 //
 // CLI Ver. API Ver. Description
 // -------- -------- -----------
@@ -80,15 +80,7 @@ const (
 //	                 to the legacy heterogeneous form (bare string when not
 //	                 secret, {"secret": "..."} when secret). Tolerant decoder
 //	                 added in https://github.com/pulumi/pulumi/pull/22699.
-const (
-	// apiVersionExplicitSecretValueObjectForm: CLI decodes the explicit
-	// {"isSecret", "value"} SecretValue form. See row 9 in the table above.
-	apiVersionExplicitSecretValueObjectForm = 9
-
-	// currentAPIVersion is the value this CLI sends in the `Accept` header.
-	// Bump (and add a row to the table above) when introducing a new capability.
-	currentAPIVersion = apiVersionExplicitSecretValueObjectForm
-)
+const currentAPIVersion = 9
 
 // acceptAPIVersionHeader is the rendered `Accept` header value sent on every
 // request to the Pulumi service. See `currentAPIVersion`.

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -158,7 +159,9 @@ func TestAcceptAPIVersionHeader(t *testing.T) {
 	// because you bumped `currentAPIVersion`, also append a row to the version
 	// history table in api.go (and update the matching version block in
 	// pulumi-service `cmd/service/api/rest/request.go`).
+	var handled atomic.Bool
 	server := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		handled.Store(true)
 		assert.Equal(t, "application/vnd.pulumi+9", req.Header.Get("Accept"))
 		return `{"latestVersion": "1.0.0", "oldestWithoutWarning": "0.1.0", "latestDevVersion": "1.0.0"}`
 	})
@@ -167,6 +170,7 @@ func TestAcceptAPIVersionHeader(t *testing.T) {
 
 	_, _, _, err := client.GetCLIVersionInfo(t.Context(), nil)
 	require.NoError(t, err)
+	assert.True(t, handled.Load(), "mock server handler did not run")
 }
 
 func TestAPIVersionMetadataHeaders(t *testing.T) {

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -151,6 +151,24 @@ func TestAPIVersionResponses(t *testing.T) {
 	assert.Equal(t, latestDevVersion.String(), "1.0.0-11-gdeadbeef")
 }
 
+func TestAcceptAPIVersionHeader(t *testing.T) {
+	t.Parallel()
+
+	// This test pins the Accept header value the CLI sends. If this fails
+	// because you bumped `currentAPIVersion`, also append a row to the version
+	// history table in api.go (and update the matching version block in
+	// pulumi-service `cmd/service/api/rest/request.go`).
+	server := newMockServerRequestProcessor(200, func(req *http.Request) string {
+		assert.Equal(t, "application/vnd.pulumi+9", req.Header.Get("Accept"))
+		return `{"latestVersion": "1.0.0", "oldestWithoutWarning": "0.1.0", "latestDevVersion": "1.0.0"}`
+	})
+	defer server.Close()
+	client := newMockClient(server)
+
+	_, _, _, err := client.GetCLIVersionInfo(t.Context(), nil)
+	require.NoError(t, err)
+}
+
 func TestAPIVersionMetadataHeaders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Bumps the CLI's outbound `Accept` header to `application/vnd.pulumi+9` to advertise that this client tolerates the explicit `{"isSecret": bool, "value": "..."}` form of `SecretValue` (in addition to the legacy heterogeneous form: bare string when not secret, `{"secret": "..."}` when secret). The tolerant decoder is added in #22699.
- Adds a **version-history docblock** in `pkg/backend/httpstate/client/api.go` mirroring the table in pulumi-service `cmd/service/api/rest/request.go`. The integers are a shared contract across both repos and the docblock now spells out what each historical version means, including v8 (paginated `/user/stacks`) and the new v9.
- Replaces the magic string with a named `currentAPIVersion` constant and a precomputed `acceptAPIVersionHeader` var.
- Adds `TestAcceptAPIVersionHeader` to pin the rendered Accept header value, forcing future bumps to update the docblock and the test in lockstep.

## Why

`pulumi-service` plans to flip `SecretValue.MarshalJSON` server-side from the legacy heterogeneous form to the explicit `{"isSecret", "value"}` form so the IDL, OpenAPI spec, and TypeScript can converge on a single source of truth (tracked in `cmd/console2/TYPE_MIGRATION_PLAN.md`, Phase 1a).

Doing that flip safely requires telling newer CLIs (which can decode either form) apart from older CLIs (which only know the legacy form). The Pulumi service already has the right mechanism: the `Accept: application/vnd.pulumi+N` header. By bumping the value here once #22699 has landed, every CLI that has the tolerant decoder also self-attests the capability — so the eventual server-side flip can be gated on `r.ClientAPIVersion() >= 9` and pre-#22699 CLIs (which send `+8` or no Accept header) keep receiving the legacy form indefinitely.

This addresses the backward-compat concern raised by @iwahbe on #22699: no CLI breaks when the server-side flip lands.

The structural cleanup (docblock, constant, test) makes the version contract discoverable from the call site so that, e.g., the pulumi-service developer who eventually adds `APIExplicitSecretValueObjectForm = 9` to `cmd/service/api/rest/request.go` doesn't have to dig through git blame to figure out what 9 means on the CLI side.

## Behavior change

None today. `pulumi-service` does not yet differentiate `+8` from `+9` — `defaultAPIVersion` is `8`, `minimumAPIVersion` is `3`, and any value at or above the minimum is accepted. The response shape stays the same. This PR is purely the capability advertisement; the response-shape gate is a separate, later change in `pulumi-service`.

## Sequencing

Must land **after** #22699 but does **not** need to be in the same release. #22699 is safe to ship on its own — the tolerant decoder is dormant until the service starts sending the explicit form, so a CLI release containing only #22699 still sends `+8` and still receives the legacy form. When #22717 eventually lands in a later release, CLIs from that release onward self-attest `+9` and the service can gate on `>= 9` whenever it's ready. Pre-#22717 CLIs simply keep getting the legacy form — exactly the intended fallback.

The only forbidden ordering is #22717 before #22699: that would have CLIs advertise `+9` without actually having the decoder, permanently tainting the invariant the service gate relies on.

## Test plan

- [x] `go build ./pkg/backend/httpstate/client/...` clean
- [x] `gofmt -l pkg/backend/httpstate/client/api.go pkg/backend/httpstate/client/client_test.go` clean
- [x] `go test -run "TestAcceptAPIVersionHeader|TestAPIVersion|TestGzip" ./pkg/backend/httpstate/client/...` passes (new test pins the Accept value and asserts the mock handler ran; existing tests stay green)
- [x] CI green