### PR TITLE
Add hidden `pulumi events summary` command

### DIFF
--- a/pkg/cmd/pulumi/events/events.go
+++ b/pkg/cmd/pulumi/events/events.go
@@ -22,7 +22,7 @@ import (
 
 // NewEventsCmd is the parent of the `pulumi events` subcommand tree. It does not perform any
 // work on its own — running `pulumi events` without a subcommand prints the command's help text.
-// Behaviour lives on the subcommands (currently `filter`).
+// Behaviour lives on the subcommands (currently `filter` and `summary`).
 //
 // Hidden from `--help` while the interface is being developed.
 func NewEventsCmd() *cobra.Command {
@@ -34,5 +34,6 @@ func NewEventsCmd() *cobra.Command {
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 	cmd.AddCommand(NewFilterCmd())
+	cmd.AddCommand(NewSummaryCmd())
 	return cmd
 }

--- a/pkg/cmd/pulumi/events/summary.go
+++ b/pkg/cmd/pulumi/events/summary.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -27,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
@@ -78,8 +78,8 @@ func runSummary(in io.Reader, out io.Writer) error {
 }
 
 // reduceEvents folds a JSONL engine event stream into an EventSummary. The reduction preserves
-// arrival order for lists (diagnostics, policy violations) and picks the latest observed entry
-// per URN for steps. Failure modes (ResOpFailedEvent, ErrorEvent) are surfaced on the summary's
+// arrival order for lists (diagnostics, policy events) and picks the latest observed entry per
+// URN for steps. Failure modes (ResOpFailedEvent, ErrorEvent) are surfaced on the summary's
 // `Failed` / `Error` fields; they do not abort reduction — a partial stream still yields a
 // useful document.
 func reduceEvents(in io.Reader) (*display.EventSummary, error) {
@@ -126,15 +126,15 @@ func reduceEvents(in io.Reader) (*display.EventSummary, error) {
 			summary.Failed = true
 
 		case evt.DiagnosticEvent != nil:
-			if d := toSummaryDiagnostic(evt.DiagnosticEvent); d != nil {
+			if d := toPreviewDiagnostic(evt.DiagnosticEvent); d != nil {
 				summary.Diagnostics = append(summary.Diagnostics, *d)
 			}
 
 		case evt.PolicyEvent != nil:
-			summary.PolicyViolations = append(summary.PolicyViolations, toPolicyViolation(evt.PolicyEvent))
+			summary.PolicyViolations = append(summary.PolicyViolations, *evt.PolicyEvent)
 
 		case evt.PolicyRemediationEvent != nil:
-			summary.PolicyViolations = append(summary.PolicyViolations, toPolicyRemediation(evt.PolicyRemediationEvent))
+			summary.PolicyRemediations = append(summary.PolicyRemediations, *evt.PolicyRemediationEvent)
 
 		case evt.ErrorEvent != nil:
 			summary.Failed = true
@@ -150,10 +150,11 @@ func reduceEvents(in io.Reader) (*display.EventSummary, error) {
 }
 
 // applyResourceStep records or updates the SummaryStep for md.URN. `OpSame` is ignored —
-// consumers asked for a summary, not a full transcript. A previously-seen step for the same
-// URN is overwritten, so a `ResOutputsEvent` supersedes its earlier `ResourcePreEvent` (the
-// former is emitted strictly later and carries the final step state). The `failed` flag sticks:
-// once a resource has failed, a later successful step for the same URN shouldn't erase that.
+// consumers asked for a summary, not a full transcript. The step's embedded metadata is
+// replaced on each update, so a `ResOutputsEvent` supersedes its earlier `ResourcePreEvent`
+// (the former is emitted strictly later and carries the final step state). `Old` and `New` are
+// zeroed so the summary stays compact. The `failed` flag sticks: once a resource has failed, a
+// later step for the same URN shouldn't erase that.
 func applyResourceStep(
 	byURN map[resource.URN]*display.SummaryStep,
 	order *[]resource.URN,
@@ -166,16 +167,13 @@ func applyResourceStep(
 	urn := resource.URN(md.URN)
 	step, seen := byURN[urn]
 	if !seen {
-		step = &display.SummaryStep{URN: urn}
+		step = &display.SummaryStep{}
 		byURN[urn] = step
 		*order = append(*order, urn)
 	}
-	step.Op = display.StepOp(md.Op)
-	step.Type = md.Type
-	step.Provider = md.Provider
-	step.Diffs = md.Diffs
-	step.ReplaceReasons = md.Keys
-	step.DetailedDiff = md.DetailedDiff
+	md.Old = nil
+	md.New = nil
+	step.StepEventMetadata = md
 	if failed {
 		step.Failed = true
 	}
@@ -197,51 +195,26 @@ func captureStackOutputs(summary *display.EventSummary, md apitype.StepEventMeta
 	}
 }
 
-// toSummaryDiagnostic converts a DiagnosticEvent into a SummaryDiagnostic, dropping entries
+// toPreviewDiagnostic converts a DiagnosticEvent into a PreviewDiagnostic, dropping entries
 // that are meant for live display only. Ephemeral messages are transient progress spinners and
 // must not pollute a persisted summary; `debug`-level messages are noisy and typically hidden
 // from humans too.
-func toSummaryDiagnostic(d *apitype.DiagnosticEvent) *display.SummaryDiagnostic {
+func toPreviewDiagnostic(d *apitype.DiagnosticEvent) *display.PreviewDiagnostic {
 	if d.Ephemeral || d.Severity == "debug" {
 		return nil
 	}
-	return &display.SummaryDiagnostic{
+	return &display.PreviewDiagnostic{
 		URN:      resource.URN(d.URN),
+		Prefix:   d.Prefix,
 		Message:  d.Message,
-		Severity: d.Severity,
+		Severity: diag.Severity(d.Severity),
 	}
 }
 
-// toPolicyViolation flattens a PolicyEvent into a SummaryPolicyViolation.
-func toPolicyViolation(p *apitype.PolicyEvent) display.SummaryPolicyViolation {
-	return display.SummaryPolicyViolation{
-		URN:               resource.URN(p.ResourceURN),
-		PolicyName:        p.PolicyName,
-		PolicyPackName:    p.PolicyPackName,
-		PolicyPackVersion: p.PolicyPackVersion,
-		EnforcementLevel:  p.EnforcementLevel,
-		Severity:          p.Severity,
-		Message:           p.Message,
-		Remediated:        false,
-	}
-}
-
-// toPolicyRemediation flattens a PolicyRemediationEvent into a SummaryPolicyViolation. The
-// before/after payloads carried on remediations are intentionally dropped from the summary —
-// consumers that need them should read the raw event stream.
-func toPolicyRemediation(p *apitype.PolicyRemediationEvent) display.SummaryPolicyViolation {
-	return display.SummaryPolicyViolation{
-		URN:               resource.URN(p.ResourceURN),
-		PolicyPackName:    p.PolicyPackName,
-		PolicyPackVersion: p.PolicyPackVersion,
-		PolicyName:        p.PolicyName,
-		Remediated:        true,
-	}
-}
-
-// applySummaryEvent copies the scalar fields of a SummaryEvent onto the summary and converts
-// `PolicyPacks` into a deterministic sorted list. `DurationSeconds` is expanded to a
-// `time.Duration` to match the convention used by `PreviewDigest.Duration`.
+// applySummaryEvent copies the scalar fields of a SummaryEvent onto the summary.
+// `DurationSeconds` is expanded to a `time.Duration` to match the convention used by
+// `PreviewDigest.Duration`. `PolicyPacks` is passed through as a map — `encoding/json` sorts
+// map keys so the output stays deterministic.
 func applySummaryEvent(summary *display.EventSummary, s *apitype.SummaryEvent) {
 	summary.IsPreview = s.IsPreview
 	summary.MaybeCorrupt = s.MaybeCorrupt
@@ -254,12 +227,7 @@ func applySummaryEvent(summary *display.EventSummary, s *apitype.SummaryEvent) {
 		summary.ChangeSummary = changes
 	}
 	if len(s.PolicyPacks) > 0 {
-		packs := make([]display.SummaryPolicyPack, 0, len(s.PolicyPacks))
-		for name, version := range s.PolicyPacks {
-			packs = append(packs, display.SummaryPolicyPack{Name: name, Version: version})
-		}
-		sort.Slice(packs, func(i, j int) bool { return packs[i].Name < packs[j].Name })
-		summary.PolicyPacks = packs
+		summary.PolicyPacks = s.PolicyPacks
 	}
 }
 

--- a/pkg/cmd/pulumi/events/summary.go
+++ b/pkg/cmd/pulumi/events/summary.go
@@ -1,0 +1,277 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// summarySchemaVersion is the version of the EventSummary document this command emits. Bumped
+// only on breaking schema changes — additive changes keep the same version.
+const summarySchemaVersion = 1
+
+// NewSummaryCmd builds the `pulumi events summary` command. It reads a JSONL engine event
+// stream from stdin and emits a single JSON `display.EventSummary` object to stdout,
+// capturing the same information a human sees in the CLI output of `pulumi preview`,
+// `pulumi up`, `pulumi refresh`, or `pulumi destroy`.
+//
+// Hidden while the interface is being developed.
+func NewSummaryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Summarise an engine event stream as JSON",
+		Long: "Summarise an engine event stream as JSON.\n" +
+			"\n" +
+			"Reads an engine event stream on stdin and writes a single structured JSON\n" +
+			"document on stdout, mirroring the information a human sees in the output of\n" +
+			"`pulumi preview`, `pulumi up`, `pulumi refresh`, or `pulumi destroy`:\n" +
+			"configuration, per-resource steps, stack outputs, resource change counts,\n" +
+			"duration, diagnostics, and policy results.\n",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSummary(cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	return cmd
+}
+
+// runSummary reads JSONL engine events from in, reduces them into a single EventSummary, and
+// writes the result as a pretty-printed JSON object to out. Decoding errors surface to the
+// caller so that malformed input fails fast.
+func runSummary(in io.Reader, out io.Writer) error {
+	summary, err := reduceEvents(in)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(summary); err != nil {
+		return fmt.Errorf("encoding summary: %w", err)
+	}
+	return nil
+}
+
+// reduceEvents folds a JSONL engine event stream into an EventSummary. The reduction preserves
+// arrival order for lists (diagnostics, policy violations) and picks the latest observed entry
+// per URN for steps. Failure modes (ResOpFailedEvent, ErrorEvent) are surfaced on the summary's
+// `Failed` / `Error` fields; they do not abort reduction — a partial stream still yields a
+// useful document.
+func reduceEvents(in io.Reader) (*display.EventSummary, error) {
+	summary := &display.EventSummary{Version: summarySchemaVersion}
+
+	// stepOrder preserves the order URNs first appear in the stream; stepByURN holds the
+	// current snapshot for each. At the end we flatten stepByURN in stepOrder into Steps.
+	stepOrder := []resource.URN{}
+	stepByURN := map[resource.URN]*display.SummaryStep{}
+
+	dec := json.NewDecoder(in)
+	first := true
+	for {
+		var evt apitype.EngineEvent
+		if err := dec.Decode(&evt); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decoding event: %w", err)
+		}
+
+		if first {
+			summary.StartTime = evt.Timestamp
+			first = false
+		}
+		if evt.Timestamp != 0 {
+			summary.EndTime = evt.Timestamp
+		}
+
+		switch {
+		case evt.PreludeEvent != nil:
+			summary.Config = evt.PreludeEvent.Config
+
+		case evt.ResourcePreEvent != nil:
+			applyResourceStep(stepByURN, &stepOrder, evt.ResourcePreEvent.Metadata, false)
+			captureStackOutputs(summary, evt.ResourcePreEvent.Metadata)
+
+		case evt.ResOutputsEvent != nil:
+			applyResourceStep(stepByURN, &stepOrder, evt.ResOutputsEvent.Metadata, false)
+			captureStackOutputs(summary, evt.ResOutputsEvent.Metadata)
+
+		case evt.ResOpFailedEvent != nil:
+			applyResourceStep(stepByURN, &stepOrder, evt.ResOpFailedEvent.Metadata, true)
+			summary.Failed = true
+
+		case evt.DiagnosticEvent != nil:
+			if d := toSummaryDiagnostic(evt.DiagnosticEvent); d != nil {
+				summary.Diagnostics = append(summary.Diagnostics, *d)
+			}
+
+		case evt.PolicyEvent != nil:
+			summary.PolicyViolations = append(summary.PolicyViolations, toPolicyViolation(evt.PolicyEvent))
+
+		case evt.PolicyRemediationEvent != nil:
+			summary.PolicyViolations = append(summary.PolicyViolations, toPolicyRemediation(evt.PolicyRemediationEvent))
+
+		case evt.ErrorEvent != nil:
+			summary.Failed = true
+			summary.Error = evt.ErrorEvent.Error
+
+		case evt.SummaryEvent != nil:
+			applySummaryEvent(summary, evt.SummaryEvent)
+		}
+	}
+
+	summary.Steps = flattenSteps(stepByURN, stepOrder)
+	return summary, nil
+}
+
+// applyResourceStep records or updates the SummaryStep for md.URN. `OpSame` is ignored —
+// consumers asked for a summary, not a full transcript. A previously-seen step for the same
+// URN is overwritten, so a `ResOutputsEvent` supersedes its earlier `ResourcePreEvent` (the
+// former is emitted strictly later and carries the final step state). The `failed` flag sticks:
+// once a resource has failed, a later successful step for the same URN shouldn't erase that.
+func applyResourceStep(
+	byURN map[resource.URN]*display.SummaryStep,
+	order *[]resource.URN,
+	md apitype.StepEventMetadata,
+	failed bool,
+) {
+	if md.Op == apitype.OpSame {
+		return
+	}
+	urn := resource.URN(md.URN)
+	step, seen := byURN[urn]
+	if !seen {
+		step = &display.SummaryStep{URN: urn}
+		byURN[urn] = step
+		*order = append(*order, urn)
+	}
+	step.Op = display.StepOp(md.Op)
+	step.Type = md.Type
+	step.Provider = md.Provider
+	step.Diffs = md.Diffs
+	step.ReplaceReasons = md.Keys
+	step.DetailedDiff = md.DetailedDiff
+	if failed {
+		step.Failed = true
+	}
+}
+
+// captureStackOutputs picks up the root-stack's outputs from a resource step. The last
+// ResOutputsEvent / ResourcePreEvent for the root stack wins. Outputs are taken from the New
+// state if present, falling back to the Old state (useful for destroys, where the final step
+// has no New).
+func captureStackOutputs(summary *display.EventSummary, md apitype.StepEventMetadata) {
+	if md.Type != string(tokens.RootStackType) {
+		return
+	}
+	switch {
+	case md.New != nil && md.New.Outputs != nil:
+		summary.Outputs = md.New.Outputs
+	case md.Old != nil && md.Old.Outputs != nil:
+		summary.Outputs = md.Old.Outputs
+	}
+}
+
+// toSummaryDiagnostic converts a DiagnosticEvent into a SummaryDiagnostic, dropping entries
+// that are meant for live display only. Ephemeral messages are transient progress spinners and
+// must not pollute a persisted summary; `debug`-level messages are noisy and typically hidden
+// from humans too.
+func toSummaryDiagnostic(d *apitype.DiagnosticEvent) *display.SummaryDiagnostic {
+	if d.Ephemeral || d.Severity == "debug" {
+		return nil
+	}
+	return &display.SummaryDiagnostic{
+		URN:      resource.URN(d.URN),
+		Message:  d.Message,
+		Severity: d.Severity,
+	}
+}
+
+// toPolicyViolation flattens a PolicyEvent into a SummaryPolicyViolation.
+func toPolicyViolation(p *apitype.PolicyEvent) display.SummaryPolicyViolation {
+	return display.SummaryPolicyViolation{
+		URN:               resource.URN(p.ResourceURN),
+		PolicyName:        p.PolicyName,
+		PolicyPackName:    p.PolicyPackName,
+		PolicyPackVersion: p.PolicyPackVersion,
+		EnforcementLevel:  p.EnforcementLevel,
+		Severity:          p.Severity,
+		Message:           p.Message,
+		Remediated:        false,
+	}
+}
+
+// toPolicyRemediation flattens a PolicyRemediationEvent into a SummaryPolicyViolation. The
+// before/after payloads carried on remediations are intentionally dropped from the summary —
+// consumers that need them should read the raw event stream.
+func toPolicyRemediation(p *apitype.PolicyRemediationEvent) display.SummaryPolicyViolation {
+	return display.SummaryPolicyViolation{
+		URN:               resource.URN(p.ResourceURN),
+		PolicyPackName:    p.PolicyPackName,
+		PolicyPackVersion: p.PolicyPackVersion,
+		PolicyName:        p.PolicyName,
+		Remediated:        true,
+	}
+}
+
+// applySummaryEvent copies the scalar fields of a SummaryEvent onto the summary and converts
+// `PolicyPacks` into a deterministic sorted list. `DurationSeconds` is expanded to a
+// `time.Duration` to match the convention used by `PreviewDigest.Duration`.
+func applySummaryEvent(summary *display.EventSummary, s *apitype.SummaryEvent) {
+	summary.IsPreview = s.IsPreview
+	summary.MaybeCorrupt = s.MaybeCorrupt
+	summary.Duration = time.Duration(s.DurationSeconds) * time.Second
+	if len(s.ResourceChanges) > 0 {
+		changes := make(display.ResourceChanges, len(s.ResourceChanges))
+		for op, n := range s.ResourceChanges {
+			changes[display.StepOp(op)] = n
+		}
+		summary.ChangeSummary = changes
+	}
+	if len(s.PolicyPacks) > 0 {
+		packs := make([]display.SummaryPolicyPack, 0, len(s.PolicyPacks))
+		for name, version := range s.PolicyPacks {
+			packs = append(packs, display.SummaryPolicyPack{Name: name, Version: version})
+		}
+		sort.Slice(packs, func(i, j int) bool { return packs[i].Name < packs[j].Name })
+		summary.PolicyPacks = packs
+	}
+}
+
+// flattenSteps returns the per-URN SummaryStep snapshots in first-seen order. `nil` for an
+// empty map so the field is omitted from JSON output rather than serialised as `[]`.
+func flattenSteps(byURN map[resource.URN]*display.SummaryStep, order []resource.URN) []*display.SummaryStep {
+	if len(order) == 0 {
+		return nil
+	}
+	out := make([]*display.SummaryStep, 0, len(order))
+	for _, urn := range order {
+		out = append(out, byURN[urn])
+	}
+	return out
+}

--- a/pkg/cmd/pulumi/events/summary.go
+++ b/pkg/cmd/pulumi/events/summary.go
@@ -211,11 +211,13 @@ func toPreviewDiagnostic(d *apitype.DiagnosticEvent) *display.PreviewDiagnostic 
 	}
 }
 
-// applySummaryEvent copies the scalar fields of a SummaryEvent onto the summary.
-// `DurationSeconds` is expanded to a `time.Duration` to match the convention used by
-// `PreviewDigest.Duration`. `PolicyPacks` is passed through as a map — `encoding/json` sorts
-// map keys so the output stays deterministic.
+// applySummaryEvent copies the scalar fields of a SummaryEvent onto the summary and marks the
+// run as `Completed` — the SummaryEvent is the engine's end-of-update handshake, so seeing one
+// is the positive signal that the stream wasn't truncated. `DurationSeconds` is expanded to a
+// `time.Duration` to match the convention used by `PreviewDigest.Duration`. `PolicyPacks` is
+// passed through as a map — `encoding/json` sorts map keys so the output stays deterministic.
 func applySummaryEvent(summary *display.EventSummary, s *apitype.SummaryEvent) {
+	summary.Completed = true
 	summary.IsPreview = s.IsPreview
 	summary.MaybeCorrupt = s.MaybeCorrupt
 	summary.Duration = time.Duration(s.DurationSeconds) * time.Second

--- a/pkg/cmd/pulumi/events/summary_test.go
+++ b/pkg/cmd/pulumi/events/summary_test.go
@@ -546,3 +546,74 @@ func TestRunSummary_WritesIndentedJSON(t *testing.T) {
 	assert.True(t, strings.Contains(out.String(), "\n  \""),
 		"expected indented JSON, got: %s", out.String())
 }
+
+func TestRunSummary_ComposesWithChangesOnlyFilter(t *testing.T) {
+	t.Parallel()
+
+	// Exercise the documented pipeline: `pulumi up --json | filter --changes-only | summary`.
+	// Everything that isn't carried by an OpSame event should survive. There is one known
+	// limitation: the root-stack `ResOutputsEvent` is typically emitted with `Op=OpSame`
+	// (the stack itself didn't change even when children did) and carries the stack's
+	// outputs. `--changes-only` drops that event, so the `Outputs` field ends up empty.
+	// This test pins both the happy path *and* the limitation so we notice if either moves.
+	events := []apitype.EngineEvent{
+		{Timestamp: 1000, PreludeEvent: &apitype.PreludeEvent{
+			Config: map[string]string{"proj:region": "us-west-2"},
+		}},
+		{Timestamp: 1010, ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op: apitype.OpCreate, URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+				Type: "aws:s3/bucket:Bucket",
+			},
+		}},
+		{Timestamp: 1020, DiagnosticEvent: &apitype.DiagnosticEvent{
+			URN:     "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+			Message: "provisioning bucket", Severity: "info",
+		}},
+		// Root-stack OpSame event: dropped by `--changes-only`, so the outputs carried here
+		// never reach summary.
+		{Timestamp: 1030, ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op:   apitype.OpSame,
+				URN:  rootStackURN,
+				Type: string(tokens.RootStackType),
+				New:  &apitype.StepEventStateMetadata{Outputs: map[string]any{"bucketName": "b"}},
+			},
+		}},
+		{Timestamp: 1040, SummaryEvent: &apitype.SummaryEvent{
+			DurationSeconds: 30,
+			ResourceChanges: map[apitype.OpType]int{apitype.OpCreate: 1, apitype.OpSame: 1},
+		}},
+	}
+
+	// Pipe through filter, then summary — verbatim what a user would do at the shell.
+	var filtered bytes.Buffer
+	require.NoError(t, runChangesOnly(encodeStream(t, events), &filtered))
+	var out bytes.Buffer
+	require.NoError(t, runSummary(&filtered, &out))
+
+	var got display.EventSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+
+	// Everything that doesn't ride on an OpSame event survives the pipe.
+	assert.True(t, got.Completed, "SummaryEvent is a non-resource event — passes through the filter")
+	assert.False(t, got.Failed)
+	assert.Equal(t, map[string]string{"proj:region": "us-west-2"}, got.Config,
+		"PreludeEvent passes through the filter untouched")
+	assert.Equal(t, 30*time.Second, got.Duration)
+	assert.Equal(t, display.ResourceChanges{
+		display.StepOp(apitype.OpCreate): 1,
+		display.StepOp(apitype.OpSame):   1,
+	}, got.ChangeSummary, "change counts come from SummaryEvent and are not touched by the filter")
+	require.Len(t, got.Steps, 1, "non-OpSame steps survive the pipe")
+	assert.Equal(t, apitype.OpCreate, got.Steps[0].Op)
+	require.Len(t, got.Diagnostics, 1, "DiagnosticEvents are non-resource and pass through the filter")
+	assert.Equal(t, 1000, got.StartTime)
+	assert.Equal(t, 1040, got.EndTime)
+
+	// KNOWN LIMITATION: the root-stack OpSame event gets dropped by `--changes-only`, so
+	// the stack outputs never reach summary. Consumers that want outputs should pipe
+	// `pulumi up --json | summary` directly, without `filter --changes-only` in between.
+	assert.Empty(t, got.Outputs,
+		"root-stack OpSame event is dropped by --changes-only, so summary can't recover stack outputs")
+}

--- a/pkg/cmd/pulumi/events/summary_test.go
+++ b/pkg/cmd/pulumi/events/summary_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
@@ -113,6 +114,25 @@ func TestReduceEvents_ResOutputsSupersedesResourcePre(t *testing.T) {
 		"the later ResOutputsEvent state should win")
 }
 
+func TestReduceEvents_StepZerosOldAndNew(t *testing.T) {
+	t.Parallel()
+
+	// The summary stays compact by zeroing Old/New — full state is available in the raw
+	// event stream for consumers that need it.
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpUpdate, URN: "urn:r", Type: "pkg:index:Res",
+			Old: &apitype.StepEventStateMetadata{Inputs: map[string]any{"foo": "old"}},
+			New: &apitype.StepEventStateMetadata{Inputs: map[string]any{"foo": "new"}},
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	require.Len(t, summary.Steps, 1)
+	assert.Nil(t, summary.Steps[0].Old, "Old must be nil so the summary stays compact")
+	assert.Nil(t, summary.Steps[0].New, "New must be nil so the summary stays compact")
+}
+
 func TestReduceEvents_CarriesDetailedDiffAndReplaceReasons(t *testing.T) {
 	t.Parallel()
 
@@ -132,8 +152,8 @@ func TestReduceEvents_CarriesDetailedDiffAndReplaceReasons(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, summary.Steps, 1)
 	s := summary.Steps[0]
-	assert.Equal(t, display.StepOp(apitype.OpReplace), s.Op)
-	assert.Equal(t, []string{"foo"}, s.ReplaceReasons)
+	assert.Equal(t, apitype.OpReplace, s.Op)
+	assert.Equal(t, []string{"foo"}, s.Keys)
 	assert.Equal(t, detailed, s.DetailedDiff)
 	assert.Equal(t, "urn:provider", s.Provider)
 }
@@ -234,15 +254,17 @@ func TestReduceEvents_DiagnosticsKeepsNonEphemeralNonDebug(t *testing.T) {
 	summary, err := reduceEvents(encodeStream(t, events))
 	require.NoError(t, err)
 	require.Len(t, summary.Diagnostics, 2)
-	assert.Equal(t, "warning", summary.Diagnostics[0].Severity)
+	assert.Equal(t, diag.Severity("warning"), summary.Diagnostics[0].Severity)
 	assert.Equal(t, "heads up", summary.Diagnostics[0].Message)
 	assert.Equal(t, resource.URN("urn:a"), summary.Diagnostics[0].URN)
-	assert.Equal(t, "error", summary.Diagnostics[1].Severity)
+	assert.Equal(t, diag.Severity("error"), summary.Diagnostics[1].Severity)
 }
 
-func TestReduceEvents_PolicyViolationsAndRemediations(t *testing.T) {
+func TestReduceEvents_PolicyViolationsAndRemediationsGoToSeparateLists(t *testing.T) {
 	t.Parallel()
 
+	// Keeping the two event types in separate fields preserves the PolicyRemediationEvent's
+	// before/after payload — a single fused list would've forced us to drop it.
 	events := []apitype.EngineEvent{
 		{PolicyEvent: &apitype.PolicyEvent{
 			ResourceURN: "urn:a", PolicyName: "require-tag",
@@ -252,16 +274,18 @@ func TestReduceEvents_PolicyViolationsAndRemediations(t *testing.T) {
 		{PolicyRemediationEvent: &apitype.PolicyRemediationEvent{
 			ResourceURN: "urn:b", PolicyName: "default-tag",
 			PolicyPackName: "aws-best", PolicyPackVersion: "1.0.0",
+			Before: map[string]any{"tag": nil},
+			After:  map[string]any{"tag": "auto"},
 		}},
 	}
 	summary, err := reduceEvents(encodeStream(t, events))
 	require.NoError(t, err)
-	require.Len(t, summary.PolicyViolations, 2)
-	assert.False(t, summary.PolicyViolations[0].Remediated,
-		"PolicyEvent must be Remediated=false")
+	require.Len(t, summary.PolicyViolations, 1)
 	assert.Equal(t, "missing tag", summary.PolicyViolations[0].Message)
-	assert.True(t, summary.PolicyViolations[1].Remediated,
-		"PolicyRemediationEvent must be Remediated=true")
+	require.Len(t, summary.PolicyRemediations, 1)
+	assert.Equal(t, map[string]any{"tag": nil}, summary.PolicyRemediations[0].Before,
+		"Before payload must be preserved on remediations")
+	assert.Equal(t, map[string]any{"tag": "auto"}, summary.PolicyRemediations[0].After)
 }
 
 func TestReduceEvents_ErrorEventSetsFailedAndError(t *testing.T) {
@@ -302,10 +326,7 @@ func TestReduceEvents_SummaryEventPopulatesScalarsAndChanges(t *testing.T) {
 		display.StepOp(apitype.OpUpdate): 1,
 		display.StepOp(apitype.OpSame):   5,
 	}, summary.ChangeSummary)
-	// PolicyPacks must be sorted by name regardless of map iteration order.
-	require.Len(t, summary.PolicyPacks, 2)
-	assert.Equal(t, "a-pack", summary.PolicyPacks[0].Name)
-	assert.Equal(t, "z-pack", summary.PolicyPacks[1].Name)
+	assert.Equal(t, map[string]string{"a-pack": "1", "z-pack": "2"}, summary.PolicyPacks)
 }
 
 func TestReduceEvents_PreviewLeavesOutputsEmpty(t *testing.T) {
@@ -399,8 +420,8 @@ func TestRunSummary_EndToEndForUp(t *testing.T) {
 	assert.Equal(t, map[string]any{"bucketName": "b"}, got.Outputs)
 	// Even though the root-stack step is `OpSame`, the non-stack steps should appear.
 	require.Len(t, got.Steps, 2)
-	assert.Equal(t, display.StepOp(apitype.OpCreate), got.Steps[0].Op)
-	assert.Equal(t, display.StepOp(apitype.OpUpdate), got.Steps[1].Op)
+	assert.Equal(t, apitype.OpCreate, got.Steps[0].Op)
+	assert.Equal(t, apitype.OpUpdate, got.Steps[1].Op)
 	assert.Equal(t, 1000, got.StartTime)
 	assert.Equal(t, 1040, got.EndTime)
 }
@@ -485,7 +506,7 @@ func TestRunSummary_EndToEndForRefresh(t *testing.T) {
 	var got display.EventSummary
 	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
 	require.Len(t, got.Steps, 1)
-	assert.Equal(t, display.StepOp(apitype.OpRefresh), got.Steps[0].Op)
+	assert.Equal(t, apitype.OpRefresh, got.Steps[0].Op)
 	assert.Equal(t, []string{"tags"}, got.Steps[0].Diffs)
 }
 

--- a/pkg/cmd/pulumi/events/summary_test.go
+++ b/pkg/cmd/pulumi/events/summary_test.go
@@ -1,0 +1,501 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// encodeStream renders a slice of events as a JSONL stream, mirroring what `pulumi up --json`
+// would write to disk or stdout. Kept next to the tests that need it because every test case
+// builds its own stream.
+func encodeStream(t *testing.T, events []apitype.EngineEvent) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, e := range events {
+		require.NoError(t, enc.Encode(e))
+	}
+	return &buf
+}
+
+// rootStackURN is the canonical root-stack URN used in fixtures. The type segment
+// (`pulumi:pulumi:Stack`) is what the summary uses to identify the stack's outputs.
+const rootStackURN = "urn:pulumi:dev::proj::pulumi:pulumi:Stack::proj-dev"
+
+func TestReduceEvents_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	// An empty stream must still produce a valid document: version set, everything else
+	// zero-valued. Consumers can rely on `version` being present even when nothing happened.
+	summary, err := reduceEvents(strings.NewReader(""))
+	require.NoError(t, err)
+	require.NotNil(t, summary)
+	assert.Equal(t, summarySchemaVersion, summary.Version)
+	assert.False(t, summary.IsPreview)
+	assert.Empty(t, summary.Steps)
+	assert.Empty(t, summary.Diagnostics)
+}
+
+func TestReduceEvents_PopulatesConfigFromPrelude(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{PreludeEvent: &apitype.PreludeEvent{Config: map[string]string{"proj:region": "us-west-2"}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"proj:region": "us-west-2"}, summary.Config)
+}
+
+func TestReduceEvents_IgnoresOpSameSteps(t *testing.T) {
+	t.Parallel()
+
+	// OpSame must never appear in Steps — the summary is about what changed, not about what
+	// didn't. The user explicitly confirmed this decision on 2026-04-24.
+	events := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpSame, URN: "urn:unchanged",
+		}}},
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpSame, URN: "urn:unchanged",
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Empty(t, summary.Steps, "OpSame steps must not appear in the summary")
+}
+
+func TestReduceEvents_ResOutputsSupersedesResourcePre(t *testing.T) {
+	t.Parallel()
+
+	// A resource typically emits a ResourcePreEvent then a ResOutputsEvent. The latter arrives
+	// with the completed step state, so the summary must reflect that — not the pre event.
+	urn := "urn:pulumi:dev::proj::pkg:index:Res::r"
+	events := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpUpdate, URN: urn, Type: "pkg:index:Res",
+			Diffs: []string{"pre"},
+		}}},
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpUpdate, URN: urn, Type: "pkg:index:Res",
+			Diffs: []string{"post"},
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	require.Len(t, summary.Steps, 1)
+	assert.Equal(t, []string{"post"}, summary.Steps[0].Diffs,
+		"the later ResOutputsEvent state should win")
+}
+
+func TestReduceEvents_CarriesDetailedDiffAndReplaceReasons(t *testing.T) {
+	t.Parallel()
+
+	detailed := map[string]apitype.PropertyDiff{
+		"foo": {Kind: apitype.DiffUpdateReplace, InputDiff: true},
+	}
+	events := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpReplace, URN: "urn:r", Type: "pkg:index:Res",
+			Diffs:        []string{"foo"},
+			Keys:         []string{"foo"},
+			DetailedDiff: detailed,
+			Provider:     "urn:provider",
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	require.Len(t, summary.Steps, 1)
+	s := summary.Steps[0]
+	assert.Equal(t, display.StepOp(apitype.OpReplace), s.Op)
+	assert.Equal(t, []string{"foo"}, s.ReplaceReasons)
+	assert.Equal(t, detailed, s.DetailedDiff)
+	assert.Equal(t, "urn:provider", s.Provider)
+}
+
+func TestReduceEvents_ResOpFailedSetsStepAndSummaryFailed(t *testing.T) {
+	t.Parallel()
+
+	urn := "urn:pulumi:dev::proj::pkg:index:Res::r"
+	events := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpCreate, URN: urn, Type: "pkg:index:Res",
+		}}},
+		{ResOpFailedEvent: &apitype.ResOpFailedEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op: apitype.OpCreate, URN: urn, Type: "pkg:index:Res",
+			},
+		}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.True(t, summary.Failed, "ResOpFailedEvent must flip summary.Failed")
+	require.Len(t, summary.Steps, 1)
+	assert.True(t, summary.Steps[0].Failed, "the failed URN's step must be flagged")
+}
+
+func TestReduceEvents_CapturesRootStackOutputsFromNew(t *testing.T) {
+	t.Parallel()
+
+	outputs := map[string]any{"endpoint": "https://api.example.com"}
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op:   apitype.OpUpdate,
+			URN:  rootStackURN,
+			Type: string(tokens.RootStackType),
+			New:  &apitype.StepEventStateMetadata{Outputs: outputs},
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Equal(t, outputs, summary.Outputs)
+}
+
+func TestReduceEvents_CapturesRootStackOutputsFromOldOnDestroy(t *testing.T) {
+	t.Parallel()
+
+	// On destroy the final root-stack step has no `New` (the stack is being deleted). The
+	// outputs we care about are in `Old` — that's what the human saw printed before destroy.
+	outputs := map[string]any{"endpoint": "https://api.example.com"}
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op:   apitype.OpDelete,
+			URN:  rootStackURN,
+			Type: string(tokens.RootStackType),
+			Old:  &apitype.StepEventStateMetadata{Outputs: outputs},
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Equal(t, outputs, summary.Outputs,
+		"destroy should surface the pre-destroy outputs from Old")
+}
+
+func TestReduceEvents_IgnoresOutputsFromNonRootResources(t *testing.T) {
+	t.Parallel()
+
+	// Non-root resource outputs must not end up in the summary's top-level Outputs — that
+	// field is reserved for the stack outputs a user explicitly exports.
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op:   apitype.OpCreate,
+			URN:  "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+			Type: "aws:s3/bucket:Bucket",
+			New:  &apitype.StepEventStateMetadata{Outputs: map[string]any{"arn": "arn:aws:s3:::b"}},
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Nil(t, summary.Outputs, "only root-stack outputs should populate summary.Outputs")
+}
+
+func TestReduceEvents_DiagnosticsKeepsNonEphemeralNonDebug(t *testing.T) {
+	t.Parallel()
+
+	// Ephemeral diagnostics are progress-spinner text meant for live rendering only; they
+	// must not show up in a persisted summary. Debug messages are just as noisy.
+	events := []apitype.EngineEvent{
+		{DiagnosticEvent: &apitype.DiagnosticEvent{
+			URN: "urn:a", Message: "heads up", Severity: "warning",
+		}},
+		{DiagnosticEvent: &apitype.DiagnosticEvent{
+			Message: "transient", Severity: "info", Ephemeral: true,
+		}},
+		{DiagnosticEvent: &apitype.DiagnosticEvent{Message: "verbose", Severity: "debug"}},
+		{DiagnosticEvent: &apitype.DiagnosticEvent{
+			URN: "urn:b", Message: "boom", Severity: "error",
+		}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	require.Len(t, summary.Diagnostics, 2)
+	assert.Equal(t, "warning", summary.Diagnostics[0].Severity)
+	assert.Equal(t, "heads up", summary.Diagnostics[0].Message)
+	assert.Equal(t, resource.URN("urn:a"), summary.Diagnostics[0].URN)
+	assert.Equal(t, "error", summary.Diagnostics[1].Severity)
+}
+
+func TestReduceEvents_PolicyViolationsAndRemediations(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{PolicyEvent: &apitype.PolicyEvent{
+			ResourceURN: "urn:a", PolicyName: "require-tag",
+			PolicyPackName: "aws-best", PolicyPackVersion: "1.0.0",
+			EnforcementLevel: "mandatory", Message: "missing tag",
+		}},
+		{PolicyRemediationEvent: &apitype.PolicyRemediationEvent{
+			ResourceURN: "urn:b", PolicyName: "default-tag",
+			PolicyPackName: "aws-best", PolicyPackVersion: "1.0.0",
+		}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	require.Len(t, summary.PolicyViolations, 2)
+	assert.False(t, summary.PolicyViolations[0].Remediated,
+		"PolicyEvent must be Remediated=false")
+	assert.Equal(t, "missing tag", summary.PolicyViolations[0].Message)
+	assert.True(t, summary.PolicyViolations[1].Remediated,
+		"PolicyRemediationEvent must be Remediated=true")
+}
+
+func TestReduceEvents_ErrorEventSetsFailedAndError(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{ErrorEvent: &apitype.ErrorEvent{Error: "engine exploded"}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.True(t, summary.Failed)
+	assert.Equal(t, "engine exploded", summary.Error)
+}
+
+func TestReduceEvents_SummaryEventPopulatesScalarsAndChanges(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{SummaryEvent: &apitype.SummaryEvent{
+			IsPreview:       false,
+			DurationSeconds: 42,
+			MaybeCorrupt:    true,
+			ResourceChanges: map[apitype.OpType]int{
+				apitype.OpCreate: 3,
+				apitype.OpUpdate: 1,
+				apitype.OpSame:   5,
+			},
+			PolicyPacks: map[string]string{"z-pack": "2", "a-pack": "1"},
+		}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.False(t, summary.IsPreview)
+	assert.True(t, summary.MaybeCorrupt)
+	assert.Equal(t, 42*time.Second, summary.Duration)
+	assert.Equal(t, display.ResourceChanges{
+		display.StepOp(apitype.OpCreate): 3,
+		display.StepOp(apitype.OpUpdate): 1,
+		display.StepOp(apitype.OpSame):   5,
+	}, summary.ChangeSummary)
+	// PolicyPacks must be sorted by name regardless of map iteration order.
+	require.Len(t, summary.PolicyPacks, 2)
+	assert.Equal(t, "a-pack", summary.PolicyPacks[0].Name)
+	assert.Equal(t, "z-pack", summary.PolicyPacks[1].Name)
+}
+
+func TestReduceEvents_PreviewLeavesOutputsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A preview's SummaryEvent has IsPreview=true and DurationSeconds=0. The stack hasn't been
+	// realised, so there are no applied Outputs to capture.
+	events := []apitype.EngineEvent{
+		{SummaryEvent: &apitype.SummaryEvent{IsPreview: true, ResourceChanges: map[apitype.OpType]int{
+			apitype.OpCreate: 1,
+		}}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.True(t, summary.IsPreview)
+	assert.Zero(t, summary.Duration)
+	assert.Empty(t, summary.Outputs)
+}
+
+func TestReduceEvents_RecordsStartAndEndTimestamps(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{Sequence: 1, Timestamp: 1000, PreludeEvent: &apitype.PreludeEvent{}},
+		{Sequence: 2, Timestamp: 1050, StdoutEvent: &apitype.StdoutEngineEvent{Message: "hi"}},
+		{Sequence: 3, Timestamp: 1100, SummaryEvent: &apitype.SummaryEvent{}},
+	}
+	summary, err := reduceEvents(encodeStream(t, events))
+	require.NoError(t, err)
+	assert.Equal(t, 1000, summary.StartTime)
+	assert.Equal(t, 1100, summary.EndTime)
+}
+
+func TestReduceEvents_MalformedJSONReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := reduceEvents(strings.NewReader("{not json}\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decoding event")
+}
+
+func TestRunSummary_EndToEndForUp(t *testing.T) {
+	t.Parallel()
+
+	// A realistic-ish stream for a small `pulumi up`: prelude, one create, one update, the
+	// root stack's outputs, and a summary. Exercises the full pipeline including JSON
+	// encoding.
+	events := []apitype.EngineEvent{
+		{Timestamp: 1000, PreludeEvent: &apitype.PreludeEvent{
+			Config: map[string]string{"proj:region": "us-west-2"},
+		}},
+		{Timestamp: 1010, ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op: apitype.OpCreate, URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+				Type: "aws:s3/bucket:Bucket",
+			},
+		}},
+		{Timestamp: 1020, ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op: apitype.OpUpdate, URN: "urn:pulumi:dev::proj::aws:lambda/function:Function::f",
+				Type:  "aws:lambda/function:Function",
+				Diffs: []string{"code"},
+			},
+		}},
+		{Timestamp: 1030, ResOutputsEvent: &apitype.ResOutputsEvent{
+			Metadata: apitype.StepEventMetadata{
+				Op: apitype.OpSame, URN: rootStackURN, Type: string(tokens.RootStackType),
+				New: &apitype.StepEventStateMetadata{
+					Outputs: map[string]any{"bucketName": "b"},
+				},
+			},
+		}},
+		{Timestamp: 1040, SummaryEvent: &apitype.SummaryEvent{
+			DurationSeconds: 30,
+			ResourceChanges: map[apitype.OpType]int{
+				apitype.OpCreate: 1, apitype.OpUpdate: 1, apitype.OpSame: 1,
+			},
+		}},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSummary(encodeStream(t, events), &out))
+
+	// The wire format is a single indented JSON object — decode it and spot-check fields.
+	var got display.EventSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, summarySchemaVersion, got.Version)
+	assert.False(t, got.IsPreview)
+	assert.Equal(t, map[string]string{"proj:region": "us-west-2"}, got.Config)
+	assert.Equal(t, 30*time.Second, got.Duration)
+	assert.Equal(t, map[string]any{"bucketName": "b"}, got.Outputs)
+	// Even though the root-stack step is `OpSame`, the non-stack steps should appear.
+	require.Len(t, got.Steps, 2)
+	assert.Equal(t, display.StepOp(apitype.OpCreate), got.Steps[0].Op)
+	assert.Equal(t, display.StepOp(apitype.OpUpdate), got.Steps[1].Op)
+	assert.Equal(t, 1000, got.StartTime)
+	assert.Equal(t, 1040, got.EndTime)
+}
+
+func TestRunSummary_EndToEndForPreview(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpCreate, URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+			Type: "aws:s3/bucket:Bucket",
+		}}},
+		{SummaryEvent: &apitype.SummaryEvent{
+			IsPreview:       true,
+			ResourceChanges: map[apitype.OpType]int{apitype.OpCreate: 1},
+		}},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSummary(encodeStream(t, events), &out))
+
+	var got display.EventSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.True(t, got.IsPreview)
+	assert.Zero(t, got.Duration, "preview must not report a duration")
+	assert.Empty(t, got.Outputs, "preview must not report outputs — nothing was applied")
+	require.Len(t, got.Steps, 1)
+}
+
+func TestRunSummary_EndToEndForDestroy(t *testing.T) {
+	t.Parallel()
+
+	// Destroy streams delete the root stack; outputs come from Old. Every step is OpDelete.
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpDelete, URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+			Type: "aws:s3/bucket:Bucket",
+		}}},
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpDelete, URN: rootStackURN, Type: string(tokens.RootStackType),
+			Old: &apitype.StepEventStateMetadata{
+				Outputs: map[string]any{"bucketName": "b"},
+			},
+		}}},
+		{SummaryEvent: &apitype.SummaryEvent{
+			DurationSeconds: 5,
+			ResourceChanges: map[apitype.OpType]int{apitype.OpDelete: 2},
+		}},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSummary(encodeStream(t, events), &out))
+
+	var got display.EventSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, map[string]any{"bucketName": "b"}, got.Outputs,
+		"destroy surfaces the pre-destroy outputs so a human can see what was there")
+	assert.Equal(t, display.ResourceChanges{
+		display.StepOp(apitype.OpDelete): 2,
+	}, got.ChangeSummary)
+}
+
+func TestRunSummary_EndToEndForRefresh(t *testing.T) {
+	t.Parallel()
+
+	// Refresh streams consist of OpRefresh steps — they must be represented in the summary.
+	events := []apitype.EngineEvent{
+		{ResOutputsEvent: &apitype.ResOutputsEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpRefresh, URN: "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::b",
+			Type:  "aws:s3/bucket:Bucket",
+			Diffs: []string{"tags"},
+		}}},
+		{SummaryEvent: &apitype.SummaryEvent{
+			DurationSeconds: 2,
+			ResourceChanges: map[apitype.OpType]int{apitype.OpRefresh: 1},
+		}},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSummary(encodeStream(t, events), &out))
+
+	var got display.EventSummary
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.Steps, 1)
+	assert.Equal(t, display.StepOp(apitype.OpRefresh), got.Steps[0].Op)
+	assert.Equal(t, []string{"tags"}, got.Steps[0].Diffs)
+}
+
+func TestRunSummary_WritesIndentedJSON(t *testing.T) {
+	t.Parallel()
+
+	// The command's contract is "a single JSON document" — pretty-printed so that a human
+	// redirecting stdout to a file gets readable output.
+	var out bytes.Buffer
+	require.NoError(t, runSummary(strings.NewReader(""), &out))
+	assert.True(t, strings.Contains(out.String(), "\n  \""),
+		"expected indented JSON, got: %s", out.String())
+}

