### PR TITLE
emit SameSteps when resources are not included in operation in refresh v2

### DIFF
--- a/changelog/pending/20260428--engine--fix-snapshot-integrity-error-in-refresh-v2.yaml
+++ b/changelog/pending/20260428--engine--fix-snapshot-integrity-error-in-refresh-v2.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix snapshot integrity error in refresh v2

--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -62,8 +62,6 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludeDependenciesOnPendingReplacementRefreshV2,
 		// TODO[pulumi/pulumi#21700]
 		ExcludePendingReplacementRegisteredInUpdate,
-		// TODO[pulumi/pulumi#22481]
-		ExcludeDeletedWithRefreshV2,
 		// TODO[pulumi/pulumi#22511]
 		ExcludeTargetedUpdateRefreshWithChildProvider,
 	}

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -3657,9 +3657,6 @@ func TestRefreshV2IncludeTarget(t *testing.T) {
 func TestRefreshV2DeletedWithOrdering(t *testing.T) {
 	t.Parallel()
 
-	// TODO[pulumi/pulumi#22481]: Fix the underlying issue and remove the skip.
-	t.Skip("Skipping test due to snapshot integrity error with DeletedWith during refreshV2")
-
 	p := &lt.TestPlan{
 		Project: "test-project",
 		Stack:   "test-stack",

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -802,6 +802,8 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, boo
 		var step Step
 		if !goal.Custom || sdkproviders.IsProviderType(goal.Type) {
 			step = NewInternalRefreshStep(sg.deployment, cts, old, oldViews, new)
+		} else if !sg.isIncludedInOperation(old) {
+			step = NewSameStep(sg.deployment, event, old, new)
 		} else {
 			step = NewRefreshStep(sg.deployment, cts, old, oldViews, new)
 		}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi/pull/22404, we fixed refresh v2 with `--target` (among other things).  To do this, we stopped creating refresh steps for untargeted resources.  However that leads to corrupt snapshots, because refresh steps for some resources are generated, but not for resources dependent on them, and thus the ordering ends up being wrong.

To fix this, we generate SameSteps for resources that are not included in the operation instead.

Fixes https://github.com/pulumi/pulumi/issues/22578, https://github.com/pulumi/pulumi/issues/22481
Closes https://github.com/pulumi/pulumi/pull/22579