### PR TITLE
Fix some secret checks in secret_provider

### DIFF
--- a/pkg/testing/pulumi-test-language/providers/secret_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/secret_provider.go
@@ -171,6 +171,21 @@ func (p *SecretProvider) Check(
 		}, nil
 	}
 
+	unsecret := func(v resource.PropertyValue) resource.PropertyValue {
+		for {
+			if v.IsSecret() {
+				v = v.SecretValue().Element
+				continue
+			}
+			if v.IsOutput() {
+				v = v.OutputValue().Element
+				continue
+			}
+			break
+		}
+		return v
+	}
+
 	assertField := func(props resource.PropertyMap, key resource.PropertyKey, typ string,
 		assertType func(resource.PropertyValue) bool,
 	) *plugin.CheckResponse {
@@ -189,18 +204,14 @@ func (p *SecretProvider) Check(
 		return nil
 	}
 
+	// isSecretString and isSecretObject require the outermost wrapper to be a secret,
+	// but accept any number of additional secret layers beneath it.
 	isSecretString := func(v resource.PropertyValue) bool {
-		if !v.IsSecret() {
-			return false
-		}
-		return v.SecretValue().Element.IsString()
+		return v.IsSecret() && unsecret(v).IsString()
 	}
 
 	isSecretObject := func(v resource.PropertyValue) bool {
-		if !v.IsSecret() {
-			return false
-		}
-		return v.SecretValue().Element.IsObject()
+		return v.IsSecret() && unsecret(v).IsObject()
 	}
 
 	check := assertField(req.News, "privateData", "secret object", isSecretObject)
@@ -215,7 +226,9 @@ func (p *SecretProvider) Check(
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(req.News, "public", "string", resource.PropertyValue.IsString)
+	check = assertField(req.News, "public", "string", func(v resource.PropertyValue) bool {
+		return unsecret(v).IsString()
+	})
 	if check != nil {
 		return *check, nil
 	}
@@ -227,15 +240,15 @@ func (p *SecretProvider) Check(
 	}
 
 	publicData := req.News["publicData"].ObjectValue()
-	check = assertField(publicData, "private", "string or secret string", func(v resource.PropertyValue) bool {
-		// TODO[https://github.com/pulumi/pulumi/issues/10319] publicData.private should be a secret string, but
-		// we tolerate a plain string here. Most SDKs do not correctly send a secret string on nested inputs.
-		return v.IsString() || (v.IsSecret() && v.SecretValue().Element.IsString())
+	check = assertField(publicData, "private", "string", func(v resource.PropertyValue) bool {
+		return unsecret(v).IsString()
 	})
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(publicData, "public", "string", resource.PropertyValue.IsString)
+	check = assertField(publicData, "public", "string", func(v resource.PropertyValue) bool {
+		return unsecret(v).IsString()
+	})
 	if check != nil {
 		return *check, nil
 	}
@@ -245,12 +258,16 @@ func (p *SecretProvider) Check(
 		}, nil
 	}
 
-	privateData := req.News["privateData"].SecretValue().Element.ObjectValue()
-	check = assertField(privateData, "private", "string", resource.PropertyValue.IsString)
+	privateData := unsecret(req.News["privateData"]).ObjectValue()
+	check = assertField(privateData, "private", "string", func(v resource.PropertyValue) bool {
+		return unsecret(v).IsString()
+	})
 	if check != nil {
 		return *check, nil
 	}
-	check = assertField(privateData, "public", "string", resource.PropertyValue.IsString)
+	check = assertField(privateData, "public", "string", func(v resource.PropertyValue) bool {
+		return unsecret(v).IsString()
+	})
 	if check != nil {
 		return *check, nil
 	}

--- a/pkg/testing/pulumi-test-language/providers/secret_provider_test.go
+++ b/pkg/testing/pulumi-test-language/providers/secret_provider_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+)
+
+func TestSecretProvider_Check(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		props    resource.PropertyMap
+		wantFail bool
+	}{
+		{
+			name: "valid input",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "publicData.private as secret<string>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.MakeSecret(resource.NewProperty("data-hidden")),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "privateData.private as secret<string>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.MakeSecret(resource.NewProperty("inner-hidden")),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "public as secret<string>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.MakeSecret(resource.NewProperty("visible")),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "publicData.public as secret<string>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.MakeSecret(resource.NewProperty("data-visible")),
+				}),
+			},
+		},
+		{
+			name: "privateData.public as secret<string>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.MakeSecret(resource.NewProperty("inner-visible")),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "publicData.private as secret<secret<string>>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.MakeSecret(resource.MakeSecret(resource.NewProperty("data-hidden"))),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "private is secret<secret<string>>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.MakeSecret(resource.NewProperty("hidden"))),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "privateData is secret<secret<object>>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				}))),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+		},
+		{
+			name: "all fields deeply nested in secrets",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.MakeSecret(resource.MakeSecret(resource.NewProperty("hidden")))),
+				"public":  resource.MakeSecret(resource.MakeSecret(resource.NewProperty("visible"))),
+				"privateData": resource.MakeSecret(resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.MakeSecret(resource.MakeSecret(resource.NewProperty("inner-hidden"))),
+					"public":  resource.MakeSecret(resource.NewProperty("inner-visible")),
+				}))),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.MakeSecret(resource.MakeSecret(resource.MakeSecret(resource.NewProperty("data-hidden")))),
+					"public":  resource.MakeSecret(resource.MakeSecret(resource.NewProperty("data-visible"))),
+				}),
+			},
+		},
+		{
+			name: "private is plain string, not secret",
+			props: resource.PropertyMap{
+				"private": resource.NewProperty("not-a-secret"),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+			wantFail: true,
+		},
+		{
+			name: "privateData is plain object, not secret",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				}),
+				"publicData": resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				}),
+			},
+			wantFail: true,
+		},
+		{
+			name: "publicData is secret<object>",
+			props: resource.PropertyMap{
+				"private": resource.MakeSecret(resource.NewProperty("hidden")),
+				"public":  resource.NewProperty("visible"),
+				"privateData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("inner-hidden"),
+					"public":  resource.NewProperty("inner-visible"),
+				})),
+				"publicData": resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+					"private": resource.NewProperty("data-hidden"),
+					"public":  resource.NewProperty("data-visible"),
+				})),
+			},
+			wantFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := &SecretProvider{}
+			resp, err := p.Check(t.Context(), plugin.CheckRequest{
+				URN:  resource.NewURN("test-stack", "test-project", "", "secret:index:Resource", "res"),
+				News: tt.props,
+			})
+			require.NoError(t, err)
+			if tt.wantFail {
+				assert.NotEmpty(t, resp.Failures)
+			} else {
+				assert.Empty(t, resp.Failures)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Found this while working on dotnet conformance. A `Check` call was failing because a nested value was itself `secret`. That should be fine so this updates the check logic to allow string or secret string.