### PR TITLE
Bundle `github.com/pulumi-labs/pulumi-hcl`

### DIFF
--- a/changelog/pending/20260501--cli--bundle-pulumi-language-hcl.yaml
+++ b/changelog/pending/20260501--cli--bundle-pulumi-language-hcl.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Bundle the `hcl` language host (from pulumi-labs/pulumi-hcl)

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -35,17 +35,19 @@ retry_with_backoff() {
 }
 
 download_release() {
-  local lang="$1"
-  local tag="$2"
-  local filename="$3"
+  local owner="$1"
+  local lang="$2"
+  local tag="$3"
+  local filename="$4"
 
   if "${USE_GH}"; then
-    retry_with_backoff gh release download "${tag}" --repo "pulumi/pulumi-${lang}" -p "${filename}"
+    retry_with_backoff gh release download "${tag}" --repo "${owner}/pulumi-${lang}" -p "${filename}"
   else
-    curl -OL --fail --retry 3 "https://github.com/pulumi/pulumi-${lang}/releases/download/${tag}/${filename}"
+    curl -OL --fail --retry 3 "https://github.com/${owner}/pulumi-${lang}/releases/download/${tag}/${filename}"
   fi
 }
 
+# Each entry is "lang tag [owner]". The owner defaults to "pulumi" when omitted.
 LANGUAGES=(
   # renovate: datasource=github-releases depName=pulumi/pulumi-dotnet
   "dotnet v3.103.1"
@@ -53,12 +55,15 @@ LANGUAGES=(
   "java v1.25.0"
   # renovate: datasource=github-releases depName=pulumi/pulumi-yaml
   "yaml v1.32.0"
+  # renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl
+  "hcl v0.0.2 pulumi-labs"
 )
 
 for i in "${LANGUAGES[@]}"; do
   set -- $i # treat strings in loop as args
   PULUMI_LANG="$1"
   TAG="$2"
+  PULUMI_OWNER="${3:-pulumi}"
 
   LANG_DIST="$(pwd)/bin"
   mkdir -p "${LANG_DIST}"
@@ -96,7 +101,7 @@ for i in "${LANGUAGES[@]}"; do
 
         mkdir -p "${OUTDIR}"
 
-        download_release "${PULUMI_LANG}" "${TAG}" "${ARCHIVE}.tar.gz"
+        download_release "${PULUMI_OWNER}" "${PULUMI_LANG}" "${TAG}" "${ARCHIVE}.tar.gz"
         tar -xzvf "${ARCHIVE}.tar.gz" -C "${OUTDIR}" "pulumi-language-${PULUMI_LANG}${DIST_EXT}"
       done
     done

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1991,6 +1991,7 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 		(kind == apitype.LanguagePlugin && name == "dotnet") ||
 		(kind == apitype.LanguagePlugin && name == "yaml") ||
 		(kind == apitype.LanguagePlugin && name == "java") ||
+		(kind == apitype.LanguagePlugin && name == "hcl") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-nodejs") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-python")
 }


### PR DESCRIPTION
This makes `runtime: hcl` usable without external support.