### PR TITLE
Reject schemas with duplicate tokens after applying `moduleFormat`

### DIFF
--- a/changelog/pending/20260429--pkg--reject-schemas-with-tokens-that-collide-after-moduleformat.yaml
+++ b/changelog/pending/20260429--pkg--reject-schemas-with-tokens-that-collide-after-moduleformat.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: fix
+  scope: pkg
+  description: |
+    Schema validation now rejects packages whose resource or function tokens collide after
+    applying Meta.ModuleFormat (e.g. "pkg:mod/a:T" and "pkg:mod/b:T" both normalizing to
+    "pkg:mod:T"). Such schemas previously bound silently but were unreachable through PCL,
+    which canonicalizes tokens before lookup.

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -193,7 +193,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 	parameterization, parameterizationDiags := bindParameterization(spec.Parameterization)
 	diags = diags.Extend(parameterizationDiags)
 
-	diags = diags.Extend(checkDuplicates(spec.Resources, spec.Functions))
+	diags = diags.Extend(checkDuplicates(spec.Resources, spec.Functions, types.pkg.TokenToModule))
 
 	pkg := types.pkg
 	pkg.Config = config
@@ -1444,12 +1444,28 @@ func (t *types) finishTypes(tokens []string, options ValidationOptions) ([]Type,
 }
 
 func checkDuplicates(
-	resources map[string]ResourceSpec, functions map[string]FunctionSpec,
+	resources map[string]ResourceSpec,
+	functions map[string]FunctionSpec,
+	tokenToModule func(string) string,
 ) hcl.Diagnostics {
 	type schemaPath = string
 	type token = string
 	names := make(map[token][]schemaPath, len(resources)+len(functions))
 	duplicates := map[token]struct{}{}
+
+	// normalize folds tok to its case-insensitive canonical form, applying Meta.ModuleFormat
+	// to the module component. PCL canonicalizes tokens before lookup, so two source tokens
+	// that share a normalized form are unreachable through any external reference.
+	normalize := func(tok string) string {
+		parts := strings.Split(tok, ":")
+		if len(parts) != 3 {
+			return tok // Token is invalid, and will error later.
+		}
+		if p1 := tokenToModule(tok); p1 != "" {
+			parts[1] = p1
+		}
+		return strings.ToLower(strings.Join(parts, ":"))
+	}
 
 	process := func(token token, schemaPath schemaPath) {
 		v := append(names[token], schemaPath)
@@ -1459,11 +1475,28 @@ func checkDuplicates(
 		}
 	}
 
+	// Each source token contributes both its lowercased literal form and its canonical
+	// (moduleFormat-applied) form. Collisions across either dimension are ambiguous: a
+	// query for X may match a source whose literal is X *or* a source whose canonical
+	// form is X, and PCL has no way to disambiguate. For example, with ModuleFormat
+	// "(\w+)_v\d+", the source tokens "test:mod_v1_v2:A" (canonical "test:mod_v1:A")
+	// and "test:mod_v1:A" (canonical "test:mod:A") have disjoint canonicals but the
+	// first's canonical equals the second's literal — querying "test:mod_v1:A" is
+	// ambiguous.
+	processSource := func(tok, schemaPath string) {
+		lit := strings.ToLower(tok)
+		canon := normalize(tok)
+		process(lit, schemaPath)
+		if canon != lit {
+			process(canon, schemaPath)
+		}
+	}
+
 	for r := range resources {
-		process(strings.ToLower(r), memberPath("resources", r))
+		processSource(r, memberPath("resources", r))
 	}
 	for f := range functions {
-		process(strings.ToLower(f), memberPath("functions", f))
+		processSource(f, memberPath("functions", f))
 	}
 
 	diags := slice.Prealloc[*hcl.Diagnostic](len(duplicates))

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -3056,3 +3056,129 @@ func TestGetWithModuleFormat(t *testing.T) {
 		assert.Equal(t, "test:mod_v2:Thing", rt.Token)
 	})
 }
