### PR TITLE
backend/httpstate: pass diag in New() to tests

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -224,7 +224,7 @@ var _ backend.SpecificDeploymentExporter = &cloudBackend{}
 func New(ctx context.Context, d diag.Sink,
 	cloudURL string, project *workspace.Project, insecure bool,
 ) (Backend, error) {
-	contract.Assertf(d != nil, "expected a non-nil diag.Sink")
+	contract.Requiref(d != nil, "d", "expected a non-nil diag.Sink")
 	cloudURL = ValueOrDefaultURL(pkgWorkspace.Instance, cloudURL)
 	account, err := workspace.GetAccount(cloudURL)
 	if err != nil {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -224,6 +224,7 @@ var _ backend.SpecificDeploymentExporter = &cloudBackend{}
 func New(ctx context.Context, d diag.Sink,
 	cloudURL string, project *workspace.Project, insecure bool,
 ) (Backend, error) {
+	contract.Assertf(d != nil, "expected a non-nil diag.Sink")
 	cloudURL = ValueOrDefaultURL(pkgWorkspace.Instance, cloudURL)
 	account, err := workspace.GetAccount(cloudURL)
 	if err != nil {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -739,7 +739,8 @@ func TestCreateStackDeploymentSchemaVersion(t *testing.T) {
 	}))
 	defer server.Client()
 
-	b, err := New(ctx, nil, server.URL, nil, false)
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	b, err := New(ctx, sink, server.URL, nil, false)
 	require.NoError(t, err)
 
 	ref, err := b.ParseStackReference("owner/project/stack")
@@ -773,7 +774,7 @@ func TestCreateStackDeploymentSchemaVersion(t *testing.T) {
 	// Test 3: v4 supported: send v3 expect v3.
 
 	v4 = true
-	b, err = New(ctx, nil, server.URL, nil, false)
+	b, err = New(ctx, sink, server.URL, nil, false)
 	require.NoError(t, err)
 
 	_, err = b.CreateStack(ctx, ref, "", &apitype.UntypedDeployment{
@@ -843,7 +844,8 @@ func TestCreateStackDisplaysBackendMessages(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	b, err := New(ctx, nil, server.URL, nil, false)
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	b, err := New(ctx, sink, server.URL, nil, false)
 	require.NoError(t, err)
 
 	ref, err := b.ParseStackReference("owner/project/stack")
@@ -946,7 +948,8 @@ func TestImportDeploymentSchemaVersion(t *testing.T) {
 	}))
 	defer server.Client()
 
-	b, err := New(ctx, nil, server.URL, nil, false)
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	b, err := New(ctx, sink, server.URL, nil, false)
 	require.NoError(t, err)
 
 	ref, err := b.ParseStackReference("owner/project/stack")
@@ -983,7 +986,7 @@ func TestImportDeploymentSchemaVersion(t *testing.T) {
 	// Test 3: v4 supported: send v3 expect v3.
 
 	v4 = true
-	b, err = New(ctx, nil, server.URL, nil, false)
+	b, err = New(ctx, sink, server.URL, nil, false)
 	require.NoError(t, err)
 
 	err = b.ImportDeployment(ctx, s, &apitype.UntypedDeployment{

--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -44,6 +44,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -199,8 +201,10 @@ func TestCloudSnapshotPersisterDeploymentSchemaVersion(t *testing.T) {
 		})
 	}
 
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+
 	initPersister := func() *cloudSnapshotPersister {
-		backendGeneric, err := New(ctx, nil, server.URL, nil, false)
+		backendGeneric, err := New(ctx, sink, server.URL, nil, false)
 		require.NoError(t, err)
 		backend := backendGeneric.(*cloudBackend)
 		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{
@@ -712,9 +716,11 @@ func TestCloudSnapshotPersisterUseOfDiffProtocol(t *testing.T) {
 		})
 	}
 
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+
 	initPersister := func() *cloudSnapshotPersister {
 		server := newMockServer()
-		backendGeneric, err := New(ctx, nil, server.URL, nil, false)
+		backendGeneric, err := New(ctx, sink, server.URL, nil, false)
 		require.NoError(t, err)
 		backend := backendGeneric.(*cloudBackend)
 		persister := backend.newSnapshotPersister(ctx, client.UpdateIdentifier{


### PR DESCRIPTION
These tests fail occasionally.  Letting Claude do its thing it tells me it's because we're sometimes trying to use the sink to submit a message, even though it's `nil`.

Pass in a proper sink in the tests to avoid this kind of flake.  Locally this passes 20/20 tests, where previously only 13/20 passed.

Co-authored-by: Claude
