### PR TITLE
cli/cloud: add `pulumi cloud api describe`

### DIFF
--- a/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-describe.yaml
+++ b/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-describe.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: |
+    Add `pulumi cloud api describe` for inspecting the parameters, request
+    body, and response schema of any Pulumi Cloud API operation, with
+    text, markdown, and JSON output

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -37,9 +37,10 @@ func newAPICmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Call any Pulumi Cloud API endpoint",
-		Long: "Call any Pulumi Cloud API endpoint.\n\n" +
-			"The OpenAPI spec is cached locally for 24 hours; pass --refresh-spec " +
-			"on any subcommand to force a re-fetch.",
+		Long: "Call any Pulumi Cloud API endpoint.\n" +
+			"\n" +
+			"The OpenAPI spec is cached locally for 24 hours; pass --refresh-spec on any\n" +
+			"subcommand to force a re-fetch.",
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
@@ -47,6 +48,7 @@ func newAPICmd() *cobra.Command {
 		"Re-fetch the OpenAPI spec from Pulumi Cloud and overwrite the local cache")
 
 	cmd.AddCommand(newLsCmd(api))
+	cmd.AddCommand(newDescribeCmd(api))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/cloud/describe.go
+++ b/pkg/cmd/pulumi/cloud/describe.go
@@ -1,0 +1,263 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// newDescribeCmd builds `pulumi cloud api describe <path>`. api carries the
+// parent command's persistent flags (--refresh-spec).
+func newDescribeCmd(api *apiCommand) *cobra.Command {
+	var method string
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Short: "Show the parameters and schemas for a Pulumi Cloud API operation",
+		Long: "Show the parameters, request body, and response schema for a Pulumi Cloud\n" +
+			"API operation.\n" +
+			"\n" +
+			"The argument may be either a path (with optional template variables, e.g.\n" +
+			"`/api/stacks/{orgName}`) or an operation ID as shown in `list` (e.g.\n" +
+			"`ListAccounts`). Operation IDs are matched case-insensitively.\n" +
+			"\n" +
+			"Default output is a human-readable schema render. Pass --format=json for the\n" +
+			"stable agent envelope, including the inlined JSON schema.",
+		Example: "  # Describe an operation by its ID.\n" +
+			"  pulumi cloud api describe ListOrgMembers\n\n" +
+			"  # Describe by path — use --method when the same path maps to multiple ops.\n" +
+			"  pulumi cloud api describe /api/orgs/{orgName}/members --method=POST\n\n" +
+			"  # Paste-friendly: copy a METHOD + path row from `list` verbatim.\n" +
+			"  pulumi cloud api describe 'GET /api/user'\n\n" +
+			"  # Extract just the request body schema.\n" +
+			"  pulumi cloud api describe CreateStackTag --format=json | jq '.operation.requestBody.jsonSchema'\n\n" +
+			"  # Pull the parameter list for scripting.\n" +
+			"  pulumi cloud api describe GetStack --format=json | jq '.operation.parameters[] | {name, in, required}'",
+	}
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "path-or-operation-id"}},
+		Required:  1,
+	})
+	cmd.Flags().StringVarP(&method, "method", "X", "GET",
+		"HTTP method to look up (a path can map to multiple ops by method)")
+	cmd.Flags().StringVar(&format, "format", "",
+		"Output format: default is a human-readable schema render; "+
+			"`markdown` emits a markdown document (piping friendly, renders in IDEs/glow); "+
+			"`json` emits the stable agent envelope")
+
+	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
+		return runDescribe(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, method,
+			cmd.Flags().Changed("method"), format, api.refreshSpec)
+	})
+	return cmd
+}
+
+func runDescribe(
+	ctx context.Context,
+	w, warnW io.Writer,
+	args []string, method string, methodExplicit bool, format string, refresh bool,
+) error {
+	mode, err := resolveOutput(format)
+	if err != nil {
+		return err
+	}
+
+	idx, err := LoadIndex(ctx, warnW, refresh)
+	if err != nil {
+		return err
+	}
+
+	method = strings.ToUpper(method)
+	userArg := strings.TrimSpace(args[0])
+
+	if verb, rest, ok := splitLeadingHTTPMethod(userArg); ok {
+		if methodExplicit && method != verb {
+			return NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
+				fmt.Sprintf("conflicting methods: argument has %q, --method is %q", verb, method)).
+				WithField("method")
+		}
+		method = verb
+		userArg = rest
+	}
+
+	var mr *MatchResult
+	if looksLikeOperationID(userArg) {
+		mr, err = MatchByOperationID(idx, userArg)
+		if err != nil {
+			return err
+		}
+	} else {
+		userPath, _ := splitPathQuery(userArg)
+		mr, err = MatchPath(idx, method, userPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	//exhaustive:ignore // outputDefault/outputTable/outputRaw all render text.
+	switch mode {
+	case outputJSON:
+		return emitDescribeJSON(w, mr.Op)
+	case outputMarkdown:
+		return emitDescribeMarkdown(w, mr.Op)
+	default:
+		return emitDescribeText(w, mr.Op)
+	}
+}
+
+// emitDescribeMarkdown writes a markdown description of the operation to w.
+func emitDescribeMarkdown(w io.Writer, op *Operation) error {
+	s := RenderDescribeMarkdown(op)
+	if _, err := io.WriteString(w, s); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(s, "\n") {
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+func emitDescribeJSON(w io.Writer, op *Operation) error {
+	payload := describedOp{
+		OperationID:  op.OperationID,
+		Method:       op.Method,
+		Path:         op.Path,
+		Summary:      op.Summary,
+		Description:  op.Description,
+		Tag:          op.Tag,
+		Preview:      op.IsPreview,
+		Deprecated:   op.IsDeprecated,
+		SupersededBy: op.SupersededBy,
+		Parameters:   op.Params,
+	}
+	if op.HasBody {
+		payload.RequestBody = &bodyJSON{
+			ContentType: op.BodyContentType,
+			Schema:      op.BodySchemaText,
+			JSONSchema:  op.BodySchemaJSON,
+		}
+	}
+	if op.ResponseSchemaText != "" || op.ResponseContentType != "" {
+		payload.SuccessResponse = &bodyJSON{
+			ContentType: op.ResponseContentType,
+			Schema:      op.ResponseSchemaText,
+			JSONSchema:  op.ResponseSchemaJSON,
+		}
+	}
+	return WriteJSON(w, describeEnvelope{
+		SchemaVersion: SchemaVersion,
+		Operation:     payload,
+	}, cmdutil.Interactive())
+}
+
+// emitDescribeText writes a human-readable view to w.
+func emitDescribeText(w io.Writer, op *Operation) error {
+	s := RenderDescribeText(op)
+	if _, err := io.WriteString(w, s); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(s, "\n") {
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// RenderDescribeText builds the human-readable view of an operation and
+// returns it as a string. Used by emitDescribeText for the CLI and by the
+// TUI's Browse tab to fill the details viewport.
+func RenderDescribeText(op *Operation) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s\n", op.Method, op.Path)
+	if op.Tag != "" {
+		fmt.Fprintf(&b, "Tag: %s\n", op.Tag)
+	}
+	if op.IsPreview {
+		fmt.Fprintf(&b, "Status: PREVIEW — not yet stable, may change without notice\n")
+	}
+	if op.IsDeprecated {
+		if op.SupersededBy != "" {
+			fmt.Fprintf(&b, "Status: DEPRECATED — use %s instead\n", op.SupersededBy)
+		} else {
+			fmt.Fprintf(&b, "Status: DEPRECATED — will be removed in a future version\n")
+		}
+	}
+	if op.OperationID != "" {
+		fmt.Fprintf(&b, "Operation: %s\n", op.OperationID)
+	}
+	if op.Summary != "" {
+		fmt.Fprintf(&b, "\n%s\n", op.Summary)
+	}
+	if op.Description != "" && op.Description != op.Summary {
+		fmt.Fprintf(&b, "\n%s\n", op.Description)
+	}
+
+	if len(op.Params) > 0 {
+		b.WriteString("\nParameters:\n")
+		for _, p := range op.Params {
+			req := ""
+			if p.Required {
+				req = "*"
+			}
+			fmt.Fprintf(&b, "  [%s] %s%s (%s) — %s\n",
+				p.In, p.Name, req, p.Type, p.Description)
+			if len(p.Values) > 0 {
+				fmt.Fprintf(&b, "      allowed: %s\n", strings.Join(p.Values, ", "))
+			}
+		}
+	}
+
+	if op.HasBody {
+		fmt.Fprintf(&b, "\nRequest body (%s):\n", op.BodyContentType)
+		b.WriteString(indent(op.BodySchemaText, "  "))
+	}
+	if op.ResponseSchemaText != "" {
+		fmt.Fprintf(&b, "\nSuccess response (%s):\n", op.ResponseContentType)
+		b.WriteString(indent(op.ResponseSchemaText, "  "))
+	}
+	return b.String()
+}
+
+// indent prefixes every non-empty line of s with prefix. Used to visually
+// nest rendered schema blocks under their "Request body:" / "Response:"
+// headers — structural indentation that terminal wrapping can't replicate.
+func indent(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	var out strings.Builder
+	for i, ln := range lines {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		if ln != "" {
+			out.WriteString(prefix)
+		}
+		out.WriteString(ln)
+	}
+	if !strings.HasSuffix(s, "\n") {
+		out.WriteByte('\n')
+	}
+	return out.String()
+}

--- a/pkg/cmd/pulumi/cloud/describe_markdown.go
+++ b/pkg/cmd/pulumi/cloud/describe_markdown.go
@@ -1,0 +1,170 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RenderDescribeMarkdown produces a markdown document describing the operation,
+// laid out to mirror pulumi/docs' OpenAPI rendering (method + path header,
+// admonitions for preview/deprecated, description, a parameters table, request
+// body, and a bucketed list of responses). The output is plain GitHub-flavored
+// markdown suitable for `describe --format=markdown`; callers piping to a
+// terminal may further pass it through glow or similar for ANSI rendering.
+func RenderDescribeMarkdown(op *Operation) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# `%s` %s\n\n", op.Method, op.Path)
+
+	summary := strings.TrimSpace(op.Summary)
+	if summary == "" {
+		summary = op.OperationID
+	}
+	if summary != "" {
+		fmt.Fprintf(&b, "_%s_\n\n", summary)
+	}
+	if op.OperationID != "" {
+		fmt.Fprintf(&b, "**Operation:** `%s`", op.OperationID)
+		if op.Tag != "" {
+			fmt.Fprintf(&b, " · **Tag:** %s", op.Tag)
+		}
+		b.WriteString("\n\n")
+	}
+
+	if op.IsPreview {
+		b.WriteString("> **Preview** — this endpoint is not yet stable and may change without notice.\n\n")
+	}
+	if op.IsDeprecated {
+		if op.SupersededBy != "" {
+			fmt.Fprintf(&b, "> **Deprecated** — use `%s` instead.\n\n", op.SupersededBy)
+		} else {
+			b.WriteString("> **Deprecated** — will be removed in a future version.\n\n")
+		}
+	}
+
+	if desc := strings.TrimSpace(op.Description); desc != "" && desc != strings.TrimSpace(op.Summary) {
+		b.WriteString("## Description\n\n")
+		b.WriteString(desc)
+		b.WriteString("\n\n")
+	}
+
+	if len(op.Params) > 0 {
+		b.WriteString("## Parameters\n\n")
+		b.WriteString(parametersList(op.Params))
+		b.WriteString("\n")
+	}
+
+	if op.HasBody {
+		if op.BodyContentType != "" {
+			fmt.Fprintf(&b, "## Request body (`%s`)\n\n", op.BodyContentType)
+		} else {
+			b.WriteString("## Request body\n\n")
+		}
+		if op.BodySchemaMarkdown != "" {
+			b.WriteString(op.BodySchemaMarkdown)
+		} else {
+			b.WriteString("_No schema._")
+		}
+		b.WriteString("\n\n")
+	}
+
+	if len(op.InlineResponses) > 0 {
+		b.WriteString("## Responses\n\n")
+		for _, r := range op.InlineResponses {
+			reason := httpReasonPhrase(r.Status)
+			status := r.Status
+			if reason != "" {
+				status = r.Status + " " + reason
+			}
+			// Elide the description when it duplicates the reason phrase (e.g.
+			// spec description "No Content" on a 204).
+			desc := strings.TrimSpace(r.Description)
+			if desc == "" || strings.EqualFold(desc, reason) {
+				fmt.Fprintf(&b, "### `%s`\n\n", status)
+			} else {
+				fmt.Fprintf(&b, "### `%s` — %s\n\n", status, desc)
+			}
+			if r.SchemaMarkdown != "" {
+				b.WriteString(r.SchemaMarkdown)
+				b.WriteString("\n\n")
+			}
+		}
+	}
+	if len(op.StockErrors) > 0 {
+		b.WriteString("**Errors:** ")
+		parts := make([]string, 0, len(op.StockErrors))
+		for _, e := range op.StockErrors {
+			if e.Description != "" {
+				parts = append(parts, fmt.Sprintf("`%s` (%s)", e.Status, e.Description))
+			} else {
+				parts = append(parts, fmt.Sprintf("`%s`", e.Status))
+			}
+		}
+		b.WriteString(strings.Join(parts, ", "))
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+// parametersList renders parameters as a bullet list. Each row carries the
+// same data a table would — name, location, required flag, type, and a
+// flattened description — but without GFM table formatting so terminal
+// renderers that style tables with backgrounds don't clobber the rest of the
+// page. Mirrors pulumi/docs' `parameters.html` partial.
+func parametersList(params []ParamSpec) string {
+	rows := append([]ParamSpec(nil), params...)
+	inPrecedence := map[string]int{"path": 0, "query": 1, "header": 2, "cookie": 3}
+	sort.SliceStable(rows, func(i, j int) bool {
+		pi, pj := inPrecedence[rows[i].In], inPrecedence[rows[j].In]
+		if pi != pj {
+			return pi < pj
+		}
+		return rows[i].Name < rows[j].Name
+	})
+
+	var b strings.Builder
+	for _, p := range rows {
+		req := "_optional_"
+		if p.Required {
+			req = "**required**"
+		}
+		fmt.Fprintf(&b, "- `%s` `%s` _(in: %s)_ %s", p.Name, p.Type, p.In, req)
+		if desc := mdInline(p.Description); desc != "" {
+			fmt.Fprintf(&b, " — %s", desc)
+		}
+		b.WriteByte('\n')
+		if len(p.Values) > 0 {
+			fmt.Fprintf(&b, "  - %s\n", markdownEnumTail(p.Values))
+		}
+	}
+	return b.String()
+}
+
+// httpReasonPhrase returns the standard HTTP reason phrase for a numeric
+// status code ("OK" for 200, "Not Found" for 404). Returns "" for non-numeric
+// or unrecognized status strings so callers can fall back to the bare code.
+func httpReasonPhrase(status string) string {
+	n, err := strconv.Atoi(status)
+	if err != nil {
+		return ""
+	}
+	return http.StatusText(n)
+}

--- a/pkg/cmd/pulumi/cloud/describe_markdown_test.go
+++ b/pkg/cmd/pulumi/cloud/describe_markdown_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// loadMarkdownOp resolves an op from the embedded spec for renderer tests.
+// Fails the test outright when the op is missing so a spec drift doesn't
+// silently mask a bug in the renderer.
+func loadMarkdownOp(t *testing.T, id string) *Operation {
+	t.Helper()
+	idx := loadTestIndex(t)
+	res, err := MatchByOperationID(idx, id)
+	if err != nil {
+		t.Fatalf("match %s: %v", id, err)
+	}
+	return res.Op
+}
+
+func TestRenderDescribeMarkdownHeader(t *testing.T) {
+	t.Parallel()
+
+	op := loadMarkdownOp(t, "ListOrgTokens")
+	md := RenderDescribeMarkdown(op)
+
+	assert.True(t, strings.HasPrefix(md, "# `GET` /api/orgs/{orgName}/tokens"),
+		"first line should be a top-level heading with method chip + path, got: %q",
+		firstLine(md))
+	assert.Contains(t, md, "**Operation:** `ListOrgTokens`")
+	assert.Contains(t, md, "**Tag:** AccessTokens")
+}
+
+func TestRenderDescribeMarkdownPreviewAdmonition(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:      "GET",
+		Path:        "/api/preview",
+		OperationID: "GetPreview",
+		IsPreview:   true,
+	}
+	md := RenderDescribeMarkdown(op)
+	assert.Contains(t, md, "> **Preview**",
+		"preview ops should render a blockquote admonition")
+}
+
+func TestRenderDescribeMarkdownDeprecatedAdmonition(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:       "GET",
+		Path:         "/api/deprecated",
+		OperationID:  "GetDeprecated",
+		IsDeprecated: true,
+		SupersededBy: "GetReplacement",
+	}
+	md := RenderDescribeMarkdown(op)
+	assert.Contains(t, md, "> **Deprecated**")
+	assert.Contains(t, md, "use `GetReplacement` instead")
+}
+
+func TestRenderDescribeMarkdownParametersList(t *testing.T) {
+	t.Parallel()
+
+	op := loadMarkdownOp(t, "ListOrgTokens")
+	md := RenderDescribeMarkdown(op)
+
+	assert.Contains(t, md, "## Parameters")
+	// orgName is a required path param.
+	assert.Contains(t, md, "- `orgName` `string` _(in: path)_ **required**")
+	// filter is an optional query param.
+	assert.Contains(t, md, "- `filter` `string` _(in: query)_ _optional_")
+}
+
+func TestRenderDescribeMarkdownRequestBody(t *testing.T) {
+	t.Parallel()
+
+	op := loadMarkdownOp(t, "CreateOrgToken")
+	md := RenderDescribeMarkdown(op)
+
+	assert.Contains(t, md, "## Request body (`application/json`)")
+	assert.Contains(t, md, "- `name` `string` **required**",
+		"required properties should be flagged")
+	assert.Contains(t, md, "- `expires`",
+		"optional properties should still appear")
+}
+
+func TestRenderDescribeMarkdownResponsesSection(t *testing.T) {
+	t.Parallel()
+
+	op := loadMarkdownOp(t, "ListOrgTokens")
+	md := RenderDescribeMarkdown(op)
+
+	assert.Contains(t, md, "## Responses")
+	assert.Contains(t, md, "### `200 OK`",
+		"inline response headings should use the HTTP reason phrase")
+}
+
+func TestRenderDescribeMarkdownEnumTail(t *testing.T) {
+	t.Parallel()
+
+	vals := markdownEnumTail([]string{"a", "b", "c"})
+	assert.Equal(t, "_enum:_ `a`, `b`, `c`", vals)
+}
+
+func TestRenderDescribeMarkdownEnumTailTruncates(t *testing.T) {
+	t.Parallel()
+
+	vals := markdownEnumTail([]string{"a", "b", "c", "d", "e", "f", "g", "h"})
+	assert.Contains(t, vals, "`a`")
+	assert.Contains(t, vals, "`f`")
+	assert.Contains(t, vals, "…", "more than six enum values should be ellipsized")
+	assert.NotContains(t, vals, "`g`", "extra values past 6 are dropped")
+}
+
+func TestParametersListEnumTail(t *testing.T) {
+	t.Parallel()
+
+	params := []ParamSpec{{
+		Name: "level", In: "query", Type: "string",
+		Description: "Log level", Values: []string{"info", "warn", "error"},
+	}}
+	out := parametersList(params)
+	assert.Contains(t, out, "- `level` `string` _(in: query)_ _optional_ — Log level")
+	assert.Contains(t, out, "_enum:_ `info`, `warn`, `error`")
+}
+
+func TestMarkdownStockErrors(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method: "GET", Path: "/api/x", OperationID: "X",
+		StockErrors: []ErrorRef{
+			{Status: "404", Description: "Not Found"},
+			{Status: "429", Description: "Too Many Requests"},
+		},
+	}
+	md := RenderDescribeMarkdown(op)
+	assert.Contains(t, md, "**Errors:**")
+	assert.Contains(t, md, "`404` (Not Found)")
+	assert.Contains(t, md, "`429` (Too Many Requests)")
+}
+
+func TestPopulateResponsesSchemalessSuccessIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	// DeletePersonalToken returns 204 No Content; the spec's schemaless 2xx
+	// should appear under InlineResponses (rendered as a heading with
+	// description), NOT under StockErrors (which is for 4xx/5xx).
+	op := loadMarkdownOp(t, "DeletePersonalToken")
+
+	for _, err := range op.StockErrors {
+		assert.NotEqual(t, "204", err.Status,
+			"204 is a success status and should not be bucketed as a stock error")
+	}
+
+	found204 := false
+	for _, r := range op.InlineResponses {
+		if r.Status == "204" {
+			found204 = true
+			break
+		}
+	}
+	assert.True(t, found204, "204 should appear under InlineResponses")
+}
+
+func firstLine(s string) string {
+	if i := strings.Index(s, "\n"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/pkg/cmd/pulumi/cloud/describe_test.go
+++ b/pkg/cmd/pulumi/cloud/describe_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderDescribeTextShowsPreviewStatus(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:      "GET",
+		Path:        "/api/example",
+		OperationID: "GetExample",
+		Tag:         "Example",
+		IsPreview:   true,
+	}
+	out := RenderDescribeText(op)
+	assert.Contains(t, out, "Status: PREVIEW", "preview ops must surface a status line")
+}
+
+func TestRenderDescribeTextShowsDeprecatedStatus(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:       "GET",
+		Path:         "/api/example",
+		OperationID:  "GetExample",
+		Tag:          "Example",
+		IsDeprecated: true,
+	}
+	out := RenderDescribeText(op)
+	assert.Contains(t, out, "Status: DEPRECATED",
+		"deprecated ops must surface a status line")
+	assert.Contains(t, out, "will be removed in a future version",
+		"plain DEPRECATED line should hint at future removal")
+}
+
+func TestRenderDescribeTextShowsSupersededBy(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:       "GET",
+		Path:         "/api/example",
+		OperationID:  "GetExample",
+		Tag:          "Example",
+		IsDeprecated: true,
+		SupersededBy: "NewExample",
+	}
+	out := RenderDescribeText(op)
+	assert.Contains(t, out, "DEPRECATED — use NewExample instead",
+		"SupersededBy should steer users to the replacement op")
+	assert.False(t, strings.Contains(out, "will be removed in a future version"),
+		"with SupersededBy we use the targeted hint, not the generic one")
+}
+
+func TestRenderDescribeTextStableOpsOmitStatus(t *testing.T) {
+	t.Parallel()
+
+	op := &Operation{
+		Method:      "GET",
+		Path:        "/api/example",
+		OperationID: "GetExample",
+		Tag:         "Example",
+	}
+	out := RenderDescribeText(op)
+	assert.NotContains(t, out, "Status:", "stable ops shouldn't render a Status line")
+}
+
+// describeGoldenCases are the operations exercised by the text + markdown
+// golden tests. Each case either loads an op from the fixture or builds a
+// synthetic *Operation inline so deprecated/preview/superseded variants stay
+// deterministic even if the embedded spec changes.
+func describeGoldenCases(t *testing.T) []struct {
+	name string
+	op   *Operation
+} {
+	t.Helper()
+	return []struct {
+		name string
+		op   *Operation
+	}{
+		{"list_org_tokens", loadMarkdownOp(t, "ListOrgTokens")},
+		{"create_org_token", loadMarkdownOp(t, "CreateOrgToken")},
+		{"preview_op", &Operation{
+			Method:      "GET",
+			Path:        "/api/preview/things/{id}",
+			OperationID: "GetPreviewThing",
+			Tag:         "Preview",
+			Summary:     "Fetch a preview thing.",
+			IsPreview:   true,
+			Params: []ParamSpec{
+				{Name: "id", In: "path", Type: "string", Required: true, Description: "Thing ID."},
+			},
+		}},
+		{"deprecated_with_successor", &Operation{
+			Method:       "GET",
+			Path:         "/api/old/things",
+			OperationID:  "ListOldThings",
+			Tag:          "Legacy",
+			Summary:      "List legacy things.",
+			IsDeprecated: true,
+			SupersededBy: "ListThings",
+			Params: []ParamSpec{
+				{Name: "filter", In: "query", Type: "string", Description: "Optional filter."},
+			},
+		}},
+	}
+}
+
+// TestRenderDescribeText_Golden pins the exact text-render output for a set
+// of representative operations. Regenerate with PULUMI_ACCEPT=true when the
+// render changes intentionally.
+func TestRenderDescribeText_Golden(t *testing.T) {
+	t.Parallel()
+	for _, tc := range describeGoldenCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := RenderDescribeText(tc.op)
+			path := filepath.Join("testdata", "describe_golden", tc.name+".txt")
+			assertGolden(t, path, got)
+		})
+	}
+}
+
+// TestRenderDescribeMarkdown_Golden pins the exact markdown-render output.
+// Regenerate with PULUMI_ACCEPT=true when the render changes intentionally.
+func TestRenderDescribeMarkdown_Golden(t *testing.T) {
+	t.Parallel()
+	for _, tc := range describeGoldenCases(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := RenderDescribeMarkdown(tc.op)
+			path := filepath.Join("testdata", "describe_golden", tc.name+".md")
+			assertGolden(t, path, got)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -221,14 +221,14 @@ func WriteEvent(w io.Writer, ev *Event) error {
 	return WriteJSON(w, ev, false)
 }
 
-// Command-output envelopes. Each top-level `--output=json` payload gets a
+// Command-output envelopes. Each top-level `--format=json` payload gets a
 // dedicated envelope type here so the wire format is reviewable in one place.
 
 // orderedByDesc describes the sort order `ls` commits to. Agents can key off
 // this so they skip defensive resorting.
 const orderedByDesc = "tag asc, path asc, method precedence (GET, POST, PUT, PATCH, DELETE, HEAD)"
 
-// lsOperation is the per-row shape of the `ls --output=json` payload.
+// lsOperation is the per-row shape of the `list --format=json` payload.
 // Summary and Description both appear: Pulumi's spec generator fills Summary
 // from the same Java annotation value as OperationID (so the two often match),
 // while Description holds the long-form prose. Both are emitted as "" when
@@ -246,13 +246,47 @@ type lsOperation struct {
 }
 
 // lsEnvelope is the top-level JSON shape emitted by `ls` on stdout when
-// piped or when --output=json is set.
+// piped or when --format=json is set.
 type lsEnvelope struct {
 	SchemaVersion int           `json:"schemaVersion"`
 	OrderedBy     string        `json:"orderedBy"`
 	SpecVersion   string        `json:"specVersion,omitempty"`
 	Count         int           `json:"count"`
 	Operations    []lsOperation `json:"operations"`
+}
+
+// describedOp is the per-operation payload emitted by `describe --format=json`.
+// It's a view over Operation with stable JSON names so the envelope remains
+// usable across CLI versions.
+type describedOp struct {
+	OperationID     string      `json:"operationId"`
+	Method          string      `json:"method"`
+	Path            string      `json:"path"`
+	Summary         string      `json:"summary"`
+	Description     string      `json:"description"`
+	Tag             string      `json:"tag,omitempty"`
+	Preview         bool        `json:"preview,omitempty"`
+	Deprecated      bool        `json:"deprecated,omitempty"`
+	SupersededBy    string      `json:"supersededBy,omitempty"`
+	Parameters      []ParamSpec `json:"parameters,omitempty"`
+	RequestBody     *bodyJSON   `json:"requestBody,omitempty"`
+	SuccessResponse *bodyJSON   `json:"successResponse,omitempty"`
+}
+
+// bodyJSON is the shape for request / response bodies in the describe
+// envelope. `schema` is the human-readable inline rendering; `jsonSchema`
+// is the raw OpenAPI schema with all $refs resolved, for agents that want
+// to walk the structure programmatically.
+type bodyJSON struct {
+	ContentType string          `json:"contentType,omitempty"`
+	Schema      string          `json:"schema,omitempty"`
+	JSONSchema  json.RawMessage `json:"jsonSchema,omitempty"`
+}
+
+// describeEnvelope is the top-level `describe --format=json` shape.
+type describeEnvelope struct {
+	SchemaVersion int         `json:"schemaVersion"`
+	Operation     describedOp `json:"operation"`
 }
 
 // errorDetailFromErr converts a generic error into a minimal ErrorDetail.

--- a/pkg/cmd/pulumi/cloud/ls.go
+++ b/pkg/cmd/pulumi/cloud/ls.go
@@ -40,15 +40,16 @@ func newLsCmd(api *apiCommand) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List every Pulumi Cloud API endpoint",
-		Long: "List every endpoint exposed by the Pulumi Cloud OpenAPI spec. " +
-			"Output is sorted by (tag asc, path asc, method precedence). The default " +
-			"is a human-readable table on a terminal; when stdout is piped to another " +
-			"process, list automatically switches to the JSON envelope so downstream " +
-			"parsers don't trip on the table's box-drawing characters. Pass " +
-			"--format=json to request JSON explicitly, or --format=table to keep the " +
-			"table even when piped.\n\n" +
-			"Preview endpoints are listed by default; deprecated endpoints are hidden. " +
-			"Use --include-preview=false or --include-deprecated to change that.",
+		Long: "List every endpoint exposed by the Pulumi Cloud OpenAPI spec.\n" +
+			"\n" +
+			"Output is sorted by (tag asc, path asc, method precedence). The default is a\n" +
+			"human-readable table when interactive; when non-interactive, list switches to\n" +
+			"the JSON envelope so downstream parsers don't have to deal with the table's\n" +
+			"box-drawing characters. Pass --format=json to request JSON explicitly, or\n" +
+			"--format=table to keep the table when redirecting.\n" +
+			"\n" +
+			"Preview endpoints are listed by default; deprecated endpoints are hidden. Use\n" +
+			"--include-preview=false or --include-deprecated to change that.",
 		Example: "  # Print the table of stable endpoints.\n" +
 			"  pulumi cloud api list\n\n" +
 			"  # Grab every operation as JSON (the default when piped).\n" +

--- a/pkg/cmd/pulumi/cloud/pathmatch.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch.go
@@ -1,0 +1,231 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/pgavlin/fx/v2"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// Binding is one resolved or deferred path-parameter value derived from
+// matching a concrete path against an OpenAPI template.
+type Binding struct {
+	// Literal is the value the user supplied verbatim in the path
+	// (e.g. "acme" for `/api/stacks/acme`). Empty when the user supplied
+	// a template placeholder instead.
+	Literal string
+	// Placeholder is the alias the user wrote (e.g. "org" from `{org}`)
+	// when they want the CLI to resolve the value from --org / context.
+	// Empty when Literal is set.
+	Placeholder string
+}
+
+// isTemplateSegment reports whether a path segment is wrapped in {braces}.
+func isTemplateSegment(s string) bool {
+	return len(s) >= 2 && s[0] == '{' && s[len(s)-1] == '}'
+}
+
+// trimBraces strips the surrounding {} from a template segment.
+func trimBraces(s string) string {
+	if !isTemplateSegment(s) {
+		return s
+	}
+	return s[1 : len(s)-1]
+}
+
+// splitSegments normalises p with path.Clean and splits on "/".
+func splitSegments(p string) []string {
+	return strings.Split(path.Clean(p), "/")
+}
+
+// countTemplateParams returns the number of {param} segments in a spec path.
+// More-specific paths (fewer params) win ties when multiple operations match.
+func countTemplateParams(p string) int {
+	n := 0
+	for _, seg := range splitSegments(p) {
+		if isTemplateSegment(seg) {
+			n++
+		}
+	}
+	return n
+}
+
+// MatchResult is the outcome of matching a user-provided path against the
+// parsed spec.
+type MatchResult struct {
+	Op       *Operation
+	Bindings map[string]Binding // keyed by spec param name (e.g. "orgName")
+}
+
+// MatchByOperationID finds the Operation in idx whose OperationID matches id
+// case-insensitively. Returns a structured APIError on no match or on an
+// ambiguous match.
+func MatchByOperationID(idx *Index, id string) (*MatchResult, error) {
+	matches := slices.Collect(fx.Filter(
+		slices.Values(idx.Operations),
+		func(op *Operation) bool { return strings.EqualFold(op.OperationID, id) },
+	))
+	if len(matches) == 0 {
+		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
+			"no operation with ID "+id).
+			WithSuggestions(
+				"run 'pulumi cloud api list' to see available endpoints",
+				"operation IDs are case-insensitive but must match exactly otherwise",
+			)
+	}
+	if len(matches) > 1 {
+		paths := make([]string, 0, len(matches))
+		for _, op := range matches {
+			paths = append(paths, op.Method+" "+op.Path)
+		}
+		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
+			"operation ID "+id+" matches multiple operations").
+			WithSuggestions(paths...)
+	}
+	return &MatchResult{Op: matches[0], Bindings: map[string]Binding{}}, nil
+}
+
+// looksLikeOperationID reports whether s looks like an operation identifier
+// (e.g. "ListAccounts") rather than a URL path.
+func looksLikeOperationID(s string) bool {
+	return s != "" && !strings.Contains(s, "/")
+}
+
+// splitLeadingHTTPMethod peels a leading HTTP verb off of s. Returns the
+// verb upper-cased, the remainder trimmed, and ok=true when it found one.
+// Verbs are the set in methodPrecedence (spec.go), so adding a new method
+// to the spec auto-enables it here.
+func splitLeadingHTTPMethod(s string) (verb, rest string, ok bool) {
+	sp := strings.IndexByte(s, ' ')
+	if sp <= 0 {
+		return "", "", false
+	}
+	head := strings.ToUpper(s[:sp])
+	if _, ok := methodPrecedence[head]; !ok {
+		return "", "", false
+	}
+	return head, strings.TrimSpace(s[sp+1:]), true
+}
+
+// MatchPath finds the Operation in idx whose template best matches userPath
+// for the given HTTP method. Returns a structured APIError on no match.
+// Ties between equally-specific templates produce an "ambiguous" error.
+//
+// Matching rules, segment by segment:
+//   - spec literal must equal user literal (case-sensitive)
+//   - spec {param} captures either a user literal value, or a user {alias}
+//     placeholder that the caller will resolve later
+//   - a user {alias} cannot align with a spec literal — that means the user
+//     typed the wrong path
+//
+// Specificity preference: among matches, pick the one with the fewest
+// template parameters. If two are equally specific, return an error so the
+// agent has to disambiguate explicitly.
+func MatchPath(idx *Index, method, userPath string) (*MatchResult, error) {
+	userSegs := splitSegments(userPath)
+
+	var matches []*MatchResult
+	for _, op := range idx.Operations {
+		if op.Method != method {
+			continue
+		}
+		specSegs := splitSegments(op.Path)
+		if len(specSegs) != len(userSegs) {
+			continue
+		}
+
+		bindings := make(map[string]Binding)
+		ok := true
+		for i, spec := range specSegs {
+			user := userSegs[i]
+			specIsParam := isTemplateSegment(spec)
+			userIsParam := isTemplateSegment(user)
+
+			switch {
+			case specIsParam && userIsParam:
+				bindings[trimBraces(spec)] = Binding{Placeholder: trimBraces(user)}
+			case specIsParam && !userIsParam:
+				bindings[trimBraces(spec)] = Binding{Literal: user}
+			case !specIsParam && userIsParam:
+				ok = false // can't parametrize a literal segment
+			default:
+				if spec != user {
+					ok = false
+				}
+			}
+			if !ok {
+				break
+			}
+		}
+		if ok {
+			matches = append(matches, &MatchResult{Op: op, Bindings: bindings})
+		}
+	}
+
+	if len(matches) == 0 {
+		suggestions := []string{
+			"run 'pulumi cloud api list' to see available endpoints",
+			"check the method with -X / --method",
+		}
+		if looksLikeOperationID(userPath) {
+			suggestions = append([]string{
+				"if you meant an operation ID, try 'pulumi cloud api describe " + userPath + "'",
+			}, suggestions...)
+		}
+		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
+			"no operation matches "+method+" "+userPath).
+			WithSuggestions(suggestions...)
+	}
+
+	// Prefer the most specific (fewest param segments) match.
+	best := matches[0]
+	bestCount := countTemplateParams(best.Op.Path)
+	tied := false
+	for _, m := range matches[1:] {
+		c := countTemplateParams(m.Op.Path)
+		switch {
+		case c < bestCount:
+			best = m
+			bestCount = c
+			tied = false
+		case c == bestCount:
+			tied = true
+		}
+	}
+	if tied {
+		paths := make([]string, 0, len(matches))
+		for _, m := range matches {
+			if countTemplateParams(m.Op.Path) == bestCount {
+				paths = append(paths, m.Op.Method+" "+m.Op.Path)
+			}
+		}
+		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
+			"path matches multiple operations with equal specificity").
+			WithSuggestions(paths...)
+	}
+	return best, nil
+}
+
+// splitPathQuery separates `?...` from a user-supplied path. Used by both
+// describe (which discards the query) and the dispatcher (which forwards it).
+func splitPathQuery(userPath string) (string, string) {
+	path, query, _ := strings.Cut(userPath, "?")
+	return path, query
+}

