### PR TITLE
fix(codegen/python): normalize dotted dev/post prereleases to PEP 440

### DIFF
--- a/changelog/pending/20260429--codegen-python--normalize-dotted-dev-and-post-prereleases.yaml
+++ b/changelog/pending/20260429--codegen-python--normalize-dotted-dev-and-post-prereleases.yaml
@@ -1,0 +1,4 @@
+changes:
+  - type: fix
+    scope: codegen/python
+    description: Translate `X.Y.Z-dev.N` and `X.Y.Z-post.N` semver prereleases to PEP 440 `X.Y.Z.devN` / `X.Y.Z.postN` releases

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -128,7 +128,7 @@ var pypiPost = regexp.MustCompile("^post[0-9]+$")
 // versions.
 func normPypiVersion(v semver.Version) semver.Version {
 	s := v.String()
-	s = regexp.MustCompile(`(alpha|beta|rc)[.](\d+)`).ReplaceAllString(s, `$1$2`)
+	s = regexp.MustCompile(`(alpha|beta|rc|dev|post)[.](\d+)`).ReplaceAllString(s, `$1$2`)
 	return semver.MustParse(s)
 }
 

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -107,6 +107,10 @@ func TestMakePyPiVersion(t *testing.T) {
 		{"0.0.1-alpha.18", "0.0.1a18"},
 		{"0.0.1-beta.18", "0.0.1b18"},
 		{"0.0.1-rc.18", "0.0.1rc18"},
+		{"1.2.3-dev.20", "1.2.3.dev20"},
+		{"1.2.3-dev.1", "1.2.3.dev1"},
+		{"1.2.3-post.1", "1.2.3.post1"},
+		{"1.2.3-post.20", "1.2.3.post20"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Normalize `dev` and `post` SemVer prereleases to PEP 440.

The regex covered `alpha|beta|rc` but not `dev` or `post`. Without this change, the SemVer version `1.2.3-dev.20` is converted to `1.2.3+dev.`.

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [x] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [x] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [x] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [x] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.