### PR TITLE
`schema` token lookups now accept normalized tokens

### DIFF
--- a/changelog/pending/20260429--pkg--accept-pcl-normalized-tokens-in-schema-getters.yaml
+++ b/changelog/pending/20260429--pkg--accept-pcl-normalized-tokens-in-schema-getters.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: fix
+  scope: pkg
+  description: |
+    Schema lookups (Package.GetResource/GetFunction/GetType/GetResourceType and the
+    PackageReference variants) now accept PCL-normalized tokens in addition to source-form
+    tokens, so consumers no longer need to reconstruct the original token to find an entry
+    when Meta.ModuleFormat or the index-module shorthand has been applied.

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -248,7 +248,7 @@ func (p packageDefTypes) Range() TypesIter {
 }
 
 func (p packageDefTypes) Get(token string) (Type, bool, error) {
-	def, ok := p.typeTable[token]
+	def, ok := lookupToken(p.typeTable, token, p.typeAliases)
 	return def, ok, nil
 }
 
@@ -289,7 +289,7 @@ func (p packageDefResources) Get(token string) (*Resource, bool, error) {
 		return p.Provider, true, nil
 	}
 
-	def, ok := p.resourceTable[token]
+	def, ok := lookupToken(p.resourceTable, token, p.resourceAliases)
 	return def, ok, nil
 }
 
@@ -328,7 +328,7 @@ func (p packageDefFunctions) Range() FunctionsIter {
 }
 
 func (p packageDefFunctions) Get(token string) (*Function, bool, error) {
-	def, ok := p.functionTable[token]
+	def, ok := lookupToken(p.functionTable, token, p.functionAliases)
 	return def, ok, nil
 }
 
