### PR TITLE
test: neo-only PR to verify fast-path CI

### DIFF
--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -11,15 +11,14 @@ on:
   pull_request:
     paths-ignore:
       - "**" # Skip all files…
-      - "!sdk/.version" # …except if only these paths change and nothing else.
-      - "!changelog/**"
+      - "!sdk/.version" # …except if only this file changes and nothing else.
 jobs:
   no-op:
-    name: Skip CI on no-op changes
+    name: Skip CI on .version changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip CI on no-op changes
-        run: echo 'No need to run CI tests when only .version or changelog files change'
+      - name: Skip CI on .version changes
+        run: echo 'No need to run CI tests when only .version changes'
 
   ci-ok:
     name: ci-ok

--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -11,14 +11,15 @@ on:
   pull_request:
     paths-ignore:
       - "**" # Skip all files…
-      - "!sdk/.version" # …except if only this file changes and nothing else.
+      - "!sdk/.version" # …except if only these paths change and nothing else.
+      - "!changelog/**"
 jobs:
   no-op:
-    name: Skip CI on .version changes
+    name: Skip CI on no-op changes
     runs-on: ubuntu-latest
     steps:
-      - name: Skip CI on .version changes
-        run: echo 'No need to run CI tests when only .version changes'
+      - name: Skip CI on no-op changes
+        run: echo 'No need to run CI tests when only .version or changelog files change'
 
   ci-ok:
     name: ci-ok

--- a/.github/workflows/on-pr-neo.yml
+++ b/.github/workflows/on-pr-neo.yml
@@ -8,8 +8,8 @@ permissions:
 # Fast-path CI for PRs that touch only `pkg/cmd/pulumi/neo/**` (and optionally
 # changelog/.version files). The heavy `on-pr.yml` workflow auto-skips for
 # neo-only PRs via paths-ignore; this workflow runs a focused subset:
-# lint + neo unit tests + tests/smoke. The `ci-ok` job here satisfies the
-# required status check that `on-pr.yml` would normally provide.
+# lint + neo unit tests. The `ci-ok` job here satisfies the required status
+# check that `on-pr.yml` would normally provide.
 on:
   pull_request:
     paths:
@@ -74,58 +74,16 @@ jobs:
       version-set: ${{ needs.version-set.outputs.version-set }}
     secrets: inherit
 
-  build-cli:
-    name: build CLI
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, version-set]
-    uses: ./.github/workflows/ci-build-binaries.yml
-    with:
-      ref: ${{ github.head_ref }}
-      version: ${{ needs.info.outputs.version }}
-      os: linux
-      arch: amd64
-      build-platform: ubuntu-latest
-      version-set: ${{ needs.version-set.outputs.version-set }}
-      artifact-suffix: '-integration'
-    secrets: inherit
-
-  build-sdks:
-    name: Build SDKs
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, version-set]
-    uses: ./.github/workflows/ci-build-sdks.yml
-    with:
-      ref: ${{ github.head_ref }}
-      version: ${{ needs.info.outputs.version }}
-      version-set: ${{ needs.version-set.outputs.version-set }}
-    secrets: inherit
-
-  smoke:
-    name: Smoke tests
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: [info, version-set, build-cli, build-sdks]
-    uses: ./.github/workflows/ci-run-test.yml
-    with:
-      ref: ${{ github.head_ref }}
-      version: ${{ needs.info.outputs.version }}
-      platform: ubuntu-latest
-      test-name: tests/smoke
-      test-command: PKGS="./..." ./scripts/retry make gotestsum/tests/smoke
-      is-integration-test: true
-      enable-coverage: false
-      version-set: ${{ needs.version-set.outputs.version-set }}
-    secrets: inherit
-
   ci-ok:
     name: ci-ok
-    needs: [lint, neo-unit-tests, smoke]
+    needs: [lint, neo-unit-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:
       # Mirror on-pr.yml: community PRs route through on-community-pr.yml,
       # so don't gate on lint/test results when the PR is from a fork.
       - name: CI failed
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (needs.lint.result != 'success' || needs.neo-unit-tests.result != 'success' || needs.smoke.result != 'success') }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (needs.lint.result != 'success' || needs.neo-unit-tests.result != 'success') }}
         run: exit 1
       - name: CI succeeded
         run: exit 0

