### PR TITLE
fix(cli/neo): make Ctrl+C cancel-then-quit and surface Esc/Ctrl+C

### DIFF
--- a/changelog/pending/20260428--cli-neo--surface-cancel-keys-and-make-ctrl-c-cancel-then-quit.yaml
+++ b/changelog/pending/20260428--cli-neo--surface-cancel-keys-and-make-ctrl-c-cancel-then-quit.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/neo
-  description: Make `Ctrl+C` in `pulumi neo` cancel the current turn on the first press and exit on the second, and surface both `Esc` and `Ctrl+C` as cancel keys in the busy footer.
+  description: Make `Ctrl+C` (and `Ctrl+D`) in `pulumi neo` cancel the current turn on the first press and exit on the second, surface both `Esc` and `Ctrl+C` as cancel keys in the busy footer, and disarm the second-press-to-exit gate after a short timeout.

--- a/changelog/pending/20260428--cli-neo--surface-cancel-keys-and-make-ctrl-c-cancel-then-quit.yaml
+++ b/changelog/pending/20260428--cli-neo--surface-cancel-keys-and-make-ctrl-c-cancel-then-quit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Make `Ctrl+C` in `pulumi neo` cancel the current turn on the first press and exit on the second, and surface both `Esc` and `Ctrl+C` as cancel keys in the busy footer.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -16,6 +16,7 @@ package neo
 
 import (
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -30,6 +31,20 @@ import (
 // inputBarHeight is the number of terminal lines reserved for the input area
 // (separator + input line + hint line).
 const inputBarHeight = 3
+
+// ctrlCArmTimeout is how long the "press Ctrl+C again to exit" gate stays
+// armed after the first press. Matches the cadence other agent CLIs use so
+// the second press still has to be deliberate but the gate doesn't silently
+// linger across long idle periods.
+const ctrlCArmTimeout = 1500 * time.Millisecond
+
+// ctrlCDisarmMsg is the deferred disarm signal scheduled when the user first
+// presses Ctrl+C. It carries the generation it was scheduled under; the
+// handler ignores it if the user has since re-armed (gen advanced) or
+// already disarmed by typing another key.
+type ctrlCDisarmMsg struct {
+	gen int
+}
 
 // blockKind identifies the type of rendered block in the output log.
 type blockKind int
@@ -140,12 +155,16 @@ type Model struct {
 	// can see their request is being acted on even if the agent is still
 	// mid-tool.
 	cancelling bool
-	// ctrlCArmed is true after the first Ctrl+C press, until any other key is
-	// seen. While armed the footer hint reads "Press Ctrl+C again to exit" and
-	// a second Ctrl+C quits. The first press also acts like ESC when busy:
-	// posts user_cancel upstream so users don't need to learn ESC to abort a
-	// turn. Any other keypress disarms.
+	// ctrlCArmed is true after the first Ctrl+C (or Ctrl+D) press, until any
+	// other key is seen or the timeout fires. While armed the footer hint
+	// reads "Press Ctrl+C again to exit" and a second press quits. The first
+	// press also acts like ESC when busy: posts user_cancel upstream so users
+	// don't need to learn ESC to abort a turn. Any other keypress disarms.
 	ctrlCArmed bool
+	// ctrlCArmGen increments each time ctrlCArmed flips on. Disarm ticks
+	// scheduled for an earlier arm carry the older gen, so a fresh arm racing
+	// with a stale tick is not silently disarmed.
+	ctrlCArmGen int
 }
 
 var (
@@ -258,28 +277,44 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.rebuildContent()
 
+	case ctrlCDisarmMsg:
+		// Stale tick: the user already pressed another key (gen still
+		// matches but ctrlCArmed=false) or re-armed (gen advanced). Either
+		// way, leave the current state alone.
+		if msg.gen == m.ctrlCArmGen && m.ctrlCArmed {
+			m.ctrlCArmed = false
+			m.rebuildContent()
+		}
+		return m, nil
+
 	case tea.KeyMsg:
-		if msg.Type == tea.KeyCtrlC {
+		// Ctrl+D mirrors Ctrl+C: same arm/quit gate, same cancel-when-busy
+		// semantics. Two bindings is friendlier than picking one and forcing
+		// users to discover it.
+		if msg.Type == tea.KeyCtrlC || msg.Type == tea.KeyCtrlD {
 			if m.ctrlCArmed {
 				return m, tea.Quit
 			}
 			m.ctrlCArmed = true
+			m.ctrlCArmGen++
+			disarmCmd := m.scheduleCtrlCDisarm()
 			// First press doubles as a cancel when the agent is mid-turn, so
 			// users who reach for Ctrl+C don't need to learn ESC to abort.
 			// Same guards as the ESC handler below.
 			if m.busy && !m.pendingApproval && !m.cancelling {
 				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
 				m.cancelling = true
-				cmd := m.showBusy("Cancelling...", shimmerVerb)
+				cancelCmd := m.showBusy("Cancelling...", shimmerVerb)
 				m.rebuildContent()
-				return m, cmd
+				return m, tea.Batch(cancelCmd, disarmCmd)
 			}
 			m.rebuildContent()
-			return m, nil
+			return m, disarmCmd
 		}
 		// Any other key disarms the second-press-to-exit prompt. Keeps the
-		// "two Ctrl+C in a row" semantics tight: a stray keystroke between
-		// presses goes back to needing two presses again.
+		// "two presses in a row" semantics tight: a stray keystroke between
+		// presses goes back to needing two presses again. The pending tick
+		// will fire later but no-op because ctrlCArmed is already false.
 		m.ctrlCArmed = false
 
 		// Shift+Tab toggles plan mode. The toggle must run before the approval
@@ -704,6 +739,17 @@ func (m *Model) appendBlock(b block) {
 		return
 	}
 	m.blocks = append(m.blocks, b)
+}
+
+// scheduleCtrlCDisarm returns a tea.Cmd that, after ctrlCArmTimeout, posts a
+// ctrlCDisarmMsg tagged with the current arm generation. The Update handler
+// ignores stale ticks (gen mismatch or already-disarmed state) so a rapid
+// arm → disarm → re-arm sequence remains correct.
+func (m *Model) scheduleCtrlCDisarm() tea.Cmd {
+	gen := m.ctrlCArmGen
+	return tea.Tick(ctrlCArmTimeout, func(time.Time) tea.Msg {
+		return ctrlCDisarmMsg{gen: gen}
+	})
 }
 
 // sendOut is a non-blocking send on the outbound channel. Returns true on

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -140,6 +140,12 @@ type Model struct {
 	// can see their request is being acted on even if the agent is still
 	// mid-tool.
 	cancelling bool
+	// ctrlCArmed is true after the first Ctrl+C press, until any other key is
+	// seen. While armed the footer hint reads "Press Ctrl+C again to exit" and
+	// a second Ctrl+C quits. The first press also acts like ESC when busy:
+	// posts user_cancel upstream so users don't need to learn ESC to abort a
+	// turn. Any other keypress disarms.
+	ctrlCArmed bool
 }
 
 var (
@@ -254,8 +260,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyCtrlC {
-			return m, tea.Quit
+			if m.ctrlCArmed {
+				return m, tea.Quit
+			}
+			m.ctrlCArmed = true
+			// First press doubles as a cancel when the agent is mid-turn, so
+			// users who reach for Ctrl+C don't need to learn ESC to abort.
+			// Same guards as the ESC handler below.
+			if m.busy && !m.pendingApproval && !m.cancelling {
+				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
+				m.cancelling = true
+				cmd := m.showBusy("Cancelling...", shimmerVerb)
+				m.rebuildContent()
+				return m, cmd
+			}
+			m.rebuildContent()
+			return m, nil
 		}
+		// Any other key disarms the second-press-to-exit prompt. Keeps the
+		// "two Ctrl+C in a row" semantics tight: a stray keystroke between
+		// presses goes back to needing two presses again.
+		m.ctrlCArmed = false
 
 		// Shift+Tab toggles plan mode. The toggle must run before the approval
 		// and busy guards so users can flip the indicator at any point in the
@@ -545,14 +570,20 @@ func (m Model) View() string {
 	// code doesn't need to track hint-line count.
 	hintText := "enter to send · shift+tab to toggle plan mode · ctrl+c to quit"
 	if m.busy {
-		hintText = "agent is working · enter disabled · ctrl+c to quit"
+		hintText = "agent is working · enter disabled · esc or ctrl+c to cancel"
 	}
 	hint := "  "
 	if m.planMode {
 		hint += planAccentStyle.Render("⏸ plan mode")
 		hintText = " · " + hintText
 	}
-	hint += inputHintStyle.Render(hintText)
+	if m.ctrlCArmed {
+		// Override everything else: this is a transient prompt, the user just
+		// pressed Ctrl+C and needs to see what a second press will do.
+		hint = "  " + inputHintStyle.Render("Press Ctrl+C again to exit")
+	} else {
+		hint += inputHintStyle.Render(hintText)
+	}
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		m.viewport.View(),

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -307,16 +307,98 @@ func TestModel_Update_WindowSize_MinimumViewportHeight(t *testing.T) {
 	assert.GreaterOrEqual(t, um.viewport.Height, 1)
 }
 
-func TestModel_Update_KeyCtrlC_ReturnsQuit(t *testing.T) {
+func TestModel_Update_KeyCtrlC_TwoPressesQuit(t *testing.T) {
 	t.Parallel()
 
+	// First Ctrl+C arms the "press again to exit" prompt without quitting,
+	// matching the cancel-vs-quit semantics requested in pulumi-service#42029.
+	// Only a second Ctrl+C in a row produces tea.QuitMsg.
 	m := NewModel(ModelConfig{})
-	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
-	require.NotNil(t, cmd)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um := updated.(Model)
+	assert.True(t, um.ctrlCArmed, "first Ctrl+C must arm the second-press-to-exit prompt")
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			_, isQuit := msg.(tea.QuitMsg)
+			assert.False(t, isQuit, "first Ctrl+C must not quit")
+		}
+	}
+	assert.Contains(t, um.View(), "Press Ctrl+C again to exit",
+		"footer must surface the second-press-to-exit hint")
 
-	// Running the returned Cmd should surface tea.QuitMsg.
+	// Second Ctrl+C in a row quits.
+	_, cmd = um.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	require.NotNil(t, cmd)
 	_, ok := cmd().(tea.QuitMsg)
-	assert.True(t, ok, "Ctrl-C must produce a tea.QuitMsg")
+	assert.True(t, ok, "second consecutive Ctrl+C must produce a tea.QuitMsg")
+}
+
+func TestModel_Update_KeyCtrlC_FirstPressCancelsWhenBusy(t *testing.T) {
+	t.Parallel()
+
+	// First Ctrl+C while the agent is mid-turn must mirror ESC: post a
+	// user_cancel upstream and flip the cancelling flag, while still arming
+	// the second-press-to-exit prompt.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um := updated.(Model)
+	assert.True(t, um.ctrlCArmed, "Ctrl+C must arm the exit prompt")
+	assert.True(t, um.cancelling, "Ctrl+C while busy must trigger cancellation")
+	assert.True(t, um.busy, "spinner stays on until the backend confirms")
+
+	select {
+	case ev := <-outCh:
+		c, ok := ev.event.(apitype.AgentUserEventCancel)
+		require.True(t, ok, "Ctrl+C must post an AgentUserEventCancel, got %T", ev.event)
+		assert.Equal(t, userEventUserCancel, c.Type)
+	default:
+		t.Fatal("Ctrl+C while busy did not post a cancel event")
+	}
+
+	idx := um.findBlockKind(blockBusy)
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, "Cancelling...", um.blocks[idx].label)
+}
+
+func TestModel_Update_KeyCtrlC_OtherKeyDisarms(t *testing.T) {
+	t.Parallel()
+
+	// A keystroke between the two Ctrl+C presses resets the gate. Without
+	// this, an idle session could be exited by a Ctrl+C now and another one
+	// minutes later — the user would have lost the "press again" context.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um := updated.(Model)
+	require.True(t, um.ctrlCArmed)
+
+	updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	um = updated.(Model)
+	assert.False(t, um.ctrlCArmed, "any other key must disarm the exit prompt")
+	assert.NotContains(t, um.View(), "Press Ctrl+C again to exit")
+
+	// Another Ctrl+C now arms again rather than quitting.
+	_, cmd := um.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		if msg := cmd(); msg != nil {
+			_, isQuit := msg.(tea.QuitMsg)
+			assert.False(t, isQuit, "Ctrl+C after disarm must not quit")
+		}
+	}
+}
+
+func TestModel_View_BusyHintMentionsCancelKeys(t *testing.T) {
+	t.Parallel()
+
+	// Per pulumi-service#42029 the busy footer must surface both ways to
+	// abort a turn so the affordance isn't hidden behind a key the user has
+	// to discover.
+	busy := NewModel(ModelConfig{Busy: true})
+	view := busy.View()
+	assert.Contains(t, view, "esc")
+	assert.Contains(t, view, "ctrl+c")
+	assert.Contains(t, view, "cancel")
 }
 
 func TestModel_Update_KeyEnter_WhileBusy_SwallowsAndDoesNotSend(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -388,6 +388,103 @@ func TestModel_Update_KeyCtrlC_OtherKeyDisarms(t *testing.T) {
 	}
 }
 
+func TestModel_Update_KeyCtrlC_TimeoutDisarms(t *testing.T) {
+	t.Parallel()
+
+	// The "press again to exit" gate must auto-disarm after a brief window so
+	// it doesn't silently linger across a long idle. The first press schedules
+	// a ctrlCDisarmMsg tagged with the current arm gen; receiving that msg
+	// while still armed at the same gen flips ctrlCArmed back off.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um := updated.(Model)
+	require.True(t, um.ctrlCArmed)
+	gen := um.ctrlCArmGen
+
+	updated2, _ := um.Update(ctrlCDisarmMsg{gen: gen})
+	um2 := updated2.(Model)
+	assert.False(t, um2.ctrlCArmed, "disarm tick at the current gen must clear the arm")
+	assert.NotContains(t, um2.View(), "Press Ctrl+C again to exit")
+}
+
+func TestModel_Update_KeyCtrlC_StaleDisarmIgnored(t *testing.T) {
+	t.Parallel()
+
+	// A disarm tick from an earlier arm cycle must not clear a fresh arm.
+	// Mechanism: arm, type a key (disarms locally and leaves the old tick
+	// in flight), arm again (gen advances). Delivering the old tick now
+	// must be a no-op because its gen no longer matches.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um := updated.(Model)
+	staleGen := um.ctrlCArmGen
+
+	updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	um = updated.(Model)
+	require.False(t, um.ctrlCArmed)
+
+	updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um = updated.(Model)
+	require.True(t, um.ctrlCArmed)
+	require.Greater(t, um.ctrlCArmGen, staleGen, "re-arm must advance the generation")
+
+	updated, _ = um.Update(ctrlCDisarmMsg{gen: staleGen})
+	um = updated.(Model)
+	assert.True(t, um.ctrlCArmed, "stale-gen disarm tick must not clear a fresh arm")
+}
+
+func TestModel_Update_KeyCtrlD_BehavesLikeCtrlC(t *testing.T) {
+	t.Parallel()
+
+	// Ctrl+D is wired as an alias for Ctrl+C — same two-press quit gate, same
+	// cancel-when-busy semantics — so users who reach for either binding to
+	// exit get the same behaviour.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	um := updated.(Model)
+	assert.True(t, um.ctrlCArmed, "first Ctrl+D must arm the second-press-to-exit prompt")
+	assert.Contains(t, um.View(), "Press Ctrl+C again to exit",
+		"footer hint must surface even when the first press was Ctrl+D")
+
+	_, cmd := um.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	require.NotNil(t, cmd)
+	_, ok := cmd().(tea.QuitMsg)
+	assert.True(t, ok, "second consecutive Ctrl+D must produce a tea.QuitMsg")
+
+	// Also verify the cross-binding case: Ctrl+C followed by Ctrl+D quits.
+	m2 := NewModel(ModelConfig{})
+	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	um2 := updated2.(Model)
+	require.True(t, um2.ctrlCArmed)
+	_, cmd2 := um2.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	require.NotNil(t, cmd2)
+	_, ok = cmd2().(tea.QuitMsg)
+	assert.True(t, ok, "Ctrl+C then Ctrl+D must quit just like two Ctrl+Cs")
+}
+
+func TestModel_Update_KeyCtrlD_FirstPressCancelsWhenBusy(t *testing.T) {
+	t.Parallel()
+
+	// Ctrl+D while busy mirrors Ctrl+C: post a user_cancel upstream, flip
+	// the cancelling flag, and arm the second-press-to-exit prompt.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	um := updated.(Model)
+	assert.True(t, um.ctrlCArmed)
+	assert.True(t, um.cancelling, "Ctrl+D while busy must trigger cancellation")
+
+	select {
+	case ev := <-outCh:
+		c, ok := ev.event.(apitype.AgentUserEventCancel)
+		require.True(t, ok, "Ctrl+D must post an AgentUserEventCancel, got %T", ev.event)
+		assert.Equal(t, userEventUserCancel, c.Type)
+	default:
+		t.Fatal("Ctrl+D while busy did not post a cancel event")
+	}
+}
+
 func TestModel_View_BusyHintMentionsCancelKeys(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Makes cancellation in the `pulumi neo` TUI more discoverable and gives Ctrl+C a familiar two-press semantics.

- First `Ctrl+C` while the agent is mid-turn now mirrors `Esc`: posts `user_cancel` upstream, flips into the `Cancelling...` substate.
- First `Ctrl+C` always arms a `Press Ctrl+C again to exit` footer prompt; a second consecutive `Ctrl+C` quits.
- Any other keystroke disarms, so a stray key between presses goes back to needing two presses.
- Busy-state footer now reads `agent is working · enter disabled · esc or ctrl+c to cancel` so cancellation is visible without having to learn `Esc`.

One judgement call: an idle (non-busy) `Ctrl+C` now also requires two presses to exit, which changes the previous "instant quit" behaviour. I went this way for consistency with the issue's "double Ctrl+C should still be interrupt" line — happy to flip it back to instant-quit-when-idle if reviewers prefer.

Fixes pulumi/pulumi-service#42029

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes

New unit tests in `pkg/cmd/pulumi/neo/tui_test.go`:
- `TestModel_Update_KeyCtrlC_TwoPressesQuit` - first arms, second quits, footer surfaces the prompt
- `TestModel_Update_KeyCtrlC_FirstPressCancelsWhenBusy` - posts `AgentUserEventCancel` and sets cancelling state
- `TestModel_Update_KeyCtrlC_OtherKeyDisarms` - intermediate keystroke resets the gate
- `TestModel_View_BusyHintMentionsCancelKeys` - busy footer mentions both `esc` and `ctrl+c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)