### PR TITLE
Add a string function to the id test

### DIFF
--- a/pkg/testing/pulumi-test-language/tests/l2_id_type.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_id_type.go
@@ -77,6 +77,7 @@ func init() {
 							"source2Token": resource.NewProperty("true"),
 							"source1Token": resource.NewProperty("1234"),
 						}),
+						"base64": resource.NewProperty("YWJj"),
 					}, stack.Outputs)
 				},
 			},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-id-type/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-id-type/main.pp
@@ -53,3 +53,8 @@ resource "sink2" "primitive:index:Resource" {
 output "ids" {
   value = idMap
 }
+
+// test an id value can flow through a string function
+output "base64" { 
+  value = toBase64(sink2.id)
+}

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-id-type/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+
 	"example.com/pulumi-primitive/sdk/go/v7/primitive"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -58,7 +60,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
+		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
 			Boolean: idMap["source2Token"].(string),
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
@@ -73,7 +75,10 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("ids", pulumi.ToMap(idMap))
+		ctx.Export("ids", idMap)
+		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		}).(pulumi.StringOutput))
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-id-type/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+
 	"example.com/pulumi-primitive/sdk/go/v7/primitive"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -58,7 +60,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
+		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
 			Boolean: idMap["source2Token"].(string),
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
@@ -73,7 +75,10 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("ids", pulumi.ToMap(idMap))
+		ctx.Export("ids", idMap)
+		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		}).(pulumi.StringOutput))
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-id-type/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/base64"
+
 	"example.com/pulumi-primitive/sdk/go/v7/primitive"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -58,7 +60,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
+		sink2, err := primitive.NewResource(ctx, "sink2", &primitive.ResourceArgs{
 			Boolean: idMap["source2Token"].(string),
 			Float:   pulumi.Float64(1),
 			Integer: pulumi.Int(2),
@@ -73,7 +75,10 @@ func main() {
 		if err != nil {
 			return err
 		}
-		ctx.Export("ids", pulumi.ToMap(idMap))
+		ctx.Export("ids", idMap)
+		ctx.Export("base64", sink2.ID().ApplyT(func(id string) (pulumi.String, error) {
+			return pulumi.String(base64.StdEncoding.EncodeToString([]byte(id))), nil
+		}).(pulumi.StringOutput))
 		return nil
 	})
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-id-type/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-id-type/index.ts
@@ -48,3 +48,4 @@ const sink2 = new primitive.Resource("sink2", {
     },
 });
 export const ids = idMap;
+export const base64 = sink2.id.apply(id => Buffer.from(id).toString("base64"));

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-id-type/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-id-type/index.ts
@@ -48,3 +48,4 @@ const sink2 = new primitive.Resource("sink2", {
     },
 });
 export const ids = idMap;
+export const base64 = sink2.id.apply(id => Buffer.from(id).toString("base64"));

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-id-type/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-id-type/index.ts
@@ -48,3 +48,4 @@ const sink2 = new primitive.Resource("sink2", {
     },
 });
 export const ids = idMap;
+export const base64 = sink2.id.apply(id => Buffer.from(id).toString("base64"));

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-id-type/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-id-type/main.pp
@@ -53,3 +53,8 @@ resource "sink2" "primitive:index:Resource" {
 output "ids" {
   value = idMap
 }
+
+// test an id value can flow through a string function
+output "base64" { 
+  value = toBase64(sink2.id)
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-id-type/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-id-type/main.pp
@@ -53,3 +53,8 @@ resource "sink2" "primitive:index:Resource" {
 output "ids" {
   value = idMap
 }
+
+// test an id value can flow through a string function
+output "base64" { 
+  value = toBase64(sink2.id)
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-id-type/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-id-type/main.pp
@@ -53,3 +53,8 @@ resource "sink2" "primitive:index:Resource" {
 output "ids" {
   value = idMap
 }
+
+// test an id value can flow through a string function
+output "base64" { 
+  value = toBase64(sink2.id)
+}

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-id-type/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-id-type/__main__.py
@@ -1,4 +1,5 @@
 import pulumi
+import base64
 import pulumi_primitive as primitive
 
 # Test that the ID type is treated the same as a string type, despite being tracked as a distinct type. This 
@@ -44,3 +45,4 @@ sink2 = primitive.Resource("sink2",
         "sink": id_map["source2Token"].apply(lambda x: x == "true"),
     })
 pulumi.export("ids", id_map)
+pulumi.export("base64", sink2.id.apply(lambda id: base64.b64encode(id.encode()).decode()))


### PR DESCRIPTION
This tests that we can pass an `id` value to a string expecting function. Should be the same as passing to a string field, but this triggers apply behaviour that might be different. 