### PR TITLE
use macos-latest runners for download pulumi cron

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   macos-homebrew-install:
     name: Install Pulumi with Homebrew on macOS
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       # Workaround for https://github.com/pulumi/pulumi/issues/13938
       - name: Delete default golang installed on the runner
@@ -36,7 +36,7 @@ jobs:
           exit 1
   macOS-direct-install:
     name: Install Pulumi via script on macOS
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - run: curl -fsSL https://get.pulumi.com | sh
       - run: echo "/Users/runner/.pulumi/bin" >> "${GITHUB_PATH}"
@@ -53,7 +53,7 @@ jobs:
           exit 1
   macos-verify-download-link:
     name: Verify Direct Download link on macOS
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Direct Download
         run: curl -L -o pulumi.tar.gz "https://get.pulumi.com/releases/sdk/pulumi-v$(curl -sS https://www.pulumi.com/latest-version)-darwin-x64.tar.gz"
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-13"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     steps:
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@v1.0.1


### PR DESCRIPTION
This job has been silently timing out since April 13th, because it can't find macos-13 runners. They are probably deprecated, though I didn't check.  Replace the runners with macos-latest, rather than pinning them, because it's easy to forget about this, as we have here.
