### PR TITLE
split tests module on macos further

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
               --version-set current \
               --partition-module pkg 1 \
               --partition-module sdk 1 \
-              --partition-module tests 4 \
+              --partition-module tests 8 \
               --partition-package github.com/pulumi/pulumi/tests/smoke tests/smoke 4 \
               --partition-package github.com/pulumi/pulumi/tests/integration tests/integration 8
             )


### PR DESCRIPTION
We currently run this in 4 partitions, but it seems like we're bumping up against the GHA timeout (1h) with the tests here often recently. Split the module further to hopefully reduce the amount of timeouts we're seeing.

<img width="735" height="1088" alt="image" src="https://github.com/user-attachments/assets/bd2dc58a-f025-4ca1-bd66-631f497b8549" />

All of the ones I checked of these failed because of timeouts.