### PR TITLE
retry pip install a few times

### DIFF
--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/errutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
@@ -500,24 +499,30 @@ func InstallDependencies(ctx context.Context, cwd, venvDir string, useLanguageVe
 			pipCmd.Dir = cwd
 			pipCmd.Env = ActivateVirtualEnv(os.Environ(), venvDir)
 
+			var stderrBuf bytes.Buffer
 			if showOutput {
 				// Show stdout/stderr output.
 				pipCmd.Stdout = infoWriter
-				pipCmd.Stderr = errorWriter
-				if err := pipCmd.Run(); err != nil {
-					lastErr = fmt.Errorf("%s via '%s': %w", errorMsg, strings.Join(pipCmd.Args, " "), err)
-					if attempt < maxAttempts-1 {
-						fmt.Fprintf(errorWriter, "Retrying (%d/%d)...\n", attempt+1, maxAttempts)
-					}
-					continue
-				}
+				pipCmd.Stderr = io.MultiWriter(errorWriter, &stderrBuf)
 			} else {
-				if _, err := pipCmd.Output(); err != nil {
-					lastErr = errutil.ErrorWithStderr(err, strings.Join(pipCmd.Args, " "))
-					continue
+				pipCmd.Stderr = &stderrBuf
+			}
+			if err := pipCmd.Run(); err != nil {
+				stderr := strings.TrimSpace(stderrBuf.String())
+				if stderr != "" {
+					lastErr = fmt.Errorf("%s via '%s': %w: %s", errorMsg, strings.Join(pipCmd.Args, " "), err, stderr)
+				} else {
+					lastErr = fmt.Errorf("%s via '%s': %w", errorMsg, strings.Join(pipCmd.Args, " "), err)
 				}
 			}
-			return nil
+			if lastErr == nil {
+				return nil
+			}
+			if attempt < maxAttempts-1 && pipErrorIsTransient(stderrBuf.String()) {
+				fmt.Fprintf(errorWriter, "Retrying (%d/%d)...\n", attempt+1, maxAttempts)
+				continue
+			}
+			return lastErr
 		}
 		return lastErr
 	}
@@ -549,6 +554,20 @@ func InstallDependencies(ctx context.Context, cwd, venvDir string, useLanguageVe
 	printmsg("Finished installing dependencies")
 
 	return nil
+}
+
+// pipErrorIsTransient returns true if pip's stderr output suggests a transient
+// upstream issue that is worth retrying.
+func pipErrorIsTransient(stderr string) bool {
+	transientPatterns := []string{
+		"because the GET request got Content-Type",
+	}
+	for _, pattern := range transientPatterns {
+		if strings.Contains(stderr, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *pip) PrepareProject(

--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -482,32 +482,44 @@ func InstallDependencies(ctx context.Context, cwd, venvDir string, useLanguageVe
 	runPipInstall := func(errorMsg string, arg ...string) error {
 		args := append([]string{"-m", "pip", "install"}, arg...)
 
-		var pipCmd *exec.Cmd
-		if venvDir == "" {
-			var err error
-			pipCmd, err = Command(ctx, args...)
-			if err != nil {
-				return err
+		// Retry up to 3 times to handle transient PyPI issues (e.g. CDN
+		// returning unexpected Content-Type responses).
+		const maxAttempts = 3
+		var lastErr error
+		for attempt := range maxAttempts {
+			var pipCmd *exec.Cmd
+			if venvDir == "" {
+				var err error
+				pipCmd, err = Command(ctx, args...)
+				if err != nil {
+					return err
+				}
+			} else {
+				pipCmd = VirtualEnvCommand(venvDir, "python", args...)
 			}
-		} else {
-			pipCmd = VirtualEnvCommand(venvDir, "python", args...)
-		}
-		pipCmd.Dir = cwd
-		pipCmd.Env = ActivateVirtualEnv(os.Environ(), venvDir)
+			pipCmd.Dir = cwd
+			pipCmd.Env = ActivateVirtualEnv(os.Environ(), venvDir)
 
-		if showOutput {
-			// Show stdout/stderr output.
-			pipCmd.Stdout = infoWriter
-			pipCmd.Stderr = errorWriter
-			if err := pipCmd.Run(); err != nil {
-				return fmt.Errorf("%s via '%s': %w", errorMsg, strings.Join(pipCmd.Args, " "), err)
+			if showOutput {
+				// Show stdout/stderr output.
+				pipCmd.Stdout = infoWriter
+				pipCmd.Stderr = errorWriter
+				if err := pipCmd.Run(); err != nil {
+					lastErr = fmt.Errorf("%s via '%s': %w", errorMsg, strings.Join(pipCmd.Args, " "), err)
+					if attempt < maxAttempts-1 {
+						fmt.Fprintf(errorWriter, "Retrying (%d/%d)...\n", attempt+1, maxAttempts)
+					}
+					continue
+				}
+			} else {
+				if _, err := pipCmd.Output(); err != nil {
+					lastErr = errutil.ErrorWithStderr(err, strings.Join(pipCmd.Args, " "))
+					continue
+				}
 			}
-		} else {
-			if _, err := pipCmd.Output(); err != nil {
-				return errutil.ErrorWithStderr(err, strings.Join(pipCmd.Args, " "))
-			}
+			return nil
 		}
-		return nil
+		return lastErr
 	}
 
 	printmsg("Updating pip, setuptools, and wheel in virtual environment...")


### PR DESCRIPTION
Lately we've been seeing a bit of flakyness from `pip install` in CI. See also https://github.com/pulumi/pulumi/issues/22775.

This seems like it's CDN issues, as we get the wrong header. Retry the command a few times hoping that the issues will go away in subsequent requests.  This will also affect the product, but I think retrying the install when it fails doesn't hurt, and might help in some cases, so it's probably a good thing for that as well.

Fixes https://github.com/pulumi/pulumi/issues/22775