### PR TITLE
cli/cloud: add `pulumi cloud api` dispatcher

### DIFF
--- a/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-dispatcher.yaml
+++ b/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-dispatcher.yaml
@@ -1,0 +1,7 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: |
+    Add `pulumi cloud api <op-or-path>` for calling any Pulumi Cloud API
+    endpoint, with `--field`/`--header`/`--input`/`--body` flag handling, path
+    template binding, content negotiation via `--format`, and `--dry-run`

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -142,7 +142,7 @@ type httpCallOptions struct {
 	ErrorResponse any
 
 	// SkipDecodeErrors, when true, makes pulumiAPICall skip the 401/429/4xx/5xx
-	// typed-error classification and hand the *http.Response back unchanged.
+	// typed-error classification.
 	// The caller is responsible for inspecting status, reading the body, and
 	// closing it. The body read/decode/close is still handled by passing
 	// **http.Response to Call's respObj — this only controls error decoding.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -140,6 +140,13 @@ type httpCallOptions struct {
 
 	// ErrorResponse is an optional response body for errors.
 	ErrorResponse any
+
+	// SkipDecodeErrors, when true, makes pulumiAPICall skip the 401/429/4xx/5xx
+	// typed-error classification and hand the *http.Response back unchanged.
+	// The caller is responsible for inspecting status, reading the body, and
+	// closing it. The body read/decode/close is still handled by passing
+	// **http.Response to Call's respObj — this only controls error decoding.
+	SkipDecodeErrors bool
 }
 
 // apiAccessToken is an implementation of accessToken for Pulumi API tokens (i.e. tokens of kind
