### PR TITLE
Autodetect and send os/lang query params

### DIFF
--- a/changelog/pending/20260507--cli-cloud--autodetect-lang-and-os-on-cloud-api-get.yaml
+++ b/changelog/pending/20260507--cli-cloud--autodetect-lang-and-os-on-cloud-api-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Auto-fill `lang` and `os` query parameters on `pulumi cloud api` GET/HEAD requests when the matched OpenAPI operation declares them and the caller hasn't supplied them

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -260,6 +261,8 @@ func runAPI(cmd *cobra.Command, args []string, api *apiCommand) error {
 	if err != nil {
 		return err
 	}
+
+	injectContextQueryParams(mr.Op, method, rawQuery, resolvedCtx, queryExtras)
 
 	query := mergeQuery(rawQuery, queryExtras)
 
@@ -709,6 +712,66 @@ func stringifyFieldForPath(f ParsedField) (string, error) {
 			WithField(f.Key)
 	default:
 		return fmt.Sprintf("%v", v), nil
+	}
+}
+
+var runtimeToLang = map[string]string{
+	"nodejs": "typescript",
+	"dotnet": "csharp",
+	"go":     "go",
+	"python": "python",
+	"yaml":   "yaml",
+	"java":   "java",
+}
+
+func opDeclaresQueryParam(op *Operation, name string) bool {
+	if op == nil {
+		return false
+	}
+	for _, p := range op.Params {
+		if p.In == "query" && p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func contextQueryValues(rctx *ResolvedContext) map[string]string {
+	if rctx == nil {
+		return nil
+	}
+	out := make(map[string]string, 2)
+	if rctx.Project != nil {
+		if lang, ok := runtimeToLang[rctx.Project.Runtime.Name()]; ok {
+			out["lang"] = lang
+		}
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		out["os"] = "macos"
+	case "linux", "windows":
+		out["os"] = runtime.GOOS
+	}
+	return out
+}
+
+func injectContextQueryParams(op *Operation, method, rawQuery string, rctx *ResolvedContext, extras url.Values) {
+	if method != "GET" && method != "HEAD" {
+		return
+	}
+	values := contextQueryValues(rctx)
+	if len(values) == 0 {
+		return
+	}
+	rawVals, _ := url.ParseQuery(rawQuery)
+	for name, val := range values {
+		if !opDeclaresQueryParam(op, name) {
+			continue
+		}
+		if extras.Has(name) || rawVals.Has(name) {
+			continue
+		}
+		extras.Add(name, val)
 	}
 }
 

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -29,6 +31,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // TestResolveBindings_FieldFillsPathParam covers the core bug fix:
@@ -232,6 +235,154 @@ func TestNegotiateAccept_InvalidValue(t *testing.T) {
 	var apiErr *APIError
 	require.True(t, errors.As(err, &apiErr))
 	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+}
+
+func TestOpDeclaresQueryParam(t *testing.T) {
+	t.Parallel()
+	op := &Operation{Params: []ParamSpec{
+		{Name: "id", In: "path"},
+		{Name: "lang", In: "query"},
+		{Name: "os", In: "query"},
+	}}
+	assert.True(t, opDeclaresQueryParam(op, "lang"))
+	assert.True(t, opDeclaresQueryParam(op, "os"))
+	assert.False(t, opDeclaresQueryParam(op, "id"), "path param must not count")
+	assert.False(t, opDeclaresQueryParam(op, "unknown"))
+	assert.False(t, opDeclaresQueryParam(nil, "lang"))
+}
+
+func rctxWithRuntime(name string) *ResolvedContext {
+	return &ResolvedContext{
+		Project: &workspace.Project{
+			Runtime: workspace.NewProjectRuntimeInfo(name, nil),
+		},
+	}
+}
+
+func TestContextQueryValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil rctx returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, contextQueryValues(nil))
+	})
+
+	t.Run("nodejs runtime maps to typescript", func(t *testing.T) {
+		t.Parallel()
+		got := contextQueryValues(rctxWithRuntime("nodejs"))
+		assert.Equal(t, "typescript", got["lang"])
+	})
+
+	t.Run("dotnet runtime maps to csharp", func(t *testing.T) {
+		t.Parallel()
+		got := contextQueryValues(rctxWithRuntime("dotnet"))
+		assert.Equal(t, "csharp", got["lang"])
+	})
+
+	t.Run("go/python/yaml/java pass through", func(t *testing.T) {
+		t.Parallel()
+		for _, rt := range []string{"go", "python", "yaml", "java"} {
+			got := contextQueryValues(rctxWithRuntime(rt))
+			assert.Equal(t, rt, got["lang"], "runtime %q", rt)
+		}
+	})
+
+	t.Run("unknown runtime omits lang", func(t *testing.T) {
+		t.Parallel()
+		got := contextQueryValues(rctxWithRuntime("brainfuck"))
+		assert.NotContains(t, got, "lang")
+	})
+
+	t.Run("rctx without project omits lang", func(t *testing.T) {
+		t.Parallel()
+		got := contextQueryValues(&ResolvedContext{})
+		assert.NotContains(t, got, "lang")
+	})
+
+	t.Run("os reflects host platform", func(t *testing.T) {
+		t.Parallel()
+		got := contextQueryValues(&ResolvedContext{})
+		switch runtime.GOOS {
+		case "darwin":
+			assert.Equal(t, "macos", got["os"])
+		case "linux", "windows":
+			assert.Equal(t, runtime.GOOS, got["os"])
+		default:
+			assert.NotContains(t, got, "os", "unsupported OS should be omitted")
+		}
+	})
+}
+
+func TestInjectContextQueryParams(t *testing.T) {
+	t.Parallel()
+
+	rctx := rctxWithRuntime("nodejs")
+
+	t.Run("declared and unset is injected", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{}
+		injectContextQueryParams(op, "GET", "", rctx, extras)
+		assert.Equal(t, "typescript", extras.Get("lang"))
+	})
+
+	t.Run("not declared is skipped", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{}
+		extras := url.Values{}
+		injectContextQueryParams(op, "GET", "", rctx, extras)
+		assert.Empty(t, extras)
+	})
+
+	t.Run("value in extras wins over auto-inject", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{"lang": {"go"}}
+		injectContextQueryParams(op, "GET", "", rctx, extras)
+		assert.Equal(t, []string{"go"}, extras["lang"])
+	})
+
+	t.Run("value in raw query wins over auto-inject", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{}
+		injectContextQueryParams(op, "GET", "lang=go", rctx, extras)
+		assert.False(t, extras.Has("lang"), "must not duplicate when raw query already sets it")
+	})
+
+	t.Run("raw query with unrelated key does not block injection", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{}
+		injectContextQueryParams(op, "GET", "filter=foo", rctx, extras)
+		assert.Equal(t, "typescript", extras.Get("lang"))
+	})
+
+	t.Run("non-GET/HEAD methods are no-ops", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+			extras := url.Values{}
+			injectContextQueryParams(op, method, "", rctx, extras)
+			assert.Empty(t, extras, "method %s must not trigger injection", method)
+		}
+	})
+
+	t.Run("HEAD behaves like GET", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{}
+		injectContextQueryParams(op, "HEAD", "", rctx, extras)
+		assert.Equal(t, "typescript", extras.Get("lang"))
+	})
+
+	t.Run("nil rctx is a no-op", func(t *testing.T) {
+		t.Parallel()
+		op := &Operation{Params: []ParamSpec{{Name: "lang", In: "query"}}}
+		extras := url.Values{}
+		injectContextQueryParams(op, "GET", "", nil, extras)
+		assert.Empty(t, extras)
+	})
 }
 
 // TestResolveBindings_FieldValueStringification covers the non-string