--- a/.github/workflows/on-pr-neo.yml
+++ b/.github/workflows/on-pr-neo.yml
@@ -36,7 +36,9 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
-      version-set: ${{ steps.gen.outputs.version-set }}
+      # set-output JSON-encodes the value, so consumers must fromJSON-unwrap it
+      # here for downstream `fromJson(inputs.version-set).<key>` lookups to work.
+      version-set: ${{ fromJSON(steps.gen.outputs.version-set) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/on-pr-neo.yml
+++ b/.github/workflows/on-pr-neo.yml
@@ -5,11 +5,11 @@ permissions:
   pull-requests: write
   id-token: write
 
-# Fast-path CI for PRs that touch only `pkg/cmd/pulumi/neo/**` (and optionally
-# changelog/.version files). The heavy `on-pr.yml` workflow auto-skips for
-# neo-only PRs via paths-ignore; this workflow runs a focused subset:
-# lint + neo unit tests. The `ci-ok` job here satisfies the required status
-# check that `on-pr.yml` would normally provide.
+# Fast-path CI for PRs that touch only `pkg/cmd/pulumi/neo/**`. The heavy
+# `on-pr.yml` workflow auto-skips for neo-only PRs via paths-ignore; this
+# workflow runs a focused subset: lint + neo unit tests + a Linux/amd64 CLI
+# build. The `ci-ok` job here satisfies the required status check that
+# `on-pr.yml` would normally provide.
 on:
   pull_request:
     paths:
@@ -70,22 +70,37 @@ jobs:
       version: ${{ needs.info.outputs.version }}
       platform: ubuntu-latest
       test-name: neo unit tests
-      test-command: PKGS="./cmd/pulumi/neo/..." ./scripts/retry make gotestsum/pkg
+      test-command: PKGS="./cmd/pulumi/neo/..." make gotestsum/pkg
       is-integration-test: false
       enable-coverage: false
       version-set: ${{ needs.version-set.outputs.version-set }}
     secrets: inherit
 
+  build-cli:
+    name: build CLI
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [info, version-set]
+    uses: ./.github/workflows/ci-build-binaries.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version: ${{ needs.info.outputs.version }}
+      os: linux
+      arch: amd64
+      build-platform: ubuntu-latest
+      version-set: ${{ needs.version-set.outputs.version-set }}
+      artifact-suffix: '-integration'
+    secrets: inherit
+
   ci-ok:
     name: ci-ok
-    needs: [lint, neo-unit-tests]
+    needs: [lint, neo-unit-tests, build-cli]
     if: always()
     runs-on: ubuntu-latest
     steps:
       # Mirror on-pr.yml: community PRs route through on-community-pr.yml,
       # so don't gate on lint/test results when the PR is from a fork.
       - name: CI failed
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (needs.lint.result != 'success' || needs.neo-unit-tests.result != 'success') }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (needs.lint.result != 'success' || needs.neo-unit-tests.result != 'success' || needs.build-cli.result != 'success') }}
         run: exit 1
       - name: CI succeeded
         run: exit 0

