### PR TITLE
Fix canonicalisation bug with StackReferences

### DIFF
--- a/changelog/pending/20260424--pcl--fix-binding-of-stackreference-resources-to-still-have-the-token-pulumi-pulumi-stackreference.yaml
+++ b/changelog/pending/20260424--pcl--fix-binding-of-stackreference-resources-to-still-have-the-token-pulumi-pulumi-stackreference.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pcl
+  description: Fix binding of StackReference resources to still have the token `pulumi:pulumi:StackReference`

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -891,7 +891,7 @@ func (g *generator) collectImports(program *pcl.Program) (helpers codegen.String
 				if mod == "providers" {
 					pkg = name
 					mod = ""
-				} else if mod == "" {
+				} else if mod == "" || mod == "pulumi" {
 					continue
 				}
 			} else {
@@ -1504,6 +1504,9 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		pkg = typ
 		mod = ""
 		typ = "Provider"
+	}
+	if pkg == "pulumi" && mod == "pulumi" {
+		mod = ""
 	}
 	if mod == "" || strings.HasPrefix(mod, "/") || mod == IndexToken {
 		originalMod = mod

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1061,11 +1061,13 @@ func containsPlainCall(expr model.Expression) bool {
 // resourceTypeName computes the NodeJS package, module, and type name for the given resource.
 func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
-	token, tokenRange := r.GetToken()
-	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
+	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
 
 	if r.Schema != nil {
-		module = moduleName(r.Schema.PackageReference.TokenToModule(token), r.Schema.PackageReference)
+		// Use the schema's original token (not the binder's canonical form) so that
+		// TokenToModule gets the full module path (e.g. "iam/policy") that the package's
+		// moduleFormat regex expects, rather than the already-stripped canonical form.
+		module = moduleName(r.Schema.PackageReference.TokenToModule(r.Schema.Token), r.Schema.PackageReference)
 	}
 
 	return pkg, module, title(member), diagnostics

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1061,10 +1061,11 @@ func containsPlainCall(expr model.Expression) bool {
 // resourceTypeName computes the NodeJS package, module, and type name for the given resource.
 func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
-	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
+	token, tokenRange := r.GetToken()
+	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 
 	if r.Schema != nil {
-		module = moduleName(module, r.Schema.PackageReference)
+		module = moduleName(r.Schema.PackageReference.TokenToModule(token), r.Schema.PackageReference)
 	}
 
 	return pkg, module, title(member), diagnostics

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -1064,10 +1064,7 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
 
 	if r.Schema != nil {
-		// Use the schema's original token (not the binder's canonical form) so that
-		// TokenToModule gets the full module path (e.g. "iam/policy") that the package's
-		// moduleFormat regex expects, rather than the already-stripped canonical form.
-		module = moduleName(r.Schema.PackageReference.TokenToModule(r.Schema.Token), r.Schema.PackageReference)
+		module = moduleName(module, r.Schema.PackageReference)
 	}
 
 	return pkg, module, title(member), diagnostics
@@ -1081,6 +1078,11 @@ func moduleName(module string, pkg schema.PackageReference) string {
 			if m, ok := pkgInfo.ModuleToPackage[module]; ok {
 				module = m
 			}
+		}
+		// pulumi:pulumi:* resources (e.g. StackReference) belong to the root of the
+		// package, not a "pulumi" submodule.
+		if pkg.Name() == "pulumi" && module == "pulumi" {
+			return ""
 		}
 	}
 	if module == "index" {

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -344,7 +344,14 @@ func (b *binder) bindResourceTypes(ctx context.Context, node *Resource) hcl.Diag
 			return hcl.Diagnostics{unknownResourceType(token, tokenRange)}
 		}
 		res = r
-		token = tk
+		// For pulumi built-in resources (e.g. pulumi:pulumi:StackReference), canonicalizeToken
+		// strips the module to produce "pulumi::StackReference" because TokenToModule returns ""
+		// for the pulumi:pulumi module. Reconstruct the full token from the decomposed parts.
+		if pkg == pulumiPackage {
+			token = fmt.Sprintf("%s:%s:%s", pkg, module, name)
+		} else {
+			token = tk
+		}
 	}
 	node.Schema = res
 	inputProperties, properties = res.InputProperties, res.Properties

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -1442,3 +1442,28 @@ output "result" {
 	}}, diags)
 	require.Nil(t, program)
 }
