### PR TITLE
double timeout in "does not hang" test

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -545,7 +545,7 @@ describe("LocalWorkspace", () => {
     });
     // Regression test for https://github.com/pulumi/pulumi/issues/17613
     it(`does not hang on a failed input`, async function () {
-        this.timeout(20 * 1000); // This test hangs indefinitely if it fails
+        this.timeout(40 * 1000); // This test hangs indefinitely if it fails
 
         const program = async () => {
             class MyResource extends CustomResource {


### PR DESCRIPTION
This test has a timeout of 20 seconds, which makes it often flaky in CI.  There's at least 3 invocations of the CLI, which each takes at least 4-5 seconds, and especially in a slow CI environment it can often take longer.  Bump the timeout up, to avoid flakyness in this test.
