### PR TITLE
Use in-scope sinks rather than calling cmdutil.Diag

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1367,7 +1367,7 @@ func (b *diyBackend) apply(
 				// printing a statefile perma link happens after all the providers have finished
 				// deploying the infrastructure, failing the pulumi update because there was a
 				// problem printing a statefile perma link can be missleading in automated CI environments.
-				cmdutil.Diag().Warningf(diag.Message("", "Unable to create signed url for current backend to "+
+				b.d.Warningf(diag.Message("", "Unable to create signed url for current backend to "+
 					"create a Permalink. Please visit https://www.pulumi.com/docs/troubleshooting/ "+
 					"for more information\n"))
 			}

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -146,7 +146,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 
 	fmt.Fprintf(cmd.parent.stdout, "Creating environment %v/%v for stack %v...\n", envProject, envName, stack.Ref().Name())
 
-	projectStack, config, err := cmd.getStackConfig(ctx, cmdutil.Diag(), project, stack)
+	projectStack, config, err := cmd.getStackConfig(ctx, cmd.parent.diags, project, stack)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -83,7 +82,7 @@ func getStackConfigurationWithFallback(
 	project *workspace.Project,
 	fallbackGetConfig func(err error) (config.Map, error), // optional
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	workspaceStack, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, s)
+	workspaceStack, err := cmdStack.LoadProjectStack(ctx, sink, project, s)
 	if err != nil || workspaceStack == nil {
 		if fallbackGetConfig == nil {
 			return backend.StackConfiguration{}, nil, err

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -137,7 +137,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			// Process packages section from Pulumi.yaml. Do so before installing language-specific dependencies,
 			// so that the SDKs folder is present and references to it from package.json etc are valid.
 			if err := newcmd.InstallPackagesFromProject(cmd.Context(), proj, root,
-				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global()),
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, proj, pctx.Diag, env.Global()),
 				parallel, useLanguageVersionTools, cmd.OutOrStdout(), cmd.ErrOrStderr(), env.Global(),
 			); err != nil {
 				return fmt.Errorf("installing `packages` from Pulumi.yaml: %w", err)

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -898,7 +898,7 @@ func NewImportCmd() *cobra.Command {
 			// Fetch the current stack.
 			s, err := cmdStack.RequireStack(
 				ctx,
-				cmdutil.Diag(),
+				sink,
 				ws,
 				cmdBackend.DefaultLoginManager,
 				stackName,
@@ -909,7 +909,7 @@ func NewImportCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -442,7 +442,7 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
-		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, pctx.Diag, ssml, s, proj)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -64,7 +64,7 @@ empty string.`,
 			}
 			defer contract.IgnoreClose(pctx)
 
-			registry := cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
+			registry := cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, sink, env.Global())
 			p, _, err := packages.ProviderFromSource(pctx, source, registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -58,7 +58,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			spec, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
-				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, sink, env.Global()),
 				env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -66,7 +66,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			spec, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
-				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, sink, env.Global()),
 				env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -69,7 +69,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			spec, _, err := packages.SchemaFromSchemaSource(pctx, args[0], parameters,
-				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
+				cmdCmd.NewDefaultRegistry(cmd.Context(), pkgWorkspace.Instance, nil, sink, env.Global()),
 				env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -75,7 +75,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			var handleProtected func(*resource.State) error
 			if force {
 				handleProtected = func(res *resource.State) error {
-					cmdutil.Diag().Warningf(diag.Message(res.URN,
+					sink.Warningf(diag.Message(res.URN,
 						"deleting protected resource %s due to presence of --force"), res.URN)
 					res.Protect = false
 					return nil

--- a/sdk/go/common/util/cmdutil/diag.go
+++ b/sdk/go/common/util/cmdutil/diag.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 var (
@@ -92,10 +91,4 @@ func Diag() diag.Sink {
 		})
 	}
 	return snk
-}
-
-// InitDiag forces initialization of the diagnostics sink with the given options.
-func InitDiag(opts diag.FormatOptions) {
-	contract.Assertf(snk == nil, "Cannot initialize diagnostics sink more than once")
-	snk = diag.DefaultSink(os.Stderr, os.Stderr, opts)
 }


### PR DESCRIPTION
Little cleanup noticed with codex, use sinks in scope rather than calling `cmdutil.Diag()`