### PR TITLE
unflake TestNodejsComponentProviderRun

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -3154,20 +3154,33 @@ func TestNodejsComponentProviderRun(t *testing.T) {
 	//nolint:paralleltest // t.Parallel is called by integration.ProgramTest
 	for _, runtime := range []string{"yaml", "python", "nodejs-pnpm", "nodejs-npm"} {
 		t.Run(runtime, func(t *testing.T) {
+			// Each subtest needs its own PULUMI_HOME to avoid race conditions when
+			// multiple subtests concurrently download and install the same provider
+			// plugins.
+			// TODO[pulumi/pulumi#22784]: Make sure plugin installation can be run from multiple
+			// processes in parallel.
+			pulumiHome := t.TempDir()
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				PulumiHomeDir: pulumiHome,
 				PrepareProject: func(info *engine.Projinfo) error {
 					providerPath := filepath.Join(info.Root, "..", "provider")
 					installNodejsProviderDependencies(t, providerPath)
 
 					cmd := exec.Command("pulumi", "package", "add", providerPath)
 					cmd.Dir = info.Root
-					cmd.Env = append(os.Environ(), "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+					cmd.Env = append(os.Environ(),
+						"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false",
+						"PULUMI_HOME="+pulumiHome,
+					)
 					out, err := cmd.CombinedOutput()
 					require.NoError(t, err, "%s failed with: %s", cmd.String(), string(out))
 
 					cmd = exec.Command("pulumi", "install")
 					cmd.Dir = info.Root
-					cmd.Env = append(os.Environ(), "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+					cmd.Env = append(os.Environ(),
+						"PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false",
+						"PULUMI_HOME="+pulumiHome,
+					)
 					out, err = cmd.CombinedOutput()
 					require.NoError(t, err, "%s failed with: %s", cmd.String(), string(out))
 


### PR DESCRIPTION
These subtests can run into a race condition, as seen in https://github.com/pulumi/pulumi/issues/22761.  Claude has tracked this down to the tests all using the same PULUMI_HOME which seems plausigle.  Use a tmpdir instead to try and avoid this test flaking.

Fixes https://github.com/pulumi/pulumi/issues/22761