### PR TITLE
fix(cli/neo): cancel shared context on TUI exit so process terminates

### DIFF
--- a/changelog/pending/20260504--cli-neo--exit-cleanly-on-double-ctrl-c.yaml
+++ b/changelog/pending/20260504--cli-neo--exit-cleanly-on-double-ctrl-c.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Exit cleanly when the user presses Ctrl+C twice in `pulumi neo` instead of hanging until a third press

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -266,39 +266,23 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 			// any task exists — the first one creates it. Other event types (approvals
 			// and anything we add later) only make sense once a task is live.
 			g.Go(func() error {
-				taskCreated := prompt != ""
-				for {
-					select {
-					case <-gctx.Done():
-						return nil
-					case ob, ok := <-outCh:
-						if !ok {
-							return nil
-						}
-						if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
-							taskCreated = true
-							planMode := ob.planMode
-							g.Go(func() error {
-								return createTask(msg.Content, planMode)
-							})
-							continue
-						}
+				return dispatchUserEvents(
+					gctx, outCh, uiCh,
+					prompt != "",
+					func() string {
 						ts.mu.Lock()
-						taskID := ts.taskID
-						ts.mu.Unlock()
-						if taskID == "" {
-							// Unreachable in normal use: the TUI gates Enter on busy state
-							// until UITaskIdle, and approvals only fire in response to backend
-							// events that imply the task exists. Surface instead of silently
-							// dropping.
-							sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
-							continue
-						}
-						if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, ob.event); err != nil {
-							sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
-						}
-					}
-				}
+						defer ts.mu.Unlock()
+						return ts.taskID
+					},
+					func(message string, planMode bool) {
+						g.Go(func() error {
+							return createTask(message, planMode)
+						})
+					},
+					func(ctx context.Context, taskID string, body any) error {
+						return pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
+					},
+				)
 			})
 		},
 	)
@@ -335,6 +319,59 @@ func runWithTUI(
 	})
 
 	return g.Wait()
+}
+
+// dispatchUserEvents drives the runNeo dispatcher loop: it reads TUI-originated
+// user events from outCh, posts them to the backend once a task exists, and
+// lazily creates the task on the first user_message when no initial prompt was
+// provided. The function returns when ctx is cancelled or outCh is closed.
+//
+// Extracted from runNeo so each branch (lazy creation, taskID-not-ready
+// warning, post error) can be unit-tested without standing up the full
+// interactive machinery.
+//
+// initialTaskCreated reflects whether the caller has already kicked off
+// CreateNeoTask (true when runNeo was given a CLI prompt, false when it must
+// wait for the user's first chat message). spawnCreateTask is invoked when the
+// lazy path triggers; the caller wires it to its own goroutine orchestration
+// (the production caller spawns into the runWithTUI errgroup).
+func dispatchUserEvents(
+	ctx context.Context,
+	outCh <-chan outboundEvent,
+	uiCh chan<- UIEvent,
+	initialTaskCreated bool,
+	getTaskID func() string,
+	spawnCreateTask func(message string, planMode bool),
+	postEvent func(ctx context.Context, taskID string, body any) error,
+) error {
+	taskCreated := initialTaskCreated
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ob, ok := <-outCh:
+			if !ok {
+				return nil
+			}
+			if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
+				taskCreated = true
+				spawnCreateTask(msg.Content, ob.planMode)
+				continue
+			}
+			taskID := getTaskID()
+			if taskID == "" {
+				// Unreachable in normal use: the TUI gates Enter on busy state
+				// until UITaskIdle, and approvals only fire in response to backend
+				// events that imply the task exists. Surface instead of silently
+				// dropping.
+				sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
+				continue
+			}
+			if err := postEvent(ctx, taskID, ob.event); err != nil {
+				sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
+			}
+		}
+	}
 }
 
 // resolveTaskTarget figures out the org, project, and stack name to attach to the new Neo

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -197,6 +197,12 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := tea.NewProgram(model)
 
+	// errgroup.WithContext only cancels gctx on a non-nil error or parent
+	// cancellation; tea.Quit returns nil, so without an explicit cancel the
+	// session and dispatcher goroutines keep running and g.Wait() blocks.
+	ctx, cancelAll := context.WithCancel(ctx)
+	defer cancelAll()
+
 	g, gctx := errgroup.WithContext(ctx)
 
 	// taskState tracks the task ID once created (may be deferred if no prompt).
@@ -249,6 +255,10 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	g.Go(func() error {
 		_, err := p.Run()
+		// Cancel the shared context so session.Run and the outbound
+		// dispatcher exit and g.Wait() can return; otherwise the process
+		// would hang after the TUI tears down the terminal.
+		cancelAll()
 		return err
 	})
 

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -197,9 +197,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := tea.NewProgram(model)
 
-	// errgroup.WithContext only cancels gctx on a non-nil error or parent
-	// cancellation; tea.Quit returns nil, so without an explicit cancel the
-	// session and dispatcher goroutines keep running and g.Wait() blocks.
+	// errgroup only cancels gctx on a non-nil error, but tea.Quit returns
+	// nil — without an explicit cancel, session.Run and the dispatcher
+	// keep blocking and g.Wait() hangs.
 	ctx, cancelAll := context.WithCancel(ctx)
 	defer cancelAll()
 
@@ -255,9 +255,6 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	g.Go(func() error {
 		_, err := p.Run()
-		// Cancel the shared context so session.Run and the outbound
-		// dispatcher exit and g.Wait() can return; otherwise the process
-		// would hang after the TUI tears down the terminal.
 		cancelAll()
 		return err
 	})

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -197,105 +197,131 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := tea.NewProgram(model)
 
