### PR TITLE
Use t.Context() in more places

### DIFF
--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -58,7 +58,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 		_, err := b.RemoveStack(ctx, aStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
-	deployment, err := makeUntypedDeployment("a", "abc123",
+	deployment, err := makeUntypedDeployment(t, "a", "abc123",
 		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
 	require.NoError(t, err)
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
@@ -76,7 +76,7 @@ func TestListStacksWithMultiplePassphrases_legacy(t *testing.T) {
 		_, err := b.RemoveStack(ctx, bStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
-	deployment, err = makeUntypedDeployment("b", "123abc",
+	deployment, err = makeUntypedDeployment(t, "b", "123abc",
 		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
 	require.NoError(t, err)
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -16,7 +16,6 @@ package diy
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -225,11 +224,12 @@ func TestGetLogsForTargetWithNoSnapshot(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func makeUntypedDeployment(name string, phrase, state string) (*apitype.UntypedDeployment, error) {
-	return makeUntypedDeploymentTimestamp(name, phrase, state, nil, nil)
+func makeUntypedDeployment(t *testing.T, name string, phrase, state string) (*apitype.UntypedDeployment, error) {
+	return makeUntypedDeploymentTimestamp(t, name, phrase, state, nil, nil)
 }
 
 func makeUntypedDeploymentTimestamp(
+	t *testing.T,
 	name string,
 	phrase, state string,
 	created, modified *time.Time,
@@ -252,9 +252,8 @@ func makeUntypedDeploymentTimestamp(
 	}
 
 	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
-	ctx := context.Background()
 
-	udep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
+	udep, err := stack.SerializeUntypedDeployment(t.Context(), snap, nil /*opts*/)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +279,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 		_, err := b.RemoveStack(ctx, aStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
-	deployment, err := makeUntypedDeployment("a", "abc123",
+	deployment, err := makeUntypedDeployment(t, "a", "abc123",
 		"v1:4iF78gb0nF0=:v1:Co6IbTWYs/UdrjgY:FSrAWOFZnj9ealCUDdJL7LrUKXX9BA==")
 	require.NoError(t, err)
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "abc123")
@@ -298,7 +297,7 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 		_, err := b.RemoveStack(ctx, bStack, true /*force*/, false /*removeBackups*/)
 		require.NoError(t, err)
 	}()
-	deployment, err = makeUntypedDeployment("b", "123abc",
+	deployment, err = makeUntypedDeployment(t, "b", "123abc",
 		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==")
 	require.NoError(t, err)
 	t.Setenv("PULUMI_CONFIG_PASSPHRASE", "123abc")
@@ -1497,7 +1496,7 @@ func TestSerializeTimestampRFC3339(t *testing.T) {
 	created := time.Now().UTC()
 	modified := created.Add(time.Hour)
 
-	deployment, err := makeUntypedDeploymentTimestamp("b", "123abc",
+	deployment, err := makeUntypedDeploymentTimestamp(t, "b", "123abc",
 		"v1:C7H2a7/Ietk=:v1:yfAd1zOi6iY9DRIB:dumdsr+H89VpHIQWdB01XEFqYaYjAg==", &created, &modified)
 	require.NoError(t, err)
 

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -35,7 +35,7 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	require.NoError(b, err)
 	sink := diagtest.LogSink(b)
 	//nolint:usetesting // plugin.NewContext manages gRPC providers; b.Context cancels too early
-	ctx, err := plugin.NewContext(context.Background(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
+	ctx, err := plugin.NewContext(b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2389,7 +2389,7 @@ func debugProvidersHelperHost(t *testing.T) plugin.Host {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	//nolint:usetesting // plugin.NewContext manages the lifecycle of gRPC providers; t.Context cancels before they shut down
-	pluginCtx, err := plugin.NewContext(context.Background(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
+	pluginCtx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
 	require.NoError(t, err)
 	return pluginCtx.Host
 }

--- a/pkg/engine/lifecycletest/fuzz_test.go
+++ b/pkg/engine/lifecycletest/fuzz_test.go
@@ -15,7 +15,6 @@
 package lifecycletest
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -78,7 +77,7 @@ func TestFuzzFromStateFile(t *testing.T) {
 	require.NoError(t, err)
 
 	//nolint:usetesting // outlives t.Context inside the engine
-	v3Deployment, err := stack.UnmarshalUntypedDeployment(context.Background(), &deployment)
+	v3Deployment, err := stack.UnmarshalUntypedDeployment(t.Context(), &deployment)
 	require.NoError(t, err)
 
 	if len(v3Deployment.Resources) == 0 {

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -758,8 +758,8 @@ func TestDeserializePropertyValue(t *testing.T) {
 	})
 }
 
-func wireValue(v resource.PropertyValue) (any, error) {
-	object, err := SerializePropertyValue(context.Background(), v, config.NopEncrypter, false)
+func wireValue(ctx context.Context, v resource.PropertyValue) (any, error) {
+	object, err := SerializePropertyValue(ctx, v, config.NopEncrypter, false)
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +782,7 @@ func TestPropertyValueSchema(t *testing.T) {
 
 	//nolint:paralleltest // uses rapid.T not golang testing.T
 	t.Run("serialized", rapid.MakeCheck(func(t *rapid.T) {
-		wireObject, err := wireValue(resource_testing.PropertyValueGenerator(6).Draw(t, "property value"))
+		wireObject, err := wireValue(t.Context(), resource_testing.PropertyValueGenerator(6).Draw(t, "property value"))
 		require.NoError(t, err)
 
 		err = propertyValueSchema.Validate(wireObject)
@@ -830,7 +830,7 @@ func TestRoundTripPropertyValue(t *testing.T) {
 
 	rapid.Check(t, func(t *rapid.T) {
 		original := resource_testing.PropertyValueGenerator(6).Draw(t, "property value")
-		wireObject, err := wireValue(original)
+		wireObject, err := wireValue(t.Context(), original)
 		require.NoError(t, err)
 
 		deserialized, err := DeserializePropertyValue(wireObject, config.NopDecrypter)

--- a/sdk/go/common/util/cmdutil/term_test.go
+++ b/sdk/go/common/util/cmdutil/term_test.go
@@ -179,7 +179,7 @@ func TestTerminate_forceKill(t *testing.T) {
 			}
 
 			require.NoError(t,
-				waitPidDead(pid, 100*time.Millisecond),
+				waitPidDead(t, pid, 100*time.Millisecond),
 				"error waiting for process to die")
 		})
 	}
@@ -238,7 +238,7 @@ func TestTerminate_forceKill_processGroup(t *testing.T) {
 
 	for _, pid := range []int{pid, childPid} {
 		require.NoError(t,
-			waitPidDead(pid, 100*time.Millisecond),
+			waitPidDead(t, pid, 100*time.Millisecond),
 			"error waiting for process to die")
 	}
 }
@@ -297,7 +297,7 @@ func TestTerminate_unhandledInterrupt(t *testing.T) {
 			}
 
 			require.NoError(t,
-				waitPidDead(pid, 100*time.Millisecond),
+				waitPidDead(t, pid, 100*time.Millisecond),
 				"error waiting for process to die")
 		})
 	}
@@ -445,8 +445,8 @@ func (b *lockedBuffer) Len() int {
 // or the given timeout has elapsed.
 //
 // Returns an error if the timeout has elapsed.
-func waitPidDead(pid int, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func waitPidDead(t *testing.T, pid int, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	var (

--- a/sdk/go/common/util/rpcutil/writer_test.go
+++ b/sdk/go/common/util/rpcutil/writer_test.go
@@ -31,9 +31,9 @@ import (
 	"golang.org/x/term"
 )
 
-func makeStreamMock() *streamMock {
+func makeStreamMock(t *testing.T) *streamMock {
 	return &streamMock{
-		ctx: context.Background(),
+		ctx: t.Context(),
 	}
 }
 
@@ -61,7 +61,7 @@ func (m *streamMock) Send(resp *pulumirpc.InstallDependenciesResponse) error {
 func TestWriter_NoTerminal(t *testing.T) {
 	t.Parallel()
 
-	server := makeStreamMock()
+	server := makeStreamMock(t)
 
 	closer, stdout, stderr, err := MakeInstallDependenciesStreams(server, false)
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestWriter_NoTerminal(t *testing.T) {
 func TestWriter_Terminal(t *testing.T) {
 	t.Parallel()
 
-	server := makeStreamMock()
+	server := makeStreamMock(t)
 
 	closer, stdout, stderr, err := MakeInstallDependenciesStreams(server, true)
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestWriter_Terminal(t *testing.T) {
 func TestWriter_IsPTY(t *testing.T) {
 	t.Parallel()
 
-	server := makeStreamMock()
+	server := makeStreamMock(t)
 
 	closer, stdout, stderr, err := MakeInstallDependenciesStreams(server, true)
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func TestWriter_IsPTY(t *testing.T) {
 func TestWriter_SafeToCloseTwice(t *testing.T) {
 	t.Parallel()
 
-	server := makeStreamMock()
+	server := makeStreamMock(t)
 
 	closer, _, _, err := MakeInstallDependenciesStreams(server, true)
 	require.NoError(t, err)

--- a/sdk/go/internal/gen-pux-applyn/tmpl/applyn_test.go.tmpl
+++ b/sdk/go/internal/gen-pux-applyn/tmpl/applyn_test.go.tmpl
@@ -61,7 +61,7 @@ func Test{{ $name }}_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -92,7 +92,7 @@ func Test{{ $name }}_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -110,7 +110,7 @@ func Test{{ $name }}Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -139,7 +139,7 @@ func Test{{ $name }}_failedOutput(t *testing.T) {
 	{{/* Because the outputs past the first are not filled,
 	     awaiting on them will hang forever if the test fails.
 	     Prevent that with a timeout. */}}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -932,9 +932,9 @@ func (m *packageRefMonitor) RegisterPackage(_ context.Context, _ *pulumirpc.Regi
 
 // newTestContextWithMonitor creates a minimal Context for testing with
 // the given monitor and supportsParameterization enabled.
-func newTestContextWithMonitor(monitor pulumirpc.ResourceMonitorClient) *Context {
+func newTestContextWithMonitor(t *testing.T, monitor pulumirpc.ResourceMonitorClient) *Context {
 	return &Context{
-		ctx: context.Background(),
+		ctx: t.Context(),
 		state: &contextState{
 			monitor:                  monitor,
 			supportsParameterization: true,
@@ -960,7 +960,7 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 	t.Run("returns registered ref", func(t *testing.T) {
 		t.Parallel()
 		mon := &packageRefMonitor{ref: "uuid-1"}
-		ctx := newTestContextWithMonitor(mon)
+		ctx := newTestContextWithMonitor(t, mon)
 
 		ref, err := ctx.GetOrRegisterPackageRef("pkg:1.0", dummyRegisterReq)
 
@@ -972,7 +972,7 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 	t.Run("caches ref for same key", func(t *testing.T) {
 		t.Parallel()
 		mon := &packageRefMonitor{ref: "uuid-1"}
-		ctx := newTestContextWithMonitor(mon)
+		ctx := newTestContextWithMonitor(t, mon)
 
 		ref1, err := ctx.GetOrRegisterPackageRef("pkg:1.0", dummyRegisterReq)
 		require.NoError(t, err)
@@ -986,7 +986,7 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 	t.Run("different keys register separately", func(t *testing.T) {
 		t.Parallel()
 		mon := &packageRefMonitor{ref: "uuid-1"}
-		ctx := newTestContextWithMonitor(mon)
+		ctx := newTestContextWithMonitor(t, mon)
 
 		_, err := ctx.GetOrRegisterPackageRef("pkg-a:1.0", dummyRegisterReq)
 		require.NoError(t, err)
@@ -1000,7 +1000,7 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 		t.Parallel()
 		expectedErr := errors.New("registration failed")
 		mon := &packageRefMonitor{err: expectedErr}
-		ctx := newTestContextWithMonitor(mon)
+		ctx := newTestContextWithMonitor(t, mon)
 
 		_, err1 := ctx.GetOrRegisterPackageRef("pkg:1.0", dummyRegisterReq)
 		_, err2 := ctx.GetOrRegisterPackageRef("pkg:1.0", dummyRegisterReq)
@@ -1014,8 +1014,8 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 		t.Parallel()
 		monA := &packageRefMonitor{ref: "uuid-A"}
 		monB := &packageRefMonitor{ref: "uuid-B"}
-		ctxA := newTestContextWithMonitor(monA)
-		ctxB := newTestContextWithMonitor(monB)
+		ctxA := newTestContextWithMonitor(t, monA)
+		ctxB := newTestContextWithMonitor(t, monB)
 
 		refA, err := ctxA.GetOrRegisterPackageRef("pkg:1.0", dummyRegisterReq)
 		require.NoError(t, err)
@@ -1031,7 +1031,7 @@ func TestGetOrRegisterPackageRef(t *testing.T) {
 	t.Run("concurrent goroutines same key single registration", func(t *testing.T) {
 		t.Parallel()
 		mon := &packageRefMonitor{ref: "uuid-concurrent"}
-		ctx := newTestContextWithMonitor(mon)
+		ctx := newTestContextWithMonitor(t, mon)
 
 		const goroutines = 50
 		var wg sync.WaitGroup

--- a/sdk/go/pulumi/generate/templates/types_builtins_test.go.template
+++ b/sdk/go/pulumi/generate/templates/types_builtins_test.go.template
@@ -18,7 +18,6 @@
 package pulumi
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -296,13 +295,13 @@ func TestTo{{.Name}}Output(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.To{{.Name}}OutputWithContext(context.Background())
+	out = in.To{{.Name}}OutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.To{{.Name}}OutputWithContext(context.Background())
+	out = out.To{{.Name}}OutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)

--- a/sdk/go/pulumi/internals/outputs_test.go
+++ b/sdk/go/pulumi/internals/outputs_test.go
@@ -15,7 +15,6 @@
 package internals
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -24,8 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func await(out pulumi.Output) (any, bool, bool, []pulumi.Resource, error) {
-	result, err := UnsafeAwaitOutput(context.Background(), out)
+func await(t *testing.T, out pulumi.Output) (any, bool, bool, []pulumi.Resource, error) {
+	result, err := UnsafeAwaitOutput(t.Context(), out)
 
 	return result.Value, result.Known, result.Secret, result.Dependencies, err
 }
@@ -45,7 +44,7 @@ func TestBasicOutputs(t *testing.T) {
 		go func() {
 			resolve(42)
 		}()
-		v, known, secret, deps, err := await(out)
+		v, known, secret, deps, err := await(t, out)
 		require.NoError(t, err)
 		assert.True(t, known)
 		assert.False(t, secret)
@@ -58,7 +57,7 @@ func TestBasicOutputs(t *testing.T) {
 		go func() {
 			reject(errors.New("boom"))
 		}()
-		v, _, _, _, err := await(out)
+		v, _, _, _, err := await(t, out)
 		assert.EqualError(t, err, "boom")
 		assert.Nil(t, v)
 	}

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -18,7 +18,6 @@
 package pulumi
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -4054,13 +4053,13 @@ func TestToArchiveOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveOutputWithContext(context.Background())
+	out = in.ToArchiveOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveOutputWithContext(context.Background())
+	out = out.ToArchiveOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4084,13 +4083,13 @@ func TestToArchiveArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayOutputWithContext(context.Background())
+	out = in.ToArchiveArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayOutputWithContext(context.Background())
+	out = out.ToArchiveArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4114,13 +4113,13 @@ func TestToArchiveMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapOutputWithContext(context.Background())
+	out = in.ToArchiveMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapOutputWithContext(context.Background())
+	out = out.ToArchiveMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4144,13 +4143,13 @@ func TestToArchiveArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayMapOutputWithContext(context.Background())
+	out = in.ToArchiveArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayMapOutputWithContext(context.Background())
+	out = out.ToArchiveArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4174,13 +4173,13 @@ func TestToArchiveMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapArrayOutputWithContext(context.Background())
+	out = in.ToArchiveMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapArrayOutputWithContext(context.Background())
+	out = out.ToArchiveMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4204,13 +4203,13 @@ func TestToArchiveMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapMapOutputWithContext(context.Background())
+	out = in.ToArchiveMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapMapOutputWithContext(context.Background())
+	out = out.ToArchiveMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4234,13 +4233,13 @@ func TestToArchiveArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayArrayOutputWithContext(context.Background())
+	out = in.ToArchiveArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayArrayOutputWithContext(context.Background())
+	out = out.ToArchiveArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4264,13 +4263,13 @@ func TestToArchiveArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayMapMapOutputWithContext(context.Background())
+	out = in.ToArchiveArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayMapMapOutputWithContext(context.Background())
+	out = out.ToArchiveArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4294,13 +4293,13 @@ func TestToArchiveMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapArrayMapOutputWithContext(context.Background())
+	out = in.ToArchiveMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapArrayMapOutputWithContext(context.Background())
+	out = out.ToArchiveMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4324,13 +4323,13 @@ func TestToArchiveMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapMapArrayOutputWithContext(context.Background())
+	out = in.ToArchiveMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapMapArrayOutputWithContext(context.Background())
+	out = out.ToArchiveMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4354,13 +4353,13 @@ func TestToArchiveArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToArchiveArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToArchiveArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4384,13 +4383,13 @@ func TestToArchiveArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToArchiveArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToArchiveArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4414,13 +4413,13 @@ func TestToArchiveArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToArchiveArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToArchiveArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4444,13 +4443,13 @@ func TestToArchiveMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArchiveMapMapMapOutputWithContext(context.Background())
+	out = in.ToArchiveMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArchiveMapMapMapOutputWithContext(context.Background())
+	out = out.ToArchiveMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4474,13 +4473,13 @@ func TestToAssetOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOutputWithContext(context.Background())
+	out = in.ToAssetOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOutputWithContext(context.Background())
+	out = out.ToAssetOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4504,13 +4503,13 @@ func TestToAssetArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayOutputWithContext(context.Background())
+	out = in.ToAssetArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayOutputWithContext(context.Background())
+	out = out.ToAssetArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4534,13 +4533,13 @@ func TestToAssetMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapOutputWithContext(context.Background())
+	out = in.ToAssetMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapOutputWithContext(context.Background())
+	out = out.ToAssetMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4564,13 +4563,13 @@ func TestToAssetArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4594,13 +4593,13 @@ func TestToAssetMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4624,13 +4623,13 @@ func TestToAssetMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapMapOutputWithContext(context.Background())
+	out = in.ToAssetMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapMapOutputWithContext(context.Background())
+	out = out.ToAssetMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4654,13 +4653,13 @@ func TestToAssetArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayArrayOutputWithContext(context.Background())
+	out = in.ToAssetArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayArrayOutputWithContext(context.Background())
+	out = out.ToAssetArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4684,13 +4683,13 @@ func TestToAssetArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayMapMapOutputWithContext(context.Background())
+	out = in.ToAssetArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayMapMapOutputWithContext(context.Background())
+	out = out.ToAssetArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4714,13 +4713,13 @@ func TestToAssetMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4744,13 +4743,13 @@ func TestToAssetMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4774,13 +4773,13 @@ func TestToAssetArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4804,13 +4803,13 @@ func TestToAssetArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4834,13 +4833,13 @@ func TestToAssetArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToAssetArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToAssetArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4864,13 +4863,13 @@ func TestToAssetMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetMapMapMapOutputWithContext(context.Background())
+	out = in.ToAssetMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetMapMapMapOutputWithContext(context.Background())
+	out = out.ToAssetMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4894,13 +4893,13 @@ func TestToAssetOrArchiveOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4924,13 +4923,13 @@ func TestToAssetOrArchiveArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4954,13 +4953,13 @@ func TestToAssetOrArchiveMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -4984,13 +4983,13 @@ func TestToAssetOrArchiveArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5014,13 +5013,13 @@ func TestToAssetOrArchiveMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5044,13 +5043,13 @@ func TestToAssetOrArchiveMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5074,13 +5073,13 @@ func TestToAssetOrArchiveArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5104,13 +5103,13 @@ func TestToAssetOrArchiveArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayMapMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayMapMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5134,13 +5133,13 @@ func TestToAssetOrArchiveMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5164,13 +5163,13 @@ func TestToAssetOrArchiveMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5194,13 +5193,13 @@ func TestToAssetOrArchiveArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5224,13 +5223,13 @@ func TestToAssetOrArchiveArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5254,13 +5253,13 @@ func TestToAssetOrArchiveArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5284,13 +5283,13 @@ func TestToAssetOrArchiveMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToAssetOrArchiveMapMapMapOutputWithContext(context.Background())
+	out = in.ToAssetOrArchiveMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToAssetOrArchiveMapMapMapOutputWithContext(context.Background())
+	out = out.ToAssetOrArchiveMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5314,13 +5313,13 @@ func TestToBoolOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolOutputWithContext(context.Background())
+	out = in.ToBoolOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolOutputWithContext(context.Background())
+	out = out.ToBoolOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5344,13 +5343,13 @@ func TestToBoolPtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolPtrOutputWithContext(context.Background())
+	out = in.ToBoolPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolPtrOutputWithContext(context.Background())
+	out = out.ToBoolPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5374,13 +5373,13 @@ func TestToBoolArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayOutputWithContext(context.Background())
+	out = in.ToBoolArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayOutputWithContext(context.Background())
+	out = out.ToBoolArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5404,13 +5403,13 @@ func TestToBoolMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapOutputWithContext(context.Background())
+	out = in.ToBoolMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapOutputWithContext(context.Background())
+	out = out.ToBoolMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5434,13 +5433,13 @@ func TestToBoolArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayMapOutputWithContext(context.Background())
+	out = in.ToBoolArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayMapOutputWithContext(context.Background())
+	out = out.ToBoolArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5464,13 +5463,13 @@ func TestToBoolMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapArrayOutputWithContext(context.Background())
+	out = in.ToBoolMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapArrayOutputWithContext(context.Background())
+	out = out.ToBoolMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5494,13 +5493,13 @@ func TestToBoolMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapMapOutputWithContext(context.Background())
+	out = in.ToBoolMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapMapOutputWithContext(context.Background())
+	out = out.ToBoolMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5524,13 +5523,13 @@ func TestToBoolArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayArrayOutputWithContext(context.Background())
+	out = in.ToBoolArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayArrayOutputWithContext(context.Background())
+	out = out.ToBoolArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5554,13 +5553,13 @@ func TestToBoolArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayMapMapOutputWithContext(context.Background())
+	out = in.ToBoolArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayMapMapOutputWithContext(context.Background())
+	out = out.ToBoolArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5584,13 +5583,13 @@ func TestToBoolMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapArrayMapOutputWithContext(context.Background())
+	out = in.ToBoolMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapArrayMapOutputWithContext(context.Background())
+	out = out.ToBoolMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5614,13 +5613,13 @@ func TestToBoolMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapMapArrayOutputWithContext(context.Background())
+	out = in.ToBoolMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapMapArrayOutputWithContext(context.Background())
+	out = out.ToBoolMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5644,13 +5643,13 @@ func TestToBoolArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToBoolArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToBoolArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5674,13 +5673,13 @@ func TestToBoolArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToBoolArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToBoolArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5704,13 +5703,13 @@ func TestToBoolArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToBoolArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToBoolArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5734,13 +5733,13 @@ func TestToBoolMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToBoolMapMapMapOutputWithContext(context.Background())
+	out = in.ToBoolMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToBoolMapMapMapOutputWithContext(context.Background())
+	out = out.ToBoolMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5764,13 +5763,13 @@ func TestToFloat64Output(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64OutputWithContext(context.Background())
+	out = in.ToFloat64OutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64OutputWithContext(context.Background())
+	out = out.ToFloat64OutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5794,13 +5793,13 @@ func TestToFloat64PtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64PtrOutputWithContext(context.Background())
+	out = in.ToFloat64PtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64PtrOutputWithContext(context.Background())
+	out = out.ToFloat64PtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5824,13 +5823,13 @@ func TestToFloat64ArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5854,13 +5853,13 @@ func TestToFloat64MapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapOutputWithContext(context.Background())
+	out = in.ToFloat64MapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapOutputWithContext(context.Background())
+	out = out.ToFloat64MapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5884,13 +5883,13 @@ func TestToFloat64ArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayMapOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayMapOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5914,13 +5913,13 @@ func TestToFloat64MapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapArrayOutputWithContext(context.Background())
+	out = in.ToFloat64MapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapArrayOutputWithContext(context.Background())
+	out = out.ToFloat64MapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5944,13 +5943,13 @@ func TestToFloat64MapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapMapOutputWithContext(context.Background())
+	out = in.ToFloat64MapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapMapOutputWithContext(context.Background())
+	out = out.ToFloat64MapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -5974,13 +5973,13 @@ func TestToFloat64ArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayArrayOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayArrayOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6004,13 +6003,13 @@ func TestToFloat64ArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayMapMapOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayMapMapOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6034,13 +6033,13 @@ func TestToFloat64MapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapArrayMapOutputWithContext(context.Background())
+	out = in.ToFloat64MapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapArrayMapOutputWithContext(context.Background())
+	out = out.ToFloat64MapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6064,13 +6063,13 @@ func TestToFloat64MapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapMapArrayOutputWithContext(context.Background())
+	out = in.ToFloat64MapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapMapArrayOutputWithContext(context.Background())
+	out = out.ToFloat64MapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6094,13 +6093,13 @@ func TestToFloat64ArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6124,13 +6123,13 @@ func TestToFloat64ArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6154,13 +6153,13 @@ func TestToFloat64ArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64ArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToFloat64ArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64ArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToFloat64ArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6184,13 +6183,13 @@ func TestToFloat64MapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToFloat64MapMapMapOutputWithContext(context.Background())
+	out = in.ToFloat64MapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToFloat64MapMapMapOutputWithContext(context.Background())
+	out = out.ToFloat64MapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6214,13 +6213,13 @@ func TestToIDOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDOutputWithContext(context.Background())
+	out = in.ToIDOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDOutputWithContext(context.Background())
+	out = out.ToIDOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6244,13 +6243,13 @@ func TestToIDPtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDPtrOutputWithContext(context.Background())
+	out = in.ToIDPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDPtrOutputWithContext(context.Background())
+	out = out.ToIDPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6274,13 +6273,13 @@ func TestToIDArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayOutputWithContext(context.Background())
+	out = in.ToIDArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayOutputWithContext(context.Background())
+	out = out.ToIDArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6304,13 +6303,13 @@ func TestToIDMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapOutputWithContext(context.Background())
+	out = in.ToIDMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapOutputWithContext(context.Background())
+	out = out.ToIDMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6334,13 +6333,13 @@ func TestToIDArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayMapOutputWithContext(context.Background())
+	out = in.ToIDArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayMapOutputWithContext(context.Background())
+	out = out.ToIDArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6364,13 +6363,13 @@ func TestToIDMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapArrayOutputWithContext(context.Background())
+	out = in.ToIDMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapArrayOutputWithContext(context.Background())
+	out = out.ToIDMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6394,13 +6393,13 @@ func TestToIDMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapMapOutputWithContext(context.Background())
+	out = in.ToIDMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapMapOutputWithContext(context.Background())
+	out = out.ToIDMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6424,13 +6423,13 @@ func TestToIDArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayArrayOutputWithContext(context.Background())
+	out = in.ToIDArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayArrayOutputWithContext(context.Background())
+	out = out.ToIDArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6454,13 +6453,13 @@ func TestToIDArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayMapMapOutputWithContext(context.Background())
+	out = in.ToIDArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayMapMapOutputWithContext(context.Background())
+	out = out.ToIDArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6484,13 +6483,13 @@ func TestToIDMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapArrayMapOutputWithContext(context.Background())
+	out = in.ToIDMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapArrayMapOutputWithContext(context.Background())
+	out = out.ToIDMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6514,13 +6513,13 @@ func TestToIDMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapMapArrayOutputWithContext(context.Background())
+	out = in.ToIDMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapMapArrayOutputWithContext(context.Background())
+	out = out.ToIDMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6544,13 +6543,13 @@ func TestToIDArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToIDArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToIDArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6574,13 +6573,13 @@ func TestToIDArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToIDArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToIDArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6604,13 +6603,13 @@ func TestToIDArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToIDArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToIDArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6634,13 +6633,13 @@ func TestToIDMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIDMapMapMapOutputWithContext(context.Background())
+	out = in.ToIDMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIDMapMapMapOutputWithContext(context.Background())
+	out = out.ToIDMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6664,13 +6663,13 @@ func TestToArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayOutputWithContext(context.Background())
+	out = in.ToArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayOutputWithContext(context.Background())
+	out = out.ToArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6694,13 +6693,13 @@ func TestToMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapOutputWithContext(context.Background())
+	out = in.ToMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapOutputWithContext(context.Background())
+	out = out.ToMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6724,13 +6723,13 @@ func TestToArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayMapOutputWithContext(context.Background())
+	out = in.ToArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayMapOutputWithContext(context.Background())
+	out = out.ToArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6754,13 +6753,13 @@ func TestToMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapArrayOutputWithContext(context.Background())
+	out = in.ToMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapArrayOutputWithContext(context.Background())
+	out = out.ToMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6784,13 +6783,13 @@ func TestToMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapMapOutputWithContext(context.Background())
+	out = in.ToMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapMapOutputWithContext(context.Background())
+	out = out.ToMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6814,13 +6813,13 @@ func TestToArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayArrayOutputWithContext(context.Background())
+	out = in.ToArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayArrayOutputWithContext(context.Background())
+	out = out.ToArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6844,13 +6843,13 @@ func TestToArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayMapMapOutputWithContext(context.Background())
+	out = in.ToArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayMapMapOutputWithContext(context.Background())
+	out = out.ToArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6874,13 +6873,13 @@ func TestToMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapArrayMapOutputWithContext(context.Background())
+	out = in.ToMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapArrayMapOutputWithContext(context.Background())
+	out = out.ToMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6904,13 +6903,13 @@ func TestToMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapMapArrayOutputWithContext(context.Background())
+	out = in.ToMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapMapArrayOutputWithContext(context.Background())
+	out = out.ToMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6934,13 +6933,13 @@ func TestToArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6964,13 +6963,13 @@ func TestToArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -6994,13 +6993,13 @@ func TestToArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7024,13 +7023,13 @@ func TestToMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToMapMapMapOutputWithContext(context.Background())
+	out = in.ToMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToMapMapMapOutputWithContext(context.Background())
+	out = out.ToMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7054,13 +7053,13 @@ func TestToIntOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntOutputWithContext(context.Background())
+	out = in.ToIntOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntOutputWithContext(context.Background())
+	out = out.ToIntOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7084,13 +7083,13 @@ func TestToIntPtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntPtrOutputWithContext(context.Background())
+	out = in.ToIntPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntPtrOutputWithContext(context.Background())
+	out = out.ToIntPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7114,13 +7113,13 @@ func TestToIntArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayOutputWithContext(context.Background())
+	out = in.ToIntArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayOutputWithContext(context.Background())
+	out = out.ToIntArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7144,13 +7143,13 @@ func TestToIntMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapOutputWithContext(context.Background())
+	out = in.ToIntMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapOutputWithContext(context.Background())
+	out = out.ToIntMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7174,13 +7173,13 @@ func TestToIntArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayMapOutputWithContext(context.Background())
+	out = in.ToIntArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayMapOutputWithContext(context.Background())
+	out = out.ToIntArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7204,13 +7203,13 @@ func TestToIntMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapArrayOutputWithContext(context.Background())
+	out = in.ToIntMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapArrayOutputWithContext(context.Background())
+	out = out.ToIntMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7234,13 +7233,13 @@ func TestToIntMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapMapOutputWithContext(context.Background())
+	out = in.ToIntMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapMapOutputWithContext(context.Background())
+	out = out.ToIntMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7264,13 +7263,13 @@ func TestToIntArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayArrayOutputWithContext(context.Background())
+	out = in.ToIntArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayArrayOutputWithContext(context.Background())
+	out = out.ToIntArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7294,13 +7293,13 @@ func TestToIntArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayMapMapOutputWithContext(context.Background())
+	out = in.ToIntArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayMapMapOutputWithContext(context.Background())
+	out = out.ToIntArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7324,13 +7323,13 @@ func TestToIntMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapArrayMapOutputWithContext(context.Background())
+	out = in.ToIntMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapArrayMapOutputWithContext(context.Background())
+	out = out.ToIntMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7354,13 +7353,13 @@ func TestToIntMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapMapArrayOutputWithContext(context.Background())
+	out = in.ToIntMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapMapArrayOutputWithContext(context.Background())
+	out = out.ToIntMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7384,13 +7383,13 @@ func TestToIntArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToIntArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToIntArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7414,13 +7413,13 @@ func TestToIntArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToIntArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToIntArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7444,13 +7443,13 @@ func TestToIntArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToIntArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToIntArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7474,13 +7473,13 @@ func TestToIntMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToIntMapMapMapOutputWithContext(context.Background())
+	out = in.ToIntMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToIntMapMapMapOutputWithContext(context.Background())
+	out = out.ToIntMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7504,13 +7503,13 @@ func TestToStringOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringOutputWithContext(context.Background())
+	out = in.ToStringOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringOutputWithContext(context.Background())
+	out = out.ToStringOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7534,13 +7533,13 @@ func TestToStringPtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringPtrOutputWithContext(context.Background())
+	out = in.ToStringPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringPtrOutputWithContext(context.Background())
+	out = out.ToStringPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7564,13 +7563,13 @@ func TestToStringArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayOutputWithContext(context.Background())
+	out = in.ToStringArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayOutputWithContext(context.Background())
+	out = out.ToStringArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7594,13 +7593,13 @@ func TestToStringMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapOutputWithContext(context.Background())
+	out = in.ToStringMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapOutputWithContext(context.Background())
+	out = out.ToStringMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7624,13 +7623,13 @@ func TestToStringArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayMapOutputWithContext(context.Background())
+	out = in.ToStringArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayMapOutputWithContext(context.Background())
+	out = out.ToStringArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7654,13 +7653,13 @@ func TestToStringMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapArrayOutputWithContext(context.Background())
+	out = in.ToStringMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapArrayOutputWithContext(context.Background())
+	out = out.ToStringMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7684,13 +7683,13 @@ func TestToStringMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapMapOutputWithContext(context.Background())
+	out = in.ToStringMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapMapOutputWithContext(context.Background())
+	out = out.ToStringMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7714,13 +7713,13 @@ func TestToStringArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayArrayOutputWithContext(context.Background())
+	out = in.ToStringArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayArrayOutputWithContext(context.Background())
+	out = out.ToStringArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7744,13 +7743,13 @@ func TestToStringArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayMapMapOutputWithContext(context.Background())
+	out = in.ToStringArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayMapMapOutputWithContext(context.Background())
+	out = out.ToStringArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7774,13 +7773,13 @@ func TestToStringMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapArrayMapOutputWithContext(context.Background())
+	out = in.ToStringMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapArrayMapOutputWithContext(context.Background())
+	out = out.ToStringMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7804,13 +7803,13 @@ func TestToStringMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapMapArrayOutputWithContext(context.Background())
+	out = in.ToStringMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapMapArrayOutputWithContext(context.Background())
+	out = out.ToStringMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7834,13 +7833,13 @@ func TestToStringArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToStringArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToStringArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7864,13 +7863,13 @@ func TestToStringArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToStringArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToStringArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7894,13 +7893,13 @@ func TestToStringArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToStringArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToStringArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7924,13 +7923,13 @@ func TestToStringMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToStringMapMapMapOutputWithContext(context.Background())
+	out = in.ToStringMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToStringMapMapMapOutputWithContext(context.Background())
+	out = out.ToStringMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7954,13 +7953,13 @@ func TestToURNOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNOutputWithContext(context.Background())
+	out = in.ToURNOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNOutputWithContext(context.Background())
+	out = out.ToURNOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -7984,13 +7983,13 @@ func TestToURNPtrOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNPtrOutputWithContext(context.Background())
+	out = in.ToURNPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNPtrOutputWithContext(context.Background())
+	out = out.ToURNPtrOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8014,13 +8013,13 @@ func TestToURNArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayOutputWithContext(context.Background())
+	out = in.ToURNArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayOutputWithContext(context.Background())
+	out = out.ToURNArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8044,13 +8043,13 @@ func TestToURNMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapOutputWithContext(context.Background())
+	out = in.ToURNMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapOutputWithContext(context.Background())
+	out = out.ToURNMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8074,13 +8073,13 @@ func TestToURNArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayMapOutputWithContext(context.Background())
+	out = in.ToURNArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayMapOutputWithContext(context.Background())
+	out = out.ToURNArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8104,13 +8103,13 @@ func TestToURNMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapArrayOutputWithContext(context.Background())
+	out = in.ToURNMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapArrayOutputWithContext(context.Background())
+	out = out.ToURNMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8134,13 +8133,13 @@ func TestToURNMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapMapOutputWithContext(context.Background())
+	out = in.ToURNMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapMapOutputWithContext(context.Background())
+	out = out.ToURNMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8164,13 +8163,13 @@ func TestToURNArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayArrayOutputWithContext(context.Background())
+	out = in.ToURNArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayArrayOutputWithContext(context.Background())
+	out = out.ToURNArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8194,13 +8193,13 @@ func TestToURNArrayMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayMapMapOutputWithContext(context.Background())
+	out = in.ToURNArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayMapMapOutputWithContext(context.Background())
+	out = out.ToURNArrayMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8224,13 +8223,13 @@ func TestToURNMapArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapArrayMapOutputWithContext(context.Background())
+	out = in.ToURNMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapArrayMapOutputWithContext(context.Background())
+	out = out.ToURNMapArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8254,13 +8253,13 @@ func TestToURNMapMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapMapArrayOutputWithContext(context.Background())
+	out = in.ToURNMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapMapArrayOutputWithContext(context.Background())
+	out = out.ToURNMapMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8284,13 +8283,13 @@ func TestToURNArrayMapArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayMapArrayOutputWithContext(context.Background())
+	out = in.ToURNArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayMapArrayOutputWithContext(context.Background())
+	out = out.ToURNArrayMapArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8314,13 +8313,13 @@ func TestToURNArrayArrayMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayArrayMapOutputWithContext(context.Background())
+	out = in.ToURNArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayArrayMapOutputWithContext(context.Background())
+	out = out.ToURNArrayArrayMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8344,13 +8343,13 @@ func TestToURNArrayArrayArrayOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNArrayArrayArrayOutputWithContext(context.Background())
+	out = in.ToURNArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNArrayArrayArrayOutputWithContext(context.Background())
+	out = out.ToURNArrayArrayArrayOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
@@ -8374,13 +8373,13 @@ func TestToURNMapMapMapOutput(t *testing.T) {
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = in.ToURNMapMapMapOutputWithContext(context.Background())
+	out = in.ToURNMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)
 	require.NoError(t, err)
 
-	out = out.ToURNMapMapMapOutputWithContext(context.Background())
+	out = out.ToURNMapMapMapOutputWithContext(t.Context())
 
 	_, known, _, _, err = await(out)
 	assert.True(t, known)

--- a/sdk/go/pulumix/applyn_test.go
+++ b/sdk/go/pulumix/applyn_test.go
@@ -44,7 +44,7 @@ func TestApply_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -66,7 +66,7 @@ func TestApply_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -82,7 +82,7 @@ func TestApplyErr_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -103,7 +103,7 @@ func TestApply_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -124,7 +124,7 @@ func TestApply2_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -148,7 +148,7 @@ func TestApply2_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -165,7 +165,7 @@ func TestApply2Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -188,7 +188,7 @@ func TestApply2_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -211,7 +211,7 @@ func TestApply3_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -237,7 +237,7 @@ func TestApply3_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -255,7 +255,7 @@ func TestApply3Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -279,7 +279,7 @@ func TestApply3_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -304,7 +304,7 @@ func TestApply4_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -332,7 +332,7 @@ func TestApply4_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -351,7 +351,7 @@ func TestApply4Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -376,7 +376,7 @@ func TestApply4_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -403,7 +403,7 @@ func TestApply5_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -433,7 +433,7 @@ func TestApply5_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -453,7 +453,7 @@ func TestApply5Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -479,7 +479,7 @@ func TestApply5_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -508,7 +508,7 @@ func TestApply6_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -540,7 +540,7 @@ func TestApply6_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -561,7 +561,7 @@ func TestApply6Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -588,7 +588,7 @@ func TestApply6_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -619,7 +619,7 @@ func TestApply7_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -653,7 +653,7 @@ func TestApply7_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -675,7 +675,7 @@ func TestApply7Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -703,7 +703,7 @@ func TestApply7_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)
@@ -736,7 +736,7 @@ func TestApply8_simpleSuccess(t *testing.T) {
 		},
 	)
 
-	val, known, secret, deps, err := internal.AwaitOutput(context.Background(), out)
+	val, known, secret, deps, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.False(t, secret)
@@ -772,7 +772,7 @@ func TestApply8_secretValue(t *testing.T) {
 		},
 	)
 
-	_, _, secret, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, secret, _, err := internal.AwaitOutput(t.Context(), out)
 	require.NoError(t, err)
 	assert.True(t, secret)
 }
@@ -795,7 +795,7 @@ func TestApply8Err_applyError(t *testing.T) {
 		},
 	)
 
-	_, _, _, _, err := internal.AwaitOutput(context.Background(), out)
+	_, _, _, _, err := internal.AwaitOutput(t.Context(), out)
 	assert.ErrorIs(t, err, giveErr)
 }
 
@@ -824,7 +824,7 @@ func TestApply8_failedOutput(t *testing.T) {
 		},
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	_, _, _, _, err := internal.AwaitOutput(ctx, out)

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -148,7 +148,7 @@ func TestOrgSearchAi_SingleQuery(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearchAi(
-			t.Context()
+			t.Context(),
 			optorgsearchai.Query("hello"),
 		)
 		return r.Stdout, err

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -133,7 +133,7 @@ func TestOrgSearch_RepeatableQuery(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearch(
-			t.Context()
+			t.Context(),
 			optorgsearch.Query([]string{"foo", "bar"}),
 		)
 		return r.Stdout, err

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -29,7 +29,6 @@
 package runtime_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/tools/automation/output/automation"
@@ -61,7 +60,7 @@ func runStdout(t *testing.T, fn func() (stdout string, err error)) string {
 func TestCancel_Empty(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(context.Background(), nil)
+		r, err := api.Cancel(t.Context(), nil)
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes"
@@ -73,7 +72,7 @@ func TestCancel_Empty(t *testing.T) {
 func TestCancel_WithStackName(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(context.Background(), strPtr("my-stack"))
+		r, err := api.Cancel(t.Context(), strPtr("my-stack"))
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes -- my-stack"
@@ -85,7 +84,7 @@ func TestCancel_WithStackName(t *testing.T) {
 func TestCancel_WithStackFlag(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(context.Background(), nil, optcancel.WithStack("dev"))
+		r, err := api.Cancel(t.Context(), nil, optcancel.WithStack("dev"))
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes --stack dev"
@@ -97,7 +96,7 @@ func TestCancel_WithStackFlag(t *testing.T) {
 func TestOrg_ExecutableMenu(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Org(context.Background())
+		r, err := api.Org(t.Context())
 		return r.Stdout, err
 	})
 	want := "pulumi org"
@@ -109,7 +108,7 @@ func TestOrg_ExecutableMenu(t *testing.T) {
 func TestOrgGetDefault(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.OrgGetDefault(context.Background())
+		r, err := api.OrgGetDefault(t.Context())
 		return r.Stdout, err
 	})
 	want := "pulumi org get-default"
@@ -121,7 +120,7 @@ func TestOrgGetDefault(t *testing.T) {
 func TestOrgSetDefault(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.OrgSetDefault(context.Background(), "my-org")
+		r, err := api.OrgSetDefault(t.Context(), "my-org")
 		return r.Stdout, err
 	})
 	want := "pulumi org set-default -- my-org"
@@ -134,7 +133,7 @@ func TestOrgSearch_RepeatableQuery(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearch(
-			context.Background(),
+			t.Context(),
 			optorgsearch.WithQuery([]string{"foo", "bar"}),
 		)
 		return r.Stdout, err
@@ -149,7 +148,7 @@ func TestOrgSearchAi_SingleQuery(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.OrgSearchAi(
-			context.Background(),
+			t.Context(),
 			optorgsearchai.WithQuery("hello"),
 		)
 		return r.Stdout, err
@@ -163,7 +162,7 @@ func TestOrgSearchAi_SingleQuery(t *testing.T) {
 func TestStateMove_VariadicOnly(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.StateMove(context.Background(), []string{"urn:1", "urn:2"})
+		r, err := api.StateMove(t.Context(), []string{"urn:1", "urn:2"})
 		return r.Stdout, err
 	})
 	want := "pulumi state move --yes -- urn:1 urn:2"
@@ -175,7 +174,7 @@ func TestStateMove_VariadicOnly(t *testing.T) {
 func TestStateMove_EmptyVariadic(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.StateMove(context.Background(), nil)
+		r, err := api.StateMove(t.Context(), nil)
 		return r.Stdout, err
 	})
 	want := "pulumi state move --yes"
@@ -188,7 +187,7 @@ func TestStateMove_WithBooleanFlag(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.StateMove(
-			context.Background(),
+			t.Context(),
 			[]string{"urn:1"},
 			optstatemove.WithIncludeParents(true),
 		)
@@ -204,7 +203,7 @@ func TestStateMove_WithSourceAndDest(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
 		r, err := api.StateMove(
-			context.Background(),
+			t.Context(),
 			[]string{"urn:1"},
 			optstatemove.WithSource("dev"),
 			optstatemove.WithDest("prod"),

--- a/tests/testdata/codegen/plain-and-default/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/plain-and-default/go-extras/tests/codegen_test.go
@@ -80,7 +80,7 @@ func pulumiTest(t *testing.T, name string, testBody func(*pulumi.Context) error)
 }
 
 func waitOut(t *testing.T, output pulumi.Output) interface{} {
-	result, err := waitOutput(output, 1*time.Second)
+	result, err := waitOutput(t, output, 1*time.Second)
 	require.NoError(t, err, "output not received")
 	return result
 }

--- a/tests/testdata/codegen/plain-and-default/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/plain-and-default/go-extras/tests/codegen_test.go
@@ -85,8 +85,8 @@ func waitOut(t *testing.T, output pulumi.Output) interface{} {
 	return result
 }
 
-func waitOutput(output pulumi.Output, timeout time.Duration) (interface{}, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func waitOutput(t *testing.T, output pulumi.Output, timeout time.Duration) (interface{}, error) {
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	defer cancel()
 
 	ch := make(chan interface{})

--- a/tests/testdata/codegen/regress-go-12971/go-extras/tests/codegen_test.go
+++ b/tests/testdata/codegen/regress-go-12971/go-extras/tests/codegen_test.go
@@ -235,7 +235,7 @@ func waitForOutput[T any](t testing.TB, o pulumi.Output) T {
 		return x
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 
 	select {


### PR DESCRIPTION
Update some more call sites to use `t.Context()`. Including some rapid cases now https://github.com/pulumi/pulumi/pull/22730 is merged.