### PR TITLE
Skip flaky TestInstallWithOptions

### DIFF
--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -3485,6 +3485,7 @@ func TestListStacksAllCorrectArgs(t *testing.T) {
 
 func TestInstallWithOptions(t *testing.T) {
 	t.Parallel()
+	t.Skip("Flaky: pip can emit cache deserialization warnings to stderr. See https://github.com/pulumi/pulumi/issues/22745")
 	ctx := t.Context()
 	pDir := filepath.Join(".", "test", "install")
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -3485,7 +3485,8 @@ func TestListStacksAllCorrectArgs(t *testing.T) {
 
 func TestInstallWithOptions(t *testing.T) {
 	t.Parallel()
-	t.Skip("Flaky: pip can emit cache deserialization warnings to stderr. See https://github.com/pulumi/pulumi/issues/22745")
+	// TODO[pulumi/pulumi#22745]: flaky test
+	t.Skip("Flaky: pip can emit cache deserialization warnings to stderr.")
 	ctx := t.Context()
 	pDir := filepath.Join(".", "test", "install")
 


### PR DESCRIPTION
## Summary

- Skip `TestInstallWithOptions` until we fix the flake. The test asserts pip's stderr is empty after install, but pip occasionally writes `WARNING: Cache entry deserialization failed, entry ignored` to stderr on Windows runners.

Example failure: https://github.com/pulumi/pulumi/actions/runs/25048347233/job/73370452679?pr=22743

xref #22745

## Test plan

- [x] `go test -run '^TestInstallWithOptions$' -v ./sdk/go/auto/` shows `--- SKIP`