### PR TITLE
Always close mapper plugins

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -20,6 +20,7 @@ scopes:
     - package
     - policy
     - state
+    - convert
   components: [dotnet, go, java, nodejs, python, yaml, pcl]
   docs: []
   engine: []

--- a/changelog/pending/20260424--cli-convert--stop-incorrectly-erroring-on-plugin-shutdown.yaml
+++ b/changelog/pending/20260424--cli-convert--stop-incorrectly-erroring-on-plugin-shutdown.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/convert
+  description: Stop incorrectly erroring on plugin shutdown

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
@@ -502,14 +501,6 @@ func (r *Registry) setProviderLocked(ref providers.Reference, provider plugin.Pr
 	}
 }
 
-func (r *Registry) cancelAndCloseProvider(provider plugin.Provider) {
-	cancelCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	contract.IgnoreError(provider.SignalCancellation(cancelCtx))
-	contract.IgnoreClose(provider)
-}
-
 // setProviderAndCloseOld sets the provider at ref and closes any previously registered provider at that ref.
 // This should be used when overwriting is expected (e.g., Update) to avoid leaking the old provider instance.
 func (r *Registry) setProviderAndCloseOld(ref providers.Reference, provider plugin.Provider) {
@@ -520,7 +511,7 @@ func (r *Registry) setProviderAndCloseOld(ref providers.Reference, provider plug
 
 	if hadOld && oldProvider != provider {
 		logging.V(7).Infof("setProviderAndCloseOld(%v): closing old provider", ref)
-		r.cancelAndCloseProvider(oldProvider)
+		contract.IgnoreClose(oldProvider)
 	}
 }
 
@@ -689,7 +680,7 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 		AllowUnknowns: true,
 	})
 	if len(resp.Failures) != 0 || err != nil {
-		r.cancelAndCloseProvider(provider)
+		contract.IgnoreClose(provider)
 		return plugin.CheckResponse{Failures: resp.Failures}, err
 	}
 
@@ -783,7 +774,7 @@ func (r *Registry) Diff(ctx context.Context, req plugin.DiffRequest) (plugin.Dif
 
 	// If the diff requires replacement, unload the provider: the engine will reload it during its replacememnt Check.
 	if diff.Replace() {
-		r.cancelAndCloseProvider(provider)
+		contract.IgnoreClose(provider)
 	}
 
 	logging.V(7).Infof("%s: executed (%#v, %#v)", label, diff.Changes, diff.ReplaceKeys)
@@ -878,7 +869,7 @@ func (r *Registry) Same(ctx context.Context, res *resource.State, fromCheck bool
 		ID:     &res.ID,
 		Inputs: FilterProviderConfig(res.Inputs),
 	}); err != nil {
-		r.cancelAndCloseProvider(provider)
+		contract.IgnoreClose(provider)
 		return fmt.Errorf("configure provider '%v': %w", urn, err)
 	}
 
@@ -892,7 +883,7 @@ func (r *Registry) Same(ctx context.Context, res *resource.State, fromCheck bool
 	} else {
 		if !r.setProviderIfNotExists(ref, provider) {
 			// A provider was already registered (likely by a concurrent Update). Close ours to avoid leaks.
-			r.cancelAndCloseProvider(provider)
+			contract.IgnoreClose(provider)
 		}
 	}
 
@@ -1037,7 +1028,7 @@ func (r *Registry) Delete(_ context.Context, req plugin.DeleteRequest) (plugin.D
 		return plugin.DeleteResponse{}, nil
 	}
 
-	r.cancelAndCloseProvider(provider)
+	contract.IgnoreClose(provider)
 	return plugin.DeleteResponse{}, nil
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -133,22 +133,6 @@ type testProvider struct {
 	config     func(resource.PropertyMap) error
 }
 
-type lifecycleTrackingProvider struct {
-	*testProvider
-	closeCalls  int
-	cancelCalls int
-}
-
-func (p *lifecycleTrackingProvider) Close() error {
-	p.closeCalls++
-	return nil
-}
-
-func (p *lifecycleTrackingProvider) SignalCancellation(context.Context) error {
-	p.cancelCalls++
-	return nil
-}
-
 func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
@@ -715,57 +699,6 @@ func TestCRUDNoProviders(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, check.Failures)
 	assert.Nil(t, check.Properties)
