### PR TITLE
Refactor pulumi neo to be an inline program

### DIFF
--- a/changelog/pending/20260429--cli-neo--refactor-tui-as-an-inline-program.yaml
+++ b/changelog/pending/20260429--cli-neo--refactor-tui-as-an-inline-program.yaml
@@ -1,0 +1,9 @@
+changes:
+- type: improvement
+  scope: cli/neo
+  description: |
+    Run the experimental `pulumi neo` TUI inline instead of in an alt-screen.
+    Completed blocks (user messages, tool results, assistant replies, pulumi
+    ops, errors, warnings) are committed to terminal scrollback as they
+    finish, and the full transcript remains visible in the terminal after
+    the session exits.

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -189,10 +189,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		InitialPrompt: prompt,
 	})
 
-	p := tea.NewProgram(model,
-		tea.WithAltScreen(),
-		tea.WithMouseCellMotion(),
-	)
+	// Inline (non-alt-screen) so the transcript stays in the user's terminal
+	// scrollback after exit.
+	p := tea.NewProgram(model)
 
 	g, gctx := errgroup.WithContext(ctx)
 

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -528,11 +528,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case UIAssistantMessage:
-		// A truly-final message closes out any in-flight streaming block. The
-		// final-marker append is guarded because IsFinal=true can arrive with
-		// empty content (e.g. a hand-off that became final once the server
-		// reconciled pending tool calls) and we don't want a phantom marker.
-		if msg.IsFinal && !msg.HasPendingCLIWork {
+		// Any IsFinal=true assistant_message is a complete utterance and must be
+		// committed to scrollback — including hand-offs (HasPendingCLIWork=true),
+		// where the agent's commentary precedes a CLI tool call. HasPendingCLIWork
+		// only governs busy-state management (see applyBusyForEvent); it must not
+		// gate commit, otherwise hand-off commentary lives only in the live frame
+		// and is overwritten by the next hand-off / final message.
+		// The empty-content guard avoids a phantom marker for is_final=true
+		// messages that arrive with no text (e.g. a server-side hand-off finalized
+		// once tool calls were reconciled).
+		if msg.IsFinal {
 			m.removeBlockKind(blockAssistantStreaming)
 			if msg.Content != "" {
 				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -18,21 +18,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
-	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/wordwrap"
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
-
-// inputBarHeight is the number of terminal lines reserved for the input area
-// (separator + input line + hint line).
-const inputBarHeight = 3
 
 // ctrlCArmTimeout is how long the "press Ctrl+C again to exit" gate stays
 // armed after the first press. Matches the cadence other agent CLIs use so
@@ -145,13 +140,24 @@ type ModelConfig struct {
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
+//
+// The TUI runs inline (no alt-screen). Completed blocks (user messages, tool
+// completions, final assistant replies, errors, warnings, finished pulumi ops)
+// are committed to terminal scrollback via tea.Println as soon as they reach a
+// terminal state. Only "live" blocks render in the bubbletea frame above the
+// input bar: the busy spinner, an in-flight streaming assistant message, and
+// an in-flight pulumi op that hasn't received UIPulumiEnd yet.
 type Model struct {
 	welcome   welcomeModel
-	viewport  viewport.Model
 	textInput textinput.Model
 	blocks    []block
 	eventCh   <-chan UIEvent
 	outCh     chan<- outboundEvent
+	// sizeReceived flips on the first WindowSizeMsg. The first resize is also
+	// the moment we know the terminal width, so it's when we emit the welcome
+	// banner and any pre-seeded committed blocks (e.g. an InitialPrompt user
+	// message) to scrollback.
+	sizeReceived bool
 	// busy is true from the moment the user sends a message (or a prompt was
 	// provided up front) until the session emits UITaskIdle / UICancelled /
 	// UIError. While busy, Enter is swallowed so the user can't talk over
@@ -206,7 +212,6 @@ type Model struct {
 }
 
 var (
-	inputSepStyle  = lipgloss.NewStyle().Faint(true)
 	inputHintStyle = lipgloss.NewStyle().Faint(true)
 	promptStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 	errorStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
@@ -220,6 +225,32 @@ var (
 	// and the "Proposed plan" block header so they read as the same visual cue.
 	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 )
+
+// renderLeftBracket decorates content with a left-only bracket border: a
+// "╭─" tick above the first content line, a "│ " prefix on every content
+// line, and a "╰─" tick below the last line. The right edge and full
+// horizontal bars are intentionally omitted so no rendered line ever
+// stretches across the terminal width — that would wrap on resize-shrink
+// and corrupt bubbletea's inline-renderer line accounting (see View() for
+// context). All bracket glyphs are colored via borderStyle.
+//
+// Empty content collapses to two corner ticks ("╭─" / "╰─") with no body.
+func renderLeftBracket(borderStyle lipgloss.Style, content string) string {
+	bar := borderStyle.Render("│")
+	topTick := borderStyle.Render("╭─")
+	bottomTick := borderStyle.Render("╰─")
+
+	body := strings.TrimRight(content, "\n")
+	out := make([]string, 0, 2)
+	out = append(out, topTick)
+	if body != "" {
+		for line := range strings.SplitSeq(body, "\n") {
+			out = append(out, bar+" "+line)
+		}
+	}
+	out = append(out, bottomTick)
+	return strings.Join(out, "\n")
+}
 
 // renderIndented word-wraps content (ANSI-safe) to termWidth minus the
 // 2-space transcript gutter, or returns un-wrapped if the width is too
@@ -240,16 +271,6 @@ func NewModel(cfg ModelConfig) Model {
 	ti.Focus()
 	ti.CharLimit = 4096
 
-	vp := viewport.New(80, 24-inputBarHeight)
-	// The default viewport KeyMap binds plain letters (u/d/f/b/j/k) and
-	// space to scroll actions, which collide with typing in the chat
-	// input. Restrict to PgUp/PgDn so we don't shadow system or text-input
-	// shortcuts (arrows move the cursor, Ctrl+U/Ctrl+D have terminal meanings).
-	vp.KeyMap = viewport.KeyMap{
-		PageDown: key.NewBinding(key.WithKeys("pgdown")),
-		PageUp:   key.NewBinding(key.WithKeys("pgup")),
-	}
-
 	sp := spinner.New(
 		spinner.WithSpinner(spinner.MiniDot),
 		spinner.WithStyle(lipgloss.NewStyle().Foreground(lipgloss.Color("6"))),
@@ -263,7 +284,6 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		viewport:    vp,
 		textInput:   ti,
 		eventCh:     cfg.EventCh,
 		outCh:       cfg.OutCh,
@@ -273,8 +293,10 @@ func NewModel(cfg ModelConfig) Model {
 		height:      24,
 		messageSent: cfg.MessageSent,
 	}
-	m.viewport.SetContent(m.welcome.View())
 	if cfg.InitialPrompt != "" {
+		// Render the initial-prompt block now so tests can find it via
+		// findBlockKind. The actual scrollback emission happens on the first
+		// WindowSizeMsg, when we have the real terminal width.
 		m.appendUserMessageBlock(cfg.InitialPrompt)
 		m.pendingUserEchoes = append(m.pendingUserEchoes, cfg.InitialPrompt)
 	}
@@ -302,26 +324,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		firstSize := !m.sizeReceived
+		m.sizeReceived = true
 		m.width = msg.Width
 		m.height = msg.Height
-		m.welcome.termWidth = msg.Width
-
-		vpHeight := max(msg.Height-inputBarHeight, 1)
-		m.viewport.Width = msg.Width
-		m.viewport.Height = vpHeight
-		m.textInput.Width = msg.Width - lipgloss.Width(m.textInput.Prompt) - 1
+		safeWidth := m.liveWidth()
+		m.welcome.termWidth = safeWidth
+		m.textInput.Width = max(safeWidth-lipgloss.Width(m.textInput.Prompt)-1, 1)
 
 		// Glamour's wrap width is baked in at construction, so rebuild on resize.
+		// Wrap at liveWidth-4 so glamour-rendered output (assistant finals, plan
+		// markdown) stays inside the safe live-frame width.
 		if r, err := glamour.NewTermRenderer(
 			glamour.WithStylePath("dark"),
-			glamour.WithWordWrap(msg.Width-4),
+			glamour.WithWordWrap(safeWidth-4),
 		); err == nil {
 			m.mdRenderer = r
 		}
+		// Re-render every block at the new width. Live blocks (busy / streaming /
+		// open pulumi op) get reflected in View() on the next draw; committed
+		// blocks already in scrollback don't reflow — only the initial-prompt
+		// block, queued by NewModel before the width was known, is committed
+		// here for the first time below.
 		for i := range m.blocks {
 			m.renderBlock(&m.blocks[i])
 		}
-		m.rebuildContent()
+		if firstSize {
+			cmds = append(cmds, tea.Println(m.welcome.View()))
+			for _, b := range m.blocks {
+				if isCommittedKind(b) && b.rendered != "" {
+					cmds = append(cmds, tea.Println(b.rendered))
+				}
+			}
+		}
 
 	case ctrlCDisarmMsg:
 		// Stale tick: the user already pressed another key (gen still
@@ -329,7 +364,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// way, leave the current state alone.
 		if msg.gen == m.ctrlCArmGen && m.ctrlCArmed {
 			m.ctrlCArmed = false
-			m.rebuildContent()
 		}
 		return m, nil
 
@@ -351,10 +385,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
 				m.cancelling = true
 				cancelCmd := m.showBusy("Cancelling...", shimmerVerb)
-				m.rebuildContent()
 				return m, tea.Batch(cancelCmd, disarmCmd)
 			}
-			m.rebuildContent()
 			return m, disarmCmd
 		}
 		// Any other key disarms the second-press-to-exit prompt. Keeps the
@@ -373,13 +405,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Plan mode is task-level on the wire and gets snapshotted at
 				// the moment the first message is sent. A post-send toggle
 				// would be misleading — it could not affect the task.
-				m.appendWarningBlock(
+				return m, m.appendWarningBlock(
 					"Plan mode is task-level — start a new `pulumi neo` session to change it.")
-				m.rebuildContent()
-				return m, nil
 			}
 			m.planMode = !m.planMode
-			m.rebuildContent()
 			return m, nil
 		}
 
@@ -393,9 +422,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.busy && !m.pendingApproval && !m.cancelling {
 				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
 				m.cancelling = true
-				cmd := m.showBusy("Cancelling...", shimmerVerb)
-				m.rebuildContent()
-				return m, cmd
+				return m, m.showBusy("Cancelling...", shimmerVerb)
 			}
 			return m, nil
 		}
@@ -434,18 +461,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.textInput.PromptStyle = promptStyle
 				m.textInput.Placeholder = "Send a message..."
 				m.textInput.Reset()
-				m.appendRenderedBlock(block{
+				choiceCmd := m.commitBlock(block{
 					kind:     blockApprovalChoice,
 					approved: approved,
 					raw:      denialMsg,
 				})
 				if approved {
-					cmd := m.showBusy(thinkingLabel, shimmerVerb)
-					m.rebuildContent()
-					return m, cmd
+					return m, tea.Batch(choiceCmd, m.showBusy(thinkingLabel, shimmerVerb))
 				}
-				m.rebuildContent()
-				return m, nil
+				return m, choiceCmd
 			}
 			var tiCmd tea.Cmd
 			m.textInput, tiCmd = m.textInput.Update(msg)
@@ -473,32 +497,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// the transcript before the server echoes it back. The
 					// echo is reconciled against pendingUserEchoes in the
 					// UIUserMessage handler to avoid duplicates.
-					m.appendUserMessageBlock(text)
+					userCmd := m.appendUserMessageBlock(text)
 					m.pendingUserEchoes = append(m.pendingUserEchoes, text)
 					// Freeze the plan-mode affordance: planMode has now been
 					// committed to the dispatcher and any later Shift+Tab
 					// would be a no-op on the server.
 					m.messageSent = true
-					return m, m.showBusy(thinkingLabel, shimmerVerb)
+					return m, tea.Batch(userCmd, m.showBusy(thinkingLabel, shimmerVerb))
 				}
 			}
 			return m, nil
 		}
 
-		// Pass to text input first for typing.
+		// Pass to text input for typing. The terminal's own scrollback is
+		// what the user uses to look back, so pgup/pgdn aren't forwarded.
 		var tiCmd tea.Cmd
 		m.textInput, tiCmd = m.textInput.Update(msg)
 		cmds = append(cmds, tiCmd)
-
-		// Also pass to viewport for scrolling (pgup/pgdn/etc).
-		var vpCmd tea.Cmd
-		m.viewport, vpCmd = m.viewport.Update(msg)
-		cmds = append(cmds, vpCmd)
-
-	case tea.MouseMsg:
-		var cmd tea.Cmd
-		m.viewport, cmd = m.viewport.Update(msg)
-		cmds = append(cmds, cmd)
 
 	case spinner.TickMsg:
 		if !m.busy {
@@ -510,7 +525,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Modulo a large bound keeps the int from growing unbounded across
 		// long sessions; the value itself only matters mod label length.
 		m.frame = (m.frame + 1) & 0x3fffffff
-		m.rebuildContent()
 		return m, cmd
 
 	case UIAssistantMessage:
@@ -521,7 +535,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.IsFinal && !msg.HasPendingCLIWork {
 			m.removeBlockKind(blockAssistantStreaming)
 			if msg.Content != "" {
-				m.appendRenderedBlock(block{kind: blockAssistantFinal, raw: msg.Content})
+				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
 			}
 		} else if msg.Content != "" {
 			if idx := m.findBlockKind(blockAssistantStreaming); idx >= 0 {
@@ -532,17 +546,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolStarted:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolProgress:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolCompleted:
@@ -550,43 +561,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.IsError {
 			marker = toolErrMarker
 		}
-		m.appendBlock(block{
+		cmds = append(cmds, m.commitBlock(block{
 			kind:     blockToolComplete,
 			rendered: "  " + marker + " " + styledToolLabel(msg.Name, msg.Args),
-		})
+		}))
 		// Keep the busy block alive across the inter-tool gap so the spinner
 		// stays visible while the agent decides its next move.
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIError:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.appendRenderedBlock(block{kind: blockError, raw: msg.Message})
-		m.rebuildContent()
+		cmds = append(cmds, m.commitBlock(block{kind: blockError, raw: msg.Message}))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIWarning:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.appendWarningBlock(msg.Message)
-		m.rebuildContent()
+		cmds = append(cmds, m.appendWarningBlock(msg.Message))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UICancelled:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.appendRenderedBlock(block{kind: blockCancelled, raw: "Session cancelled."})
-		m.rebuildContent()
+		cmds = append(cmds, m.commitBlock(block{kind: blockCancelled, raw: "Session cancelled."}))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UITaskIdle:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UISessionURL:
-		// Informational metadata for the welcome box — has no opinion on busy state.
+		// The welcome banner is already in scrollback by the time the task URL
+		// arrives, so emit the URL as its own line rather than re-rendering.
 		m.welcome.consoleURL = msg.URL
-		m.rebuildContent()
+		cmds = append(cmds, tea.Println("  "+inputHintStyle.Render("⟡ "+msg.URL)))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIUserMessage:
@@ -597,20 +604,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if len(m.pendingUserEchoes) > 0 && m.pendingUserEchoes[0] == msg.Content {
 			m.pendingUserEchoes = m.pendingUserEchoes[1:]
 		} else {
-			m.appendUserMessageBlock(msg.Content)
+			cmds = append(cmds, m.appendUserMessageBlock(msg.Content))
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIAwaitingApprovals:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIContextCompression:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIPulumiStart:
@@ -638,7 +642,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.renderBlock(&m.blocks[idx])
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIPulumiResource:
@@ -647,7 +650,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.renderBlock(&m.blocks[idx])
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIPulumiDiag:
@@ -661,7 +663,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.renderBlock(&m.blocks[idx])
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIPulumiEnd:
@@ -672,9 +673,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			st.err = msg.Err
 			st.done = true
 			m.renderBlock(&m.blocks[idx])
+			// done==true flips it from live to committed; emit to scrollback.
+			if rendered := m.blocks[idx].rendered; rendered != "" {
+				cmds = append(cmds, tea.Println(rendered))
+			}
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIApprovalRequest:
@@ -685,16 +689,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.pendingApprovalType == approvalTypePlanExit {
 			// The plan body is authored as markdown and lives in
 			// PlanDescription; msg.Message is just a generic intro.
-			m.appendRenderedBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription})
+			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription}))
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
 		} else {
-			m.appendRenderedBlock(block{kind: blockApprovalGeneral, raw: msg.Message})
+			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalGeneral, raw: msg.Message}))
 			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
 		}
 		m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		m.textInput.Placeholder = ""
 		m.textInput.Reset()
