### PR TITLE
Unify how outputs are emitted

### DIFF
--- a/changelog/pending/20260504--codegen-go--fix-asset-archive-types-in-nested-collections.yaml
+++ b/changelog/pending/20260504--codegen-go--fix-asset-archive-types-in-nested-collections.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: codegen/go
+  description: Correctly generate `[]pulumi.Asset` & `[]pulumi.Archive`

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -210,6 +210,19 @@ func TestArgumentTypeName(t *testing.T) {
 	inputDynamicListType := g.argumentTypeName(model.NewListType(model.DynamicType), true /*isInput*/)
 	assert.Equal(t, "pulumi.Array", inputDynamicListType)
 
+	// Asset and Archive opaque types must be qualified with the pulumi package, otherwise nested compositions
+	// render bare names like []AssetMap which is invalid Go.
+	assert.Equal(t, "pulumi.AssetOrArchive", g.argumentTypeName(pcl.AssetType, false /*isInput*/))
+	assert.Equal(t, "pulumi.AssetOrArchive", g.argumentTypeName(pcl.AssetType, true /*isInput*/))
+	assert.Equal(t, "pulumi.Archive", g.argumentTypeName(pcl.ArchiveType, false /*isInput*/))
+	assert.Equal(t, "pulumi.Archive", g.argumentTypeName(pcl.ArchiveType, true /*isInput*/))
+	assert.Equal(t,
+		"pulumi.AssetOrArchiveArrayMap",
+		g.argumentTypeName(
+			model.NewObjectType(map[string]model.Type{"k": model.NewListType(pcl.AssetType)}),
+			true, /*isInput*/
+		))
+
 	// assert that the Output[T] + input=false is the same as T + input=true
 	// in this case where T = string
 	assert.Equal(t,

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -349,6 +349,15 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 					g.Fgenf(w, "%.v", from)
 				} else if typeName == "pulumi.String" && isID {
 					g.Fgenf(w, "%.v", from)
+				} else if typeName == "pulumi.Asset" ||
+					typeName == "pulumi.Archive" ||
+					typeName == "pulumi.AssetOrArchive" {
+					// Asset/Archive are interface types in the SDK; the values
+					// returned by NewFileAsset/etc. already implement the
+					// corresponding *Input interface. Wrapping with the
+					// interface type strips those methods and breaks use in
+					// pulumi.AssetOrArchiveArray, etc.
+					g.Fgenf(w, "%.v", from)
 				} else {
 					g.Fgenf(w, "%s(%.v)", typeName, from)
 				}
@@ -1223,6 +1232,13 @@ func (g *generator) argumentTypeName(destType model.Type, isInput bool) (result 
 			pkg:              (&schema.Package{Name: "main"}).Reference(),
 			externalPackages: g.externalCache,
 		}).argsType(schemaType)