--- a/pkg/cmd/pulumi/events/summary_test.go
+++ b/pkg/cmd/pulumi/events/summary_test.go
@@ -298,6 +298,32 @@ func TestReduceEvents_ErrorEventSetsFailedAndError(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, summary.Failed)
 	assert.Equal(t, "engine exploded", summary.Error)
+	assert.False(t, summary.Completed,
+		"an ErrorEvent without a SummaryEvent means the run didn't reach the end-of-update handshake")
+}
+
+func TestReduceEvents_CompletedFlagTracksSummaryEvent(t *testing.T) {
+	t.Parallel()
+
+	// Without a SummaryEvent the run is "interrupted" — no positive signal of a clean end.
+	noSummary := []apitype.EngineEvent{
+		{ResourcePreEvent: &apitype.ResourcePreEvent{Metadata: apitype.StepEventMetadata{
+			Op: apitype.OpCreate, URN: "urn:r", Type: "pkg:index:Res",
+		}}},
+	}
+	got, err := reduceEvents(encodeStream(t, noSummary))
+	require.NoError(t, err)
+	assert.False(t, got.Completed,
+		"a stream without SummaryEvent must leave Completed=false — we can't tell success from interruption")
+
+	// With a SummaryEvent, Completed is true. `Failed` stays independent so the consumer can
+	// distinguish "completed cleanly and succeeded" from "completed with failures".
+	withSummary := append(noSummary, apitype.EngineEvent{SummaryEvent: &apitype.SummaryEvent{}})
+	got, err = reduceEvents(encodeStream(t, withSummary))
+	require.NoError(t, err)
+	assert.True(t, got.Completed,
+		"a SummaryEvent in the stream must flip Completed — it's the engine's end-of-update handshake")
+	assert.False(t, got.Failed, "SummaryEvent alone does not imply failure")
 }
 
 func TestReduceEvents_SummaryEventPopulatesScalarsAndChanges(t *testing.T) {

--- a/pkg/display/json.go
+++ b/pkg/display/json.go
@@ -82,3 +82,137 @@ type PreviewDiagnostic struct {
 	Message  string        `json:"message,omitempty"`
 	Severity diag.Severity `json:"severity,omitempty"`
 }
+
+// EventSummary is a JSON-serialisable digest of an engine event stream produced by
+// `pulumi preview`, `pulumi up`, `pulumi refresh`, or `pulumi destroy`. It captures the same
+// information a human would see printed by these commands: the configuration, per-resource
+// steps, final stack outputs, policy results, diagnostics, and aggregate counts.
+//
+// The document is emitted by `pulumi events summary` as a single JSON object, the terminal
+// reduction of the JSONL event stream.
+type EventSummary struct {
+	// Version is the schema version. Starts at 1 and will only increase on
+	// backwards-incompatible changes; additive changes keep the same version.
+	Version int `json:"version"`
+
+	// IsPreview is true when the stream came from `pulumi preview`. Taken directly from
+	// SummaryEvent.IsPreview — if no SummaryEvent was seen (an interrupted run) it stays false.
+	IsPreview bool `json:"isPreview"`
+
+	// StartTime is the timestamp of the first event seen, as seconds since the Unix epoch.
+	StartTime int `json:"startTime,omitempty"`
+	// EndTime is the timestamp of the last event seen.
+	EndTime int `json:"endTime,omitempty"`
+
+	// Config contains the stack configuration keys and values for the update, taken from
+	// PreludeEvent. Secrets are blinded by the emitter.
+	Config map[string]string `json:"config,omitempty"`
+
+	// Steps is the list of resource steps excluding `OpSame`. Each URN appears at most once:
+	// the final observed step (ResOutputsEvent preferred over ResourcePreEvent) wins.
+	Steps []*SummaryStep `json:"steps,omitempty"`
+
+	// Outputs is the root stack's final outputs, taken from the last ResOutputsEvent with
+	// type `pulumi:pulumi:Stack`. Empty for previews — outputs aren't applied in a preview.
+	Outputs map[string]any `json:"outputs,omitempty"`
+
+	// ChangeSummary is the per-op resource change count from the final SummaryEvent.
+	ChangeSummary ResourceChanges `json:"changeSummary,omitempty"`
+
+	// Duration is how long the update took, as reported by SummaryEvent.DurationSeconds.
+	// Zero for previews (no duration is reported for a preview).
+	Duration time.Duration `json:"duration,omitempty"`
+
+	// Diagnostics lists non-ephemeral DiagnosticEvents observed in the stream, in the order
+	// they arrived. Ephemeral diagnostics (intended for live display only) are filtered out.
+	Diagnostics []SummaryDiagnostic `json:"diagnostics,omitempty"`
+
+	// PolicyPacks lists the policy packs that ran during the update, sorted by name for
+	// deterministic output. Sourced from SummaryEvent.PolicyPacks.
+	PolicyPacks []SummaryPolicyPack `json:"policyPacks,omitempty"`
+
+	// PolicyViolations collects PolicyEvent and PolicyRemediationEvent entries. Remediations
+	// are represented with `remediated: true`; plain violations with `remediated: false`.
+	PolicyViolations []SummaryPolicyViolation `json:"policyViolations,omitempty"`
+
+	// MaybeCorrupt is true if the engine reported that one or more resources may be corrupt.
+	// Sourced from SummaryEvent.MaybeCorrupt.
+	MaybeCorrupt bool `json:"maybeCorrupt,omitempty"`
+
+	// Failed is true if any `ResOpFailedEvent` was seen, or the engine reported an internal
+	// error. A successful preview/up leaves this false.
+	Failed bool `json:"failed,omitempty"`
+
+	// Error is set to the message of the last `ErrorEvent` in the stream, if any. These are
+	// emitted for engine-internal errors, not user-facing ones — user errors arrive as
+	// DiagnosticEvents with severity=error.
+	Error string `json:"error,omitempty"`
+}
+
+// SummaryStep is the reduced form of a resource step carried in the summary. It contains only
+// what a human sees in the CLI output plus the structured diff — OldState/NewState inputs and
+// outputs are intentionally omitted, as a summary is meant to be compact; consumers that want
+// full state should read the raw event stream.
+type SummaryStep struct {
+	// Op is the operation the engine performed on this resource.
+	Op StepOp `json:"op"`
+	// URN uniquely identifies the resource within the stack.
+	URN resource.URN `json:"urn"`
+	// Type is the resource type token (e.g. `aws:s3/bucket:Bucket`).
+	Type string `json:"type,omitempty"`
+	// Provider is the provider reference that performed the step.
+	Provider string `json:"provider,omitempty"`
+	// Diffs is the list of top-level property keys that changed (same as
+	// StepEventMetadata.Diffs).
+	Diffs []string `json:"diffs,omitempty"`
+	// ReplaceReasons lists keys that triggered a replacement, for `OpReplace` /
+	// `OpCreateReplacement` / `OpDeleteReplaced` (same as StepEventMetadata.Keys).
+	ReplaceReasons []string `json:"replaceReasons,omitempty"`
+	// DetailedDiff is the engine's property-path indexed diff. Preserved verbatim.
+	DetailedDiff map[string]apitype.PropertyDiff `json:"detailedDiff,omitempty"`
+	// Failed is true if a `ResOpFailedEvent` was emitted for this URN.
+	Failed bool `json:"failed,omitempty"`
+}
+
+// SummaryDiagnostic is a diagnostic observed during the update. Ephemeral and debug-level
+// diagnostics are omitted upstream; the rest are preserved here.
+type SummaryDiagnostic struct {
+	// URN is the resource the diagnostic is associated with, if any.
+	URN resource.URN `json:"urn,omitempty"`
+	// Message is the diagnostic text, un-colored.
+	Message string `json:"message"`
+	// Severity is one of `info`, `info#err`, `warning`, `error` — matching
+	// `apitype.DiagnosticEvent.Severity`.
+	Severity string `json:"severity,omitempty"`
+}
+
+// SummaryPolicyPack is a policy pack that ran during the update.
+type SummaryPolicyPack struct {
+	// Name is the policy pack name.
+	Name string `json:"name"`
+	// Version is the pack's version string (may be a version tag prepended with `v` on newer
+	// clients — see `apitype.SummaryEvent.PolicyPacks`).
+	Version string `json:"version,omitempty"`
+}
+
+// SummaryPolicyViolation is a policy violation or remediation emitted for a resource. The
+// `Remediated` flag distinguishes the two: violations come from `PolicyEvent`, remediations
+// from `PolicyRemediationEvent`.
+type SummaryPolicyViolation struct {
+	// URN identifies the resource the policy flagged.
+	URN resource.URN `json:"urn,omitempty"`
+	// PolicyName is the name of the specific policy that fired.
+	PolicyName string `json:"policyName,omitempty"`
+	// PolicyPackName is the enclosing pack.
+	PolicyPackName string `json:"policyPackName,omitempty"`
+	// PolicyPackVersion is the enclosing pack's version.
+	PolicyPackVersion string `json:"policyPackVersion,omitempty"`
+	// EnforcementLevel is one of `warning`, `mandatory`, `remediate`, `none`.
+	EnforcementLevel string `json:"enforcementLevel,omitempty"`
+	// Severity is one of `low`, `medium`, `high`, `critical` — or empty if unspecified.
+	Severity string `json:"severity,omitempty"`
+	// Message is the violation text (empty for remediations, which carry `before`/`after`).
+	Message string `json:"message,omitempty"`
+	// Remediated is true for `PolicyRemediationEvent`, false for `PolicyEvent`.
+	Remediated bool `json:"remediated,omitempty"`
+}

--- a/pkg/display/json.go
+++ b/pkg/display/json.go
@@ -124,16 +124,21 @@ type EventSummary struct {
 	Duration time.Duration `json:"duration,omitempty"`
 
 	// Diagnostics lists non-ephemeral DiagnosticEvents observed in the stream, in the order
-	// they arrived. Ephemeral diagnostics (intended for live display only) are filtered out.
-	Diagnostics []SummaryDiagnostic `json:"diagnostics,omitempty"`
+	// they arrived. Ephemeral diagnostics (intended for live display only) are filtered out,
+	// as are debug-level messages.
+	Diagnostics []PreviewDiagnostic `json:"diagnostics,omitempty"`
 
-	// PolicyPacks lists the policy packs that ran during the update, sorted by name for
-	// deterministic output. Sourced from SummaryEvent.PolicyPacks.
-	PolicyPacks []SummaryPolicyPack `json:"policyPacks,omitempty"`
+	// PolicyPacks lists the policy packs that ran during the update, as name → version.
+	// Sourced verbatim from SummaryEvent.PolicyPacks; encoding/json sorts map keys so the
+	// output is deterministic.
+	PolicyPacks map[string]string `json:"policyPacks,omitempty"`
 
-	// PolicyViolations collects PolicyEvent and PolicyRemediationEvent entries. Remediations
-	// are represented with `remediated: true`; plain violations with `remediated: false`.
-	PolicyViolations []SummaryPolicyViolation `json:"policyViolations,omitempty"`
+	// PolicyViolations collects PolicyEvents (plain violations) in arrival order.
+	PolicyViolations []apitype.PolicyEvent `json:"policyViolations,omitempty"`
+
+	// PolicyRemediations collects PolicyRemediationEvents (transformed resources) in arrival
+	// order, preserving the `before`/`after` payloads.
+	PolicyRemediations []apitype.PolicyRemediationEvent `json:"policyRemediations,omitempty"`
 
 	// MaybeCorrupt is true if the engine reported that one or more resources may be corrupt.
 	// Sourced from SummaryEvent.MaybeCorrupt.
@@ -149,70 +154,12 @@ type EventSummary struct {
 	Error string `json:"error,omitempty"`
 }
 
-// SummaryStep is the reduced form of a resource step carried in the summary. It contains only
-// what a human sees in the CLI output plus the structured diff — OldState/NewState inputs and
-// outputs are intentionally omitted, as a summary is meant to be compact; consumers that want
-// full state should read the raw event stream.
+// SummaryStep is the reduced form of a resource step carried in the summary. It embeds the
+// engine's `StepEventMetadata` verbatim and adds a `Failed` flag surfaced from
+// `ResOpFailedEvent`. `Old` and `New` are zeroed before storage — the summary stays compact by
+// design, so consumers that need full per-step state should read the raw event stream.
 type SummaryStep struct {
-	// Op is the operation the engine performed on this resource.
-	Op StepOp `json:"op"`
-	// URN uniquely identifies the resource within the stack.
-	URN resource.URN `json:"urn"`
-	// Type is the resource type token (e.g. `aws:s3/bucket:Bucket`).
-	Type string `json:"type,omitempty"`
-	// Provider is the provider reference that performed the step.
-	Provider string `json:"provider,omitempty"`
-	// Diffs is the list of top-level property keys that changed (same as
-	// StepEventMetadata.Diffs).
-	Diffs []string `json:"diffs,omitempty"`
-	// ReplaceReasons lists keys that triggered a replacement, for `OpReplace` /
-	// `OpCreateReplacement` / `OpDeleteReplaced` (same as StepEventMetadata.Keys).
-	ReplaceReasons []string `json:"replaceReasons,omitempty"`
-	// DetailedDiff is the engine's property-path indexed diff. Preserved verbatim.
-	DetailedDiff map[string]apitype.PropertyDiff `json:"detailedDiff,omitempty"`
-	// Failed is true if a `ResOpFailedEvent` was emitted for this URN.
+	apitype.StepEventMetadata
+	// Failed is true iff a `ResOpFailedEvent` was emitted for this URN.
 	Failed bool `json:"failed,omitempty"`
-}
-
-// SummaryDiagnostic is a diagnostic observed during the update. Ephemeral and debug-level
-// diagnostics are omitted upstream; the rest are preserved here.
-type SummaryDiagnostic struct {
-	// URN is the resource the diagnostic is associated with, if any.
-	URN resource.URN `json:"urn,omitempty"`
-	// Message is the diagnostic text, un-colored.
-	Message string `json:"message"`
-	// Severity is one of `info`, `info#err`, `warning`, `error` — matching
-	// `apitype.DiagnosticEvent.Severity`.
-	Severity string `json:"severity,omitempty"`
-}
-
-// SummaryPolicyPack is a policy pack that ran during the update.
-type SummaryPolicyPack struct {
-	// Name is the policy pack name.
-	Name string `json:"name"`
-	// Version is the pack's version string (may be a version tag prepended with `v` on newer
-	// clients — see `apitype.SummaryEvent.PolicyPacks`).
-	Version string `json:"version,omitempty"`
-}
-
-// SummaryPolicyViolation is a policy violation or remediation emitted for a resource. The
-// `Remediated` flag distinguishes the two: violations come from `PolicyEvent`, remediations
-// from `PolicyRemediationEvent`.
-type SummaryPolicyViolation struct {
-	// URN identifies the resource the policy flagged.
-	URN resource.URN `json:"urn,omitempty"`
-	// PolicyName is the name of the specific policy that fired.
-	PolicyName string `json:"policyName,omitempty"`
-	// PolicyPackName is the enclosing pack.
-	PolicyPackName string `json:"policyPackName,omitempty"`
-	// PolicyPackVersion is the enclosing pack's version.
-	PolicyPackVersion string `json:"policyPackVersion,omitempty"`
-	// EnforcementLevel is one of `warning`, `mandatory`, `remediate`, `none`.
-	EnforcementLevel string `json:"enforcementLevel,omitempty"`
-	// Severity is one of `low`, `medium`, `high`, `critical` — or empty if unspecified.
-	Severity string `json:"severity,omitempty"`
-	// Message is the violation text (empty for remediations, which carry `before`/`after`).
-	Message string `json:"message,omitempty"`
-	// Remediated is true for `PolicyRemediationEvent`, false for `PolicyEvent`.
-	Remediated bool `json:"remediated,omitempty"`
 }

--- a/pkg/display/json.go
+++ b/pkg/display/json.go
@@ -144,6 +144,13 @@ type EventSummary struct {
 	// Sourced from SummaryEvent.MaybeCorrupt.
 	MaybeCorrupt bool `json:"maybeCorrupt,omitempty"`
 
+	// Completed is true iff a `SummaryEvent` was observed in the stream — the engine's
+	// end-of-update handshake. This distinguishes a cleanly-finished run from an interrupted
+	// one (Ctrl-C, pipe broken, wrapper crashed): both can leave `Failed` false, but only a
+	// completed run has `Completed == true`. Always present in the JSON output so consumers
+	// can rely on it unconditionally.
+	Completed bool `json:"completed"`
+
 	// Failed is true if any `ResOpFailedEvent` was seen, or the engine reported an internal
 	// error. A successful preview/up leaves this false.
 	Failed bool `json:"failed,omitempty"`


### PR DESCRIPTION
## Summary

Second iteration of the `pulumi events` tree from the [design doc](https://www.notion.so/pulumi-events-344fdbdf1cce803b92edd4b16bb4f3b7), after #22669.

Adds `pulumi events summary`: a reducer over the JSONL engine event stream that emits a single structured `display.EventSummary` JSON object on stdout. The document mirrors the information a human sees in the CLI output of `pulumi preview`, `pulumi up`, `pulumi refresh`, and `pulumi destroy`.

One schema covers all four commands — the `isPreview` flag and the `changeSummary` tell the consumer which shape they're looking at; preview-specific gaps (no `duration`, no `outputs`) are represented by omitted fields.

Like `filter`, `summary` is `Hidden: true` while the interface is being shaped. No changelog entry.

## Shape of the output

```jsonc
{
  "version": 1,
  "isPreview": false,
  "startTime": 1000,
  "endTime": 1040,
  "config": { "proj:region": "us-west-2" },
  "steps": [
    {
      "op": "update",
      "urn": "urn:pulumi:dev::proj::aws:lambda/function:Function::f",
      "type": "aws:lambda/function:Function",
      "diffs": ["code"],
      "detailedDiff": { "code": { "diffKind": "update", "inputDiff": true } }
    }
  ],
  "outputs": { "bucketName": "b" },
  "changeSummary": { "create": 1, "update": 1, "same": 3 },
  "duration": 30000000000,
  "diagnostics": [...],
  "policyPacks": [{ "name": "aws-best", "version": "1.0.0" }],
  "policyViolations": [...]
}
```

## Where each field comes from

| Field | Source |
| --- | --- |
| `config` | `PreludeEvent.Config` |
| `steps[]` | `ResourcePreEvent` / `ResOutputsEvent` / `ResOpFailedEvent`, keyed by URN (latest wins); `OpSame` steps are omitted |
| `outputs` | Last `ResOutputsEvent` with `type = pulumi:pulumi:Stack` — `New.Outputs` for up/refresh, `Old.Outputs` for destroy |
| `changeSummary`, `duration`, `maybeCorrupt`, `isPreview`, `policyPacks` | `SummaryEvent` |
| `diagnostics[]` | `DiagnosticEvent`, excluding `ephemeral` and severity=`debug` |
| `policyViolations[]` | `PolicyEvent` (Remediated=false) and `PolicyRemediationEvent` (Remediated=true) |
| `failed`, `error` | `ResOpFailedEvent` / `ErrorEvent` |
| `startTime`, `endTime` | first and last `Timestamp` observed |

## Per-command behaviour

The schema is identical across the four commands. What differs is which fields populate meaningfully — fields without a source are omitted via `omitempty`.

### `pulumi preview`

The program runs, the engine computes planned steps, and no state is mutated.

- `isPreview`: `true`.
- `steps[]`: planned steps from `ResourcePreEvent`s. No `ResOutputsEvent`s are emitted — nothing was applied — so each step carries the engine's *intended* op, diffs, and detailed diff.
- `changeSummary`: counts per planned op.
- `outputs`: **omitted**. Stack outputs aren't applied in a preview.
- `duration`: **omitted** (zero). The engine doesn't report a duration for a preview.
- `diagnostics[]`, `policyViolations[]`, `policyPacks[]`: anything surfaced during analysis.
- `failed`: `true` iff the program errored before a plan could be produced.

### `pulumi up`

The program runs, the engine applies steps, the stack is mutated.

- `isPreview`: `false`.
- `steps[]`: the engine emits both `ResourcePreEvent` and `ResOutputsEvent` per resource; the latter wins per URN, so each step reflects the *final* state after the op.
- `outputs`: the root stack's applied outputs, from the last `ResOutputsEvent` with type `pulumi:pulumi:Stack` — `New.Outputs`.
- `changeSummary`: actual counts per op performed.
- `duration`: total wall-clock seconds from `SummaryEvent.DurationSeconds`.
- `maybeCorrupt`: `true` iff the engine flagged any resource as possibly corrupt.
- `failed`: `true` iff any `ResOpFailedEvent` was emitted. The offending URN's step also has `failed: true`.

### `pulumi refresh`

The engine reconciles state with the cloud. No provider mutations.

- `isPreview`: `false`.
- `steps[]`: resources whose state drifted appear with `op: refresh` (or `op: same`, which we drop). `diffs[]` names the top-level properties that drifted.
- `outputs`: if a refresh changed the root stack's outputs, this reflects the refreshed values — same source as `up`, `New.Outputs`.
- `changeSummary`: a mix of `refresh` and `same` (the latter is counted but its per-step entries are dropped from `steps[]`).
- `duration`: reported by the `SummaryEvent`.

### `pulumi destroy`

The engine tears the stack down.

- `isPreview`: `false`.
- `steps[]`: every step is `op: delete`. The root stack's delete step has no `New` — it's being removed.
- `outputs`: the *pre-destroy* outputs, captured from the root stack's `Old.Outputs` (since `New` is nil for a delete). This matches what a human sees: destroy prints the outputs that existed before teardown.
- `changeSummary`: `delete` counts.
- `duration`: reported by the `SummaryEvent`.

## Composition

```sh
pulumi up --json | pulumi events summary                         # live
cat event-log.jsonl | pulumi events summary > summary.json       # replay
pulumi preview --json | pulumi events filter --changes-only | pulumi events summary
```

## Design decisions

- **One schema across all four commands.** `IsPreview` and `ChangeSummary` disambiguate — no `Kind` enum that would require heuristics (e.g. "all OpDeletes = destroy").
- **`Steps` omits `OpSame`.** The summary is about what changed, not a transcript.
- **Steps are lean.** No `OldState` / `NewState` inputs/outputs bloat — only op, URN, type, provider, diffs, detailed diff, and a failure flag. Consumers that want full state can read the raw stream.
- **No `StackName`.** Derivable from the URN; keeps the schema minimal.
- **No `Permalink`.** Not in the event stream; a caller that wants it can merge it in.
- **Deterministic JSON.** `PolicyPacks` is sorted by name.

## Test plan

- [x] `mise exec -- go test ./cmd/pulumi/events/... ./display/...` — pass.
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/events/... ./display/...` — 0 issues.
- [x] `mise exec -- gofmt -l` on touched files — clean.
- [x] Covered:
  - prelude populates `config`
  - `OpSame` steps dropped
  - `ResOutputsEvent` supersedes earlier `ResourcePreEvent` for same URN
  - `DetailedDiff` / `ReplaceReasons` / `Provider` preserved
  - `ResOpFailedEvent` flips `step.Failed` and `summary.Failed`
  - root stack outputs captured (from `New`, and from `Old` on destroy)
  - non-root resource outputs don't leak into top-level `Outputs`
  - `DiagnosticEvent`: kept for info/warning/error; dropped for ephemeral/debug
  - `PolicyEvent` / `PolicyRemediationEvent` both map to `policyViolations` with the right `Remediated` flag
  - `ErrorEvent` flips `failed` and sets `error`
  - `SummaryEvent` scalar + `ResourceChanges` + sorted `PolicyPacks`
  - preview: `IsPreview=true`, `Duration=0`, no `Outputs`
  - destroy: outputs come from `Old`
  - refresh: `OpRefresh` steps pass through
  - timestamps (first/last) recorded
  - malformed JSON → error
  - indented JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)