### PR TITLE
Update some output constructors to use `Output._from_data`

### DIFF
--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -17,7 +17,7 @@ instance as a gRPC server so that it can be used as a Pulumi plugin.
 
 """
 
-from typing import Optional, TypeVar, Any, cast
+from typing import Optional, Any, cast
 import argparse
 import asyncio
 import sys
@@ -50,6 +50,7 @@ import pulumi
 import pulumi.resource
 import pulumi.runtime.config
 import pulumi.runtime.settings
+from pulumi.output import _OutputData
 from pulumi.runtime._grpc_settings import _GRPC_CHANNEL_OPTIONS
 from pulumi.errors import (
     InputPropertiesError,
@@ -239,11 +240,17 @@ class ProviderServicer(ResourceProviderServicer):
         # and/or track dependencies.
         # Note: If the value is or contains an unknown value, the Output will mark its value as
         # unknown automatically, so we just pass true for is_known here.
-        return pulumi.Output(
-            resources={DependencyResource(urn) for urn in deps},
-            future=_as_future(rpc.unwrap_rpc_secret(the_input)),
-            is_known=_as_future(True),
-            is_secret=_as_future(is_secret),
+        data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
+        data_future.set_result(
+            _OutputData(
+                resources={DependencyResource(urn) for urn in deps},
+                value=rpc.unwrap_rpc_secret(the_input),
+                is_known=True,
+                is_secret=is_secret,
+            )
+        )
+        return pulumi.Output._from_data(
+            data_future
         )
 
     @staticmethod
@@ -673,15 +680,6 @@ def main(args: list[str], version: str, provider: provider.Provider) -> None:
         asyncio.run(serve())
     except KeyboardInterrupt:
         pass
-
-
-T = TypeVar("T")
-
-
-def _as_future(value: T) -> "asyncio.Future[T]":
-    fut: asyncio.Future[T] = asyncio.Future()
-    fut.set_result(value)
-    return fut
 
 
 def _empty_as_none(text: str) -> Optional[str]:

--- a/sdk/python/lib/pulumi/provider/experimental/server.py
+++ b/sdk/python/lib/pulumi/provider/experimental/server.py
@@ -249,9 +249,7 @@ class ProviderServicer(ResourceProviderServicer):
                 is_secret=is_secret,
             )
         )
-        return pulumi.Output._from_data(
-            data_future
-        )
+        return pulumi.Output._from_data(data_future)
 
     @staticmethod
     def _construct_options(request: proto.ConstructRequest) -> pulumi.ResourceOptions:

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -242,9 +242,7 @@ class ProviderServicer(ResourceProviderServicer):
                 is_secret=is_secret,
             )
         )
-        return pulumi.Output._from_data(
-            data_future
-        )
+        return pulumi.Output._from_data(data_future)
 
     @staticmethod
     def _alias_from_proto(alias: alias_pb2.Alias) -> Union[str | pulumi.Alias]:

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -17,7 +17,7 @@ instance as a gRPC server so that it can be used as a Pulumi plugin.
 
 """
 
-from typing import Optional, TypeVar, Any, cast, Union
+from typing import Optional, Any, cast, Union
 import types
 import argparse
 import asyncio
@@ -50,6 +50,7 @@ import pulumi
 import pulumi.resource
 import pulumi.runtime.config
 import pulumi.runtime.settings
