### PR TITLE
Cancel in-flight fuzz iterations when the 20s cap fires

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -152,7 +152,7 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 		// provider subprocesses into later iterations and can eventually saturate the CI runner,
 		// surfacing as the opaque `panic: test timed out after 10m0s`
 		// (see https://github.com/pulumi/pulumi/issues/22719).
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		go func() {
 			defer close(done)

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -147,11 +147,9 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 			)
 		}
 		done := make(chan struct{})
-		// Cancellable context so the 20s cap below can actually interrupt the engine. Without
-		// propagating cancellation, a timed-out iteration leaks its goroutine, plugin host, and
-		// provider subprocesses into later iterations and can eventually saturate the CI runner,
-		// surfacing as the opaque `panic: test timed out after 10m0s`
-		// (see https://github.com/pulumi/pulumi/issues/22719).
+		// Cancellable context so the 20s cap below can signal the engine to shut down.
+		// This is best-effort: a genuinely hung engine may not honor cancellation, in
+		// which case the post-cancel drain below escalates to a hard failure.
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		go func() {
@@ -193,16 +191,16 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 			// Test completed within the timeout.
 		case <-time.After(20 * time.Second):
 			cancel()
-			// Wait briefly for the goroutine to observe cancellation and drain before this
-			// iteration returns. Otherwise the next rapid iteration starts on top of a live
-			// engine and the leak cascades. If the engine is genuinely hung it likely won't
-			// respond to cancellation at all, so keep this short to fail fast.
+			// Give the engine a brief window to observe cancellation and drain. A
+			// genuinely hung engine likely won't respond at all, so keep this short and
+			// fail loudly below if it doesn't drain in time.
 			select {
 			case <-done:
 			case <-time.After(5 * time.Second):
 				reproMessage := generateAndWriteRepro(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
-				t.Fatalf(
-					"test timed out after 20 seconds and did not respond to cancellation within 5 more seconds\n%s",
+				assert.Failf(
+					t,
+					"test timed out after 20 seconds and did not respond to cancellation within 5 more seconds",
 					reproMessage,
 				)
 				return

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -15,6 +15,7 @@
 package fuzzing
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -146,10 +147,25 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 			)
 		}
 		done := make(chan struct{})
+		// Cancellable context so the 20s cap below can actually interrupt the engine. Without
+		// propagating cancellation, a timed-out iteration leaks its goroutine, plugin host, and
+		// provider subprocesses into later iterations and can eventually saturate the CI runner,
+		// surfacing as the opaque `panic: test timed out after 10m0s`
+		// (see https://github.com/pulumi/pulumi/issues/22719).
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		go func() {
+			defer close(done)
 			// Operations may fail for legitimate reasons -- e.g. we have configured a provider operation to fail, aborting
 			// execution. We thus only fail if we encounter an actual snapshot integrity error.
-			outSnap, err := op.RunStep(project, p.GetTarget(t, inSnap), opOpts, false, p.BackendClient, nil, "0")
+			outSnap, err := op.RunWithContextStep(
+				ctx, project, p.GetTarget(t, inSnap), opOpts, false, p.BackendClient, nil, "0")
+			// If the outer select cancelled us after the 20s cap, skip all post-op checks — the
+			// outer goroutine is responsible for reporting the timeout, and any error we observe
+			// here is cancellation noise, not a bug.
+			if ctx.Err() != nil {
+				return
+			}
 			if _, isSIE := snapshot.AsSnapshotIntegrityError(err); isSIE {
 				failWithError(err)
 			}
@@ -171,14 +187,27 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 
 			// In all other cases, we expect errors to be "expected", or "bails" in our terminology.
 			assert.True(t, err == nil || result.IsBail(err), "unexpected error: %v", err)
-			close(done)
 		}()
 		select {
-		case <-time.After(20 * time.Second):
-			reproMessage := generateAndWriteRepro(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
-			assert.Failf(t, "test timed out after 20 seconds", reproMessage)
 		case <-done:
 			// Test completed within the timeout.
+		case <-time.After(20 * time.Second):
+			cancel()
+			// Wait for the goroutine to observe cancellation and drain before this iteration
+			// returns. Otherwise the next rapid iteration starts on top of a live engine and the
+			// leak cascades.
+			select {
+			case <-done:
+			case <-time.After(30 * time.Second):
+				reproMessage := generateAndWriteRepro(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
+				t.Fatalf(
+					"test timed out after 20 seconds and did not respond to cancellation within 30 more seconds\n%s",
+					reproMessage,
+				)
+				return
+			}
+			reproMessage := generateAndWriteRepro(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
+			assert.Failf(t, "test timed out after 20 seconds", reproMessage)
 		}
 	}
 }

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -193,15 +193,16 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 			// Test completed within the timeout.
 		case <-time.After(20 * time.Second):
 			cancel()
-			// Wait for the goroutine to observe cancellation and drain before this iteration
-			// returns. Otherwise the next rapid iteration starts on top of a live engine and the
-			// leak cascades.
+			// Wait briefly for the goroutine to observe cancellation and drain before this
+			// iteration returns. Otherwise the next rapid iteration starts on top of a live
+			// engine and the leak cascades. If the engine is genuinely hung it likely won't
+			// respond to cancellation at all, so keep this short to fail fast.
 			select {
 			case <-done:
-			case <-time.After(30 * time.Second):
+			case <-time.After(5 * time.Second):
 				reproMessage := generateAndWriteRepro(t, fo.StackSpecOptions, snapSpec, progSpec, provSpec, planSpec)
 				t.Fatalf(
-					"test timed out after 20 seconds and did not respond to cancellation within 30 more seconds\n%s",
+					"test timed out after 20 seconds and did not respond to cancellation within 5 more seconds\n%s",
 					reproMessage,
 				)
 				return


### PR DESCRIPTION
## Summary

When `TestFuzz`'s 20s per-iteration cap fires, the master code records an `assert.Failf` and returns, but the goroutine running `op.RunStep` keeps executing because `RunStep` uses `context.Background()`. This PR switches to `op.RunWithContextStep` with a cancellable context derived from `t.Context()`, so the per-iteration cap can signal the engine to shut down. If the engine doesn't honor cancellation within 5 seconds, the iteration fails loudly with a reproducer rather than letting the goroutine linger.

This is **defense-in-depth**, not the root-cause fix for #22719. @tgummerer's #22739 (skip on program-generation cycles) addresses the actual hang location — when a `Draw` call infinite-loops, the per-iteration timeout in this PR never fires because the hang occurs before the goroutine spawns. This PR adds value if the engine itself ever hangs inside `RunStep`, with the caveat that a genuinely-hung engine may not honor cancellation either.

Total per-iteration cap is 25s (20s body + 5s drain), in line with the pre-PR 20s budget.

## Test plan

No new test artifacts. This change tightens the fuzz harness itself and is exercised by every `TestFuzz` run. A reproducer-style test would require contriving an iteration that deliberately ignores cancellation, which adds code without meaningfully tightening coverage. Local validation below.

## Validation

- [x] ``make lint`` — clean (``golangci-lint run ./engine/lifecycletest/fuzzing/...`` → 0 issues)
- [x] ``go vet -tags all ./engine/lifecycletest/...`` — clean
- [x] ``gofmt -l`` — clean
- [x] ``PULUMI_LIFECYCLE_TEST_FUZZ=1 go test -run '^TestFuzz$' -tags all -rapid.checks=10000 -cpu=2 -timeout=15m`` — PASS in 25.77 s
- [x] Smoke test after revisions: ``PULUMI_LIFECYCLE_TEST_FUZZ=1 go test -run '^TestFuzz$' -tags all -rapid.checks=200 -timeout=2m`` — PASS in 1.86 s

## Risk

Low. The change is confined to `pkg/engine/lifecycletest/fuzzing/fixture.go`, runs only when `PULUMI_LIFECYCLE_TEST_FUZZ=1`, and cannot affect the `pulumi` CLI, SDKs, or any user-facing surface. Worst case if the fix is wrong: `TestFuzz` becomes noisier (extra failure reports when the engine genuinely refuses to cancel), which is the intended failure mode.