### PR DESCRIPTION
## Summary

The Pulumi cloud registry docs API accepts optional `?lang=` and `?os=` query parameters to scope returned content (language-specific snippets, OS-specific install instructions). Callers shouldn't have to repeat what the dispatcher already has on hand — `Pulumi.yaml`'s `runtime` (via the already-resolved `*ResolvedContext`) and the host's `runtime.GOOS` — every time they hit one of these endpoints. AI coding agents in particular produce these requests programmatically and benefit from sensible defaults.

On `GET`/`HEAD`, the dispatcher now auto-fills `lang` and `os` when:
- The matched OpenAPI operation declares the parameter
- The caller hasn't supplied it via `-F` or in the path query string

User-supplied values always win.

Implementation mirrors the existing `contextPathValues`: a pure `contextQueryValues(rctx *ResolvedContext) map[string]string` is the single source of truth, and `injectContextQueryParams` is a thin loop filtering by what the operation declares. No disk reads, no error returns.

## Test plan

Unit tests:

- [x] Cover: nil rctx, runtime → lang mapping (nodejs/dotnet/go/python/yaml/java + unknown), per-platform OS mapping, `-F` precedence, raw-query precedence, method gating (POST/PUT/PATCH/DELETE no-op), HEAD parity, op without the param declared
- [x] `make lint`, `make test_fast` (cloud/ subset)

Manual dry-run verification with the built binary against `api.pulumi.com`:

- [x] `runtime: nodejs` project, `/installation` → `?lang=typescript&os=linux` injected
- [x] same project, `-F lang=python` → `?lang=python&os=linux` (caller `-F` wins for `lang`, `os` still injected)
- [x] same project, raw query `?lang=go` → `?lang=go&os=linux` (raw query wins for `lang`, `os` still injected)
- [x] `runtime: python` project, `/installation` → `lang=python` injected
- [x] `/api/user` (operation declares neither) → URL clean, no injection
- [x] No `Pulumi.yaml` in cwd → only `os=linux` injected, `lang` omitted (no project context)

## Risk

Scoped to the `pulumi cloud api` dispatcher. No protocol, engine, or SDK surface affected. Worst case: an auto-injected `lang`/`os` reaches a route that ignores it (server-side no-op).