--- a/pkg/cmd/pulumi/cloud/pathmatch_test.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestIndex(ops ...*Operation) *Index {
+	idx := &Index{
+		Operations: ops,
+		ByKey:      make(map[string]*Operation, len(ops)),
+	}
+	for _, op := range ops {
+		idx.ByKey[op.Key()] = op
+	}
+	return idx
+}
+
+func TestMatchPath_Literal(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/user")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/user", mr.Op.Path)
+	assert.Empty(t, mr.Bindings)
+}
+
+func TestMatchPath_TemplateCapture(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/stacks/{orgName}/{projectName}"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/stacks/acme/widgets")
+	require.NoError(t, err)
+	assert.Equal(t, Binding{Literal: "acme"}, mr.Bindings["orgName"])
+	assert.Equal(t, Binding{Literal: "widgets"}, mr.Bindings["projectName"])
+}
+
+func TestMatchPath_UserAliasPlaceholder(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/stacks/{orgName}"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/stacks/{org}")
+	require.NoError(t, err)
+	assert.Equal(t, Binding{Placeholder: "org"}, mr.Bindings["orgName"])
+}
+
+func TestMatchPath_MixedLiteralAndPlaceholder(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/stacks/{orgName}/{projectName}"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/stacks/acme/{project}")
+	require.NoError(t, err)
+	assert.Equal(t, Binding{Literal: "acme"}, mr.Bindings["orgName"])
+	assert.Equal(t, Binding{Placeholder: "project"}, mr.Bindings["projectName"])
+}
+
+func TestMatchPath_MethodMismatch(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "POST", Path: "/api/user"},
+	)
+	_, err := MatchPath(idx, "GET", "/api/user")
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
+	assert.Equal(t, ErrNoMatch, apiErr.Envelope.Error.Code)
+}
+
+func TestMatchPath_SegmentLengthMismatch(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/stacks/{orgName}"},
+	)
+	_, err := MatchPath(idx, "GET", "/api/stacks/acme/extra")
+	assert.Error(t, err)
+}
+
+func TestMatchPath_PrefersMoreSpecific(t *testing.T) {
+	t.Parallel()
+	// Both could structurally match but the literal one wins.
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/users/{userLogin}"},
+		&Operation{Method: "GET", Path: "/api/users/me"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/users/me")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/users/me", mr.Op.Path)
+}
+
+func TestMatchPath_UserTemplateAgainstLiteralSegmentFails(t *testing.T) {
+	t.Parallel()
+	// User types {x} in a position where the spec has a literal "me".
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/users/me"},
+	)
+	_, err := MatchPath(idx, "GET", "/api/users/{x}")
+	assert.Error(t, err)
+}
+
+func TestCountTemplateParams(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 0, countTemplateParams("/api/user"))
+	assert.Equal(t, 2, countTemplateParams("/api/stacks/{org}/{project}"))
+	assert.Equal(t, 1, countTemplateParams("/api/orgs/{orgName}/members"))
+}
+
+func TestMatchByOperationID_Exact(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user", OperationID: "GetCurrentUser"},
+		&Operation{Method: "GET", Path: "/api/orgs", OperationID: "ListOrgs"},
+	)
+	mr, err := MatchByOperationID(idx, "GetCurrentUser")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/user", mr.Op.Path)
+}
+
+func TestMatchByOperationID_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/orgs", OperationID: "ListOrgs"},
+	)
+	mr, err := MatchByOperationID(idx, "listorgs")
+	require.NoError(t, err)
+	assert.Equal(t, "ListOrgs", mr.Op.OperationID)
+}
+
+func TestMatchByOperationID_NoMatch(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user", OperationID: "GetCurrentUser"},
+	)
+	_, err := MatchByOperationID(idx, "Nonexistent")
+	assert.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrNoMatch, apiErr.Envelope.Error.Code)
+}
+
+func TestMatchByOperationID_Ambiguous(t *testing.T) {
+	t.Parallel()
+	// Shouldn't happen in a real spec, but guard against duplicates anyway.
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/a", OperationID: "Dup"},
+		&Operation{Method: "POST", Path: "/api/b", OperationID: "Dup"},
+	)
+	_, err := MatchByOperationID(idx, "Dup")
+	assert.Error(t, err)
+}
+
+func TestLooksLikeOperationID(t *testing.T) {
+	t.Parallel()
+	assert.True(t, looksLikeOperationID("ListAccounts"))
+	assert.True(t, looksLikeOperationID("get-user"))
+	assert.False(t, looksLikeOperationID("/api/user"))
+	assert.False(t, looksLikeOperationID(""))
+}
+
+func TestSplitLeadingHTTPMethod(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in       string
+		wantVerb string
+		wantRest string
+		wantOK   bool
+	}{
+		{"GET /api/user", "GET", "/api/user", true},
+		{"get /api/user", "GET", "/api/user", true},
+		{"POST   /api/stacks", "POST", "/api/stacks", true},
+		{"/api/user", "", "", false},
+		{"ListAccounts", "", "", false},
+		{"BOGUS /api/user", "", "", false},
+		{"", "", "", false},
+		{"GET", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			v, r, ok := splitLeadingHTTPMethod(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantVerb, v)
+			assert.Equal(t, tc.wantRest, r)
+		})
+	}
+}
+
+func TestMatchPath_SuggestsOperationIDWhenInputLooksLikeOne(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user", OperationID: "GetCurrentUser"},
+	)
+	_, err := MatchPath(idx, "GET", "ListAccounts")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	// The suggestion mentioning operation-ID usage should be present.
+	found := false
+	for _, s := range apiErr.Envelope.Error.Suggestions {
+		if strings.Contains(s, "describe ListAccounts") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected an operation-ID suggestion, got %v", apiErr.Envelope.Error.Suggestions)
+}

