### PR TITLE
chore(cli/neo): drop themed thinking verbs

### DIFF
--- a/changelog/pending/20260428--cli-neo--simplify-thinking-indicator-to-just-thinking.yaml
+++ b/changelog/pending/20260428--cli-neo--simplify-thinking-indicator-to-just-thinking.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/neo
+  description: Simplify the busy indicator to always show "Thinking..." instead of occasionally rotating in Pulumi-themed verbs (Puluminating, Cloudforming, etc.).

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -210,7 +210,7 @@ func NewModel(cfg ModelConfig) Model {
 	if cfg.Busy {
 		m.blocks = append(m.blocks, block{
 			kind:    blockBusy,
-			label:   pickThinkingVerb() + "...",
+			label:   thinkingLabel,
 			shimmer: shimmerVerb,
 		})
 	}
@@ -334,7 +334,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					raw:      denialMsg,
 				})
 				if approved {
-					cmd := m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
+					cmd := m.showBusy(thinkingLabel, shimmerVerb)
 					m.rebuildContent()
 					return m, cmd
 				}
@@ -373,7 +373,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// committed to the dispatcher and any later Shift+Tab
 					// would be a no-op on the server.
 					m.messageSent = true
-					return m, m.showBusy(pickThinkingVerb()+"...", shimmerVerb)
+					return m, m.showBusy(thinkingLabel, shimmerVerb)
 				}
 			}
 			return m, nil
@@ -629,11 +629,11 @@ func (m *Model) labelForUIEvent(ev UIEvent) (string, shimmerKind, bool) {
 	case UIToolProgress:
 		return toolLabel(e.Name, nil) + ": " + truncate(e.Message, 60), shimmerWave, true
 	case UIToolCompleted:
-		return pickThinkingVerb() + "...", shimmerVerb, true
+		return thinkingLabel, shimmerVerb, true
 	case UIAssistantMessage:
 		// Only reached when non-final (streaming) or when IsFinal=true with
 		// pending CLI work — i.e. the agent is still working.
-		return pickThinkingVerb() + "...", shimmerVerb, true
+		return thinkingLabel, shimmerVerb, true
 	case UIAwaitingApprovals:
 		return "Awaiting approvals...", shimmerVerb, true
 	case UIContextCompression:

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -85,7 +85,7 @@ func TestBusy_NoFlickerOnCLIToolHandoff(t *testing.T) {
 	model, _ = model.Update(UIToolProgress{Name: "filesystem__read", Message: "reading"})
 	assert.True(t, model.(Model).busy)
 
-	// Step 4: first tool completes; inter-tool gap uses a thinking verb.
+	// Step 4: first tool completes; inter-tool gap shows the thinking label.
 	model, _ = model.Update(UIToolCompleted{Name: "filesystem__read", Args: json.RawMessage(`{"file_path":"/x"}`)})
 	assert.True(t, model.(Model).busy)
 
@@ -164,8 +164,8 @@ func TestBusy_CancellingSubstate(t *testing.T) {
 	require.NotEqual(t, -1, idx)
 	assert.Equal(t, "Cancelling...", m.blocks[idx].label)
 
-	// Any non-final event while cancelling keeps the cancelling label, not a
-	// fresh thinking verb or tool label.
+	// Any non-final event while cancelling keeps the cancelling label, not the
+	// thinking label or a tool label.
 	model, _ = model.Update(UIToolStarted{Name: "filesystem__read"})
 	m = model.(Model)
 	idx = m.findBlockKind(blockBusy)

--- a/pkg/cmd/pulumi/neo/tui_shimmer.go
+++ b/pkg/cmd/pulumi/neo/tui_shimmer.go
@@ -15,27 +15,14 @@
 package neo
 
 import (
-	"math/rand"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 )
 
-// thinkingVerbs contains Pulumi-themed verbs for the thinking indicator.
-var thinkingVerbs = []string{
-	"Puluminating", "Cloudforming", "Driftifying", "Ephemerizing",
-	"Stacking", "Reconcifying", "Planifesting", "Speculating",
-	"Dreamforming", "Outputting", "Resourcifying", "Providering",
-	"Previewizing", "Pipelining", "Summoning", "Materializing", "Crunching",
-}
-
-// pickThinkingVerb returns a thinking verb: 60% "Thinking", 40% random themed.
-func pickThinkingVerb() string {
-	if rand.Intn(5) < 3 { //nolint:gosec
-		return "Thinking"
-	}
-	return thinkingVerbs[rand.Intn(len(thinkingVerbs))] //nolint:gosec
-}
+// thinkingLabel is the label shown by the busy indicator while the agent is
+// thinking (i.e. between tools, after a streaming message, etc.).
+const thinkingLabel = "Thinking..."
 
 // shimmerKind selects how a busy block's label is animated.
 type shimmerKind int

--- a/pkg/cmd/pulumi/neo/tui_shimmer_test.go
+++ b/pkg/cmd/pulumi/neo/tui_shimmer_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // containsAllRunes returns true if every rune in want appears in s. Lipgloss
@@ -32,35 +31,6 @@ func containsAllRunes(s, want string) bool {
 		}
 	}
 	return true
-}
-
-func TestPickThinkingVerb(t *testing.T) {
-	t.Parallel()
-
-	// Every draw must be either "Thinking" or one of the curated themed verbs —
-	// the function must never leak an out-of-list string (e.g. from a slice
-	// index off-by-one after the list is edited). With the global math/rand
-	// auto-seeded, 200 draws are enough to hit both the 60% "Thinking" branch
-	// and the 40% themed branch with overwhelming probability; the allowlist
-	// check itself is deterministic regardless of the seed.
-	allowed := map[string]bool{"Thinking": true}
-	for _, v := range thinkingVerbs {
-		allowed[v] = true
-	}
-
-	sawThinking := false
-	sawThemed := false
-	for range 200 {
-		got := pickThinkingVerb()
-		require.True(t, allowed[got], "unexpected verb: %q", got)
-		if got == "Thinking" {
-			sawThinking = true
-		} else {
-			sawThemed = true
-		}
-	}
-	assert.True(t, sawThinking, "expected at least one \"Thinking\" draw in 200 iterations")
-	assert.True(t, sawThemed, "expected at least one themed-verb draw in 200 iterations")
 }
 
 func TestShimmerLabel_EmptyText(t *testing.T) {


### PR DESCRIPTION
## Summary

- Always show `Thinking...` in the busy indicator instead of occasionally rotating in Pulumi-themed verbs (`Puluminating`, `Cloudforming`, `Driftifying`, etc.).
- Replaces `pickThinkingVerb` and the `thinkingVerbs` list with a single `thinkingLabel` constant; drops the now-unneeded `math/rand` use in `tui_shimmer.go`.
- Removes `TestPickThinkingVerb`, prunes the unused `require` import in `tui_shimmer_test.go`, and updates a couple of stale comments in `tui_busy_test.go` that referred to the "thinking verb".

## Test plan

- [x] `go test ./cmd/pulumi/neo/...` (from `pkg/`)
- [x] `golangci-lint run ./cmd/pulumi/neo/...`
- [x] `go vet ./cmd/pulumi/neo/...`
- [x] `make format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)