### PR TITLE
Add GetPlugins to pluginstorage

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
@@ -350,7 +351,7 @@ func runConvert(
 	loader := schema.NewPluginLoader(pCtx.Host)
 
 	baseMapper, err := convert.NewBasePluginMapper(
-		convert.DefaultWorkspace(),
+		pluginstorage.Instance,
 		from, /*conversionKey*/
 		convert.ProviderFactoryFromHost(ctx, pCtx.Host),
 		installPlugin,

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/importer"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	resourcestack "github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -769,7 +770,7 @@ func NewImportCmd() *cobra.Command {
 				}
 
 				baseMapper, err := convert.NewBasePluginMapper(
-					convert.DefaultWorkspace(),
+					pluginstorage.Instance,
 					from, /*conversionKey*/
 					convert.ProviderFactoryFromHost(ctx, pCtx.Host),
 					installPlugin,

--- a/pkg/cmd/pulumi/packageinstallation/invariant_test.go
+++ b/pkg/cmd/pulumi/packageinstallation/invariant_test.go
@@ -297,6 +297,10 @@ func (w invariantWorkspace) GetStoredCredentials() (workspace.Credentials, error
 	return workspace.Credentials{}, nil
 }
 
+func (w invariantWorkspace) GetPlugins(context.Context) ([]workspace.PluginInfo, error) {
+	return nil, nil
+}
+
 func (w invariantWorkspace) GenerateLocalSDK(
 	ctx context.Context,
 	project *workspace.ProjectRuntimeInfo, projectDir string,

--- a/pkg/cmd/pulumi/packageinstallation/record_test.go
+++ b/pkg/cmd/pulumi/packageinstallation/record_test.go
@@ -181,6 +181,13 @@ func (w *recordingWorkspace) GetStoredCredentials() (workspace.Credentials, erro
 	return creds, err
 }
 
+func (w *recordingWorkspace) GetPlugins(ctx context.Context) ([]workspace.PluginInfo, error) {
+	w.start("GetPlugins", ctx)
+	plugins, err := w.w.GetPlugins(ctx)
+	w.finish(plugins, err)
+	return plugins, err
+}
+
 func (w *recordingWorkspace) LoadPluginProjectAt(
 	ctx context.Context, path string,
 ) (*workspace.PluginProject, string, error) {

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -51,8 +52,8 @@ func NewPluginCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newPluginInstallCmd())
-	cmd.AddCommand(newPluginLsCmd())
-	cmd.AddCommand(newPluginRmCmd())
+	cmd.AddCommand(newPluginLsCmd(pluginstorage.Instance))
+	cmd.AddCommand(newPluginRmCmd(pluginstorage.Instance))
 	cmd.AddCommand(newPluginRunCmd(pkgWorkspace.Instance))
 
 	return cmd

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -25,12 +25,13 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPluginLsCmd() *cobra.Command {
+func newPluginLsCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var projectOnly bool
 	var jsonOut bool
 	cmd := &cobra.Command{
@@ -51,7 +52,7 @@ func newPluginLsCmd() *cobra.Command {
 					return fmt.Errorf("loading project plugins: %w", err)
 				}
 			} else {
-				if plugins, err = workspace.GetPluginsWithMetadata(); err != nil {
+				if plugins, err = pluginContext.GetPlugins(cmd.Context()); err != nil {
 					return fmt.Errorf("loading plugins: %w", err)
 				}
 			}

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -30,12 +30,13 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func newPluginRmCmd() *cobra.Command {
+func newPluginRmCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var all bool
 	var yes bool
 	cmd := &cobra.Command{
@@ -82,7 +83,7 @@ func newPluginRmCmd() *cobra.Command {
 
 			// Now build a list of plugins that match.
 			var deletes []workspace.PluginInfo
-			plugins, err := workspace.GetPlugins()
+			plugins, err := pluginContext.GetPlugins(cmd.Context())
 			if err != nil {
 				return fmt.Errorf("loading plugins: %w", err)
 			}

--- a/pkg/cmd/pulumi/plugin/rpc.go
+++ b/pkg/cmd/pulumi/plugin/rpc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blang/semver"
 	pconvert "github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -66,7 +67,7 @@ func createPluginRPCServer(
 	installPlugin := newInstallPluginFunc(pctx)
 
 	baseMapper, err := pconvert.NewBasePluginMapper(
-		pconvert.DefaultWorkspace(),
+		pluginstorage.Instance,
 		"terraform",
 		pconvert.ProviderFactoryFromHost(ctx, pctx.Host),
 		installPlugin,

--- a/pkg/codegen/convert/base_plugin_mapper.go
+++ b/pkg/codegen/convert/base_plugin_mapper.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -58,38 +59,21 @@ type basePluginMapperSpec struct {
 }
 
 // Workspace encapsulates an environment containing an enumerable set of plugins.
-type Workspace interface {
-	// GetPlugins returns the list of plugins installed in the workspace.
-	GetPlugins() ([]workspace.PluginInfo, error)
-}
-
-type defaultWorkspace struct{}
-
-func (defaultWorkspace) GetPlugins() ([]workspace.PluginInfo, error) {
-	return workspace.GetPlugins()
-}
-
-// DefaultWorkspace returns a default workspace implementation that uses the workspace module directly to get plugin
-// info.
-func DefaultWorkspace() Workspace {
-	return defaultWorkspace{}
-}
-
-// NewBasePluginMapper creates a new plugin mapper backed by the supplied workspace.
+// NewBasePluginMapper creates a new plugin mapper backed by the supplied plugin context.
 func NewBasePluginMapper(
-	ws Workspace,
+	pluginContext pluginstorage.Context,
 	conversionKey string,
 	providerFactory ProviderFactory,
 	installPlugin func(pluginName string) *semver.Version,
 	mappings []string,
 ) (Mapper, error) {
-	contract.Requiref(ws != nil, "ws", "must not be nil")
+	contract.Requiref(pluginContext != nil, "pluginContext", "must not be nil")
 	contract.Requiref(providerFactory != nil, "providerFactory", "must not be nil")
 
 	// Enumerate _all_ our installed plugins to ask for any mappings they provide. This allows users to convert aws
 	// terraform code for example by just having 'pulumi-aws' plugin locally, without needing to specify it anywhere on
 	// the command line, and without tf2pulumi needing to know about every possible plugin.
-	allPlugins, err := ws.GetPlugins()
+	allPlugins, err := pluginContext.GetPlugins(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("could not get plugins: %w", err)
 	}

--- a/pkg/codegen/convert/base_plugin_mapper_test.go
+++ b/pkg/codegen/convert/base_plugin_mapper_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -660,12 +661,13 @@ func TestBasePluginMapper_InfiniteLoopRegression(t *testing.T) {
 	assert.Equal(t, []byte{}, data)
 }
 
-// testWorkspace implements the Workspace interface with a fixed set of plugins.
+// testWorkspace implements the pluginstorage.Context interface with a fixed set of plugins.
 type testWorkspace struct {
+	pluginstorage.MockContext
 	infos []workspace.PluginInfo
 }
 
-func (ws *testWorkspace) GetPlugins() ([]workspace.PluginInfo, error) {
+func (ws *testWorkspace) GetPlugins(_ context.Context) ([]workspace.PluginInfo, error) {
 	return ws.infos, nil
 }
 

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -135,6 +135,10 @@ func (NopPluginManager) InstallPlugin(
 	return nil
 }
 
+func (NopPluginManager) GetPlugins(ctx context.Context) ([]workspace.PluginInfo, error) {
+	return []workspace.PluginInfo{}, nil
+}
+
 func NewUpdateInfo(project workspace.Project, target deploy.Target) engine.UpdateInfo {
 	return engine.UpdateInfo{
 		// The tests run in-memory, so we don't have a real root. Just pretend we're at the filesystem root.

--- a/pkg/pluginstorage/pluginstorage.go
+++ b/pkg/pluginstorage/pluginstorage.go
@@ -33,6 +33,7 @@ type Context interface {
 	HasPlugin(ctx context.Context, spec workspace.PluginDescriptor) bool
 	HasPluginGTE(ctx context.Context, spec workspace.PluginDescriptor) (bool, *semver.Version, error)
 	GetLatestVersion(ctx context.Context, spec workspace.PluginDescriptor) (*semver.Version, error)
+	GetPlugins(ctx context.Context) ([]workspace.PluginInfo, error)
 }
 
 type defaultContext struct{}
@@ -49,12 +50,17 @@ func (defaultContext) GetLatestVersion(ctx context.Context, spec workspace.Plugi
 	return spec.GetLatestVersion(ctx)
 }
 
+func (defaultContext) GetPlugins(_ context.Context) ([]workspace.PluginInfo, error) {
+	return workspace.GetPlugins()
+}
+
 var _ Context = MockContext{}
 
 type MockContext struct {
 	HasPluginF        func(ctx context.Context, spec workspace.PluginDescriptor) bool
 	HasPluginGTEF     func(ctx context.Context, spec workspace.PluginDescriptor) (bool, *semver.Version, error)
 	GetLatestVersionF func(ctx context.Context, spec workspace.PluginDescriptor) (*semver.Version, error)
+	GetPluginsF       func(ctx context.Context) ([]workspace.PluginInfo, error)
 }
 
 func (m MockContext) HasPlugin(ctx context.Context, spec workspace.PluginDescriptor) bool {
@@ -76,4 +82,11 @@ func (m MockContext) GetLatestVersion(ctx context.Context, spec workspace.Plugin
 		return m.GetLatestVersionF(ctx, spec)
 	}
 	return nil, workspace.ErrGetLatestVersionNotSupported
+}
+
+func (m MockContext) GetPlugins(ctx context.Context) ([]workspace.PluginInfo, error) {
+	if m.GetPluginsF != nil {
+		return m.GetPluginsF(ctx)
+	}
+	return nil, nil
 }


### PR DESCRIPTION
I needed GetPlugins to be mockable for a new command, so figured a good first step was to get it added to the existing `pluginstorage.Context`. Fixed up the GetPlugin calls in pkg/ so far to use this.

This only abstracts `workspace.GetPlugins` not `workspace.GetPluginsWithMetadata` as I'm going to just remove that in https://github.com/pulumi/pulumi/pull/22732.