@@ -390,6 +397,10 @@ func pulumiAPICall(ctx context.Context,
 
 	requestSpan.SetTag("responseCode", resp.Status)
 
+	if opts.SkipDecodeErrors {
+		return url, resp, nil
+	}
+
 	if warningHeader, ok := resp.Header["X-Pulumi-Warning"]; ok {
 		for _, warning := range warningHeader {
 			d.Warningf(diag.RawMessage("", warning))
@@ -627,4 +638,26 @@ func bodyIntoReader(resp *http.Response) (io.ReadCloser, error) {
 	default:
 		return nil, fmt.Errorf("unrecognized encoding %s", contentEncoding[0])
 	}
+}
+
+// gzipReadCloser wraps a gzip.Reader so closing the wrapper closes both the
+// gzip stream and the underlying response body. Used by Call when the caller
+// passes a **http.Response — the body needs to outlive Call's stack frame, so
+// bodyIntoReader's defer-close pattern doesn't apply.
+type gzipReadCloser struct {
+	gzip *gzip.Reader
+	body io.ReadCloser
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzip.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	gzipErr := g.gzip.Close()
+	bodyErr := g.body.Close()
+	if gzipErr != nil {
+		return gzipErr
+	}
+	return bodyErr
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -2066,6 +2067,65 @@ func (pc *Client) DeletePackageVersion(
 	url := deletePackageVersionPath(source, publisher, name, version.String())
 	err := pc.restCall(ctx, "DELETE", url, nil, nil, nil)
 	return err
+}
+
+// RawCall issues an arbitrary Pulumi API request and returns the raw
+// *http.Response. Unlike the typed Call methods, RawCall does not
+// deserialize the response body and does not classify 4xx/5xx into typed
+// errors; the caller inspects status, headers, and body. When
+// gzipDecompressResponse is true and the server returns a gzip-encoded
+// body, the body is transparently decompressed; the Content-Encoding and
+// Content-Length response headers are left intact so the caller can still
+// see what the server sent.
+func (pc *Client) RawCall(
+	ctx context.Context,
+	method, path string,
+	query url.Values,
+	body io.Reader,
+	header http.Header,
+	gzipCompressBody bool,
+	gzipDecompressResponse bool,
+) (*http.Response, error) {
+	fullPath := path
+	if len(query) > 0 {
+		fullPath += "?" + query.Encode()
+	}
+
+	var reqObj any
+	if body != nil {
+		bodyBytes, err := io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("reading request body: %w", err)
+		}
+		if len(bodyBytes) > 0 {
+			// json.RawMessage is sent verbatim by the rest-call path — works
+			// for non-JSON content too
+			reqObj = json.RawMessage(bodyBytes)
+		}
+	}
+
+	var resp *http.Response
+	err := pc.restCallWithOptions(ctx, method, fullPath, nil, reqObj, &resp, httpCallOptions{
+		SkipDecodeErrors: true,
+		Header:           header,
+		GzipCompress:     gzipCompressBody,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if gzipDecompressResponse {
+		if encs, ok := resp.Header["Content-Encoding"]; ok && len(encs) == 1 &&
+			(encs[0] == "gzip" || encs[0] == "x-gzip") {
+			gr, gzerr := gzip.NewReader(resp.Body)
+			if gzerr != nil {
+				resp.Body.Close()
+				return nil, fmt.Errorf("decompressing gzipped response: %w", gzerr)
+			}
+			resp.Body = &gzipReadCloser{gzip: gr, body: resp.Body}
+		}
+	}
+	return resp, nil
 }
 
 // GetCloudAPISpec fetches the Pulumi Cloud OpenAPI document as raw bytes.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2072,9 +2072,8 @@ func (pc *Client) DeletePackageVersion(
 // RawCall issues an arbitrary Pulumi API request and returns the raw
 // *http.Response. Unlike the typed Call methods, RawCall does not
 // deserialize the response body and does not classify 4xx/5xx into typed
-// errors; the caller inspects status, headers, and body. When
-// gzipDecompressResponse is true and the server returns a gzip-encoded
-// body, the body is transparently decompressed; the Content-Encoding and
+// errors; the caller inspects status, headers, and body. Gzip-encoded
+// responses are transparently decompressed; the Content-Encoding and
 // Content-Length response headers are left intact so the caller can still
 // see what the server sent.
 func (pc *Client) RawCall(
@@ -2084,7 +2083,6 @@ func (pc *Client) RawCall(
 	body io.Reader,
 	header http.Header,
 	gzipCompressBody bool,
-	gzipDecompressResponse bool,
 ) (*http.Response, error) {
 	fullPath := path
 	if len(query) > 0 {
@@ -2114,16 +2112,14 @@ func (pc *Client) RawCall(
 		return nil, err
 	}
 
-	if gzipDecompressResponse {
-		if encs, ok := resp.Header["Content-Encoding"]; ok && len(encs) == 1 &&
-			(encs[0] == "gzip" || encs[0] == "x-gzip") {
-			gr, gzerr := gzip.NewReader(resp.Body)
-			if gzerr != nil {
-				resp.Body.Close()
-				return nil, fmt.Errorf("decompressing gzipped response: %w", gzerr)
-			}
-			resp.Body = &gzipReadCloser{gzip: gr, body: resp.Body}
+	if encs, ok := resp.Header["Content-Encoding"]; ok && len(encs) == 1 &&
+		(encs[0] == "gzip" || encs[0] == "x-gzip") {
+		gr, gzerr := gzip.NewReader(resp.Body)
+		if gzerr != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("decompressing gzipped response: %w", gzerr)
 		}
+		resp.Body = &gzipReadCloser{gzip: gr, body: resp.Body}
 	}
 	return resp, nil
 }

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -15,40 +15,934 @@
 package cloud
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	fxmaps "github.com/pgavlin/fx/v2/maps"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// apiCommand carries the state and persistent flags shared by every
-// `pulumi cloud api` subcommand.
+// apiCommand carries state and api for `pulumi cloud api` and the
+// dispatcher path beneath it. refreshSpec is persistent and inherits
+// into subcommands (list/describe); the rest are local to the dispatcher
+// invocation (`pulumi cloud api <path>`).
 type apiCommand struct {
-	// refreshSpec is the value of the persistent --refresh-spec flag.
-	// True forces a re-fetch of the OpenAPI spec, bypassing the local cache.
+	// Persistent flag inherited by subcommands.
 	refreshSpec bool
+
+	// Local api for the dispatcher path. Flag names are a stable contract
+	// matching `gh api`.
+	method        string
+	fields        []string
+	rawFields     []string
+	headers       []string
+	input         string
+	body          string
+	include       bool
+	silent        bool
+	verbose       bool
+	dryRun        bool
+	format        string
+	schemaVersion int
 }
 
-// newAPICmd builds `pulumi cloud api` — the parent command that hosts `list`
-// for browsing the API surface. The dispatcher (calling arbitrary endpoints)
-// and `describe` subcommand land in follow-up PRs.
+// bindFlags attaches the full flag set to cmd, binding each flag to a field
+// on api. refreshSpec is persistent (inherited by subcommands); the rest
+// are local to the dispatcher path.
+func bindFlags(cmd *cobra.Command, api *apiCommand) {
+	cmd.PersistentFlags().BoolVar(&api.refreshSpec, "refresh-spec", false,
+		"Re-fetch the OpenAPI spec from Pulumi Cloud and overwrite the local cache")
+
+	pf := cmd.Flags()
+	pf.StringVarP(&api.method, "method", "X", "",
+		"HTTP method (default GET, POST when body fields are present)")
+	pf.StringArrayVarP(&api.fields, "field", "F", nil,
+		"Typed key=value; numbers/bools/null auto-detected; JSON object/array "+
+			"literals parsed; @file reads file; @- reads stdin. "+
+			"Sent as query params on GET/HEAD, JSON body fields otherwise")
+	pf.StringArrayVarP(&api.rawFields, "raw-field", "f", nil,
+		"String key=value with no type coercion. "+
+			"Sent as query params on GET/HEAD, JSON body fields otherwise")
+	pf.StringArrayVarP(&api.headers, "header", "H", nil,
+		"Custom HTTP header `Key: Value` (repeatable)")
+	pf.StringVar(&api.input, "input", "",
+		"Read request body from file; `-` reads stdin")
+	pf.StringVar(&api.body, "body", "",
+		"Inline request body sent verbatim (default Content-Type: application/json). "+
+			"Mutually exclusive with --input")
+	pf.BoolVarP(&api.include, "include", "i", false,
+		"Include HTTP status line and response headers in output")
+	pf.BoolVar(&api.silent, "silent", false,
+		"Do not print the response body on success; errors are still printed and exit non-zero")
+	pf.BoolVar(&api.verbose, "verbose", false,
+		"Dump full request and response to stderr")
+	pf.BoolVar(&api.dryRun, "dry-run", false,
+		"Print the resolved request without sending it")
+	pf.StringVar(&api.format, "format", "",
+		"Drive content negotiation and rendering. Default uses the op's primary "+
+			"response content type (usually JSON). `json` or `markdown` request that "+
+			"format via the Accept header — rejected if the op's spec doesn't declare it. "+
+			"`raw` keeps the op's default Accept and writes the body through unchanged.")
+	pf.IntVar(&api.schemaVersion, "schema-version", SchemaVersion,
+		"Pin the envelope schema version the caller expects")
+}
+
 func newAPICmd() *cobra.Command {
-	api := &apiCommand{}
+	api := &apiCommand{schemaVersion: SchemaVersion}
 
 	cmd := &cobra.Command{
 		Use:   "api",
 		Short: "Call any Pulumi Cloud API endpoint",
 		Long: "Call any Pulumi Cloud API endpoint.\n" +
 			"\n" +
+			"The positional argument may be: a path (with optional {template} variables, e.g.\n" +
+			"`/api/orgs/{orgName}/members`), an operation ID as shown in `list` (e.g.\n" +
+			"`ListOrgMembers`), or a paste-friendly row (`GET /api/...`). Template variables\n" +
+			"are resolved from the current Pulumi project / selected stack, or supplied\n" +
+			"with -F (e.g. `-F orgName=acme`).\n" +
+			"\n" +
+			"Fields provided via -F/--field and -f/--raw-field are sent as query parameters\n" +
+			"on GET/HEAD requests and as a JSON request body on POST/PUT/PATCH/DELETE. Method\n" +
+			"defaults to GET, or POST when body fields, --body, or --input are present.\n" +
+			"\n" +
+			"Value forms accepted by -F:\n" +
+			"  - scalars: `-F name=acme`, `-F count=3`, `-F enabled=true`, `-F note=null`\n" +
+			"  - nested JSON: `-F 'labels={\"env\":\"prod\"}'`, `-F 'tags=[\"a\",\"b\"]'`\n" +
+			"  - file / stdin: `-F body=@./payload.json`, `-F note=@-`\n" +
+			"Use -f/--raw-field to suppress coercion and send the value verbatim as a string.\n" +
+			"\n" +
+			"For an entire request body, pass --body '<json>' inline, or --input <file> (use\n" +
+			"`-` for stdin) to stream from a file.\n" +
+			"\n" +
+			"A field whose key matches a path template variable (e.g. `-F poolId=123` against\n" +
+			"`{poolId}`) fills that variable and is not forwarded as a query or body parameter.\n" +
+			"This is the way to supply non-context path parameters when calling by operation\n" +
+			"ID.\n" +
+			"\n" +
 			"The OpenAPI spec is cached locally for 24 hours; pass --refresh-spec on any\n" +
-			"subcommand to force a re-fetch.",
+			"subcommand to force a re-fetch.\n" +
+			"\n" +
+			"Exit codes: 0 success; 1 caller error; 2 invalid flags; 3 auth; 8 cancelled;\n" +
+			"255 internal.",
+		Example: "  # Inspect the currently authenticated user.\n" +
+			"  pulumi cloud api /api/user\n\n" +
+			"  # Call by raw path with template variables filled from -F.\n" +
+			"  pulumi cloud api /api/orgs/{orgName}/members -F orgName=acme\n\n" +
+			"  # Multiple template variables in the path are filled the same way.\n" +
+			"  pulumi cloud api /api/stacks/{orgName}/{projectName}/{stackName} \\\n" +
+			"    -F orgName=acme -F projectName=web -F stackName=prod\n\n" +
+			"  # Call by operation ID — orgName is taken from the current Pulumi project.\n" +
+			"  pulumi cloud api ListOrgMembers\n\n" +
+			"  # Pass path variables explicitly when no project context is available.\n" +
+			"  pulumi cloud api GetStack -F orgName=acme -F projectName=web -F stackName=prod\n\n" +
+			"  # Create a resource via POST; body fields go into a JSON body automatically.\n" +
+			"  pulumi cloud api CreateStackTag -F orgName=acme -F projectName=web \\\n" +
+			"    -F stackName=prod -F name=env -F value=prod\n\n" +
+			"  # Build a nested body by mixing scalar fields with an inline JSON object.\n" +
+			"  pulumi cloud api CreateStack -F orgName=acme -F projectName=web \\\n" +
+			"    -F stackName=prod -F 'tags={\"env\":\"prod\",\"team\":\"platform\"}'\n\n" +
+			"  # Send an array of items using a JSON literal.\n" +
+			"  pulumi cloud api AddTeamMembers -F orgName=acme -F teamName=eng \\\n" +
+			"    -F 'members=[\"alice\",\"bob\",\"carol\"]'\n\n" +
+			"  # Pass the entire request body inline with --body.\n" +
+			"  pulumi cloud api UpdateStack -F orgName=acme -F projectName=web -F stackName=prod \\\n" +
+			"    --body '{\"description\":\"managed by agent\"}'\n\n" +
+			"  # Read a JSON body from a file, or from stdin with `-`.\n" +
+			"  pulumi cloud api UpdateStackTag --input ./tag.json\n" +
+			"  cat tag.json | pulumi cloud api UpdateStackTag --input -\n\n" +
+			"  # Filter the JSON response with jq.\n" +
+			"  pulumi cloud api /api/user --format=json | jq '.githubLogin'\n\n" +
+			"  # Extract just the status line + headers without the body.\n" +
+			"  pulumi cloud api /api/user --include --silent\n\n" +
+			"  # Preview the resolved request without sending it.\n" +
+			"  pulumi cloud api CreateStackTag -F orgName=acme --dry-run",
 	}
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "path-or-operation-id"}},
+		Required:  0,
+	})
 
-	cmd.PersistentFlags().BoolVar(&api.refreshSpec, "refresh-spec", false,
-		"Re-fetch the OpenAPI spec from Pulumi Cloud and overwrite the local cache")
+	bindFlags(cmd, api)
+
+	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
+		return runAPI(cmd, args, api)
+	})
 
 	cmd.AddCommand(newLsCmd(api))
 	cmd.AddCommand(newDescribeCmd(api))
 
 	return cmd
+}
+
+func runAPI(cmd *cobra.Command, args []string, api *apiCommand) error {
+	if err := validateFlagCombos(api); err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return NewAPIError(cmdutil.ExitCodeError, ErrRequiredInputMissing,
+			"no endpoint provided").
+			WithField("path").
+			WithSuggestions(
+				"pass a path, e.g. `pulumi cloud api /api/user`",
+				"or an operation ID, e.g. `pulumi cloud api ListAccounts`",
+				"run `pulumi cloud api list` to see available endpoints",
+				"run `pulumi cloud api describe <path-or-operation-id>` to inspect one",
+			)
+	}
+	userArg := strings.TrimSpace(args[0])
+
+	idx, err := LoadIndex(cmd.Context(), cmd.ErrOrStderr(), api.refreshSpec)
+	if err != nil {
+		return err
+	}
+
+	methodExplicit := cmd.Flags().Changed("method")
+	method, mr, rawQuery, err := resolveAPIArg(idx, userArg, api, methodExplicit)
+	if err != nil {
+		return err
+	}
+
+	fields, err := parseFields(api.fields, api.rawFields, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	// Resolve cloud context up front so the backend-aware default org is
+	// available to template-var resolution. ResolveContext is non-interactive
+	// and returns a usable (anonymous) context when the user isn't logged in.
+	resolvedCtx, err := ResolveContext(cmd.Context())
+	if err != nil {
+		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("resolving cloud context: %v", err))
+	}
+
+	bindings, fields, err := resolveBindings(mr, fields, resolvedCtx)
+	if err != nil {
+		return err
+	}
+
+	concretePath := buildConcretePath(mr.Op, bindings)
+
+	hdrs, err := parseHeaders(api.headers)
+	if err != nil {
+		return err
+	}
+
+	bodyBytes, queryExtras, contentType, err := encodeFields(method, fields, api, mr.Op)
+	if err != nil {
+		return err
+	}
+
+	query := mergeQuery(rawQuery, queryExtras)
+
+	accept, err := negotiateAccept(mr.Op, api.format)
+	if err != nil {
+		return err
+	}
+
+	if api.dryRun {
+		fullURL := strings.TrimRight(resolvedCtx.CloudURL, "/") + concretePath
+		if query != "" {
+			fullURL += "?" + query
+		}
+		return emitDryRun(cmd.OutOrStdout(), method, fullURL, hdrs, contentType, accept, bodyBytes)
+	}
+
+	return executeLive(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), mr.Op, method, concretePath, query, hdrs,
+		contentType, accept, bodyBytes, api, resolvedCtx)
+}
+
+// executeLive issues the HTTP request and post-processes the response
+// according to the flag set (--include, --silent, --verbose). resolved is
+// the cloud context produced by runAPI; this layer only enforces that the
+// caller is authenticated. accept is the Accept header value chosen by
+// negotiateAccept upstream.
+func executeLive(
+	ctx context.Context,
+	w, errW io.Writer,
+	op *Operation,
+	method, concretePath, query string,
+	hdrs []ParsedHeader,
+	contentType, accept string,
+	body []byte,
+	api *apiCommand,
+	resolved *ResolvedContext,
+) error {
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if !resolved.LoggedIn {
+		return NewAPIError(cmdutil.ExitAuthenticationError, ErrNotLoggedIn,
+			"not logged in to Pulumi Cloud").
+			WithSuggestions("run `pulumi login` first")
+	}
+
+	apiClient := resolved.Client
+
+	if api.verbose {
+		dumpRequestVerbose(errW, method, strings.TrimRight(resolved.CloudURL, "/")+concretePath+queryFragment(query),
+			hdrs, contentType, accept, body)
+	}
+
+	baseQuery, err := url.ParseQuery(query)
+	if err != nil {
+		return NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+			fmt.Sprintf("parsing query string %q: %v", query, err)).WithField("path")
+	}
+
+	var bodyReader io.Reader
+	if len(body) > 0 {
+		bodyReader = bytes.NewReader(body)
+	}
+	resp, err := apiClient.RawCall(ctx, method, concretePath, baseQuery, bodyReader,
+		buildAPIHeaders(contentType, accept, hdrs), len(body) > 0, true)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return &APIError{ExitCode: cmdutil.ExitCancelled, Silent: true}
+		}
+		return NewAPIError(cmdutil.ExitCodeError, ErrNetwork,
+			fmt.Sprintf("HTTP %s %s: %v", method, concretePath, err))
+	}
+	defer resp.Body.Close()
+
+	return handleResponse(w, errW, resp, api)
+}
+
+// queryFragment returns "?<query>" when query is non-empty, else "".
+func queryFragment(query string) string {
+	if query == "" {
+		return ""
+	}
+	return "?" + query
+}
+
+// dumpRequestVerbose writes the full outgoing request to errW for --verbose.
+// Authorization is redacted; user-supplied Authorization overrides are dropped
+// to match apiClient.Do, which also drops them.
+func dumpRequestVerbose(
+	errW io.Writer,
+	method, fullURL string, hdrs []ParsedHeader,
+	contentType, accept string, body []byte,
+) {
+	fmt.Fprintf(errW, "> %s %s\n", method, fullURL)
+	fmt.Fprintf(errW, "> Authorization: token ***\n")
+	fmt.Fprintf(errW, "> Accept: %s, application/vnd.pulumi+8\n", accept)
+	if contentType != "" {
+		fmt.Fprintf(errW, "> Content-Type: %s\n", contentType)
+	}
+	for _, h := range hdrs {
+		if strings.EqualFold(h.Name, "Authorization") {
+			continue
+		}
+		fmt.Fprintf(errW, "> %s: %s\n", h.Name, h.Value)
+	}
+	if len(body) > 0 {
+		fmt.Fprintln(errW, ">")
+		_, _ = errW.Write(body)
+		fmt.Fprintln(errW)
+	}
+}
+
+// handleResponse applies post-processing api (--include, --silent, --verbose)
+// and renders the body via the content-type router.
+func handleResponse(w, errW io.Writer, resp *http.Response, api *apiCommand) error {
+	if api.include || api.verbose {
+		writeStatusAndHeaders(w, resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return NewAPIError(cmdutil.ExitCodeError, ErrNetwork,
+			fmt.Sprintf("reading response body: %v", err))
+	}
+
+	if api.verbose {
+		if len(body) > 0 {
+			fmt.Fprintln(errW, "<")
+			_, _ = errW.Write(body)
+			fmt.Fprintln(errW)
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		return httpErrorEnvelopeBytes(resp, body)
+	}
+
+	if api.silent {
+		return nil
+	}
+	if len(body) == 0 {
+		return nil
+	}
+
+	return renderBody(w, resp.Header.Get("Content-Type"), body)
+}
+
+// writeStatusAndHeaders writes the status line + sorted headers to w.
+// Headers are sorted lexicographically for deterministic output.
+func writeStatusAndHeaders(w io.Writer, resp *http.Response) {
+	fmt.Fprintf(w, "HTTP/%d.%d %s\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status)
+	keys := make([]string, 0, len(resp.Header))
+	for k := range resp.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range resp.Header.Values(k) {
+			fmt.Fprintf(w, "%s: %s\n", k, v)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// negotiateAccept picks the Accept header value to send for op based on the
+// user's --format flag. When --format is unset we use the op's primary
+// response content type (historically JSON for Pulumi Cloud). When the user
+// explicitly asks for JSON or markdown we validate against the op's declared
+// response content types so the call fails fast with a helpful message
+// instead of surprising the caller with a 406 from the server.
+func negotiateAccept(op *Operation, format string) (string, error) {
+	switch strings.ToLower(format) {
+	case "", "raw", "auto", "default":
+		if op.ResponseContentType != "" {
+			return op.ResponseContentType, nil
+		}
+		return "application/json", nil
+	case "json":
+		for _, ct := range op.SuccessContentTypes {
+			if isJSONContentType(ct) {
+				return ct, nil
+			}
+		}
+		return "", unsupportedFormatError(op, "json", "application/json")
+	case "markdown", "md":
+		for _, ct := range op.SuccessContentTypes {
+			if strings.EqualFold(ct, "text/markdown") {
+				return ct, nil
+			}
+		}
+		return "", unsupportedFormatError(op, "markdown", "text/markdown")
+	default:
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+			"invalid --format value: "+format).
+			WithField("format").
+			WithSuggestions("--format=json", "--format=markdown", "--format=raw")
+	}
+}
+
+// unsupportedFormatError returns a caller-actionable error when the user
+// asks for a format the op doesn't declare. The suggestions surface the
+// content types the op does declare so the user can pick one that works.
+func unsupportedFormatError(op *Operation, want, mediaType string) error {
+	msg := fmt.Sprintf("operation %s does not declare a %s response", op.OperationID, mediaType)
+	suggestions := []string{"omit --format to use the op's default content type"}
+	if len(op.SuccessContentTypes) > 0 {
+		suggestions = append(suggestions,
+			"declared response content types: "+strings.Join(op.SuccessContentTypes, ", "))
+	}
+	return NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags, msg).
+		WithField("format").
+		WithSuggestions(suggestions...)
+}
+
+// isJSONContentType loosely matches `application/json` plus any `+json`
+// subtype (application/vnd.pulumi+json etc.).
+func isJSONContentType(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(strings.SplitN(ct, ";", 2)[0]))
+	if ct == "application/json" || ct == "text/json" {
+		return true
+	}
+	return strings.HasSuffix(ct, "+json")
+}
+
+// renderBody writes body to w, pretty-printing JSON when the content type
+// indicates JSON, passing through text/binary otherwise. A thin adapter
+// over format.go's existing helpers.
+func renderBody(w io.Writer, contentType string, body []byte) error {
+	ct := strings.ToLower(contentType)
+	switch {
+	case isJSONContentType(contentType), ct == "":
+		return formatJSON(w, body)
+	case strings.Contains(ct, "application/x-yaml"),
+		strings.Contains(ct, "text/plain"),
+		strings.Contains(ct, "text/markdown"):
+		return formatText(w, body)
+	case strings.Contains(ct, "application/x-tar"),
+		strings.Contains(ct, "application/octet-stream"):
+		return formatBinary(w, body)
+	default:
+		return formatBinary(w, body)
+	}
+}
+
+// validateFlagCombos enforces flag-set invariants before we do any work.
+func validateFlagCombos(api *apiCommand) error {
+	if api.schemaVersion != SchemaVersion {
+		return NewAPIError(cmdutil.ExitCodeError, ErrUnsupportedSchemaVersion,
+			fmt.Sprintf("schemaVersion %d is not supported; this CLI speaks schemaVersion %d",
+				api.schemaVersion, SchemaVersion)).
+			WithField("schema-version").
+			WithSuggestions("omit --schema-version to use the current version")
+	}
+	if api.body != "" && api.input != "" {
+		return NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
+			"--body and --input are mutually exclusive").
+			WithSuggestions(
+				"use --body for inline JSON",
+				"use --input to read the body from a file",
+			)
+	}
+	if api.silent && api.verbose {
+		return NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
+			"--silent and --verbose are mutually exclusive").
+			WithSuggestions(
+				"use --silent to drop the response body",
+				"use --verbose to dump the full request and response to stderr",
+			)
+	}
+	return nil
+}
+
+// resolveAPIArg maps the user's positional argument to a concrete operation.
+// Accepts three forms: a path with optional {template} params, an operation
+// ID (e.g. "ListAccounts"), or a paste-friendly "METHOD /path" row from
+// `ls`. methodExplicit signals whether --method was set; when true and the
+// argument pins a different method, a conflict error is returned.
+func resolveAPIArg(idx *Index, arg string, api *apiCommand, methodExplicit bool) (string, *MatchResult, string, error) {
+	if verb, rest, ok := splitLeadingHTTPMethod(arg); ok {
+		if methodExplicit && strings.ToUpper(api.method) != verb {
+			return "", nil, "", NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
+				fmt.Sprintf("conflicting methods: argument has %q, --method is %q", verb, api.method)).
+				WithField("method")
+		}
+		rawPath, rawQuery := splitPathQuery(rest)
+		mr, err := MatchPath(idx, verb, rawPath)
+		if err != nil {
+			return "", nil, "", err
+		}
+		return verb, mr, rawQuery, nil
+	}
+
+	rawPath, rawQuery := splitPathQuery(arg)
+	if looksLikeOperationID(rawPath) {
+		mr, err := MatchByOperationID(idx, rawPath)
+		if err != nil {
+			return "", nil, "", err
+		}
+		if methodExplicit && strings.ToUpper(api.method) != mr.Op.Method {
+			return "", nil, "", NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
+				fmt.Sprintf("operation %s is %s; --method=%s disagrees",
+					mr.Op.OperationID, mr.Op.Method, api.method)).
+				WithField("method")
+		}
+		mr.Bindings = bindingsForTemplate(mr.Op.Path)
+		return mr.Op.Method, mr, rawQuery, nil
+	}
+
+	// Path form — defaults to GET, or POST when body fields are present
+	// AND the spec has a POST variant. Some GET endpoints accept `-F` as
+	// query params, so we only auto-switch when the spec actually pairs
+	// this path with POST.
+	method := strings.ToUpper(api.method)
+	if method == "" &&
+		methodDefaultsToPost(len(api.fields)+len(api.rawFields), api.input != "", api.body != "") {
+		if mr, err := MatchPath(idx, "POST", rawPath); err == nil {
+			return "POST", mr, rawQuery, nil
+		}
+		method = "GET"
+	}
+	if method == "" {
+		method = "GET"
+	}
+	mr, err := MatchPath(idx, method, rawPath)
+	if err != nil {
+		return "", nil, "", err
+	}
+	return method, mr, rawQuery, nil
+}
+
+// bindingsForTemplate synthesizes placeholder-style bindings for each
+// {param} in specPath — the form resolveBindings feeds into context
+// resolution. Used when an operation is looked up by ID rather than by
+// a user-supplied concrete path.
+func bindingsForTemplate(specPath string) map[string]Binding {
+	bindings := map[string]Binding{}
+	for _, seg := range splitSegments(specPath) {
+		if isTemplateSegment(seg) {
+			name := trimBraces(seg)
+			bindings[name] = Binding{Placeholder: name}
+		}
+	}
+	return bindings
+}
+
+// resolveBindings resolves every path-parameter binding to a concrete string.
+// Precedence per var: path literal > matching -F/-f field (consumed) > context
+// auto-resolution from the current Pulumi project / selected stack.
+//
+// A field whose key matches a path template variable is consumed — it is
+// removed from the returned slice so encodeFields won't re-route it to the
+// query string or request body.
+func resolveBindings(
+	mr *MatchResult, fields []ParsedField, rctx *ResolvedContext,
+) (map[string]string, []ParsedField, error) {
+	out := make(map[string]string, len(mr.Bindings))
+	remaining := fields
+	// Iterate bindings in a deterministic order so error messages and the
+	// remaining-fields slice stay stable across runs.
+	for name, b := range fxmaps.Sorted(mr.Bindings) {
+		if b.Literal != "" {
+			out[name] = b.Literal
+			continue
+		}
+		idx := findFieldIndex(remaining, name)
+		if idx >= 0 {
+			val, err := stringifyFieldForPath(remaining[idx])
+			if err != nil {
+				return nil, nil, err
+			}
+			out[name] = val
+			remaining = append(remaining[:idx], remaining[idx+1:]...)
+			continue
+		}
+		val, err := resolveTemplateVar(name, b.Placeholder, rctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		out[name] = val
+	}
+	return out, remaining, nil
+}
+
+// findFieldIndex returns the index of the first field whose key matches name,
+// or -1 if none.
+func findFieldIndex(fields []ParsedField, name string) int {
+	for i := range fields {
+		if fields[i].Key == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// stringifyFieldForPath converts a ParsedField value to the plain-text form
+// used for path substitution. Null values are rejected — a null would either
+// collapse the segment to the empty string (breaking routing) or serialize
+// as the literal "null", neither of which is what the user meant. The
+// Pulumi Cloud OpenAPI spec only declares string and integer path params;
+// other types fall through the default and stringify with %v.
+func stringifyFieldForPath(f ParsedField) (string, error) {
+	switch v := f.Value.(type) {
+	case string:
+		return v, nil
+	case int64:
+		return strconv.FormatInt(v, 10), nil
+	case nil:
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+			fmt.Sprintf("field %q is null; path parameters cannot be null", f.Key)).
+			WithField(f.Key)
+	default:
+		return fmt.Sprintf("%v", v), nil
+	}
+}
+
+type templateKind int
+
+const (
+	kindNone templateKind = iota
+	kindOrg
+	kindProject
+	kindStack
+)
+
+func templateVarKind(name string) templateKind {
+	switch name {
+	case "orgName", "org":
+		return kindOrg
+	case "projectName", "project":
+		return kindProject
+	case "stackName", "stack":
+		return kindStack
+	}
+	return kindNone
+}
+
+// resolveTemplateVar resolves a single unbound template variable from the
+// current Pulumi context. Org/project/stack template vars auto-fill from
+// rctx (selected stack ref, project, default org); everything else must be
+// supplied with -F. rctx may be nil — in that case all kinds fall through
+// to the missing-context error with a -F suggestion.
+func resolveTemplateVar(specName, alias string, rctx *ResolvedContext) (string, error) {
+	kind := templateVarKind(specName)
+	if kind == kindNone {
+		kind = templateVarKind(alias)
+	}
+
+	switch kind {
+	case kindOrg:
+		if rctx != nil {
+			if rctx.StackOrg != "" {
+				return rctx.StackOrg, nil
+			}
+			if rctx.OrgName != "" {
+				return rctx.OrgName, nil
+			}
+		}
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
+			"template var {"+specName+"} is unresolved").
+			WithField(specName).
+			WithSuggestions(
+				"pass -F "+specName+"=<name>",
+				"select a stack with `pulumi stack select <org>/<project>/<stack>`",
+				"set a default with `pulumi org set-default <name>`",
+			)
+	case kindProject:
+		if rctx != nil && rctx.Project != nil && rctx.Project.Name != "" {
+			return string(rctx.Project.Name), nil
+		}
+		if rctx != nil && rctx.StackProj != "" {
+			return rctx.StackProj, nil
+		}
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
+			"template var {"+specName+"} is unresolved").
+			WithField(specName).
+			WithSuggestions(
+				"pass -F "+specName+"=<name>",
+				"run from a directory containing Pulumi.yaml",
+			)
+	case kindStack:
+		if rctx != nil && rctx.StackName != "" {
+			return rctx.StackName, nil
+		}
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
+			"template var {"+specName+"} is unresolved").
+			WithField(specName).
+			WithSuggestions(
+				"pass -F "+specName+"=<name>",
+				"select a stack with `pulumi stack select <name>` first",
+			)
+	case kindNone:
+		fallthrough
+	default:
+		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
+			"template var {"+specName+"} is unresolved").
+			WithField(specName).
+			WithSuggestions(
+				"pass -F "+specName+"=<value>",
+				"include the value literally in the path",
+			)
+	}
+}
+
+// buildConcretePath substitutes resolved values into an OpenAPI path template,
+// URL-escaping each parameter. A handful of param names (see encoding.go)
+// require double-escaping because their server-side handlers decode twice.
+func buildConcretePath(op *Operation, resolved map[string]string) string {
+	segs := splitSegments(op.Path)
+	for i, seg := range segs {
+		if !isTemplateSegment(seg) {
+			continue
+		}
+		name := trimBraces(seg)
+		segs[i] = escapePathParam(resolved[name], requiresDoubleEncoding(name))
+	}
+	return strings.Join(segs, "/")
+}
+
+// encodeFields splits parsed -F / -f values into a body blob (JSON-encoded
+// when fields present, file bytes when --input, raw when --body), plus extra
+// query parameters for GET/HEAD. Returns body, queryExtras, contentType.
+//
+// For --input, the content type is chosen in order of precedence:
+//  1. file extension (.yaml/.yml → application/x-yaml, .json → application/json)
+//     so a user can force a shape when the spec accepts more than one.
+//  2. op.BodyContentType when the spec pins one (e.g. ESC UpdateEnvironment is
+//     application/x-yaml only).
+//  3. application/json as the final default.
+//
+// --body sends the string verbatim with application/json as the default
+// Content-Type. A user-supplied -H 'Content-Type: …' wins over all of the
+// above at the transport layer (buildAPIHeaders applies user headers after
+// encoder defaults).
+func encodeFields(
+	method string, fields []ParsedField, api *apiCommand, op *Operation,
+) ([]byte, url.Values, string, error) {
+	extras := url.Values{}
+
+	if api.input != "" {
+		raw, err := readAtSource(api.input, os.Stdin)
+		if err != nil {
+			return nil, nil, "", NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+				fmt.Sprintf("reading --input: %v", err)).WithField("input")
+		}
+		// Matches gh: when --input supplies the body, fields (if any) become query params.
+		for _, f := range fields {
+			extras.Add(f.Key, fieldToQueryString(f))
+		}
+		return raw, extras, chooseInputContentType(api.input, op), nil
+	}
+
+	if api.body != "" {
+		// Same rule as --input: fields alongside --body become query params.
+		for _, f := range fields {
+			extras.Add(f.Key, fieldToQueryString(f))
+		}
+		return []byte(api.body), extras, "application/json", nil
+	}
+
+	isBodyless := method == "GET" || method == "HEAD"
+	if isBodyless {
+		for _, f := range fields {
+			extras.Add(f.Key, fieldToQueryString(f))
+		}
+		return nil, extras, "", nil
+	}
+
+	if len(fields) == 0 {
+		return nil, extras, "", nil
+	}
+	obj := make(map[string]any, len(fields))
+	for _, f := range fields {
+		if existing, ok := obj[f.Key]; ok {
+			// Repeated key collapses into an array, preserving order.
+			switch prev := existing.(type) {
+			case []any:
+				obj[f.Key] = append(prev, f.Value)
+			default:
+				obj[f.Key] = []any{prev, f.Value}
+			}
+		} else {
+			obj[f.Key] = f.Value
+		}
+	}
+	body, err := json.Marshal(obj)
+	if err != nil {
+		return nil, nil, "", NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("marshaling body: %v", err))
+	}
+	return body, extras, "application/json", nil
+}
+
+// chooseInputContentType picks the Content-Type for --input data.
+// Precedence: explicit file extension → op's declared BodyContentType → JSON.
+// Stdin (@-) and @path sources without a recognised extension fall through.
+func chooseInputContentType(input string, op *Operation) string {
+	// @path syntax is handled by readAtSource; strip the @ for extension sniffing.
+	source := strings.TrimPrefix(input, "@")
+	switch strings.ToLower(filepath.Ext(source)) {
+	case ".yaml", ".yml":
+		return "application/x-yaml"
+	case ".json":
+		return "application/json"
+	}
+	if op != nil && op.BodyContentType != "" {
+		return op.BodyContentType
+	}
+	return "application/json"
+}
+
+// fieldToQueryString serializes a ParsedField's value for use in a query string.
+// Nested objects/arrays (from JSON-literal -F values) serialize back to JSON so
+// the result is round-trippable on the server side.
+func fieldToQueryString(f ParsedField) string {
+	switch v := f.Value.(type) {
+	case string:
+		return v
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case nil:
+		return ""
+	default:
+		if b, err := json.Marshal(v); err == nil {
+			return string(b)
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+// mergeQuery combines a raw user-provided query string with additional values
+// from -F / -f. The raw string is preserved verbatim here. The live-request
+// path (url.ParseQuery → url.Values.Encode in Client.RawCall) canonicalizes
+// key order and percent-encoding on the wire; --dry-run prints the raw string
+// unchanged.
+func mergeQuery(raw string, extras url.Values) string {
+	extrasEnc := extras.Encode()
+	switch {
+	case raw == "" && extrasEnc == "":
+		return ""
+	case raw == "":
+		return extrasEnc
+	case extrasEnc == "":
+		return raw
+	default:
+		return raw + "&" + extrasEnc
+	}
+}
+
+// emitDryRun renders the resolved request as JSON on stdout without sending
+// it. Template vars and field coercion are resolved, but no network call
+// (or server-side validation) has happened.
+func emitDryRun(
+	w io.Writer, method, fullURL string,
+	hdrs []ParsedHeader, contentType, accept string, body []byte,
+) error {
+	if accept == "" {
+		accept = "application/json"
+	}
+	headers := map[string]string{
+		"Authorization": "token ***",
+		"Accept":        accept + ", application/vnd.pulumi+8",
+		"User-Agent":    client.UserAgent(),
+	}
+	if contentType != "" {
+		headers["Content-Type"] = contentType
+	}
+	for _, h := range hdrs {
+		headers[h.Name] = h.Value
+	}
+
+	var bodyRaw json.RawMessage
+	if len(body) > 0 {
+		if json.Valid(body) {
+			bodyRaw = json.RawMessage(body)
+		} else {
+			quoted, _ := json.Marshal(string(body))
+			bodyRaw = json.RawMessage(quoted)
+		}
+	}
+
+	env := dryRunEnvelope{SchemaVersion: SchemaVersion}
+	env.DryRun.Plan = DryRunPlan{
+		Method:  method,
+		URL:     fullURL,
+		Headers: headers,
+		Body:    bodyRaw,
+	}
+
+	return WriteJSON(w, env, cmdutil.Interactive())
 }

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -553,7 +553,6 @@ func resolveAPIArg(idx *Index, arg string, api *apiCommand, methodExplicit bool)
 					mr.Op.OperationID, mr.Op.Method, api.method)).
 				WithField("method")
 		}
