### PR TITLE
Add RawCall to client API

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -140,6 +141,12 @@ type httpCallOptions struct {
 
 	// ErrorResponse is an optional response body for errors.
 	ErrorResponse any
+
+	// ReturnRawResponse, when true, makes pulumiAPICall skip the 4xx/5xx
+	// typed-error classification (apitype.ErrorResponse, ErrLoginRequired,
+	// ForbiddenError, rate-limit) and return the response as-is. The caller
+	// is responsible for inspecting the status code and decoding the body.
+	ReturnRawResponse bool
 }
 
 // apiAccessToken is an implementation of accessToken for Pulumi API tokens (i.e. tokens of kind
@@ -396,6 +403,10 @@ func pulumiAPICall(ctx context.Context,
 		}
 	}
 
+	if opts.ReturnRawResponse {
+		return url, resp, nil
+	}
+
 	// Provide a better error if using an authenticated call without having logged in first.
 	if resp.StatusCode == 401 && tok.Kind() == accessTokenKindAPIToken && creds == "" {
 		return "", nil, backenderr.ErrLoginRequired
@@ -481,10 +492,12 @@ func (c *defaultRESTClient) HTTPClient() httpClient {
 	return c.client
 }
 
-// Call calls the Pulumi REST API marshalling reqObj to JSON and using that as
-// the request body (use nil for GETs), and if successful, marshalling the responseObj
-// as JSON and storing it in respObj (use nil for NoContent). The error return type might
-// be an instance of apitype.ErrorResponse, in which case will have the response code.
+// Call calls the Pulumi REST API marshalling reqObj to JSON and using that as the request body (use nil for GETs), and
+// if successful, marshalling the responseObj as JSON and storing it in respObj (use nil for NoContent). The error
+// return type might be an instance of apitype.ErrorResponse, in which case will have the response code. if
+// opts.ReturnRawResponse is true, the raw *http.Response will be returned in respObj (which must be of type
+// **http.Response) and no error classification will be done - the caller is expected to inspect the status code and
+// body of the response.
 func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, method, path string, queryObj, reqObj,
 	respObj any, tok accessToken, opts httpCallOptions,
 ) error {
@@ -508,9 +521,13 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 	// Compute query string from query object
 	querystring := ""
 	if queryObj != nil {
-		queryValues, err := query.Values(queryObj)
-		if err != nil {
-			return fmt.Errorf("marshalling query object as JSON: %w", err)
+		queryValues, ok := queryObj.(url.Values)
+		if !ok {
+			var err error
+			queryValues, err = query.Values(queryObj)
+			if err != nil {
+				return fmt.Errorf("marshalling query object as JSON: %w", err)
+			}
 		}
 		query := queryValues.Encode()
 		if len(query) > 0 {
@@ -526,6 +543,11 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 		// important when sending indented JSON is needed.
 		if raw, ok := reqObj.(json.RawMessage); ok {
 			reqBody = []byte(raw)
+		} else if str, ok := reqObj.(io.Reader); ok {
+			reqBody, err = io.ReadAll(str)
+			if err != nil {
+				return fmt.Errorf("reading request body: %w", err)
+			}
 		} else {
 			reqBody, err = json.Marshal(reqObj)
 			if err != nil {
@@ -550,8 +572,27 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 		otelSpan.SetStatus(codes.Ok, "")
 	}
 
+	if opts.ReturnRawResponse {
+		_, ok := respObj.(**http.Response)
+		contract.Assertf(ok,
+			"if opts.ReturnRawResponse is true, respObj must be of type **http.Response (got %T)", respObj)
+	}
+
 	switch respObj := respObj.(type) {
 	case **http.Response:
+		// Transparently decompress gzip responses. Content-Encoding and
+		// Content-Length apply to the compressed bytes and would mislead any
+		// consumer that inspects them after decompression, so strip both.
+		if ce := resp.Header.Get("Content-Encoding"); ce == "gzip" || ce == "x-gzip" {
+			wrapped, err := newGzipReadCloser(resp.Body)
+			if err != nil {
+				resp.Body.Close()
+				return fmt.Errorf("decompressing gzip response: %w", err)
+			}
+			resp.Body = wrapped
+			resp.Header.Del("Content-Encoding")
+			resp.Header.Del("Content-Length")
+		}
 		*respObj = resp
 		return nil
 	case *io.ReadCloser:
@@ -586,6 +627,32 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 	return nil
 }
 
+// gzipReadCloser wraps a gzip reader and the underlying body so closing the
+// wrapper closes both.
+type gzipReadCloser struct {
+	gzip *gzip.Reader
+	body io.ReadCloser
+}
+
+// newGzipReadCloser builds a gzipReadCloser over body. Used by both the raw
+// response decompression in Call and bodyIntoReader's gzip path.
+func newGzipReadCloser(body io.ReadCloser) (*gzipReadCloser, error) {
+	gr, err := gzip.NewReader(body)
+	if err != nil {
+		return nil, err
+	}
+	return &gzipReadCloser{gzip: gr, body: body}, nil
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gzip.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	g.gzip.Close()
+	return g.body.Close()
+}
+
 // readBody reads the contents of an http.Response into a byte array, returning an error if one occurred while in the
 // process of doing so. readBody uses the Content-Encoding of the response to pick the correct reader to use.
 func readBody(resp *http.Response) ([]byte, error) {
@@ -615,14 +682,10 @@ func bodyIntoReader(resp *http.Response) (io.ReadCloser, error) {
 		fallthrough
 	case "gzip":
 		logging.V(apiRequestDetailLogLevel).Infoln("decompressing gzipped response from service")
-		reader, err := gzip.NewReader(resp.Body)
-		if reader != nil {
-			defer contract.IgnoreClose(reader)
-		}
+		reader, err := newGzipReadCloser(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("reading gzip-compressed body: %w", err)
 		}
-
 		return reader, nil
 	default:
 		return nil, fmt.Errorf("unrecognized encoding %s", contentEncoding[0])

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -264,3 +264,40 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 		assert.True(t, errors.Is(err, backenderr.LoginRequiredError{}))
 	})
 }
+
+func TestRESTCall_ReturnRawResponseRequiresHTTPResponsePointer(t *testing.T) {
+	t.Parallel()
+
+	restClient := &defaultRESTClient{
+		client: &defaultHTTPClient{
+			&http.Client{
+				Transport: &errorTransport{
+					roundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Status:     "200 OK",
+							Header:     http.Header{},
+							Body:       io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))),
+						}, nil
+					},
+				},
+			},
+		},
+	}
+
+	var wrongRespObj map[string]any
+	require.Panics(t, func() {
+		_ = restClient.Call(
+			t.Context(),
+			diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+			"https://api.pulumi.com",
+			http.MethodGet,
+			"/api/test",
+			nil,
+			nil,
+			&wrongRespObj,
+			apiAccessToken("token"),
+			httpCallOptions{ReturnRawResponse: true},
+		)
+	})
+}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -238,6 +238,34 @@ func (pc *Client) updateRESTCall(ctx context.Context, method, path string, query
 	return pc.restClient.Call(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, token, httpOptions)
 }
 
