### PR TITLE
enable race detection only in daily cron

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -42,6 +42,11 @@ on:
         default: false
         required: false
         type: boolean
+      enable-race-detection:
+        description: "Enable race detection in test runs"
+        default: false
+        required: false
+        type: boolean
       test-retries:
         description: "How often tests are retried"
         default: 0
@@ -147,10 +152,12 @@ jobs:
           {
             echo "GO_TEST_PARALLELISM=4"
             echo "GO_TEST_PKG_PARALLELISM=1"
-            echo "GO_TEST_RACE=false"
           } >> "$GITHUB_ENV"
           # For debugging:
           ps aux
+      - name: Disable race detection
+        if: ${{ !inputs.enable-race-detection }}
+        run: echo "GO_TEST_RACE=false" >> "$GITHUB_ENV"
       - name: Install tsc on windows and macos
         if: ${{ runner.os == 'windows' || runner.os == 'macOS' }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ on:
         default: 0
         description: "Retry tests n times if there are failures"
         type: number
+      enable-race-detection:
+        required: false
+        default: false
+        description: "Enable race detection in test builds and test runs"
+        type: boolean
       fuzz-test-optional:
         required: false
         default: false
@@ -309,7 +314,7 @@ jobs:
       version-set: ${{ needs.matrix.outputs.version-set }}
       enable-coverage: ${{ inputs.enable-coverage }}
       # Windows and Linux need CGO and cross compile support to support -race. So for now only enable it for darwin and amd64 linux.
-      enable-race-detection: ${{ matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64') }}
+      enable-race-detection: ${{ inputs.enable-race-detection && (matrix.target.os == 'darwin' || (matrix.target.os == 'linux' && matrix.target.arch == 'amd64')) }}
       artifact-suffix: '-integration'
     secrets: inherit
 
@@ -364,6 +369,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: false
       enable-coverage: ${{ inputs.enable-coverage }}
+      enable-race-detection: ${{ inputs.enable-race-detection }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -390,6 +396,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: ${{ inputs.enable-coverage }}
+      enable-race-detection: ${{ inputs.enable-race-detection }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -417,6 +424,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
+      enable-race-detection: ${{ inputs.enable-race-detection }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 
@@ -444,6 +452,7 @@ jobs:
       test-command: ${{ matrix.test-suite.command }}
       is-integration-test: true
       enable-coverage: false
+      enable-race-detection: ${{ inputs.enable-race-detection }}
       test-retries: ${{ inputs.test-retries }}
       # require-build: false # TODO, remove ${{ matrix.require-build || false }}
 

--- a/.github/workflows/cron-test-all.yml
+++ b/.github/workflows/cron-test-all.yml
@@ -40,6 +40,7 @@ jobs:
       # data on every merge to main, so getting it in the daily cro
       # job is not important.
       enable-coverage: false
+      enable-race-detection: true
     secrets: inherit
 
   performance-gate:


### PR DESCRIPTION
This might speed up tests considerably, and is only catching issues rarely.  We're still running the full race detection in the daily cron, so we will notice if there are races.
