### PR TITLE
unflake TestInstallWithOptions

### DIFF
--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -3504,7 +3504,6 @@ func TestInstallWithOptions(t *testing.T) {
 	require.Contains(t, stdout.String(), "Creating virtual environment...")
 	require.Contains(t, stdout.String(), "Successfully installed urllib3")
 	require.Contains(t, stdout.String(), "Finished installing dependencies")
-	require.Empty(t, stderr.String())
 	require.DirExists(t, filepath.Join(pDir, "venv"))
 
 	// Run without options


### PR DESCRIPTION
Python cache can occasionally become corrupted for whatever reason (see https://github.com/pulumi/pulumi/issues/22745).  This has nothing to do with pulumi behaviour, but it makes `pip` write warnings to stderr.  Let's just ignore these errors to avoid this test flaking.

Alternative to https://github.com/pulumi/pulumi/pull/22746

Fixes #22745 
Fixes https://github.com/pulumi/pulumi/issues/22737