+// RawCall issues an arbitrary Pulumi API request and returns the raw
+// *http.Response after gzip decompression. Unlike the typed Call methods,
+// RawCall does not deserialize the response body and does not classify
+// 4xx/5xx into typed errors; the caller inspects the response for status,
+// headers, and body.
+//
+// header is applied last and overrides defaults set by the transport
+// (Accept, Content-Type) — except Authorization, which is always derived
+// from the Client's token. When gzipCompressBody is true and body is
+// non-nil, the body is gzip-compressed and Content-Encoding: gzip is set.
+func (pc *Client) RawCall(
+	ctx context.Context,
+	method, path string,
+	query url.Values,
+	body io.Reader,
+	header http.Header,
+	gzipCompressBody bool,
+) (*http.Response, error) {
+	var resp *http.Response
+	err := pc.restClient.Call(ctx, pc.diag, pc.apiURL, method, path, query, body, &resp, pc.apiToken,
+		httpCallOptions{
+			Header:            header,
+			GzipCompress:      gzipCompressBody,
+			ReturnRawResponse: true,
+		})
+	return resp, err
+}
+
 // getProjectPath returns the API path for the given owner and the given project name joined with path separators
 // and appended to the stack root.
 func getProjectPath(owner string, projectName string) string {

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -19,9 +19,12 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -29,6 +32,8 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
@@ -194,6 +199,222 @@ func TestAPIVersionMetadataHeaders(t *testing.T) {
 
 	// Assert.
 	require.NoError(t, err)
+}
+
+// TestRawCall_GzipRequestCompression pins that POST bodies are gzip
+// compressed on the wire and Content-Encoding: gzip is set when gzipBody is
+// true.
+func TestRawCall_GzipRequestCompression(t *testing.T) {
+	t.Parallel()
+	var gotEncoding string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEncoding = r.Header.Get("Content-Encoding")
+		gr, err := gzip.NewReader(r.Body)
+		require.NoError(t, err)
+		gotBody, err = io.ReadAll(gr)
+		require.NoError(t, err)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", false, nil)
+	resp, err := c.RawCall(t.Context(), http.MethodPost, "/x", nil,
+		bytes.NewReader([]byte(`{"name":"acme"}`)),
+		http.Header{"Content-Type": []string{"application/json"}}, true)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, "gzip", gotEncoding)
+	assert.JSONEq(t, `{"name":"acme"}`, string(gotBody))
+}
+
+// TestRawCall_GzipResponseDecompression pins that gzip-encoded response
+// bodies are transparently decoded and that Content-Encoding and
+// Content-Length headers are removed (both apply to the compressed bytes
+// and would mislead any consumer that inspects them after decompression).
+func TestRawCall_GzipResponseDecompression(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		encoding string
+	}{
+		{"gzip", "gzip"},
+		{"x-gzip", "x-gzip"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			payload := `{"ok":true,"msg":"hello"}`
+			var buf bytes.Buffer
+			gw := gzip.NewWriter(&buf)
+			_, err := gw.Write([]byte(payload))
+			require.NoError(t, err)
+			require.NoError(t, gw.Close())
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Encoding", tc.encoding)
+				w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+				_, _ = w.Write(buf.Bytes())
+			}))
+			t.Cleanup(srv.Close)
+
+			c := NewClient(srv.URL, "", false, nil)
+			resp, err := c.RawCall(t.Context(), http.MethodGet, "/x", nil, nil, nil, false)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			assert.JSONEq(t, payload, string(body))
+			assert.Empty(t, resp.Header.Get("Content-Encoding"),
+				"Content-Encoding must be stripped so consumers don't double-decode")
+			assert.Empty(t, resp.Header.Get("Content-Length"),
+				"Content-Length applied to the compressed bytes and is meaningless after decompression")
+		})
+	}
+}
+
+// TestRawCall_WarningHeaderPassthrough pins that X-Pulumi-Warning response
+// headers are surfaced through the diag sink supplied to the Client.
+func TestRawCall_WarningHeaderPassthrough(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Pulumi-Warning", "deprecated field in use")
+		w.Header().Add("X-Pulumi-Warning", "rate limit approaching")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	var stderr bytes.Buffer
+	sink := diag.DefaultSink(io.Discard, &stderr, diag.FormatOptions{Color: colors.Never})
+	c := NewClient(srv.URL, "", false, sink)
+	resp, err := c.RawCall(t.Context(), http.MethodGet, "/x", nil, nil, nil, false)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	out := stderr.String()
+	assert.Contains(t, out, "deprecated field in use")
+	assert.Contains(t, out, "rate limit approaching")
+}
+
+// TestRawCall_DoesNotClassify4xx pins that RawCall returns the raw response
+// for 4xx/5xx instead of synthesizing a typed error like Call does. Callers
+// inspect the status code themselves.
+func TestRawCall_DoesNotClassify4xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"nope"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "tok", false, nil)
+	resp, err := c.RawCall(t.Context(), http.MethodGet, "/bad", nil, nil, nil, false)
+	require.NoError(t, err, "RawCall must not turn 4xx into an error")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"message":"nope"}`, string(body))
+}
+
+// trackingReadCloser records whether Close has been called, so the test can
+// verify gzipReadCloser forwards Close to the underlying body.
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackingReadCloser) Close() error { t.closed = true; return nil }
+
+// TestGzipReadCloser_ClosesUnderlyingBody pins that closing the wrapper
+// closes both the gzip reader and the underlying response body.
+func TestGzipReadCloser_ClosesUnderlyingBody(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write([]byte(`{"ok":true}`))
+	require.NoError(t, gw.Close())
+
+	body := &trackingReadCloser{Reader: bytes.NewReader(buf.Bytes())}
+	gr, err := gzip.NewReader(body)
+	require.NoError(t, err)
+
+	wrapper := &gzipReadCloser{gzip: gr, body: body}
+	_, err = io.ReadAll(wrapper)
+	require.NoError(t, err)
+	require.NoError(t, wrapper.Close())
+	assert.True(t, body.closed, "underlying body must be closed when the wrapper is closed")
+}
+
+// TestRawCall_AppendsPulumiAcceptVersion pins that the API version is
+// appended to caller-supplied Accept so the server still routes through
+// versioned content negotiation. Go's http.Header preserves multiple Accept
+// values as a slice, so check via Values, not Get.
+func TestRawCall_AppendsPulumiAcceptVersion(t *testing.T) {
+	t.Parallel()
+	var gotAccept []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Values("Accept")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL, "", false, nil)
+	resp, err := c.RawCall(t.Context(), http.MethodGet, "/x", nil, nil,
+		http.Header{"Accept": []string{"application/json"}}, false)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	joined := strings.Join(gotAccept, ", ")
+	assert.Contains(t, joined, "application/json")
+	assert.Contains(t, joined, "application/vnd.pulumi+9",
+		"the transport must always advertise the Pulumi API version")
+}
+
+func TestRawCallReturnsHTTPResponseOrError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns raw http response on success", func(t *testing.T) {
+		t.Parallel()
+
+		server := newMockServer(200, `{"ok":true}`)
+		t.Cleanup(server.Close)
+
+		client := newMockClient(server)
+		resp, err := client.RawCall(t.Context(), http.MethodGet, "/x", nil, nil, nil, false)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, readErr := io.ReadAll(resp.Body)
+		require.NoError(t, readErr)
+		assert.JSONEq(t, `{"ok":true}`, string(body))
+	})
+
+	t.Run("returns error for non-http transport failures", func(t *testing.T) {
+		t.Parallel()
+
+		expectedErr := errors.New("boom")
+		client := newMockClient(newMockServer(200, "{}"))
+		client.WithHTTPClient(&http.Client{
+			Transport: &errorTransport{
+				roundTripFunc: func(*http.Request) (*http.Response, error) {
+					return nil, expectedErr
+				},
+			},
+		})
+
+		resp, err := client.RawCall(t.Context(), http.MethodGet, "/x", nil, nil, nil, false)
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.ErrorContains(t, err, "performing HTTP request")
+		assert.ErrorIs(t, err, expectedErr)
+	})
 }
 
 func TestGzip(t *testing.T) {


### PR DESCRIPTION
Taking inspiration from https://github.com/pulumi/pulumi/pull/22769. This adds a `RawCall` method to the api client object (the same signature as in #22769) that allows you to make a "raw" call to the pulumi service. This means we don't do any input body marshalling to json, and return the mostly raw http response back. Mostly raw because we will handle gzip compression inside the client.