### PR TITLE
Tighten parsing on new property paths (v2)

### DIFF
--- a/changelog/pending/20260518--cli-import--emit-ignorechanges-as-property-path-traversals.yaml
+++ b/changelog/pending/20260518--cli-import--emit-ignorechanges-as-property-path-traversals.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Emit `ignoreChanges` paths in generated PCL as property-path traversals, correctly quoting non-identifier keys and escaping HCL template sequences

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 var matchAnsiControlCodes = regexp.MustCompile(`\x1b\[[0-9;]*[mK]`)
@@ -362,7 +363,9 @@ func convertStepEventStateMetadata(md *engine.StepEventStateMetadata,
 		Inputs:         inputs,
 		Outputs:        outputs,
 		InitErrors:     md.InitErrors,
-		HideDiffs:      md.HideDiffs,
+		HideDiffs: slice.Map(md.HideDiffs, func(p resource.PropertyPath) resource.BackCompatPropertyPath {
+			return resource.BackCompatPropertyPath(resource.FromResourcePropertyPath(p))
+		}),
 	}
 }
 
@@ -633,6 +636,8 @@ func convertJSONStepEventStateMetadata(md *apitype.StepEventStateMetadata) *engi
 		Inputs:         inputs,
 		Outputs:        outputs,
 		InitErrors:     md.InitErrors,
-		HideDiffs:      md.HideDiffs,
+		HideDiffs: slice.Map(md.HideDiffs, func(p resource.BackCompatPropertyPath) resource.PropertyPath {
+			return resource.ToResourcePropertyPath(property.Glob(p))
+		}),
 	}
 }

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
@@ -553,7 +554,7 @@ func makeStepEventStateMetadata(state *resource.State, debug bool, showSecrets b
 		Outputs:        filterResourceProperties(state.Outputs, debug, showSecrets),
 		Provider:       state.Provider,
 		InitErrors:     state.InitErrors,
-		HideDiffs:      state.HideDiff,
+		HideDiffs:      slice.Map(state.HideDiff, resource.ToResourcePropertyPath),
 	}
 }
 

--- a/pkg/engine/lifecycletest/hide_diffs_test.go
+++ b/pkg/engine/lifecycletest/hide_diffs_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func TestHideDiffs_Plain(t *testing.T) {
@@ -156,11 +158,9 @@ func testHideDiffs(t *testing.T, detailedDiff bool) {
 	}
 
 	created := p.Run(t, &deploy.Snapshot{})
-	assert.Equal(t, created.Resources[1].HideDiff, []resource.PropertyPath{
-		{"array"},
-		{"map"},
-		{"scalar"},
-	})
+	assert.Equal(t,
+		slice.Map([]string{"array", "map", "scalar"}, property.MustParseGlob),
+		created.Resources[1].HideDiff)
 	propValue = resource.NewProperty("b")
 	p.Run(t, created) // Update
 }

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1447,7 +1447,7 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 				"h": "bar",
 			},
 		},
-	}), []string{"a", "b.c", "d", "e[0]", "f.g[\"h\"]"}, []display.StepOp{deploy.OpCreate}, "initial")
+	}), []string{"a", "b.c", "d", "e[0]", "f.g.h"}, []display.StepOp{deploy.OpCreate}, "initial")
 
 	// Ensure that a change to an ignored property results in an OpSame
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]any{
@@ -1462,7 +1462,7 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 				"h": "baz",
 			},
 		},
