### PR TITLE
fuzzing: fix potential infinite loops when generating programs

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/program.go
+++ b/pkg/engine/lifecycletest/fuzzing/program.go
@@ -308,8 +308,14 @@ func GeneratedProgramSpec(
 			if urn == "" {
 				return "", false
 			}
+			visited := map[resource.URN]bool{}
 			wasRewritten := false
 			for {
+				if visited[urn] {
+					t.Skipf("cycle detected in rewritten URNs: %v", visited)
+					return urn, wasRewritten
+				}
+				visited[urn] = true
 				if newURN, has := rewritten[urn]; has {
 					urn = newURN
 					wasRewritten = true


### PR DESCRIPTION
In `GenerateProgramSpec`, when there's a cycle when generating programs, we may end up in an infinite loop, causing the lifecycletests to time out.  If this happens, let's just skip the test, since this is still in the program generation, so we really shouldn't generate any cycles here.

I *think* this might be the real fix for https://github.com/pulumi/pulumi/issues/22719, and it explains better why we didn't hit the timeout. I had some fuzz tests running locally, that were timing out pretty consistently, and this seems to fix it.

/cc @lblackstone 

Co-authored-by: Claude