### PR TITLE
fix(sdk/go): require .git marker for GitLab subgroup URLs

### DIFF
--- a/changelog/pending/20260429--sdk-go--require-git-marker-for-gitlab-subgroup-urls.yaml
+++ b/changelog/pending/20260429--sdk-go--require-git-marker-for-gitlab-subgroup-urls.yaml
@@ -1,0 +1,10 @@
+changes:
+  - type: fix
+    scope: sdk/go
+    description: |
+      Require an explicit `.git` marker when parsing GitLab URLs with more than two
+      path segments. GitLab supports nested subgroups, which made bare URLs like
+      `gitlab.com/group/subgroup/repo` ambiguous: the parser previously assumed the
+      first two segments were `owner/repo`, which fails to clone subgroup projects.
+      Such URLs now return a clear error pointing at the fix; URLs with a `.git`
+      marker (e.g. `gitlab.com/group/subgroup/repo.git`) work as before.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -863,6 +863,21 @@ func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
 		}, nil
 	}
 
+	// GitLab supports arbitrarily nested subgroups, so a bare path with more than
+	// two segments is ambiguous: "group/subgroup/repo" could be the project
+	// "group/subgroup" with subpath "repo", or the project "group/subgroup/repo"
+	// with no subpath. We can't disambiguate statically without calling the
+	// GitLab API, so require an explicit ".git" marker in this case. (Other
+	// hosts in this function -- GitHub, Bitbucket -- don't support nested groups,
+	// so the first two segments are unambiguously owner/repo.)
+	if hostname == GitLabHostName && len(paths) > 2 {
+		return gitRepoURLParts{}, errors.New(
+			"ambiguous GitLab URL: paths with more than two segments must include " +
+				"a .git marker to indicate the repository boundary " +
+				"(e.g. https://gitlab.com/group/subgroup/repo.git or " +
+				"https://gitlab.com/group/repo.git/subpath)")
+	}
+
 	owner := paths[0]
 	if owner == "" {
 		return gitRepoURLParts{}, errors.New("invalid Git URL; no owner")
@@ -893,6 +908,12 @@ func parseGitRepoURLParts(rawurl string) (gitRepoURLParts, error) {
 // Additionally, it supports nested git projects, as used by GitLab.
 // For example, "https://github.com/pulumi/platform-team/templates.git/templates/javascript"
 // returns "https://github.com/pulumi/platform-team/templates.git" and "templates/javascript"
+//
+// For GitLab URLs (gitlab.com), paths with more than two segments require an
+// explicit ".git" marker to indicate the repository boundary, since GitLab
+// supports arbitrarily nested subgroups and the boundary is otherwise ambiguous.
+// For example, "https://gitlab.com/group/subgroup/repo" returns an error;
+// use "https://gitlab.com/group/subgroup/repo.git" instead.
 //
 // Note: URL with a hostname of `dev.azure.com`, are currently treated as a raw git clone url
 // and currently do not support subpaths.

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -128,7 +128,9 @@ func TestParseGitRepoURL(t *testing.T) {
 	pre = "https://user1:12345@gitlab.com/proj/finally"
 	exp = pre + ".git"
 	test(exp, "", pre)
-	test(exp, "foobar", pre+"/foobar")
+	// GitLab URLs with more than two path segments require an explicit ".git"
+	// marker to disambiguate the repository boundary from a subgroup path.
+	test(exp, "foobar", pre+".git/foobar")
 
 	// SSH URLs.
 	pre = "git@github.com:acmecorp/templates"
@@ -176,6 +178,27 @@ func TestParseGitRepoURL(t *testing.T) {
 	// Not HTTPS.
 	testError("http://github.com/pulumi/templates.git", "invalid URL scheme: http")
 	testError("http://github.com/pulumi/templates", "invalid URL scheme: http")
+
+	// GitLab subgroup URLs without an explicit .git marker are ambiguous and rejected.
+	const gitlabAmbiguousErr = "ambiguous GitLab URL: paths with more than two segments must include " +
+		"a .git marker to indicate the repository boundary " +
+		"(e.g. https://gitlab.com/group/subgroup/repo.git or " +
+		"https://gitlab.com/group/repo.git/subpath)"
+	testError("https://gitlab.com/group/subgroup/repo", gitlabAmbiguousErr)
+	testError("https://gitlab.com/group/subgroup/nested/repo", gitlabAmbiguousErr)
+	// Two-segment GitLab URLs are unambiguous and continue to work (covered above
+	// via "https://user1:12345@gitlab.com/proj/finally"). Adding a .git marker
+	// disambiguates >2-segment URLs in either direction:
+	test(
+		"https://gitlab.com/group/subgroup/repo.git",
+		"",
+		"https://gitlab.com/group/subgroup/repo.git",
+	)
+	test(
+		"https://gitlab.com/group/repo.git",
+		"templates/javascript",
+		"https://gitlab.com/group/repo.git/templates/javascript",
+	)
 }
 
 func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {


### PR DESCRIPTION
## What

Reject bare GitLab URLs with more than two path segments in `gitutil.ParseGitRepoURL`, requiring an explicit `.git` marker to indicate the repository boundary.

## Why

GitLab supports arbitrarily nested subgroups, so a URL like `gitlab.com/group/subgroup/repo` is ambiguous — it could mean the project `group/subgroup` with subpath `repo`, or the project `group/subgroup/repo` with no subpath. The parser previously assumed the first two segments were always `owner/repo`, which silently produced an invalid clone URL for subgroup projects.

The failure mode surfaced far from the cause: when `pulumi-deploy-executor` resolves a `Pulumi.yaml` `packages:` entry that points at a GitLab subgroup project, the resolver tries to clone the wrong path, GitLab returns "The project you were looking for could not be found", and the user sees:

```
error: installing `packages` from Pulumi.yaml: unable to resolve: unable to parse spec: repository not found:
The project you were looking for could not be found or you don't have permission to view it.
```

There is no static way to tell where the repo ends without calling the GitLab API, so we now require an explicit `.git` marker for `>2` segments and point users at the fix in the error message:

```
ambiguous GitLab URL: paths with more than two segments must include a .git marker to indicate the repository boundary
(e.g. https://gitlab.com/group/subgroup/repo.git or https://gitlab.com/group/repo.git/subpath)
```

## How

- `sdk/go/common/util/gitutil/git.go`: in `parseGitRepoURLParts`, after the existing `.git`-marker shortcut and before the bottom owner/repo split, return an error for `gitlab.com` hosts when the path has more than two segments.
- `sdk/go/common/util/gitutil/git_test.go`: cover the new error and the explicit-marker variants. One pre-existing test asserted the silently-broken behavior for a 3-segment GitLab URL without a marker; updated it to use the marker form.
- `changelog/pending/`: added a fix entry.

GitHub, Bitbucket, and other hosts handled by this function don't support nested groups, so their behavior is untouched. Two-segment GitLab URLs (`gitlab.com/group/repo`) are still unambiguous and continue to work.

## Migration

Users with a Pulumi.yaml `packages:` entry pointing at a GitLab subgroup will need to add a `.git` marker. Either form works, depending on the actual GitLab layout:

```yaml
packages:
  # Each component-* is its own repo at that path:
  component-random: https://gitlab.com/group/subgroup/repo.git/components/component-random.git

  # Or: pulumi-idp-in-a-box is the repo and components/* are subdirs:
  component-random: https://gitlab.com/group/subgroup/repo.git/components/component-random
```

## Test plan

- [x] `go test ./go/common/util/gitutil/...` (new + existing cases pass)
- [x] `go test ./go/common/workspace/...` (downstream callers in plugin spec parsing still pass)
- [x] `go test ./pkg/v3/cmd/pulumi/deployment/... ./pkg/v3/cmd/pulumi/packageresolution/...` (downstream callers pass)