-		mr.Bindings = bindingsForTemplate(mr.Op.Path)
 		return mr.Op.Method, mr, rawQuery, nil
 	}
 
@@ -577,21 +576,6 @@ func resolveAPIArg(idx *Index, arg string, api *apiCommand, methodExplicit bool)
 		return "", nil, "", err
 	}
 	return method, mr, rawQuery, nil
-}
-
-// bindingsForTemplate synthesizes placeholder-style bindings for each
-// {param} in specPath — the form resolveBindings feeds into context
-// resolution. Used when an operation is looked up by ID rather than by
-// a user-supplied concrete path.
-func bindingsForTemplate(specPath string) map[string]Binding {
-	bindings := map[string]Binding{}
-	for _, seg := range splitSegments(specPath) {
-		if isTemplateSegment(seg) {
-			name := trimBraces(seg)
-			bindings[name] = Binding{Placeholder: name}
-		}
-	}
-	return bindings
 }
 
 // resolveBindings resolves every path-parameter binding to a concrete string.

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -49,18 +49,18 @@ type apiCommand struct {
 
 	// Local api for the dispatcher path. Flag names are a stable contract
 	// matching `gh api`.
-	method        string
-	fields        []string
-	rawFields     []string
-	headers       []string
-	input         string
-	body          string
-	include       bool
-	silent        bool
-	verbose       bool
-	dryRun        bool
-	format        string
-	schemaVersion int
+	method          string
+	fields          []string
+	rawFields       []string
+	headers         []string
+	input           string
+	body            string
+	include         bool
+	silent          bool
+	verbose         bool
+	dryRun          bool
+	format          string
+	envelopeVersion int
 }
 
 // bindFlags attaches the full flag set to cmd, binding each flag to a field
@@ -100,12 +100,12 @@ func bindFlags(cmd *cobra.Command, api *apiCommand) {
 			"response content type (usually JSON). `json` or `markdown` request that "+
 			"format via the Accept header — rejected if the op's spec doesn't declare it. "+
 			"`raw` keeps the op's default Accept and writes the body through unchanged.")