-	// errgroup only cancels gctx on a non-nil error, but tea.Quit returns
-	// nil — without an explicit cancel, session.Run and the dispatcher
-	// keep blocking and g.Wait() hangs.
+	return runWithTUI(
+		ctx,
+		func() error {
+			_, err := p.Run()
+			return err
+		},
+		func(g *errgroup.Group, gctx context.Context) {
+			// taskState tracks the task ID once created (may be deferred if no prompt).
+			type taskState struct {
+				mu     sync.Mutex
+				taskID string
+			}
+			ts := &taskState{}
+
+			// createTask creates the Neo task with the given prompt and starts the session.
+			// Called immediately if a prompt was provided, or on the first user message.
+			// planMode is the value the TUI captured at the moment the first message was
+			// sent; the CLI-prompt path always passes false.
+			createTask := func(initialPrompt string, planMode bool) error {
+				resp, err := pc.CreateNeoTask(
+					gctx, orgName, initialPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
+						ToolExecutionMode: "cli",
+						ApprovalMode:      client.NeoApprovalModeManual,
+						PlanMode:          planMode,
+					})
+				if err != nil {
+					return err
+				}
+
+				ts.mu.Lock()
+				ts.taskID = resp.TaskID
+				ts.mu.Unlock()
+
+				consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
+				if consoleURL != "" {
+					sendUI(uiCh, UISessionURL{URL: consoleURL})
+				}
+
+				session := &Session{
+					Client:   pc,
+					Handlers: handlers,
+					OrgName:  orgName,
+					TaskID:   resp.TaskID,
+					UIEvents: uiCh,
+				}
+				return session.Run(gctx)
+			}
+
+			if prompt != "" {
+				// The command-line prompt path always passes false for planMode.
+				g.Go(func() error {
+					return createTask(prompt, false)
+				})
+			}
+
+			// Post TUI-originated user events to the API. Chat messages may arrive before
+			// any task exists — the first one creates it. Other event types (approvals
+			// and anything we add later) only make sense once a task is live.
+			g.Go(func() error {
+				taskCreated := prompt != ""
+				for {
+					select {
+					case <-gctx.Done():
+						return nil
+					case ob, ok := <-outCh:
+						if !ok {
+							return nil
+						}
+						if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
+							taskCreated = true
+							planMode := ob.planMode
+							g.Go(func() error {
+								return createTask(msg.Content, planMode)
+							})
+							continue
+						}
+						ts.mu.Lock()
+						taskID := ts.taskID
+						ts.mu.Unlock()
+						if taskID == "" {
+							// Unreachable in normal use: the TUI gates Enter on busy state
+							// until UITaskIdle, and approvals only fire in response to backend
+							// events that imply the task exists. Surface instead of silently
+							// dropping.
+							sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
+							continue
+						}
+						if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, ob.event); err != nil {
+							sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
+						}
+					}
+				}
+			})
+		},
+	)
+}
+
+// runWithTUI runs the bubbletea program alongside caller-registered worker
+// goroutines under a shared errgroup. When runTUI returns the shared context
+// is cancelled, so any worker watching gctx.Done can unblock and return.
+//
+// errgroup only cancels its derived context on a non-nil error, but tea.Quit
+// returns nil from p.Run — without this explicit cancellation, the dispatcher
+// and any active session.Run loop would block on gctx.Done forever, g.Wait
+// would never return, and `pulumi neo` would require a third Ctrl+C to exit.
+//
+// register is invoked synchronously before the TUI goroutine starts so callers
+// can stage their workers; it may also retain g to spawn additional workers
+// later (the dispatcher does this when the first user message arrives).
+func runWithTUI(
+	ctx context.Context,
+	runTUI func() error,
+	register func(g *errgroup.Group, gctx context.Context),
+) error {
 	ctx, cancelAll := context.WithCancel(ctx)
 	defer cancelAll()
 
 	g, gctx := errgroup.WithContext(ctx)
 
-	// taskState tracks the task ID once created (may be deferred if no prompt).
-	type taskState struct {
-		mu     sync.Mutex
-		taskID string
-	}
-	ts := &taskState{}
-
-	// createTask creates the Neo task with the given prompt and starts the session.
-	// Called immediately if a prompt was provided, or on the first user message.
-	// planMode is the value the TUI captured at the moment the first message was
-	// sent; the CLI-prompt path always passes false.
-	createTask := func(initialPrompt string, planMode bool) error {
-		resp, err := pc.CreateNeoTask(
-			gctx, orgName, initialPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
-				ToolExecutionMode: "cli",
-				ApprovalMode:      client.NeoApprovalModeManual,
-				PlanMode:          planMode,
-			})
-		if err != nil {
-			return err
-		}
-
-		ts.mu.Lock()
-		ts.taskID = resp.TaskID
-		ts.mu.Unlock()
-
-		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
-		if consoleURL != "" {
-			sendUI(uiCh, UISessionURL{URL: consoleURL})
-		}
-
-		session := &Session{
-			Client:   pc,
-			Handlers: handlers,
-			OrgName:  orgName,
-			TaskID:   resp.TaskID,
-			UIEvents: uiCh,
-		}
-		return session.Run(gctx)
-	}
-
-	if prompt != "" {
-		// The command-line prompt path always passes false for planMode.
-		g.Go(func() error {
-			return createTask(prompt, false)
-		})
-	}
+	register(g, gctx)
 
 	g.Go(func() error {
-		_, err := p.Run()
+		err := runTUI()
 		cancelAll()
 		return err
-	})
-
-	// Post TUI-originated user events to the API. Chat messages may arrive before
-	// any task exists — the first one creates it. Other event types (approvals
-	// and anything we add later) only make sense once a task is live.
-	g.Go(func() error {
-		taskCreated := prompt != ""
-		for {
-			select {
-			case <-gctx.Done():
-				return nil
-			case ob, ok := <-outCh:
-				if !ok {
-					return nil
-				}
-				if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
-					taskCreated = true
-					planMode := ob.planMode
-					g.Go(func() error {
-						return createTask(msg.Content, planMode)
-					})
-					continue
-				}
-				ts.mu.Lock()
-				taskID := ts.taskID
-				ts.mu.Unlock()
-				if taskID == "" {
-					// Unreachable in normal use: the TUI gates Enter on busy state
-					// until UITaskIdle, and approvals only fire in response to backend
-					// events that imply the task exists. Surface instead of silently
-					// dropping.
-					sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
-					continue
-				}
-				if err := pc.PostNeoTaskUserEvent(gctx, orgName, taskID, ob.event); err != nil {
-					sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
-				}
-			}
-		}
 	})
 
 	return g.Wait()

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -50,6 +50,16 @@ type outboundEvent struct {
 	planMode bool
 }
 
+// Indirection points for the integration test in neo_integration_test.go.
+// Production behavior is unchanged: newTeaProgram defers to tea.NewProgram and
+// isInteractive defers to cmdutil.Interactive. The test swaps both so it can
+// run the interactive code path under `go test` (no TTY, no terminal renderer)
+// and capture the bubbletea program reference to drive a clean shutdown.
+var (
+	newTeaProgram = func(m tea.Model) *tea.Program { return tea.NewProgram(m) }
+	isInteractive = cmdutil.Interactive
+)
+
 // NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
 // Neo task in `cli` tool execution mode, prints a console URL the user can open in a
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
@@ -148,7 +158,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	handlers["pulumi"] = pu
 
 	// Non-interactive mode requires a prompt — there's no input mechanism.
