### PR TITLE
Bundle `pcl`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,19 @@ builds:
     - grpcnotrace
   tool: ../../../../scripts/go-wrapper.sh
 - <<: *pulumibin
+  id: pulumi-language-pcl
+  binary: pulumi-language-pcl
+  dir: sdk/pcl
+  main: ./cmd/pulumi-language-pcl
+  tags:
+    # Enforce the pure Go implementation of os/user, even when cgo is available.
+    # See https://pkg.go.dev/os/user#pkg-overview.
+    - osusergo
+    # google.golang.org/grpc has a build tag `grpcnotrace` which builds the package without x/net/trace. This avoids
+    # dead code elimation from being disabled by the compiler, see https://github.com/pulumi/pulumi/pull/22012.
+    - grpcnotrace
+  tool: ../../scripts/go-wrapper.sh
+- <<: *pulumibin
   id: pulumi-display-wasm
   binary: pulumi-display
   dir: pkg

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1992,6 +1992,7 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 		(kind == apitype.LanguagePlugin && name == "yaml") ||
 		(kind == apitype.LanguagePlugin && name == "java") ||
 		(kind == apitype.LanguagePlugin && name == "hcl") ||
+		(kind == apitype.LanguagePlugin && name == "pcl") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-nodejs") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-python")
 }


### PR DESCRIPTION
Stacked on top of https://github.com/pulumi/pulumi/pull/22807.

This makes `runtime: pcl` usable without external support. No changelog entry since we don't intend this to be user facing.