### PR TITLE
Add api-version capability to apitype

### DIFF
--- a/changelog/pending/20260424--sdk--add-api-version-capability-typed-constant-and-parsing.yaml
+++ b/changelog/pending/20260424--sdk--add-api-version-capability-typed-constant-and-parsing.yaml
@@ -1,0 +1,9 @@
+changes:
+- type: feat
+  scope: sdk/go
+  description: |
+    Add a typed `APIVersion` capability constant and `APIVersionCapabilityConfig` struct to
+    `apitype`, plus `Parse()` handling to populate a new `Capabilities.APIVersion` field. This
+    lets clients discover the REST API version range (negotiated via the
+    `Accept: application/vnd.pulumi+N` header) that a Pulumi service advertises via
+    `/api/capabilities`. Older servers that do not emit this capability yield `APIVersion: nil`.

--- a/changelog/pending/20260424--sdk--add-api-version-capability-typed-constant-and-parsing.yaml
+++ b/changelog/pending/20260424--sdk--add-api-version-capability-typed-constant-and-parsing.yaml
@@ -1,9 +1,4 @@
 changes:
 - type: feat
   scope: sdk/go
-  description: |
-    Add a typed `APIVersion` capability constant and `APIVersionCapabilityConfig` struct to
-    `apitype`, plus `Parse()` handling to populate a new `Capabilities.APIVersion` field. This
-    lets clients discover the REST API version range (negotiated via the
-    `Accept: application/vnd.pulumi+N` header) that a Pulumi service advertises via
-    `/api/capabilities`. Older servers that do not emit this capability yield `APIVersion: nil`.
+  description: Add typed `APIVersion` capability to apitype

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -45,6 +45,11 @@ const (
 
 	// Indicates whether the service supports retrieving a stack's required policy packs.
 	StackPolicyPacks APICapability = "stack-policy-packs"
+
+	// APIVersion advertises the REST API version range that the service speaks, negotiated
+	// via the `Accept: application/vnd.pulumi+N` header. The configuration carries the
+	// server's max, min, and default API versions; see APIVersionCapabilityConfig.
+	APIVersion APICapability = "api-version"
 )
 
 type DeltaCheckpointUploadsConfigV2 struct {
@@ -57,6 +62,40 @@ type DeltaCheckpointUploadsConfigV2 struct {
 type DeploymentSchemaVersionConfig struct {
 	// Version is the maximum version of the deployment schema that the service supports.
 	Version int `json:"version"`
+}
+
+// APIVersionCapabilityConfig is the configuration for the api-version capability. It advertises
+// the REST API version range (negotiated via the `Accept: application/vnd.pulumi+N` header) that
+// the service speaks.
+type APIVersionCapabilityConfig struct {
+	// MaxVersion is the highest API version the service understands.
+	MaxVersion int `json:"maxVersion"`
+	// MinVersion is the lowest API version the service accepts. Requests asking for a lower
+	// version via the Accept header will be rejected.
+	MinVersion int `json:"minVersion"`
+	// DefaultVersion is the version the service assumes when the client does not send an
+	// Accept header. Today this equals MaxVersion, but the two may diverge during a staged
+	// rollout of a new version.
+	DefaultVersion int `json:"defaultVersion"`
+}
+
+// validate checks that the version triple satisfies the required invariants:
+// minVersion >= 1, maxVersion >= minVersion, and defaultVersion ∈ [minVersion, maxVersion].
+// A server that advertises values outside these bounds is considered misconfigured.
+func (c APIVersionCapabilityConfig) validate() error {
+	if c.MinVersion < 1 {
+		return fmt.Errorf("minVersion must be >= 1, got %d", c.MinVersion)
+	}
+	if c.MaxVersion < c.MinVersion {
+		return fmt.Errorf("maxVersion (%d) must be >= minVersion (%d)", c.MaxVersion, c.MinVersion)
+	}
+	if c.DefaultVersion < c.MinVersion || c.DefaultVersion > c.MaxVersion {
+		return fmt.Errorf(
+			"defaultVersion (%d) must be in [minVersion, maxVersion] = [%d, %d]",
+			c.DefaultVersion, c.MinVersion, c.MaxVersion,
+		)
+	}
+	return nil
 }
 
 // APICapabilityConfig captures a service backend capability and any associated
@@ -93,6 +132,10 @@ type Capabilities struct {
 
 	// Indicates whether the service supports retrieving a stack's required policy packs.
 	StackPolicyPacks bool
+
+	// If non-nil, indicates the REST API version range the service speaks (negotiated via
+	// the `Accept: application/vnd.pulumi+N` header).
+	APIVersion *APIVersionCapabilityConfig
 }
 
 // Parse decodes the CapabilitiesResponse into a Capabilities struct for ease of use.
@@ -135,6 +178,17 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 		case StackPolicyPacks:
 			if entry.Version == 1 {
 				parsed.StackPolicyPacks = true
+			}
+		case APIVersion:
+			if entry.Version == 1 {
+				var cfg APIVersionCapabilityConfig
+				if err := json.Unmarshal(entry.Configuration, &cfg); err != nil {
+					return Capabilities{}, fmt.Errorf("decoding APIVersionCapabilityConfig returned %w", err)
+				}
+				if err := cfg.validate(); err != nil {
+					return Capabilities{}, fmt.Errorf("invalid APIVersionCapabilityConfig: %w", err)
+				}
+				parsed.APIVersion = &cfg
 			}
 		default:
 			continue

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -276,7 +276,6 @@ func TestCapabilities(t *testing.T) {
 			},
 		}
 		for _, tc := range cases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				response := CapabilitiesResponse{

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -174,4 +174,147 @@ func TestCapabilities(t *testing.T) {
 			StackPolicyPacks: true,
 		}, actual)
 	})