-	if !cmdutil.Interactive() {
+	if !isInteractive() {
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
@@ -195,7 +205,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 	// Inline (non-alt-screen) so the transcript stays in the user's terminal
 	// scrollback after exit.
-	p := tea.NewProgram(model)
+	p := newTeaProgram(model)
 
 	return runWithTUI(
 		ctx,

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// neoFakeServer fakes the four Pulumi Cloud HTTP endpoints runNeo touches
+// (account details, create-task, SSE event stream, and post-user-event) over
+// httptest. The handlers record the requests they observe so the test can
+// assert on the wire path, and expose a streamSend channel for pushing SSE
+// events on demand.
+type neoFakeServer struct {
+	server *httptest.Server
+
+	mu        sync.Mutex
+	posts     []recordedPost
+	streamHit bool
+
+	// streamSend pushes raw event payloads (one JSON object per send) to the
+	// SSE handler, which frames them as `data: ...\n\n` and flushes. Closing
+	// it ends the stream cleanly.
+	streamSend chan []byte
+}
+
+type recordedPost struct {
+	path string
+	body []byte
+}
+
+func newNeoFakeServer(t *testing.T) *neoFakeServer {
+	t.Helper()
+
+	s := &neoFakeServer{streamSend: make(chan []byte, 16)}
+	mux := http.NewServeMux()
+
+	// runNeo discards the result and error of GetPulumiAccountDetails, but a
+	// 404 here would log noise. Return a minimal valid serviceUser shape.
+	mux.HandleFunc("/api/user", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"githubLogin":   "test-user",
+			"organizations": []map[string]any{{"githubLogin": "test-org"}},
+		})
+	})
+
+	// POST /api/preview/agents/{org}/tasks → CreateNeoTask. Record the body so
+	// the test can assert the prompt was forwarded, then return a fixed task ID.
+	mux.HandleFunc("/api/preview/agents/test-org/tasks",
+		func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			s.mu.Lock()
+			s.posts = append(s.posts, recordedPost{path: r.URL.Path, body: body})
+			s.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(client.NeoTaskResponse{TaskID: "task-1"})
+		})
+
+	// GET /api/preview/agents/{org}/tasks/{id}/events/stream → SSE handler.
+	// Mirrors the framing in client_test.go:TestStreamNeoTaskEvents — flush
+	// initial headers, then emit one event per streamSend value, each as a
+	// `data:` frame followed by a blank line. Exits when the request context
+	// is cancelled (the test triggers this by quitting the TUI).
+	mux.HandleFunc("/api/preview/agents/test-org/tasks/task-1/events/stream",
+		func(w http.ResponseWriter, r *http.Request) {
+			s.mu.Lock()
+			s.streamHit = true
+			s.mu.Unlock()
+
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				return
+			}
+			flusher.Flush()
+
+			for {
+				select {
+				case data, ok := <-s.streamSend:
+					if !ok {
+						return
+					}
+					fmt.Fprintf(w, "data: %s\n\n", data)
+					flusher.Flush()
+				case <-r.Context().Done():
+					return
+				}
+			}
+		})
+
+	// POST /api/preview/agents/{org}/tasks/{id} → PostNeoTaskUserEvent. Record
+	// the wrapped {"event": ...} body. The dispatcher posts here when the user
+	// types into the TUI; the bug-fix scenario doesn't strictly need it, but
+	// recording lets the test assert the wiring is reachable.
+	mux.HandleFunc("/api/preview/agents/test-org/tasks/task-1",
+		func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			s.mu.Lock()
+			s.posts = append(s.posts, recordedPost{path: r.URL.Path, body: body})
+			s.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		})
+
+	s.server = httptest.NewServer(mux)
+	t.Cleanup(func() {
+		// Closing streamSend lets any blocked SSE handler return promptly so
+		// httptest.Server.Close (also called below) doesn't have to wait on
+		// the request context cancellation path.
+		close(s.streamSend)
+		s.server.Close()
+	})
+	return s
+}
+
+func (s *neoFakeServer) recordedPosts() []recordedPost {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]recordedPost, len(s.posts))
+	copy(out, s.posts)
+	return out
+}
+
+func (s *neoFakeServer) sawStreamConnect() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.streamHit
+}
+
+// TestRunNeoIntegration_DoubleCtrlCExits is the high-fidelity regression test
+// for the Ctrl+C double-press hang. It runs the full runNeo entrypoint
+// (interactive path) against an in-process httptest.Server with a real
+// *client.Client — exercising HTTP marshalling, SSE parsing, and the real
+// Session.Run loop — then triggers the TUI to quit and asserts runNeo
+// returns within 5s. Pre-fix, p.Run returned nil from tea.Quit, errgroup
+// kept gctx alive, Session.Run blocked on `<-ctx.Done` forever, and g.Wait
+// hung — this test would time out instead of completing.
+//
+//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, newTeaProgram, isInteractive)
+func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
+	isolateWorkspace(t) // PULUMI_STACK="", PULUMI_HOME=t.TempDir()
+
+	srv := newNeoFakeServer(t)
+
+	// Real *client.Client pointed at the fake server. NewClient is the public
+	// constructor; it reads no global state and performs no I/O at construction.
+	pc := client.NewClient(srv.server.URL, "", false, nil)
+
+	// Fake backend wired with the real client. CurrentBackend short-circuits
+	// to BackendInstance when set, bypassing all login / cloud-URL resolution.
+	be := newFakeBackend()
+	be.ClientV = pc
+	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "test-user", []string{"test-org"}, nil, nil
+	}
+
+	prevBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = be
+	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+
+	prevWorkspace := pkgWorkspace.Instance
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
+	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
+
+	// Force the interactive path. cmdutil.Interactive() reads stdout-is-a-tty,
+	// which is false under `go test`, so without this override runNeo would
+	// take the non-interactive branch and we'd never hit the bug.
+	prevInteractive := isInteractive
+	isInteractive = func() bool { return true }
+	t.Cleanup(func() { isInteractive = prevInteractive })
+
+	// Headless tea.Program, plus capture so the test can drive Quit.
+	var (
+		programMu sync.Mutex
+		program   *tea.Program
+	)
+	prevProgram := newTeaProgram
+	newTeaProgram = func(m tea.Model) *tea.Program {
+		p := tea.NewProgram(
+			m,
+			tea.WithInput(nil),
+			tea.WithOutput(io.Discard),
+			tea.WithoutSignals(),
+			tea.WithoutSignalHandler(),
+			tea.WithoutRenderer(),
+		)
+		programMu.Lock()
+		program = p
+		programMu.Unlock()
+		return p
+	}
+	t.Cleanup(func() { newTeaProgram = prevProgram })
+
+	// Drive shutdown once the SSE stream is established. This is the moment
+	// equivalent to "user pressed Ctrl+C twice and the TUI called tea.Quit".
+	go func() {
+		// Wait briefly for runNeo to call CreateNeoTask and open the SSE
+		// stream. 100ms is generous on local hardware; if the test ever
+		// flakes here, switch to polling srv.sawStreamConnect().
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if srv.sawStreamConnect() {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		programMu.Lock()
+		p := program
+		programMu.Unlock()
+		if p != nil {
+			p.Quit()
+		}
+	}()
+
+	// runNeo on its own goroutine so the test can enforce a hard timeout
+	// rather than relying on `go test -timeout` to catch a hang.
+	done := make(chan error, 1)
+	go func() {
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+	}()
+
+	select {
+	case err := <-done:
+		// Session.Run returns ctx.Err() on cancellation; createTask propagates
+		// that through the errgroup. Either context.Canceled or nil is an
+		// acceptable surface — the load-bearing assertion is "we got here at
+		// all". Pre-fix, this branch never fires and the timeout below does.
+		if err != nil {
+			require.ErrorIs(t, err, context.Canceled,
+				"unexpected error from runNeo: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runNeo did not return within 5s — the cancel-on-TUI-exit fix has regressed " +
+			"(real *client.Client + real Session.Run hung after tea.Quit)")
+	}
+
+	// The fake server should have seen at least the CreateNeoTask call. The
+	// SSE stream should also have been opened — otherwise the test wasn't
+	// actually exercising the dispatcher / Session.Run lifecycle the bug
+	// lives in.
+	posts := srv.recordedPosts()
+	require.NotEmpty(t, posts, "server saw no requests — runNeo never reached CreateNeoTask")
+	assert.Equal(t, "/api/preview/agents/test-org/tasks", posts[0].path,
+		"first request must be CreateNeoTask")
+	assert.Contains(t, string(posts[0].body), "do a thing",
+		"CreateNeoTask body must include the prompt")
+	assert.True(t, srv.sawStreamConnect(),
+		"SSE stream was never opened — test did not exercise Session.Run")
+}

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -17,6 +17,7 @@ package neo
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,9 +30,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -49,8 +52,9 @@ type neoFakeServer struct {
 
 	// streamSend pushes raw event payloads (one JSON object per send) to the
 	// SSE handler, which frames them as `data: ...\n\n` and flushes. Closing
-	// it ends the stream cleanly.
+	// it via endStream ends the stream cleanly.
 	streamSend chan []byte
+	endOnce    sync.Once
 }
 
 type recordedPost struct {
@@ -137,10 +141,51 @@ func newNeoFakeServer(t *testing.T) *neoFakeServer {
 		// Closing streamSend lets any blocked SSE handler return promptly so
 		// httptest.Server.Close (also called below) doesn't have to wait on
 		// the request context cancellation path.
-		close(s.streamSend)
+		s.endStream()
 		s.server.Close()
 	})
 	return s
+}
+
+// endStream closes streamSend so the SSE handler returns. Idempotent so tests
+// can call it as part of their flow without conflicting with the cleanup.
+func (s *neoFakeServer) endStream() {
+	s.endOnce.Do(func() { close(s.streamSend) })
+}
+
+// sendFinalAssistantMessage pushes a final-turn assistant_message event to the
+// SSE stream. Session.Run treats a final message with no CLI tool calls as the
+// natural end of an agent turn — used by the non-interactive happy-path test
+// to drive the session to a clean shutdown after sendFinalAssistantMessage +
+// endStream.
+func (s *neoFakeServer) sendFinalAssistantMessage(t *testing.T) {
+	t.Helper()
+	body, err := json.Marshal(apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+	})
+	require.NoError(t, err)
+	env, err := json.Marshal(apitype.AgentConsoleEvent{
+		Type:      consoleEventAgentResponse,
+		ID:        "evt-1",
+		EventBody: body,
+	})
+	require.NoError(t, err)
+	s.streamSend <- env
+}
+
+// awaitStreamConnect polls until the SSE handler sees a request or the
+// deadline elapses. Returns whether the connect was observed.
+func (s *neoFakeServer) awaitStreamConnect(t *testing.T, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s.sawStreamConnect() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
 }
 
 func (s *neoFakeServer) recordedPosts() []recordedPost {
@@ -278,4 +323,284 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 		"CreateNeoTask body must include the prompt")
 	assert.True(t, srv.sawStreamConnect(),
 		"SSE stream was never opened — test did not exercise Session.Run")
