### PR TITLE
[python/codegen] Generate parameterized package refs via runtime settings

### DIFF
--- a/changelog/pending/20260429--sdk-python--store-parameterized-package-refs-in-runtime-settings.yaml
+++ b/changelog/pending/20260429--sdk-python--store-parameterized-package-refs-in-runtime-settings.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Store parameterized provider package refs in deployment-scoped Python runtime settings

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -72,6 +72,7 @@ class Settings:
         self.dry_run = dry_run
         self.legacy_apply_enabled = legacy_apply_enabled
         self.feature_support = {}
+        self.package_refs = {}
         self.organization = organization
 
         if self.legacy_apply_enabled is None:
@@ -141,6 +142,9 @@ class Settings:
 
     @contextproperty
     def feature_support(self) -> Optional[dict]: ...
+
+    @contextproperty
+    def package_refs(self) -> Optional[dict]: ...
 
     @contextproperty
     def callbacks(self) -> Optional[_CallbackServicer]: ...
@@ -380,8 +384,16 @@ def _sync_monitor_supports_invoke_transforms() -> bool:
     return SETTINGS.feature_support.get("invokeTransforms", False)
 
 
-def _sync_monitor_supports_parameterization() -> bool:
-    return SETTINGS.feature_support.get("parameterization", False)
+async def get_package_ref(key: tuple) -> Any:
+    if not await monitor_supports_feature("parameterization"):
+        return None
+    return SETTINGS.package_refs.get(key, ...)
+
+
+async def set_package_ref(key: tuple, ref: str):
+    if not await monitor_supports_feature("parameterization"):
+        return
+    SETTINGS.package_refs[key] = ref
 
 
 async def monitor_supports_resource_hooks() -> bool:

--- a/sdk/python/lib/test/runtime/test_localized_global_state.py
+++ b/sdk/python/lib/test/runtime/test_localized_global_state.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+from pulumi.runtime import settings
 from pulumi.runtime.settings import Settings
 
 
@@ -15,3 +18,20 @@ async def test_settings():
     bar_name = await set_and_retrieve_settings_value("bar")
     assert foo_name != bar_name != "project"
     assert default_settings_instance.project == "project"
+
+
+def test_package_refs_reset_with_settings():
+    old_settings = settings.SETTINGS
+    package_key = ("parameterized", "1.0.0")
+
+    try:
+        settings.configure(Settings("project", "stack"))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        asyncio.run(settings.set_package_ref(package_key, "ref-1"))
+        assert asyncio.run(settings.get_package_ref(package_key)) == "ref-1"
+
+        settings.configure(Settings("project", "stack"))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        assert asyncio.run(settings.get_package_ref(package_key)) is ...
+    finally:
+        settings.configure(old_settings)