+from pulumi.output import _OutputData
 from pulumi.runtime._grpc_settings import _GRPC_CHANNEL_OPTIONS
 from pulumi.errors import (
     InputPropertiesError,
@@ -232,11 +233,17 @@ class ProviderServicer(ResourceProviderServicer):
         # and/or track dependencies.
         # Note: If the value is or contains an unknown value, the Output will mark its value as
         # unknown automatically, so we just pass true for is_known here.
-        return pulumi.Output(
-            resources={DependencyResource(urn) for urn in deps},
-            future=_as_future(rpc.unwrap_rpc_secret(the_input)),
-            is_known=_as_future(True),
-            is_secret=_as_future(is_secret),
+        data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
+        data_future.set_result(
+            _OutputData(
+                resources={DependencyResource(urn) for urn in deps},
+                value=rpc.unwrap_rpc_secret(the_input),
+                is_known=True,
+                is_secret=is_secret,
+            )
+        )
+        return pulumi.Output._from_data(
+            data_future
         )
 
     @staticmethod
@@ -543,15 +550,6 @@ def main(provider: Provider, args: list[str]) -> None:  # args not in use?
         asyncio.run(serve())
     except KeyboardInterrupt:
         pass
-
-
-T = TypeVar("T")
-
-
-def _as_future(value: T) -> "asyncio.Future[T]":
-    fut: asyncio.Future[T] = asyncio.Future()
-    fut.set_result(value)
-    return fut
 
 
 def _empty_as_none(text: str) -> Optional[str]:

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -39,7 +39,7 @@ from .runtime.resource import (
     create_urn as create_urn_internal,
 )
 from .runtime.settings import get_root_resource
-from .output import _is_prompt, _map_input, _map2_input, Output
+from .output import _is_prompt, _map_input, _map2_input, Output, _OutputData
 from . import urn as urn_util
 from . import log
 
@@ -1308,13 +1308,11 @@ class DependencyResource(CustomResource):
     def __init__(self, urn: str) -> None:
         super().__init__(t="", name="", props={}, opts=None, dependency=True)
 
-        urn_future: asyncio.Future[str] = asyncio.Future()
-        urn_known: asyncio.Future[bool] = asyncio.Future()
-        urn_secret: asyncio.Future[bool] = asyncio.Future()
-        urn_future.set_result(urn)
-        urn_known.set_result(True)
-        urn_secret.set_result(False)
-        self.__dict__["urn"] = Output({self}, urn_future, urn_known, urn_secret)
+        urn_data: asyncio.Future[_OutputData[str]] = asyncio.Future()
+        urn_data.set_result(
+            _OutputData(resources={self}, value=urn, is_known=True, is_secret=False)
+        )
+        self.__dict__["urn"] = Output._from_data(urn_data)
 
 
 class DependencyProviderResource(ProviderResource):
@@ -1333,21 +1331,17 @@ class DependencyProviderResource(ProviderResource):
 
         super().__init__(pkg=pkg, name="", props={}, opts=None, dependency=True)
 
-        urn_future: asyncio.Future[str] = asyncio.Future()
-        urn_known: asyncio.Future[bool] = asyncio.Future()
-        urn_secret: asyncio.Future[bool] = asyncio.Future()
-        urn_future.set_result(ref_urn)
-        urn_known.set_result(True)
-        urn_secret.set_result(False)
-        self.__dict__["urn"] = Output({self}, urn_future, urn_known, urn_secret)
+        urn_data: asyncio.Future[_OutputData[str]] = asyncio.Future()
+        urn_data.set_result(
+            _OutputData(resources={self}, value=ref_urn, is_known=True, is_secret=False)
+        )
+        self.__dict__["urn"] = Output._from_data(urn_data)
 
-        id_future: asyncio.Future[str] = asyncio.Future()
-        id_known: asyncio.Future[bool] = asyncio.Future()
-        id_secret: asyncio.Future[bool] = asyncio.Future()
-        id_future.set_result(ref_id)
-        id_known.set_result(True)
-        id_secret.set_result(False)
-        self.__dict__["id"] = Output({self}, id_future, id_known, id_secret)
+        id_data: asyncio.Future[_OutputData[str]] = asyncio.Future()
+        id_data.set_result(
+            _OutputData(resources={self}, value=ref_id, is_known=True, is_secret=False)
+        )
+        self.__dict__["id"] = Output._from_data(id_data)
 
 
 def export(name: str, value: Any):

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -31,6 +31,7 @@ from semver import VersionInfo
 
 from .. import _types, log
 from ..invoke import InvokeOptions, InvokeOutputOptions
+from ..output import _OutputData
 from ..runtime.proto import resource_pb2
 from ..resource import CustomResource
 from . import rpc
@@ -157,15 +158,12 @@ def invoke_output(
     resolves when the invoke finishes.
     """
 
-    # Setup the futures for the output.
-    resolve_value: asyncio.Future = asyncio.Future()
-    resolve_is_known: asyncio.Future[bool] = asyncio.Future()
-    resolve_is_secret: asyncio.Future[bool] = asyncio.Future()
-    resolve_deps: asyncio.Future[set[Resource]] = asyncio.Future()
+    # Setup the future for the output data.
+    resolve_data: asyncio.Future[_OutputData[Any]] = asyncio.Future()
 
     from .. import Output
 
-    out = Output(resolve_deps, resolve_value, resolve_is_known, resolve_is_secret)
+    out = Output._from_data(resolve_data)
 
     async def do_invoke_output() -> None:
         try:
@@ -173,19 +171,16 @@ def invoke_output(
                 tok, props, opts, typ, package_ref=package_ref, check_dependencies=True
             )
 
-            resolve_value.set_result(
-                invoke_result.value if invoke_result.is_known else None
+            resolve_data.set_result(
+                _OutputData(
+                    resources=set(invoke_result.dependencies),
+                    value=invoke_result.value if invoke_result.is_known else None,
+                    is_known=invoke_result.is_known,
+                    is_secret=invoke_result.is_secret and invoke_result.is_known,
+                )
             )
-            resolve_is_known.set_result(invoke_result.is_known)
-            resolve_is_secret.set_result(
-                invoke_result.is_secret and invoke_result.is_known
-            )
-            resolve_deps.set_result(set(invoke_result.dependencies))
         except Exception as exn:  # noqa: BLE001 catch blind exception
-            resolve_value.set_exception(exn)
-            resolve_is_known.set_exception(exn)
-            resolve_is_secret.set_exception(exn)
-            resolve_deps.set_exception(exn)
+            resolve_data.set_exception(exn)
 
     asyncio.ensure_future(_get_rpc_manager().do_rpc("invoke", do_invoke_output)())
     return out
@@ -550,19 +545,20 @@ def call(
                         else deserialized
                     )
 
-            resolve_value.set_result(value)
-            resolve_is_known.set_result(is_known)
-            resolve_is_secret.set_result(is_secret)
-            resolve_deps.set_result(deps)
+            resolve_data.set_result(
+                _OutputData(
+                    resources=deps,
+                    value=value,
+                    is_known=is_known,
+                    is_secret=is_secret,
+                )
+            )
 
         except Exception as exn:
             log.debug(
                 f"exception when preparing or executing rpc: {traceback.format_exc()}"
             )
-            resolve_value.set_exception(exn)
-            resolve_is_known.set_exception(exn)
-            resolve_is_secret.set_exception(exn)
-            resolve_deps.set_result(set())
+            resolve_data.set_exception(exn)
             raise
 
     asyncio.ensure_future(_get_rpc_manager().do_rpc("call", do_call)())

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -415,15 +415,12 @@ def call(
     if typ and not _types.is_output_type(typ):
         raise TypeError("Expected typ to be decorated with @output_type")
 
-    # Setup the futures for the output.
-    resolve_value: asyncio.Future = asyncio.Future()
-    resolve_is_known: asyncio.Future[bool] = asyncio.Future()
-    resolve_is_secret: asyncio.Future[bool] = asyncio.Future()
-    resolve_deps: asyncio.Future[set[Resource]] = asyncio.Future()
+    # Setup the future for the output data.
+    resolve_data: asyncio.Future[_OutputData[Any]] = asyncio.Future()
 
     from .. import Output
 
-    out = Output(resolve_deps, resolve_value, resolve_is_known, resolve_is_secret)
+    out = Output._from_data(resolve_data)
 
     async def do_call() -> None:
         try:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -32,7 +32,7 @@ from google.protobuf import struct_pb2
 
 from .. import _types, log
 from .. import urn as urn_util
-from ..output import Input, Output, _safe_str
+from ..output import Input, Output, _OutputData, _safe_str
 from ..runtime.proto import alias_pb2, resource_pb2, source_pb2, callback_pb2
 from . import known_types, rpc, settings
 from ._depends_on import _resolve_depends_on_urns
@@ -534,21 +534,17 @@ def create_urn(
 def resource_output(
     res: "Resource",
 ) -> tuple[Callable[[Any, bool, bool, Optional[Exception]], None], "Output"]:
-    value_future: asyncio.Future[Any] = asyncio.Future()
-    known_future: asyncio.Future[bool] = asyncio.Future()
-    secret_future: asyncio.Future[bool] = asyncio.Future()
+    data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
 
     def resolve(value: Any, known: bool, secret: bool, exn: Optional[Exception]):
         if exn is not None:
-            value_future.set_exception(exn)
-            known_future.set_exception(exn)
-            secret_future.set_exception(exn)
+            data_future.set_exception(exn)
         else:
-            value_future.set_result(value)
-            known_future.set_result(known)
-            secret_future.set_result(secret)
+            data_future.set_result(
+                _OutputData(resources={res}, value=value, is_known=known, is_secret=secret)
+            )
 
-    return resolve, Output({res}, value_future, known_future, secret_future)
+    return resolve, Output._from_data(data_future)
 
 
 def get_resource(

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -541,7 +541,9 @@ def resource_output(
             data_future.set_exception(exn)
         else:
             data_future.set_result(
-                _OutputData(resources={res}, value=value, is_known=known, is_secret=secret)
+                _OutputData(
+                    resources={res}, value=value, is_known=known, is_secret=secret
+                )
             )
 
     return resolve, Output._from_data(data_future)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -1014,20 +1014,14 @@ def deserialize_resource(
 
 def deserialize_output_value(ref_struct: struct_pb2.Struct) -> "Output[Any]":
     is_known = "value" in ref_struct
-    is_known_future: asyncio.Future = asyncio.Future()
-    is_known_future.set_result(is_known)
 
     value = None
     if is_known:
         value = deserialize_property(ref_struct["value"])
-    value_future: asyncio.Future = asyncio.Future()
-    value_future.set_result(value)
 
     is_secret = False
     if "secret" in ref_struct:
         is_secret = deserialize_property(ref_struct["secret"]) is True
-    is_secret_future: asyncio.Future = asyncio.Future()
-    is_secret_future.set_result(is_secret)
 
     resources: set[Resource] = set()
     if "dependencies" in ref_struct:
@@ -1039,9 +1033,15 @@ def deserialize_output_value(ref_struct: struct_pb2.Struct) -> "Output[Any]":
         for urn in dependencies:
             resources.add(DependencyResource(urn))
 
-    from .. import Output
+    from ..output import Output, _OutputData
 
-    return Output(resources, value_future, is_known_future, is_secret_future)
+    data_future: asyncio.Future[_OutputData[Any]] = asyncio.Future()
+    data_future.set_result(
+        _OutputData(
+            resources=resources, value=value, is_known=is_known, is_secret=is_secret
+        )
+    )
+    return Output._from_data(data_future)
 
 
 def is_rpc_secret(value: Any) -> bool:


### PR DESCRIPTION
Now we have `Output._from_data` update some more internal call sites to use it rather than constructing multiple future objects to resolve.