+}
+
+// installNeoTestEnv wires the fake backend and workspace globals for an
+// integration test and registers cleanup to restore the originals. The
+// `interactive` flag selects which branch of runNeo the test exercises;
+// only the interactive path needs the tea.NewProgram override (the caller
+// installs that separately when needed).
+func installNeoTestEnv(t *testing.T, srv *neoFakeServer, interactive bool) {
+	t.Helper()
+
+	pc := client.NewClient(srv.server.URL, "", false, nil)
+
+	be := newFakeBackend()
+	be.ClientV = pc
+	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
+
+	prevBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = be
+	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+
+	prevWorkspace := pkgWorkspace.Instance
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
+	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
+
+	prevInteractive := isInteractive
+	isInteractive = func() bool { return interactive }
+	t.Cleanup(func() { isInteractive = prevInteractive })
+}
+
+// TestRunNeoIntegration_NonInteractiveHappyPath drives the non-interactive
+// branch of runNeo: a prompt is supplied, no TUI is started, and the session
+// loop runs against the SSE stream until the server closes the connection.
+// Pre-this test, lines 161-186 of neo.go (the entire non-interactive block —
+// CreateNeoTask, console URL print, Session construction, session.Run) had no
+// coverage.
+//
+//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, isInteractive)
+func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	// Once Session.Run opens the SSE stream, push a final assistant_message
+	// and close the stream so Session.Run sees the channel close and returns
+	// nil. Without this nudge the handler would block forever on streamSend.
+	go func() {
+		if !srv.awaitStreamConnect(t, 2*time.Second) {
+			return
+		}
+		srv.sendFinalAssistantMessage(t)
+		srv.endStream()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-interactive runNeo did not return within 5s")
+	}
+
+	posts := srv.recordedPosts()
+	require.NotEmpty(t, posts, "server saw no requests")
+	assert.Equal(t, "/api/preview/agents/test-org/tasks", posts[0].path)
+	assert.Contains(t, string(posts[0].body), "do a thing",
+		"CreateNeoTask body must include the prompt")
+}
+
+// TestRunNeoIntegration_NonInteractiveRequiresPrompt covers the early-return
+// guard that rejects an empty prompt in non-interactive mode (there's no input
+// mechanism, so the agent has nothing to react to).
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	err := runNeo(t.Context(), "" /*prompt*/, "", "test-org", t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prompt argument is required")
+
+	// The guard fires before any HTTP call — server must be untouched.
+	assert.Empty(t, srv.recordedPosts(), "no API calls should be made when the prompt guard fires")
+}
+
+// TestRunNeoIntegration_RequiresCloudBackend covers the type-assertion guard
+// that rejects backends not implementing httpstate.Backend (filestate, DIY,
+// etc. — only the Pulumi Cloud backend exposes the Neo API).
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
+	isolateWorkspace(t)
+
+	// A bare MockBackend deliberately doesn't implement httpstate.Backend.
+	prevBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = &backend.MockBackend{}
+	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+
+	prevWorkspace := pkgWorkspace.Instance
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
+	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
+
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
+		"non-cloud backends must surface a clear error rather than panic on the type assertion")
+}
+
+// TestRunNeoIntegration_ResolvesCwdWhenEmpty covers the os.Getwd() fallback at
+// the top of runNeo: when the caller passes an empty cwdFlag, runNeo must
+// resolve the process working directory rather than handing the empty string
+// to the tools constructors (which would otherwise reject it).
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	go func() {
+		if !srv.awaitStreamConnect(t, 2*time.Second) {
+			return
+		}
+		srv.sendFinalAssistantMessage(t)
+		srv.endStream()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		// cwdFlag empty → runNeo calls os.Getwd. The test's own working
+		// directory is always a real, readable path, so the tools constructors
+		// accept it and runNeo proceeds.
+		done <- runNeo(t.Context(), "do a thing", "", "test-org", "" /*cwd*/)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("runNeo with empty cwd did not return within 5s")
+	}
+}
+
+// TestRunNeoIntegration_RejectsNonexistentCwd covers the tools.NewFilesystem
+// error path: when cwdFlag points at a directory that doesn't exist, runNeo
+// must surface the underlying os.Stat error rather than continuing to a half-
+// initialized session.
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	missing := t.TempDir() + "/does-not-exist"
+	err := runNeo(t.Context(), "do a thing", "", "test-org", missing)
+	require.Error(t, err)
+	// The exact wrapping is internal to tools.NewFilesystem, but the missing
+	// path should be referenced so the user can see what went wrong.
+	assert.Contains(t, err.Error(), "does-not-exist")
+
+	assert.Empty(t, srv.recordedPosts(),
+		"no API calls should be made when filesystem setup fails")
+}
+
+// TestRunNeoIntegration_PropagatesReadProjectError covers the ReadProject
+// error branch — any error other than ErrProjectNotFound must abort runNeo
+// before it touches the backend (otherwise we'd create a Neo task against a
+// half-loaded project).
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
+	isolateWorkspace(t)
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	// Override the workspace to surface a non-NotFound error from ReadProject.
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return nil, "", errors.New("synthetic ReadProject failure")
+		},
+	}
+
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
+	assert.Empty(t, srv.recordedPosts(),
+		"no API calls should be made when project resolution fails")
+}
+
+// TestRunNeoIntegration_PropagatesCreateNeoTaskError covers the non-interactive
+// CreateNeoTask error branch: a server-side failure during task creation must
+// surface as the runNeo return value, with no session.Run started.
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
+	isolateWorkspace(t)
+
+	// Bespoke server: CreateNeoTask returns 500. We don't reuse newNeoFakeServer
+	// because here we want CreateNeoTask itself to fail.
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/preview/agents/test-org/tasks" {
+				http.Error(w, "synthetic 500", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+	t.Cleanup(server.Close)
+
+	pc := client.NewClient(server.URL, "", false, nil)
+	be := newFakeBackend()
+	be.ClientV = pc
+	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
+
+	prevBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = be
+	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+
+	prevWorkspace := pkgWorkspace.Instance
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
+	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
+
+	prevInteractive := isInteractive
+	isInteractive = func() bool { return false }
+	t.Cleanup(func() { isInteractive = prevInteractive })
+
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating Neo task")
+}
+
+// TestRunNeoIntegration_NewNeoCmdRunE covers the cobra RunE closure in
+// NewNeoCmd: it pulls the prompt from positional args, reads the flag values,
+// and forwards everything to runNeo. Without this test the entire RunE body
+// (lines 83-90 in neo.go) is uncovered — the flag-registration test in
+// neo_test.go only inspects cmd.Args, never invokes RunE.
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
+	isolateWorkspace(t)
+	t.Setenv("PULUMI_EXPERIMENTAL", "true")
+
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	go func() {
+		if !srv.awaitStreamConnect(t, 2*time.Second) {
+			return
+		}
+		srv.sendFinalAssistantMessage(t)
+		srv.endStream()
+	}()
+
+	cmd := NewNeoCmd()
+	cmd.SetContext(t.Context())
+	require.NoError(t, cmd.Flags().Set("org", "test-org"))
+	require.NoError(t, cmd.Flags().Set("cwd", t.TempDir()))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.RunE(cmd, []string{"my prompt"})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cmd.RunE did not return within 5s")
+	}
+
+	posts := srv.recordedPosts()
+	require.NotEmpty(t, posts, "RunE did not reach CreateNeoTask")
+	assert.Contains(t, string(posts[0].body), "my prompt",
+		"prompt from positional args must reach CreateNeoTask")
 }

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -17,13 +17,11 @@ package neo
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -554,84 +552,4 @@ func TestRunWithTUI_ParentContextCancellationStopsWorkers(t *testing.T) {
 	// nil after observing cancellation. The helper itself returns nil — the
 	// caller of runNeo would surface ctx.Err() via session.Run separately.
 	require.NoError(t, err)
-}
-
-// noopTeaModel is a minimal tea.Model that does nothing. The integration test
-// drives it via p.Quit so the model itself doesn't need to handle any messages.
-type noopTeaModel struct{}
-
-func (noopTeaModel) Init() tea.Cmd                       { return nil }
-func (noopTeaModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return noopTeaModel{}, nil }
-func (noopTeaModel) View() string                        { return "" }
-
-// TestRunWithTUI_IntegrationRealBubbleteaAndSession is an integration test
-// that wires the real bubbletea program (the production TUI runtime) to a
-// real Session.Run loop. The unit tests on runWithTUI use stub TUI runners
-// and stub workers; this one swaps both for the production types so a future
-// change to either's shutdown semantics — say bubbletea changing what p.Run
-// returns on Quit, or Session.Run no longer honoring ctx.Done — would surface
-// here even if the helper's contract appeared satisfied in isolation.
-//
-// The bug being guarded: pressing Ctrl+C twice in `pulumi neo` made the TUI
-// call tea.Quit, and tea.Quit returned nil from p.Run. errgroup keeps its
-// derived context alive on a nil error, so Session.Run's `<-ctx.Done` arm
-// never fired and g.Wait blocked forever — the user had to press Ctrl+C a
-// third time to send the engine a kill signal.
-func TestRunWithTUI_IntegrationRealBubbleteaAndSession(t *testing.T) {
-	t.Parallel()
-
-	// Detach bubbletea from the test environment: nil input, discarded output,
-	// no signal handler (so SIGINT to the test runner doesn't poison the
-	// program), and no renderer (so we don't write escape sequences anywhere).
-	p := tea.NewProgram(
-		noopTeaModel{},
-		tea.WithInput(nil),
-		tea.WithOutput(io.Discard),
-		tea.WithoutSignals(),
-		tea.WithoutSignalHandler(),
-		tea.WithoutRenderer(),
-	)
-
-	// Real Session.Run blocked on the SSE stream and ctx.Done. The fake
-	// streamer keeps its stream channel open and silent so Session.Run has
-	// nothing to consume — exactly the production state during idle wait.
-	streamer := newFakeStreamer()
-	session := &Session{
-		Client:   streamer,
-		Handlers: map[string]ToolHandler{},
-		OrgName:  "org",
-		TaskID:   "task",
-	}
-
-	// Trigger a clean TUI shutdown. p.Quit() blocks on the program's message
-	// channel until the program is consuming, so it has the necessary
-	// happens-before with p.Run starting — no sleep needed.
-	go p.Quit()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- runWithTUI(
-			t.Context(),
-			func() error {
-				_, err := p.Run()
-				return err
-			},
-			func(g *errgroup.Group, gctx context.Context) {
-				g.Go(func() error { return session.Run(gctx) })
-			},
-		)
-	}()
-
-	select {
-	case err := <-done:
-		// Session.Run returns ctx.Err() on cancellation, and errgroup surfaces
-		// the first non-nil error — context.Canceled is the expected shape.
-		// The load-bearing assertion is "we got here at all": without the
-		// cancel-on-TUI-exit fix, runWithTUI never returns and the timeout
-		// branch fires.
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(3 * time.Second):
-		t.Fatal("runWithTUI did not return within 3s — the cancel-on-TUI-exit fix has regressed " +
-			"(real bubbletea + real Session would hang on a clean Quit)")
-	}
 }

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -44,11 +44,14 @@ import (
 // cloud-only hooks are no-ops.
 type fakeHTTPBackend struct {
 	*backend.MockBackend
+	// ClientV is returned from Client(); leave nil for tests that don't need a
+	// live client (the integration test wires a real *client.Client here).
+	ClientV *client.Client
 }
 
 func (f *fakeHTTPBackend) CloudURL() string                                       { return "" }
 func (f *fakeHTTPBackend) StackConsoleURL(backend.StackReference) (string, error) { return "", nil }
-func (f *fakeHTTPBackend) Client() *client.Client                                 { return nil }
+func (f *fakeHTTPBackend) Client() *client.Client                                 { return f.ClientV }
 
 func (f *fakeHTTPBackend) RunDeployment(
 	context.Context, backend.StackReference, apitype.CreateDeploymentRequest,

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -556,3 +556,196 @@ func TestRunWithTUI_ParentContextCancellationStopsWorkers(t *testing.T) {
 	// caller of runNeo would surface ctx.Err() via session.Run separately.
 	require.NoError(t, err)
 }
+
+// -----------------------------------------------------------------------------
+// dispatchUserEvents
+//
+// The dispatcher used to live as an inline goroutine inside runNeo, where its
+// branches couldn't be exercised without driving the bubbletea model. It was
+// extracted so each branch (context cancel, channel close, lazy task
+// creation, taskID-not-ready warning, post-event success and failure) is
+// directly testable.
+// -----------------------------------------------------------------------------
+
+// noopPostEvent is the postEvent stub for dispatcher tests that aren't
+// exercising the post path. Always succeeds; receiving a call here means the
+// test reached the post branch when it shouldn't have.
+func noopPostEvent(context.Context, string, any) error { return nil }
+
+func TestDispatchUserEvents_ContextCancelExits(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	out := make(chan outboundEvent)
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(ctx, out, nil, true,
+			func() string { return "task-1" },
+			func(string, bool) {}, noopPostEvent)
+	}()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "ctx-cancel exit must return nil, not ctx.Err()")
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after ctx cancel")
+	}
+}
+
+func TestDispatchUserEvents_ChannelCloseExits(t *testing.T) {
+	t.Parallel()
+
+	out := make(chan outboundEvent)
+	done := make(chan error, 1)
+	go func() {
+		done <- dispatchUserEvents(t.Context(), out, nil, true,
+			func() string { return "task-1" },
+			func(string, bool) {}, noopPostEvent)
+	}()
+
+	close(out)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not exit after outCh close")
+	}
+}
+
+func TestDispatchUserEvents_LazyTaskCreationOnFirstUserMessage(t *testing.T) {
+	t.Parallel()
+
+	// initialTaskCreated=false: no CLI prompt was passed, so the first
+	// user_message must trigger CreateNeoTask via spawnCreateTask. Subsequent
+	// events should NOT spawn again — the dispatcher tracks taskCreated.
+	var spawned []string
+	var spawnedPlanMode []bool
+	spawn := func(msg string, planMode bool) {
+		spawned = append(spawned, msg)
+		spawnedPlanMode = append(spawnedPlanMode, planMode)
+	}
+
+	postCalls := 0
+	post := func(_ context.Context, _ string, _ any) error {
+		postCalls++
+		return nil
+	}
+
+	out := make(chan outboundEvent, 4)
+	out <- outboundEvent{
+		event:    apitype.AgentUserEventUserMessage{Type: userEventUserMessage, Content: "hello"},
+		planMode: true,
+	}
+	// Second event arrives after taskCreated is true and a taskID is set —
+	// must take the post branch, not the spawn branch.
+	out <- outboundEvent{
+		event: apitype.AgentUserEventCancel{Type: userEventUserCancel},
+	}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, nil, false,
+		func() string { return "task-1" },
+		spawn, post)
+	require.NoError(t, err)
+
+	require.Len(t, spawned, 1, "only the first user_message must trigger lazy task creation")
+	assert.Equal(t, "hello", spawned[0])
+	assert.Equal(t, []bool{true}, spawnedPlanMode,
+		"planMode must be forwarded from the outboundEvent envelope")
+	assert.Equal(t, 1, postCalls, "the second event must be posted to the live task")
+}
+
+func TestDispatchUserEvents_WarnsWhenTaskNotReady(t *testing.T) {
+	t.Parallel()
+
+	// Non-user_message event arrives before any task exists. The dispatcher
+	// must surface a UIWarning instead of silently dropping; the comment in
+	// runNeo notes this is unreachable in normal TUI flow but defends against
+	// future event types or bugs in the busy-state gate.
+	uiCh := make(chan UIEvent, 4)
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, uiCh, false,
+		func() string { return "" }, // no task yet
+		func(string, bool) { t.Fatal("spawn must not fire for non-user_message") },
+		func(context.Context, string, any) error {
+			t.Fatal("post must not fire when taskID is empty")
+			return nil
+		})
+	require.NoError(t, err)
+
+	close(uiCh)
+	var got []UIWarning
+	for evt := range uiCh {
+		if w, ok := evt.(UIWarning); ok {
+			got = append(got, w)
+		}
+	}
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Message, "task not ready")
+}
+
+func TestDispatchUserEvents_PostsEventToBackend(t *testing.T) {
+	t.Parallel()
+
+	// Once a task is live, non-user_message events flow through to postEvent.
+	type postCall struct {
+		taskID string
+		body   any
+	}
+	var calls []postCall
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, nil, true,
+		func() string { return "task-1" },
+		func(string, bool) {},
+		func(_ context.Context, taskID string, body any) error {
+			calls = append(calls, postCall{taskID: taskID, body: body})
+			return nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, calls, 1)
+	assert.Equal(t, "task-1", calls[0].taskID)
+	cancelEvt, ok := calls[0].body.(apitype.AgentUserEventCancel)
+	require.True(t, ok, "body must round-trip the original AgentUserEvent type")
+	assert.Equal(t, userEventUserCancel, cancelEvt.Type)
+}
+
+func TestDispatchUserEvents_WarnsOnPostFailure(t *testing.T) {
+	t.Parallel()
+
+	// A backend error during PostNeoTaskUserEvent must surface as a UIWarning
+	// — losing a single user event shouldn't tear down the dispatcher loop.
+	uiCh := make(chan UIEvent, 4)
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, uiCh, true,
+		func() string { return "task-1" },
+		func(string, bool) {},
+		func(context.Context, string, any) error {
+			return errors.New("network down")
+		})
+	require.NoError(t, err, "post errors must be reported via UIWarning, not propagated")
+
+	close(uiCh)
+	var got []UIWarning
+	for evt := range uiCh {
+		if w, ok := evt.(UIWarning); ok {
+			got = append(got, w)
+		}
+	}
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Message, "failed to send event")
+	assert.Contains(t, got[0].Message, "network down")
+}

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -354,4 +357,199 @@ func TestNewPulumiSinkForUI_NonBlockingOnFullChannel(t *testing.T) {
 	require.NotPanics(t, func() {
 		sink.OnStart("pulumi__pulumi_preview", "dev", true)
 	}, "OnStart must not block when the UI channel is full")
+}
+
+// -----------------------------------------------------------------------------
+// runWithTUI
+//
+// Regression tests for the Ctrl+C double-press hang: when the bubbletea program
+// exits, the shared errgroup context must be cancelled so the dispatcher and
+// any active session.Run unblock. errgroup itself only cancels its derived
+// context on a non-nil error, but tea.Quit returns nil from p.Run, so without
+// the explicit cancel inside runWithTUI the helper would hang on g.Wait.
+// -----------------------------------------------------------------------------
+
+// awaitClose returns once ch is closed or the deadline elapses, failing the
+// test if the channel never closes. Tests use it to assert that worker
+// goroutines actually exit instead of relying on test-timeout to catch a hang.
+func awaitClose(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting: %s", msg)
+	}
+}
+
+func TestRunWithTUI_CleanTUIExitCancelsWorkers(t *testing.T) {
+	t.Parallel()
+
+	// The bug: tea.Quit returns nil from p.Run, errgroup keeps gctx alive on
+	// nil errors, so workers blocked on gctx.Done would never exit. Simulate
+	// the clean exit and verify the worker is unblocked.
+	workerExited := make(chan struct{})
+
+	err := runWithTUI(
+		t.Context(),
+		func() error { return nil }, // tea.Quit-style clean exit
+		func(g *errgroup.Group, gctx context.Context) {
+			g.Go(func() error {
+				<-gctx.Done()
+				close(workerExited)
+				return nil
+			})
+		},
+	)
+	require.NoError(t, err)
+	awaitClose(t, workerExited, "worker should unblock when TUI exits cleanly")
+}
+
+func TestRunWithTUI_PropagatesTUIError(t *testing.T) {
+	t.Parallel()
+
+	// A non-nil error from runTUI must surface through g.Wait, and workers
+	// must still get cancelled on the way out so g.Wait can return.
+	boom := errors.New("tui boom")
+	workerExited := make(chan struct{})
+
+	err := runWithTUI(
+		t.Context(),
+		func() error { return boom },
+		func(g *errgroup.Group, gctx context.Context) {
+			g.Go(func() error {
+				<-gctx.Done()
+				close(workerExited)
+				return nil
+			})
+		},
+	)
+	require.ErrorIs(t, err, boom)
+	awaitClose(t, workerExited, "worker should unblock when TUI exits with error")
+}
+
+func TestRunWithTUI_PropagatesWorkerError(t *testing.T) {
+	t.Parallel()
+
+	// Worker errors must propagate; the TUI goroutine should still complete
+	// (errgroup cancels gctx on the worker's non-nil return, but runTUI is
+	// not bound to gctx in production — here we make it watch ctx so the
+	// test terminates without relying on the test-timeout).
+	boom := errors.New("worker boom")
+
+	err := runWithTUI(
+		t.Context(),
+		func() error {
+			// Real bubbletea programs aren't ctx-aware; in production the
+			// errgroup waits for tea.Quit. For the test we just exit
+			// immediately so g.Wait can collect the worker's error.
+			return nil
+		},
+		func(g *errgroup.Group, _ context.Context) {
+			g.Go(func() error { return boom })
+		},
+	)
+	require.ErrorIs(t, err, boom)
+}
+
+func TestRunWithTUI_RegisterRunsBeforeTUI(t *testing.T) {
+	t.Parallel()
+
+	// register must run synchronously before the TUI goroutine starts so the
+	// dispatcher (which the register callback installs) is already listening
+	// on outCh by the time the TUI begins emitting events. If runWithTUI ever
+	// inverted the order, an early TUI message could race past the dispatcher.
+	var registerDone atomic.Bool
+	tuiStarted := make(chan struct{})
+
+	err := runWithTUI(
+		t.Context(),
+		func() error {
+			close(tuiStarted)
+			// Assert the ordering invariant from inside the TUI goroutine.
+			assert.True(t, registerDone.Load(), "register must complete before runTUI starts")
+			return nil
+		},
+		func(g *errgroup.Group, gctx context.Context) {
+			g.Go(func() error {
+				<-gctx.Done()
+				return nil
+			})
+			registerDone.Store(true)
+		},
+	)
+	require.NoError(t, err)
+	awaitClose(t, tuiStarted, "TUI goroutine should run")
+}
+
+func TestRunWithTUI_LazilySpawnedWorkersJoin(t *testing.T) {
+	t.Parallel()
+
+	// The dispatcher captures g and calls g.Go from inside its loop when the
+	// first user message arrives (lazy task creation). g.Wait must include
+	// those late-spawned goroutines, so the helper can't return until they
+	// also finish. Verify by spawning a delayed worker and checking it ran.
+	var lateWorkerRan atomic.Bool
+
+	err := runWithTUI(
+		t.Context(),
+		func() error { return nil },
+		func(g *errgroup.Group, gctx context.Context) {
+			g.Go(func() error {
+				// Spawn a sibling after this worker starts. In production this
+				// is the dispatcher reacting to its first outbound user_message.
+				g.Go(func() error {
+					lateWorkerRan.Store(true)
+					return nil
+				})
+				<-gctx.Done()
+				return nil
+			})
+		},
+	)
+	require.NoError(t, err)
+	assert.True(t, lateWorkerRan.Load(), "late-spawned worker must run before runWithTUI returns")
+}
+
+func TestRunWithTUI_ParentContextCancellationStopsWorkers(t *testing.T) {
+	t.Parallel()
+
+	// External cancellation (Ctrl+C delivered to the parent ctx) must
+	// propagate to workers via gctx. The TUI is not ctx-aware in production
+	// — we simulate that by having it block until the test releases it via
+	// tuiRelease, mimicking a TUI that exits in response to its own input.
+	parentCtx, cancelParent := context.WithCancel(t.Context())
+	tuiRelease := make(chan struct{})
+	workerExited := make(chan struct{})
+
+	go func() {
+		// Cancel the parent shortly after starting; the worker should observe
+		// it via gctx.Done and exit, after which we release the TUI so the
+		// helper can return.
+		time.Sleep(20 * time.Millisecond)
+		cancelParent()
+	}()
+
+	go func() {
+		<-workerExited
+		close(tuiRelease)
+	}()
+
+	err := runWithTUI(
+		parentCtx,
+		func() error {
+			<-tuiRelease
+			return nil
+		},
+		func(g *errgroup.Group, gctx context.Context) {
+			g.Go(func() error {
+				<-gctx.Done()
+				close(workerExited)
+				return nil
+			})
+		},
+	)
+	// errgroup returns the first non-nil worker error, but workers here return
+	// nil after observing cancellation. The helper itself returns nil — the
+	// caller of runNeo would surface ctx.Err() via session.Run separately.
+	require.NoError(t, err)
 }

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -17,11 +17,13 @@ package neo
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -552,4 +554,84 @@ func TestRunWithTUI_ParentContextCancellationStopsWorkers(t *testing.T) {
 	// nil after observing cancellation. The helper itself returns nil — the
 	// caller of runNeo would surface ctx.Err() via session.Run separately.
 	require.NoError(t, err)
+}
+
+// noopTeaModel is a minimal tea.Model that does nothing. The integration test
+// drives it via p.Quit so the model itself doesn't need to handle any messages.
+type noopTeaModel struct{}
+
+func (noopTeaModel) Init() tea.Cmd                       { return nil }
+func (noopTeaModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return noopTeaModel{}, nil }
+func (noopTeaModel) View() string                        { return "" }
+
+// TestRunWithTUI_IntegrationRealBubbleteaAndSession is an integration test
+// that wires the real bubbletea program (the production TUI runtime) to a
+// real Session.Run loop. The unit tests on runWithTUI use stub TUI runners
+// and stub workers; this one swaps both for the production types so a future
+// change to either's shutdown semantics — say bubbletea changing what p.Run
+// returns on Quit, or Session.Run no longer honoring ctx.Done — would surface
+// here even if the helper's contract appeared satisfied in isolation.
+//
+// The bug being guarded: pressing Ctrl+C twice in `pulumi neo` made the TUI
+// call tea.Quit, and tea.Quit returned nil from p.Run. errgroup keeps its
+// derived context alive on a nil error, so Session.Run's `<-ctx.Done` arm
+// never fired and g.Wait blocked forever — the user had to press Ctrl+C a
+// third time to send the engine a kill signal.
+func TestRunWithTUI_IntegrationRealBubbleteaAndSession(t *testing.T) {
+	t.Parallel()
+
+	// Detach bubbletea from the test environment: nil input, discarded output,
+	// no signal handler (so SIGINT to the test runner doesn't poison the
+	// program), and no renderer (so we don't write escape sequences anywhere).
+	p := tea.NewProgram(
+		noopTeaModel{},
+		tea.WithInput(nil),
+		tea.WithOutput(io.Discard),
+		tea.WithoutSignals(),
+		tea.WithoutSignalHandler(),
+		tea.WithoutRenderer(),
+	)
+
+	// Real Session.Run blocked on the SSE stream and ctx.Done. The fake
+	// streamer keeps its stream channel open and silent so Session.Run has
+	// nothing to consume — exactly the production state during idle wait.
+	streamer := newFakeStreamer()
+	session := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{},
+		OrgName:  "org",
+		TaskID:   "task",
+	}
+
+	// Trigger a clean TUI shutdown. p.Quit() blocks on the program's message
+	// channel until the program is consuming, so it has the necessary
+	// happens-before with p.Run starting — no sleep needed.
+	go p.Quit()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWithTUI(
+			t.Context(),
+			func() error {
+				_, err := p.Run()
+				return err
+			},
+			func(g *errgroup.Group, gctx context.Context) {
+				g.Go(func() error { return session.Run(gctx) })
+			},
+		)
+	}()
+
+	select {
+	case err := <-done:
+		// Session.Run returns ctx.Err() on cancellation, and errgroup surfaces
+		// the first non-nil error — context.Canceled is the expected shape.
+		// The load-bearing assertion is "we got here at all": without the
+		// cancel-on-TUI-exit fix, runWithTUI never returns and the timeout
+		// branch fires.
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("runWithTUI did not return within 3s — the cancel-on-TUI-exit fix has regressed " +
+			"(real bubbletea + real Session would hang on a clean Quit)")
+	}
 }


