### PR TITLE
increase max duration for journaling perf test (again)

### DIFF
--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -187,8 +187,8 @@ func TestPerfStackReferenceSecretsBatchUpdate(t *testing.T) {
 func TestPerfManyResourcesWithJournaling(t *testing.T) {
 	initialBenchmark := &integration.AssertPerfBenchmark{
 		T:                      t,
-		MaxUpdateDuration:      110 * time.Second,
-		MaxEmptyUpdateDuration: 50 * time.Second,
+		MaxUpdateDuration:      200 * time.Second,
+		MaxEmptyUpdateDuration: 100 * time.Second,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
Double(-ish for nice numbers) the threshold for this performance test. This should hopefully keep it off our backs for a while, and the threshold is still more than short enough to catch if we're not using journaling or something breaks in a major way.

Fixes https://github.com/pulumi/pulumi/issues/22776

I know @i-am-tom has more ideas on how to improve performance testing in general, but in the meantime this is probably worth it just so we get a few more PRs that are green instead of the constant red we're seeing.