### PR TITLE
[python/sdk] Store parameterized package refs in runtime settings

### DIFF
--- a/changelog/pending/20260412--sdk-python--cache-parameterized-package-refs-per-monitor.yaml
+++ b/changelog/pending/20260412--sdk-python--cache-parameterized-package-refs-per-monitor.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Generate parameterized Python SDKs that cache package refs in runtime settings and require the updated runtime SDK version

--- a/changelog/pending/20260429--sdk-python--store-parameterized-package-refs-in-runtime-settings.yaml
+++ b/changelog/pending/20260429--sdk-python--store-parameterized-package-refs-in-runtime-settings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Store parameterized provider package refs in deployment-scoped Python runtime settings

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -548,33 +548,35 @@ def get_version():
 
 		_, err = fmt.Fprintf(buffer, `
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = (%q, get_version(), %q, %q, %q)
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name=%q,
+					version=get_version(),
+					value=base64.b64decode(%q),
+				)
+				registerPackageResponse = monitor.RegisterPackage(
+					resource_pb2.RegisterPackageRequest(
 						name=%q,
-						version=get_version(),
-						value=base64.b64decode(%q),
-					)
-					registerPackageResponse = monitor.RegisterPackage(
-						resource_pb2.RegisterPackageRequest(
-							name=%q,
-							version=%q,
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						version=%q,
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:
 		raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
 	return _package_ref
 	`,
+			pkg.Name, pkg.Parameterization.BaseProvider.Name, pkg.Parameterization.BaseProvider.Version, param,
 			pkg.Name, param, pkg.Parameterization.BaseProvider.Name, pkg.Parameterization.BaseProvider.Version)
 		if err != nil {
 			return nil, err
@@ -3430,6 +3432,7 @@ func setDependencies(schema *PyprojectSchema, pkg *schema.Package, dependencies 
 
 // Require the SDK to fall within the same major version.
 var MinimumValidSDKVersion = ">=3.165.0,<4.0.0"
+var MinimumValidParameterizedSDKVersion = ">=3.227.0,<4.0.0"
 
 // ensureValidPulumiVersion ensures that the Pulumi SDK has an entry.
 // It accepts a list of dependencies
@@ -3443,16 +3446,20 @@ var MinimumValidSDKVersion = ">=3.165.0,<4.0.0"
 // validate.
 func ensureValidPulumiVersion(parameterized bool, requires map[string]string) (map[string]string, error) {
 	deps := map[string]string{}
+	minPulumiVersion := MinimumValidSDKVersion
+	if parameterized {
+		minPulumiVersion = MinimumValidParameterizedSDKVersion
+	}
 	// Special case: if the map is empty, we return just pulumi with the minimum version constraint.
 
 	if len(requires) == 0 {
 		result := map[string]string{
-			"pulumi": MinimumValidSDKVersion,
+			"pulumi": minPulumiVersion,
 		}
 		return result, nil
 	}
 	if pulumiDep, ok := requires["pulumi"]; !ok {
-		deps["pulumi"] = MinimumValidSDKVersion
+		deps["pulumi"] = minPulumiVersion
 	} else {
 		deps["pulumi"] = pulumiDep
 	}

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -106,6 +107,40 @@ func TestGeneratePackage(t *testing.T) {
 		},
 		TestCases: test.PulumiPulumiSDKTests,
 	})
+}
+
+func TestGeneratePackageCachesPackageRefInRuntimeSettings(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	baseVersion := semver.MustParse("1.1.0")
+	pkg := &schema.Package{
+		Name:    "parameterized",
+		Version: &version,
+		Parameterization: &schema.Parameterization{
+			BaseProvider: schema.BaseProvider{
+				Name:    "terraform-provider",
+				Version: baseVersion,
+			},
+			Parameter: []byte("example"),
+		},
+	}
+	mod := &modContext{
+		pkg:  pkg.Reference(),
+		tool: "test",
+	}
+
+	utilities, err := mod.genUtilitiesFile()
+	require.NoError(t, err)
+
+	text := string(utilities)
+	assert.Contains(t, text, `_package_key = ("parameterized", get_version(), "terraform-provider", "1.1.0", "ZXhhbXBsZQ==")`)
+	assert.Contains(t, text, "_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)")
+	assert.Contains(t, text, "await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)")
+	assert.NotContains(t, text, "_package_refs = {}")
+	assert.NotContains(t, text, "_package_ref = ...")
+	assert.NotContains(t, text, "global _package_ref")
+	assert.NotContains(t, text, "_sync_monitor_supports_parameterization")
 }
 
 func absTestsPath() (string, error) {
@@ -302,6 +337,7 @@ Here \\\\N slashes should be escaped but not N
 func TestCalculateDeps(t *testing.T) {
 	t.Parallel()
 	type TestCase struct {
+		parameterized bool
 		// This is the input to the calculate deps function, a list of
 		// deps provided in the schema.
 		inputDeps map[string]string
@@ -313,6 +349,7 @@ func TestCalculateDeps(t *testing.T) {
 	}
 	cases := []TestCase{{
 		// Test 1: Give no explicit deps.
+		parameterized: false,
 		inputDeps: map[string]string{},
 		expected: [][2]string{
 			// We expect three alphabetized deps,
@@ -325,6 +362,7 @@ func TestCalculateDeps(t *testing.T) {
 	}, {
 		// Test 2: If you only one dep, we expect Pulumi to have a narrower
 		//         constraint than if you had provided no deps.
+		parameterized: false,
 		inputDeps: map[string]string{
 			"foobar": "7.10.8",
 		},
@@ -337,6 +375,7 @@ func TestCalculateDeps(t *testing.T) {
 	}, {
 		// Test 3: If you provide pulumi, we expect the constraint to
 		// be respected.
+		parameterized: false,
 		inputDeps: map[string]string{
 			"pulumi": ">=3.0.0,<3.50.0",
 		},
@@ -347,13 +386,23 @@ func TestCalculateDeps(t *testing.T) {
 			{"pulumi", ">=3.0.0,<3.50.0"},
 			{"semver>=2.8.1"},
 		},
+	}, {
+		// Test 4: Parameterized packages must depend on the runtime
+		// version that includes deployment-scoped package ref caching.
+		parameterized: true,
+		inputDeps:     map[string]string{},
+		expected: [][2]string{
+			{"parver>=0.2.1", ""},
+			{"pulumi", ">=3.227.0,<4.0.0"},
+			{"semver>=2.8.1"},
+		},
 	}}
 
 	for i, tc := range cases {
 		name := fmt.Sprintf("CalculateDeps #%d", i+1)
 		t.Run(name, func(tt *testing.T) {
 			tt.Parallel()
-			observedDeps, err := calculateDeps(false, tc.inputDeps)
+			observedDeps, err := calculateDeps(tc.parameterized, tc.inputDeps)
 			assert.Equal(tt, tc.expectedErr, err)
 			for index := range observedDeps {
 				observedDep := observedDeps[index]

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/byepackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_byepackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/hipackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_hipackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/byepackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_byepackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/hipackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_hipackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1'
       ],
       zip_safe=False)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/byepackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_byepackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/hipackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_hipackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/byepackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_byepackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/goodbye-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_goodbye',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/hipackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_hipackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/setup.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/subpackage-2.0.0/setup.py
@@ -32,7 +32,7 @@ setup(name='pulumi_subpackage',
       },
       install_requires=[
           'parver>=0.2.1',
-          'pulumi>=3.165.0,<4.0.0',
+          'pulumi>=3.227.0,<4.0.0',
           'semver>=2.8.1',
           'typing-extensions>=4.11,<5; python_version < "3.11"'
       ],

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/byepackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_byepackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/hipackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_hipackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pulumi_byepackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("byepackage", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZVdvcmxk")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="byepackage",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="byepackage",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZVdvcmxk"),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/byepackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_byepackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pulumi_goodbye/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("goodbye", get_version(), "parameterized", "1.2.3", "R29vZGJ5ZQ==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="goodbye",
-						version=get_version(),
-						value=base64.b64decode("R29vZGJ5ZQ=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="goodbye",
+					version=get_version(),
+					value=base64.b64decode("R29vZGJ5ZQ=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/goodbye-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_goodbye"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pulumi_hipackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("hipackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="hipackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="hipackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/hipackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_hipackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pulumi_subpackage/_utilities.py
@@ -328,27 +328,28 @@ def get_version():
     return "2.0.0"
 
 _package_lock = asyncio.Lock()
-_package_ref = ...
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
 async def get_package():
-	global _package_ref
+	_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
 	if _package_ref is ...:
-		if pulumi.runtime.settings._sync_monitor_supports_parameterization():
-			async with _package_lock:
-				if _package_ref is ...:
-					monitor = pulumi.runtime.settings.get_monitor()
-					parameterization = resource_pb2.Parameterization(
-						name="subpackage",
-						version=get_version(),
-						value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+		async with _package_lock:
+			_package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+			if _package_ref is ...:
+				monitor = pulumi.runtime.settings.get_monitor()
+				parameterization = resource_pb2.Parameterization(
+					name="subpackage",
+					version=get_version(),
+					value=base64.b64decode("SGVsbG9Xb3JsZA=="),
 					)
-					registerPackageResponse = monitor.RegisterPackage(
+				registerPackageResponse = monitor.RegisterPackage(
 						resource_pb2.RegisterPackageRequest(
-							name="parameterized",
-							version="1.2.3",
-							download_url=get_plugin_download_url(),
-							parameterization=parameterization,
-						))
-					_package_ref = registerPackageResponse.ref
+						name="parameterized",
+						version="1.2.3",
+						download_url=get_plugin_download_url(),
+						parameterization=parameterization,
+					))
+				_package_ref = registerPackageResponse.ref
+				await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
 	# TODO: This check is only needed for parameterized providers, normal providers can return None for get_package when we start
 	# using package with them.
 	if _package_ref is None or _package_ref is ...:

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pyproject.toml
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/subpackage-2.0.0/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
   name = "pulumi_subpackage"
-  dependencies = ["parver>=0.2.1", "pulumi>=3.165.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.227.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11,<5; python_version < \"3.11\""]
   readme = "README.md"
   requires-python = ">=3.9"
   version = "2.0.0"

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -384,15 +384,15 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
     return SETTINGS.feature_support.get("invokeTransforms", False)
 
 
+def _sync_monitor_supports_parameterization() -> bool:
+    return SETTINGS.feature_support.get("parameterization", False)
+
+
 async def get_package_ref(key: tuple) -> Any:
-    if not await monitor_supports_feature("parameterization"):
-        return None
     return SETTINGS.package_refs.get(key, ...)
 
 
 async def set_package_ref(key: tuple, ref: str):
-    if not await monitor_supports_feature("parameterization"):
-        return
     SETTINGS.package_refs[key] = ref
 
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -72,6 +72,7 @@ class Settings:
         self.dry_run = dry_run
         self.legacy_apply_enabled = legacy_apply_enabled
         self.feature_support = {}
+        self.package_refs = {}
         self.organization = organization
 
         if self.legacy_apply_enabled is None:
@@ -141,6 +142,9 @@ class Settings:
 
     @contextproperty
     def feature_support(self) -> Optional[dict]: ...
+
+    @contextproperty
+    def package_refs(self) -> Optional[dict]: ...
 
     @contextproperty
     def callbacks(self) -> Optional[_CallbackServicer]: ...
@@ -380,8 +384,16 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
     return SETTINGS.feature_support.get("invokeTransforms", False)
 
 
-def _sync_monitor_supports_parameterization() -> bool:
-    return SETTINGS.feature_support.get("parameterization", False)
+async def get_package_ref(key: tuple) -> Any:
+    if not await monitor_supports_feature("parameterization"):
+        return None
+    return SETTINGS.package_refs.get(key, ...)
+
+
+async def set_package_ref(key: tuple, ref: str):
+    if not await monitor_supports_feature("parameterization"):
+        return
+    SETTINGS.package_refs[key] = ref
 
 
 async def monitor_supports_resource_hooks() -> bool:

--- a/sdk/python/lib/test/runtime/test_localized_global_state.py
+++ b/sdk/python/lib/test/runtime/test_localized_global_state.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+from pulumi.runtime import settings
 from pulumi.runtime.settings import Settings
 
 
@@ -15,3 +18,20 @@ async def test_settings():
     bar_name = await set_and_retrieve_settings_value("bar")
     assert foo_name != bar_name != "project"
     assert default_settings_instance.project == "project"
+
+
+def test_package_refs_reset_with_settings():
+    old_settings = settings.SETTINGS
+    package_key = ("parameterized", "1.0.0")
+
+    try:
+        settings.configure(Settings("project", "stack"))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        asyncio.run(settings.set_package_ref(package_key, "ref-1"))
+        assert asyncio.run(settings.get_package_ref(package_key)) == "ref-1"
+
+        settings.configure(Settings("project", "stack"))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        assert asyncio.run(settings.get_package_ref(package_key)) is ...
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/runtime/test_package_ref_cache.py
+++ b/sdk/python/lib/test/runtime/test_package_ref_cache.py
@@ -1,0 +1,120 @@
+import asyncio
+import sys
+import types
+from copy import deepcopy
+
+import pytest
+
+import pulumi
+from pulumi.runtime import settings
+from pulumi.runtime.settings import Settings
+from pulumi.runtime.proto import resource_pb2
+
+
+class _FakeMonitor:
+    def __init__(self, ref):
+        self.ref = ref
+        self.known_refs = set()
+        self.register_package_calls = 0
+
+    def RegisterPackage(self, _):
+        self.register_package_calls += 1
+        self.known_refs.add(self.ref)
+        return types.SimpleNamespace(ref=self.ref)
+
+    def assert_known_package_ref(self, ref):
+        if ref not in self.known_refs:
+            raise Exception(f"unknown provider package '{ref}'")
+
+
+def _load_generated_utilities():
+    source = '''
+import asyncio
+import base64
+import pulumi
+import pulumi.runtime
+from pulumi.runtime.proto import resource_pb2
+
+def get_version():
+    return "2.0.0"
+
+def get_plugin_download_url():
+    return None
+
+_package_lock = asyncio.Lock()
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
+
+async def get_package():
+    _package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+    if _package_ref is ...:
+        async with _package_lock:
+            _package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+            if _package_ref is ...:
+                monitor = pulumi.runtime.settings.get_monitor()
+                parameterization = resource_pb2.Parameterization(
+                    name="subpackage",
+                    version=get_version(),
+                    value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+                )
+                registerPackageResponse = monitor.RegisterPackage(
+                    resource_pb2.RegisterPackageRequest(
+                        name="parameterized",
+                        version="1.2.3",
+                        download_url=get_plugin_download_url(),
+                        parameterization=parameterization,
+                    ))
+                _package_ref = registerPackageResponse.ref
+                await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
+    if _package_ref is None or _package_ref is ...:
+        raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
+    return _package_ref
+'''
+
+    module = types.ModuleType("pulumi_subpackage._utilities_test")
+    module.__dict__.update({
+        "asyncio": asyncio,
+        "base64": __import__("base64"),
+        "pulumi": pulumi,
+        "resource_pb2": resource_pb2,
+    })
+    sys.modules[module.__name__] = module
+    exec(source, module.__dict__)
+    return module
+
+
+@pytest.mark.parametrize("first_ref,second_ref", [("ref-1", "ref-2")])
+def test_generated_package_refs_are_reset_per_deployment_settings(first_ref, second_ref):
+    old_settings = deepcopy(settings.SETTINGS)
+    utilities = _load_generated_utilities()
+
+    try:
+        first_monitor = _FakeMonitor(first_ref)
+        settings.configure(Settings("project", "stack", monitor=first_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        first_monitor.assert_known_package_ref(ref)
+
+        second_monitor = _FakeMonitor(second_ref)
+        settings.configure(Settings("project", "stack", monitor=second_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        second_monitor.assert_known_package_ref(ref)
+
+        assert first_monitor.register_package_calls == 1
+        assert second_monitor.register_package_calls == 1
+        assert ref == second_ref
+    finally:
+        settings.configure(old_settings)
+
+
+def test_public_package_ref_apis_return_none_without_parameterization_support():
+    old_settings = deepcopy(settings.SETTINGS)
+    package_key = ("parameterized", "1.0.0")
+
+    try:
+        settings.configure(Settings("project", "stack"))
+        assert asyncio.run(settings.get_package_ref(package_key)) is None
+        asyncio.run(settings.set_package_ref(package_key, "ref-1"))
+        assert asyncio.run(settings.get_package_ref(package_key)) is None
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/runtime/test_package_ref_cache.py
+++ b/sdk/python/lib/test/runtime/test_package_ref_cache.py
@@ -107,14 +107,14 @@ def test_generated_package_refs_are_reset_per_deployment_settings(first_ref, sec
         settings.configure(old_settings)
 
 
-def test_public_package_ref_apis_return_none_without_parameterization_support():
+def test_public_package_ref_apis_are_independent_of_parameterization_support():
     old_settings = deepcopy(settings.SETTINGS)
     package_key = ("parameterized", "1.0.0")
 
     try:
         settings.configure(Settings("project", "stack"))
-        assert asyncio.run(settings.get_package_ref(package_key)) is None
+        assert asyncio.run(settings.get_package_ref(package_key)) is ...
         asyncio.run(settings.set_package_ref(package_key, "ref-1"))
-        assert asyncio.run(settings.get_package_ref(package_key)) is None
+        assert asyncio.run(settings.get_package_ref(package_key)) == "ref-1"
     finally:
         settings.configure(old_settings)


### PR DESCRIPTION
## Summary
Fixes #22459.

Python Automation API inline programs can fail on sequential operations such as `preview` followed
by `up` when using parameterized providers.

The root cause is that package references returned by `RegisterPackage` can outlive a single
deployment session. When a later operation starts with a fresh engine/monitor session, the Python
runtime can reuse a stale package-ref UUID from the previous session, which causes errors like:

```text
unknown provider package '<uuid>'
```

This PR fixes the Python runtime side of that behavior by storing parameterized package refs in
deployment-scoped runtime settings instead of process-global state.

The new runtime APIs are:

- `pulumi.runtime.settings.get_package_ref(...)`
- `pulumi.runtime.settings.set_package_ref(...)`

These APIs are async, check parameterization support internally, and use the active deployment
settings so cached package refs are reset when settings are replaced for a new deployment.

This PR intentionally contains only the SDK/runtime part of the fix. A follow-up codegen PR updates
generated parameterized Python SDKs to consume these APIs and require the SDK version that contains
them.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Commands run:
- `python -m pytest sdk/python/lib/test/runtime/test_package_ref_cache.py -q`
- `python -m pytest sdk/python/lib/test/runtime/test_localized_global_state.py -q -k test_package_refs_reset_with_settings`

## Changelog
- [x] Changelog entry added.

## Risk
Low.

Blast radius is limited to the Python SDK runtime settings layer for parameterized provider package
refs. This does not change engine behavior, provider behavior, or Python codegen in this PR.

The intended behavior change is that package refs are now scoped to the active deployment settings,
which prevents stale package-ref reuse across sequential Automation API operations while preserving
per-deployment caching.