-	}), []string{"a", "b.c", "d", "e[0]", "f.g[\"h\"]"}, []display.StepOp{deploy.OpSame}, "ignored-property")
+	}), []string{"a", "b.c", "d", "e[0]", "f.g.h"}, []display.StepOp{deploy.OpSame}, "ignored-property")
 
 	// Ensure that a change to an un-ignored property results in an OpUpdate
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]any{

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -1646,6 +1646,78 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIgnoreChangesLegacyPaths(t *testing.T) {
+	t.Parallel()
+
+	legacyPaths := []string{"foo-bar", "root.foo-bar", "with:colon", "with/slash"}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	register := func(t *testing.T, monitor *deploytest.ResourceMonitor, inputs resource.PropertyMap) {
+		_, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs:           inputs,
+			IgnoreChanges:    legacyPaths,
+			ReplaceOnChanges: legacyPaths,
+		})
+		require.NoError(t, err)
+	}
+
+	initial := resource.NewPropertyMapFromMap(map[string]any{
+		"foo-bar": "v1",
+		"root": map[string]any{
+			"foo-bar": "v1",
+		},
+	})
+	changed := resource.NewPropertyMapFromMap(map[string]any{
+		"foo-bar": "v2",
+		"root": map[string]any{
+			"foo-bar": "v2",
+		},
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil,
+		deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			register(t, monitor, initial)
+			return nil
+		}),
+		loaders...)
+	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true}}
+	project := p.GetProject()
+
+	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "create")
+	require.NoError(t, err)
+
+	hostF = deploytest.NewPluginHostF(nil, nil,
+		deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+			register(t, monitor, changed)
+			return nil
+		}),
+		loaders...)
+	p.Options.HostF = hostF
+
+	var saw display.StepOp
+	p.Steps = []lt.TestStep{{
+		Op: Update,
+		Validate: func(_ workspace.Project, _ deploy.Target, _ JournalEntries, events []Event, err error) error {
+			for _, e := range events {
+				if e.Type != ResourcePreEvent {
+					continue
+				}
+				if md := e.Payload().(ResourcePreEventPayload).Metadata; md.URN == "urn:pulumi:test::test::pkgA:m:typA::resA" {
+					saw = md.Op
+				}
+			}
+			return err
+		},
+	}}
+	_ = p.RunWithName(t, snap, "update")
+	assert.Equal(t, deploy.OpSame, saw, "hyphenated ignoreChanges path should suppress the diff")
+}
+
 type DiffFunc = func(context.Context, plugin.DiffRequest) (plugin.DiffResult, error)
 
 func replaceOnChangesTest(t *testing.T, name string, diffFunc DiffFunc) {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -324,22 +326,28 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 		})
 	}
 	if len(state.IgnoreChanges) > 0 {
-		ignoreChanges := make([]model.Expression, len(state.IgnoreChanges))
-		for i, prop := range state.IgnoreChanges {
-			text, err := prop.MarshalText()
-			if err != nil {
-				return nil, err
+		ignoreChanges := make([]model.Expression, 0, len(state.IgnoreChanges))
+		var skipped []string
+		for _, g := range state.IgnoreChanges {
+			expr, reason := globToTraversal(g)
+			if expr == nil {
+				text, _ := g.MarshalText()
+				skipped = append(skipped, fmt.Sprintf(
+					"// WARNING: dropped ignoreChanges path %s (%s)\n",
+					string(text), reason))
+				continue
 			}
-			v := cty.StringVal(string(text))
-			ignoreChanges[i] = &model.LiteralValueExpression{
-				Tokens: syntax.NewLiteralValueTokens(v),
-				Value:  v,
-			}
+			ignoreChanges = append(ignoreChanges, expr)
 		}
-		resourceOptions = appendResourceOption(resourceOptions, "ignoreChanges", &model.TupleConsExpression{
-			Tokens:      syntax.NewTupleConsTokens(len(ignoreChanges)),
-			Expressions: ignoreChanges,
-		})
+		if len(ignoreChanges) > 0 {
+			resourceOptions = appendResourceOption(resourceOptions, "ignoreChanges", &model.TupleConsExpression{
+				Tokens:      syntax.NewTupleConsTokens(len(ignoreChanges)),
+				Expressions: ignoreChanges,
+			})
+		}
+		if len(skipped) > 0 {
+			attachIgnoreChangesWarnings(resourceOptions, skipped)
+		}
 	}
 	if state.DeletedWith != "" {
 		name, ok := names[state.DeletedWith]
@@ -381,6 +389,87 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 	}
 
 	return resourceOptions, nil
+}
+
+// globToTraversal converts a property.Glob into a PCL property-path
+// traversal. Returns (nil, reason) when the glob has no PCL representation:
+// HCL traversals must start with an identifier root, and have no wildcard
+// counterpart to property.SplatSegment.
+func globToTraversal(g property.Glob) (*model.ScopeTraversalExpression, string) {
+	segments := slices.Collect(g.Segments)
+	if len(segments) == 0 {
+		return nil, "empty path"
+	}
+
+	root, ok := segments[0].(property.KeySegment)
+	if !ok {
+		return nil, fmt.Sprintf("path root is %T; PCL requires an identifier", segments[0])
+	}
+	if !isHCLIdentifier(root.Key()) {
+		return nil, fmt.Sprintf("path root %q is not a valid HCL identifier", root.Key())
+	}
+
+	traversal := hcl.Traversal{hcl.TraverseRoot{Name: root.Key()}}
+	for _, s := range segments[1:] {
+		switch s := s.(type) {
+		case property.KeySegment:
+			if isHCLIdentifier(s.Key()) {
+				traversal = append(traversal, hcl.TraverseAttr{Name: s.Key()})
+			} else {
+				traversal = append(traversal, hcl.TraverseIndex{Key: cty.StringVal(s.Key())})
+			}
+		case property.IndexSegment:
+			traversal = append(traversal, hcl.TraverseIndex{Key: cty.NumberIntVal(int64(s.Index()))})
+		case property.SplatSegment:
+			return nil, "path contains a splat (`*`) segment; PCL has no traversal counterpart"
+		default:
+			return nil, fmt.Sprintf("unknown path segment type %T", s)
+		}
+	}
+
+	return &model.ScopeTraversalExpression{
+		RootName:  root.Key(),
+		Traversal: traversal,
+	}, ""
+}
+
+func isHCLIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, c := range s {
+		isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+		isDigit := c >= '0' && c <= '9'
+		if !isLetter && (i == 0 || !isDigit) {
+			return false
+		}
+	}
+	return true
+}
+
+func attachIgnoreChangesWarnings(options *model.Block, warnings []string) {
+	if options == nil {
+		return
+	}
+	var attr *model.Attribute
+	for _, item := range options.Body.Items {
+		a, ok := item.(*model.Attribute)
+		if ok && a.Name == "ignoreChanges" {
+			attr = a
+		}
+	}
+
+	trivia := make(syntax.TriviaList, 0, len(warnings))
+	for _, w := range warnings {
+		trivia = append(trivia, syntax.NewWhitespace([]byte("\n"+w)...))
+	}
+
+	switch {
+	case attr != nil:
+		attr.Tokens.Name.LeadingTrivia = append(attr.Tokens.Name.LeadingTrivia, trivia...)
+	case options.Tokens != nil:
+		options.Tokens.OpenBrace.TrailingTrivia = append(options.Tokens.OpenBrace.TrailingTrivia, trivia...)
+	}
 }
 
 // typeRank orders types by their simplicity.

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -326,7 +326,11 @@ func makeResourceOptions(state *resource.State, names NameTable, addedRefs map[s
 	if len(state.IgnoreChanges) > 0 {
 		ignoreChanges := make([]model.Expression, len(state.IgnoreChanges))
 		for i, prop := range state.IgnoreChanges {
-			v := cty.StringVal(prop)
+			text, err := prop.MarshalText()
+			if err != nil {
+				return nil, err
+			}
+			v := cty.StringVal(string(text))
 			ignoreChanges[i] = &model.LiteralValueExpression{
 				Tokens: syntax.NewLiteralValueTokens(v),
 				Value:  v,

--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -47,7 +47,13 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 
 	rapid.Check(t, func(t *rapid.T) {
 		pkg := rapidschema.Package().Filter(hasSelectableResource).Draw(t, "pkg")
-		sample := rapidimporter.State(pkg).Draw(t, "sample")
+		// TODO[https://github.com/pulumi/pulumi/issues/23232]: drop the
+		// allPathRootsAreHCLIdentifiers filter once schema property names are
+		// constrained to be valid HCL identifiers. Today the schema permits
+		// names like `a-` that have no valid PCL property-path expression.
+		sample := rapidimporter.State(pkg).
+			Filter(allPathRootsAreHCLIdentifiers).
+			Draw(t, "sample")
 
 		if checkPropertyMap(sample.State.Inputs, property.Value.IsNull) {
 			// generatePropertyValue (pkg/importer/hcl2.go:588) normalizes a
@@ -223,6 +229,23 @@ func hasSelectableResource(pkg *schema.Package) bool {
 		}
 	}
 	return false
+}
+
+func allPathRootsAreHCLIdentifiers(s *rapidimporter.Sample) bool {
+	for _, globs := range [][]property.Glob{s.State.IgnoreChanges, s.State.ReplaceOnChanges} {
+		for _, g := range globs {
+			var first property.GlobSegment
+			for seg := range g.Segments {
+				first = seg
+				break
+			}
+			key, ok := first.(property.KeySegment)
+			if !ok || !isHCLIdentifier(key.Key()) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // buildImportState assembles the [ImportState] needed by

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -240,7 +240,7 @@ func renderResource(t require.TestingT, r *pcl.Resource) *resource.State {
 	var parent resource.URN
 	var providerRef string
 	var importID resource.ID
-	var ignoreChanges []string
+	var ignoreChanges []property.Glob
 	if r.Options != nil {
 		if r.Options.Protect != nil {
 			v, diags := r.Options.Protect.Evaluate(&hcl.EvalContext{})
@@ -272,7 +272,9 @@ func renderResource(t require.TestingT, r *pcl.Resource) *resource.State {
 			if assert.True(t, v.IsArray()) {
 				for _, item := range v.AsArray().All {
 					if assert.True(t, item.IsString()) {
-						ignoreChanges = append(ignoreChanges, item.AsString())
+						var p property.Glob
+						require.NoError(t, p.UnmarshalText([]byte(item.AsString())))
+						ignoreChanges = append(ignoreChanges, p)
 					}
 				}
 			}
@@ -337,7 +339,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 					Custom:         true,
 					Type:           "pulumi:providers:aws",
 					RetainOnDelete: true,
-					IgnoreChanges:  []string{"fooIgnore"},
+					IgnoreChanges:  []property.Glob{property.MustParseGlob("fooIgnore")},
 					DeletedWith:    "123",
 					URN:            "urn:pulumi:stack::project::pulumi:providers:aws::default_123",
 				},
@@ -347,7 +349,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 					Custom:         true,
 					Type:           "pulumi:providers:random",
 					RetainOnDelete: true,
-					IgnoreChanges:  []string{"fooIgnore"},
+					IgnoreChanges:  []property.Glob{property.MustParseGlob("fooIgnore")},
 					DeletedWith:    "123",
 					URN:            "urn:pulumi:stack::project::pulumi:providers:random::default_123",
 				},
@@ -357,7 +359,7 @@ func TestGenerateHCL2Definition(t *testing.T) {
 					Custom:         true,
 					Type:           "pulumi:providers:pkg",
 					RetainOnDelete: true,
-					IgnoreChanges:  []string{"fooIgnore"},
+					IgnoreChanges:  []property.Glob{property.MustParseGlob("fooIgnore")},
 					DeletedWith:    "123",
 					URN:            "urn:pulumi:stack::project::pulumi:providers:pkg::provider",
 				},

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -479,6 +479,168 @@ func TestGenerateHCL2DefinitionWithProviderDeclaration(t *testing.T) {
 	}}, block.Body.Items, "expected region to be set on custom provider")
 }
 
+func TestGenerateHCL2DefinitionEmitsIgnoreChangesAsTraversal(t *testing.T) {
+	t.Parallel()
+
+	pkg, diags, err := schema.BindSpec(schema.PackageSpec{
+		Name:     "pkg",
+		Version:  "1.0.0",
+		Provider: schema.ResourceSpec{ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"}},
+		Resources: map[string]schema.ResourceSpec{
+			"pkg:index:Res": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"foo": {TypeSpec: schema.TypeSpec{Type: "object"}},
+					},
+				},
+			},
+		},
+	}, nil, schema.ValidationOptions{})
+	require.NoError(t, err)
+	require.Falsef(t, diags.HasErrors(), "schema diagnostics: %v", diags.Error())
+	loader := &stubSchemaLoader{pkg: pkg}
+
+	cases := []struct {
+		name     string
+		glob     property.Glob
+		expected string
+	}{
+		{
+			name:     "bare identifier root",
+			glob:     property.MustParseGlob("foo"),
+			expected: "foo",
+		},
+		{
+			name:     "dotted identifier path",
+			glob:     property.MustParseGlob("foo.bar"),
+			expected: "foo.bar",
+		},
+		{
+			name:     "numeric index",
+			glob:     property.MustParseGlob("foo[3]"),
+			expected: "foo[3]",
+		},
+		{
+			name:     "bracketed key needing quotes",
+			glob:     property.MustParseGlob(`foo["bar-baz"]`),
+			expected: `foo["bar-baz"]`,
+		},
+		{
+			name:     "key containing a template-interpolation sequence is escaped",
+			glob:     property.MustParseGlob(`foo["${bar}"]`),
+			expected: `foo["$${bar}"]`,
+		},
+		{
+			name:     "key containing a double-quote is escaped",
+			glob:     property.MustParseGlob(`foo["a\"b"]`),
+			expected: `foo["a\"b"]`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			providerURN := resource.NewURN("s", "p", "", "pulumi:providers:pkg", "default")
+			state := &resource.State{
+				Type:          "pkg:index:Res",
+				URN:           resource.NewURN("s", "p", "", "pkg:index:Res", "R"),
+				Custom:        true,
+				Provider:      string(providerURN) + "::id",
+				Inputs:        resource.PropertyMap{},
+				IgnoreChanges: []property.Glob{tc.glob},
+			}
+			importState := ImportState{
+				Snapshot: []*resource.State{{
+					ID:     "id",
+					Custom: true,
+					Type:   "pulumi:providers:pkg",
+					URN:    providerURN,
+				}},
+			}
+			block, _, err := GenerateHCL2Definition(loader, state, importState)
+			require.NoError(t, err)
+
+			text := fmt.Sprint(block)
+			require.Containsf(t, text, tc.expected,
+				"emitted block did not contain expected traversal %q:\n%s", tc.expected, text)
+
+			parser := syntax.NewParser()
+			require.NoError(t, parser.ParseFile(strings.NewReader(text), "test.pp"))
+			require.Falsef(t, parser.Diagnostics.HasErrors(),
+				"parse diagnostics: %v\nblock:\n%s", parser.Diagnostics.Error(), text)
+
+			_, bindDiags, err := pcl.BindProgram(parser.Files, pcl.Loader(loader), pcl.AllowMissingVariables)
+			require.NoErrorf(t, err, "bind diagnostics: %v\nblock:\n%s", bindDiags.Error(), text)
+			require.Falsef(t, bindDiags.HasErrors(),
+				"bind diagnostics: %v\nblock:\n%s", bindDiags.Error(), text)
+		})
+	}
+}
+
+func TestGenerateHCL2DefinitionDropsInexpressibleIgnoreChangesPaths(t *testing.T) {
+	t.Parallel()
+
+	pkg, diags, err := schema.BindSpec(schema.PackageSpec{
+		Name:     "pkg",
+		Version:  "1.0.0",
+		Provider: schema.ResourceSpec{ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"}},
+		Resources: map[string]schema.ResourceSpec{
+			"pkg:index:Res": {ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"}},
+		},
+	}, nil, schema.ValidationOptions{})
+	require.NoError(t, err)
+	require.Falsef(t, diags.HasErrors(), "schema diagnostics: %v", diags.Error())
+	loader := &stubSchemaLoader{pkg: pkg}
+
+	providerURN := resource.NewURN("s", "p", "", "pulumi:providers:pkg", "default")
+	state := &resource.State{
+		Type:     "pkg:index:Res",
+		URN:      resource.NewURN("s", "p", "", "pkg:index:Res", "R"),
+		Custom:   true,
+		Provider: string(providerURN) + "::id",
+		Inputs:   resource.PropertyMap{},
+		IgnoreChanges: []property.Glob{
+			property.MustParseGlob(`["a-"]`),
+			property.MustParseGlob("good"),
+		},
+	}
+	importState := ImportState{
+		Snapshot: []*resource.State{{
+			ID:     "id",
+			Custom: true,
+			Type:   "pulumi:providers:pkg",
+			URN:    providerURN,
+		}},
+	}
+	block, _, err := GenerateHCL2Definition(loader, state, importState)
+	require.NoError(t, err)
+
+	text := fmt.Sprint(block)
+	assert.Equal(t, `resource R "pkg:index:Res" {
+options {
+
+// WARNING: dropped ignoreChanges path ["a-"] (path root "a-" is not a valid HCL identifier)
+ignoreChanges =[
+            good]
+
+}
+
+}
+`, text)
+
+	parser := syntax.NewParser()
+	require.NoError(t, parser.ParseFile(strings.NewReader(text), "test.pp"))
+	require.Falsef(t, parser.Diagnostics.HasErrors(),
+		"parse diagnostics: %v\nblock:\n%s", parser.Diagnostics.Error(), text)
+
+	_, bindDiags, err := pcl.BindProgram(parser.Files, pcl.Loader(loader), pcl.AllowMissingVariables)
+	require.NoErrorf(t, err, "bind diagnostics: %v\nblock:\n%s", bindDiags.Error(), text)
+	require.Falsef(t, bindDiags.HasErrors(),
+		"bind diagnostics: %v\nblock:\n%s", bindDiags.Error(), text)
+}
+
 // Tests that HCL definitions can be generated even if there is a mismatch in the version of the provider in the
 // snapshot and the version of the provider loaded from the plugin.
 func TestGenerateHCL2DefinitionsWithVersionMismatches(t *testing.T) {

--- a/pkg/importer/rapid/rapid.go
+++ b/pkg/importer/rapid/rapid.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Sample is a generated resource state and the snapshot needed to import it.
@@ -106,8 +107,8 @@ func drawSample(t *rapid.T, pkg *schema.Package, pickable []*schema.Resource) *S
 		External:            rapid.Bool().Draw(t, "external"),
 		RefreshBeforeUpdate: rapid.Bool().Draw(t, "refresh-before-update"),
 		ImportID:            drawOptionalResourceID(t, "import-id"),
-		IgnoreChanges:       drawPropertyNames(t, "ignore-changes", r.InputProperties),
-		ReplaceOnChanges:    drawPropertyNames(t, "replace-on-changes", r.InputProperties),
+		IgnoreChanges:       propertyNamesAsGlobs(drawPropertyNames(t, "ignore-changes", r.InputProperties)),
+		ReplaceOnChanges:    propertyNamesAsGlobs(drawPropertyNames(t, "replace-on-changes", r.InputProperties)),
 		Aliases:             drawAliases(t, typ),
 	}
 
@@ -210,11 +211,24 @@ func drawPropertyNames(t *rapid.T, label string, props []*schema.Property) []str
 		return nil
 	}
 	names := make([]string, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		idx := rapid.IntRange(0, len(props)-1).Draw(t, fmt.Sprintf("%s:%d", label, i))
 		names[i] = props[idx].Name
 	}
 	return names
+}
+
+// propertyNamesAsGlobs lifts a list of bare property names into single-segment [property.Glob]s
+// for fields like [resource.State.IgnoreChanges] that hold structured property paths.
+func propertyNamesAsGlobs(names []string) []property.Glob {
+	if len(names) == 0 {
+		return nil
+	}
+	globs := make([]property.Glob, len(names))
+	for i, n := range names {
+		globs[i] = property.GlobFromSegments(property.NewSegment(n))
+	}
+	return globs
 }
 
 func drawAliases(t *rapid.T, typ tokens.Type) []resource.URN {

--- a/pkg/resource/deploy/analyze_snapshot.go
+++ b/pkg/resource/deploy/analyze_snapshot.go
@@ -121,7 +121,7 @@ func stateToAnalyzerResource(
 		Properties: properties,
 		Options: plugin.AnalyzerResourceOptions{
 			Protect:                 res.Protect,
-			IgnoreChanges:           res.IgnoreChanges,
+			IgnoreChanges:           globsToStrings(res.IgnoreChanges),
 			AdditionalSecretOutputs: res.AdditionalSecretOutputs,
 			Aliases:                 res.GetAliases(),
 			CustomTimeouts:          res.CustomTimeouts,

--- a/pkg/resource/deploy/init_copystructure.go
+++ b/pkg/resource/deploy/init_copystructure.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"reflect"
+
+	"github.com/mitchellh/copystructure"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+func init() {
+	// [property.Glob] and [resource.BackCompatPropertyPath] wrap an internal pathRepr which holds
+	// its data in an unexported embedded string. reflect-based deep copy cannot set that field,
+	// so we register value-copy functions that return the input unchanged (both types are
+	// effectively immutable).
+	copystructure.Copiers[reflect.TypeFor[property.Glob]()] = func(v any) (any, error) {
+		return v.(property.Glob), nil
+	}
+	copystructure.Copiers[reflect.TypeFor[property.Path]()] = func(v any) (any, error) {
+		return v.(property.Path), nil
+	}
+	copystructure.Copiers[reflect.TypeFor[resource.BackCompatPropertyPath]()] = func(v any) (any, error) {
+		return v.(resource.BackCompatPropertyPath), nil
+	}
+}

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // A Plan is a mapping from URNs to ResourcePlans. The plan defines an expected set of resources and the expected
@@ -157,7 +158,7 @@ type GoalPlan struct {
 	// true if this resource should be deleted prior to replacement.
 	DeleteBeforeReplace *bool
 	// a list of property names to ignore during changes.
-	IgnoreChanges []string
+	IgnoreChanges []property.Glob
 	// outputs that should always be treated as secrets.
 	AdditionalSecretOutputs []resource.PropertyKey
 	// Structured Alias objects to be assigned to this resource
@@ -632,7 +633,10 @@ func (rp *ResourcePlan) checkGoal(
 	}
 
 	// Check that the ignoreChanges sets are identical.
-	if message, changed := rp.diffStringSets(rp.Goal.IgnoreChanges, programGoal.IgnoreChanges); changed {
+	if message, changed := rp.diffStringSets(
+		globsToStrings(rp.Goal.IgnoreChanges),
+		globsToStrings(programGoal.IgnoreChanges),
+	); changed {
 		return fmt.Errorf("ignoreChanges changed: %v", message)
 	}
 

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -463,8 +464,8 @@ func TestResourcePlan(t *testing.T) {
 				t.Parallel()
 				rp := &ResourcePlan{
 					Goal: &GoalPlan{
-						IgnoreChanges: []string{
-							"foo",
+						IgnoreChanges: []property.Glob{
+							property.MustParseGlob("foo"),
 						},
 					},
 				}
@@ -472,8 +473,8 @@ func TestResourcePlan(t *testing.T) {
 					resource.PropertyMap{},
 					resource.PropertyMap{},
 					&resource.Goal{
-						IgnoreChanges: []string{
-							"bar",
+						IgnoreChanges: []property.Glob{
+							property.MustParseGlob("bar"),
 						},
 					})
 				assert.ErrorContains(t, err, "ignoreChanges changed")

--- a/pkg/resource/deploy/resource_options.go
+++ b/pkg/resource/deploy/resource_options.go
@@ -28,12 +28,12 @@ func resourceOptionsFromState(state *resource.State) *pulumirpc.ResourceOptions 
 
 	resourceOptions := &pulumirpc.ResourceOptions{
 		DependsOn:        urnsToStrings(state.Dependencies),
-		IgnoreChanges:    append([]string(nil), state.IgnoreChanges...),
-		ReplaceOnChanges: append([]string(nil), state.ReplaceOnChanges...),
+		IgnoreChanges:    globsToStrings(state.IgnoreChanges),
+		ReplaceOnChanges: globsToStrings(state.ReplaceOnChanges),
 		Provider:         state.Provider,
 		DeletedWith:      string(state.DeletedWith),
 		Import:           string(state.ImportID),
-		HideDiff:         propertyPathsToStrings(state.HideDiff),
+		HideDiff:         globsToStrings(state.HideDiff),
 		ReplaceWith:      urnsToStrings(state.ReplaceWith),
 		Hooks:            hookBindingsToProto(state.ResourceHooks),
 		Parent:           string(state.Parent),
@@ -93,17 +93,6 @@ func urnsToStrings(urns []resource.URN) []string {
 	values := make([]string, 0, len(urns))
 	for _, urn := range urns {
 		values = append(values, string(urn))
-	}
-	return values
-}
-
-func propertyPathsToStrings(paths []resource.PropertyPath) []string {
-	if len(paths) == 0 {
-		return nil
-	}
-	values := make([]string, 0, len(paths))
-	for _, path := range paths {
-		values = append(values, path.String())
 	}
 	return values
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -58,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 	interceptors "github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/rpcdebug"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -2694,16 +2695,18 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	}
 
 	protect := opts.Protect
-	ignoreChanges := opts.IgnoreChanges
-	hiddenDiffs := slice.Prealloc[resource.PropertyPath](len(opts.GetHideDiff()))
-	for i, v := range opts.GetHideDiff() {
-		path, err := resource.ParsePropertyPath(v)
-		if err != nil {
-			return nil, fmt.Errorf("%d: %w", i, err)
-		}
-		hiddenDiffs = append(hiddenDiffs, path)
+	ignoreChanges, err := parsePropertyGlobs(opts.IgnoreChanges)
+	if err != nil {
+		return nil, rpcerror.New(codes.InvalidArgument, fmt.Sprintf("invalid ignoreChanges path: %s", err))
 	}
-	replaceOnChanges := opts.ReplaceOnChanges
+	hiddenDiffs, err := parsePropertyGlobs(opts.GetHideDiff())
+	if err != nil {
+		return nil, rpcerror.New(codes.InvalidArgument, fmt.Sprintf("invalid hideDiffs path: %s", err))
+	}
+	replaceOnChanges, err := parsePropertyGlobs(opts.GetReplaceOnChanges())
+	if err != nil {
+		return nil, rpcerror.New(codes.InvalidArgument, fmt.Sprintf("invalid replaceOnChanges path: %s", err))
+	}
 
 	replacementTrigger := resource.NewNullProperty()
 	replacementTriggerValue := opts.GetReplacementTrigger()
@@ -2817,8 +2820,8 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			AdditionalSecretOutputs: additionalSecretOutputs,
 			DeletedWith:             deletedWith,
 			ReplaceWith:             replaceWith,
-			IgnoreChanges:           ignoreChanges,
-			ReplaceOnChanges:        replaceOnChanges,
+			IgnoreChanges:           globsToStrings(ignoreChanges),
+			ReplaceOnChanges:        globsToStrings(replaceOnChanges),
 			ReplacementTrigger:      replacementTrigger,
 			RetainOnDelete:          retainOnDelete,
 			ResourceHooks:           resourceHooks,
@@ -3253,6 +3256,22 @@ func (g *readResourceEvent) Done(result *ReadResult) {
 	g.done <- result
 }
 
+// parsePropertyGlobs parses a list of property path strings from user-facing RPC input into
+// [property.Glob]s. A nil input returns a nil slice. If any path is malformed, the index of the
+// first failing entry and the underlying parse error are returned.
+func parsePropertyGlobs(paths []string) ([]property.Glob, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	globs := make([]property.Glob, len(paths))
+	for i, p := range paths {
+		if err := globs[i].UnmarshalText([]byte(p)); err != nil {
+			return nil, fmt.Errorf("%d: %w", i, err)
+		}
+	}
+	return globs, nil
+}
+
 func generateTimeoutInSeconds(timeout string) (float64, error) {
 	duration, err := time.ParseDuration(timeout)
 	if err != nil {
@@ -3403,4 +3422,17 @@ func addOutputDependencies(deps mapset.Set[resource.URN], v resource.PropertyVal
 	if v.IsSecret() {
 		addOutputDependencies(deps, v.SecretValue().Element)
 	}
+}
+
+// GlobsToStrings renders each [property.Glob] in globs to its canonical string form. The
+// zero-value glob is rendered as the empty string.
+func globsToStrings(globs []property.Glob) []string {
+	return slice.Map(globs, func(g property.Glob) string {
+		if g == (property.Glob{}) {
+			return ""
+		}
+		b, err := g.MarshalText()
+		contract.AssertNoErrorf(err, "non-empty glob should always marshal")
+		return string(b)
+	})
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -3265,9 +3265,11 @@ func parsePropertyGlobs(paths []string) ([]property.Glob, error) {
 	}
 	globs := make([]property.Glob, len(paths))
 	for i, p := range paths {
-		if err := globs[i].UnmarshalText([]byte(p)); err != nil {
+		var bc resource.BackCompatPropertyPath
+		if err := bc.UnmarshalText([]byte(p)); err != nil {
 			return nil, fmt.Errorf("%d: %w", i, err)
 		}
+		globs[i] = property.Glob(bc)
 	}
 	return globs, nil
 }

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // StepCompleteFunc is the type of functions returned from Step.Apply. These
@@ -875,7 +876,7 @@ type UpdateStep struct {
 	stables       []resource.PropertyKey         // an optional list of properties that won't change during this update.
 	diffs         []resource.PropertyKey         // the keys causing a diff.
 	detailedDiff  map[string]plugin.PropertyDiff // the structured diff.
-	ignoreChanges []string                       // a list of property paths to ignore when updating.
+	ignoreChanges []property.Glob                // a list of property paths to ignore when updating.
 	provider      plugin.Provider                // the optional provider to use.
 	oldViews      []plugin.View                  // the old views for this resource.
 }
@@ -884,7 +885,7 @@ var _ Step = (*UpdateStep)(nil)
 
 func NewUpdateStep(deployment *Deployment, reg RegisterResourceEvent, old, new *resource.State,
 	stables, diffs []resource.PropertyKey, detailedDiff map[string]plugin.PropertyDiff,
-	ignoreChanges []string, oldViews []plugin.View,
+	ignoreChanges []property.Glob, oldViews []plugin.View,
 ) Step {
 	contract.Requiref(old != nil, "old", "must not be nil")
 	contract.Requiref(old.URN != "", "old", "must have a URN")
@@ -986,7 +987,7 @@ func (s *UpdateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 					OldOutputs:            s.old.Outputs,
 					NewInputs:             s.new.Inputs,
 					Timeout:               s.new.CustomTimeouts.Update,
-					IgnoreChanges:         s.ignoreChanges,
+					IgnoreChanges:         globsToStrings(s.ignoreChanges),
 					Preview:               s.deployment.opts.DryRun,
 					ResourceStatusAddress: resourceStatusAddress,
 					ResourceStatusToken:   resourceStatusToken,
@@ -1709,7 +1710,7 @@ type ImportStep struct {
 	old           *resource.State       // the state of the resource fetched from the provider.
 	new           *resource.State       // the newly computed state of the resource after importing.
 	replacing     bool                  // true if we are replacing a Pulumi-managed resource.
-	ignoreChanges []string              // a list of property paths to ignore when updating.
+	ignoreChanges []property.Glob       // a list of property paths to ignore when updating.
 	randomSeed    []byte                // the random seed to use for Check.
 	provider      plugin.Provider       // the optional provider to use.
 
@@ -1721,7 +1722,7 @@ type ImportStep struct {
 }
 
 func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resource.State,
-	ignoreChanges []string, randomSeed []byte, cts *promise.CompletionSource[*resource.State],
+	ignoreChanges []property.Glob, randomSeed []byte, cts *promise.CompletionSource[*resource.State],
 ) Step {
 	contract.Requiref(new != nil, "new", "must not be nil")
 	contract.Requiref(new.URN != "", "new", "must have a URN")
@@ -1745,7 +1746,7 @@ func NewImportStep(deployment *Deployment, reg RegisterResourceEvent, new *resou
 }
 
 func NewImportReplacementStep(deployment *Deployment, reg RegisterResourceEvent, original, new *resource.State,
-	ignoreChanges []string, randomSeed []byte, cts *promise.CompletionSource[*resource.State],
+	ignoreChanges []property.Glob, randomSeed []byte, cts *promise.CompletionSource[*resource.State],
 ) Step {
 	contract.Requiref(original != nil, "original", "must not be nil")
 
@@ -2277,12 +2278,12 @@ type DiffStep struct {
 	pcs           *promise.CompletionSource[plugin.DiffResult] // the completion source for this diff
 	old           *resource.State                              // the old resource state
 	new           *resource.State                              // the new resource state
-	ignoreChanges []string                                     // a list of property paths to ignore when diffing
+	ignoreChanges []property.Glob                              // a list of property paths to ignore when diffing
 }
 
 func NewDiffStep(
 	deployment *Deployment, pcs *promise.CompletionSource[plugin.DiffResult], old, new *resource.State,
-	ignoreChanges []string,
+	ignoreChanges []property.Glob,
 ) Step {
 	return &DiffStep{
 		deployment:    deployment,

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // The mode in which the step generator is running.
@@ -1287,7 +1288,7 @@ func (sg *stepGenerator) continueStepsFromImport(event ContinueResourceImportEve
 			Properties: inputs,
 			Options: plugin.AnalyzerResourceOptions{
 				Protect:                 new.Protect,
-				IgnoreChanges:           goal.IgnoreChanges,
+				IgnoreChanges:           globsToStrings(goal.IgnoreChanges),
 				DeleteBeforeReplace:     goal.DeleteBeforeReplace,
 				AdditionalSecretOutputs: new.AdditionalSecretOutputs,
 				Aliases:                 new.GetAliases(),
@@ -2739,7 +2740,7 @@ func (sg *stepGenerator) diff(
 // diffResource invokes the Diff function for the given custom resource's provider and returns the result.
 func diffResource(d diag.Sink, urn resource.URN, id resource.ID, oldInputs, oldOutputs,
 	newInputs resource.PropertyMap, prov plugin.Provider, allowUnknowns bool,
-	ignoreChanges []string,
+	ignoreChanges []property.Glob,
 ) (plugin.DiffResult, error) {
 	contract.Requiref(prov != nil, "prov", "must not be nil")
 
@@ -2754,7 +2755,7 @@ func diffResource(d diag.Sink, urn resource.URN, id resource.ID, oldInputs, oldO
 		OldOutputs:    oldOutputs,
 		NewInputs:     newInputs,
 		AllowUnknowns: allowUnknowns,
-		IgnoreChanges: ignoreChanges,
+		IgnoreChanges: globsToStrings(ignoreChanges),
 	})
 	if err != nil {
 		return diff, err
@@ -2803,18 +2804,16 @@ func issueCheckFailures(printf func(*diag.Diag, ...any), new *resource.State, ur
 // processIgnoreChanges sets the value for each ignoreChanges property in inputs to the value from oldInputs.  This has
 // the effect of ensuring that no changes will be made for the corresponding property.
 func processIgnoreChanges(d diag.Sink, urn resource.URN, inputs, oldInputs resource.PropertyMap,
-	ignoreChanges []string,
+	ignoreChanges []property.Glob,
 ) resource.PropertyMap {
 	ignoredInputs := inputs.Copy()
 	var invalidPaths []string
 	for _, ignoreChange := range ignoreChanges {
-		path, err := resource.ParsePropertyPath(ignoreChange)
-		if err != nil {
-			continue
-		}
+		path := resource.ToResourcePropertyPath(ignoreChange)
 		ok := path.Reset(oldInputs, ignoredInputs)
 		if !ok {
-			invalidPaths = append(invalidPaths, ignoreChange)
+			text, _ := ignoreChange.MarshalText()
+			invalidPaths = append(invalidPaths, string(text))
 		}
 	}
 	if len(invalidPaths) != 0 {
@@ -2876,7 +2875,7 @@ const initErrorSpecialKey = "#initerror"
 // applyReplaceOnChanges adjusts a DiffResult returned from a provider to apply the ReplaceOnChange
 // settings in the desired state and init errors from the previous state.
 func applyReplaceOnChanges(diff plugin.DiffResult,
-	replaceOnChanges []string, hasInitErrors bool,
+	replaceOnChanges []property.Glob, hasInitErrors bool,
 ) (plugin.DiffResult, error) {
 	// No further work is necessary for DiffNone unless init errors are present.
 	if diff.Changes != plugin.DiffSome && !hasInitErrors {
@@ -2885,11 +2884,7 @@ func applyReplaceOnChanges(diff plugin.DiffResult,
 
 	replaceOnChangePaths := slice.Prealloc[resource.PropertyPath](len(replaceOnChanges))
 	for _, p := range replaceOnChanges {
-		path, err := resource.ParsePropertyPath(p)
-		if err != nil {
-			return diff, err
-		}
-		replaceOnChangePaths = append(replaceOnChangePaths, path)
+		replaceOnChangePaths = append(replaceOnChangePaths, resource.ToResourcePropertyPath(p))
 	}
 
 	// Calculate the new DetailedDiff
@@ -3162,7 +3157,7 @@ func (sg *stepGenerator) analyzeAll(
 		Properties: inputs,
 		Options: plugin.AnalyzerResourceOptions{
 			Protect:                 new.Protect,
-			IgnoreChanges:           goal.IgnoreChanges,
+			IgnoreChanges:           globsToStrings(goal.IgnoreChanges),
 			DeleteBeforeReplace:     goal.DeleteBeforeReplace,
 			AdditionalSecretOutputs: new.AdditionalSecretOutputs,
 			Aliases:                 new.GetAliases(),
@@ -3217,7 +3212,7 @@ func (sg *stepGenerator) AnalyzeResources() error {
 					Properties: v.Outputs,
 					Options: plugin.AnalyzerResourceOptions{
 						Protect:                 v.Protect,
-						IgnoreChanges:           v.IgnoreChanges,
+						IgnoreChanges:           globsToStrings(v.IgnoreChanges),
 						DeleteBeforeReplace:     deleteBeforeReplace,
 						AdditionalSecretOutputs: v.AdditionalSecretOutputs,
 						Aliases:                 v.GetAliases(),

--- a/pkg/resource/deploy/step_generator_test.go
+++ b/pkg/resource/deploy/step_generator_test.go
@@ -228,7 +228,9 @@ func TestIgnoreChanges(t *testing.T) {
 			d := &diag.MockSink{}
 			urn := resource.URN("urn:pulumi:dev::test::test:resource:Resource::my-resource")
 
-			processed := processIgnoreChanges(d, urn, news, olds, c.ignoreChanges)
+			ignoreChangesGlobs, err := parsePropertyGlobs(c.ignoreChanges)
+			require.NoError(t, err)
+			processed := processIgnoreChanges(d, urn, news, olds, ignoreChangesGlobs)
 			assert.Equal(t, expected, processed)
 			if c.expectMessage {
 				infomsgs := d.Messages[diag.Info]
@@ -334,7 +336,9 @@ func TestApplyReplaceOnChangesEmptyDetailedDiff(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			newdiff, err := applyReplaceOnChanges(c.diff, c.replaceOnChanges, c.hasInitErrors)
+			replaceOnChangesGlobs, err := parsePropertyGlobs(c.replaceOnChanges)
+			require.NoError(t, err)
+			newdiff, err := applyReplaceOnChanges(c.diff, replaceOnChangesGlobs, c.hasInitErrors)
 			require.NoError(t, err)
 			assert.Equal(t, c.expected, newdiff)
 		})
@@ -425,8 +429,10 @@ func TestEngineDiff(t *testing.T) {
 			t.Parallel()
 
 			d := &diag.MockSink{}
+			ignoreChangesGlobs, err := parsePropertyGlobs(c.ignoreChanges)
+			require.NoError(t, err)
 			diff, err := diffResource(
-				d, urn, id, c.oldInputs, oldOutputs, c.newInputs, &provider, allowUnknowns, c.ignoreChanges)
+				d, urn, id, c.oldInputs, oldOutputs, c.newInputs, &provider, allowUnknowns, ignoreChangesGlobs)
 			t.Logf("diff.ChangedKeys = %v", diff.ChangedKeys)
 			t.Logf("diff.StableKeys = %v", diff.StableKeys)
 			t.Logf("diff.ReplaceKeys = %v", diff.ReplaceKeys)

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/maputil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -553,12 +554,14 @@ func SerializeResource(
 		Modified:                res.Modified,
 		SourcePosition:          res.SourcePosition,
 		StackTrace:              stackTrace,
-		HideDiff:                res.HideDiff,
-		IgnoreChanges:           res.IgnoreChanges,
-		ReplaceOnChanges:        res.ReplaceOnChanges,
-		RefreshBeforeUpdate:     res.RefreshBeforeUpdate,
-		ViewOf:                  res.ViewOf,
-		ResourceHooks:           res.ResourceHooks,
+		HideDiff: slice.Map(res.HideDiff, func(g property.Glob) resource.BackCompatPropertyPath {
+			return resource.BackCompatPropertyPath(g)
+		}),
+		IgnoreChanges:       resource.BackCompatPropertyPathList(res.IgnoreChanges),
+		ReplaceOnChanges:    resource.BackCompatPropertyPathList(res.ReplaceOnChanges),
+		RefreshBeforeUpdate: res.RefreshBeforeUpdate,
+		ViewOf:              res.ViewOf,
+		ResourceHooks:       res.ResourceHooks,
 	}
 
 	if res.CustomTimeouts.IsNotEmpty() {
@@ -783,13 +786,15 @@ func DeserializeResource(res apitype.ResourceV3, dec config.Decrypter) (*resourc
 			Modified:                res.Modified,
 			SourcePosition:          res.SourcePosition,
 			StackTrace:              stackTrace,
-			IgnoreChanges:           res.IgnoreChanges,
-			HideDiff:                res.HideDiff,
-			ReplaceOnChanges:        res.ReplaceOnChanges,
-			ReplacementTrigger:      trigger,
-			RefreshBeforeUpdate:     res.RefreshBeforeUpdate,
-			ViewOf:                  res.ViewOf,
-			ResourceHooks:           res.ResourceHooks,
+			IgnoreChanges:           []property.Glob(res.IgnoreChanges),
+			HideDiff: slice.Map(res.HideDiff, func(p resource.BackCompatPropertyPath) property.Glob {
+				return property.Glob(p)
+			}),
+			ReplaceOnChanges:    []property.Glob(res.ReplaceOnChanges),
+			ReplacementTrigger:  trigger,
+			RefreshBeforeUpdate: res.RefreshBeforeUpdate,
+			ViewOf:              res.ViewOf,
+			ResourceHooks:       res.ResourceHooks,
 		}.Make(),
 		nil
 }

--- a/pkg/resource/stack/plan.go
+++ b/pkg/resource/stack/plan.go
@@ -118,7 +118,7 @@ func SerializeResourcePlan(
 			Provider:                plan.Goal.Provider,
 			PropertyDependencies:    plan.Goal.PropertyDependencies,
 			DeleteBeforeReplace:     plan.Goal.DeleteBeforeReplace,
-			IgnoreChanges:           plan.Goal.IgnoreChanges,
+			IgnoreChanges:           resource.BackCompatPropertyPathList(plan.Goal.IgnoreChanges),
 			AdditionalSecretOutputs: plan.Goal.AdditionalSecretOutputs,
 			Aliases:                 plan.Goal.Aliases,
 			ID:                      plan.Goal.ID,

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_option_hide_diffs.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_option_hide_diffs.go
@@ -16,8 +16,8 @@ package tests
 
 import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +41,7 @@ func init() {
 					require.Len(l, snap.Resources, 4, "expected 4 resources in snapshot")
 
 					hideDiffs := RequireSingleNamedResource(l, snap.Resources, "hideDiffs")
-					assert.Equal(l, []resource.PropertyPath{{"value"}}, hideDiffs.HideDiff)
+					assert.Equal(l, []property.Glob{property.MustParseGlob("value")}, hideDiffs.HideDiff)
 
 					notHideDiffs := RequireSingleNamedResource(l, snap.Resources, "notHideDiffs")
 					assert.Empty(l, notHideDiffs.HideDiff)

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_option_ignore_changes.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_option_ignore_changes.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,13 +41,15 @@ func init() {
 					require.Len(l, snap.Resources, 5, "expected 5 resources in snapshot")
 
 					receiverIgnore := RequireSingleNamedResource(l, snap.Resources, "receiverIgnore")
-					assert.Equal(l, []string{"details[0].key"}, receiverIgnore.IgnoreChanges)
+					assert.Equal(l, []property.Glob{
+						property.MustParseGlob("details[0].key"),
+					}, receiverIgnore.IgnoreChanges)
 
 					mapIgnore := RequireSingleNamedResource(l, snap.Resources, "mapIgnore")
-					assert.Equal(l, []string{
-						`tags["env"]`,
-						`tags["with.dot"]`,
-						`tags["with escaped \""]`,
+					assert.Equal(l, []property.Glob{
+						property.MustParseGlob("tags.env"),
+						property.MustParseGlob(`tags["with.dot"]`),
+						property.MustParseGlob(`tags["with escaped \""]`),
 					}, mapIgnore.IgnoreChanges)
 
 					noIgnore := RequireSingleNamedResource(l, snap.Resources, "noIgnore")

--- a/pkg/testing/pulumi-test-language/tests/provider_ignore_changes_component.go
+++ b/pkg/testing/pulumi-test-language/tests/provider_ignore_changes_component.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,9 @@ func init() {
 					require.Len(l, snap.Resources, 8, "expected 8 resources in snapshot")
 
 					withIgnore := RequireSingleNamedResource(l, snap.Resources, "withIgnoreChanges")
-					assert.Equal(l, []string{"value"}, withIgnore.IgnoreChanges,
+					assert.Equal(l, []property.Glob{
+						property.GlobFromSegments(property.NewSegment("value")),
+					}, withIgnore.IgnoreChanges,
 						"expected component with ignoreChanges to have IgnoreChanges set")
 
 					withoutIgnore := RequireSingleNamedResource(l, snap.Resources, "withoutIgnoreChanges")

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -487,11 +487,11 @@ type ResourceV3 struct {
 	// StackTrace records the stack at the time this resource was registered
 	StackTrace []StackFrameV1 `json:"stackTrace,omitempty" yaml:"stackTrace,omitempty"`
 	// IgnoreChanges is a list of properties to ignore changes for.
-	IgnoreChanges []string `json:"ignoreChanges,omitempty" yaml:"ignoreChanges,omitempty"`
+	IgnoreChanges resource.BackCompatPropertyPathList `json:"ignoreChanges,omitempty" yaml:"ignoreChanges,omitempty"`
 	// HideDiff is a list of properties to hide the diff for.
-	HideDiff []resource.PropertyPath `json:"hideDiff,omitempty" yaml:"hideDiff,omitempty"`
+	HideDiff []resource.BackCompatPropertyPath `json:"hideDiff,omitempty" yaml:"hideDiff,omitempty"`
 	// ReplaceOnChanges is a list of properties that if changed trigger a replace.
-	ReplaceOnChanges []string `json:"replaceOnChanges,omitempty" yaml:"replaceOnChanges,omitempty"`
+	ReplaceOnChanges resource.BackCompatPropertyPathList `json:"replaceOnChanges,omitempty" yaml:"replaceOnChanges,omitempty"`
 	// If set, the engine will diff this with the last recorded value, and trigger a replace if they are not equal.
 	ReplacementTrigger any `json:"replacementTrigger,omitempty" yaml:"replacementTrigger,omitempty"`
 	// RefreshBeforeUpdate indicates that this resource should always be refreshed prior to updates.

--- a/sdk/go/common/apitype/core_test.go
+++ b/sdk/go/common/apitype/core_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceV3DeserializeInvalidIgnoreChangesPath(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"urn": "urn:pulumi:stack::project::pkg:index:Type::name",
+		"type": "pkg:index:Type",
+		"ignoreChanges": ["prop["]
+	}`)
+
+	var r ResourceV3
+	require.NoError(t, json.Unmarshal(data, &r))
+	require.Empty(t, r.IgnoreChanges)
+}

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -279,7 +279,7 @@ type StepEventStateMetadata struct {
 	// InitErrors is the set of errors encountered in the process of initializing resource.
 	InitErrors []string `json:"initErrors,omitempty"`
 	// HideDiffs is the set of property paths where diffs are not displayed.
-	HideDiffs []resource.PropertyPath `json:"hideDiffs,omitempty"`
+	HideDiffs []resource.BackCompatPropertyPath `json:"hideDiffs,omitempty"`
 }
 
 // ResourcePreEvent is emitted before a resource is modified.

--- a/sdk/go/common/apitype/plan.go
+++ b/sdk/go/common/apitype/plan.go
@@ -57,7 +57,7 @@ type GoalV1 struct {
 	// true if this resource should be deleted prior to replacement.
 	DeleteBeforeReplace *bool `json:"deleteBeforeReplace,omitempty"`
 	// a list of property names to ignore during changes.
-	IgnoreChanges []string `json:"ignoreChanges,omitempty"`
+	IgnoreChanges resource.BackCompatPropertyPathList `json:"ignoreChanges,omitempty"`
 	// outputs that should always be treated as secrets.
 	AdditionalSecretOutputs []resource.PropertyKey `json:"additionalSecretOutputs,omitempty"`
 	// additional URNs that should be aliased to this resource.

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -16,14 +16,77 @@ package resource
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
+
+// BackCompatPropertyPathList represents a list of [property.Glob] that used to be represented as a list of unvalidated
+// string. It should only be used to replace a value represented as []string. If the value was represented as
+// []resource.PropertyPath, then []BackCompatPropertyPath should be used instead.
+//
+// It parses using [BackCompatPropertyPath], skipping unparsable property paths.
+type BackCompatPropertyPathList []property.Glob
+
+var _ json.Unmarshaler = (*BackCompatPropertyPathList)(nil)
+
+func (list *BackCompatPropertyPathList) UnmarshalJSON(bytes []byte) error {
+	var original []string
+	if err := json.Unmarshal(bytes, &original); err != nil {
+		return err
+	}
+	list.unmarshalFromList(original)
+	return nil
+}
+
+func (list *BackCompatPropertyPathList) UnmarshalYAML(unmarshal func(any) error) error {
+	var obj []string
+	if err := unmarshal(obj); err != nil {
+		return err
+	}
+	list.unmarshalFromList(obj)
+	return nil
+}
+
+func (list *BackCompatPropertyPathList) unmarshalFromList(src []string) {
+	(*list) = make(BackCompatPropertyPathList, 0, len(src))
+	for _, v := range src {
+		var path BackCompatPropertyPath
+		if err := path.UnmarshalText([]byte(v)); err != nil {
+			slog.Warn("discarding invalid property value", slog.String("property path", v))
+			continue
+		}
+		(*list) = append(*list, property.Glob(path))
+	}
+}
+
+// BackCompatPropertyPath represents a [property.Glob] that allows serializing non-strict property paths to avoid
+// breaking existing state. Property paths will always be re-serialized as valid [property.Glob] values.
+//
+// Invalid property paths will still error.
+type BackCompatPropertyPath property.Glob
+
+func (p BackCompatPropertyPath) MarshalText() ([]byte, error) { return property.Glob(p).MarshalText() }
+
+func (p *BackCompatPropertyPath) UnmarshalText(b []byte) error {
+	// If we are able to parse strictly, then we do so
+	if err := ((*property.Glob)(p)).UnmarshalText(b); err == nil {
+		return nil
+	}
+	var oldP PropertyPath
+	if err := oldP.UnmarshalText(b); err != nil {
+		return err
+	}
+	*p = BackCompatPropertyPath(FromResourcePropertyPath(oldP))
+	return nil
+}
 
 // PropertyPath represents a path to a nested property. The path may be composed of strings (which access properties
 // in ObjectProperty values) and integers (which access elements of ArrayProperty values).

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -19,9 +19,40 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/deepcopy"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBackCompactPropertyPathMarshal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected []property.GlobSegment
+	}{
+		{"foo", []property.GlobSegment{property.NewSegment("foo")}},
+		{"foo.bar", []property.GlobSegment{property.NewSegment("foo"), property.NewSegment("bar")}},
+		{"foo[\"bar\"]", []property.GlobSegment{property.NewSegment("foo"), property.NewSegment("bar")}},
+		{"foo.[\"bar\"]", []property.GlobSegment{property.NewSegment("foo"), property.NewSegment("bar")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			var b BackCompatPropertyPath
+			require.NoError(t, b.UnmarshalText([]byte(tt.input)))
+			assert.Equal(t, property.GlobFromSegments(tt.expected...), property.Glob(b))
+
+			marshalled, err := b.MarshalText()
+			require.NoError(t, err)
+			var g property.Glob
+			require.NoError(t, g.UnmarshalText(marshalled))
+			assert.Equal(t, property.Glob(b), g)
+		})
+	}
+}
 
 func TestPropertyPathMarshal(t *testing.T) {
 	t.Parallel()

--- a/sdk/go/common/resource/property_compatibility.go
+++ b/sdk/go/common/resource/property_compatibility.go
@@ -174,3 +174,38 @@ func FromResourcePropertyValue(v PropertyValue) property.Value {
 		return property.Value{}
 	}
 }
+
+func FromResourcePropertyPath(path PropertyPath) property.Glob {
+	var dst []property.GlobSegment
+	for _, s := range path {
+		switch s := s.(type) {
+		case int:
+			dst = append(dst, property.NewSegment(s))
+		case string:
+			if s == "*" {
+				dst = append(dst, property.Splat)
+			} else {
+				dst = append(dst, property.NewSegment(s))
+			}
+		}
+	}
+	return property.GlobFromSegments(dst...)
+}
+
+func ToResourcePropertyPath(path property.Glob) PropertyPath {
+	if path == (property.Glob{}) {
+		return nil
+	}
+	var dst PropertyPath
+	for s := range path.Segments {
+		switch s := s.(type) {
+		case property.IndexSegment:
+			dst = append(dst, s.Index())
+		case property.KeySegment:
+			dst = append(dst, s.Key())
+		case property.SplatSegment:
+			dst = append(dst, "*")
+		}
+	}
+	return dst
+}

--- a/sdk/go/common/resource/property_compatibility_test.go
+++ b/sdk/go/common/resource/property_compatibility_test.go
@@ -107,3 +107,43 @@ func TestConversionThroughGRPC(t *testing.T) {
 		})
 	}
 }
+
+func TestPropertyPathConvert(t *testing.T) {
+	t.Parallel()
+
+	// property.Glob to PropertyPath
+	//
+	// This is information preserving as long as there are no keys of "*"
+	rapid.Check(t, func(t *rapid.T) {
+		glob := pTest.Glob().Filter(func(p property.Glob) bool {
+			for s := range p.Segments {
+				if s, ok := s.(property.KeySegment); ok && s.Key() == "*" {
+					return false
+				}
+			}
+			return true
+		}).Draw(t, "source")
+		propertyPath := resource.ToResourcePropertyPath(glob)
+		glob2 := resource.FromResourcePropertyPath(propertyPath)
+
+		assert.Equal(t, glob, glob2, "intermediary path: %#v", propertyPath)
+	})
+
+	// PropertyPath to property.Glob
+	//
+	// This should always be information preserving.
+	rapid.Check(t, func(t *rapid.T) {
+		propertyPath := resource.PropertyPath(rapid.SliceOf(rapid.OneOf(
+			rapid.Map(rapid.String(), func(s string) any { return s }),
+			rapid.Map(rapid.Int().Filter(func(i int) bool { return i >= 0 }), func(i int) any { return i }),
+		)).Draw(t, "source"))
+		if len(propertyPath) == 0 {
+			propertyPath = nil
+		}
+
+		glob := resource.FromResourcePropertyPath(propertyPath)
+		propertyPath2 := resource.ToResourcePropertyPath(glob)
+
+		assert.Equal(t, propertyPath, propertyPath2, "intermediary path: %#v", glob)
+	})
+}

--- a/sdk/go/common/resource/resource_goal.go
+++ b/sdk/go/common/resource/resource_goal.go
@@ -16,6 +16,7 @@ package resource
 
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Goal is a desired state for a resource object. Normally it represents a subset of the resource's state expressed by
@@ -32,13 +33,13 @@ type Goal struct {
 	InitErrors              []string              // errors encountered as we attempted to initialize the resource.
 	PropertyDependencies    map[PropertyKey][]URN // the set of dependencies that affect each property.
 	DeleteBeforeReplace     *bool                 // true if this resource should be deleted prior to replacement.
-	IgnoreChanges           []string              // a list of property paths to ignore when diffing.
-	HideDiff                []PropertyPath        // a list of property paths to hide the diffs of.
+	IgnoreChanges           []property.Glob       // a list of property paths to ignore when diffing.
+	HideDiff                []property.Glob       // a list of property paths to hide the diffs of.
 	AdditionalSecretOutputs []PropertyKey         // outputs that should always be treated as secrets.
 	Aliases                 []Alias               // additional structured Aliases that should be assigned.
 	ID                      ID                    // the expected ID of the resource, if any.
 	CustomTimeouts          CustomTimeouts        // an optional config object for resource options
-	ReplaceOnChanges        []string              // a list of property paths that if changed should force a replacement.
+	ReplaceOnChanges        []property.Glob       // a list of property paths that if changed should force a replacement.
 	// if set, the engine will diff this with the last recorded value, and trigger a replace if they are not equal.
 	ReplacementTrigger PropertyValue
 	// if set to True, the providers Delete method will not be called for this resource.
@@ -90,7 +91,7 @@ type NewGoal struct {
 	DeleteBeforeReplace *bool // required
 
 	// a list of property paths to ignore when diffing.
-	IgnoreChanges []string // required
+	IgnoreChanges []property.Glob // required
 
 	// outputs that should always be treated as secrets.
 	AdditionalSecretOutputs []PropertyKey // required
@@ -105,7 +106,7 @@ type NewGoal struct {
 	CustomTimeouts *CustomTimeouts // required
 
 	// a list of property paths that if changed should force a replacement.
-	ReplaceOnChanges []string // required
+	ReplaceOnChanges []property.Glob // required
 
 	// if set, the engine will diff this with the last recorded value, and trigger a replace if they are not equal.
 	ReplacementTrigger PropertyValue // required
@@ -131,7 +132,7 @@ type NewGoal struct {
 	ResourceHooks map[HookType][]string // required
 
 	// If set, the list of property paths to hide the diff output of.
-	HideDiff []PropertyPath // required
+	HideDiff []property.Glob // required
 }
 
 // Make consumes the NewGoal to create a *Goal.

--- a/sdk/go/common/resource/resource_state.go
+++ b/sdk/go/common/resource/resource_state.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // State is a structure containing state associated with a resource. This resource may have been serialized and
@@ -63,10 +64,10 @@ type State struct {
 	Modified                *time.Time            // If set, the time when the state was last modified in the state file.
 	SourcePosition          string                // If set, the source location of the resource registration
 	StackTrace              []StackFrame          // If set, the stack trace at time of registration
-	IgnoreChanges           []string              // If set, the list of properties to ignore changes for.
-	ReplaceOnChanges        []string              // If set, the list of properties that if changed trigger a replace.
+	IgnoreChanges           []property.Glob       // If set, the list of properties to ignore changes for.
+	ReplaceOnChanges        []property.Glob       // If set, the list of properties that if changed trigger a replace.
 	ReplacementTrigger      PropertyValue         // If set, the engine will diff this with the last recorded value, and trigger a replace if they are not equal.
-	HideDiff                []PropertyPath        // If set, the list of property paths to compact the diff for.
+	HideDiff                []property.Glob       // If set, the list of property paths to compact the diff for.
 	RefreshBeforeUpdate     bool                  // true if this resource should always be refreshed prior to updates.
 	ViewOf                  URN                   // If set, the URN of the resource this resource is a view of.
 	ResourceHooks           map[HookType][]string // The resource hooks attached to the resource, by type.
@@ -222,16 +223,16 @@ type NewState struct {
 	StackTrace []StackFrame // required
 
 	// If set, the list of properties to ignore changes for.
-	IgnoreChanges []string // required
+	IgnoreChanges []property.Glob // required
 
 	// If set, the list of properties that if changed trigger a replace.
-	ReplaceOnChanges []string // required
+	ReplaceOnChanges []property.Glob // required
 
 	// If set, the engine will diff this with the last recorded value, and trigger a replace if they are not equal.
 	ReplacementTrigger PropertyValue // required
 
 	// If set, the list of properties that should have their diff suppressed.
-	HideDiff []PropertyPath // required
+	HideDiff []property.Glob // required
 
 	// true if this resource should always be refreshed prior to updates.
 	RefreshBeforeUpdate bool // required

--- a/sdk/go/property/glob.go
+++ b/sdk/go/property/glob.go
@@ -32,6 +32,17 @@ func GlobFromSegments(segments ...GlobSegment) Glob {
 	return Glob{pathReprFromSegments(segments)}
 }
 
+// MustParseGlob parses text into a [Glob], panicking on parse errors.
+//
+// It is intended for tests and other contexts where the input is a known-good literal.
+func MustParseGlob(text string) Glob {
+	var g Glob
+	if err := g.UnmarshalText([]byte(text)); err != nil {
+		panic(err)
+	}
+	return g
+}
+
 var (
 	_ encoding.TextMarshaler   = Glob{}
 	_ encoding.TextUnmarshaler = &Glob{}
@@ -220,7 +231,7 @@ func (g Glob) Get(v Value) (map[Path]Value, error) {
 			e := stack[i]
 			var expansion []entry
 			switch segment := segment.(type) {
-			case splat:
+			case SplatSegment:
 				switch {
 				case e.val.IsMap():
 					for k, v := range e.val.AsMap().AllStable {
@@ -285,15 +296,15 @@ var (
 	_ GlobSegment = IndexSegment{}
 )
 
-var Splat splat
+var Splat SplatSegment
 
-type splat struct{}
+type SplatSegment struct{}
 
-func (splat) GoString() string          { return "property.Splat" }
+func (SplatSegment) GoString() string   { return "property.Splat" }
 func (s KeySegment) GoString() string   { return fmt.Sprintf("property.NewSegment(%q)", s.string) }
 func (i IndexSegment) GoString() string { return fmt.Sprintf("property.NewSegment(%d)", i.i) }
 
-func (splat) globApply(v Value) ([]Value, PathApplyFailure) {
+func (SplatSegment) globApply(v Value) ([]Value, PathApplyFailure) {
 	switch {
 	case v.IsMap():
 		values := make([]Value, 0, v.AsMap().Len())
@@ -352,7 +363,7 @@ func (g Glob) Matches(p Path) bool {
 				continue
 			}
 			return false
-		case splat:
+		case SplatSegment:
 			continue
 		default:
 			contract.Failf("invalid glob segment %T", gp)

--- a/sdk/go/property/glob_test.go
+++ b/sdk/go/property/glob_test.go
@@ -193,6 +193,24 @@ func TestGlobEncoding(t *testing.T) {
 	})
 }
 
+func TestMustParseGlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t,
+			GlobFromSegments(KeySegment{"x"}, Splat),
+			MustParseGlob("x.*"))
+	})
+
+	t.Run("panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithError(t, "cannot unmarshal an empty property path", func() {
+			MustParseGlob("")
+		})
+	})
+}
+
 func TestMatches(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/property/path.go
+++ b/sdk/go/property/path.go
@@ -38,6 +38,17 @@ func PathFromSegments(segments ...PathSegment) Path {
 	return Path{pathReprFromSegments(segments), struct{}{}}
 }
 
+// MustParsePath parses text into a [Path], panicking on parse errors.
+//
+// It is intended for tests and other contexts where the input is a known-good literal.
+func MustParsePath(text string) Path {
+	var p Path
+	if err := p.UnmarshalText([]byte(text)); err != nil {
+		panic(err)
+	}
+	return p
+}
+
 var (
 	_ encoding.TextMarshaler   = Path{}
 	_ encoding.TextUnmarshaler = &Path{}
@@ -54,7 +65,7 @@ func (p *Path) UnmarshalText(text []byte) error {
 	}
 	*p = Path{}
 	for v := range g.segments {
-		if _, ok := v.(splat); ok {
+		if _, ok := v.(SplatSegment); ok {
 			return errors.New("splat not allowed in non-glob paths")
 		}
 	}

--- a/sdk/go/property/path_repr.go
+++ b/sdk/go/property/path_repr.go
@@ -37,7 +37,7 @@ func (p pathRepr) appendGlobSegment(segment GlobSegment) pathRepr {
 		return p.appendKey(segment.string)
 	case IndexSegment:
 		return p.appendIndex(segment.i)
-	case splat:
+	case SplatSegment:
 		return p.appendSplat()
 	default:
 		contract.Failf("unexpected glob segment %T", segment)
@@ -74,7 +74,7 @@ func pathReprFromSegments[S any](segments []S) (ret pathRepr) {
 			ret = ret.appendKey(s.string)
 		case IndexSegment:
 			ret = ret.appendIndex(s.i)
-		case splat:
+		case SplatSegment:
 			ret = ret.appendSplat()
 		default:
 			contract.Failf("unknown segment type %T", s)

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -307,3 +307,21 @@ func TestAlter(t *testing.T) {
 		})
 	}
 }
+
+func TestMustParsePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t,
+			property.PathFromSegments(property.NewSegment("x"), property.NewSegment(0)),
+			property.MustParsePath("x[0]"))
+	})
+
+	t.Run("panics", func(t *testing.T) {
+		t.Parallel()
+		assert.PanicsWithError(t, "splat not allowed in non-glob paths", func() {
+			property.MustParsePath("x.*")
+		})
+	})
+}

--- a/sdk/go/property/testing/rapid.go
+++ b/sdk/go/property/testing/rapid.go
@@ -106,3 +106,15 @@ func URN() *rapid.Generator[urn.URN] {
 		return urn.URN(rapid.String().Draw(t, "urn-body"))
 	})
 }
+
+func Glob() *rapid.Generator[property.Glob] {
+	return rapid.Map(rapid.SliceOf(rapid.OneOf(
+		rapid.Just[property.GlobSegment](property.Splat),
+		rapid.Map(rapid.String(), func(s string) property.GlobSegment {
+			return property.NewSegment(s)
+		}),
+		rapid.Map(rapid.Int().Filter(func(i int) bool { return i >= 0 }), func(s int) property.GlobSegment {
+			return property.NewSegment(s)
+		}),
+	)), func(s []property.GlobSegment) property.Glob { return property.GlobFromSegments(s...) })
+}


### PR DESCRIPTION
Reverts pulumi/pulumi#22801

This re-applies #22695, but without the strict parsing of user input. This is a refactor more then the user-facing break-change that #22801 was intended to be.