+
+func TestStackReferenceGetToken(t *testing.T) {
+	t.Parallel()
+	source := `
+resource stackRef "pulumi:pulumi:StackReference" {
+    name = "org/project/stack"
+}
+`
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+	require.NotNil(t, program)
+
+	var resource *pcl.Resource
+	for _, node := range program.Nodes {
+		if r, ok := node.(*pcl.Resource); ok && r.Name() == "stackRef" {
+			resource = r
+			break
+		}
+	}
+	require.NotNil(t, resource, "expected a resource named stackRef")
+
+	token, _ := resource.GetToken()
+	assert.Equal(t, "pulumi:pulumi:StackReference", token)
+}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -765,10 +765,12 @@ func tokenToQualifiedName(pkgAlias, module, member string) string {
 // resourceTypeName computes the qualified name of a python resource.
 func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
-	pkg, module, member, diagnostics := pcl.DecomposeToken(r.GetToken())
+	token, tokenRange := r.GetToken()
+	pkg, module, member, diagnostics := pcl.DecomposeToken(token, tokenRange)
 
 	// Normalize module.
 	if r.Schema != nil {
+		module = r.Schema.PackageReference.TokenToModule(token)
 		pkg, err := r.Schema.PackageReference.Definition()
 		if err != nil {
 			diagnostics = append(diagnostics, &hcl.Diagnostic{

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -770,10 +770,11 @@ func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) 
 
 	// Normalize module.
 	if r.Schema != nil {
-		// Use the schema's original token (not the binder's canonical form) so that
-		// TokenToModule gets the full module path (e.g. "iam/policy") that the package's
-		// moduleFormat regex expects, rather than the already-stripped canonical form.
-		module = r.Schema.PackageReference.TokenToModule(r.Schema.Token)
+		// pulumi:pulumi:* resources (e.g. StackReference) belong to the root of the
+		// package, not a "pulumi" submodule.
+		if r.Schema.PackageReference.Name() == "pulumi" && module == "pulumi" {
+			module = ""
+		}
 		pkg, err := r.Schema.PackageReference.Definition()
 		if err != nil {
 			diagnostics = append(diagnostics, &hcl.Diagnostic{

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -770,7 +770,10 @@ func (g *generator) resourceTypeName(r *pcl.Resource) (string, hcl.Diagnostics) 
 
 	// Normalize module.
 	if r.Schema != nil {
-		module = r.Schema.PackageReference.TokenToModule(token)
+		// Use the schema's original token (not the binder's canonical form) so that
+		// TokenToModule gets the full module path (e.g. "iam/policy") that the package's
+		// moduleFormat regex expects, rather than the already-stripped canonical form.
+		module = r.Schema.PackageReference.TokenToModule(r.Schema.Token)
 		pkg, err := r.Schema.PackageReference.Definition()
 		if err != nil {
 			diagnostics = append(diagnostics, &hcl.Diagnostic{


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/22663 changed TokenToModule to return "" for the "pulumi:pulumi" module, instead of "pulumi". This was to work around code generators trying to put stack references into nested "pulumi" modules instead of at the root of the core sdk with the removal of `FixupPulumiPackageTokens`.

Unfortunately that brakes YAML which depended on the bound token to emit the next program, and the bound token had also become "pulumi::StackReference" because it had gone through `TokenToModule`.

We can work around this in YAML pretty easy, but it feels like the token ought to still be "pulumi:pulumi:StackReference" so this fixes the binder to special case the pulumi package for that.