@@ -369,6 +369,15 @@ type PartialPackage struct {
 	config []*Property
 
 	def *Package
+
+	// specAliases maps PCL-normalized tokens to their source-form keys in spec.Types,
+	// spec.Resources, and spec.Functions. Built lazily on first miss in a Get* call.
+	specAliases struct {
+		once      sync.Once
+		types     map[string]string
+		resources map[string]string
+		functions map[string]string
+	}
 }
 
 func (p *PartialPackage) Name() string {
@@ -587,6 +596,45 @@ func (p *PartialPackage) TokenToModule(token string) string {
 	return p.types.pkg.TokenToModule(token)
 }
 
+// resolveSpecToken returns the source-form key in m matching token. If token is already
+// a direct key of m it is returned unchanged without forcing the alias build; otherwise
+// the (lazy) alias map is consulted. Returns the input token unchanged if neither hits.
+//
+// The caller must hold p.m.
+func resolveSpecToken[V any](m map[string]V, token string, aliases func() map[string]string) string {
+	if _, ok := m[token]; ok {
+		return token
+	}
+	if src, ok := aliases()[token]; ok {
+		return src
+	}
+	return token
+}
+
+func (p *PartialPackage) typeAliases() map[string]string {
+	p.specAliases.once.Do(p.buildSpecAliases)
+	return p.specAliases.types
+}
+
+func (p *PartialPackage) resourceAliases() map[string]string {
+	p.specAliases.once.Do(p.buildSpecAliases)
+	return p.specAliases.resources
+}
+
+func (p *PartialPackage) functionAliases() map[string]string {
+	p.specAliases.once.Do(p.buildSpecAliases)
+	return p.specAliases.functions
+}
+
+// buildSpecAliases builds normalized→source-form alias maps over the spec's token keys.
+// Called via specAliases.once; must not access fields guarded by p.m.
+func (p *PartialPackage) buildSpecAliases() {
+	tokenToModule := p.types.pkg.TokenToModule
+	p.specAliases.types = buildTokenAliases(p.spec.Types, tokenToModule)
+	p.specAliases.resources = buildTokenAliases(p.spec.Resources, tokenToModule)
+	p.specAliases.functions = buildTokenAliases(p.spec.Functions, tokenToModule)
+}
+
 func (p *PartialPackage) Definition() (*Package, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
@@ -748,6 +796,7 @@ func (p partialPackageTypes) Get(token string) (Type, bool, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	token = resolveSpecToken(p.spec.Types, token, p.typeAliases)
 	typ, diags, err := p.types.bindTypeDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -793,6 +842,9 @@ func (p partialPackageResources) Get(token string) (*Resource, bool, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	if token != "pulumi:providers:"+p.spec.Name {
+		token = resolveSpecToken(p.spec.Resources, token, p.resourceAliases)
+	}
 	res, diags, err := p.types.bindResourceDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -809,6 +861,9 @@ func (p partialPackageResources) GetType(token string) (*ResourceType, bool, err
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	if token != "pulumi:providers:"+p.spec.Name {
+		token = resolveSpecToken(p.spec.Resources, token, p.resourceAliases)
+	}
 	typ, diags, err := p.types.bindResourceTypeDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -854,6 +909,7 @@ func (p partialPackageFunctions) Get(token string) (*Function, bool, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	token = resolveSpecToken(p.spec.Functions, token, p.functionAliases)
 	fn, diags, err := p.types.bindFunctionDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
@@ -664,6 +665,16 @@ type Package struct {
 	functionTable     map[string]*Function
 	typeTable         map[string]Type
 
+	// aliases maps PCL-normalized tokens to their source-form keys in the tables above.
+	// Built lazily on first miss in a Get* call. See buildTokenAliases.
+	aliases struct {
+		once          sync.Once
+		resources     map[string]string
+		functions     map[string]string
+		types         map[string]string
+		resourceTypes map[string]string
+	}
+
 	importedLanguages map[string]struct{}
 }
 
@@ -944,23 +955,130 @@ func (pkg *Package) TokenToRuntimeModule(tok string) string {
 }
 
 func (pkg *Package) GetResource(token string) (*Resource, bool) {
-	r, ok := pkg.resourceTable[token]
-	return r, ok
+	return lookupToken(pkg.resourceTable, token, pkg.resourceAliases)
 }
 
 func (pkg *Package) GetFunction(token string) (*Function, bool) {
-	f, ok := pkg.functionTable[token]
-	return f, ok
+	return lookupToken(pkg.functionTable, token, pkg.functionAliases)
 }
 
 func (pkg *Package) GetResourceType(token string) (*ResourceType, bool) {
-	t, ok := pkg.resourceTypeTable[token]
-	return t, ok
+	return lookupToken(pkg.resourceTypeTable, token, pkg.resourceTypeAliases)
 }
 
 func (pkg *Package) GetType(token string) (Type, bool) {
-	t, ok := pkg.typeTable[token]
-	return t, ok
+	return lookupToken(pkg.typeTable, token, pkg.typeAliases)
+}
+
+func (pkg *Package) resourceAliases() map[string]string {
+	pkg.aliases.once.Do(pkg.buildAliases)
+	return pkg.aliases.resources
+}
+
+func (pkg *Package) functionAliases() map[string]string {
+	pkg.aliases.once.Do(pkg.buildAliases)
+	return pkg.aliases.functions
+}
+
+func (pkg *Package) typeAliases() map[string]string {
+	pkg.aliases.once.Do(pkg.buildAliases)
+	return pkg.aliases.types
+}
+
+func (pkg *Package) resourceTypeAliases() map[string]string {
+	pkg.aliases.once.Do(pkg.buildAliases)
+	return pkg.aliases.resourceTypes
+}
+
+func (pkg *Package) buildAliases() {
+	pkg.aliases.resources = buildTokenAliases(pkg.resourceTable, pkg.TokenToModule)
+	pkg.aliases.functions = buildTokenAliases(pkg.functionTable, pkg.TokenToModule)
+	pkg.aliases.types = buildTokenAliases(pkg.typeTable, pkg.TokenToModule)
+	pkg.aliases.resourceTypes = buildTokenAliases(pkg.resourceTypeTable, pkg.TokenToModule)
+}
+
+// decomposeToken splits a token of the form "pkg:mod:name", "pkg::name", or "pkg:name" into
+// its components. An empty module is returned as "index". Invalid tokens return ok=false.
+func decomposeToken(tok string) (pkg, mod, name string, ok bool) {
+	parts := strings.Split(tok, ":")
+	switch len(parts) {
+	case 2:
+		pkg, mod, name = parts[0], "index", parts[1]
+	case 3:
+		pkg, mod, name = parts[0], parts[1], parts[2]
+		if mod == "" {
+			mod = "index"
+		}
+	default:
+		return "", "", "", false
+	}
+	if pkg == "" || name == "" {
+		return "", "", "", false
+	}
+	return pkg, mod, name, true
+}
+
+// buildTokenAliases returns a map from normalized-form tokens to the source-form keys of m.
+//
+// PCL normalizes tokens before lookup in two ways that this map inverts:
+//   - module components are rewritten via tokenToModule (e.g. "pkg:mod/x:y" → "pkg:mod:y"
+//     when Meta.ModuleFormat is "(.*)(?:/[^/]*)"), and
+//   - the "index" module may be elided ("pkg:index:name" → "pkg:name" / "pkg::name").
+//
+// The shortening cannot be reversed in general — different source tokens may collide on the
+// same normalized form (e.g. both "pkg:mod/a:B" and "pkg:mod/b:B" normalize to "pkg:mod:B").
+// We drop colliding entries so an ambiguous query misses cleanly rather than silently
+// resolving to one of the candidates. Aliases also never shadow a real key in m.
+func buildTokenAliases[V any](m map[string]V, tokenToModule func(string) string) map[string]string {
+	aliases := make(map[string]string, len(m))
+	collisions := map[string]struct{}{}
+	add := func(alias, src string) {
+		if alias == "" || alias == src {
+			return
+		}
+		if _, exists := m[alias]; exists {
+			return
+		}
+		if _, ambiguous := collisions[alias]; ambiguous {
+			return
+		}
+		if existing, ok := aliases[alias]; ok && existing != src {
+			delete(aliases, alias)
+			collisions[alias] = struct{}{}
+			return
+		}
+		aliases[alias] = src
+	}
+	for tok := range m {
+		pkg, _, name, ok := decomposeToken(tok)
+		if !ok {
+			continue
+		}
+		mod := tokenToModule(tok)
+		if mod == "" {
+			mod = "index"
+		}
+		add(pkg+":"+mod+":"+name, tok)
+		if mod == "index" {
+			add(pkg+"::"+name, tok)
+			add(pkg+":"+name, tok)
+		}
+	}
+	return aliases
+}
+
+// lookupToken finds an entry in m by token, falling back to the prebuilt alias map for
+// PCL-normalized tokens.
+func lookupToken[V any](m map[string]V, token string, aliases func() map[string]string) (V, bool) {
+	v, ok := m[token]
+	if ok {
+		return v, true
+	}
+	if src, aOk := aliases()[token]; aOk {
+		v, ok = m[src]
+	}
+
+	return v, ok
 }
 
 func (pkg *Package) Reference() PackageReference {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2729,3 +2729,209 @@ func TestTokenToModuleIndexPrefix(t *testing.T) {
 	assert.Equal(t, "", formattedPkg.TokenToModule("test:index/getResource:getResource"))
 	assert.Equal(t, "indexMine", formattedPkg.TokenToModule("test:indexMine/getResource:getResource"))
 }
+
+// TestAliasBuildIsLazy verifies that the alias maps stay unbuilt when every Get* call
+// is satisfied by a direct table hit.
+func TestAliasBuildIsLazy(t *testing.T) {
+	t.Parallel()
+
+	spec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]ResourceSpec{
+			"test:mod:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+		},
+		Functions: map[string]FunctionSpec{
+			"test:mod:getThing": {},
+		},
+		Types: map[string]ComplexTypeSpec{
+			"test:mod:ThingBlock": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+		},
+	}
+
+	t.Run("Package", func(t *testing.T) {
+		t.Parallel()
+
+		pkg, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+
+		_, ok := pkg.GetResource("test:mod:Thing")
+		require.True(t, ok)
+		_, ok = pkg.GetFunction("test:mod:getThing")
+		require.True(t, ok)
+		_, ok = pkg.GetType("test:mod:ThingBlock")
+		require.True(t, ok)
+		_, ok = pkg.GetResourceType("test:mod:Thing")
+		require.True(t, ok)
+
+		assert.Nil(t, pkg.aliases.resources)
+		assert.Nil(t, pkg.aliases.functions)
+		assert.Nil(t, pkg.aliases.types)
+		assert.Nil(t, pkg.aliases.resourceTypes)
+	})
+
+	t.Run("PartialPackage", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := json.Marshal(spec)
+		require.NoError(t, err)
+		var partial PartialPackageSpec
+		require.NoError(t, json.Unmarshal(raw, &partial))
+
+		pkg, err := ImportPartialSpec(partial, nil, nil)
+		require.NoError(t, err)
+
+		_, ok, err := pkg.Resources().Get("test:mod:Thing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		_, ok, err = pkg.Functions().Get("test:mod:getThing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		_, ok, err = pkg.Types().Get("test:mod:ThingBlock")
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		assert.Nil(t, pkg.specAliases.resources)
+		assert.Nil(t, pkg.specAliases.functions)
+		assert.Nil(t, pkg.specAliases.types)
+	})
+}
+
+// TestGetWithCollidingAliases verifies that when two source-form tokens normalize to the
+// same alias, the alias is dropped (an ambiguous query misses cleanly) while direct
+// lookups of either source-form token still succeed.
+func TestGetWithCollidingAliases(t *testing.T) {
+	t.Parallel()
+
+	spec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Meta:    &MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+		Resources: map[string]ResourceSpec{
+			"test:mod/a:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			"test:mod/b:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+		},
+	}
+
+	pkg, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+	require.NoError(t, err)
+
+	a, ok := pkg.GetResource("test:mod/a:Thing")
+	require.True(t, ok)
+	assert.Equal(t, "test:mod/a:Thing", a.Token)
+
+	b, ok := pkg.GetResource("test:mod/b:Thing")
+	require.True(t, ok)
+	assert.Equal(t, "test:mod/b:Thing", b.Token)
+
+	_, ok = pkg.GetResource("test:mod:Thing")
+	assert.False(t, ok, "ambiguous alias must miss")
+}
+
+// TestGetWithIndexAliases verifies short-form aliases for tokens whose normalized module
+// is "index" — both "pkg:name" and "pkg::name" should resolve to the source token.
+func TestGetWithIndexAliases(t *testing.T) {
+	t.Parallel()
+
+	spec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]ResourceSpec{
+			"test:index:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+		},
+	}
+
+	pkg, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+	require.NoError(t, err)
+
+	for _, query := range []string{"test:index:Thing", "test::Thing", "test:Thing"} {
+		r, ok := pkg.GetResource(query)
+		require.Truef(t, ok, "query %q should resolve", query)
+		assert.Equal(t, "test:index:Thing", r.Token)
+	}
+}
+
+// TestGetWithModuleFormat verifies that the schema's Get* methods accept tokens normalized
+// via Meta.ModuleFormat as well as the source-form token. PCL canonicalizes tokens before
+// lookup (e.g. "test:mod/getThing:getThing" → "test:mod:getThing"), so callers should not
+// have to reconstruct the source token themselves.
+func TestGetWithModuleFormat(t *testing.T) {
+	t.Parallel()
+
+	// A deliberately non-standard ModuleFormat: strip a "_v\d+" suffix from the module
+	// (e.g. source "mod_v2" → normalized "mod"). This exercises the actual regex rather
+	// than masquerading as the default format.
+	spec := PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+		Resources: map[string]ResourceSpec{
+			"test:mod_v2:Thing": {
+				ObjectTypeSpec: ObjectTypeSpec{Type: "object"},
+			},
+		},
+		Functions: map[string]FunctionSpec{
+			"test:mod_v2:getThing": {},
+		},
+		Types: map[string]ComplexTypeSpec{
+			"test:mod_v2:ThingBlock": {
+				ObjectTypeSpec: ObjectTypeSpec{Type: "object"},
+			},
+		},
+	}
+
+	t.Run("Package", func(t *testing.T) {
+		t.Parallel()
+
+		pkg, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+
+		r, ok := pkg.GetResource("test:mod:Thing")
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:Thing", r.Token)
+
+		f, ok := pkg.GetFunction("test:mod:getThing")
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:getThing", f.Token)
+
+		typ, ok := pkg.GetType("test:mod:ThingBlock")
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:ThingBlock", typ.(*ObjectType).Token)
+
+		rt, ok := pkg.GetResourceType("test:mod:Thing")
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:Thing", rt.Token)
+	})
+
+	t.Run("PartialPackage", func(t *testing.T) {
+		t.Parallel()
+
+		raw, err := json.Marshal(spec)
+		require.NoError(t, err)
+		var partial PartialPackageSpec
+		require.NoError(t, json.Unmarshal(raw, &partial))
+
+		pkg, err := ImportPartialSpec(partial, nil, nil)
+		require.NoError(t, err)
+
+		r, ok, err := pkg.Resources().Get("test:mod:Thing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:Thing", r.Token)
+
+		f, ok, err := pkg.Functions().Get("test:mod:getThing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:getThing", f.Token)
+
+		typ, ok, err := pkg.Types().Get("test:mod:ThingBlock")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:ThingBlock", typ.(*ObjectType).Token)
+
+		rt, ok, err := pkg.Resources().GetType("test:mod:Thing")
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "test:mod_v2:Thing", rt.Token)
+	})
+}


### PR DESCRIPTION
Schema lookups (Package.GetResource/GetFunction/GetType/GetResourceType and the PackageReference variants) now accept PCL-normalized tokens in addition to source-form tokens, so consumers no longer need to reconstruct the original token to find an entry when Meta.ModuleFormat or the index-module shorthand has been applied.

This allows us to remove code like https://github.com/pulumi-labs/pulumi-hcl/pull/101 from YAML/HCL/PCL, and simply pass-through the tokens used in PCL.