-	pf.IntVar(&api.schemaVersion, "schema-version", SchemaVersion,
-		"Pin the envelope schema version the caller expects")
+	pf.IntVar(&api.envelopeVersion, "envelope-version", SchemaVersion,
+		"Pin the JSON envelope version the caller expects")
 }
 
 func newAPICmd() *cobra.Command {
-	api := &apiCommand{schemaVersion: SchemaVersion}
+	api := &apiCommand{envelopeVersion: SchemaVersion}
 
 	cmd := &cobra.Command{
 		Use:   "api",
@@ -135,6 +135,11 @@ func newAPICmd() *cobra.Command {
 			"`{poolId}`) fills that variable and is not forwarded as a query or body parameter.\n" +
 			"This is the way to supply non-context path parameters when calling by operation\n" +
 			"ID.\n" +
+			"\n" +
+			"When a path template and the request body share a parameter name, the first\n" +
+			"matching -F is consumed for the path and any subsequent -F with the same key is\n" +
+			"sent in the body. Pass -F twice to fill both, or use --body / --input to supply\n" +
+			"the body separately.\n" +
 			"\n" +
 			"The OpenAPI spec is cached locally for 24 hours; pass --refresh-spec on any\n" +
 			"subcommand to force a re-fetch.\n" +
@@ -313,7 +318,7 @@ func executeLive(
 		bodyReader = bytes.NewReader(body)
 	}
 	resp, err := apiClient.RawCall(ctx, method, concretePath, baseQuery, bodyReader,
-		buildAPIHeaders(contentType, accept, hdrs), len(body) > 0, true)
+		buildAPIHeaders(contentType, accept, hdrs), len(body) > 0)
 	if err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return &APIError{ExitCode: cmdutil.ExitCancelled, Silent: true}
@@ -495,12 +500,12 @@ func renderBody(w io.Writer, contentType string, body []byte) error {
 
 // validateFlagCombos enforces flag-set invariants before we do any work.
 func validateFlagCombos(api *apiCommand) error {
-	if api.schemaVersion != SchemaVersion {
+	if api.envelopeVersion != SchemaVersion {
 		return NewAPIError(cmdutil.ExitCodeError, ErrUnsupportedSchemaVersion,
-			fmt.Sprintf("schemaVersion %d is not supported; this CLI speaks schemaVersion %d",
-				api.schemaVersion, SchemaVersion)).
-			WithField("schema-version").
-			WithSuggestions("omit --schema-version to use the current version")
+			fmt.Sprintf("envelope version %d is not supported; this CLI speaks envelope version %d",
+				api.envelopeVersion, SchemaVersion)).
+			WithField("envelope-version").
+			WithSuggestions("omit --envelope-version to use the current version")
 	}
 	if api.body != "" && api.input != "" {
 		return NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
@@ -582,6 +587,10 @@ func resolveAPIArg(idx *Index, arg string, api *apiCommand, methodExplicit bool)
 // Precedence per var: path literal > matching -F/-f field (consumed) > context
 // auto-resolution from the current Pulumi project / selected stack.
 //
+// When the user wrote a placeholder alias in the path (e.g. `{foo}` for a
+// spec param named `orgName`), the alias is the lookup key for the matching
+// -F field — Otherwise the spec param name is the lookup key.
+//
 // A field whose key matches a path template variable is consumed — it is
 // removed from the returned slice so encodeFields won't re-route it to the
 // query string or request body.
@@ -590,6 +599,7 @@ func resolveBindings(
 ) (map[string]string, []ParsedField, error) {
 	out := make(map[string]string, len(mr.Bindings))
 	remaining := fields
+	ctxValues := contextPathValues(rctx)
 	// Iterate bindings in a deterministic order so error messages and the
 	// remaining-fields slice stay stable across runs.
 	for name, b := range fxmaps.Sorted(mr.Bindings) {
@@ -597,7 +607,11 @@ func resolveBindings(
 			out[name] = b.Literal
 			continue
 		}
-		idx := findFieldIndex(remaining, name)
+		lookupKey := name
+		if b.Placeholder != "" {
+			lookupKey = b.Placeholder
+		}
+		idx := findFieldIndex(remaining, lookupKey)
 		if idx >= 0 {
 			val, err := stringifyFieldForPath(remaining[idx])
 			if err != nil {
@@ -607,13 +621,45 @@ func resolveBindings(
 			remaining = append(remaining[:idx], remaining[idx+1:]...)
 			continue
 		}
-		val, err := resolveTemplateVar(name, b.Placeholder, rctx)
-		if err != nil {
-			return nil, nil, err
+		if v, ok := ctxValues[lookupKey]; ok {
+			out[name] = v
+			continue
 		}
-		out[name] = val
+		return nil, nil, NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
+			"template var {"+name+"} is unresolved").
+			WithField(name).
+			WithSuggestions(
+				"pass -F "+lookupKey+"=<value>",
+				"or include the value literally in the path",
+			)
 	}
 	return out, remaining, nil
+}
+
+// contextPathValues pre-fills the path values that the dispatcher can derive
+// from the current Pulumi context (selected stack, project file, default
+// org). Keyed by the OpenAPI spec name only. Returns nil when rctx is nil.
+func contextPathValues(rctx *ResolvedContext) map[string]string {
+	if rctx == nil {
+		return nil
+	}
+	out := make(map[string]string, 3)
+	switch {
+	case rctx.StackOrg != "":
+		out["orgName"] = rctx.StackOrg
+	case rctx.OrgName != "":
+		out["orgName"] = rctx.OrgName
+	}
+	switch {
+	case rctx.Project != nil && rctx.Project.Name != "":
+		out["projectName"] = string(rctx.Project.Name)
+	case rctx.StackProj != "":
+		out["projectName"] = rctx.StackProj
+	}
+	if rctx.StackName != "" {
+		out["stackName"] = rctx.StackName
+	}
+	return out
 }
 
 // findFieldIndex returns the index of the first field whose key matches name,
@@ -645,94 +691,6 @@ func stringifyFieldForPath(f ParsedField) (string, error) {
 			WithField(f.Key)
 	default:
 		return fmt.Sprintf("%v", v), nil
-	}
-}
-
-type templateKind int
-
-const (
-	kindNone templateKind = iota
-	kindOrg
-	kindProject
-	kindStack
-)
-
-func templateVarKind(name string) templateKind {
-	switch name {
-	case "orgName", "org":
-		return kindOrg
-	case "projectName", "project":
-		return kindProject
-	case "stackName", "stack":
-		return kindStack
-	}
-	return kindNone
-}
-
-// resolveTemplateVar resolves a single unbound template variable from the
-// current Pulumi context. Org/project/stack template vars auto-fill from
-// rctx (selected stack ref, project, default org); everything else must be
-// supplied with -F. rctx may be nil — in that case all kinds fall through
-// to the missing-context error with a -F suggestion.
-func resolveTemplateVar(specName, alias string, rctx *ResolvedContext) (string, error) {
-	kind := templateVarKind(specName)
-	if kind == kindNone {
-		kind = templateVarKind(alias)
-	}
-
-	switch kind {
-	case kindOrg:
-		if rctx != nil {
-			if rctx.StackOrg != "" {
-				return rctx.StackOrg, nil
-			}
-			if rctx.OrgName != "" {
-				return rctx.OrgName, nil
-			}
-		}
-		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
-			"template var {"+specName+"} is unresolved").
-			WithField(specName).
-			WithSuggestions(
-				"pass -F "+specName+"=<name>",
-				"select a stack with `pulumi stack select <org>/<project>/<stack>`",
-				"set a default with `pulumi org set-default <name>`",
-			)
-	case kindProject:
-		if rctx != nil && rctx.Project != nil && rctx.Project.Name != "" {
-			return string(rctx.Project.Name), nil
-		}
-		if rctx != nil && rctx.StackProj != "" {
-			return rctx.StackProj, nil
-		}
-		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
-			"template var {"+specName+"} is unresolved").
-			WithField(specName).
-			WithSuggestions(
-				"pass -F "+specName+"=<name>",
-				"run from a directory containing Pulumi.yaml",
-			)
-	case kindStack:
-		if rctx != nil && rctx.StackName != "" {
-			return rctx.StackName, nil
-		}
-		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
-			"template var {"+specName+"} is unresolved").
-			WithField(specName).
-			WithSuggestions(
-				"pass -F "+specName+"=<name>",
-				"select a stack with `pulumi stack select <name>` first",
-			)
-	case kindNone:
-		fallthrough
-	default:
-		return "", NewAPIError(cmdutil.ExitCodeError, ErrMissingContext,
-			"template var {"+specName+"} is unresolved").
-			WithField(specName).
-			WithSuggestions(
-				"pass -F "+specName+"=<value>",
-				"include the value literally in the path",
-			)
 	}
 }
 

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -1,0 +1,591 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// TestResolveBindings_FieldFillsPathParam covers the core bug fix:
+// a non-context path template variable (e.g. {poolId}) resolves from a
+// matching -F field, and that field is consumed — it must not appear
+// in the remaining slice (i.e. it won't be sent as a query or body param).
+func TestResolveBindings_FieldFillsPathParam(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "GET", Path: "/api/orgs/{orgName}/agentPools/{poolId}"},
+		Bindings: map[string]Binding{
+			"orgName": {Literal: "acme"},
+			"poolId":  {Placeholder: "poolId"},
+		},
+	}
+	fields := []ParsedField{
+		{Key: "poolId", Value: int64(123)},
+	}
+	resolved, remaining, err := resolveBindings(mr, fields, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", resolved["orgName"])
+	assert.Equal(t, "123", resolved["poolId"])
+	assert.Empty(t, remaining, "poolId field should have been consumed")
+}
+
+// TestResolveBindings_NonMatchingFieldPassesThrough verifies that a -F
+// field whose key does not match any path template variable is left
+// untouched in the remaining slice so encodeFields can route it to
+// the query or body.
+func TestResolveBindings_NonMatchingFieldPassesThrough(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "GET", Path: "/api/orgs/{orgName}/agentPools/{poolId}"},
+		Bindings: map[string]Binding{
+			"orgName": {Literal: "acme"},
+			"poolId":  {Placeholder: "poolId"},
+		},
+	}
+	fields := []ParsedField{
+		{Key: "poolId", Value: int64(123)},
+		{Key: "extra", Value: "foo"},
+	}
+	_, remaining, err := resolveBindings(mr, fields, nil)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "extra", remaining[0].Key)
+	assert.Equal(t, "foo", remaining[0].Value)
+}
+
+// TestResolveBindings_FieldOverridesContextAutoResolve verifies that a
+// -F field takes precedence over context auto-resolution for a
+// context-kind param (orgName/projectName/stackName).
+func TestResolveBindings_FieldOverridesContextAutoResolve(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "GET", Path: "/api/orgs/{orgName}"},
+		Bindings: map[string]Binding{
+			"orgName": {Placeholder: "orgName"},
+		},
+	}
+	fields := []ParsedField{
+		{Key: "orgName", Value: "from-field"},
+	}
+	resolved, remaining, err := resolveBindings(mr, fields, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "from-field", resolved["orgName"])
+	assert.Empty(t, remaining)
+}
+
+// TestResolveBindings_FieldWithContextVarButNoPathVar: a -F orgName field
+// on an endpoint whose path does NOT contain {orgName} must pass through
+// as a regular body/query field. We don't hijack fields based on name alone.
+func TestResolveBindings_FieldWithContextVarButNoPathVar(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op:       &Operation{Method: "POST", Path: "/api/user"},
+		Bindings: map[string]Binding{},
+	}
+	fields := []ParsedField{
+		{Key: "orgName", Value: "foo"},
+	}
+	_, remaining, err := resolveBindings(mr, fields, nil)
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "orgName", remaining[0].Key)
+}
+
+// TestResolveBindings_MissingParamErrorSuggestsFlag: an unresolved
+// non-context path var produces an error that suggests the -F form.
+func TestResolveBindings_MissingParamErrorSuggestsFlag(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "GET", Path: "/api/orgs/acme/agentPools/{poolId}"},
+		Bindings: map[string]Binding{
+			"poolId": {Placeholder: "poolId"},
+		},
+	}
+	_, _, err := resolveBindings(mr, nil, nil)
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrMissingContext, apiErr.Envelope.Error.Code)
+	joined := strings.Join(apiErr.Envelope.Error.Suggestions, "|")
+	assert.Contains(t, joined, "-F poolId=")
+}
+
+// TestResolveBindings_NullFieldRejected: -F poolId=null must not produce
+// a literal "null" in the path; it must error.
+func TestResolveBindings_NullFieldRejected(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "GET", Path: "/api/orgs/acme/agentPools/{poolId}"},
+		Bindings: map[string]Binding{
+			"poolId": {Placeholder: "poolId"},
+		},
+	}
+	fields := []ParsedField{
+		{Key: "poolId", Value: nil},
+	}
+	_, _, err := resolveBindings(mr, fields, nil)
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+}
+
+// TestNegotiateAccept_Default uses the op's declared primary response content type.
+func TestNegotiateAccept_Default(t *testing.T) {
+	t.Parallel()
+	op := &Operation{
+		ResponseContentType: "application/json",
+		SuccessContentTypes: []string{"application/json", "text/markdown"},
+	}
+	got, err := negotiateAccept(op, "")
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", got)
+}
+
+// TestNegotiateAccept_JSONWithPlainJSON and the +json variant both pass.
+func TestNegotiateAccept_JSONMatchesSubtypes(t *testing.T) {
+	t.Parallel()
+	op := &Operation{SuccessContentTypes: []string{"application/vnd.pulumi+json"}}
+	got, err := negotiateAccept(op, "json")
+	require.NoError(t, err)
+	assert.Equal(t, "application/vnd.pulumi+json", got)
+}
+
+// TestNegotiateAccept_MarkdownSupported picks text/markdown when declared.
+func TestNegotiateAccept_MarkdownSupported(t *testing.T) {
+	t.Parallel()
+	op := &Operation{SuccessContentTypes: []string{"application/json", "text/markdown"}}
+	got, err := negotiateAccept(op, "markdown")
+	require.NoError(t, err)
+	assert.Equal(t, "text/markdown", got)
+}
+
+// TestNegotiateAccept_MarkdownNotDeclared errors with a descriptive
+// suggestion listing the op's actual declared types.
+func TestNegotiateAccept_MarkdownNotDeclared(t *testing.T) {
+	t.Parallel()
+	op := &Operation{
+		OperationID:         "GetX",
+		SuccessContentTypes: []string{"application/json"},
+	}
+	_, err := negotiateAccept(op, "markdown")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+	joined := strings.Join(apiErr.Envelope.Error.Suggestions, "|")
+	assert.Contains(t, joined, "application/json")
+}
+
+// TestNegotiateAccept_InvalidValue rejects unknown --format values.
+func TestNegotiateAccept_InvalidValue(t *testing.T) {
+	t.Parallel()
+	_, err := negotiateAccept(&Operation{}, "yaml")
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+}
+
+// TestResolveBindings_FieldValueStringification covers the non-string
+// ParsedField.Value types (int64, float64, bool) being converted to
+// plain decimal / bool strings for path substitution.
+func TestResolveBindings_FieldValueStringification(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{"int64", int64(42), "42"},
+		{"float64 whole", 3.0, "3"},
+		{"float64 frac", 3.14, "3.14"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"string", "literal", "literal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mr := &MatchResult{
+				Op: &Operation{Method: "GET", Path: "/api/thing/{id}"},
+				Bindings: map[string]Binding{
+					"id": {Placeholder: "id"},
+				},
+			}
+			fields := []ParsedField{{Key: "id", Value: tc.value}}
+			resolved, _, err := resolveBindings(mr, fields, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, resolved["id"])
+		})
+	}
+}
+
+// TestRawCall_ForwardsUserHeaders pins the contract that -H/--header values
+// make it onto the outgoing HTTP request through buildAPIHeaders →
+// Client.RawCall. Authorization is reserved (a user override is dropped by
+// buildAPIHeaders and pinned again by the transport); everything else is
+// forwarded and wins over encoder defaults (Accept, Content-Type).
+func TestRawCall_ForwardsUserHeaders(t *testing.T) {
+	t.Parallel()
+	var received http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient(srv.URL, "my-token", false, nil)
+	hdrs := []ParsedHeader{
+		{Name: "X-Trace-Id", Value: "abc-123"},
+		{Name: "Idempotency-Key", Value: "key-42"},
+		// User-supplied Content-Type must beat the encoder default.
+		{Name: "Content-Type", Value: "application/x-yaml"},
+		// Authorization override must be ignored so a typo can't leak the token.
+		{Name: "Authorization", Value: "token attacker"},
+	}
+	resp, err := apiClient.RawCall(t.Context(), http.MethodGet, "/echo", nil, nil,
+		buildAPIHeaders("application/json", "application/json", hdrs), false, true)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "abc-123", received.Get("X-Trace-Id"))
+	assert.Equal(t, "key-42", received.Get("Idempotency-Key"))
+	assert.Equal(t, "application/x-yaml", received.Get("Content-Type"),
+		"user-supplied Content-Type must win over encoder default")
+	assert.Equal(t, "token my-token", received.Get("Authorization"),
+		"Authorization must stay pinned to the resolved token")
+}
+
+// TestValidateFlagCombos_BodyAndInputMutuallyExclusive pins the user-visible
+// error when both --body and --input are set.
+func TestValidateFlagCombos_BodyAndInputMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	err := validateFlagCombos(&apiCommand{
+		schemaVersion: SchemaVersion,
+		body:          `{"a":1}`,
+		input:         "payload.json",
+	})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+	assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
+}
+
+// TestValidateFlagCombos_SilentAndVerboseMutuallyExclusive pins the
+// user-visible error when both --silent and --verbose are set: silent
+// suppresses the response body, verbose dumps everything — combining them
+// is contradictory.
+func TestValidateFlagCombos_SilentAndVerboseMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	err := validateFlagCombos(&apiCommand{
+		schemaVersion: SchemaVersion,
+		silent:        true,
+		verbose:       true,
+	})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+	assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
+}
+
+// TestEncodeFields_BodyFlagPassesThroughVerbatim verifies --body is sent as-is
+// with application/json, and that any -F alongside it is routed to the query
+// string (mirroring --input behavior).
+func TestEncodeFields_BodyFlagPassesThroughVerbatim(t *testing.T) {
+	t.Parallel()
+	fields := []ParsedField{{Key: "dry", Value: true}}
+	body, extras, ct, err := encodeFields(
+		"POST", fields, &apiCommand{body: `{"name":"acme"}`}, &Operation{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"acme"}`, string(body))
+	assert.Equal(t, "application/json", ct)
+	assert.Equal(t, "true", extras.Get("dry"))
+}
+
+// TestEncodeFields_NestedJSONFieldMarshalsAsObject verifies that a JSON-literal
+// -F value round-trips into the body as a nested object (not a quoted string).
+func TestEncodeFields_NestedJSONFieldMarshalsAsObject(t *testing.T) {
+	t.Parallel()
+	tags, err := parseField(`tags={"env":"prod"}`, true, nil)
+	require.NoError(t, err)
+	body, _, ct, err := encodeFields(
+		"POST",
+		[]ParsedField{{Key: "name", Value: "web"}, tags},
+		&apiCommand{},
+		&Operation{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "application/json", ct)
+	assert.JSONEq(t, `{"name":"web","tags":{"env":"prod"}}`, string(body))
+}
+
+// TestFieldToQueryString_ComplexValueJSONEncoded verifies that map/slice
+// values from JSON-literal -F round-trip to the query string as JSON.
+func TestFieldToQueryString_ComplexValueJSONEncoded(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t,
+		`{"env":"prod"}`,
+		fieldToQueryString(ParsedField{Key: "tags", Value: map[string]any{"env": "prod"}}),
+	)
+	assert.Equal(t,
+		`["a","b"]`,
+		fieldToQueryString(ParsedField{Key: "tags", Value: []any{"a", "b"}}),
+	)
+}
+
+// TestChooseInputContentType covers the precedence: file extension, then
+// op.BodyContentType, then the JSON default.
+func TestChooseInputContentType(t *testing.T) {
+	t.Parallel()
+	yamlOp := &Operation{BodyContentType: "application/x-yaml"}
+	jsonOp := &Operation{BodyContentType: "application/json"}
+	cases := []struct {
+		name  string
+		input string
+		op    *Operation
+		want  string
+	}{
+		{"yaml ext beats json op", "env.yaml", jsonOp, "application/x-yaml"},
+		{"yml ext beats json op", "env.yml", jsonOp, "application/x-yaml"},
+		{"json ext beats yaml op", "body.json", yamlOp, "application/json"},
+		{"at-prefixed yaml", "@env.yaml", nil, "application/x-yaml"},
+		{"no ext, yaml op", "payload", yamlOp, "application/x-yaml"},
+		{"no ext, no op → json default", "-", nil, "application/json"},
+		{"unknown ext falls through to op", "env.txt", yamlOp, "application/x-yaml"},
+		{"unknown ext, no op → json", "env.txt", nil, "application/json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, chooseInputContentType(tc.input, tc.op))
+		})
+	}
+}
+
+// TestBuildConcretePath covers template substitution with URL-safe encoding,
+// double-encoding for the reserved param names, and multi-segment paths.
+func TestBuildConcretePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		path     string
+		resolved map[string]string
+		want     string
+	}{
+		{
+			name:     "single_segment",
+			path:     "/api/orgs/{orgName}/members",
+			resolved: map[string]string{"orgName": "acme"},
+			want:     "/api/orgs/acme/members",
+		},
+		{
+			name:     "multiple_segments",
+			path:     "/api/stacks/{orgName}/{projectName}/{stackName}",
+			resolved: map[string]string{"orgName": "acme", "projectName": "proj", "stackName": "dev"},
+			want:     "/api/stacks/acme/proj/dev",
+		},
+		{
+			name:     "slash_in_value_is_escaped",
+			path:     "/api/stacks/{orgName}/{projectName}",
+			resolved: map[string]string{"orgName": "acme", "projectName": "p/q"},
+			want:     "/api/stacks/acme/p%2Fq",
+		},
+		{
+			name: "double_encoded_name_is_double_escaped",
+			path: "/api/preview/insights/{orgName}/accounts/{accountName}",
+			resolved: map[string]string{
+				"orgName":     "acme",
+				"accountName": "team/a",
+			},
+			want: "/api/preview/insights/acme/accounts/team%252Fa",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			op := &Operation{Path: tc.path}
+			got := buildConcretePath(op, tc.resolved)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestEmitDryRun_Envelope pins the JSON envelope shape: schemaVersion, dryRun
+// plan with method/URL/headers/body, Authorization redacted, body inlined as
+// JSON when it's valid JSON and as a quoted string otherwise.
+func TestEmitDryRun_Envelope(t *testing.T) {
+	t.Parallel()
+	t.Run("valid_json_body_inlined", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		err := emitDryRun(&buf, "POST", "https://example.test/api/x?y=1",
+			[]ParsedHeader{{Name: "X-Trace", Value: "abc"}},
+			"application/json", "application/json",
+			[]byte(`{"name":"acme"}`))
+		require.NoError(t, err)
+		var env struct {
+			SchemaVersion int `json:"schemaVersion"`
+			DryRun        struct {
+				Plan struct {
+					Method  string            `json:"method"`
+					URL     string            `json:"url"`
+					Headers map[string]string `json:"headers"`
+					Body    json.RawMessage   `json:"body"`
+				} `json:"plan"`
+			} `json:"dryRun"`
+		}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+		assert.Equal(t, SchemaVersion, env.SchemaVersion)
+		assert.Equal(t, "POST", env.DryRun.Plan.Method)
+		assert.Equal(t, "https://example.test/api/x?y=1", env.DryRun.Plan.URL)
+		assert.Equal(t, "token ***", env.DryRun.Plan.Headers["Authorization"])
+		assert.Equal(t, "application/json", env.DryRun.Plan.Headers["Content-Type"])
+		assert.Equal(t, "abc", env.DryRun.Plan.Headers["X-Trace"])
+		assert.JSONEq(t, `{"name":"acme"}`, string(env.DryRun.Plan.Body))
+	})
+	t.Run("non_json_body_quoted", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		err := emitDryRun(&buf, "POST", "https://example.test/x", nil,
+			"text/plain", "application/json", []byte("hello world"))
+		require.NoError(t, err)
+		var env struct {
+			DryRun struct {
+				Plan struct {
+					Body json.RawMessage `json:"body"`
+				} `json:"plan"`
+			} `json:"dryRun"`
+		}
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+		var s string
+		require.NoError(t, json.Unmarshal(env.DryRun.Plan.Body, &s))
+		assert.Equal(t, "hello world", s)
+	})
+}
+
+// TestDumpRequestVerbose_DropsUserAuthorization pins that a user-supplied
+// Authorization override does NOT appear in the verbose dump — the dump must
+// reflect the real wire, and APIClient.Do drops such overrides.
+func TestDumpRequestVerbose_DropsUserAuthorization(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	dumpRequestVerbose(&buf, "GET", "https://example.test/api/x",
+		[]ParsedHeader{
+			{Name: "Authorization", Value: "token attacker"},
+			{Name: "X-Trace", Value: "abc"},
+		},
+		"", "application/json", nil)
+	stderr := buf.String()
+	assert.NotContains(t, stderr, "token attacker",
+		"user-supplied Authorization must be filtered out of the verbose dump")
+	assert.Contains(t, stderr, "Authorization: token ***",
+		"the redacted Authorization line must still appear")
+	assert.Contains(t, stderr, "X-Trace: abc")
+}
+
+// fakeBody wraps a reader with a no-op Close so we can hand-build *http.Response
+// values without pulling in httptest for handleResponse tests.
+func fakeBody(s string) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader([]byte(s)))
+}
+
+// TestHandleResponse covers the main post-processing branches: body
+// rendering, --silent suppression, --include status+headers, and 4xx
+// returning an APIError.
+func TestHandleResponse(t *testing.T) {
+	t.Parallel()
+	newResp := func(status int, ct, body string) *http.Response {
+		return &http.Response{
+			StatusCode: status,
+			Status:     http.StatusText(status),
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     http.Header{"Content-Type": []string{ct}},
+			Body:       fakeBody(body),
+		}
+	}
+
+	t.Run("200_renders_body", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		require.NoError(t, handleResponse(&buf, io.Discard, newResp(200, "application/json", `{"a":1}`), &apiCommand{}))
+		assert.Contains(t, buf.String(), `"a"`)
+	})
+	t.Run("204_empty", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		require.NoError(t, handleResponse(&buf, io.Discard, newResp(204, "application/json", ""), &apiCommand{}))
+		assert.Empty(t, strings.TrimSpace(buf.String()))
+	})
+	t.Run("silent_suppresses_body", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		require.NoError(t, handleResponse(&buf, io.Discard, newResp(200, "application/json", `{"a":1}`),
+			&apiCommand{silent: true}))
+		assert.Empty(t, strings.TrimSpace(buf.String()))
+	})
+	t.Run("include_prints_status_line_and_headers", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		require.NoError(t, handleResponse(&buf, io.Discard, newResp(200, "application/json", `{}`),
+			&apiCommand{include: true}))
+		assert.Contains(t, buf.String(), "HTTP/1.1")
+		assert.Contains(t, buf.String(), "Content-Type: application/json")
+	})
+	t.Run("silent_does_not_suppress_error", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		err := handleResponse(&buf, io.Discard, newResp(500, "application/json", `{"code":500}`),
+			&apiCommand{silent: true})
+		require.Error(t, err)
+		var apiErr *APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
+	})
+	t.Run("4xx_returns_apierror", func(t *testing.T) {
+		t.Parallel()
+		err := handleResponse(io.Discard, io.Discard, newResp(404, "application/json", `{"code":404}`), &apiCommand{})
+		require.Error(t, err)
+		var apiErr *APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
+		assert.Equal(t, ErrHTTP4xx, apiErr.Envelope.Error.Code)
+	})
+	t.Run("401_returns_auth_apierror", func(t *testing.T) {
+		t.Parallel()
+		err := handleResponse(io.Discard, io.Discard, newResp(401, "application/json", `{"code":401}`), &apiCommand{})
+		require.Error(t, err)
+		var apiErr *APIError
+		require.True(t, errors.As(err, &apiErr))
+		assert.Equal(t, cmdutil.ExitAuthenticationError, apiErr.ExitCode)
+	})
+}

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -78,6 +78,28 @@ func TestResolveBindings_NonMatchingFieldPassesThrough(t *testing.T) {
 	assert.Equal(t, "foo", remaining[0].Value)
 }
 
+// TestResolveBindings_AliasFieldFillsPath verifies that when the user
+// writes their own alias for a path template variable (e.g. `{foobar}`
+// for a spec param named `orgName`), a -F field whose key matches the
+// alias fills the path — not the spec param name. Without this, an
+// aliased path silently resolves from context instead.
+func TestResolveBindings_AliasFieldFillsPath(t *testing.T) {
+	t.Parallel()
+	mr := &MatchResult{
+		Op: &Operation{Method: "POST", Path: "/api/orgs/{orgName}/hooks"},
+		Bindings: map[string]Binding{
+			"orgName": {Placeholder: "foo"},
+		},
+	}
+	fields := []ParsedField{
+		{Key: "foo", Value: "bar"},
+	}
+	resolved, remaining, err := resolveBindings(mr, fields, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", resolved["orgName"])
+	assert.Empty(t, remaining, "aliased -F should be consumed by the path")
+}
+
 // TestResolveBindings_FieldOverridesContextAutoResolve verifies that a
 // -F field takes precedence over context auto-resolution for a
 // context-kind param (orgName/projectName/stackName).
@@ -270,7 +292,7 @@ func TestRawCall_ForwardsUserHeaders(t *testing.T) {
 		{Name: "Authorization", Value: "token attacker"},
 	}
 	resp, err := apiClient.RawCall(t.Context(), http.MethodGet, "/echo", nil, nil,
-		buildAPIHeaders("application/json", "application/json", hdrs), false, true)
+		buildAPIHeaders("application/json", "application/json", hdrs), false)
 	require.NoError(t, err)
 	resp.Body.Close()
 
@@ -287,9 +309,9 @@ func TestRawCall_ForwardsUserHeaders(t *testing.T) {
 func TestValidateFlagCombos_BodyAndInputMutuallyExclusive(t *testing.T) {
 	t.Parallel()
 	err := validateFlagCombos(&apiCommand{
-		schemaVersion: SchemaVersion,
-		body:          `{"a":1}`,
-		input:         "payload.json",
+		envelopeVersion: SchemaVersion,
+		body:            `{"a":1}`,
+		input:           "payload.json",
 	})
 	require.Error(t, err)
 	var apiErr *APIError
@@ -305,9 +327,9 @@ func TestValidateFlagCombos_BodyAndInputMutuallyExclusive(t *testing.T) {
 func TestValidateFlagCombos_SilentAndVerboseMutuallyExclusive(t *testing.T) {
 	t.Parallel()
 	err := validateFlagCombos(&apiCommand{
-		schemaVersion: SchemaVersion,
-		silent:        true,
-		verbose:       true,
+		envelopeVersion: SchemaVersion,
+		silent:          true,
+		verbose:         true,
 	})
 	require.Error(t, err)
 	var apiErr *APIError

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -287,6 +288,44 @@ type bodyJSON struct {
 type describeEnvelope struct {
 	SchemaVersion int         `json:"schemaVersion"`
 	Operation     describedOp `json:"operation"`
+}
+
+// DryRunPlan is the `dryRun.plan` sub-object emitted by --dry-run.
+type DryRunPlan struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers"`
+	Body    json.RawMessage   `json:"body,omitempty"`
+}
+
+// dryRunEnvelope is the full stdout shape for --dry-run.
+type dryRunEnvelope struct {
+	SchemaVersion int `json:"schemaVersion"`
+	DryRun        struct {
+		Plan DryRunPlan `json:"plan"`
+	} `json:"dryRun"`
+}
+
+// httpErrorEnvelopeBytes turns a 4xx/5xx HTTP response into the standard
+// APIError envelope, classifying 401/403 as ExitAuthenticationError and
+// preserving a parsed body when it's valid JSON.
+func httpErrorEnvelopeBytes(resp *http.Response, body []byte) *APIError {
+	exit := cmdutil.ExitCodeError
+	code := ErrHTTP4xx
+	if resp.StatusCode >= 500 {
+		code = ErrHTTP5xx
+	} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		exit = cmdutil.ExitAuthenticationError
+	}
+	var parsed any
+	if json.Valid(body) {
+		_ = json.Unmarshal(body, &parsed)
+	} else {
+		parsed = string(body)
+	}
+	return NewAPIError(exit, code,
+		fmt.Sprintf("server returned HTTP %d", resp.StatusCode)).
+		WithHTTP(resp.StatusCode, parsed)
 }
 
 // errorDetailFromErr converts a generic error into a minimal ErrorDetail.