--- a/.github/workflows/on-pr-neo.yml
+++ b/.github/workflows/on-pr-neo.yml
@@ -1,0 +1,131 @@
+name: Pull Request
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+# Fast-path CI for PRs that touch only `pkg/cmd/pulumi/neo/**` (and optionally
+# changelog/.version files). The heavy `on-pr.yml` workflow auto-skips for
+# neo-only PRs via paths-ignore; this workflow runs a focused subset:
+# lint + neo unit tests + tests/smoke. The `ci-ok` job here satisfies the
+# required status check that `on-pr.yml` would normally provide.
+on:
+  pull_request:
+    paths:
+      - "pkg/cmd/pulumi/neo/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  info:
+    name: info
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/ci-info.yml
+    permissions:
+      contents: read
+    with:
+      ref: ${{ github.head_ref }}
+      is-snapshot: true
+    secrets: inherit
+
+  version-set:
+    name: version-set
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      version-set: ${{ steps.gen.outputs.version-set }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: jdx/mise-action@v2
+        with:
+          experimental: true
+      - id: gen
+        run: |
+          VERSION_SET=$(./scripts/get-job-matrix.py generate-version-set --version-set current)
+          ./.github/scripts/set-output version-set "${VERSION_SET}"
+
+  lint:
+    name: Lint
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [version-set]
+    uses: ./.github/workflows/ci-lint.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version-set: ${{ needs.version-set.outputs.version-set }}
+
+  neo-unit-tests:
+    name: Neo unit tests
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [info, version-set]
+    uses: ./.github/workflows/ci-run-test.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version: ${{ needs.info.outputs.version }}
+      platform: ubuntu-latest
+      test-name: neo unit tests
+      test-command: PKGS="./cmd/pulumi/neo/..." ./scripts/retry make gotestsum/pkg
+      is-integration-test: false
+      enable-coverage: false
+      version-set: ${{ needs.version-set.outputs.version-set }}
+    secrets: inherit
+
+  build-cli:
+    name: build CLI
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [info, version-set]
+    uses: ./.github/workflows/ci-build-binaries.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version: ${{ needs.info.outputs.version }}
+      os: linux
+      arch: amd64
+      build-platform: ubuntu-latest
+      version-set: ${{ needs.version-set.outputs.version-set }}
+      artifact-suffix: '-integration'
+    secrets: inherit
+
+  build-sdks:
+    name: Build SDKs
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [info, version-set]
+    uses: ./.github/workflows/ci-build-sdks.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version: ${{ needs.info.outputs.version }}
+      version-set: ${{ needs.version-set.outputs.version-set }}
+    secrets: inherit
+
+  smoke:
+    name: Smoke tests
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [info, version-set, build-cli, build-sdks]
+    uses: ./.github/workflows/ci-run-test.yml
+    with:
+      ref: ${{ github.head_ref }}
+      version: ${{ needs.info.outputs.version }}
+      platform: ubuntu-latest
+      test-name: tests/smoke
+      test-command: PKGS="./..." ./scripts/retry make gotestsum/tests/smoke
+      is-integration-test: true
+      enable-coverage: false
+      version-set: ${{ needs.version-set.outputs.version-set }}
+    secrets: inherit
+
+  ci-ok:
+    name: ci-ok
+    needs: [lint, neo-unit-tests, smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # Mirror on-pr.yml: community PRs route through on-community-pr.yml,
+      # so don't gate on lint/test results when the PR is from a fork.
+      - name: CI failed
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (needs.lint.result != 'success' || needs.neo-unit-tests.result != 'success' || needs.smoke.result != 'success') }}
+        run: exit 1
+      - name: CI succeeded
+        run: exit 0

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     paths-ignore:
       - "sdk/.version"
+      - "pkg/cmd/pulumi/neo/**"
+      - "changelog/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -13,7 +13,6 @@ on:
     paths-ignore:
       - "sdk/.version"
       - "pkg/cmd/pulumi/neo/**"
-      - "changelog/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -51,7 +51,7 @@ type outboundEvent struct {
 }
 
 // NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
-// Neo task in `cli` tool execution mode, prints a console URL the user can open in a
+// Neo task in `cli` tool-execution mode, prints a console URL the user can open in a
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -50,8 +50,8 @@ type outboundEvent struct {
 	planMode bool
 }
 
-// NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
-// Neo task in `cli` tool execution mode, prints a console URL the user can open in a
+// NewNeoCmd creates the `pulumi neo` command. This first iteration of the command starts
+// a Neo task in `cli` tool execution mode, prints a console URL the user can open in a
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -50,8 +50,8 @@ type outboundEvent struct {
 	planMode bool
 }
 
-// NewNeoCmd creates the `pulumi neo` command. This first iteration of the command starts
-// a Neo task in `cli` tool execution mode, prints a console URL the user can open in a
+// NewNeoCmd creates the `pulumi neo` command. This first slice of the command starts a
+// Neo task in `cli` tool execution mode, prints a console URL the user can open in a
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {


### PR DESCRIPTION
## Summary
- Stacked on top of #22822 to verify the new `on-pr-neo.yml` fast-path actually triggers (and `on-pr.yml` skips) when a PR's diff is entirely under `pkg/cmd/pulumi/neo/**`.
- Trivial doc-comment hyphen fix in `neo.go` — chosen as the smallest possible neo-only diff.

## Test plan
- [ ] Confirm `on-pr-neo.yml` runs (lint + neo unit tests).
- [ ] Confirm `on-pr.yml` is skipped.
- [ ] Confirm `ci-ok` resolves green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)