+	}
+
+	switch destType {
+	case pcl.AssetType:
+		return "pulumi.AssetOrArchive"
+	case pcl.ArchiveType:
+		return "pulumi.Archive"
 	}
 
 	switch destType := destType.(type) {

--- a/pkg/testing/pulumi-test-language/l2_resource_asset_test.go
+++ b/pkg/testing/pulumi-test-language/l2_resource_asset_test.go
@@ -207,7 +207,7 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 
 	monitor := pulumirpc.NewResourceMonitorClient(conn)
 
-	_, err = monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
+	stackResp, err := monitor.RegisterResource(ctx, &pulumirpc.RegisterResourceRequest{
 		Type: string(resource.RootStackType),
 		Name: req.Stack,
 	})
@@ -363,6 +363,51 @@ func (h *L2ResourceAssetArchiveLanguageHost) Run(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not register resource: %w", err)
+	}
+
+	stringAsset, err := plugin.MarshalAsset(&resource.Asset{
+		Text: "file contents",
+	}, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal string asset: %w", err)
+	}
+	folderArchive, err := plugin.MarshalArchive(&resource.Archive{
+		Path: "../folder",
+	}, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal folder archive: %w", err)
+	}
+
+	outputs := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"assetOutput":   asset,
+			"archiveOutput": archive,
+			"assetList": structpb.NewListValue(&structpb.ListValue{
+				Values: []*structpb.Value{asset, stringAsset},
+			}),
+			"archiveList": structpb.NewListValue(&structpb.ListValue{
+				Values: []*structpb.Value{archive, folderArchive},
+			}),
+			"assetMap": structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"file":   asset,
+					"string": stringAsset,
+				},
+			}),
+			"archiveMap": structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"tar":    archive,
+					"folder": folderArchive,
+				},
+			}),
+		},
+	}
+	_, err = monitor.RegisterResourceOutputs(ctx, &pulumirpc.RegisterResourceOutputsRequest{
+		Urn:     stackResp.Urn,
+		Outputs: outputs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not register stack outputs: %w", err)
 	}
 
 	return &pulumirpc.RunResponse{}, nil

--- a/pkg/testing/pulumi-test-language/tests/l2_resource_asset_archive.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_resource_asset_archive.go
@@ -155,6 +155,32 @@ func init() {
 						resource.PropertyMap{"value": resource.NewProperty(remotearcValue)},
 						remotearc.Inputs, "expected inputs to be {value: %v}", remotearcValue)
 					assert.Equal(l, remotearc.Inputs, remotearc.Outputs, "expected inputs and outputs to match")
+
+					stack := RequireSingleResource(l, snap.Resources, "pulumi:pulumi:Stack")
+					AssertPropertyMapMember(l, stack.Outputs, "assetOutput",
+						resource.NewProperty(assetValue))
+					AssertPropertyMapMember(l, stack.Outputs, "archiveOutput",
+						resource.NewProperty(archiveValue))
+					AssertPropertyMapMember(l, stack.Outputs, "assetList",
+						resource.NewProperty([]resource.PropertyValue{
+							resource.NewProperty(assetValue),
+							resource.NewProperty(stringAsset),
+						}))
+					AssertPropertyMapMember(l, stack.Outputs, "archiveList",
+						resource.NewProperty([]resource.PropertyValue{
+							resource.NewProperty(archiveValue),
+							resource.NewProperty(folderValue),
+						}))
+					AssertPropertyMapMember(l, stack.Outputs, "assetMap",
+						resource.NewProperty(resource.PropertyMap{
+							"file":   resource.NewProperty(assetValue),
+							"string": resource.NewProperty(stringAsset),
+						}))
+					AssertPropertyMapMember(l, stack.Outputs, "archiveMap",
+						resource.NewProperty(resource.PropertyMap{
+							"tar":    resource.NewProperty(archiveValue),
+							"folder": resource.NewProperty(folderValue),
+						}))
 				},
 			},
 		},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-asset-archive/subdir/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-resource-asset-archive/subdir/main.pp