--- a/pkg/cmd/pulumi/cloud/fields.go
+++ b/pkg/cmd/pulumi/cloud/fields.go
@@ -1,0 +1,187 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// ParsedField is one -F / -f / --input value, already decoded into the
+// right Go type for the target encoding (body JSON vs query string).
+type ParsedField struct {
+	Key   string
+	Value any  // string, bool, float64, int64, nil
+	Raw   bool // from -f: always emit as string
+}
+
+// parseField parses a single `key=value` spec into a ParsedField.
+// typed=true uses gh-style type inference:
+//   - "true"/"false" → bool
+//   - "null" → nil
+//   - integer literal → int64
+//   - float literal → float64
+//   - JSON object (`{...}`) or array (`[...]`) → parsed into map/slice so
+//     callers can build nested request bodies inline
+//   - "@path" → file contents as string (or stdin when path=="-")
+//   - everything else → string
+//
+// typed=false always emits a string value (for `-f`).
+func parseField(spec string, typed bool, stdin io.Reader) (ParsedField, error) {
+	eq := strings.IndexByte(spec, '=')
+	if eq < 0 {
+		return ParsedField{}, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+			"field must be key=value: "+spec).WithField("field")
+	}
+	key, val := spec[:eq], spec[eq+1:]
+	if key == "" {
+		return ParsedField{}, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+			"field key must not be empty: "+spec).WithField("field")
+	}
+	// @file / @- reads (applies to both typed and raw).
+	if strings.HasPrefix(val, "@") {
+		source := val[1:]
+		raw, err := readAtSource(source, stdin)
+		if err != nil {
+			return ParsedField{}, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+				fmt.Sprintf("reading field %q: %v", key, err)).WithField("field")
+		}
+		return ParsedField{Key: key, Value: string(raw), Raw: !typed}, nil
+	}
+	if !typed {
+		return ParsedField{Key: key, Value: val, Raw: true}, nil
+	}
+	// Type inference.
+	switch val {
+	case "true":
+		return ParsedField{Key: key, Value: true}, nil
+	case "false":
+		return ParsedField{Key: key, Value: false}, nil
+	case "null":
+		return ParsedField{Key: key, Value: nil}, nil
+	}
+	// Numbers — only bare decimal, no hex/octal/exp to avoid surprises.
+	if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+		return ParsedField{Key: key, Value: n}, nil
+	}
+	if f, err := strconv.ParseFloat(val, 64); err == nil {
+		return ParsedField{Key: key, Value: f}, nil
+	}
+	// JSON object/array literal: parse so nested bodies work without a file.
+	// Only triggers on `{` or `[` prefixes — bare strings are never ambiguous.
+	if len(val) > 0 && (val[0] == '{' || val[0] == '[') {
+		var parsed any
+		if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+			return ParsedField{Key: key, Value: parsed}, nil
+		}
+	}
+	return ParsedField{Key: key, Value: val}, nil
+}
+
+// readAtSource implements `@path` and `@-` file-or-stdin reading. Callers
+// must pass a non-nil stdin Reader when `@-` is used
+func readAtSource(source string, stdin io.Reader) ([]byte, error) {
+	if source == "-" {
+		if stdin == nil {
+			return nil, NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+				"@- field requires a stdin reader; caller passed nil")
+		}
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(source)
+}
+
+// parseFields parses all -F / -f / --header values into structured slices.
+// `fields` are typed, `rawFields` are strings. Duplicate keys are allowed;
+// callers decide whether to combine or overwrite per encoding target.
+func parseFields(typed, raw []string, stdin io.Reader) ([]ParsedField, error) {
+	var out []ParsedField
+	for _, spec := range typed {
+		f, err := parseField(spec, true, stdin)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	for _, spec := range raw {
+		f, err := parseField(spec, false, stdin)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// ParsedHeader is one -H value split on the first colon.
+type ParsedHeader struct {
+	Name, Value string
+}
+
+// parseHeaders splits each `Name: Value` entry on the first colon.
+func parseHeaders(specs []string) ([]ParsedHeader, error) {
+	out := make([]ParsedHeader, 0, len(specs))
+	for _, spec := range specs {
+		rawName, rawVal, ok := strings.Cut(spec, ":")
+		if !ok {
+			return nil, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+				"header must be `Name: Value`: "+spec).WithField("header")
+		}
+		name := strings.TrimSpace(rawName)
+		val := strings.TrimSpace(rawVal)
+		if name == "" {
+			return nil, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+				"header name must not be empty: "+spec).WithField("header")
+		}
+		out = append(out, ParsedHeader{Name: name, Value: val})
+	}
+	return out, nil
+}
+
+// methodDefaultsToPost reports whether the CLI should default --method to
+// POST given a field count. Matches `gh api` / `vercel api` behavior.
+func methodDefaultsToPost(fieldCount int, hasInput, hasBody bool) bool {
+	return fieldCount > 0 || hasInput || hasBody
+}
+
+// buildAPIHeaders folds contentType / accept / user `-H` headers into a
+// single http.Header for httpstate Client.RawCall. User headers win over
+// the encoder defaults (Accept, Content-Type); user-supplied Authorization
+// is dropped — RawCall pins it from the Client's token.
+func buildAPIHeaders(contentType, accept string, headers []ParsedHeader) http.Header {
+	h := http.Header{}
+	if accept != "" {
+		h.Set("Accept", accept)
+	} else {
+		h.Set("Accept", "application/json")
+	}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	for _, ph := range headers {
+		if strings.EqualFold(ph.Name, "Authorization") {
+			continue
+		}
+		h.Set(ph.Name, ph.Value)
+	}
+	return h
+}

--- a/pkg/cmd/pulumi/cloud/fields.go
+++ b/pkg/cmd/pulumi/cloud/fields.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -34,18 +33,12 @@ type ParsedField struct {
 	Raw   bool // from -f: always emit as string
 }
 
-// parseField parses a single `key=value` spec into a ParsedField.
-// typed=true uses gh-style type inference:
-//   - "true"/"false" → bool
-//   - "null" → nil
-//   - integer literal → int64
-//   - float literal → float64
-//   - JSON object (`{...}`) or array (`[...]`) → parsed into map/slice so
-//     callers can build nested request bodies inline
-//   - "@path" → file contents as string (or stdin when path=="-")
-//   - everything else → string
-//
-// typed=false always emits a string value (for `-f`).
+// parseField parses a single `key=value` spec into a ParsedField. typed=true
+// runs the value through json.Unmarshal so JSON literals decode to their
+// native Go types; anything that fails to parse, including bare unquoted strings,
+// falls through as a plain string, which is the gh-style ergonomic for `-F note=hello`.
+// `@path` (or `@-` for stdin) is honoured for both typed and raw fields.
+// typed=false always emits the value verbatim as a string (for `-f`).
 func parseField(spec string, typed bool, stdin io.Reader) (ParsedField, error) {
 	eq := strings.IndexByte(spec, '=')
 	if eq < 0 {
@@ -70,29 +63,9 @@ func parseField(spec string, typed bool, stdin io.Reader) (ParsedField, error) {
 	if !typed {
 		return ParsedField{Key: key, Value: val, Raw: true}, nil
 	}
-	// Type inference.
-	switch val {
-	case "true":
-		return ParsedField{Key: key, Value: true}, nil
-	case "false":
-		return ParsedField{Key: key, Value: false}, nil
-	case "null":
-		return ParsedField{Key: key, Value: nil}, nil
-	}
-	// Numbers — only bare decimal, no hex/octal/exp to avoid surprises.
-	if n, err := strconv.ParseInt(val, 10, 64); err == nil {
-		return ParsedField{Key: key, Value: n}, nil
-	}
-	if f, err := strconv.ParseFloat(val, 64); err == nil {
-		return ParsedField{Key: key, Value: f}, nil
-	}
-	// JSON object/array literal: parse so nested bodies work without a file.
-	// Only triggers on `{` or `[` prefixes — bare strings are never ambiguous.
-	if len(val) > 0 && (val[0] == '{' || val[0] == '[') {
-		var parsed any
-		if err := json.Unmarshal([]byte(val), &parsed); err == nil {
-			return ParsedField{Key: key, Value: parsed}, nil
-		}
+	var parsed any
+	if err := json.Unmarshal([]byte(val), &parsed); err == nil {
+		return ParsedField{Key: key, Value: parsed}, nil
 	}
 	return ParsedField{Key: key, Value: val}, nil
 }

--- a/pkg/cmd/pulumi/cloud/fields_test.go
+++ b/pkg/cmd/pulumi/cloud/fields_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseField_TypeInference(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		spec string
+		want any
+	}{
+		{"name=pulumi", "pulumi"},
+		{"count=42", int64(42)},
+		{"rate=3.14", 3.14},
+		{"enabled=true", true},
+		{"enabled=false", false},
+		{"val=null", nil},
+		{"s=12abc", "12abc"},
+	}
+	for _, tc := range cases {
+		f, err := parseField(tc.spec, true, nil)
+		require.NoError(t, err, "spec=%q", tc.spec)
+		assert.Equal(t, tc.want, f.Value, "spec=%q", tc.spec)
+	}
+}
+
+func TestParseField_RawNoCoercion(t *testing.T) {
+	t.Parallel()
+	f, err := parseField("count=42", false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "42", f.Value)
+	assert.True(t, f.Raw)
+}
+
+func TestParseField_AtStdin(t *testing.T) {
+	t.Parallel()
+	stdin := strings.NewReader("hello from stdin")
+	f, err := parseField("note=@-", true, stdin)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from stdin", f.Value)
+}
+
+func TestParseField_EmptyKey(t *testing.T) {
+	t.Parallel()
+	_, err := parseField("=value", true, nil)
+	assert.Error(t, err)
+}
+
+func TestParseField_NoEquals(t *testing.T) {
+	t.Parallel()
+	_, err := parseField("nokvhere", true, nil)
+	assert.Error(t, err)
+}
+
+func TestParseHeaders(t *testing.T) {
+	t.Parallel()
+	hs, err := parseHeaders([]string{
+		"Accept: application/json",
+		"X-Custom:value",
+		"Idempotency-Key: abc:def",
+	})
+	require.NoError(t, err)
+	require.Len(t, hs, 3)
+	assert.Equal(t, ParsedHeader{"Accept", "application/json"}, hs[0])
+	assert.Equal(t, ParsedHeader{"X-Custom", "value"}, hs[1])
+	// Only the first colon splits; later ones stay in the value.
+	assert.Equal(t, ParsedHeader{"Idempotency-Key", "abc:def"}, hs[2])
+}
+
+func TestParseHeaders_Invalid(t *testing.T) {
+	t.Parallel()
+	_, err := parseHeaders([]string{"NoColon"})
+	assert.Error(t, err)
+	_, err = parseHeaders([]string{": value"})
+	assert.Error(t, err)
+}
+
+func TestMethodDefaultsToPost(t *testing.T) {
+	t.Parallel()
+	assert.False(t, methodDefaultsToPost(0, false, false))
+	assert.True(t, methodDefaultsToPost(1, false, false))
+	assert.True(t, methodDefaultsToPost(0, true, false))
+	assert.True(t, methodDefaultsToPost(0, false, true))
+}
+
+func TestParseField_JSONObject(t *testing.T) {
+	t.Parallel()
+	f, err := parseField(`tags={"env":"prod","team":"platform"}`, true, nil)
+	require.NoError(t, err)
+	m, ok := f.Value.(map[string]any)
+	require.True(t, ok, "expected map[string]any, got %T", f.Value)
+	assert.Equal(t, "prod", m["env"])
+	assert.Equal(t, "platform", m["team"])
+}
+
+func TestParseField_JSONArray(t *testing.T) {
+	t.Parallel()
+	f, err := parseField(`members=["alice","bob"]`, true, nil)
+	require.NoError(t, err)
+	a, ok := f.Value.([]any)
+	require.True(t, ok, "expected []any, got %T", f.Value)
+	assert.Equal(t, []any{"alice", "bob"}, a)
+}
+
+func TestParseField_JSONMalformedFallsThroughToString(t *testing.T) {
+	t.Parallel()
+	// Starts with `{` but isn't valid JSON — preserved as the literal string
+	// rather than erroring, so users can send braces in plain values.
+	f, err := parseField(`note={literal}`, true, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "{literal}", f.Value)
+}
+
+func TestParseField_RawKeepsJSONAsString(t *testing.T) {
+	t.Parallel()
+	// `-f` disables all coercion, including JSON parsing.
+	f, err := parseField(`tags={"env":"prod"}`, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, `{"env":"prod"}`, f.Value)
+	assert.True(t, f.Raw)
+}

--- a/pkg/cmd/pulumi/cloud/fields_test.go
+++ b/pkg/cmd/pulumi/cloud/fields_test.go
@@ -29,7 +29,7 @@ func TestParseField_TypeInference(t *testing.T) {
 		want any
 	}{
 		{"name=pulumi", "pulumi"},
-		{"count=42", int64(42)},
+		{"count=42", float64(42)},
 		{"rate=3.14", 3.14},
 		{"enabled=true", true},
 		{"enabled=false", false},

--- a/pkg/cmd/pulumi/cloud/format.go
+++ b/pkg/cmd/pulumi/cloud/format.go
@@ -1,0 +1,63 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// formatJSON pretty-prints JSON output to w, falling back to raw bytes when
+// the server returned something that isn't valid JSON.
+func formatJSON(w io.Writer, body []byte) error {
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, body, "", "  "); err != nil {
+		if _, werr := w.Write(body); werr != nil {
+			return werr
+		}
+		fmt.Fprintln(w)
+		return nil
+	}
+	fmt.Fprintln(w, pretty.String())
+	return nil
+}
+
+// formatText writes text content directly to w with a trailing newline if
+// missing.
+func formatText(w io.Writer, body []byte) error {
+	if _, err := w.Write(body); err != nil {
+		return err
+	}
+	if len(body) > 0 && body[len(body)-1] != '\n' {
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// formatBinary writes binary content to w when not interactive, or prints a
+// hint to stderr when w is the terminal so we don't blast bytes at the user.
+func formatBinary(w io.Writer, body []byte) error {
+	if w == os.Stdout && cmdutil.Interactive() {
+		fmt.Fprintf(os.Stderr, "Binary response (%d bytes). Redirect stdout to save to a file.\n", len(body))
+		return nil
+	}
+	_, err := w.Write(body)
+	return err
+}

--- a/pkg/cmd/pulumi/cloud/pathmatch.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch.go
@@ -15,10 +15,13 @@
 package cloud
 
 import (
+	"net/http"
+	"net/url"
 	"path"
 	"slices"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/pgavlin/fx/v2"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -55,18 +58,6 @@ func splitSegments(p string) []string {
 	return strings.Split(path.Clean(p), "/")
 }
 
-// countTemplateParams returns the number of {param} segments in a spec path.
-// More-specific paths (fewer params) win ties when multiple operations match.
-func countTemplateParams(p string) int {
-	n := 0
-	for _, seg := range splitSegments(p) {
-		if isTemplateSegment(seg) {
-			n++
-		}
-	}
-	return n
-}
-
 // MatchResult is the outcome of matching a user-provided path against the
 // parsed spec.
 type MatchResult struct {
@@ -99,7 +90,14 @@ func MatchByOperationID(idx *Index, id string) (*MatchResult, error) {
 			"operation ID "+id+" matches multiple operations").
 			WithSuggestions(paths...)
 	}
-	return &MatchResult{Op: matches[0], Bindings: map[string]Binding{}}, nil
+	// Populate placeholder-style bindings by feeding the op's own templated
+	// path back through MatchPath.
+	op := matches[0]
+	mr, err := MatchPath(idx, op.Method, op.Path)
+	if err != nil {
+		return &MatchResult{Op: op, Bindings: map[string]Binding{}}, nil
+	}
+	return mr, nil
 }
 
 // looksLikeOperationID reports whether s looks like an operation identifier
@@ -126,101 +124,89 @@ func splitLeadingHTTPMethod(s string) (verb, rest string, ok bool) {
 
 // MatchPath finds the Operation in idx whose template best matches userPath
 // for the given HTTP method. Returns a structured APIError on no match.
-// Ties between equally-specific templates produce an "ambiguous" error.
 //
-// Matching rules, segment by segment:
-//   - spec literal must equal user literal (case-sensitive)
-//   - spec {param} captures either a user literal value, or a user {alias}
-//     placeholder that the caller will resolve later
-//   - a user {alias} cannot align with a spec literal — that means the user
-//     typed the wrong path
-//
-// Specificity preference: among matches, pick the one with the fewest
-// template parameters. If two are equally specific, return an error so the
-// agent has to disambiguate explicitly.
+// Routing is delegated to gorilla/mux. The captured vars are post-processed
+// so that a captured value of the form `{alias}` is treated as a
+// placeholder the caller will resolve later (org/project/stack auto-
+// resolve, or -F field).
 func MatchPath(idx *Index, method, userPath string) (*MatchResult, error) {
-	userSegs := splitSegments(userPath)
+	// Synthesize a request for gorilla.Match. URL.Path is set directly so we
+	// don't use url.Parse — `{}` characters in user input are valid here.
+	req := &http.Request{
+		Method: method,
+		URL:    &url.URL{Path: path.Clean(userPath)},
+	}
 
-	var matches []*MatchResult
-	for _, op := range idx.Operations {
-		if op.Method != method {
-			continue
-		}
-		specSegs := splitSegments(op.Path)
-		if len(specSegs) != len(userSegs) {
-			continue
-		}
-
-		bindings := make(map[string]Binding)
-		ok := true
-		for i, spec := range specSegs {
-			user := userSegs[i]
-			specIsParam := isTemplateSegment(spec)
-			userIsParam := isTemplateSegment(user)
-
-			switch {
-			case specIsParam && userIsParam:
-				bindings[trimBraces(spec)] = Binding{Placeholder: trimBraces(user)}
-			case specIsParam && !userIsParam:
-				bindings[trimBraces(spec)] = Binding{Literal: user}
-			case !specIsParam && userIsParam:
-				ok = false // can't parametrize a literal segment
-			default:
-				if spec != user {
-					ok = false
-				}
-			}
-			if !ok {
-				break
+	if idx.router != nil {
+		var rm mux.RouteMatch
+		if idx.router.Match(req, &rm) {
+			op := idx.ByKey[rm.Route.GetName()]
+			if op != nil {
+				return &MatchResult{Op: op, Bindings: varsToBindings(rm.Vars)}, nil
 			}
 		}
-		if ok {
-			matches = append(matches, &MatchResult{Op: op, Bindings: bindings})
-		}
 	}
 
-	if len(matches) == 0 {
-		suggestions := []string{
-			"run 'pulumi cloud api list' to see available endpoints",
-			"check the method with -X / --method",
-		}
-		if looksLikeOperationID(userPath) {
-			suggestions = append([]string{
-				"if you meant an operation ID, try 'pulumi cloud api describe " + userPath + "'",
-			}, suggestions...)
-		}
-		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
-			"no operation matches "+method+" "+userPath).
-			WithSuggestions(suggestions...)
+	suggestions := []string{
+		"run 'pulumi cloud api list' to see available endpoints",
+		"check the method with -X / --method",
 	}
+	if looksLikeOperationID(userPath) {
+		suggestions = append([]string{
+			"if you meant an operation ID, try 'pulumi cloud api describe " + userPath + "'",
+		}, suggestions...)
+	}
+	return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
+		"no operation matches "+method+" "+userPath).
+		WithSuggestions(suggestions...)
+}
 
-	// Prefer the most specific (fewest param segments) match.
-	best := matches[0]
-	bestCount := countTemplateParams(best.Op.Path)
-	tied := false
-	for _, m := range matches[1:] {
-		c := countTemplateParams(m.Op.Path)
-		switch {
-		case c < bestCount:
-			best = m
-			bestCount = c
-			tied = false
-		case c == bestCount:
-			tied = true
-		}
+// compareOps orders two operations for router registration: per-segment
+// static-first — at each path position a literal sorts before a {template},
+// otherwise lexical. Mirrors the pulumi-service codegen ordering
+// Returns -1, 0, or +1.
+func compareOps(a, b *Operation) int {
+	asegs := splitSegments(a.Path)
+	bsegs := splitSegments(b.Path)
+	n := len(asegs)
+	if len(bsegs) < n {
+		n = len(bsegs)
 	}
-	if tied {
-		paths := make([]string, 0, len(matches))
-		for _, m := range matches {
-			if countTemplateParams(m.Op.Path) == bestCount {
-				paths = append(paths, m.Op.Method+" "+m.Op.Path)
+	for i := 0; i < n; i++ {
+		ah, bh := isTemplateSegment(asegs[i]), isTemplateSegment(bsegs[i])
+		if ah != bh {
+			if !ah {
+				return -1
 			}
+			return 1
 		}
-		return nil, NewAPIError(cmdutil.ExitCodeError, ErrNoMatch,
-			"path matches multiple operations with equal specificity").
-			WithSuggestions(paths...)
+		if c := strings.Compare(asegs[i], bsegs[i]); c != 0 {
+			return c
+		}
 	}
-	return best, nil
+	switch {
+	case len(asegs) < len(bsegs):
+		return -1
+	case len(asegs) > len(bsegs):
+		return 1
+	}
+	return 0
+}
+
+// varsToBindings converts gorilla mux's captured path variables into our
+// Binding form. A captured value wrapped in {braces} is treated as the
+// user's placeholder alias (resolved later from -F or context); a bare
+// value is taken as a literal.
+func varsToBindings(vars map[string]string) map[string]Binding {
+	bindings := make(map[string]Binding, len(vars))
+	for name, val := range vars {
+		if isTemplateSegment(val) {
+			bindings[name] = Binding{Placeholder: trimBraces(val)}
+		} else {
+			bindings[name] = Binding{Literal: val}
+		}
+	}
+	return bindings
 }
 
 // splitPathQuery separates `?...` from a user-supplied path. Used by both

--- a/pkg/cmd/pulumi/cloud/pathmatch.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch.go
@@ -32,8 +32,8 @@ type Binding struct {
 	// a template placeholder instead.
 	Literal string
 	// Placeholder is the alias the user wrote (e.g. "org" from `{org}`)
-	// when they want the CLI to resolve the value from --org / context.
-	// Empty when Literal is set.
+	// when they want the CLI to resolve the value from -F or the current
+	// Pulumi context. Empty when Literal is set.
 	Placeholder string
 }
 

--- a/pkg/cmd/pulumi/cloud/pathmatch_test.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch_test.go
@@ -16,9 +16,11 @@ package cloud
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,9 +30,16 @@ func buildTestIndex(ops ...*Operation) *Index {
 	idx := &Index{
 		Operations: ops,
 		ByKey:      make(map[string]*Operation, len(ops)),
+		router:     mux.NewRouter(),
 	}
+	// Same per-segment static-first ordering as parseIndex.
+	sortedOps := append([]*Operation(nil), ops...)
+	slices.SortStableFunc(sortedOps, compareOps)
 	for _, op := range ops {
 		idx.ByKey[op.Key()] = op
+	}
+	for _, op := range sortedOps {
+		idx.router.Path(op.Path).Methods(op.Method).Name(op.Key())
 	}
 	return idx
 }
@@ -121,13 +130,6 @@ func TestMatchPath_UserTemplateAgainstLiteralSegmentFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestCountTemplateParams(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, 0, countTemplateParams("/api/user"))
-	assert.Equal(t, 2, countTemplateParams("/api/stacks/{org}/{project}"))
-	assert.Equal(t, 1, countTemplateParams("/api/orgs/{orgName}/members"))
-}
-
 func TestMatchByOperationID_Exact(t *testing.T) {
 	t.Parallel()
 	idx := buildTestIndex(
@@ -206,6 +208,129 @@ func TestSplitLeadingHTTPMethod(t *testing.T) {
 			assert.Equal(t, tc.wantRest, r)
 		})
 	}
+}
+
+// TestCompareOps_PerSegmentStaticFirst pins the routing-order contract
+// that powers PrefersMoreSpecific: at each depth, literal segments sort
+// before {template} segments; equal-kind segments fall back to lexical
+// compare; shorter paths sort before longer ones with the same prefix.
+// Mirrors pulumi-service's cmd/pulumi-codegen/cmd/go.go operationTree.walk.
+func TestCompareOps_PerSegmentStaticFirst(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		a, b     string
+		wantSign int // -1 a<b, 0 equal, +1 a>b
+	}{
+		{"literal_before_template_at_depth_2", "/api/users/me", "/api/users/{login}", -1},
+		{"literal_before_template_at_depth_3", "/api/{org}/me", "/api/{org}/{login}", -1},
+		{"lexical_among_literals", "/api/orgs", "/api/users", -1},
+		{"lexical_among_templates", "/api/{a}", "/api/{b}", -1},
+		{"shorter_before_longer_same_prefix", "/api/users", "/api/users/me", -1},
+		{"equal", "/api/user", "/api/user", 0},
+		{"literal_branch_wins_over_template_branch_at_root",
+			"/api/foo/{a}", "/api/{x}/bar", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &Operation{Method: "GET", Path: tc.a}
+			b := &Operation{Method: "GET", Path: tc.b}
+			got := compareOps(a, b)
+			switch {
+			case tc.wantSign < 0:
+				assert.Less(t, got, 0, "expected %s < %s", tc.a, tc.b)
+			case tc.wantSign > 0:
+				assert.Greater(t, got, 0, "expected %s > %s", tc.a, tc.b)
+			default:
+				assert.Equal(t, 0, got, "expected %s == %s", tc.a, tc.b)
+			}
+		})
+	}
+}
+
+// TestMatchPath_DeepSpecificity exercises a 3-level template tree to
+// verify that the per-segment static-first ordering still picks the
+// most-specific match when literals and templates interleave deeper than
+// the simpler PrefersMoreSpecific case.
+func TestMatchPath_DeepSpecificity(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/orgs/{orgName}/members"},
+		&Operation{Method: "GET", Path: "/api/orgs/{orgName}/{otherName}"},
+	)
+	// User input "members" should hit the literal-segment route, not the
+	// pure-template one — even though the template route would also match.
+	mr, err := MatchPath(idx, "GET", "/api/orgs/acme/members")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/orgs/{orgName}/members", mr.Op.Path)
+	assert.Equal(t, Binding{Literal: "acme"}, mr.Bindings["orgName"])
+	// And conversely a non-"members" tail falls through to the template route.
+	mr, err = MatchPath(idx, "GET", "/api/orgs/acme/teams")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/orgs/{orgName}/{otherName}", mr.Op.Path)
+	assert.Equal(t, Binding{Literal: "teams"}, mr.Bindings["otherName"])
+}
+
+// TestMatchPath_SamePathDifferentMethods verifies that two operations
+// sharing a path but differing in HTTP method both register and route
+// correctly; gorilla's per-route .Methods filter handles the dispatch.
+func TestMatchPath_SamePathDifferentMethods(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/stacks/{orgName}", OperationID: "GetStack"},
+		&Operation{Method: "POST", Path: "/api/stacks/{orgName}", OperationID: "CreateStack"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api/stacks/acme")
+	require.NoError(t, err)
+	assert.Equal(t, "GetStack", mr.Op.OperationID)
+	mr, err = MatchPath(idx, "POST", "/api/stacks/acme")
+	require.NoError(t, err)
+	assert.Equal(t, "CreateStack", mr.Op.OperationID)
+}
+
+// TestMatchByOperationID_PopulatesPlaceholderBindings verifies the
+// MatchByOperationID symmetry trick: a templated op looked up by ID gets
+// Bindings populated with one Placeholder per {var} in its path, so the
+// dispatcher can hand them to resolveTemplateVar.
+func TestMatchByOperationID_PopulatesPlaceholderBindings(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{
+			Method: "GET", Path: "/api/orgs/{orgName}/teams/{teamName}/members",
+			OperationID: "ListTeamMembers",
+		},
+	)
+	mr, err := MatchByOperationID(idx, "ListTeamMembers")
+	require.NoError(t, err)
+	assert.Equal(t, Binding{Placeholder: "orgName"}, mr.Bindings["orgName"])
+	assert.Equal(t, Binding{Placeholder: "teamName"}, mr.Bindings["teamName"])
+}
+
+// TestMatchByOperationID_LiteralPathHasNoBindings verifies that an op
+// with no template segments returns an empty (non-nil) Bindings map.
+func TestMatchByOperationID_LiteralPathHasNoBindings(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user", OperationID: "GetCurrentUser"},
+	)
+	mr, err := MatchByOperationID(idx, "GetCurrentUser")
+	require.NoError(t, err)
+	require.NotNil(t, mr.Bindings)
+	assert.Empty(t, mr.Bindings)
+}
+
+// TestMatchPath_PathNormalization verifies that user input with extra
+// slashes is normalised via path.Clean before matching, so /api//user
+// resolves to the same op as /api/user.
+func TestMatchPath_PathNormalization(t *testing.T) {
+	t.Parallel()
+	idx := buildTestIndex(
+		&Operation{Method: "GET", Path: "/api/user"},
+	)
+	mr, err := MatchPath(idx, "GET", "/api//user")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/user", mr.Op.Path)
 }
 
 func TestMatchPath_SuggestsOperationIDWhenInputLooksLikeOne(t *testing.T) {

--- a/pkg/cmd/pulumi/cloud/pathmatch_test.go
+++ b/pkg/cmd/pulumi/cloud/pathmatch_test.go
@@ -228,8 +228,10 @@ func TestCompareOps_PerSegmentStaticFirst(t *testing.T) {
 		{"lexical_among_templates", "/api/{a}", "/api/{b}", -1},
 		{"shorter_before_longer_same_prefix", "/api/users", "/api/users/me", -1},
 		{"equal", "/api/user", "/api/user", 0},
-		{"literal_branch_wins_over_template_branch_at_root",
-			"/api/foo/{a}", "/api/{x}/bar", -1},
+		{
+			"literal_branch_wins_over_template_branch_at_root",
+			"/api/foo/{a}", "/api/{x}/bar", -1,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/cmd/pulumi/cloud/resolve.go
+++ b/pkg/cmd/pulumi/cloud/resolve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -32,31 +33,37 @@ import (
 
 // ResolvedContext carries the resolved Pulumi Cloud context for an API call:
 // a Client (authenticated when LoggedIn is true, anonymous otherwise), the
-// cloud URL it targets, the resolved org name (empty when no --org flag was
-// passed and the user has no default), the current Pulumi project (nil
-// outside a project directory), and a LoggedIn flag callers can use to
-// decide whether to require credentials.
+// cloud URL it targets, the resolved default org (best-effort: from the
+// local default, the backend's opinion, or empty), the current Pulumi
+// project (nil outside a project directory), the (org, project, stack) of
+// the currently-selected stack (any/all empty when no stack is selected),
+// and a LoggedIn flag callers can use to decide whether to require
+// credentials.
 //
 // Always returns a usable Client + CloudURL so commands that hit public
 // endpoints (e.g. fetching the OpenAPI spec) work without a login.
 type ResolvedContext struct {
-	Client   *client.Client
-	CloudURL string
-	OrgName  string
-	Project  *workspace.Project
-	LoggedIn bool
+	Client    *client.Client
+	CloudURL  string
+	OrgName   string
+	Project   *workspace.Project
+	StackOrg  string
+	StackProj string
+	StackName string
+	LoggedIn  bool
 }
 
 // ResolveContext returns the Pulumi Cloud context for a `pulumi cloud api`
-// invocation. orgFlag is the user's --org value when set; when empty, the
-// org is resolved via pkgBackend.GetDefaultOrg (which prefers a
-// locally-configured default and falls back to the backend's opinion).
+// invocation. The resolved OrgName comes from pkgBackend.GetDefaultOrg
+// (which prefers a locally-configured default and falls back to the
+// backend's opinion) so {orgName} template vars resolve sensibly even
+// outside a project directory.
 //
 // Credential lookup is non-interactive: when no credentials are stored,
 // ResolveContext returns an anonymous Client + the resolved CloudURL with
 // LoggedIn=false rather than prompting or failing. Callers that require
 // authentication should check LoggedIn and surface their own error.
-func ResolveContext(ctx context.Context, orgFlag string) (*ResolvedContext, error) {
+func ResolveContext(ctx context.Context) (*ResolvedContext, error) {
 	ws := pkgWorkspace.Instance
 
 	project, _, err := ws.ReadProject()
@@ -86,7 +93,6 @@ func ResolveContext(ctx context.Context, orgFlag string) (*ResolvedContext, erro
 		return &ResolvedContext{
 			Client:   client.NewClient(cloudURL, "", false, cmdutil.Diag()),
 			CloudURL: cloudURL,
-			OrgName:  orgFlag,
 			Project:  project,
 			LoggedIn: false,
 		}, nil
@@ -106,19 +112,47 @@ func ResolveContext(ctx context.Context, orgFlag string) (*ResolvedContext, erro
 			"run `pulumi login`")
 	}
 
-	orgName := orgFlag
-	if orgName == "" {
-		orgName, err = pkgBackend.GetDefaultOrg(ctx, be, project)
-		if err != nil {
-			return nil, fmt.Errorf("resolving default org: %w", err)
-		}
+	orgName, err := pkgBackend.GetDefaultOrg(ctx, be, project)
+	if err != nil {
+		return nil, fmt.Errorf("resolving default org: %w", err)
 	}
 
+	stackOrg, stackProj, stackName := currentStackSelection(ctx, ws, be)
+
 	return &ResolvedContext{
-		Client:   cloudBe.Client(),
-		CloudURL: cloudBe.CloudURL(),
-		OrgName:  orgName,
-		Project:  project,
-		LoggedIn: true,
+		Client:    cloudBe.Client(),
+		CloudURL:  cloudBe.CloudURL(),
+		OrgName:   orgName,
+		Project:   project,
+		StackOrg:  stackOrg,
+		StackProj: stackProj,
+		StackName: stackName,
+		LoggedIn:  true,
 	}, nil
+}
+
+// currentStackSelection returns the (org, project, stack) of the user's
+// currently-selected stack via state.CurrentStack. Returns empty strings
+// when no stack is selected or the lookup fails (e.g. the ref points at
+// a deleted stack). Caller must have already verified be is an
+// httpstate.Backend; the stack is unwrapped to httpstate.Stack to read
+// OrgName.
+func currentStackSelection(
+	ctx context.Context, ws pkgWorkspace.Context, be pkgBackend.Backend,
+) (org, project, stack string) {
+	s, err := state.CurrentStack(ctx, ws, be)
+	if err != nil || s == nil {
+		return "", "", ""
+	}
+	cloudStack, ok := s.(httpstate.Stack)
+	if !ok {
+		return "", "", ""
+	}
+	ref := cloudStack.Ref()
+	stack = ref.Name().String()
+	if p, ok := ref.Project(); ok {
+		project = string(p)
+	}
+	org = cloudStack.OrgName()
+	return org, project, stack
 }

--- a/pkg/cmd/pulumi/cloud/spec.go
+++ b/pkg/cmd/pulumi/cloud/spec.go
@@ -19,9 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel/high/base"
 	v3high "github.com/pb33f/libopenapi/datamodel/high/v3"
@@ -111,6 +113,10 @@ type Index struct {
 	Operations  []*Operation
 	ByKey       map[string]*Operation // "GET /api/user" -> op
 	SpecVersion string                // the spec's own info.version, surfaced in `list --format=json`
+	// router is a gorilla/mux router with one named route per operation
+	// (route name == op.Key()). Routes are registered in specificity order
+	// consistent with the pulumi-service codegen
+	router *mux.Router
 }
 
 // methodPrecedence defines the method order used for stable sorting of operations.
@@ -184,6 +190,13 @@ func parseIndex(data []byte) (*Index, error) {
 		byKey[op.Key()] = op
 	}
 
+	router := mux.NewRouter()
+	sortedOps := append([]*Operation(nil), ops...)
+	slices.SortStableFunc(sortedOps, compareOps)
+	for _, op := range sortedOps {
+		router.Path(op.Path).Methods(op.Method).Name(op.Key())
+	}
+
 	specVersion := ""
 	if model.Info != nil {
 		specVersion = model.Info.Version
@@ -193,6 +206,7 @@ func parseIndex(data []byte) (*Index, error) {
 		Operations:  ops,
 		ByKey:       byKey,
 		SpecVersion: specVersion,
+		router:      router,
 	}, nil
 }
 

--- a/pkg/cmd/pulumi/cloud/spec_fetch.go
+++ b/pkg/cmd/pulumi/cloud/spec_fetch.go
@@ -46,7 +46,7 @@ var specCacheTTL = 24 * time.Hour
 // to the cached copy (if any) and writes a warning to warnW. When refresh
 // is true the fetch error is returned.
 func ensureSpec(ctx context.Context, warnW io.Writer, refresh bool) ([]byte, error) {
-	resolved, err := ResolveContext(ctx, "")
+	resolved, err := ResolveContext(ctx)
 	if err != nil {
 		return nil, NewAPIError(cmdutil.ExitInternalError, ErrToolError,
 			fmt.Sprintf("resolving cloud context: %v", err))


### PR DESCRIPTION
## Summary

Third of four stacked PRs splitting [#22712](https://github.com/pulumi/pulumi/pull/22712). Stacked on top of [#22770](https://github.com/pulumi/pulumi/pull/22770); review the earlier ones first.

Replaces the parent-command stub from PR 1 with the actual dispatcher, so `pulumi cloud api <op-or-method+path>` makes real HTTP calls. Surface mirrors `gh api` where the conventions overlap:

- `-F`/`--field` for typed values (numbers/bools/null auto-detected, JSON object/array literals parsed, `@file` and `@-` for file/stdin) and `-f`/`--raw-field` for the verbatim-string variant. Fields are routed as query params on `GET`/`HEAD` and JSON body fields otherwise; method defaults to `GET`, or `POST` when body fields, `--body`, or `--input` are present.
- `-H`/`--header` for custom HTTP headers — wins over the encoder's defaults (`Accept`, `Content-Type`); `Authorization` is dropped (token stays pinned to the resolved one).
- `--input` / `--body` for whole-body input (`--input -` reads stdin); `--jq` for response filtering; `-i`/`--include` and `--silent` for response shaping; `--verbose` and `--dry-run` for debugging.
- `--org` / `--project` / `--stack` to override path-template variables. Auto-resolves from the current Pulumi project when not provided; `-F orgName=...` style fields take precedence over both.

Brings in `fields.go` (field/header parsing, content-type encoding, `buildAPIHeaders`), `format.go` (response body rendering for the JSON / text / binary modes the dispatcher chooses based on the response Content-Type), and the `currentStackSelection` helper on `resolve.go`. Pulls `dryRunEnvelope`/`DryRunPlan` and `httpErrorEnvelopeBytes` into `envelope.go` so the same code can serve both the dispatcher and `--paginate` (PR 4).

`pulumi cloud` is still hidden from `--help` here; PR 4 un-hides it.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Tests cover: field parsing (typed vs raw, `@file` and `@-`, JSON literal coercion); header parsing + `buildAPIHeaders` (user `Content-Type` wins, user `Authorization` dropped, `Accept` default + Pulumi version appending); path-template binding resolution (literal > field > context, percent-encoding for slashes); method defaulting (POST when body fields present); flag-combo validation (`--body` + `--input` mutually exclusive, `--jq` + non-JSON output rejected, `--field` + body-mode args rejected on GET); `handleResponse` (200 renders, 204 empty, `--silent`, `--include`, `--jq` filters JSON, `--jq` on non-JSON warns and passes through, 4xx → `APIError`, 401 → `ExitAuthenticationError`); `emitDryRun` envelope shape (valid JSON / non-JSON body); `dumpRequestVerbose` redacts/drops Authorization.

Smoke-tested against the review stack: `pulumi cloud api /api/user --jq '.githubLogin'`, dispatched-by-operation-ID, `--dry-run`, and `--verbose` against several endpoints.

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [x] Changelog entry added.

## Risk

- All changes are scoped to `pkg/cmd/pulumi/api/`. The dispatcher reuses `httpstate/client.RawCall` introduced in PR 1, so existing `Call` callers are unaffected.
- Method defaulting (`-F …` on a path that doesn't accept POST) errors out up front rather than silently routing to a method the endpoint doesn't support — keeps surprises to a minimum.
- `--paginate` is intentionally absent here. The flag and the loop ship in PR 4 together, so users hitting a paginated endpoint without that flag in the meantime get a single page (the standard `gh api` default).