### PR TITLE
fix(cli/neo): stop intercepting plain letters as TUI scroll keys

### DIFF
--- a/changelog/pending/20260428--cli-neo--stop-intercepting-letters-as-scroll-keys.yaml
+++ b/changelog/pending/20260428--cli-neo--stop-intercepting-letters-as-scroll-keys.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: fix
+  scope: cli
+  description: |
+    `pulumi neo` no longer intercepts plain letters (`u`, `d`, `f`, `b`, `j`, `k`)
+    and space as conversation scroll shortcuts; those keys now type into the input
+    as expected. PgUp/PgDn, arrow keys, Ctrl+U/Ctrl+D, and the mouse wheel still
+    scroll the conversation.

--- a/changelog/pending/20260428--cli-neo--stop-intercepting-letters-as-scroll-keys.yaml
+++ b/changelog/pending/20260428--cli-neo--stop-intercepting-letters-as-scroll-keys.yaml
@@ -4,5 +4,4 @@ changes:
   description: |
     `pulumi neo` no longer intercepts plain letters (`u`, `d`, `f`, `b`, `j`, `k`)
     and space as conversation scroll shortcuts; those keys now type into the input
-    as expected. PgUp/PgDn, arrow keys, Ctrl+U/Ctrl+D, and the mouse wheel still
-    scroll the conversation.
+    as expected. PgUp/PgDn and the mouse wheel still scroll the conversation.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -181,14 +181,11 @@ func NewModel(cfg ModelConfig) Model {
 	vp := viewport.New(80, 24-inputBarHeight)
 	// The default viewport KeyMap binds plain letters (u/d/f/b/j/k) and
 	// space to scroll actions, which collide with typing in the chat
-	// input. Restrict to keys that can't appear in normal text.
+	// input. Restrict to PgUp/PgDn so we don't shadow system or text-input
+	// shortcuts (arrows move the cursor, Ctrl+U/Ctrl+D have terminal meanings).
 	vp.KeyMap = viewport.KeyMap{
-		PageDown:     key.NewBinding(key.WithKeys("pgdown")),
-		PageUp:       key.NewBinding(key.WithKeys("pgup")),
-		HalfPageUp:   key.NewBinding(key.WithKeys("ctrl+u")),
-		HalfPageDown: key.NewBinding(key.WithKeys("ctrl+d")),
-		Up:           key.NewBinding(key.WithKeys("up")),
-		Down:         key.NewBinding(key.WithKeys("down")),
+		PageDown: key.NewBinding(key.WithKeys("pgdown")),
+		PageUp:   key.NewBinding(key.WithKeys("pgup")),
 	}
 
 	sp := spinner.New(

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -17,6 +17,7 @@ package neo
 import (
 	"strings"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -178,6 +179,17 @@ func NewModel(cfg ModelConfig) Model {
 	ti.CharLimit = 4096
 
 	vp := viewport.New(80, 24-inputBarHeight)
+	// The default viewport KeyMap binds plain letters (u/d/f/b/j/k) and
+	// space to scroll actions, which collide with typing in the chat
+	// input. Restrict to keys that can't appear in normal text.
+	vp.KeyMap = viewport.KeyMap{
+		PageDown:     key.NewBinding(key.WithKeys("pgdown")),
+		PageUp:       key.NewBinding(key.WithKeys("pgup")),
+		HalfPageUp:   key.NewBinding(key.WithKeys("ctrl+u")),
+		HalfPageDown: key.NewBinding(key.WithKeys("ctrl+d")),
+		Up:           key.NewBinding(key.WithKeys("up")),
+		Down:         key.NewBinding(key.WithKeys("down")),
+	}
 
 	sp := spinner.New(
 		spinner.WithSpinner(spinner.MiniDot),

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -392,6 +392,36 @@ func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 	}
 }
 
+func TestModel_Update_KeyRune_TypesAndDoesNotScrollViewport(t *testing.T) {
+	t.Parallel()
+
+	// The bubbles viewport's default keymap binds plain letters (u/d/f/b/j/k)
+	// and space to scroll actions. Those collide with typing in the chat
+	// input, so the model overrides the keymap to keep only non-character
+	// navigation. Regression for pulumi/pulumi-service#42025: pressing 'u'
+	// or 'd' must type into the input and leave the viewport untouched.
+	for _, r := range []rune{'u', 'd', 'f', 'b', 'j', 'k', ' '} {
+		t.Run(string(r), func(t *testing.T) {
+			t.Parallel()
+
+			m := NewModel(ModelConfig{})
+			// Size the viewport and seed content tall enough that scroll
+			// actions would otherwise change YOffset.
+			updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 10})
+			um := updated.(Model)
+			um.viewport.SetContent(strings.Repeat("line\n", 200))
+			um.viewport.ScrollDown(20) // scroll partway so both up- and down-style binds could move
+			startOffset := um.viewport.YOffset
+
+			updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+			um = updated.(Model)
+
+			assert.Equal(t, string(r), um.textInput.Value(), "rune must reach the text input")
+			assert.Equal(t, startOffset, um.viewport.YOffset, "rune must not move the viewport")
+		})
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Approval flow
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The bubbles `viewport`'s default `KeyMap` binds `u`/`d`/`f`/`b`/`j`/`k` and space to scroll actions. The Neo TUI forwards every key event to both the text input and the viewport, so typing those characters scrolled the conversation in addition to typing into the input.
- Override the viewport's `KeyMap` in `NewModel` to keep only non-character navigation: PgUp/PgDn. Mouse-wheel scrolling is unaffected.
- Add a regression test covering all the previously stolen runes.

Fixes pulumi/pulumi-service#42025

## Test plan
- [x] `go test ./cmd/pulumi/neo/...` (new `TestModel_Update_KeyRune_TypesAndDoesNotScrollViewport` passes for `u`, `d`, `f`, `b`, `j`, `k`, space)
- [x] `make format` / `make lint` clean
- [ ] Manual: run `pulumi neo`, type each of `u d f b j k` and space — they should appear in the input without moving the conversation. PgUp/PgDn, arrow keys, Ctrl+U/Ctrl+D, and mouse wheel should still scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)