### PR DESCRIPTION
## Summary
- The previous fix (#22742) gave the `pulumi neo` TUI proper two-press Ctrl+C semantics, but pressing Ctrl+C twice still left the process hanging until a third press. The TUI tore down the terminal and disappeared (the "freeze" the user reported), but the `errgroup` running the session SSE poller and the outbound dispatcher kept blocking.
- Root cause: in `pkg/cmd/pulumi/neo/neo.go`, `runNeo` builds `errgroup.WithContext(ctx)`. `errgroup` only cancels `gctx` on a non-nil error, but `tea.Quit` makes `p.Run()` return `(model, nil)` — so `gctx` never cancels, `session.Run` never sees `<-ctx.Done()`, and `g.Wait()` blocks forever. Only a third Ctrl+C — reaching Go's default signal handler now that bubbletea's is gone — kills the process.
- Fix: wrap `ctx` with `context.WithCancel` and have the TUI goroutine call `cancelAll()` after `p.Run()` returns. The session and dispatcher then unwind via their existing `<-ctx.Done()` arms and the process exits on the second press.

The orphaned-child-process half of pulumi/pulumi-service#42030 (per-grandchild process group cleanup in the shell tool) is a separate problem and is left as a followup, per pgavlin's split.

Fixes pulumi/pulumi-service#42030

## Test plan
- [x] `cd pkg && mise exec -- go test -count=1 -tags all ./cmd/pulumi/neo/...` — passes
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/neo/...` — clean
- [ ] Manual: build, run `pulumi neo "<long prompt>"`, press Ctrl+C twice while the agent is busy → process exits on the second press
- [ ] Manual: same, press Ctrl+C twice while idle → process exits on the second press
- [ ] Manual: press Ctrl+C, wait > 1.5s, press again → second press arms (existing TUI gate behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)