### PR TITLE
cli/cloud: add `--paginate` to `pulumi cloud api`

### DIFF
--- a/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-paginate.yaml
+++ b/changelog/pending/20260429--cli-cloud--add-pulumi-cloud-api-paginate.yaml
@@ -1,0 +1,8 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: |
+    Add `--paginate` to `pulumi cloud api`: follow continuation cursors,
+    accumulate items into a single JSON envelope, and surface progress
+    events to stderr with `--emit-events` (page, complete, truncated,
+    partial_failure, cancelled).

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -55,6 +55,7 @@ type apiCommand struct {
 	headers         []string
 	input           string
 	body            string
+	paginate        bool
 	include         bool
 	silent          bool
 	verbose         bool
@@ -87,6 +88,8 @@ func bindFlags(cmd *cobra.Command, api *apiCommand) {
 	pf.StringVar(&api.body, "body", "",
 		"Inline request body sent verbatim (default Content-Type: application/json). "+
 			"Mutually exclusive with --input")
+	pf.BoolVar(&api.paginate, "paginate", false,
+		"Follow pagination cursors and emit the combined result")
 	pf.BoolVarP(&api.include, "include", "i", false,
 		"Include HTTP status line and response headers in output")
 	pf.BoolVar(&api.silent, "silent", false,
@@ -174,6 +177,8 @@ func newAPICmd() *cobra.Command {
 			"  cat tag.json | pulumi cloud api UpdateStackTag --input -\n\n" +
 			"  # Filter the JSON response with jq.\n" +
 			"  pulumi cloud api /api/user --format=json | jq '.githubLogin'\n\n" +
+			"  # Follow pagination cursors and stream the combined result to jq.\n" +
+			"  pulumi cloud api ListStacks --paginate | jq '.stacks[].name'\n\n" +
 			"  # Extract just the status line + headers without the body.\n" +
 			"  pulumi cloud api /api/user --include --silent\n\n" +
 			"  # Preview the resolved request without sending it.\n" +
@@ -311,6 +316,19 @@ func executeLive(
 	if err != nil {
 		return NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
 			fmt.Sprintf("parsing query string %q: %v", query, err)).WithField("path")
+	}
+
+	if api.paginate {
+		return runPaginate(ctx, w, apiClient, paginateRequest{
+			Method:      method,
+			Path:        concretePath,
+			BaseQuery:   baseQuery,
+			Body:        body,
+			ContentType: contentType,
+			Accept:      accept,
+			Headers:     hdrs,
+			Op:          op,
+		}, api)
 	}
 
 	var bodyReader io.Reader

--- a/pkg/cmd/pulumi/cloud/cloud.go
+++ b/pkg/cmd/pulumi/cloud/cloud.go
@@ -21,17 +21,12 @@ import (
 )
 
 // NewCloudCmd creates the top-level `pulumi cloud` command group.
-//
-// Hidden until the surface is feature-complete (the dispatcher and
-// `--paginate` land in follow-up PRs). The command still works when
-// invoked explicitly — Hidden only suppresses it from `pulumi --help`.
 func NewCloudCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Interact with Pulumi Cloud",
 		Long: "Interact with Pulumi Cloud.\n\n" +
 			"The `api` subcommand calls any endpoint in the Pulumi Cloud REST API.",
-		Hidden: true,
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 	cmd.AddCommand(newAPICmd())

--- a/pkg/cmd/pulumi/cloud/describe_test.go
+++ b/pkg/cmd/pulumi/cloud/describe_test.go
@@ -99,6 +99,7 @@ func describeGoldenCases(t *testing.T) []struct {
 	}{
 		{"list_org_tokens", loadMarkdownOp(t, "ListOrgTokens")},
 		{"create_org_token", loadMarkdownOp(t, "CreateOrgToken")},
+		{"nested_arrays", loadMarkdownOp(t, "GetNestedArrays")},
 		{"preview_op", &Operation{
 			Method:      "GET",
 			Path:        "/api/preview/things/{id}",

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -183,43 +182,6 @@ func writeErrorText(w io.Writer, d ErrorDetail) error {
 	}
 	_, err := io.WriteString(w, b.String())
 	return err
-}
-
-// Event envelopes for progress and cancellation. Streamed as JSONL on
-// stderr; each line is a complete JSON object.
-type Event struct {
-	SchemaVersion int    `json:"schemaVersion"`
-	Event         string `json:"event"` // e.g. "page", "complete", "partial_failure", "cancelled"
-	Timestamp     string `json:"timestamp"`
-	// Page-specific fields.
-	Page   int `json:"page,omitempty"`
-	Count  int `json:"count,omitempty"`
-	Cursor any `json:"cursor,omitempty"`
-	// Complete-specific fields.
-	TotalPages int `json:"totalPages,omitempty"`
-	TotalItems int `json:"totalItems,omitempty"`
-	// Partial-failure-specific fields.
-	PagesFetched int          `json:"pagesFetched,omitempty"`
-	FailedAt     int          `json:"failedAt,omitempty"`
-	ErrorDetail  *ErrorDetail `json:"error,omitempty"`
-	// Cancellation-specific fields.
-	Phase      string `json:"phase,omitempty"`
-	Completed  []int  `json:"completed,omitempty"`
-	InProgress []int  `json:"inProgress,omitempty"`
-}
-
-// NewEvent builds an event with schemaVersion and timestamp populated.
-func NewEvent(name string, ts time.Time) *Event {
-	return &Event{
-		SchemaVersion: SchemaVersion,
-		Event:         name,
-		Timestamp:     ts.UTC().Format(time.RFC3339Nano),
-	}
-}
-
-// WriteEvent writes a single JSONL event line to w.
-func WriteEvent(w io.Writer, ev *Event) error {
-	return WriteJSON(w, ev, false)
 }
 
 // Command-output envelopes. Each top-level `--format=json` payload gets a

--- a/pkg/cmd/pulumi/cloud/envelope_test.go
+++ b/pkg/cmd/pulumi/cloud/envelope_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -89,27 +88,6 @@ func TestWriteErrorEnvelope_InteractiveHTTPStatus(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, WriteErrorEnvelope(&buf, apiErr, true))
 	assert.Contains(t, buf.String(), "HTTP 404")
-}
-
-func TestNewEvent_CarriesSchemaVersionAndTimestamp(t *testing.T) {
-	t.Parallel()
-	fixedTime, err := time.Parse(time.RFC3339, "2026-04-16T10:00:00Z")
-	require.NoError(t, err)
-
-	ev := NewEvent("page", fixedTime)
-	ev.Page = 3
-	ev.Count = 42
-
-	var buf bytes.Buffer
-	require.NoError(t, WriteEvent(&buf, ev))
-	var decoded Event
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
-
-	assert.Equal(t, SchemaVersion, decoded.SchemaVersion)
-	assert.Equal(t, "page", decoded.Event)
-	assert.Equal(t, "2026-04-16T10:00:00Z", decoded.Timestamp)
-	assert.Equal(t, 3, decoded.Page)
-	assert.Equal(t, 42, decoded.Count)
 }
 
 func TestWriteJSON_RoundTrip(t *testing.T) {

--- a/pkg/cmd/pulumi/cloud/paginate.go
+++ b/pkg/cmd/pulumi/cloud/paginate.go
@@ -1,0 +1,409 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// PaginationLimit caps the number of pages we'll follow. Higher than any
+// realistic list endpoint; keeps a runaway loop from hanging the CLI if the
+// service returns a cursor that never terminates. Declared as var so tests
+// can lower it without having to fake 1000+ network round trips.
+var PaginationLimit = 1000
+
+// paginateRequest is the subset of an outgoing request that the paginate
+// loop needs to mutate the cursor on each iteration.
+type paginateRequest struct {
+	Method, Path string
+	BaseQuery    url.Values
+	Body         []byte
+	ContentType  string
+	Accept       string
+	Headers      []ParsedHeader
+	// Op is consulted when the response cursor field is named differently from the
+	// request parameter (e.g. "nextToken" in response, "continuationToken" in query).
+	Op *Operation
+}
+
+// runPaginate executes req repeatedly, following continuationToken cursors,
+// and concatenates items into a single JSON document on w.
+//
+// Returns a Silent APIError on partial failure so the caller's wrapper
+// doesn't double-emit — the accumulated pages already on w are the ground
+// truth.
+func runPaginate(
+	ctx context.Context,
+	w io.Writer,
+	apiClient *client.Client,
+	req paginateRequest,
+	flags *apiCommand,
+) error {
+	accumulated := make([]json.RawMessage, 0, 256)
+	page := 0
+	var cursor, cursorParam string
+	// itemsField is locked in from the first page that has one, so the accumulated
+	// output can be wrapped in the same envelope shape a single-page response would
+	// produce — preserving downstream `| jq` compatibility. Empty means the server
+	// returned a bare array.
+	var itemsField string
+	// truncated is set only when the loop exits because it hit PaginationLimit
+	// with a live cursor; every other exit path (natural end, safety valve)
+	// leaves it false.
+	var truncated bool
+
+	for page < PaginationLimit {
+		page++
+
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return emitCancelled(w, flags, accumulated, itemsField)
+		}
+
+		q := url.Values{}
+		for k, v := range req.BaseQuery {
+			q[k] = append([]string(nil), v...)
+		}
+		if cursor != "" && cursorParam != "" {
+			q.Set(cursorParam, cursor)
+		}
+
+		var bodyReader io.Reader
+		if len(req.Body) > 0 {
+			bodyReader = bytes.NewReader(req.Body)
+		}
+		resp, err := apiClient.RawCall(ctx, req.Method, req.Path, q, bodyReader,
+			buildAPIHeaders(req.ContentType, req.Accept, req.Headers), len(req.Body) > 0)
+		if err != nil {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return emitCancelled(w, flags, accumulated, itemsField)
+			}
+			return emitPartialFailure(w, flags, accumulated, itemsField,
+				NewAPIError(cmdutil.ExitCodeError, ErrNetwork,
+					fmt.Sprintf("HTTP %s %s: %v", req.Method, req.Path, err)))
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return emitPartialFailure(w, flags, accumulated, itemsField,
+				NewAPIError(cmdutil.ExitCodeError, ErrNetwork,
+					fmt.Sprintf("reading page %d: %v", page, err)))
+		}
+
+		if resp.StatusCode >= 400 {
+			return emitPartialFailure(w, flags, accumulated, itemsField, httpErrorEnvelopeBytes(resp, body))
+		}
+
+		items, pageItemsField, nextCursor, nextCursorParam, err := ExtractPage(body, req.Op)
+		if err != nil {
+			return emitPartialFailure(w, flags, accumulated, itemsField,
+				NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
+					fmt.Sprintf("page %d: %v; --paginate requires a JSON shape with an array and "+
+						"optional continuationToken/cursor/nextToken", page, err)))
+		}
+		if itemsField == "" && pageItemsField != "" {
+			itemsField = pageItemsField
+		}
+
+		accumulated = append(accumulated, items...)
+
+		// No-progress safety valve: if the server hands us back the same
+		// cursor we just sent, or returns a non-empty cursor alongside an
+		// empty page, we're in a loop. Stop rather than spin.
+		if nextCursor != "" && nextCursor == cursor {
+			break
+		}
+		if nextCursor != "" && len(items) == 0 {
+			break
+		}
+
+		cursor = nextCursor
+		cursorParam = nextCursorParam
+		if cursor == "" {
+			break
+		}
+		if page == PaginationLimit {
+			truncated = true
+		}
+	}
+
+	// Loop exited via the `page < PaginationLimit` guard with a live cursor:
+	// the dataset was truncated, not exhausted. Emit a partial-pagination
+	// error so agents can detect it via exit code + code field, and resume
+	// from the returned cursor.
+	if truncated {
+		flushAccumulated(w, accumulated, itemsField, flags)
+		apiErr := NewAPIError(cmdutil.ExitCodeError, ErrPartialPagination,
+			fmt.Sprintf("pagination truncated at %d pages; %d items collected; more data available",
+				PaginationLimit, len(accumulated))).
+			WithSuggestions("re-run with the returned cursor to resume")
+		apiErr.Silent = true
+		return apiErr
+	}
+
+	return writeAccumulated(w, accumulated, itemsField, flags)
+}
+
+// ExtractPage parses a JSON page and returns its items, the name of the
+// envelope field those items came from (empty when the page was a bare
+// array), the next cursor, and the query-parameter name to send that
+// cursor as on the next request.
+//
+// Supported shapes:
+//   - Top-level JSON array: items; no cursor.
+//   - Object with top-level "continuationToken" / "cursor" string: cursor param matches the field name.
+//   - Object with top-level "nextToken": cursor param resolved from op.Params (errors if unknown).
+//   - Object with nested "pagination": { "next": "<url>" } — v2; cursor param is parsed from the URL.
+//
+// In all object shapes the items collection is the sole array-valued top-level field.
+func ExtractPage(body []byte, op *Operation) ([]json.RawMessage, string, string, string, error) {
+	if len(body) == 0 {
+		return nil, "", "", "", nil
+	}
+	// Try array first.
+	var arr []json.RawMessage
+	if err := json.Unmarshal(body, &arr); err == nil {
+		return arr, "", "", "", nil
+	}
+	// Else expect object.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, "", "", "", fmt.Errorf("response is neither a JSON array nor object: %w", err)
+	}
+
+	cursor, cursorParam, err := extractCursor(obj, op)
+	if err != nil {
+		return nil, "", "", "", err
+	}
+
+	// Find the sole array-valued field at the top level.
+	var itemsField string
+	var items []json.RawMessage
+	for key, raw := range obj {
+		if key == "continuationToken" || key == "cursor" || key == "nextToken" {
+			continue
+		}
+		trim := bytes.TrimSpace(raw)
+		if len(trim) > 0 && trim[0] == '[' {
+			if itemsField != "" {
+				return nil, "", "", "", fmt.Errorf("ambiguous paginated shape: multiple array fields (%q, %q)",
+					itemsField, key)
+			}
+			var a []json.RawMessage
+			if err := json.Unmarshal(raw, &a); err != nil {
+				return nil, "", "", "", fmt.Errorf("decoding field %q: %w", key, err)
+			}
+			itemsField = key
+			items = a
+		}
+	}
+	if itemsField == "" {
+		// No array field + no cursor → legitimate empty page (some endpoints return `{}`
+		// instead of an empty array envelope). Cursor + no array would loop forever.
+		if cursor == "" {
+			return nil, "", "", "", nil
+		}
+		return nil, "", cursor, cursorParam,
+			fmt.Errorf("response has a %q cursor but no array field", cursorParam)
+	}
+	return items, itemsField, cursor, cursorParam, nil
+}
+
+// cursorParamCandidates is the ordered list of query-parameter names
+// recognised as "the pagination cursor" when a response uses a cursor
+// field whose name doesn't match the request parameter (e.g. "nextToken"
+// in the response paired with "continuationToken" in the query). Order
+// is preference — more-specific first.
+var cursorParamCandidates = []string{"continuationToken", "cursor", "nextToken", "pageToken"}
+
+// pickCursorParam returns the first query parameter on op whose name is
+// listed in cursorParamCandidates. Returns "" when op is nil or exposes
+// no recognised pagination parameter.
+func pickCursorParam(op *Operation) string {
+	if op == nil {
+		return ""
+	}
+	for _, name := range cursorParamCandidates {
+		for _, p := range op.Params {
+			if p.In == "query" && p.Name == name {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// extractCursor looks for a continuation cursor in a response object and
+// returns the cursor value and the query-parameter name the next request
+// should send it under. Returns ("", "", nil) if no cursor is present
+// (= no more pages).
+//
+// For the v2 pagination shape ({"pagination": {"cursor": ..., "next":
+// ..., "previous": ...}}) only "next" indicates there is a further page:
+// the schema documents "cursor" as "an opaque cursor for resuming
+// pagination" (a bookmark of the *current* position, which the server
+// returns on every page), while "next" is "Link to the next page of
+// results" — an empty "next" means the last page. We therefore extract
+// the cursor from the "next" URL's query string.
+//
+// For "nextToken", the query-parameter name does not match the response field, so we
+// consult op.Params via pickCursorParam.
+func extractCursor(obj map[string]json.RawMessage, op *Operation) (cursor, param string, err error) {
+	if raw, ok := obj["continuationToken"]; ok {
+		var s string
+		if jerr := json.Unmarshal(raw, &s); jerr == nil && s != "" {
+			return s, "continuationToken", nil
+		}
+	}
+	if raw, ok := obj["cursor"]; ok {
+		var s string
+		if jerr := json.Unmarshal(raw, &s); jerr == nil && s != "" {
+			return s, "cursor", nil
+		}
+	}
+	if raw, ok := obj["nextToken"]; ok {
+		var s string
+		if jerr := json.Unmarshal(raw, &s); jerr == nil && s != "" {
+			name := pickCursorParam(op)
+			if name == "" {
+				return "", "", errors.New(
+					"response has nextToken but operation exposes no recognised pagination query parameter " +
+						"(expected one of continuationToken, cursor, nextToken, pageToken)")
+			}
+			return s, name, nil
+		}
+	}
+	if raw, ok := obj["pagination"]; ok {
+		var pag map[string]json.RawMessage
+		if jerr := json.Unmarshal(raw, &pag); jerr == nil {
+			if n, ok := pag["next"]; ok {
+				var link string
+				if jerr := json.Unmarshal(n, &link); jerr == nil && link != "" {
+					if c, p := cursorFromLink(link); c != "" {
+						return c, p, nil
+					}
+				}
+			}
+		}
+	}
+	return "", "", nil
+}
+
+// cursorFromLink extracts the advance marker from a pagination-next link
+// (either a full URL or a bare path+query). Returns the value and the
+// query-param name to send it as. Recognises both cursor-style
+// ("cursor"/"continuationToken") and offset-style ("page"/"offset")
+// advance markers. Returns ("", "") when no recognised marker is
+// present.
+func cursorFromLink(link string) (cursor, param string) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return "", ""
+	}
+	q := u.Query()
+	for _, name := range []string{"cursor", "continuationToken", "page", "offset"} {
+		if v := q.Get(name); v != "" {
+			return v, name
+		}
+	}
+	return "", ""
+}
+
+// writeAccumulated writes the combined result to w. When itemsField is
+// non-empty (the server returned an object envelope with a named array), the
+// output is wrapped back into that same shape ({<itemsField>: [...]}) so
+// downstream `| jq` filters work identically whether or not --paginate is set.
+// When itemsField is empty (server returned a bare array), the output stays
+// a bare array.
+func writeAccumulated(w io.Writer, items []json.RawMessage, itemsField string, flags *apiCommand) error {
+	combined, err := marshalAccumulated(items, itemsField)
+	if err != nil {
+		return NewAPIError(cmdutil.ExitInternalError, ErrToolError,
+			fmt.Sprintf("serializing paginated results: %v", err))
+	}
+	if flags.silent {
+		return nil
+	}
+	if cmdutil.Interactive() {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, combined, "", "  "); err == nil {
+			combined = buf.Bytes()
+		}
+	}
+	if _, err := w.Write(combined); err != nil {
+		return err
+	}
+	if len(combined) > 0 && combined[len(combined)-1] != '\n' {
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+// marshalAccumulated serializes the accumulated items, wrapping them in
+// {<itemsField>: [...]} when itemsField is set. Cursor fields are
+// intentionally omitted from the wrapped envelope — they are meaningless
+// after pagination completes.
+func marshalAccumulated(items []json.RawMessage, itemsField string) ([]byte, error) {
+	if itemsField == "" {
+		return json.Marshal(items)
+	}
+	return json.Marshal(map[string]any{itemsField: items})
+}
+
+// Best-effort flush preserves the envelope shape so downstream consumers don't
+// see a different type on failure. Honors --silent (no body output), matching
+// the behaviour of the success-path writeAccumulated.
+func flushAccumulated(w io.Writer, accumulated []json.RawMessage, itemsField string, flags *apiCommand) {
+	if flags != nil && flags.silent {
+		return
+	}
+	combined, err := marshalAccumulated(accumulated, itemsField)
+	if err != nil {
+		return
+	}
+	_, _ = w.Write(combined)
+	fmt.Fprintln(w)
+}
+
+// emitPartialFailure flushes accumulated pages to w and returns the
+// underlying APIError marked Silent so the envelope contains the failed
+// page's error detail rather than the per-page printed body.
+func emitPartialFailure(
+	w io.Writer, flags *apiCommand,
+	accumulated []json.RawMessage, itemsField string, apiErr *APIError,
+) error {
+	flushAccumulated(w, accumulated, itemsField, flags)
+	apiErr.Silent = true
+	return apiErr
+}
+
+// emitCancelled flushes accumulated pages to w and returns a Silent APIError
+// with cmdutil.ExitCancelled.
+func emitCancelled(
+	w io.Writer, flags *apiCommand,
+	accumulated []json.RawMessage, itemsField string,
+) error {
+	flushAccumulated(w, accumulated, itemsField, flags)
+	return &APIError{ExitCode: cmdutil.ExitCancelled, Silent: true}
+}

--- a/pkg/cmd/pulumi/cloud/paginate_test.go
+++ b/pkg/cmd/pulumi/cloud/paginate_test.go
@@ -1,0 +1,469 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPage_Array(t *testing.T) {
+	t.Parallel()
+	items, field, cursor, param, err := ExtractPage([]byte(`[1,2,3]`), nil)
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+	assert.Empty(t, field)
+	assert.Empty(t, cursor)
+	assert.Empty(t, param)
+}
+
+func TestExtractPage_ObjectWithContinuationToken(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"items":[{"a":1},{"a":2}],"continuationToken":"abc"}`)
+	items, field, cursor, param, err := ExtractPage(body, nil)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "items", field)
+	assert.Equal(t, "abc", cursor)
+	assert.Equal(t, "continuationToken", param)
+
+	// Item preserved as RawMessage
+	var first map[string]int
+	require.NoError(t, json.Unmarshal(items[0], &first))
+	assert.Equal(t, 1, first["a"])
+}
+
+func TestExtractPage_ObjectWithTopLevelCursor(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"items":[{"a":1}],"cursor":"xyz"}`)
+	items, field, cursor, param, err := ExtractPage(body, nil)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "items", field)
+	assert.Equal(t, "xyz", cursor)
+	assert.Equal(t, "cursor", param)
+}
+
+func TestExtractPage_ObjectWithPaginationNextLink(t *testing.T) {
+	t.Parallel()
+	// v2 shape: "next" carries a link; extract its cursor query param.
+	// "cursor" in the response is an opaque bookmark of the *current*
+	// page and must NOT be used to advance.
+	body := []byte(`{"resources":[{"id":"r1"}],"pagination":{"cursor":"bookmark",` +
+		`"next":"/api/orgs/acme/search/resourcesv2?query=foo&cursor=next-token&size=1"}}`)
+	items, field, cursor, param, err := ExtractPage(body, nil)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "resources", field)
+	assert.Equal(t, "next-token", cursor)
+	assert.Equal(t, "cursor", param)
+}
+
+func TestExtractPage_ObjectWithPaginationLastPage(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"resources":[{"id":"r1"}],"pagination":{"cursor":"bookmark","next":""}}`)
+	items, field, cursor, param, err := ExtractPage(body, nil)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "resources", field)
+	assert.Empty(t, cursor)
+	assert.Empty(t, param)
+}
+
+func TestExtractPage_ObjectWithCursorButNoArray(t *testing.T) {
+	t.Parallel()
+	// A cursor field with no accompanying array is a server envelope bug —
+	// we'd loop forever if we kept sending the cursor back. Error out.
+	_, _, _, _, err := ExtractPage([]byte(`{"continuationToken":"x","status":"ok"}`), nil)
+	assert.Error(t, err)
+}
+
+// TestExtractPage_EmptyObject covers the case where the server returns
+// `{}` to signal "no results, no more pages" (seen on Insights endpoints
+// when the caller's org has no accounts). This must terminate pagination
+// gracefully rather than erroring.
+func TestExtractPage_EmptyObject(t *testing.T) {
+	t.Parallel()
+	items, field, cursor, param, err := ExtractPage([]byte(`{}`), nil)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.Empty(t, field)
+	assert.Empty(t, cursor)
+	assert.Empty(t, param)
+}
+
+// TestExtractPage_NullArrayField: a server that serialises an empty
+// collection as `null` instead of `[]` should be treated the same as an
+// empty array — no more pages.
+func TestExtractPage_NullArrayField(t *testing.T) {
+	t.Parallel()
+	items, _, cursor, _, err := ExtractPage([]byte(`{"accounts":null}`), nil)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.Empty(t, cursor)
+}
+
+func TestExtractPage_ObjectMultipleArrays(t *testing.T) {
+	t.Parallel()
+	_, _, _, _, err := ExtractPage([]byte(`{"items":[1],"other":[2]}`), nil)
+	assert.Error(t, err)
+}
+
+// TestExtractPage_NextTokenMapsToContinuationToken covers the Insights-style
+// shape where the response uses "nextToken" but the operation's pagination
+// query parameter is "continuationToken". We must resolve the cursor param
+// from the operation's parameters, not from the response field name.
+func TestExtractPage_NextTokenMapsToContinuationToken(t *testing.T) {
+	t.Parallel()
+	op := &Operation{
+		Method: "GET",
+		Path:   "/api/preview/insights/{orgName}/accounts",
+		Params: []ParamSpec{
+			{Name: "orgName", In: "path"},
+			{Name: "continuationToken", In: "query"},
+			{Name: "count", In: "query"},
+		},
+	}
+	body := []byte(`{"accounts":[{"id":"a"}],"nextToken":"abc123"}`)
+	items, field, cursor, param, err := ExtractPage(body, op)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "accounts", field)
+	assert.Equal(t, "abc123", cursor)
+	assert.Equal(t, "continuationToken", param)
+}
+
+// TestExtractPage_NextTokenWithNoKnownQueryParam: the response carries a
+// next-page cursor but the op exposes no recognised pagination query
+// parameter. That is a structural mismatch we cannot recover from — we
+// prefer to error loudly rather than silently drop the cursor or loop.
+func TestExtractPage_NextTokenWithNoKnownQueryParam(t *testing.T) {
+	t.Parallel()
+	op := &Operation{
+		Method: "GET",
+		Path:   "/api/foo",
+		Params: []ParamSpec{
+			{Name: "other", In: "query"},
+		},
+	}
+	body := []byte(`{"items":[{"a":1}],"nextToken":"abc"}`)
+	_, _, _, _, err := ExtractPage(body, op)
+	require.Error(t, err)
+}
+
+// TestExtractPage_NextTokenEmptyIsLastPage: an empty nextToken means no
+// more pages — match the behavior for continuationToken/cursor.
+func TestExtractPage_NextTokenEmptyIsLastPage(t *testing.T) {
+	t.Parallel()
+	op := &Operation{
+		Params: []ParamSpec{{Name: "continuationToken", In: "query"}},
+	}
+	body := []byte(`{"items":[{"a":1}],"nextToken":""}`)
+	_, _, cursor, param, err := ExtractPage(body, op)
+	require.NoError(t, err)
+	assert.Empty(t, cursor)
+	assert.Empty(t, param)
+}
+
+// TestPickCursorParam covers the query-param selection order.
+func TestPickCursorParam(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		params []ParamSpec
+		want   string
+	}{
+		{
+			name: "continuationToken preferred",
+			params: []ParamSpec{
+				{Name: "pageToken", In: "query"},
+				{Name: "continuationToken", In: "query"},
+				{Name: "cursor", In: "query"},
+			},
+			want: "continuationToken",
+		},
+		{
+			name:   "cursor when continuationToken absent",
+			params: []ParamSpec{{Name: "cursor", In: "query"}, {Name: "pageToken", In: "query"}},
+			want:   "cursor",
+		},
+		{
+			name:   "pageToken fallback",
+			params: []ParamSpec{{Name: "pageToken", In: "query"}},
+			want:   "pageToken",
+		},
+		{
+			name:   "ignore path params with matching name",
+			params: []ParamSpec{{Name: "continuationToken", In: "path"}},
+			want:   "",
+		},
+		{
+			name:   "no candidates",
+			params: []ParamSpec{{Name: "filter", In: "query"}},
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			op := &Operation{Params: tc.params}
+			assert.Equal(t, tc.want, pickCursorParam(op))
+		})
+	}
+}
+
+func TestExtractPage_EmptyBody(t *testing.T) {
+	t.Parallel()
+	items, field, cursor, param, err := ExtractPage(nil, nil)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.Empty(t, field)
+	assert.Empty(t, cursor)
+	assert.Empty(t, param)
+}
+
+func TestExtractPage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, _, _, _, err := ExtractPage([]byte(`not json at all`), nil)
+	assert.Error(t, err)
+}
+
+func TestMarshalAccumulated_BareArray(t *testing.T) {
+	t.Parallel()
+	// When the server returned a bare array, output stays a bare array.
+	items := []json.RawMessage{json.RawMessage(`1`), json.RawMessage(`2`)}
+	out, err := marshalAccumulated(items, "")
+	require.NoError(t, err)
+	assert.JSONEq(t, `[1,2]`, string(out))
+}
+
+func TestMarshalAccumulated_PreservesEnvelope(t *testing.T) {
+	t.Parallel()
+	// When the server returned an object envelope, we rewrap so downstream
+	// `| jq` filters like '.accounts[]' keep working across --paginate.
+	items := []json.RawMessage{json.RawMessage(`{"id":"a"}`), json.RawMessage(`{"id":"b"}`)}
+	out, err := marshalAccumulated(items, "accounts")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"accounts":[{"id":"a"},{"id":"b"}]}`, string(out))
+}
+
+func TestMarshalAccumulated_StripsCursorFields(t *testing.T) {
+	t.Parallel()
+	// The rewrapped envelope only contains the items field — cursor
+	// metadata is meaningless post-pagination and must not leak through.
+	items := []json.RawMessage{json.RawMessage(`1`)}
+	out, err := marshalAccumulated(items, "resources")
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	_, hasCursor := got["cursor"]
+	_, hasContToken := got["continuationToken"]
+	_, hasPagination := got["pagination"]
+	assert.False(t, hasCursor)
+	assert.False(t, hasContToken)
+	assert.False(t, hasPagination)
+	assert.Contains(t, got, "resources")
+}
+
+// TestFlushAccumulated_SilentSuppressesStdout pins the contract that --silent
+// suppresses the partial-failure body flush, not just the success-path output.
+func TestFlushAccumulated_SilentSuppressesStdout(t *testing.T) {
+	t.Parallel()
+	items := []json.RawMessage{json.RawMessage(`{"id":"a"}`)}
+	var buf bytes.Buffer
+	flushAccumulated(&buf, items, "accounts", &apiCommand{silent: true})
+	assert.Empty(t, buf.String(), "--silent must suppress the partial-failure flush")
+}
+
+// TestFlushAccumulated_DefaultWritesEnvelope covers the baseline (no flags).
+func TestFlushAccumulated_DefaultWritesEnvelope(t *testing.T) {
+	t.Parallel()
+	items := []json.RawMessage{json.RawMessage(`{"id":"a"}`)}
+	var buf bytes.Buffer
+	flushAccumulated(&buf, items, "accounts", &apiCommand{})
+	assert.JSONEq(t, `{"accounts":[{"id":"a"}]}`, buf.String())
+}
+
+// TestRunPaginate_TruncationEmitsPartialPaginationError pins the contract
+// that hitting PaginationLimit with a still-active cursor produces an
+// ErrPartialPagination envelope and a non-zero exit, not a silent "complete".
+//
+//nolint:paralleltest // mutates PaginationLimit
+func TestRunPaginate_TruncationEmitsPartialPaginationError(t *testing.T) {
+	// Always hand back a new cursor so the loop can never exit naturally.
+	var pagesServed int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pagesServed++
+		fmt.Fprintf(w, `{"items":[{"p":%d}],"continuationToken":"c%d"}`, pagesServed, pagesServed)
+	}))
+	t.Cleanup(srv.Close)
+
+	origLimit := PaginationLimit
+	PaginationLimit = 3
+	t.Cleanup(func() { PaginationLimit = origLimit })
+
+	apiClient := client.NewClient(srv.URL, "", false, nil)
+	req := paginateRequest{Method: "GET", Path: "/list", BaseQuery: url.Values{}, Accept: "application/json"}
+	var buf bytes.Buffer
+	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
+	assert.Equal(t, ErrPartialPagination, apiErr.Envelope.Error.Code)
+	assert.True(t, apiErr.Silent, "truncation error must be Silent so stderr is not double-written")
+	assert.Contains(t, apiErr.Envelope.Error.Message, "truncated at 3 pages")
+	assert.Equal(t, 3, pagesServed)
+}
+
+// TestHTTPErrorEnvelopeBytes_ExitCodes pins the exit-code contract:
+// 4xx and 5xx both exit 1, only 401/403 exit 3. The error code field still
+// distinguishes 4xx from 5xx for JSON consumers.
+func TestHTTPErrorEnvelopeBytes_ExitCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status   int
+		wantExit int
+		wantCode string
+	}{
+		{400, cmdutil.ExitCodeError, ErrHTTP4xx},
+		{401, cmdutil.ExitAuthenticationError, ErrHTTP4xx},
+		{403, cmdutil.ExitAuthenticationError, ErrHTTP4xx},
+		{404, cmdutil.ExitCodeError, ErrHTTP4xx},
+		{409, cmdutil.ExitCodeError, ErrHTTP4xx},
+		{429, cmdutil.ExitCodeError, ErrHTTP4xx},
+		{500, cmdutil.ExitCodeError, ErrHTTP5xx},
+		{502, cmdutil.ExitCodeError, ErrHTTP5xx},
+		{503, cmdutil.ExitCodeError, ErrHTTP5xx},
+		{504, cmdutil.ExitCodeError, ErrHTTP5xx},
+	}
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{StatusCode: tc.status, Header: http.Header{}}
+			apiErr := httpErrorEnvelopeBytes(resp, []byte(`{}`))
+			assert.Equal(t, tc.wantExit, apiErr.ExitCode, "exit code for %d", tc.status)
+			assert.Equal(t, tc.wantCode, apiErr.Envelope.Error.Code, "error code for %d", tc.status)
+		})
+	}
+}
+
+// TestRunPaginate_SafetyValveBreaksAreNotTruncation pins that the no-progress
+// safety valves (server echoes the cursor, or returns a non-empty cursor with
+// zero items) exit the loop without producing ErrPartialPagination.
+func TestRunPaginate_SafetyValveBreaksAreNotTruncation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "server echoes the last cursor",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				tok := r.URL.Query().Get("continuationToken")
+				if tok == "" {
+					fmt.Fprintln(w, `{"items":[{"p":1}],"continuationToken":"stuck"}`)
+					return
+				}
+				fmt.Fprintln(w, `{"items":[{"p":2}],"continuationToken":"stuck"}`)
+			},
+		},
+		{
+			name: "non-empty cursor with empty page",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				tok := r.URL.Query().Get("continuationToken")
+				if tok == "" {
+					fmt.Fprintln(w, `{"items":[{"p":1}],"continuationToken":"next"}`)
+					return
+				}
+				fmt.Fprintln(w, `{"items":[],"continuationToken":"still-next"}`)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			t.Cleanup(srv.Close)
+
+			apiClient := client.NewClient(srv.URL, "", false, nil)
+			req := paginateRequest{Method: "GET", Path: "/list", BaseQuery: url.Values{}, Accept: "application/json"}
+			var buf bytes.Buffer
+			require.NoError(t, runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{}))
+		})
+	}
+}
+
+// TestRunPaginate_TruncationRespectsSilent pins that the accumulated-body
+// flush on truncation still respects --silent (no stdout payload).
+//
+//nolint:paralleltest // mutates os.Stdout and PaginationLimit
+func TestRunPaginate_TruncationRespectsSilent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"items":[{"a":1}],"continuationToken":"keep-going"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	origLimit := PaginationLimit
+	PaginationLimit = 2
+	t.Cleanup(func() { PaginationLimit = origLimit })
+
+	apiClient := client.NewClient(srv.URL, "", false, nil)
+	req := paginateRequest{Method: "GET", Path: "/list", BaseQuery: url.Values{}, Accept: "application/json"}
+	var buf bytes.Buffer
+	_ = runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{silent: true})
+	assert.Empty(t, strings.TrimSpace(buf.String()), "--silent must suppress truncation flush")
+}
+
+// TestCursorFromLink exercises the four recognised advance-marker names
+// plus the non-matching and malformed cases.
+func TestCursorFromLink(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		link       string
+		wantCursor string
+		wantParam  string
+	}{
+		{"https://api.example/list?cursor=abc", "abc", "cursor"},
+		{"https://api.example/list?continuationToken=xyz", "xyz", "continuationToken"},
+		{"/list?page=3", "3", "page"},
+		{"/list?offset=50", "50", "offset"},
+		{"/list?cursor=first&continuationToken=second", "first", "cursor"}, // cursor wins
+		{"/list?other=foo", "", ""},
+		{"", "", ""},
+		{"://bad", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.link, func(t *testing.T) {
+			t.Parallel()
+			cursor, param := cursorFromLink(tc.link)
+			assert.Equal(t, tc.wantCursor, cursor)
+			assert.Equal(t, tc.wantParam, param)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/cloud/schema.go
+++ b/pkg/cmd/pulumi/cloud/schema.go
@@ -761,12 +761,7 @@ func (r *schemaRenderer) writePropertyMarkdown(
 
 	if typ == "array" {
 		if child.Items != nil && child.Items.IsA() && child.Items.A != nil {
-			it := child.Items.A.Schema()
-			itTyp := ""
-			if it != nil {
-				itTyp = schemaType(it)
-			}
-			if itTyp == "object" || orderedmap.Len(nonNil(it).Properties) > 0 || len(nonNil(it).OneOf) > 0 {
+			if it := child.Items.A.Schema(); it != nil {
 				r.writeSchemaMarkdown(b, it, depth+1, nextSt)
 			}
 		}
@@ -908,6 +903,9 @@ func (r *schemaRenderer) markdownTypeName(s *base.Schema) string {
 	case "":
 		if len(s.OneOf) > 0 || len(s.AnyOf) > 0 {
 			return "union"
+		}
+		if len(s.AllOf) > 0 || orderedmap.Len(s.Properties) > 0 {
+			return "object"
 		}
 		return "any"
 	}

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/nested_arrays.md
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/nested_arrays.md
@@ -1,0 +1,23 @@
+# `GET` /api/test/nested-arrays/{id}
+
+_GetNestedArrays_
+
+**Operation:** `GetNestedArrays` · **Tag:** TestNested
+
+## Description
+
+Regression coverage: response has both an array of allOf-wrapped objects and an array of string-enum primitives. Exercises markdown renderer paths that were silently dropping nested model fields and inline enum values.
+
+## Parameters
+
+- `id` `string` _(in: path)_ **required** — Synthetic id.
+
+## Responses
+
+### `200 OK` — Nested-array fixture response.
+
+- `owners` `array[object]` **required** — Owners list — items use allOf to merge in the OwnerSummary shape.
+  - `name` `string` **required** — Owner display name.
+  - `role` `string enum` _enum:_ `admin`, `member`, `viewer` — Owner role.
+- `statuses` `array[string enum]` **required** — Allowed status values for the thing.
+  - `string enum` _enum:_ `pending`, `active`, `archived`

--- a/pkg/cmd/pulumi/cloud/testdata/describe_golden/nested_arrays.txt
+++ b/pkg/cmd/pulumi/cloud/testdata/describe_golden/nested_arrays.txt
@@ -1,0 +1,24 @@
+GET /api/test/nested-arrays/{id}
+Tag: TestNested
+Operation: GetNestedArrays
+
+GetNestedArrays
+
+Regression coverage: response has both an array of allOf-wrapped objects and an array of string-enum primitives. Exercises markdown renderer paths that were silently dropping nested model fields and inline enum values.
+
+Parameters:
+  [path] id* (string) — Synthetic id.
+
+Success response (application/json):
+  Response:
+    {
+      owners*: Owners list — items use allOf to merge in the OwnerSummary shape. [
+        {
+          name*: (string) Owner display name.
+          role: (string) one of: admin, member, viewer Owner role.
+        }
+      ]
+      statuses*: Allowed status values for the thing. [
+        (string) one of: pending, active, archived
+      ]
+    }

--- a/pkg/cmd/pulumi/cloud/testdata/openapi_public.json
+++ b/pkg/cmd/pulumi/cloud/testdata/openapi_public.json
@@ -1194,6 +1194,86 @@
           "AccessTokens"
         ]
       }
+    },
+    "/api/test/nested-arrays/{id}": {
+      "get": {
+        "operationId": "GetNestedArrays",
+        "tags": [
+          "TestNested"
+        ],
+        "summary": "GetNestedArrays",
+        "description": "Regression coverage: response has both an array of allOf-wrapped objects and an array of string-enum primitives. Exercises markdown renderer paths that were silently dropping nested model fields and inline enum values.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Synthetic id."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Nested-array fixture response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "owners",
+                    "statuses"
+                  ],
+                  "properties": {
+                    "owners": {
+                      "type": "array",
+                      "description": "Owners list — items use allOf to merge in the OwnerSummary shape.",
+                      "items": {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Owner display name."
+                              },
+                              "role": {
+                                "type": "string",
+                                "description": "Owner role.",
+                                "enum": [
+                                  "admin",
+                                  "member",
+                                  "viewer"
+                                ]
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "statuses": {
+                      "type": "array",
+                      "description": "Allowed status values for the thing.",
+                      "items": {
+                        "type": "string",
+                        "enum": [
+                          "pending",
+                          "active",
+                          "archived"
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Last of four stacked PRs splitting [#22712](https://github.com/pulumi/pulumi/pull/22712). Stacked on top of [#22771](https://github.com/pulumi/pulumi/pull/22771); review the earlier ones first.

Adds the pagination loop to the dispatcher and unhides the `pulumi cloud` command from `--help` now that the surface is feature-complete.

`--paginate` follows the continuation cursor (`continuationToken` / `cursor` / `nextToken` / `pagination.next` URL) until the server stops emitting one, accumulates items into a single JSON envelope on stdout, and emits structured progress events on stderr when `--emit-events` is set. Hard cap at 1000 pages (`PaginationLimit`, `var` for tests) so a runaway loop can't hang the CLI; partial result is flushed on every non-natural exit so agents always have something to act on.

Event taxonomy on stderr (one JSONL record per event, `--emit-events` opt-in):

- `page` — one per request (page number, item count, cursor)
- `complete` — natural end of the cursor chain
- `truncated` — hit `PaginationLimit` with a live cursor; partial result flushed; exit 1 with `pulumi.cloud_api.partial_pagination`
- `partial_failure` — mid-loop HTTP/network failure; partial result flushed
- `cancelled` — SIGINT during the loop; partial result flushed

No-progress safety valves break the loop if the server echoes the same cursor back, or returns a non-empty cursor with zero items, so an honest server bug doesn't burn through the page limit.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Tests cover: cursor extraction across all four shapes (`continuationToken`, `cursor`, `page`/`offset`, `pagination.next` URL); items-field auto-detection (envelope vs bare array); cursor-from-`Link` header parsing; truncation flush vs natural completion; partial-failure flush on HTTP and network errors; no-progress safety valves (echo-cursor, empty-page-with-cursor) classified as natural breaks rather than truncation; `--silent` suppression of the truncation flush; SIGINT propagation.

Smoke-tested against the review stack with a paginated endpoint and `--emit-events 2>&1 | jq -c 'select(.event)'` to confirm event ordering.

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [x] Changelog entry added.

## Risk

- All changes scoped to `pkg/cmd/pulumi/api/`. The cross-cutting bit is `cloud.go` losing its `Hidden: true` — the only behavioural effect is that `pulumi cloud` now appears in `pulumi --help`. The command was already invocable on master via explicit invocation.
- The `truncated` event + `partial_pagination` exit code are a contract that agents will key on; any future change here is a breaking change for those consumers.
- The 1000-page hard cap is `var PaginationLimit` rather than `const` so tests can lower it cheaply; not exposed as a flag, since "I really wanted ≥1000 pages of API output" is a sign you should re-think the call rather than turn the limit off.