-}
-
-func TestDiffReplaceSignalsCancellationBeforeClose(t *testing.T) {
-	t.Parallel()
-
-	var tracked *lifecycleTrackingProvider
-	loader := newLoader(t, "pkgA", "1.0.0", func(pkg tokens.Package, ver semver.Version) (plugin.Provider, error) {
-		tracked = &lifecycleTrackingProvider{
-			testProvider: &testProvider{
-				pkg:     pkg,
-				version: ver,
-				checkConfig: func(
-					_ resource.URN, _ resource.PropertyMap, news resource.PropertyMap, _ bool,
-				) (resource.PropertyMap, []plugin.CheckFailure, error) {
-					return news, nil, nil
-				},
-				diffConfig: func(
-					_ resource.URN, _ resource.PropertyMap, _ resource.PropertyMap, _ bool, _ []string,
-				) (plugin.DiffResult, error) {
-					return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"id"}}, nil
-				},
-				config: func(resource.PropertyMap) error { return nil },
-			},
-		}
-		return tracked, nil
-	})
-
-	r := NewRegistry(newPluginHost(t, []*providerLoader{loader}), false, nil)
-	typ := providers.MakeProviderType("pkgA")
-	urn := resource.NewURN("test", "test", "", typ, "a")
-
-	_, err := r.Check(t.Context(), plugin.CheckRequest{
-		URN:  urn,
-		Olds: resource.PropertyMap{},
-		News: resource.PropertyMap{"version": resource.NewProperty("1.0.0")},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, tracked)
-
-	diff, err := r.Diff(t.Context(), plugin.DiffRequest{
-		URN:        urn,
-		ID:         resource.ID("existing"),
-		OldOutputs: resource.PropertyMap{},
-		NewInputs:  resource.PropertyMap{"version": resource.NewProperty("1.0.0")},
-	})
-	require.NoError(t, err)
-	require.True(t, diff.Replace())
-
-	// Registry should signal cancellation before closing on replace.
-	assert.Equal(t, 1, tracked.closeCalls)
-	assert.Equal(t, 1, tracked.cancelCalls)
 }
 
 func TestCRUDWrongPackage(t *testing.T) {

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -579,6 +579,14 @@ type hostManagedProvider struct {
 // Overrides the wrapped provider's implementation of Provider.Close to ask the managing plugin host to close the
 // provider.
 func (pc hostManagedProvider) Close() error {
+	// Send Cancel before tearing the plugin down so that the plugin can acknowledge a graceful shutdown and
+	// Plugin.Close does not treat the subsequent exit as a premature crash. defaultHost.Close does the same for
+	// providers still in resourcePlugins at shutdown, but callers that Close individual providers (e.g. the
+	// convert mapper) bypass that path.
+	cancelCtx, cancelCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelCancel()
+	contract.IgnoreError(pc.SignalCancellation(cancelCtx))
+
 	// NOTE: we're abusing loadPlugin in order to ensure proper synchronization.
 	_, err := pc.host.loadPlugin(pc.host.loadRequests, func() (any, error) {
 		if err := pc.Provider.Close(); err != nil {

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -28,6 +29,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestHostManagedProviderCloseSignalsCancellation locks in the contract that hostManagedProvider.Close sends
+// SignalCancellation before tearing the underlying provider down. Without this, Plugin.Close treats the subsequent
+// process exit as a premature crash (since shutdownAcknowledged is only flipped on Cancel RPC ack) and emits a
+// misleading "exited prematurely" error to the user. defaultHost.Close does the same thing for plugins still
+// registered at shutdown; callers that close individual providers (e.g. the convert mapper) bypass that path.
+func TestHostManagedProviderCloseSignalsCancellation(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil)
+	require.NoError(t, err)
+	host, ok := ctx.Host.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	var calls []string
+	mockProv := &MockProvider{
+		SignalCancellationF: func(context.Context) error {
+			calls = append(calls, "SignalCancellation")
+			return nil
+		},
+		CloseF: func() error {
+			calls = append(calls, "Close")
+			return nil
+		},
+	}
+
+	host.resourcePlugins[mockProv] = &resourcePlugin{Plugin: mockProv, Name: "mock"}
+
+	managed := hostManagedProvider{Provider: mockProv, host: host}
+	require.NoError(t, managed.Close())
+
+	require.Equal(t, []string{"SignalCancellation", "Close"}, calls)
+	require.NotContains(t, host.resourcePlugins, Provider(mockProv))
+}
 
 func TestClosePanic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Since we changed how we track properly shut down plugins to depend on `SignalCancellation` (https://github.com/pulumi/pulumi/pull/22569), we started erroring on every plugin that doesn't have a bulk shutdown via `defaultHost`. This includes the mapper used in converts, which currently always errors:

    $ pulumi convert --from terraform --language pcl --out ./out
    Converting from terraform...
    error: Detected that /Users/ianwahbe/.pulumi/plugins/resource-aws-v7.24.0/pulumi-resource-aws exited prematurely.
           This is *always* a bug in the provider. Please report the issue to the provider author as appropriate.
           To assist with debugging we have dumped the STDOUT and STDERR streams of the plugin:

    Converting to pcl...
    warning: main.pp:0,8-13: package block label is deprecated; Package block labels should be replaced by baseProviderName.

This PR extends `(plugin.hostManagedProvider).Close` to exhibit the same shutdown behavior as `(plugin.defaultHost).Close`. This effectively deepens the fix applied by https://github.com/pulumi/pulumi/pull/22692, so I've reverted that PR in this one.