+
+// TestModuleFormatTokenCollisions verifies that schema validation rejects packages whose
+// resource or function tokens collide after applying Meta.ModuleFormat (and case folding).
+func TestModuleFormatTokenCollisions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ResourcesDifferingOnlyInModuleFormat", func(t *testing.T) {
+		t.Parallel()
+
+		// "(\w+)_v\d+" maps both "mod_v1" and "mod_v2" to "mod".
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+			Resources: map[string]ResourceSpec{
+				"test:mod_v1:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod_v2:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple tokens map to test:mod:thing")
+	})
+
+	t.Run("ChainedModuleVersionsAdjacentLevelsCollide", func(t *testing.T) {
+		t.Parallel()
+
+		// mod_v1_v2_v3 → canonical mod_v1_v2; mod_v1_v2 is itself a literal source token.
+		// PCL's one-level canonicalization makes a query for "test:mod_v1_v2:A" ambiguous.
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+			Resources: map[string]ResourceSpec{
+				"test:mod_v1_v2_v3:A": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod_v1_v2:A":    {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple tokens map to test:mod_v1_v2:a")
+	})
+
+	t.Run("ChainedModuleVersionsNonAdjacentLevelsDoNotCollide", func(t *testing.T) {
+		t.Parallel()
+
+		// mod_v1_v2_v3 (canonical mod_v1_v2) and mod_v1 (canonical mod) have disjoint
+		// literal and canonical forms. PCL's one-level canonicalization cannot reach one
+		// from a query for the other, so no collision.
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+			Resources: map[string]ResourceSpec{
+				"test:mod_v1_v2_v3:A": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod_v1:A":       {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+	})
+
+	t.Run("LiteralCollidesWithAnothersCanonical", func(t *testing.T) {
+		t.Parallel()
+
+		// With format "(\w+)_v\d+":
+		//   "test:mod_v1_v2:A" canonicalizes to "test:mod_v1:A"
+		//   "test:mod_v1:A"    canonicalizes to "test:mod:A"
+		// The two canonical forms are distinct, but the first source's canonical form
+		// equals the second source's literal form, so a query for "test:mod_v1:A" is
+		// ambiguous.
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+			Resources: map[string]ResourceSpec{
+				"test:mod_v1_v2:A": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod_v1:A":    {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple tokens map to test:mod_v1:a")
+	})
+
+	t.Run("ModuleFormatPlusCaseFold", func(t *testing.T) {
+		t.Parallel()
+
+		// "pkg:mod/a:A" normalizes via the format to "pkg:mod:A", which case-folds to
+		// "pkg:mod:a" — colliding with the literal "pkg:mod:a".
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(.*)(?:/[^/]*)`},
+			Resources: map[string]ResourceSpec{
+				"test:mod/a:A": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod:a":   {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple tokens map to test:mod:a")
+	})
+
+	t.Run("NoCollisionPasses", func(t *testing.T) {
+		t.Parallel()
+
+		spec := PackageSpec{
+			Name:    "test",
+			Version: "1.0.0",
+			Meta:    &MetadataSpec{ModuleFormat: `(\w+)_v\d+`},
+			Resources: map[string]ResourceSpec{
+				"test:mod_v1:A": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+				"test:mod_v1:B": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
+			},
+		}
+
+		_, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+	})
+}

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2918,37 +2918,6 @@ func TestAliasBuildIsLazy(t *testing.T) {
 	})
 }
 
-// TestGetWithCollidingAliases verifies that when two source-form tokens normalize to the
-// same alias, the alias is dropped (an ambiguous query misses cleanly) while direct
-// lookups of either source-form token still succeed.
-func TestGetWithCollidingAliases(t *testing.T) {
-	t.Parallel()
-
-	spec := PackageSpec{
-		Name:    "test",
-		Version: "1.0.0",
-		Meta:    &MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
-		Resources: map[string]ResourceSpec{
-			"test:mod/a:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
-			"test:mod/b:Thing": {ObjectTypeSpec: ObjectTypeSpec{Type: "object"}},
-		},
-	}
-
-	pkg, err := ImportSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
-	require.NoError(t, err)
-
-	a, ok := pkg.GetResource("test:mod/a:Thing")
-	require.True(t, ok)
-	assert.Equal(t, "test:mod/a:Thing", a.Token)
-
-	b, ok := pkg.GetResource("test:mod/b:Thing")
-	require.True(t, ok)
-	assert.Equal(t, "test:mod/b:Thing", b.Token)
-
-	_, ok = pkg.GetResource("test:mod:Thing")
-	assert.False(t, ok, "ambiguous alias must miss")
-}
-
 // TestGetWithIndexAliases verifies short-form aliases for tokens whose normalized module
 // is "index" — both "pkg:name" and "pkg::name" should resolve to the source token.
 func TestGetWithIndexAliases(t *testing.T) {


### PR DESCRIPTION
These tokens are unreachable in PCL, and will not generate correctly in codegen (since they target the same space in generated code). We should have always rejected them from the schema.

I've verified that tier 1 schemas still pass validation:

```bash
for pkg in aws gcp azure-native command kubernetes cloudflare; do bin/pulumi package get-schema $pkg | bin/pulumi schema check --allow-dangling-references -; done
```