### PR TITLE
Surface error and exit when `pulumi neo` task creation fails

### DIFF
--- a/changelog/pending/20260504--cli--surface-error-when-pulumi-neo-task-creation-fails.yaml
+++ b/changelog/pending/20260504--cli--surface-error-when-pulumi-neo-task-creation-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Surface the error and exit when `pulumi neo` fails to create the underlying task, instead of leaving the TUI stuck in `Thinking…`.

--- a/changelog/pending/20260504--cli--surface-error-when-pulumi-neo-task-creation-fails.yaml
+++ b/changelog/pending/20260504--cli--surface-error-when-pulumi-neo-task-creation-fails.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli
-  description: Surface the error and exit when `pulumi neo` fails to create the underlying task, instead of leaving the TUI stuck in `Thinking…`.
+  description: Surface the error and exit when `pulumi neo` fails to create the underlying task, instead of leaving the TUI stuck in `Thinking…`

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -233,6 +233,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 						PlanMode:          planMode,
 					})
 				if err != nil {
+					sendUI(uiCh, UIError{Message: "failed to create Neo task: " + err.Error()})
 					return err
 				}
 
@@ -261,6 +262,18 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 					return createTask(prompt, false)
 				})
 			}
+
+			// Tear the bubbletea program down when any errgroup goroutine fails.
+			// Without this, p.Run() blocks until the user manually quits, so a
+			// CreateNeoTask failure would leave the user staring at a TUI with
+			// no backing session. runWithTUI cancels gctx when runTUI itself
+			// returns, so this goroutine is a no-op on clean TUI exits and only
+			// fires p.Quit when a worker (createTask, dispatcher, session) errors.
+			g.Go(func() error {
+				<-gctx.Done()
+				p.Quit()
+				return nil
+			})
 
 			// Post TUI-originated user events to the API. Chat messages may arrive before
 			// any task exists — the first one creates it. Other event types (approvals

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -560,6 +560,89 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
 
+// TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits covers the
+// interactive path's CreateNeoTask error handling. Two coupled behaviors must
+// hold:
+//
+//  1. createTask emits a UIError on uiCh so the user sees the failure in the
+//     TUI before it tears down (vs. an unexplained "Thinking…" hang).
+//  2. The errgroup goroutine that watches gctx.Done fires p.Quit() once the
+//     createTask worker returns the error, so runNeo returns instead of
+//     blocking on p.Run forever.
+//
+// Pre-fix, the test would time out: with no manual p.Quit and no auto-quit
+// goroutine, p.Run would block until the test deadline even though createTask
+// had already errored.
+//
+//nolint:paralleltest // mutates package globals (BackendInstance, pkgWorkspace.Instance, newTeaProgram, isInteractive)
+func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
+	isolateWorkspace(t)
+
+	// Server returns 500 on CreateNeoTask. Other endpoints 404 — they should
+	// never be hit, since the failure must abort before any session starts.
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/preview/agents/test-org/tasks" {
+				http.Error(w, "synthetic 500", http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+	t.Cleanup(server.Close)
+
+	pc := client.NewClient(server.URL, "", false, nil)
+	be := newFakeBackend()
+	be.ClientV = pc
+	be.GetDefaultOrgF = func(context.Context) (string, error) { return "test-org", nil }
+
+	prevBackend := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = be
+	t.Cleanup(func() { cmdBackend.BackendInstance = prevBackend })
+
+	prevWorkspace := pkgWorkspace.Instance
+	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
+	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
+
+	// Force the interactive branch — createTask only runs on the interactive
+	// path, where the new UIError + p.Quit goroutine live.
+	prevInteractive := isInteractive
+	isInteractive = func() bool { return true }
+	t.Cleanup(func() { isInteractive = prevInteractive })
+
+	// Headless tea.Program. Notably, the test does NOT call p.Quit anywhere —
+	// the only path to a clean exit is the new auto-quit goroutine reacting
+	// to the createTask worker's non-nil return.
+	prevProgram := newTeaProgram
+	newTeaProgram = func(m tea.Model) *tea.Program {
+		return tea.NewProgram(
+			m,
+			tea.WithInput(nil),
+			tea.WithOutput(io.Discard),
+			tea.WithoutSignals(),
+			tea.WithoutSignalHandler(),
+			tea.WithoutRenderer(),
+		)
+	}
+	t.Cleanup(func() { newTeaProgram = prevProgram })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+	}()
+
+	select {
+	case err := <-done:
+		// CreateNeoTask's wrapped error must surface to the caller; the TUI
+		// tear-down path should not swallow it.
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "creating Neo task",
+			"CreateNeoTask error must propagate, not be replaced by tear-down state")
+	case <-time.After(5 * time.Second):
+		t.Fatal("runNeo did not return within 5s after CreateNeoTask failure — " +
+			"the gctx.Done → p.Quit goroutine must tear the TUI down on worker error")
+	}
+}
+
 // TestRunNeoIntegration_NewNeoCmdRunE covers the cobra RunE closure in
 // NewNeoCmd: it pulls the prompt from positional args, reads the flag values,
 // and forwards everything to runNeo. Without this test the entire RunE body


### PR DESCRIPTION
## Summary

- When `pc.CreateNeoTask` returned an error (e.g. the service replied 403), the Neo TUI sat in the `Thinking…` shimmer indefinitely. `createTask` returned the error to the surrounding errgroup but never sent a `UIError`, so the busy state was never cleared.
- `p.Run()` does not observe `gctx`, so even after the errgroup cancelled the context the bubbletea program kept blocking and `g.Wait()` never returned — the user had to Ctrl‑C to escape and the CLI exited with the wrong status.
- Fix: send a `UIError` on the failure path so the wrapped HTTP error is rendered and `busy` clears, and add a small goroutine that calls `p.Quit()` on `gctx.Done()` so the program tears down whenever any errgroup goroutine fails. The original `CreateNeoTask` error is preserved as the CLI's exit status (errgroup keeps the first non-nil error).

Fixes pulumi/pulumi-service#42466

## Test plan

- [x] `mise exec -- make format`
- [x] `golangci-lint` on `pkg/cmd/pulumi/neo/...` (0 issues)
- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/...`
- [ ] Manual: run `pulumi neo "hello"` against an org that returns 403 from the Neo create endpoint and confirm the `Thinking…` shimmer clears, a red error block appears with the wrapped HTTP error, and the CLI exits non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)