-		m.rebuildContent()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	default:
@@ -707,12 +710,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
-// View returns the rendered TUI: viewport on top, input bar at the bottom.
+// View returns the rendered live frame: live blocks (busy spinner, in-flight
+// streaming, in-flight pulumi op) above the input bar. Completed blocks aren't
+// drawn here — they were committed to terminal scrollback via tea.Println as
+// soon as they reached a terminal state.
 func (m Model) View() string {
-	sep := inputSepStyle.Render(strings.Repeat("─", m.width))
-	// The hint stays on a single line to keep inputBarHeight constant; the
-	// plan-mode indicator is prepended inline when active so the viewport sizing
-	// code doesn't need to track hint-line count.
 	hintText := "enter to send · shift+tab to toggle plan mode · ctrl+c to quit"
 	if m.busy {
 		hintText = "agent is working · enter disabled · esc or ctrl+c to cancel"
@@ -730,32 +732,107 @@ func (m Model) View() string {
 		hint += inputHintStyle.Render(hintText)
 	}
 
-	return lipgloss.JoinVertical(lipgloss.Left,
-		m.viewport.View(),
-		sep,
-		m.textInput.View(),
-		hint,
-	)
+	parts := make([]string, 0, 3)
+	if live := m.liveView(); live != "" {
+		parts = append(parts, live)
+	}
+	parts = append(parts, m.textInput.View(), hint)
+	return strings.Join(parts, "\n")
 }
 
-// rebuildContent concatenates the welcome box and all blocks into the viewport.
-// The busy block's spinner glyph is read from m.spinner.View() at render time
-// so the animation tracks the current frame without re-caching per block.
-func (m *Model) rebuildContent() {
-	parts := []string{m.welcome.View()}
+// liveWidth returns the width to use when rendering live-frame content. We
+// cap at 80 cols (book-readable column count) and otherwise back off the
+// real terminal width by 10 cols.
+//
+// bubbletea's inline renderer (v1.3.10 standard_renderer.go) uses logical
+// line counts, not visual rows, when issuing CursorUp(linesRendered-1)
+// before each frame. Any content that wraps to two visual rows on the new
+// terminal width — a lipgloss border at width-4, a glamour-wrapped paragraph
+// at width-4, a width-padded textinput — desyncs the cursor and stacks
+// stale frame fragments into scrollback during drag-resize.
+//
+// The 80-col cap matters because it makes resize a non-event for the
+// common case: any terminal ≥ 90 cols renders content at the same constant
+// 80 cols regardless of actual width, so dragging through that range
+// doesn't change what's on screen and the renderer never sees a wrap.
+// Below 90 cols liveWidth follows the terminal (with a 10-col cushion) so
+// content stays inside the viewport.
+func (m *Model) liveWidth() int {
+	const (
+		maxLiveWidth   = 80
+		margin         = 10
+		minUsableWidth = 40 // below this, give up the cushion to keep something visible
+	)
+	w := m.width
+	if w > maxLiveWidth+margin {
+		return maxLiveWidth
+	}
+	if w > minUsableWidth {
+		return w - margin
+	}
+	return w
+}
+
+// liveView renders only the in-flight blocks that should occupy the live
+// frame: busy spinner (always pinned at the bottom of the live region), an
+// in-flight streaming assistant message, and an open pulumi op block. The
+// busy block's spinner glyph is read from m.spinner.View() at render time so
+// the animation tracks the current frame without re-caching per block.
+//
+// We deliberately use strings.Join instead of lipgloss.JoinVertical.
+// JoinVertical pads every constituent block to the widest one's column count
+// with trailing spaces, which pins every line in the frame to the longest
+// one. On a resize-shrink those wide lines wrap, bubbletea's inline renderer
+// (v1.3.10) issues CursorUp(linesRendered-1) using the logical count instead
+// of the wrapped visual rows, and stale frame fragments leak into scrollback.
+// strings.Join keeps each line at its natural length so only genuinely-wide
+// content is at risk.
+func (m *Model) liveView() string {
+	var parts []string
 	for _, b := range m.blocks {
+		if !isLiveKind(b) {
+			continue
+		}
 		if b.kind == blockBusy {
 			parts = append(parts, "  "+m.spinner.View()+" "+shimmerLabel(b.label, b.shimmer, m.frame))
 		} else {
 			parts = append(parts, b.rendered)
 		}
 	}
-
-	wasAtBottom := m.viewport.AtBottom()
-	m.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, parts...))
-	if wasAtBottom {
-		m.viewport.GotoBottom()
+	if len(parts) == 0 {
+		return ""
 	}
+	return strings.Join(parts, "\n")
+}
+
+// isLiveKind reports whether a block belongs in the live frame (true) or has
+// been committed to terminal scrollback (false).
+func isLiveKind(b block) bool {
+	switch b.kind {
+	case blockBusy, blockAssistantStreaming:
+		return true
+	case blockPulumiOp:
+		return b.pulumi != nil && !b.pulumi.done
+	case blockToolComplete, blockAssistantFinal, blockError, blockWarning,
+		blockCancelled, blockUserMessage, blockApprovalPlan,
+		blockApprovalGeneral, blockApprovalChoice:
+		return false
+	}
+	return false
+}
+
+func isCommittedKind(b block) bool { return !isLiveKind(b) }
+
+// commitBlock renders b, appends it to m.blocks, and returns a tea.Cmd that
+// prints the rendered string as new terminal scrollback. Returns nil when the
+// block renders empty (e.g. an empty assistant final from a hand-off).
+func (m *Model) commitBlock(b block) tea.Cmd {
+	m.renderBlock(&b)
+	m.appendBlock(b)
+	if b.rendered == "" {
+		return nil
+	}
+	return tea.Println(b.rendered)
 }
 
 // applyBusyForEvent is the single point that decides whether the busy
@@ -833,12 +910,12 @@ func (m *Model) showBusy(label string, shimmer shimmerKind) tea.Cmd {
 	return m.spinner.Tick
 }
 
-func (m *Model) appendWarningBlock(msg string) {
-	m.appendRenderedBlock(block{kind: blockWarning, raw: msg})
+func (m *Model) appendWarningBlock(msg string) tea.Cmd {
+	return m.commitBlock(block{kind: blockWarning, raw: msg})
 }
 
-func (m *Model) appendUserMessageBlock(content string) {
-	m.appendRenderedBlock(block{kind: blockUserMessage, raw: content})
+func (m *Model) appendUserMessageBlock(content string) tea.Cmd {
+	return m.commitBlock(block{kind: blockUserMessage, raw: content})
 }
 
 // appendBlock appends a non-busy block, keeping any existing blockBusy
@@ -972,12 +1049,18 @@ func (m *Model) renderUserBubble(content string) string {
 	return prefix + style.Render(padded)
 }
 
-// wrapPlain word-wraps non-markdown text to the terminal width.
+// wrapPlain word-wraps non-markdown text to the safe live width (m.liveWidth)
+// so streaming text never sits at the terminal wrap boundary. We use
+// reflow's wordwrap (which only inserts \n at word boundaries) instead of
+// lipgloss.Style.Width(W).Render which also pads each line with trailing
+// spaces to W. Padding produces full-width lines that wrap on resize-shrink
+// and corrupt bubbletea's inline-renderer line accounting.
 func (m *Model) wrapPlain(text string) string {
-	if m.width <= 4 {
+	w := m.liveWidth()
+	if w <= 4 {
 		return text
 	}
-	return lipgloss.NewStyle().Width(m.width - 4).Render(text)
+	return wordwrap.String(text, w-4)
 }
 
 func (m *Model) appendRenderedBlock(b block) {

--- a/pkg/cmd/pulumi/neo/tui_pulumi.go
+++ b/pkg/cmd/pulumi/neo/tui_pulumi.go
@@ -31,18 +31,10 @@ import (
 // Diagnostics reuse the existing warning/error styles for consistency with the
 // rest of the TUI's event feed.
 var (
-	pulumiBorderOpen = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("8")).
-				Padding(0, 1)
-	pulumiBorderDone = lipgloss.NewStyle().
-				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("6")).
-				Padding(0, 1)
-	pulumiBorderErr = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("1")).
-			Padding(0, 1)
+	// Bracket border colors — see renderLeftBracket for why bracket-only.
+	pulumiBracketOpen  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	pulumiBracketDone  = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	pulumiBracketErr   = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	pulumiHeaderStyle  = lipgloss.NewStyle().Bold(true)
 	pulumiSubHeader    = lipgloss.NewStyle().Faint(true)
 	pulumiMetaStyle    = lipgloss.NewStyle().Faint(true)
@@ -158,17 +150,14 @@ func (m *Model) renderPulumiBlock(st *pulumiBlockState) string {
 		body.WriteString(pulumiStatusFailed.Render("error: "+st.err) + "\n")
 	}
 
-	// Choose the border color based on terminal state. Pad the box to fit
-	// comfortably in the viewport — subtract 4 for the border+padding glyphs.
-	style := pulumiBorderOpen
+	style := pulumiBracketOpen
 	switch {
 	case st.err != "":
-		style = pulumiBorderErr
+		style = pulumiBracketErr
 	case st.done:
-		style = pulumiBorderDone
+		style = pulumiBracketDone
 	}
-	width := max(m.width-4, 20)
-	return style.Width(width).Render(strings.TrimRight(body.String(), "\n"))
+	return renderLeftBracket(style, body.String())
 }
 
 // renderPulumiResourceLine renders one resource row with an op-colored symbol,

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -278,7 +278,7 @@ func TestModel_Init_ReturnsBatch(t *testing.T) {
 	require.NotNil(t, busy.Init())
 }
 
-func TestModel_Update_WindowSize_ResizesViewportAndBuildsRenderer(t *testing.T) {
+func TestModel_Update_WindowSize_TracksDimensionsAndBuildsRenderer(t *testing.T) {
 	t.Parallel()
 
 	m := NewModel(ModelConfig{})
@@ -287,24 +287,24 @@ func TestModel_Update_WindowSize_ResizesViewportAndBuildsRenderer(t *testing.T) 
 
 	assert.Equal(t, 100, um.width)
 	assert.Equal(t, 30, um.height)
-	assert.Equal(t, 100, um.welcome.termWidth)
-	assert.Equal(t, 100, um.viewport.Width)
-	assert.Equal(t, 30-inputBarHeight, um.viewport.Height)
+	// welcome.termWidth is the safe live-frame width: capped at 80 once the
+	// terminal exceeds 90 cols, so the banner stays at a stable 80 cols
+	// across drag-resizes through that range. See liveWidth() for rationale.
+	assert.Equal(t, 80, um.welcome.termWidth)
 	// The glamour renderer is lazily built on the first WindowSize so it can
 	// pick up the real terminal width for wrapping.
 	require.NotNil(t, um.mdRenderer)
+	assert.True(t, um.sizeReceived, "first WindowSize must flip sizeReceived")
 }
 
-func TestModel_Update_WindowSize_MinimumViewportHeight(t *testing.T) {
+func TestModel_Update_WindowSize_TinyTerminalDoesNotPanic(t *testing.T) {
 	t.Parallel()
 
-	// A terminal smaller than the input bar would give a negative viewport
-	// height; the clamp in Update guarantees at least 1 row so bubbletea
-	// doesn't panic.
+	// View must not panic on a tiny terminal.
 	m := NewModel(ModelConfig{})
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 1})
 	um := updated.(Model)
-	assert.GreaterOrEqual(t, um.viewport.Height, 1)
+	require.NotPanics(t, func() { _ = um.View() })
 }
 
 func TestModel_Update_KeyCtrlC_TwoPressesQuit(t *testing.T) {
@@ -574,29 +574,21 @@ func TestModel_Update_KeyEnter_EmptyInput_NoSend(t *testing.T) {
 func TestModel_Update_KeyRune_TypesAndDoesNotScrollViewport(t *testing.T) {
 	t.Parallel()
 
-	// The bubbles viewport's default keymap binds plain letters (u/d/f/b/j/k)
-	// and space to scroll actions. Those collide with typing in the chat
-	// input, so the model overrides the keymap to keep only non-character
-	// navigation. Regression for pulumi/pulumi-service#42025: pressing 'u'
-	// or 'd' must type into the input and leave the viewport untouched.
+	// Regression for pulumi/pulumi-service#42025: pressing plain letters
+	// (u/d/f/b/j/k) or space must type into the input rather than getting
+	// intercepted as scroll keys.
 	for _, r := range []rune{'u', 'd', 'f', 'b', 'j', 'k', ' '} {
 		t.Run(string(r), func(t *testing.T) {
 			t.Parallel()
 
 			m := NewModel(ModelConfig{})
-			// Size the viewport and seed content tall enough that scroll
-			// actions would otherwise change YOffset.
 			updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 10})
 			um := updated.(Model)
-			um.viewport.SetContent(strings.Repeat("line\n", 200))
-			um.viewport.ScrollDown(20) // scroll partway so both up- and down-style binds could move
-			startOffset := um.viewport.YOffset
 
 			updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 			um = updated.(Model)
 
 			assert.Equal(t, string(r), um.textInput.Value(), "rune must reach the text input")
-			assert.Equal(t, startOffset, um.viewport.YOffset, "rune must not move the viewport")
 		})
 	}
 }
@@ -684,7 +676,7 @@ func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 	m := newApprovalPendingModel(t, outCh)
 	m.textInput.SetValue("not on prod")
 
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	um := updated.(Model)
 
 	select {
@@ -700,7 +692,6 @@ func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 
 	assert.False(t, um.pendingApproval)
 	assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
-	assert.Nil(t, cmd, "denial must not return a spinner cmd")
 }
 
 func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {
@@ -769,19 +760,6 @@ func TestModel_Update_KeyEnter_Approval_NotGatedByBusy(t *testing.T) {
 	default:
 		t.Fatal("approval Enter must not be gated by busy")
 	}
-}
-
-func TestModel_Update_MouseMsg_ForwardsToViewport(t *testing.T) {
-	t.Parallel()
-
-	// Mouse events are routed to the viewport for scrolling. We don't introspect
-	// the viewport's internal scroll state here (it's an external bubble), just
-	// verify the dispatch doesn't panic and returns a Model — the coverage of
-	// the MouseMsg arm is the goal.
-	m := NewModel(ModelConfig{})
-	updated, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
-	_, ok := updated.(Model)
-	assert.True(t, ok)
 }
 
 func TestModel_Update_UnknownMessage_ForwardsToTextInput(t *testing.T) {
@@ -1401,29 +1379,35 @@ func TestRenderBlock_SkipsWidthIndependentBlocks(t *testing.T) {
 	assert.Equal(t, "  ⏺ Read(\"/x\")", b.rendered, "empty raw must be a no-op")
 }
 
-func TestModel_RebuildContent_HandlesMixedBlocksWithoutPanic(t *testing.T) {
+func TestModel_LiveView_OnlyShowsLiveBlocks(t *testing.T) {
 	t.Parallel()
 
-	// rebuildContent handles each blockKind plus the busy-block special case
-	// (which reads the spinner glyph at render time). Feed one of each kind so
-	// every branch of the per-block switch runs, and both the "was at bottom"
-	// and default paths get exercised across multiple invocations.
+	// In inline mode, View() draws only the live frame: the busy spinner, an
+	// in-flight streaming assistant, and an open pulumi op. Committed blocks
+	// (user messages, tool completions, finals, warnings) live in terminal
+	// scrollback and must not appear in View(). Render one of each kind so
+	// the filter is exercised, and check that committed kinds are absent
+	// from the visible View string.
 	m := NewModel(ModelConfig{})
 	m.blocks = []block{
-		{kind: blockUserMessage, rendered: "  user "},
-		{kind: blockToolComplete, rendered: "  tool ok"},
-		{kind: blockAssistantFinal, rendered: "  final"},
-		{kind: blockWarning, rendered: "  warn"},
+		{kind: blockUserMessage, rendered: "USERSCROLLBACK"},
+		{kind: blockToolComplete, rendered: "TOOLCOMPLETESCROLLBACK"},
+		{kind: blockAssistantFinal, rendered: "FINALSCROLLBACK"},
+		{kind: blockWarning, rendered: "WARNSCROLLBACK"},
+		{kind: blockAssistantStreaming, rendered: "STREAMING_LIVE", raw: "STREAMING_LIVE"},
 		{kind: blockBusy, label: "Thinking...", shimmer: shimmerVerb},
 	}
 
-	// Must not panic and must not mangle the block slice.
-	require.NotPanics(t, func() { m.rebuildContent() })
-	// Second call exercises the "not at bottom" path once scrolled up and then
-	// back down (via GotoBottom internally); simply verifying it also doesn't
-	// panic is enough — we don't reach into the viewport internals here.
-	require.NotPanics(t, func() { m.rebuildContent() })
-	require.Len(t, m.blocks, 5, "blocks slice must be untouched")
+	view := m.View()
+	// Live blocks are visible.
+	assert.Contains(t, view, "STREAMING_LIVE", "in-flight streaming must appear in View")
+	assert.Contains(t, view, "Thinking", "busy label must appear in View")
+	// Committed blocks are NOT visible — they were emitted to scrollback.
+	assert.NotContains(t, view, "USERSCROLLBACK")
+	assert.NotContains(t, view, "TOOLCOMPLETESCROLLBACK")
+	assert.NotContains(t, view, "FINALSCROLLBACK")
+	assert.NotContains(t, view, "WARNSCROLLBACK")
+	require.Len(t, m.blocks, 6, "View must not mutate the blocks slice")
 }
 
 func TestApprovalGeneralWrapsToTerminalWidth(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -840,6 +840,50 @@ func TestModel_Update_UIAssistantMessage_Final_ReplacesStreaming(t *testing.T) {
 	assert.GreaterOrEqual(t, m2.findBlockKind(blockAssistantFinal), 0, "final msg must leave a final block")
 }
 
+// TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback is a
+// regression for a bug where hand-off messages (IsFinal=true,
+// HasPendingCLIWork=true) carrying assistant commentary were rendered as a
+// streaming live-frame block and then silently overwritten by the next
+// hand-off, so the commentary never reached scrollback. Each IsFinal=true
+// message — hand-off or terminal — must commit a final block.
+func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch, Busy: true})
+
+	// First hand-off: a complete utterance preceding a tool call.
+	updated, _ := m.Update(UIAssistantMessage{
+		IsFinal: true, HasPendingCLIWork: true, Content: "I'll read the file",
+	})
+	m1 := updated.(Model)
+
+	// The streaming block is the live-frame holding pen; a hand-off must
+	// flush it and append a committed final block instead. Otherwise the
+	// next hand-off's content overwrites the streaming raw and the prior
+	// commentary is lost from scrollback.
+	assert.Equal(t, -1, m1.findBlockKind(blockAssistantStreaming),
+		"hand-off must not leave a streaming block behind")
+	idx := m1.findBlockKind(blockAssistantFinal)
+	require.GreaterOrEqual(t, idx, 0, "hand-off must commit a final assistant block")
+	assert.Equal(t, "I'll read the file", m1.blocks[idx].raw)
+
+	// Second hand-off after the tool runs: must add a second committed block,
+	// not overwrite the first.
+	updated2, _ := m1.Update(UIAssistantMessage{
+		IsFinal: true, HasPendingCLIWork: true, Content: "Now editing it",
+	})
+	m2 := updated2.(Model)
+
+	finals := 0
+	for _, b := range m2.blocks {
+		if b.kind == blockAssistantFinal {
+			finals++
+		}
+	}
+	assert.Equal(t, 2, finals, "two hand-offs must produce two committed final blocks")
+}
+
 func TestModel_Update_UIToolStarted_ShowsBusyBlock(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -16,8 +16,10 @@ package neo
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,8 +27,58 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
+
+// collectPrintln walks a tea.Cmd (potentially a Batch) and returns the bodies
+// of every tea.Println-produced message inside. tea.Println builds an
+// unexported printLineMessage{messageBody string}, so we identify it by type
+// name and read the field via reflection. This is the only way to assert
+// "what would have been written to terminal scrollback" from a unit test.
+//
+// Update arms typically bundle tea.Println cmds with a waitForEvent cmd that
+// blocks forever on the event channel — running each leaf with a short
+// timeout in a goroutine sidesteps that without the test having to know
+// which cmds are "safe" to invoke.
+func collectPrintln(cmd tea.Cmd) []string {
+	if cmd == nil {
+		return nil
+	}
+	msg, ok := runCmd(cmd)
+	if !ok {
+		return nil
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []string
+		for _, c := range batch {
+			out = append(out, collectPrintln(c)...)
+		}
+		return out
+	}
+	v := reflect.ValueOf(msg)
+	if v.Kind() == reflect.Struct && v.Type().Name() == "printLineMessage" {
+		if f := v.FieldByName("messageBody"); f.IsValid() && f.Kind() == reflect.String {
+			return []string{f.String()}
+		}
+	}
+	return nil
+}
+
+// runCmd invokes cmd in a goroutine and returns its result if it produces one
+// within a short window. waitForEvent and similar blocking cmds time out and
+// are reported as "no message" — collectPrintln then ignores them.
+func runCmd(cmd tea.Cmd) (tea.Msg, bool) {
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	select {
+	case m := <-done:
+		return m, true
+	case <-time.After(50 * time.Millisecond):
+		return nil, false
+	}
+}
 
 // -----------------------------------------------------------------------------
 // Pure helpers
@@ -1557,4 +1609,130 @@ func TestApprovalChoiceApprovedStaysSingleLine(t *testing.T) {
 	widths := visibleLines(b.rendered)
 	require.Len(t, widths, 1, "approved verdict must render on a single line: %q", b.rendered)
 	assert.Contains(t, b.rendered, "Approved")
+}
+
+func TestModel_LiveView_PulumiOpLiveVsCommitted(t *testing.T) {
+	t.Parallel()
+
+	// In inline mode, an open pulumi op block (done==false) belongs in the
+	// live frame above the input. Once UIPulumiEnd fires it flips to done==true
+	// and its rendered string is committed to scrollback via tea.Println — at
+	// that point it must drop out of View(). A future refactor that flips
+	// isLiveKind's pulumi predicate would either double-print the block (live
+	// frame + scrollback) or drop the running summary entirely.
+	m := NewModel(ModelConfig{})
+	m.blocks = []block{
+		{kind: blockPulumiOp, rendered: "PULUMI_OPEN_LIVE", pulumi: &pulumiBlockState{done: false}},
+		{kind: blockPulumiOp, rendered: "PULUMI_DONE_SCROLLBACK", pulumi: &pulumiBlockState{done: true}},
+	}
+
+	view := m.View()
+	assert.Contains(t, view, "PULUMI_OPEN_LIVE",
+		"open pulumi op (done=false) must appear in the live frame")
+	assert.NotContains(t, view, "PULUMI_DONE_SCROLLBACK",
+		"finalized pulumi op (done=true) must not appear in View — it was committed to scrollback")
+}
+
+func TestModel_Update_FirstWindowSize_EmitsWelcomeAndInitialPromptToScrollback(t *testing.T) {
+	t.Parallel()
+
+	// NewModel queues an InitialPrompt as a committed user-message block but
+	// can't emit it yet — the welcome banner needs the real terminal width
+	// first. The first WindowSizeMsg is the moment we know the width, so it
+	// must (a) tea.Println the welcome banner and (b) tea.Println every
+	// pre-seeded committed block. Subsequent WindowSizeMsgs must NOT re-emit;
+	// otherwise resizing the terminal would stack duplicate banners into
+	// scrollback.
+	m := NewModel(ModelConfig{InitialPrompt: "deploy prod"})
+	require.False(t, m.sizeReceived, "fresh model has not received a size yet")
+
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	um := updated.(Model)
+	assert.True(t, um.sizeReceived, "first WindowSize must flip sizeReceived")
+
+	printed := collectPrintln(cmd)
+	welcomeMatches := 0
+	promptMatches := 0
+	for _, line := range printed {
+		if strings.Contains(line, "Pulumi Neo") {
+			welcomeMatches++
+		}
+		if strings.Contains(line, "deploy prod") {
+			promptMatches++
+		}
+	}
+	assert.Equal(t, 1, welcomeMatches, "welcome banner must reach scrollback exactly once; got: %v", printed)
+	assert.Equal(t, 1, promptMatches, "InitialPrompt user block must reach scrollback exactly once; got: %v", printed)
+
+	// A subsequent WindowSizeMsg is just a resize — no new scrollback.
+	_, cmd2 := um.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	printed2 := collectPrintln(cmd2)
+	for _, line := range printed2 {
+		assert.NotContains(t, line, "Pulumi Neo", "second resize must not re-emit the welcome banner")
+		assert.NotContains(t, line, "deploy prod", "second resize must not re-emit the initial-prompt block")
+	}
+}
+
+func TestModel_Update_UIPulumiEnd_CommitsRenderedToScrollback(t *testing.T) {
+	t.Parallel()
+
+	// UIPulumiEnd flips the open pulumi op block to done==true (live →
+	// committed) and emits its rendered form via tea.Println so the final
+	// summary lives in terminal scrollback. Without this emission, a finished
+	// pulumi run would silently disappear from view (it leaves the live frame
+	// the moment done flips, but never gets printed above).
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = updated0.(Model)
+
+	updated1, _ := m.Update(UIPulumiStart{
+		ToolName: "pulumi__pulumi_preview", StackName: "dev", IsPreview: true,
+	})
+	m = updated1.(Model)
+	updated2, _ := m.Update(UIPulumiResource{
+		ToolName: "pulumi__pulumi_preview",
+		Op:       deploy.OpCreate,
+		URN:      "urn:pulumi:dev::p::aws:s3/Bucket::b",
+		Type:     "aws:s3/Bucket",
+		Status:   "planned",
+	})
+	m = updated2.(Model)
+
+	_, endCmd := m.Update(UIPulumiEnd{
+		ToolName: "pulumi__pulumi_preview",
+		Counts:   display.ResourceChanges{deploy.OpCreate: 1},
+		Elapsed:  "1.2s",
+	})
+
+	printed := collectPrintln(endCmd)
+	matches := 0
+	for _, line := range printed {
+		if strings.Contains(line, "PulumiPreview") {
+			matches++
+		}
+	}
+	assert.GreaterOrEqual(t, matches, 1,
+		"UIPulumiEnd must tea.Println the rendered pulumi block; got: %v", printed)
+}
+
+func TestModel_WrapPlain_TinyWidthShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	// wrapPlain backs off to identity when liveWidth <= 4 — wordwrap.String
+	// with a non-positive boundary has historically panicked or produced
+	// off-by-one breakage in some reflow versions. The guard exists so a
+	// pathologically narrow terminal doesn't crash the TUI.
+	long := "a fairly long sentence that would otherwise wrap"
+
+	m := NewModel(ModelConfig{})
+	m.width = 1 // liveWidth returns m.width directly when below minUsableWidth
+	require.LessOrEqual(t, m.liveWidth(), 4, "test relies on tiny liveWidth path")
+	assert.Equal(t, long, m.wrapPlain(long), "tiny-width path must return input verbatim")
+
+	// Sanity: at a normal width, wrapPlain inserts at least one newline so
+	// we know the short-circuit isn't accidentally absorbing every input.
+	m.width = 100
+	wrapped := m.wrapPlain(strings.Repeat("word ", 30))
+	assert.Contains(t, wrapped, "\n", "normal-width path must wrap into multiple lines")
 }

--- a/pkg/cmd/pulumi/neo/tui_welcome.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome.go
@@ -90,9 +90,10 @@ func pickGreeting(name string) string {
 	return fmt.Sprintf(templates[rand.Intn(len(templates))], boldName) //nolint:gosec
 }
 
-// View renders the welcome box with the Pulumipus mascot art.
+// View renders the welcome banner with the Pulumipus mascot art.
 func (w welcomeModel) View() string {
 	magenta := lipgloss.Color("5")
+	bracketStyle := lipgloss.NewStyle().Foreground(magenta)
 	dim := lipgloss.NewStyle().Faint(true)
 
 	displayDir := w.workDir
@@ -102,16 +103,12 @@ func (w welcomeModel) View() string {
 		}
 	}
 
-	// Total box width (incl. border) = termWidth - 2 outer indent.
-	// contentWidth = total - 2 border - 4 horizontal padding.
-	totalWidth := max(w.termWidth, 30)
-	contentWidth := max(totalWidth-2-2-4, 20)
+	// Content width caps how aggressively the info line gets truncated when
+	// path + org won't fit. The bracket gutter ("│ ") is 2 cols, and we leave
+	// another small cushion so nothing ends at the wrap boundary.
+	contentWidth := max(w.termWidth-4, 20)
 
-	titleStyle := lipgloss.NewStyle().
-		Bold(true).
-		Foreground(magenta).
-		Width(contentWidth).
-		Align(lipgloss.Center)
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(magenta)
 
 	infoText := displayDir
 	if w.org != "" {
@@ -149,11 +146,5 @@ func (w welcomeModel) View() string {
 		parts = append(parts, dim.Render("⟡ "+hyperlink))
 	}
 
-	return lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(magenta).
-		Padding(1, 2).
-		Margin(1, 0, 1, 2).
-		Width(contentWidth).
-		Render(lipgloss.JoinVertical(lipgloss.Left, parts...))
+	return renderLeftBracket(bracketStyle, strings.Join(parts, "\n"))
 }

--- a/pkg/cmd/pulumi/neo/tui_welcome_test.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome_test.go
@@ -15,10 +15,13 @@
 package neo
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeOfDayKey(t *testing.T) {
@@ -140,4 +143,51 @@ func TestWelcomeView_NarrowTerminalTruncatesPath(t *testing.T) {
 	// The org suffix must always survive truncation — it's the load-bearing
 	// context (path can be abbreviated, org cannot).
 	assert.Contains(t, out, "acme")
+}
+
+func TestWelcomeView_TildeForHomePath(t *testing.T) {
+	t.Parallel()
+
+	// Paths under $HOME are presented as "~/<rel>" so the user sees the
+	// shorter, familiar shell form rather than a long absolute path. The
+	// banner has limited horizontal real estate (capped at liveWidth ≤ 80
+	// cols) and the absolute home path is the dominant chunk on most setups.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("UserHomeDir unavailable: %v", err)
+	}
+	rel := filepath.Join("code", "neo")
+	w := welcomeModel{
+		workDir:   filepath.Join(home, rel),
+		termWidth: 120,
+		greeting:  "hi",
+	}
+	out := w.View()
+
+	require.Contains(t, out, "~/"+rel, "home-relative path must render with ~/ prefix")
+	assert.NotContains(t, out, home, "absolute home path must not appear when ~/ substitution succeeded")
+}
+
+func TestWelcomeView_NarrowTerminalTruncatesConsoleURL(t *testing.T) {
+	t.Parallel()
+
+	// Long task URLs on a narrow terminal must be ellipsized in the rendered
+	// link text. The OSC-8 hyperlink target stays the full URL — only the
+	// visible label gets truncated, so clicking still works. Without the
+	// guard, a 200-char URL would blow past the bracket gutter and ruin the
+	// banner's layout.
+	longURL := "https://app.pulumi.com/acme/neo/tasks/" + strings.Repeat("x", 200)
+	w := welcomeModel{
+		workDir:    "/tmp/proj",
+		termWidth:  60,
+		greeting:   "hi",
+		consoleURL: longURL,
+	}
+	out := w.View()
+
+	assert.Contains(t, out, "...", "long console URL must be truncated with an ellipsis")
+	assert.Contains(t, out, "\x1b]8;;", "OSC-8 hyperlink escape must still be present after truncation")
+	// The hyperlink target (escape ... URL ... ESC backslash) keeps the full URL
+	// even though the visible text is shortened — clicks land on the real task.
+	assert.Contains(t, out, longURL, "full URL must be preserved as the hyperlink target")
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lib/pq v1.10.9
 	github.com/muesli/cancelreader v0.2.2
+	github.com/muesli/reflow v0.3.0
 	github.com/natefinch/atomic v1.0.1
 	github.com/pgavlin/diff v0.0.0-20230503175810-113847418e2e
 	github.com/pgavlin/fx v0.1.6
@@ -225,7 +226,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect


### PR DESCRIPTION
Based on #22697.

fixes https://github.com/pulumi/pulumi-service/issues/42026
fixes https://github.com/pulumi/pulumi-service/issues/42030

[![asciicast](https://asciinema.org/a/nzbaUmavhIeitvBv.svg)](https://asciinema.org/a/PuO1OnghAxeKB9sa)

## Summary

Run the `pulumi neo` TUI as a bubbletea **inline program** instead of a full-screen alt-screen app with a mouse-driven viewport. Terminal-state blocks (user messages, tool completions, assistant finals, errors, warnings, completed pulumi ops) are committed to the user's terminal scrollback via `tea.Println` as soon as they reach a terminal state. Only the live frame — busy spinner, in-flight streaming assistant message, in-flight pulumi op, input bar — repaints in place above scrollback.

Why:
- **Text selection works.** Mouse capture (`tea.WithMouseCellMotion`) was eating click-drag, so selecting/copying transcript text in the TUI was broken. Removing alt-screen + mouse capture hands selection back to the terminal.
- **Native scrollback.** No internal `viewport.Model` — the user scrolls the transcript with their terminal's normal scroll, and the transcript persists after the program exits.
- **Smaller surface.** Fewer mouse/scroll edge cases, no `inputBarHeight`/viewport-height clamping, no `rebuildContent` step on every event.

## What changed

- `pkg/cmd/pulumi/neo/neo.go` — `tea.NewProgram(model)` with no `WithAltScreen` / `WithMouseCellMotion`.
- `pkg/cmd/pulumi/neo/tui.go`:
  - Drop the `viewport.Model` and `MouseMsg` handling. Drop `rebuildContent`.
  - Add `commitBlock`, `isLiveKind`/`isCommittedKind`, `liveView`. Each block stays in `m.blocks` (so `findBlockKind` still works) but only live kinds render in `View()`; committed kinds are emitted to scrollback via `tea.Println`.
  - First `WindowSizeMsg` flushes the welcome banner and any pre-seeded committed blocks (e.g. an `InitialPrompt` user message queued in `NewModel`) to scrollback.
  - `liveWidth()` caps live-frame content at 80 cols, backing off by 10 cols below 90. This makes resize a non-event in the common range and keeps the inline renderer's logical-line accounting intact (see `View` and `liveWidth` comments — full-width content wraps to two visual rows on resize-shrink, and bubbletea v1.3.10's `CursorUp(linesRendered-1)` desyncs).
  - `wrapPlain` uses `muesli/reflow/wordwrap` instead of `lipgloss.Style.Width(W).Render`, which padded every line to width `W` and was the same wrap-stack hazard as full-width borders.
  - `View()` uses `strings.Join` instead of `lipgloss.JoinVertical` so each line stays at its natural length.
- `pkg/cmd/pulumi/neo/tui_pulumi.go` and `tui_welcome.go` — replace the rounded full-borders with a **left-only bracket** decoration (`renderLeftBracket` in `tui.go`: `╭─` / `│ ` / `╰─`). Same visual intent, no right edge or full-width horizontal bars, so no rendered line ever stretches across the terminal width.
- `pkg/cmd/pulumi/neo/tools/pulumi*.go` — small comment touch-ups and an explicit `TestOpSortRank` test for the `OpSortRank` ordering invariant; `TestFormatChangeCounts` extended to cover replace.
- `pkg/cmd/pulumi/neo/tui_test.go` — drop the mouse-forwarding test, retarget the window-size tests at the new dimensions/sentinels, retarget `RebuildContent` test as `LiveView_OnlyShowsLiveBlocks` to assert that committed blocks do **not** appear in `View()`.
- `pkg/go.mod` — promote `github.com/muesli/reflow` from indirect to direct (used directly for `wordwrap.String`).

## Test plan
- [x] Added/updated unit tests — `TestModel_LiveView_OnlyShowsLiveBlocks`, window-size tests, `TestOpSortRank`, extended `TestFormatChangeCounts`.
- [ ] Added a test in `pkg/engine/lifecycletest` — N/A (no engine/protocol changes).
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` — N/A.
- [ ] Added a golden test in `pkg/backend/display` — N/A.
- [x] Manual: ran `pulumi neo` end-to-end; verified text selection works, scrollback is preserved on exit, drag-resize across the 80-col cap doesn't corrupt the frame, and pulumi op blocks transition live → committed at `UIPulumiEnd`.

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass — N/A (CLI-only change).
- [ ] `make check_proto` — N/A.

## Changelog
- [ ] Changelog entry added — `pulumi neo` is not yet GA; ask a maintainer to apply `impact/no-changelog-required` if needed.

## Risk

Scoped to `pkg/cmd/pulumi/neo/`. No public SDK or CLI surface change beyond the `pulumi neo` UX. Blast radius is the Neo TUI only:
- Behavior change for Neo users: no alt-screen, transcript stays in scrollback, no mouse-driven scrolling (terminal handles it).
- Drag-resize was the trickiest correctness concern; the 80-col cap, left-bracket decoration, `strings.Join`, and `wordwrap` (not lipgloss padding) together keep the inline renderer's line accounting intact. Comments in `View`, `liveView`, `liveWidth`, `wrapPlain`, and `renderLeftBracket` explain the constraints so future edits don't reintroduce full-width content.