--- a/sdk/python/lib/test/runtime/test_package_ref_cache.py
+++ b/sdk/python/lib/test/runtime/test_package_ref_cache.py
@@ -1,0 +1,120 @@
+import asyncio
+import sys
+import types
+from copy import deepcopy
+
+import pytest
+
+import pulumi
+from pulumi.runtime import settings
+from pulumi.runtime.settings import Settings
+from pulumi.runtime.proto import resource_pb2
+
+
+class _FakeMonitor:
+    def __init__(self, ref):
+        self.ref = ref
+        self.known_refs = set()
+        self.register_package_calls = 0
+
+    def RegisterPackage(self, _):
+        self.register_package_calls += 1
+        self.known_refs.add(self.ref)
+        return types.SimpleNamespace(ref=self.ref)
+
+    def assert_known_package_ref(self, ref):
+        if ref not in self.known_refs:
+            raise Exception(f"unknown provider package '{ref}'")
+
+
+def _load_generated_utilities():
+    source = '''
+import asyncio
+import base64
+import pulumi
+import pulumi.runtime
+from pulumi.runtime.proto import resource_pb2
+
+def get_version():
+    return "2.0.0"
+
+def get_plugin_download_url():
+    return None
+
+_package_lock = asyncio.Lock()
+_package_key = ("subpackage", get_version(), "parameterized", "1.2.3", "SGVsbG9Xb3JsZA==")
+
+async def get_package():
+    _package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+    if _package_ref is ...:
+        async with _package_lock:
+            _package_ref = await pulumi.runtime.settings.get_package_ref(_package_key)
+            if _package_ref is ...:
+                monitor = pulumi.runtime.settings.get_monitor()
+                parameterization = resource_pb2.Parameterization(
+                    name="subpackage",
+                    version=get_version(),
+                    value=base64.b64decode("SGVsbG9Xb3JsZA=="),
+                )
+                registerPackageResponse = monitor.RegisterPackage(
+                    resource_pb2.RegisterPackageRequest(
+                        name="parameterized",
+                        version="1.2.3",
+                        download_url=get_plugin_download_url(),
+                        parameterization=parameterization,
+                    ))
+                _package_ref = registerPackageResponse.ref
+                await pulumi.runtime.settings.set_package_ref(_package_key, _package_ref)
+    if _package_ref is None or _package_ref is ...:
+        raise Exception("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI.")
+    return _package_ref
+'''
+
+    module = types.ModuleType("pulumi_subpackage._utilities_test")
+    module.__dict__.update({
+        "asyncio": asyncio,
+        "base64": __import__("base64"),
+        "pulumi": pulumi,
+        "resource_pb2": resource_pb2,
+    })
+    sys.modules[module.__name__] = module
+    exec(source, module.__dict__)
+    return module
+
+
+@pytest.mark.parametrize("first_ref,second_ref", [("ref-1", "ref-2")])
+def test_generated_package_refs_are_reset_per_deployment_settings(first_ref, second_ref):
+    old_settings = deepcopy(settings.SETTINGS)
+    utilities = _load_generated_utilities()
+
+    try:
+        first_monitor = _FakeMonitor(first_ref)
+        settings.configure(Settings("project", "stack", monitor=first_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        first_monitor.assert_known_package_ref(ref)
+
+        second_monitor = _FakeMonitor(second_ref)
+        settings.configure(Settings("project", "stack", monitor=second_monitor))
+        settings.SETTINGS.feature_support["parameterization"] = True
+        ref = asyncio.run(utilities.get_package())
+        second_monitor.assert_known_package_ref(ref)
+
+        assert first_monitor.register_package_calls == 1
+        assert second_monitor.register_package_calls == 1
+        assert ref == second_ref
+    finally:
+        settings.configure(old_settings)
+
+
+def test_public_package_ref_apis_return_none_without_parameterization_support():
+    old_settings = deepcopy(settings.SETTINGS)
+    package_key = ("parameterized", "1.0.0")
+
+    try:
+        settings.configure(Settings("project", "stack"))
+        assert asyncio.run(settings.get_package_ref(package_key)) is None
+        asyncio.run(settings.set_package_ref(package_key, "ref-1"))
+        assert asyncio.run(settings.get_package_ref(package_key)) is None
+    finally:
+        settings.configure(old_settings)


### PR DESCRIPTION
## Summary
Follow-up to the Python runtime fix for #22459.

This PR updates Python codegen for parameterized providers to use the new runtime settings
package-ref APIs instead of process-global package-ref state.

Generated parameterized Python SDK utilities now:
- call `await pulumi.runtime.settings.get_package_ref(...)`
- call `await pulumi.runtime.settings.set_package_ref(...)`
- no longer rely on module-global package-ref caching
- keep package-ref caching scoped to the active deployment settings

This PR also updates the generated Python SDK fixtures under
`sdk/python/cmd/pulumi-language-python/testdata` to match the new codegen output.

Because this generated code now depends on the runtime fix, parameterized generated Python SDKs are
also updated to require the Pulumi Python SDK version that contains the new runtime settings
package-ref APIs:

```text
pulumi>=3.227.0,<4.0.0
```

This version bump is applied only to the parameterized generated SDK fixtures touched by this change.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format_fix` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

Commands run:
- `go test ./codegen/python -run "Test(GeneratePackageCachesPackageRefInRuntimeSettings|CalculateDeps)" -count=1`
- Python compile check across generated `_utilities.py` fixtures in `sdk/python/cmd/pulumi-language-python/testdata`

## Changelog
- [x] Changelog entry added.

## Risk
Low to moderate.

Blast radius is limited to generated Python SDK utilities and dependency metadata for parameterized
providers. This does not change engine behavior or non-parameterized Python SDK generation.

The intended behavior change is that generated parameterized Python SDKs now consume the runtime
settings package-ref APIs and require the Python SDK version that provides them, preventing stale
package-ref reuse across deployment sessions.