### PR TITLE
don't stamp vcs information into binaries

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -120,6 +120,8 @@ func compileProgram(
 		return "", fmt.Errorf("unable to find 'go' executable: %w", err)
 	}
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
+	// We add the `-buildvcs=false` flag here because it sometimes fails on Windows.
+	// See also https://github.com/pulumi/pulumi/pull/22788
 	args := []string{"build", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -120,7 +120,7 @@ func compileProgram(
 		return "", fmt.Errorf("unable to find 'go' executable: %w", err)
 	}
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
-	args := []string{"build", "-o", outfile}
+	args := []string{"build", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
 	}


### PR DESCRIPTION
We don't make use of this vcs information anywhere, and binaries built by `pulumi-language-go` are temporary anyway.

On windows `buildvcs` sometimes flakes with exit code `0xc0000142`, which means `STATUS_DLL_NOT_FOUND` (according to Claude anyway). We've seen these issues loading DLLs in CI in other places too, so that sounds very plausible.  Since we don't really need this information in the binary, just don't stamp it in, which will avoid these flakes in CI (and potentially for customers on windows).

Fixes https://github.com/pulumi/pulumi/issues/22787