### PR TITLE
neo: honor agent shell timeouts and kill orphaned children

### DIFF
--- a/changelog/pending/20260504--cli--neo-shell-honors-agent-timeout-and-kills-orphaned-children.yaml
+++ b/changelog/pending/20260504--cli--neo-shell-honors-agent-timeout-and-kills-orphaned-children.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix the `pulumi neo` shell tool to honor the agent-supplied `timeout` and to terminate the whole process tree (and unblock cmd.Wait) when the deadline fires, so commands like `kubectl logs -f` no longer hang Neo indefinitely.

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -200,7 +200,16 @@ func (s *Session) invokeToolCall(
 	value, err := handler.Invoke(ctx, method, call.Args)
 	if err != nil {
 		res.IsError = true
-		res.Content = map[string]string{"error": err.Error()}
+		// A handler may return both a partial value and an error (e.g. shell
+		// timeout returns the captured stdout/stderr along with a deadline
+		// error). Prefer the partial value as Content so the agent can read
+		// what was captured; fall back to a synthetic {"error": msg} payload
+		// when the handler has nothing to surface.
+		if value != nil {
+			res.Content = value
+		} else {
+			res.Content = map[string]string{"error": err.Error()}
+		}
 		return res
 	}
 	res.Content = value

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -200,11 +200,8 @@ func (s *Session) invokeToolCall(
 	value, err := handler.Invoke(ctx, method, call.Args)
 	if err != nil {
 		res.IsError = true
-		// A handler may return both a partial value and an error (e.g. shell
-		// timeout returns the captured stdout/stderr along with a deadline
-		// error). Prefer the partial value as Content so the agent can read
-		// what was captured; fall back to a synthetic {"error": msg} payload
-		// when the handler has nothing to surface.
+		// Handlers may return a partial value alongside an error (e.g. shell
+		// timeout). Prefer that value so the agent sees what was captured.
 		if value != nil {
 			res.Content = value
 		} else {

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -457,6 +457,30 @@ func TestSession_InvokeToolCallHandlerError(t *testing.T) {
 	assert.Equal(t, "boom", item.Content.(map[string]string)["error"])
 }
 
+func TestSession_InvokeToolCallHandlerErrorWithPartialValue(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the shell-timeout case: the handler returns a partial result map
+	// AND a non-nil error. The dispatch layer must flip IsError (so the TUI
+	// shows the failure marker) but keep the partial result as Content so the
+	// agent can still read whatever stdout/stderr was captured before the
+	// deadline fired.
+	partial := map[string]any{"stdout": "hi\n", "timed_out": true, "exit_code": -1}
+	s := &Session{
+		Handlers: map[string]ToolHandler{
+			"shell": &fakeHandler{
+				wantMethod: "shell_execute",
+				result:     partial,
+				err:        errors.New("shell command timed out after 100ms"),
+			},
+		},
+	}
+	item := s.invokeToolCall(t.Context(), apitype.AgentBackendEventToolCall{ToolCallID: "c", Name: "shell__shell_execute"})
+
+	assert.True(t, item.IsError)
+	assert.Equal(t, partial, item.Content)
+}
+
 // errStreamer fails at StreamNeoTaskEvents so the Run loop returns immediately.
 type errStreamer struct{ err error }
 

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -150,8 +150,7 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 	// pipe open, hanging cmd.Wait() indefinitely.
 	cmdutil.RegisterProcessGroup(cmd)
 	cmd.Cancel = func() error {
-		_ = cmdutil.KillChildren(cmd.Process.Pid)
-		return cmd.Process.Kill()
+		return errors.Join(cmdutil.KillChildren(cmd.Process.Pid), cmd.Process.Kill())
 	}
 	// Even after the tree is killed, a grandchild that inherited stdout/stderr
 	// may keep the pipes open. WaitDelay forces cmd.Wait to return after this

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -24,11 +24,14 @@ import (
 	"os/exec"
 	"runtime"
 	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
 // Shell is the local handler for the Neo `shell` tool. The cloud agent exposes a single
 // method named `shell_execute` (see pulumi-service:cmd/agents/src/agents_py/mcp/shell_mcp.py)
-// with arguments `{command: string, cwd?: string}`. If cwd is supplied it must resolve
+// with arguments `{command: string, cwd?: string, timeout?: number}`. timeout is in
+// seconds; 0 or omitted falls back to DefaultTimeout. If cwd is supplied it must resolve
 // under one of the allowed roots (Cwd or any extras passed to NewShell, e.g. /tmp);
 // otherwise the request is rejected.
 type Shell struct {
@@ -72,8 +75,9 @@ func (s *Shell) Invoke(ctx context.Context, method string, args json.RawMessage)
 		return nil, fmt.Errorf("unknown shell method %q", method)
 	}
 	var p struct {
-		Command string `json:"command"`
-		Cwd     string `json:"cwd,omitempty"`
+		Command string  `json:"command"`
+		Cwd     string  `json:"cwd,omitempty"`
+		Timeout float64 `json:"timeout,omitempty"` // seconds; 0 or omitted = DefaultTimeout
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return nil, fmt.Errorf("decoding shell_execute args: %w", err)
@@ -81,11 +85,18 @@ func (s *Shell) Invoke(ctx context.Context, method string, args json.RawMessage)
 	if p.Command == "" {
 		return nil, errors.New("shell_execute requires a non-empty command")
 	}
+	if p.Timeout < 0 {
+		return nil, fmt.Errorf("shell_execute timeout must be non-negative, got %g", p.Timeout)
+	}
+	timeout := s.DefaultTimeout
+	if p.Timeout > 0 {
+		timeout = time.Duration(p.Timeout * float64(time.Second))
+	}
 	dir, err := s.resolveDir(p.Cwd)
 	if err != nil {
 		return nil, err
 	}
-	return s.run(ctx, p.Command, dir)
+	return s.run(ctx, p.Command, dir, timeout)
 }
 
 // resolveDir validates that dir is under one of the allowed roots. An empty dir
@@ -121,8 +132,8 @@ func (c *cappedBuffer) Write(p []byte) (int, error) {
 	return c.buf.Write(p)
 }
 
-func (s *Shell) run(ctx context.Context, command string, dir string) (any, error) {
-	runCtx, cancel := context.WithTimeout(ctx, s.DefaultTimeout)
+func (s *Shell) run(ctx context.Context, command string, dir string, timeout time.Duration) (any, error) {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	var cmd *exec.Cmd
@@ -132,6 +143,23 @@ func (s *Shell) run(ctx context.Context, command string, dir string) (any, error
 		cmd = exec.CommandContext(runCtx, "sh", "-c", command)
 	}
 	cmd.Dir = dir
+
+	// Run the command in its own process group so we can SIGKILL the whole tree
+	// (and not just sh) when the deadline fires; without this, long-running
+	// children like `kubectl logs -f` outlive sh and keep the inherited stdout
+	// pipe open, hanging cmd.Wait() indefinitely.
+	cmdutil.RegisterProcessGroup(cmd)
+	cmd.Cancel = func() error {
+		// On Unix this sends SIGKILL to the whole process group (including the
+		// leader); on Windows it kills direct children. The trailing
+		// Process.Kill covers the Windows root and is a harmless no-op on Unix.
+		_ = cmdutil.KillChildren(cmd.Process.Pid)
+		return cmd.Process.Kill()
+	}
+	// Even after the tree is killed, a grandchild that inherited stdout/stderr
+	// may keep the pipes open. WaitDelay forces cmd.Wait to return after this
+	// grace period instead of blocking forever on the inherited pipes.
+	cmd.WaitDelay = 5 * time.Second
 
 	stdout := &cappedBuffer{limit: maxOutputBytes}
 	stderr := &cappedBuffer{limit: maxOutputBytes}
@@ -153,11 +181,19 @@ func (s *Shell) run(ctx context.Context, command string, dir string) (any, error
 			result["error"] = err.Error()
 		}
 	}
-	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+	timedOut := errors.Is(runCtx.Err(), context.DeadlineExceeded)
+	if timedOut {
 		result["timed_out"] = true
 	}
 	if stdout.truncated || stderr.truncated {
 		result["truncated"] = true
+	}
+	if timedOut {
+		// Returning a non-nil error alongside the partial result lets the session
+		// dispatch layer mark the tool call as failed (IsError=true → red dot in
+		// the TUI, retry signal to the agent) while still surfacing the captured
+		// stdout/stderr and exit_code in Content.
+		return result, fmt.Errorf("shell command timed out after %s", timeout)
 	}
 	return result, nil
 }

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -77,7 +77,7 @@ func (s *Shell) Invoke(ctx context.Context, method string, args json.RawMessage)
 	var p struct {
 		Command string  `json:"command"`
 		Cwd     string  `json:"cwd,omitempty"`
-		Timeout float64 `json:"timeout,omitempty"` // seconds; 0 or omitted = DefaultTimeout
+		Timeout float64 `json:"timeout,omitempty"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return nil, fmt.Errorf("decoding shell_execute args: %w", err)
@@ -150,9 +150,6 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 	// pipe open, hanging cmd.Wait() indefinitely.
 	cmdutil.RegisterProcessGroup(cmd)
 	cmd.Cancel = func() error {
-		// On Unix this sends SIGKILL to the whole process group (including the
-		// leader); on Windows it kills direct children. The trailing
-		// Process.Kill covers the Windows root and is a harmless no-op on Unix.
 		_ = cmdutil.KillChildren(cmd.Process.Pid)
 		return cmd.Process.Kill()
 	}
@@ -181,18 +178,11 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 			result["error"] = err.Error()
 		}
 	}
-	timedOut := errors.Is(runCtx.Err(), context.DeadlineExceeded)
-	if timedOut {
-		result["timed_out"] = true
-	}
 	if stdout.truncated || stderr.truncated {
 		result["truncated"] = true
 	}
-	if timedOut {
-		// Returning a non-nil error alongside the partial result lets the session
-		// dispatch layer mark the tool call as failed (IsError=true → red dot in
-		// the TUI, retry signal to the agent) while still surfacing the captured
-		// stdout/stderr and exit_code in Content.
+	if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result["timed_out"] = true
 		return result, fmt.Errorf("shell command timed out after %s", timeout)
 	}
 	return result, nil

--- a/pkg/cmd/pulumi/neo/tools/shell_test.go
+++ b/pkg/cmd/pulumi/neo/tools/shell_test.go
@@ -53,8 +53,78 @@ func TestShell_ExecuteHonorsTimeout(t *testing.T) {
 	require.NoError(t, err)
 	sh.DefaultTimeout = 50 * time.Millisecond
 	res, err := sh.Invoke(t.Context(), "shell_execute", json.RawMessage(`{"command":"sleep 5"}`))
-	require.NoError(t, err)
+	require.Error(t, err, "timeout must surface as a non-nil error so the TUI marks the call failed")
+	assert.Contains(t, err.Error(), "timed out")
+	require.NotNil(t, res, "partial result must still be returned alongside the timeout error")
 	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+}
+
+func TestShell_ExecuteHonorsAgentTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh semantics")
+	}
+	t.Parallel()
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	start := time.Now()
+	res, err := sh.Invoke(t.Context(), "shell_execute",
+		json.RawMessage(`{"command":"sleep 5","timeout":0.1}`))
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.Less(t, time.Since(start), 5*time.Second, "agent-supplied timeout was ignored")
+}
+
+func TestShell_ExecuteAgentTimeoutOverridesDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh semantics")
+	}
+	t.Parallel()
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	sh.DefaultTimeout = time.Hour // way longer than the agent value below
+	start := time.Now()
+	res, err := sh.Invoke(t.Context(), "shell_execute",
+		json.RawMessage(`{"command":"sleep 5","timeout":0.1}`))
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	assert.Less(t, time.Since(start), 5*time.Second, "agent timeout did not override DefaultTimeout")
+}
+
+func TestShell_ExecuteUnblocksOnOrphanedChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh semantics")
+	}
+	t.Parallel()
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	// `sleep 30 &; wait` keeps a grandchild holding the inherited stdout/stderr
+	// pipes open well past the deadline. Without process-group kill +
+	// WaitDelay, cmd.Run() blocks for the full 30s instead of returning when
+	// the timeout fires.
+	start := time.Now()
+	res, err := sh.Invoke(t.Context(), "shell_execute",
+		json.RawMessage(`{"command":"sleep 30 & wait","timeout":0.2}`))
+	require.Error(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, true, res.(map[string]any)["timed_out"])
+	// Allow generous slack for the WaitDelay grace period (5s) plus CI noise.
+	assert.Less(t, time.Since(start), 15*time.Second, "shell hung on orphaned child")
+}
+
+func TestShell_ExecuteRejectsNegativeTimeout(t *testing.T) {
+	t.Parallel()
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	_, err = sh.Invoke(t.Context(), "shell_execute",
+		json.RawMessage(`{"command":"echo hi","timeout":-1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-negative")
 }
 
 func TestShell_ExecuteCapturesNonZeroExit(t *testing.T) {


### PR DESCRIPTION
Fixes pulumi/pulumi-service#42480.

## Summary

Two compounding bugs in the `pulumi neo` `shell_execute` tool caused long-running commands like `kubectl logs -f` to hang Neo indefinitely, and a third bug rendered the resulting tool call with a green (success) marker even when it had timed out:

1. **Agent-supplied `timeout` was dropped.** `Shell.Invoke`'s argument struct only declared `command` and `cwd`, so any `timeout` field on the JSON args was silently discarded. Every call ran with the hard-coded 2-minute `DefaultTimeout`.
2. **The default timeout didn't actually unblock the call.** `exec.CommandContext` SIGKILLed `sh -c \"...\"` when the deadline fired, but children inherited the stdout/stderr pipes and kept them open, so `cmd.Wait()` blocked forever.
3. **Timeouts rendered green in the TUI.** `Shell.Invoke` returned `(result, nil)` on timeout — the `timed_out: true` flag lived only inside the result map. `session.invokeToolCall` only flips `IsError` when `err != nil`, so the TUI saw the call as successful and drew `toolOKMarker` instead of `toolErrMarker`.

### Changes

- `tools/shell.go`: parse `timeout` (seconds, JSON number) into the args struct; reject negatives; fall back to `DefaultTimeout` when 0/omitted; no upper cap.
- `tools/shell.go`: register a process group via `cmdutil.RegisterProcessGroup` and SIGKILL the whole tree on cancel; set `cmd.WaitDelay = 5s` so `cmd.Wait()` returns even when grandchildren keep the inherited pipes open.
- `tools/shell.go`: return a non-nil error alongside the partial result on timeout so callers can distinguish failure from success.
- `session.go`: when a handler returns both a value and an error, keep the partial value as `Content` (so the agent still sees captured stdout/stderr/exit_code) while flipping `IsError` so the TUI renders the failure marker.

## Test plan

- [x] `make lint` clean.
- [x] All `TestShell_*` and `TestSession_InvokeToolCall*` tests pass; new regression tests:
  - `TestShell_ExecuteHonorsAgentTimeout` — agent-supplied `timeout: 0.1` is honored.
  - `TestShell_ExecuteAgentTimeoutOverridesDefault` — agent value beats `DefaultTimeout = 1h`.
  - `TestShell_ExecuteUnblocksOnOrphanedChild` — `sleep 30 & wait` returns within ~5s of deadline (was: hung for full 30s).
  - `TestShell_ExecuteRejectsNegativeTimeout` — negative timeout surfaces as a clear error.
  - `TestSession_InvokeToolCallHandlerErrorWithPartialValue` — handler returning (value, err) flips `IsError` while keeping the partial value as `Content`.
- [ ] Manual: confirm the wire format on the agent side is in fact a JSON number of seconds (the bug report quoted `timeout: 120s` — I read this as numeric, but `shell_mcp.py` should be checked). If the agent sends a string or millis, the field will silently fall back to default again.
- [ ] Manual: in a real Neo session, run `kubectl logs -f <pod>`; verify the tool call returns within the agent-supplied timeout, the TUI shows the failure (red) marker, and `pgrep kubectl` reports no orphan.
- [ ] Manual: omit `timeout`; confirm the 2-min default still applies to long-running commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)