@@ -26,3 +26,37 @@ resource "remoteass" "asset-archive:index:AssetResource" {
 resource "remotearc" "asset-archive:index:ArchiveResource" {
     value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
+
+// Plain (non-nested) asset/archive outputs must round-trip through stack
+// outputs in every language.
+output "assetOutput" {
+    value = fileAsset("../test.txt")
+}
+
+output "archiveOutput" {
+    value = fileArchive("../archive.tar")
+}
+
+// Regression test for pulumi/pulumi#16384: array and map of assets/archives
+// must compose properly through Go program generation.
+output "assetList" {
+    value = [fileAsset("../test.txt"), stringAsset("file contents")]
+}
+
+output "archiveList" {
+    value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+}
+
+output "assetMap" {
+    value = {
+        "file":   fileAsset("../test.txt"),
+        "string": stringAsset("file contents"),
+    }
+}
+
+output "archiveMap" {
+    value = {
+        "tar":    fileArchive("../archive.tar"),
+        "folder": fileArchive("../folder"),
+    }
+}

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-asset-archive/subdir/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-resource-asset-archive/subdir/main.go
@@ -48,6 +48,24 @@ func main() {
 		if err != nil {
 			return err
 		}
+		ctx.Export("assetOutput", pulumi.NewFileAsset("../test.txt"))
+		ctx.Export("archiveOutput", pulumi.NewFileArchive("../archive.tar"))
+		ctx.Export("assetList", pulumi.AssetOrArchiveArray{
+			pulumi.NewFileAsset("../test.txt"),
+			pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveList", pulumi.ArchiveArray{
+			pulumi.NewFileArchive("../archive.tar"),
+			pulumi.NewFileArchive("../folder"),
+		})
+		ctx.Export("assetMap", pulumi.AssetOrArchiveMap{
+			"file":   pulumi.NewFileAsset("../test.txt"),
+			"string": pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveMap", pulumi.ArchiveMap{
+			"tar":    pulumi.NewFileArchive("../archive.tar"),
+			"folder": pulumi.NewFileArchive("../folder"),
+		})
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-asset-archive/subdir/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-resource-asset-archive/subdir/main.go
@@ -48,6 +48,24 @@ func main() {
 		if err != nil {
 			return err
 		}
+		ctx.Export("assetOutput", pulumi.NewFileAsset("../test.txt"))
+		ctx.Export("archiveOutput", pulumi.NewFileArchive("../archive.tar"))
+		ctx.Export("assetList", pulumi.AssetOrArchiveArray{
+			pulumi.NewFileAsset("../test.txt"),
+			pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveList", pulumi.ArchiveArray{
+			pulumi.NewFileArchive("../archive.tar"),
+			pulumi.NewFileArchive("../folder"),
+		})
+		ctx.Export("assetMap", pulumi.AssetOrArchiveMap{
+			"file":   pulumi.NewFileAsset("../test.txt"),
+			"string": pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveMap", pulumi.ArchiveMap{
+			"tar":    pulumi.NewFileArchive("../archive.tar"),
+			"folder": pulumi.NewFileArchive("../folder"),
+		})
 		return nil
 	})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-asset-archive/subdir/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-resource-asset-archive/subdir/main.go
@@ -48,6 +48,24 @@ func main() {
 		if err != nil {
 			return err
 		}
+		ctx.Export("assetOutput", pulumi.NewFileAsset("../test.txt"))
+		ctx.Export("archiveOutput", pulumi.NewFileArchive("../archive.tar"))
+		ctx.Export("assetList", pulumi.AssetOrArchiveArray{
+			pulumi.NewFileAsset("../test.txt"),
+			pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveList", pulumi.ArchiveArray{
+			pulumi.NewFileArchive("../archive.tar"),
+			pulumi.NewFileArchive("../folder"),
+		})
+		ctx.Export("assetMap", pulumi.AssetOrArchiveMap{
+			"file":   pulumi.NewFileAsset("../test.txt"),
+			"string": pulumi.NewStringAsset("file contents"),
+		})
+		ctx.Export("archiveMap", pulumi.ArchiveMap{
+			"tar":    pulumi.NewFileArchive("../archive.tar"),
+			"folder": pulumi.NewFileArchive("../folder"),
+		})
 		return nil
 	})
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-resource-asset-archive/subdir/index.ts
@@ -12,3 +12,21 @@ const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.as
 })});
 const remoteass = new asset_archive.AssetResource("remoteass", {value: new pulumi.asset.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")});
 const remotearc = new asset_archive.ArchiveResource("remotearc", {value: new pulumi.asset.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")});
+export const assetOutput = new pulumi.asset.FileAsset("../test.txt");
+export const archiveOutput = new pulumi.asset.FileArchive("../archive.tar");
+export const assetList = [
+    new pulumi.asset.FileAsset("../test.txt"),
+    new pulumi.asset.StringAsset("file contents"),
+];
+export const archiveList = [
+    new pulumi.asset.FileArchive("../archive.tar"),
+    new pulumi.asset.FileArchive("../folder"),
+];
+export const assetMap = {
+    file: new pulumi.asset.FileAsset("../test.txt"),
+    string: new pulumi.asset.StringAsset("file contents"),
+};
+export const archiveMap = {
+    tar: new pulumi.asset.FileArchive("../archive.tar"),
+    folder: new pulumi.asset.FileArchive("../folder"),
+};

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-resource-asset-archive/subdir/index.ts
@@ -12,3 +12,21 @@ const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.as
 })});
 const remoteass = new asset_archive.AssetResource("remoteass", {value: new pulumi.asset.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")});
 const remotearc = new asset_archive.ArchiveResource("remotearc", {value: new pulumi.asset.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")});
+export const assetOutput = new pulumi.asset.FileAsset("../test.txt");
+export const archiveOutput = new pulumi.asset.FileArchive("../archive.tar");
+export const assetList = [
+    new pulumi.asset.FileAsset("../test.txt"),
+    new pulumi.asset.StringAsset("file contents"),
+];
+export const archiveList = [
+    new pulumi.asset.FileArchive("../archive.tar"),
+    new pulumi.asset.FileArchive("../folder"),
+];
+export const assetMap = {
+    file: new pulumi.asset.FileAsset("../test.txt"),
+    string: new pulumi.asset.StringAsset("file contents"),
+};
+export const archiveMap = {
+    tar: new pulumi.asset.FileArchive("../archive.tar"),
+    folder: new pulumi.asset.FileArchive("../folder"),
+};

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-resource-asset-archive/subdir/index.ts
@@ -12,3 +12,21 @@ const assarc = new asset_archive.ArchiveResource("assarc", {value: new pulumi.as
 })});
 const remoteass = new asset_archive.AssetResource("remoteass", {value: new pulumi.asset.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")});
 const remotearc = new asset_archive.ArchiveResource("remotearc", {value: new pulumi.asset.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")});
+export const assetOutput = new pulumi.asset.FileAsset("../test.txt");
+export const archiveOutput = new pulumi.asset.FileArchive("../archive.tar");
+export const assetList = [
+    new pulumi.asset.FileAsset("../test.txt"),
+    new pulumi.asset.StringAsset("file contents"),
+];
+export const archiveList = [
+    new pulumi.asset.FileArchive("../archive.tar"),
+    new pulumi.asset.FileArchive("../folder"),
+];
+export const assetMap = {
+    file: new pulumi.asset.FileAsset("../test.txt"),
+    string: new pulumi.asset.StringAsset("file contents"),
+};
+export const archiveMap = {
+    tar: new pulumi.asset.FileArchive("../archive.tar"),
+    folder: new pulumi.asset.FileArchive("../folder"),
+};

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -150,28 +150,11 @@ async function massage(key: string | undefined, prop: any, objectStack: any[]): 
 }
 
 async function massageComplex(prop: any, objectStack: any[]): Promise<any> {
-    if (asset.Asset.isInstance(prop)) {
-        if ((<asset.FileAsset>prop).path !== undefined) {
-            return { path: (<asset.FileAsset>prop).path };
-        } else if ((<asset.RemoteAsset>prop).uri !== undefined) {
-            return { uri: (<asset.RemoteAsset>prop).uri };
-        } else if ((<asset.StringAsset>prop).text !== undefined) {
-            return { text: "..." };
-        }
-
-        return undefined;
-    }
-
-    if (asset.Archive.isInstance(prop)) {
-        if ((<asset.AssetArchive>prop).assets) {
-            return { assets: await massage("assets", (<asset.AssetArchive>prop).assets, objectStack) };
-        } else if ((<asset.FileArchive>prop).path !== undefined) {
-            return { path: (<asset.FileArchive>prop).path };
-        } else if ((<asset.RemoteArchive>prop).uri !== undefined) {
-            return { uri: (<asset.RemoteArchive>prop).uri };
-        }
-
-        return undefined;
+    // Preserve Asset / Archive instances so subsequent gRPC serialization
+    // tags them with the special signature key (`specialAssetSig` /
+    // `specialArchiveSig`).
+    if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
+        return prop;
     }
 
     if (Resource.isInstance(prop)) {

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-asset-archive/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-resource-asset-archive/main.pp
@@ -26,3 +26,37 @@ resource "remoteass" "asset-archive:index:AssetResource" {
 resource "remotearc" "asset-archive:index:ArchiveResource" {
     value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
+
+// Plain (non-nested) asset/archive outputs must round-trip through stack
+// outputs in every language.
+output "assetOutput" {
+    value = fileAsset("../test.txt")
+}
+
+output "archiveOutput" {
+    value = fileArchive("../archive.tar")
+}
+
+// Regression test for pulumi/pulumi#16384: array and map of assets/archives
+// must compose properly through Go program generation.
+output "assetList" {
+    value = [fileAsset("../test.txt"), stringAsset("file contents")]
+}
+
+output "archiveList" {
+    value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+}
+
+output "assetMap" {
+    value = {
+        "file":   fileAsset("../test.txt"),
+        "string": stringAsset("file contents"),
+    }
+}
+
+output "archiveMap" {
+    value = {
+        "tar":    fileArchive("../archive.tar"),
+        "folder": fileArchive("../folder"),
+    }
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-asset-archive/subdir/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-resource-asset-archive/subdir/main.pp
@@ -26,3 +26,37 @@ resource "remoteass" "asset-archive:index:AssetResource" {
 resource "remotearc" "asset-archive:index:ArchiveResource" {
     value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
+
+// Plain (non-nested) asset/archive outputs must round-trip through stack
+// outputs in every language.
+output "assetOutput" {
+    value = fileAsset("../test.txt")
+}
+
+output "archiveOutput" {
+    value = fileArchive("../archive.tar")
+}
+
+// Regression test for pulumi/pulumi#16384: array and map of assets/archives
+// must compose properly through Go program generation.
+output "assetList" {
+    value = [fileAsset("../test.txt"), stringAsset("file contents")]
+}
+
+output "archiveList" {
+    value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+}
+
+output "assetMap" {
+    value = {
+        "file":   fileAsset("../test.txt"),
+        "string": stringAsset("file contents"),
+    }
+}
+
+output "archiveMap" {
+    value = {
+        "tar":    fileArchive("../archive.tar"),
+        "folder": fileArchive("../folder"),
+    }
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.pp
@@ -26,3 +26,37 @@ resource "remoteass" "asset-archive:index:AssetResource" {
 resource "remotearc" "asset-archive:index:ArchiveResource" {
     value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
+
+// Plain (non-nested) asset/archive outputs must round-trip through stack
+// outputs in every language.
+output "assetOutput" {
+    value = fileAsset("../test.txt")
+}
+
+output "archiveOutput" {
+    value = fileArchive("../archive.tar")
+}
+
+// Regression test for pulumi/pulumi#16384: array and map of assets/archives
+// must compose properly through Go program generation.
+output "assetList" {
+    value = [fileAsset("../test.txt"), stringAsset("file contents")]
+}
+
+output "archiveList" {
+    value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+}
+
+output "assetMap" {
+    value = {
+        "file":   fileAsset("../test.txt"),
+        "string": stringAsset("file contents"),
+    }
+}
+
+output "archiveMap" {
+    value = {
+        "tar":    fileArchive("../archive.tar"),
+        "folder": fileArchive("../folder"),
+    }
+}

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-asset-archive/subdir/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-resource-asset-archive/subdir/__main__.py
@@ -12,3 +12,21 @@ assarc = asset_archive.ArchiveResource("assarc", value=pulumi.AssetArchive({
 }))
 remoteass = asset_archive.AssetResource("remoteass", value=pulumi.RemoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt"))
 remotearc = asset_archive.ArchiveResource("remotearc", value=pulumi.RemoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar"))
+pulumi.export("assetOutput", pulumi.FileAsset("../test.txt"))
+pulumi.export("archiveOutput", pulumi.FileArchive("../archive.tar"))
+pulumi.export("assetList", [
+    pulumi.FileAsset("../test.txt"),
+    pulumi.StringAsset("file contents"),
+])
+pulumi.export("archiveList", [
+    pulumi.FileArchive("../archive.tar"),
+    pulumi.FileArchive("../folder"),
+])
+pulumi.export("assetMap", {
+    "file": pulumi.FileAsset("../test.txt"),
+    "string": pulumi.StringAsset("file contents"),
+})
+pulumi.export("archiveMap", {
+    "tar": pulumi.FileArchive("../archive.tar"),
+    "folder": pulumi.FileArchive("../folder"),
+})

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -269,6 +269,8 @@ def massage(attr: Any, seen: list[Any]):
 
 
 def massage_complex(attr: Any, seen: list[Any]) -> Any:
+    from .. import Asset, Archive
+
     def is_public_key(key: str) -> bool:
         return not key.startswith("_")
 
@@ -278,6 +280,13 @@ def massage_complex(attr: Any, seen: list[Any]) -> Any:
             if include(key):
                 plain_object[key] = massage(attr.__dict__[key], seen)
         return plain_object
+
+    # Preserve Asset / Archive instances so subsequent gRPC serialization
+    # tags them with the special signature key; without that, the engine
+    # deserializes them as weakly-typed dicts and assets in stack outputs
+    # lose their identity. See pulumi/pulumi#16384.
+    if isinstance(attr, (Asset, Archive)):
+        return attr
 
     if isinstance(attr, Resource):
         serialized_attr = serialize_all_keys(is_public_key)


### PR DESCRIPTION
This PR fixes Go's codegen so it correctly generates arrays & maps of archives/arrays. It changes how NodeJS & Python emit archives & assets on the write to match how Go emits them (adding a conformance test to lock in both changes).

Fixes https://github.com/pulumi/pulumi/issues/16384