--- a/pkg/cmd/pulumi/cloud/spec.go
+++ b/pkg/cmd/pulumi/cloud/spec.go
@@ -30,7 +30,7 @@ import (
 )
 
 // ParamSpec describes a single parameter for an API operation.
-// JSON tags are part of the `describe --output=json` envelope contract
+// JSON tags are part of the `describe --format=json` envelope contract
 // (SchemaVersion 1).
 type ParamSpec struct {
 	Name        string   `json:"name"`
@@ -76,22 +76,22 @@ type Operation struct {
 	// SuccessContentTypes lists every content type declared on the primary
 	// 2xx response, in spec order. An endpoint that offers both
 	// `application/json` and `text/markdown` will carry both, which lets the
-	// dispatcher drive content negotiation via --output. The legacy
+	// dispatcher drive content negotiation via --format. The legacy
 	// ResponseContentType field is still populated with the first preferred
 	// entry so human/JSON describe output stays stable.
 	SuccessContentTypes []string
 	BodySchemaText      string
 	ResponseSchemaText  string
-	// Request/response schemas serialized with all $refs inlined, so `describe --output=json`
+	// Request/response schemas serialized with all $refs inlined, so `describe --format=json`
 	// consumers can walk the structure programmatically.
 	BodySchemaJSON     json.RawMessage
 	ResponseSchemaJSON json.RawMessage
-	// Markdown-rendered request body schema for --output=markdown and the TUI.
+	// Markdown-rendered request body schema for --format=markdown and the TUI.
 	BodySchemaMarkdown string
 	// InlineResponses carries every response that has a schema (both success and
 	// error). The primary success response is duplicated into the flat
 	// ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields above so
-	// the existing --output=human and --output=json contracts stay stable.
+	// the text and `--format=json` outputs both keep a stable primary body.
 	InlineResponses []ResponseSpec
 	// StockErrors lists response codes with no schema — docs renders these as a
 	// compact chip row.
@@ -110,7 +110,7 @@ type Operation struct {
 type Index struct {
 	Operations  []*Operation
 	ByKey       map[string]*Operation // "GET /api/user" -> op
-	SpecVersion string                // the spec's own info.version, surfaced in `ls --output=json`
+	SpecVersion string                // the spec's own info.version, surfaced in `list --format=json`
 }
 
 // methodPrecedence defines the method order used for stable sorting of operations.
@@ -263,8 +263,8 @@ func parseOperation(path, method string, op *v3high.Operation, renderer *schemaR
 // populateResponses walks every response code on op and buckets them into
 // `InlineResponses` (has a schema) vs `StockErrors` (no schema). The first
 // 2xx success response is also duplicated into the flat
-// ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields to preserve
-// the existing `describe --output=human|json` contracts.
+// ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields so the
+// `describe` text and `--format=json` outputs both have a primary body.
 func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRenderer) {
 	if op.Responses == nil {
 		return
@@ -326,10 +326,10 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 		}
 		out.InlineResponses = append(out.InlineResponses, spec)
 
-		// Mirror the first success response into the flat fields so the existing
-		// --output=human / --output=json contracts still see the "primary" body.
+		// Mirror the first success response into the flat fields so the text
+		// and `--format=json` outputs both still see the "primary" body.
 		// Also snapshot the full list of content types the spec declares for
-		// that response — the dispatcher uses it to drive --output-based
+		// that response — the dispatcher uses it to drive --format-based
 		// content negotiation.
 		if out.ResponseSchemaText == "" && isSuccessStatus(e.status) {
 			out.ResponseContentType = spec.ContentType
@@ -340,7 +340,7 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 	}
 
 	// Fallback: if no success response had a schema, prefer the `default` block
-	// so --output=human/json still surface something — matches prior behavior.
+	// so the text and JSON outputs still surface something — matches prior behavior.
 	if out.ResponseSchemaText == "" {
 		for _, spec := range out.InlineResponses {
 			if spec.Status == "default" {

--- a/pkg/cmd/pulumi/cloud/spec_test.go
+++ b/pkg/cmd/pulumi/cloud/spec_test.go
@@ -99,7 +99,7 @@ func TestInternalOpsFiltered(t *testing.T) {
 
 // TestSuccessContentTypesCaptured asserts the parser records every content
 // type the spec declares on the primary 2xx response — the dispatcher uses
-// this list to drive --output-based content negotiation, so dropping
+// this list to drive --format-based content negotiation, so dropping
 // alternatives at parse time would silently defeat the feature.
 func TestSuccessContentTypesCaptured(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/.gitattributes
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/.gitattributes
@@ -1,0 +1,3 @@
+# Goldens are compared byte-for-byte; force LF so Windows checkouts don't
+# flip them to CRLF and break `assertGolden`.
+* text eol=lf

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/create_org_token.md
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/create_org_token.md
@@ -1,0 +1,33 @@
+# `POST` /api/orgs/{orgName}/tokens
+
+_CreateOrgToken_
+
+**Operation:** `CreateOrgToken` · **Tag:** AccessTokens
+
+## Description
+
+Generates a new access token scoped to the organization for use in CI/CD pipelines and automated workflows. Organization tokens belong to the organization rather than individual users, ensuring that access is not disrupted when team members leave.
+
+The `name` field must be unique across the organization (including deleted tokens) and cannot exceed 40 characters. The `expires` field accepts a unix epoch timestamp up to two years from the present, or `0` for no expiry (default).
+
+**Important:** The token value in the response is only returned once at creation time and cannot be retrieved later. Audit logs for actions performed with organization tokens are attributed to the organization rather than an individual user.
+
+## Parameters
+
+- `orgName` `string` _(in: path)_ **required** — The organization name
+- `reason` `string` _(in: query)_ _optional_ — Audit log reason for creating this token
+
+## Request body (`application/json`)
+
+- `description` `string` **required** — The description
+- `name` `string` **required** — The name
+- `admin` `boolean` **required** — Whether the entity has admin privileges
+- `expires` `integer (int64)` **required** — The expiration time
+- `roleID` `string` — The role identifier
+
+## Responses
+
+### `200 OK`
+
+- `id` `string` **required** — The unique identifier
+- `tokenValue` `string` **required** — The token value

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/create_org_token.txt
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/create_org_token.txt
@@ -1,0 +1,32 @@
+POST /api/orgs/{orgName}/tokens
+Tag: AccessTokens
+Operation: CreateOrgToken
+
+CreateOrgToken
+
+Generates a new access token scoped to the organization for use in CI/CD pipelines and automated workflows. Organization tokens belong to the organization rather than individual users, ensuring that access is not disrupted when team members leave.
+
+The `name` field must be unique across the organization (including deleted tokens) and cannot exceed 40 characters. The `expires` field accepts a unix epoch timestamp up to two years from the present, or `0` for no expiry (default).
+
+**Important:** The token value in the response is only returned once at creation time and cannot be retrieved later. Audit logs for actions performed with organization tokens are attributed to the organization rather than an individual user.
+
+Parameters:
+  [path] orgName* (string) — The organization name
+  [query] reason (string) — Audit log reason for creating this token
+
+Request body (application/json):
+  Request Body:
+    {
+      description*: (string) The description
+      name*: (string) The name
+      admin*: (boolean) Whether the entity has admin privileges
+      expires*: (integer format:int64) The expiration time
+      roleID: (string) The role identifier
+    }
+
+Success response (application/json):
+  Response:
+    {
+      id*: (string) The unique identifier
+      tokenValue*: (string) The token value
+    }

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/deprecated_with_successor.md
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/deprecated_with_successor.md
@@ -1,0 +1,11 @@
+# `GET` /api/old/things
+
+_List legacy things._
+
+**Operation:** `ListOldThings` · **Tag:** Legacy
+
+> **Deprecated** — use `ListThings` instead.
+
+## Parameters
+
+- `filter` `string` _(in: query)_ _optional_ — Optional filter.

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/deprecated_with_successor.txt
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/deprecated_with_successor.txt
@@ -1,0 +1,9 @@
+GET /api/old/things
+Tag: Legacy
+Status: DEPRECATED — use ListThings instead
+Operation: ListOldThings
+
+List legacy things.
+
+Parameters:
+  [query] filter (string) — Optional filter.

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/list_org_tokens.md
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/list_org_tokens.md
@@ -1,0 +1,32 @@
+# `GET` /api/orgs/{orgName}/tokens
+
+_ListOrgTokens_
+
+**Operation:** `ListOrgTokens` · **Tag:** AccessTokens
+
+## Description
+
+Retrieves all access tokens created for an organization. Organization tokens provide CI/CD automation access scoped to the organization rather than tied to individual user accounts. The response includes token metadata such as name, description, creation date, last used date, and expiration status. The actual token values are never returned after initial creation. An optional filter parameter can include expired tokens in the results.
+
+## Parameters
+
+- `orgName` `string` _(in: path)_ **required** — The organization name
+- `filter` `string` _(in: query)_ _optional_ — Filter tokens by status (e.g., include expired tokens)
+
+## Responses
+
+### `200 OK`
+
+- `tokens` `array[object]` **required** — The list of access tokens
+  - `id` `string` **required** — Unique identifier for this access token.
+  - `name` `string` **required** — Human-readable name assigned to this access token.
+  - `description` `string` **required** — User-provided description of the token's purpose.
+  - `created` `string` **required** — Timestamp when the token was created, in ISO 8601 format.
+  - `lastUsed` `integer (int64)` **required** — Unix epoch timestamp (seconds) when the token was last used. Zero if never used.
+  - `expires` `integer (int64)` **required** — Unix epoch timestamp (seconds) when the token expires. Zero if it never expires.
+  - `admin` `boolean` **required** — Whether this token has Pulumi Cloud admin privileges.
+  - `createdBy` `string` **required** — User.GitHubLogin of the user that created the access token
+  - `role` `object` — A role that can be associated with an access token to scope its permissions.
+    - `id` `string` **required** — Unique identifier for this role.
+    - `name` `string` **required** — Display name of the role.
+    - `defaultIdentifier` `string enum` **required** _enum:_ `member`, `admin`, `billing-manager`, `stack-read`, `stack-write`, `stack-admin`, … — The default identity to assume when using a token with this role.

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/list_org_tokens.txt
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/list_org_tokens.txt
@@ -1,0 +1,33 @@
+GET /api/orgs/{orgName}/tokens
+Tag: AccessTokens
+Operation: ListOrgTokens
+
+ListOrgTokens
+
+Retrieves all access tokens created for an organization. Organization tokens provide CI/CD automation access scoped to the organization rather than tied to individual user accounts. The response includes token metadata such as name, description, creation date, last used date, and expiration status. The actual token values are never returned after initial creation. An optional filter parameter can include expired tokens in the results.
+
+Parameters:
+  [path] orgName* (string) — The organization name
+  [query] filter (string) — Filter tokens by status (e.g., include expired tokens)
+
+Success response (application/json):
+  Response:
+    {
+      tokens*: The list of access tokens [
+        {
+          id*: (string) Unique identifier for this access token.
+          name*: (string) Human-readable name assigned to this access token.
+          description*: (string) User-provided description of the token's purpose.
+          created*: (string) Timestamp when the token was created, in ISO 8601 format.
+          lastUsed*: (integer format:int64) Unix epoch timestamp (seconds) when the token was last used. Zero if never used.
+          expires*: (integer format:int64) Unix epoch timestamp (seconds) when the token expires. Zero if it never expires.
+          admin*: (boolean) Whether this token has Pulumi Cloud admin privileges.
+          createdBy*: (string) User.GitHubLogin of the user that created the access token
+          role: A role that can be associated with an access token to scope its permissions. {
+            id*: (string) Unique identifier for this role.
+            name*: (string) Display name of the role.
+            defaultIdentifier*: (string) one of: member, admin, billing-manager, stack-read, stack-write, stack-admin, ... The default identity to assume when using a token with this role.
+          }
+        }
+      ]
+    }

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/preview_op.md
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/preview_op.md
@@ -1,0 +1,11 @@
+# `GET` /api/preview/things/{id}
+
+_Fetch a preview thing._
+
+**Operation:** `GetPreviewThing` · **Tag:** Preview
+
+> **Preview** — this endpoint is not yet stable and may change without notice.
+
+## Parameters
+
+- `id` `string` _(in: path)_ **required** — Thing ID.

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/preview_op.txt
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/preview_op.txt
@@ -1,0 +1,9 @@
+GET /api/preview/things/{id}
+Tag: Preview
+Status: PREVIEW — not yet stable, may change without notice
+Operation: GetPreviewThing
+
+Fetch a preview thing.
+
+Parameters:
+  [path] id* (string) — Thing ID.

--- a/pkg/cmd/pulumi/cloud/testhelpers_test.go
+++ b/pkg/cmd/pulumi/cloud/testhelpers_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// assertGolden compares got against the contents of the file at path. When
+// PULUMI_ACCEPT is truthy, writes got to path instead (creating parent dirs
+// as needed) so goldens can be regenerated with a single test run.
+func assertGolden(t *testing.T, path, got string) {
+	t.Helper()
+	if cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT")) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(got), 0o600))
+		return
+	}
+	want, err := os.ReadFile(path)
+	require.NoError(t, err, "missing golden file %s; regenerate with PULUMI_ACCEPT=true", path)
+	assert.Equal(t, string(want), got)
+}


### PR DESCRIPTION
## Summary

Second of four stacked PRs splitting [#22712](https://github.com/pulumi/pulumi/pull/22712). Stacked on top of [#22769](https://github.com/pulumi/pulumi/pull/22769); review that one first.

Adds the `describe` subcommand. Given an operation ID (`ListOrgMembers`), an OpenAPI path with template variables (`/api/orgs/{orgName}/members`), or a paste-friendly `METHOD path` row from `ls`, it prints the parameters, request body, and response schema in either a human-readable text format, markdown (for IDEs / `glow`), or the stable JSON envelope (with `--jq` for filtering).

Brings in:

- `describe.go` + `describe_markdown.go` — the two renderers that consume the text/markdown that `spec.go`'s schema renderer (PR 1) cached on each `Operation` at parse time.
- `pathmatch.go` — `MatchByOperationID` and `MatchPath`, plus the `splitPathQuery` helper. Reused by the raw dispatcher in PR 3.
- The describe-specific JSON envelope types (`describedOp`, `bodyJSON`, `describeEnvelope`) bolted onto `envelope.go`.
- Golden fixtures under `testdata/describe_golden/` covering text + markdown for two real ops from the embedded fixture (`ListOrgTokens`, `CreateOrgToken`) plus two synthetic ops (a preview op and a deprecated-with-successor op) so future drift surfaces as a test diff. `.gitattributes` pins `eol=lf` so Windows checkouts don't break byte-for-byte comparison.

`pulumi cloud` is still hidden from `--help` here; PR 4 un-hides it.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Tests cover: text renderer (preview/deprecated status lines, SupersededBy redirect, stable-op no-status); markdown renderer (top-level heading + chip, parameter list with required markers, request body with required-property flagging, responses section with HTTP reason phrases, preview/deprecated admonitions, stock-error chip row, enum-tail truncation, schemaless-2xx not bucketed as error); operation matching (operation ID case-insensitive, paste-friendly `METHOD path` form, multiple-method path with `--method` resolution, ambiguous path error); golden text + markdown output for the four representative ops.

Smoke-tested against the review stack with `pulumi cloud api describe ListOrgTokens` (text) and `--output=markdown` / `--output=json`.

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [x] Changelog entry added.

## Risk

- No changes to anything outside `pkg/cmd/pulumi/api/`. The single-line edit to `api.go` registers `newDescribeCmd()` on the existing `api` parent; everything else is new files.
- Goldens are byte-for-byte; if the schema renderer's output format changes intentionally, regenerate with `PULUMI_ACCEPT=true mise exec -- go test ./pkg/cmd/pulumi/api/...`.
- The describe-only envelope types are scoped to this command; no impact on `ls`'s existing JSON shape.