### PR TITLE
localWorkspace.config test: don't remove nested_config/dev stack

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.config.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.config.spec.ts
@@ -256,7 +256,7 @@ describe("LocalWorkspace - Config", () => {
         assert.strictEqual(list.secret, false);
         assert.strictEqual(list.value, '["one","two","three"]');
 
-        await stack.workspace.removeStack(stackName);
+        // This test uses a static stack name.  Do not remove it at the end to prevent flakes in CI due to missing stack.
     });
     // TODO[https://github.com/pulumi/pulumi/issues/7127]: Re-enabled the warning.
     // Temporarily skipping test until we've re-enabled the warning.


### PR DESCRIPTION
This stack has a static name, so it matches the `Pulumi.dev.yaml` config file.  Since other tests might use the same stack, we can not remove it at the end of the test, otherwise it's likely the test is going to be flaky. The comment for the tests already describes that. Add a comment at the end as well to warn people from doing that.

I have a vague memory of having done this before, but can't find the PR now.  Either way this seems like the right thing to do for this test, and we're not going to be accumulating stacks in moolumi, because it always has the same name.