### PR TITLE
sdk/nodejs: extract wire-protocol constants into a leaf module

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -315,58 +315,28 @@ export function resolveProperties(
     }
 }
 
-/**
- * Unknown values are encoded as a distinguished string value.
- */
-export const unknownValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9";
+// Wire-protocol marker constants live in `./sigs`, a leaf module with no
+// runtime side-imports. Re-exported here for backward compatibility with
+// external consumers that import them from `@pulumi/pulumi/runtime/rpc`.
+export {
+    unknownValue,
+    specialSigKey,
+    specialAssetSig,
+    specialArchiveSig,
+    specialSecretSig,
+    specialResourceSig,
+    specialOutputValueSig,
+} from "./sigs";
 
-/**
- * {@link specialSigKey} is sometimes used to encode type identity inside of a
- * map.
- *
- * @see sdk/go/common/resource/properties.go.
- */
-export const specialSigKey = "4dabf18193072939515e22adb298388d";
-
-/**
- * {@link specialAssetSig} is a randomly assigned hash used to identify assets
- * in maps.
- *
- * @see sdk/go/common/resource/asset.go.
- */
-export const specialAssetSig = "c44067f5952c0a294b673a41bacd8c17";
-
-/**
- * {@link specialArchiveSig} is a randomly assigned hash used to identify
- * archives in maps.
- *
- * @see sdk/go/common/resource/asset.go.
- */
-export const specialArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7";
-
-/**
- * {@link specialSecretSig} is a randomly assigned hash used to identify secrets
- * in maps.
- *
- * @see sdk/go/common/resource/properties.go.
- */
-export const specialSecretSig = "1b47061264138c4ac30d75fd1eb44270";
-
-/**
- * {@link specialResourceSig} is a randomly assigned hash used to identify
- * resources in maps.
- *
- * @see sdk/go/common/resource/properties.go.
- */
-export const specialResourceSig = "5cf8f73096256a8f31e491e813e4eb8e";
-
-/**
- * {@link specialOutputValueSig} is a randomly assigned hash used to identify
- * outputs in maps.
- *
- * @see sdk/go/common/resource/properties.go.
- */
-export const specialOutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4";
+import {
+    unknownValue,
+    specialSigKey,
+    specialAssetSig,
+    specialArchiveSig,
+    specialSecretSig,
+    specialResourceSig,
+    specialOutputValueSig,
+} from "./sigs";
 
 /** @internal */
 export function serializeSecretValue(value: any): any {

--- a/sdk/nodejs/runtime/sigs.ts
+++ b/sdk/nodejs/runtime/sigs.ts
@@ -1,0 +1,73 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Special-signature constants used to encode type identity inside resource
+// property maps over the wire. Kept in a leaf module (no side-imports) so
+// consumers — notably `@pulumi/policy` — can read them without dragging in
+// the rest of the runtime tree (`output`, `resource`, `log`, `settings`,
+// `state`, `semver`, …).
+
+/**
+ * {@link unknownValue} is a sentinel string used to represent unknown property
+ * values during preview.
+ */
+export const unknownValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9";
+
+/**
+ * {@link specialSigKey} is sometimes used to encode type identity inside of a
+ * map.
+ *
+ * @see sdk/go/common/resource/properties.go.
+ */
+export const specialSigKey = "4dabf18193072939515e22adb298388d";
+
+/**
+ * {@link specialAssetSig} is a randomly assigned hash used to identify assets
+ * in maps.
+ *
+ * @see sdk/go/common/resource/asset.go.
+ */
+export const specialAssetSig = "c44067f5952c0a294b673a41bacd8c17";
+
+/**
+ * {@link specialArchiveSig} is a randomly assigned hash used to identify
+ * archives in maps.
+ *
+ * @see sdk/go/common/resource/asset.go.
+ */
+export const specialArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7";
+
+/**
+ * {@link specialSecretSig} is a randomly assigned hash used to identify secrets
+ * in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
+ */
+export const specialSecretSig = "1b47061264138c4ac30d75fd1eb44270";
+
+/**
+ * {@link specialResourceSig} is a randomly assigned hash used to identify
+ * resources in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
+ */
+export const specialResourceSig = "5cf8f73096256a8f31e491e813e4eb8e";
+
+/**
+ * {@link specialOutputValueSig} is a randomly assigned hash used to identify
+ * outputs in maps.
+ *
+ * @see sdk/go/common/resource/properties.go.
+ */
+export const specialOutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4";


### PR DESCRIPTION
### Summary

Move the seven wire-protocol marker constants — `unknownValue`, `specialSigKey`, `specialAssetSig`, `specialArchiveSig`, `specialSecretSig`, `specialResourceSig`, and `specialOutputValueSig` — from `runtime/rpc.ts` into a new leaf module `sdk/nodejs/runtime/sigs.ts`. `runtime/rpc.ts` re-exports them for backward compatibility.

Pure refactor — no value or behaviour change. Existing consumers (`resource.ts`, `callbacks.ts`, dynamic-provider, the test suite) keep working unchanged through the re-export.

### Why

`runtime/rpc.ts` side-imports `output`, `resource`, `log`, `settings`, `state`, and `semver`. Any consumer that only needs the seven marker constants — notably `@pulumi/policy/deserialize.ts` — has to drag the entire pulumi runtime tree along to get them. Splitting the constants into a side-import-free leaf lets those consumers skip the runtime entirely.

### Downstream impact

This is the enabler for a companion PR in `pulumi/pulumi-policy` (link forthcoming) that switches `deserialize.ts` to `import * as asset from "@pulumi/pulumi/asset"` + `import { ... } from "@pulumi/pulumi/runtime/sigs"`. With both PRs in, a policy pack bundled by rollup with `external: []` lands at ~2.3 MB vs ~17 MB today on a representative pack (`cis/aws`), with no consumer-side shims.

### Backwards compatibility

`runtime/rpc.ts` re-exports every moved constant, so:

- `import { specialSigKey } from "@pulumi/pulumi/runtime/rpc"` keeps working.
- `pulumi.runtime.specialSigKey` keeps working (via existing index re-export).
- All internal call sites (`resource.ts`, `callbacks.ts`, `runtime/rpc.ts` itself, `cmd/dynamic-provider/index.ts`, the test suite) are unchanged.

### Test plan

- [ ] `make test_fast` in `sdk/nodejs`
- [ ] `runtime/rpc` tests still pass (constants re-exported)
- [ ] Smoke: `node -e "console.log(require('@pulumi/pulumi/runtime/sigs'))"` returns all seven constants