### PR TITLE
drop if/else conditions with matching branches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,6 @@ linters:
         - codegenComment
         - deprecatedComment
         - dupArg
-        - dupBranchBody
         - dupCase
         - dupSubExpr
         - exitAfterDefer

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -434,11 +434,7 @@ func TestUnprotect(t *testing.T) {
 
 	_, _, err := e.RunCommandReturnExpectedError("pulumi", "destroy", "--skip-preview", "--yes")
 	assert.Error(t, err, "expect error from pulumi destroy")
-	if runtime.GOOS == "windows" {
-		assert.ErrorContains(t, err, "exit status 1")
-	} else {
-		assert.ErrorContains(t, err, "exit status 1")
-	}
+	assert.ErrorContains(t, err, "exit status 1")
 
 	e.RunCommand("pulumi", "state", "unprotect", "--all", "--yes")
 	e.RunCommand("pulumi", "destroy", "--skip-preview", "--yes")
@@ -461,22 +457,14 @@ func TestUnprotectProtect(t *testing.T) {
 
 	_, _, err := e.RunCommandReturnExpectedError("pulumi", "destroy", "--skip-preview", "--yes")
 	assert.Error(t, err, "expect error from pulumi destroy")
-	if runtime.GOOS == "windows" {
-		assert.ErrorContains(t, err, "exit status 1")
-	} else {
-		assert.ErrorContains(t, err, "exit status 1")
-	}
+	assert.ErrorContains(t, err, "exit status 1")
 
 	e.RunCommand("pulumi", "state", "unprotect", "--all", "--yes")
 	e.RunCommand("pulumi", "state", "protect", "--all", "--yes")
 
 	_, _, err = e.RunCommandReturnExpectedError("pulumi", "destroy", "--skip-preview", "--yes")
 	assert.Error(t, err, "expect error from pulumi destroy")
-	if runtime.GOOS == "windows" {
-		assert.ErrorContains(t, err, "exit status 1")
-	} else {
-		assert.ErrorContains(t, err, "exit status 1")
-	}
+	assert.ErrorContains(t, err, "exit status 1")
 }
 
 func TestInvalidPluginError(t *testing.T) {

--- a/tests/integration/state_protect_unprotect_test.go
+++ b/tests/integration/state_protect_unprotect_test.go
@@ -16,7 +16,6 @@ package ints
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -122,11 +121,7 @@ description: A test for protecting and unprotecting resources
 	// Try to destroy - should fail because resources are now protected
 	_, _, err := e.RunCommandReturnExpectedError("pulumi", "destroy", "--skip-preview", "--yes")
 	assert.Error(t, err, "expect error from pulumi destroy after protect")
-	if runtime.GOOS == "windows" {
-		assert.ErrorContains(t, err, "exit status 1")
-	} else {
-		assert.ErrorContains(t, err, "exit status 1")
-	}
+	assert.ErrorContains(t, err, "exit status 1")
 
 	// STEP 2: Unprotect a subset of resources to verify partial unprotect works
 	unprotectSubsetArgs := append([]string{"pulumi", "state", "unprotect", "--yes"}, urns[0])


### PR DESCRIPTION
Noticed this while looking at some tests.  We have some tests that have if/else blocks with the same conditions.  No real sense in that, let's just drop the conditions.