### PR TITLE
Hard-code the HCL converter repo

### DIFF
--- a/changelog/pending/20260504--cli--auto-install-hcl-converter.yaml
+++ b/changelog/pending/20260504--cli--auto-install-hcl-converter.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Automatically install the `hcl` converter from pulumi-labs/pulumi-hcl when running `pulumi convert --from hcl`

--- a/pkg/cmd/pulumi/convert/io.go
+++ b/pkg/cmd/pulumi/convert/io.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -37,11 +36,6 @@ func LoadConverterPlugin(
 	pluginSpec, err := workspace.NewPluginDescriptor(ctx.Request(), name, apitype.ConverterPlugin, nil, "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("could not load converter plugin: %w", err)
-	}
-
-	if versionSet := util.SetKnownPluginVersion(&pluginSpec); versionSet {
-		ctx.Diag.Infof(
-			diag.Message("", "Using version %s for pulumi-converter-%s"), pluginSpec.Version, pluginSpec.Name)
 	}
 
 	// Try and load the converter plugin for this

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -166,7 +166,6 @@ func (w Workspace) DownloadPlugin(
 	defer span.End()
 
 	util.SetKnownPluginDownloadURL(&pluginSpec)
-	util.SetKnownPluginVersion(&pluginSpec)
 	if pluginSpec.Version == nil {
 		var err error
 		pluginSpec.Version, err = pluginstorage.Instance.GetLatestVersion(ctx, pluginSpec)

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -16,11 +16,9 @@
 package util
 
 import (
-	"runtime/debug"
+	"slices"
 
-	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -33,38 +31,19 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 	}
 
 	if spec.Kind == apitype.ResourcePlugin {
-		for _, plugin := range pulumiversePlugins {
-			if spec.Name == plugin {
-				spec.PluginDownloadURL = "github://api.github.com/pulumiverse"
-				return true
-			}
+		if slices.Contains(pulumiversePlugins, spec.Name) {
+			spec.PluginDownloadURL = "github://api.github.com/pulumiverse"
+			return true
 		}
 	}
 
-	return false
-}
-
-// SetKnownPluginVersion sets the Version for the given PluginSpec if it's a known plugin.
-// Returns true if it filled in the version.
-func SetKnownPluginVersion(spec *workspace.PluginDescriptor) bool {
-	// If the version is already set don't touch it
-	if spec.Version != nil {
-		return false
-	}
-
-	if spec.Kind == apitype.ConverterPlugin && spec.Name == "yaml" {
-		// By default use the version of yaml we've linked to. N.B. This has to be tested manually because
-		// ReadBuildInfo doesn't return anything in test builds (https://github.com/golang/go/issues/33976).
-		info, ok := debug.ReadBuildInfo()
-		contract.Assertf(ok, "expected to be able to read build info")
-		for _, dep := range info.Deps {
-			if dep.Path == "github.com/pulumi/pulumi-yaml" {
-				v, err := semver.ParseTolerant(dep.Version)
-				contract.AssertNoErrorf(err, "expected to be able to parse version for yaml got %q", dep.Version)
-				spec.Version = &v
-				return true
-			}
-		}
+	if spec.Kind == apitype.ConverterPlugin && spec.Name == "hcl" {
+		// The HCL converter lives in the pulumi-labs org rather than pulumi, and at a repository
+		// name (pulumi-hcl) that doesn't match the default pulumi-converter-<name> convention. We
+		// encode both pieces of information here so the auto-install machinery resolves the right
+		// release artifact.
+		spec.PluginDownloadURL = "github://api.github.com/pulumi-labs/pulumi-hcl"
+		return true
 	}
 
 	return false

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -70,7 +70,6 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 	newLoader plugin.NewLoaderFunc,
 ) (*semver.Version, error) {
 	util.SetKnownPluginDownloadURL(&pluginSpec)
-	util.SetKnownPluginVersion(&pluginSpec)
 	if pluginSpec.Version == nil {
 		var err error
 		pluginSpec.Version, err = pluginstorage.Instance.GetLatestVersion(ctx, pluginSpec)


### PR DESCRIPTION
Ensure the Pulumi HCL converter can be automatically installed.

As cleanup, I have removed `SetKnownPluginVersion` since it doesn't do anything: we don't link in `pulumi-yaml` so `debug.ReadBuildInfo()` doesn't contain "github.com/pulumi/pulumi-yaml" and we never set a version.