+
+	t.Run("parse api version v1", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    APIVersion,
+					Version:       1,
+					Configuration: json.RawMessage(`{"maxVersion":9,"minVersion":3,"defaultVersion":8}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			APIVersion: &APIVersionCapabilityConfig{
+				MaxVersion:     9,
+				MinVersion:     3,
+				DefaultVersion: 8,
+			},
+		}, actual)
+	})
+
+	t.Run("parse api version with newer version ignored", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    APIVersion,
+					Version:       2,
+					Configuration: json.RawMessage(`{"maxVersion":9,"minVersion":3,"defaultVersion":8}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{}, actual)
+	})
+
+	t.Run("parse response from older server without api version capability", func(t *testing.T) {
+		t.Parallel()
+		// A server that predates the api-version capability still emits other capabilities.
+		// Parse must leave Capabilities.APIVersion nil rather than synthesizing a value.
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{Capability: BatchEncrypt},
+				{Capability: StackPolicyPacks, Version: 1},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Nil(t, actual.APIVersion)
+		assert.Equal(t, Capabilities{
+			BatchEncryption:  true,
+			StackPolicyPacks: true,
+		}, actual)
+	})
+
+	t.Run("parse api version rejects malformed payloads", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name   string
+			config string
+			errSub string
+		}{
+			{
+				name:   "invalid json",
+				config: `{"maxVersion":`,
+				errSub: "decoding APIVersionCapabilityConfig",
+			},
+			{
+				name:   "empty object (missing fields default to zero)",
+				config: `{}`,
+				errSub: "minVersion must be >= 1",
+			},
+			{
+				name:   "zero minVersion",
+				config: `{"maxVersion":9,"minVersion":0,"defaultVersion":0}`,
+				errSub: "minVersion must be >= 1",
+			},
+			{
+				name:   "negative minVersion",
+				config: `{"maxVersion":9,"minVersion":-1,"defaultVersion":9}`,
+				errSub: "minVersion must be >= 1",
+			},
+			{
+				name:   "maxVersion less than minVersion",
+				config: `{"maxVersion":3,"minVersion":5,"defaultVersion":3}`,
+				errSub: "maxVersion (3) must be >= minVersion (5)",
+			},
+			{
+				name:   "defaultVersion below range",
+				config: `{"maxVersion":9,"minVersion":5,"defaultVersion":3}`,
+				errSub: "defaultVersion (3) must be in [minVersion, maxVersion] = [5, 9]",
+			},
+			{
+				name:   "defaultVersion above range",
+				config: `{"maxVersion":9,"minVersion":5,"defaultVersion":10}`,
+				errSub: "defaultVersion (10) must be in [minVersion, maxVersion] = [5, 9]",
+			},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				response := CapabilitiesResponse{
+					Capabilities: []APICapabilityConfig{
+						{
+							Capability:    APIVersion,
+							Version:       1,
+							Configuration: json.RawMessage(tc.config),
+						},
+					},
+				}
+				_, err := response.Parse()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSub)
+			})
+		}
+	})
+
+	t.Run("parse api version accepts min equals max equals default", func(t *testing.T) {
+		t.Parallel()
+		// Boundary case: a server that only speaks one API version.
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    APIVersion,
+					Version:       1,
+					Configuration: json.RawMessage(`{"maxVersion":5,"minVersion":5,"defaultVersion":5}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			APIVersion: &APIVersionCapabilityConfig{
+				MaxVersion:     5,
+				MinVersion:     5,
+				DefaultVersion: 5,
+			},
+		}, actual)
+	})
 }


### PR DESCRIPTION
## Summary

Adds a typed `APIVersion` capability constant plus `APIVersionCapabilityConfig` struct (`maxVersion` / `minVersion` / `defaultVersion`) to `sdk/go/common/apitype`. `CapabilitiesResponse.Parse()` now populates a new `Capabilities.APIVersion` field when the service advertises the capability, and rejects malformed payloads.

This lets clients discover the REST API version range (negotiated via the `Accept: application/vnd.pulumi+N` header) that a Pulumi service speaks via `/api/capabilities`. It's the SDK half of a small cross-repo change — the pulumi-service side of the discussion is in pulumi/pulumi-service#41969, where reviewers asked that pu/pu land the typed constant first so the service can import `apitype.APIVersion` instead of defining a local one.

### Behavior

- Older servers that don't advertise the capability → `Capabilities.APIVersion` is nil (parse continues, other fields unaffected).
- Newer version (`entry.Version > 1`) → silently ignored for forward compatibility (same pattern as `copilot-summarize-error` and friends).
- Malformed payload → `Parse()` returns an error. Enforced invariants: `minVersion >= 1`, `maxVersion >= minVersion`, `defaultVersion ∈ [minVersion, maxVersion]`. The rationale is that a known capability whose values are nonsense indicates a bugged/misconfigured server; erroring loudly matches the existing JSON-decode-error pattern and avoids silently masking a real problem.

### Example

```json
{
  "capability": "api-version",
  "version": 1,
  "configuration": {
    "maxVersion": 9,
    "minVersion": 3,
    "defaultVersion": 9
  }
}
```

## Test plan

- [x] New cases in `TestCapabilities` cover:
  - `parse api version v1` — happy path
  - `parse api version with newer version ignored` — forward-compat guard
  - `parse response from older server without api version capability` — other capabilities present, no api-version → `APIVersion` stays nil
  - `parse api version accepts min equals max equals default` — boundary (single-version server)
  - `parse api version rejects malformed payloads` — table-driven: invalid JSON, empty object, zero/negative `minVersion`, `maxVersion < minVersion`, `defaultVersion` below/above range — each asserts a specific error-message substring
- [x] `go test -run TestCapabilities ./go/common/apitype/` passes (13 subtests)
- [x] No existing capability cases modified — purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)