### PR TITLE
cli/neo: widen TUI rendering to track terminal width

### DIFF
--- a/changelog/pending/20260504--cli-neo--widen-tui-rendering-to-fill-terminal.yaml
+++ b/changelog/pending/20260504--cli-neo--widen-tui-rendering-to-fill-terminal.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/neo
+  description: Widen the `pulumi neo` TUI to track the terminal width instead of capping conversation rendering at 80 columns

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -231,8 +231,8 @@ var (
 // line, and a "╰─" tick below the last line. The right edge and full
 // horizontal bars are intentionally omitted so no rendered line ever
 // stretches across the terminal width — that would wrap on resize-shrink
-// and corrupt bubbletea's inline-renderer line accounting (see View() for
-// context). All bracket glyphs are colored via borderStyle.
+// and desync the inline-renderer line accounting. All bracket glyphs are
+// colored via borderStyle.
 //
 // Empty content collapses to two corner ticks ("╭─" / "╰─") with no body.
 func renderLeftBracket(borderStyle lipgloss.Style, content string) string {
@@ -747,17 +747,10 @@ func (m Model) View() string {
 
 // liveWidth returns the width to use when rendering live-frame content:
 // the terminal width minus a small cushion that keeps glamour, lipgloss,
-// and the textinput off the wrap column. Tracks the terminal so wide
-// windows actually fill.
-//
-// Resize-during-stream caveat: bubbletea v1.3.10's inline renderer uses
-// logical line counts, not visual rows, in CursorUp before each frame, so
-// drag-resizing while a live frame is in flight can stack stale fragments
-// into scrollback. Tracked separately; will be addressed via a bubbletea
-// upgrade or upstream fix.
+// and the textinput off the wrap column.
 func (m *Model) liveWidth() int {
 	const (
-		margin         = 4  // small cushion so content doesn't end at the wrap column
+		margin         = 4
 		minUsableWidth = 40 // below this, give up the cushion to keep something visible
 	)
 	if m.width > minUsableWidth {
@@ -772,14 +765,11 @@ func (m *Model) liveWidth() int {
 // busy block's spinner glyph is read from m.spinner.View() at render time so
 // the animation tracks the current frame without re-caching per block.
 //
-// We deliberately use strings.Join instead of lipgloss.JoinVertical.
-// JoinVertical pads every constituent block to the widest one's column count
-// with trailing spaces, which pins every line in the frame to the longest
-// one. On a resize-shrink those wide lines wrap, bubbletea's inline renderer
-// (v1.3.10) issues CursorUp(linesRendered-1) using the logical count instead
-// of the wrapped visual rows, and stale frame fragments leak into scrollback.
-// strings.Join keeps each line at its natural length so only genuinely-wide
-// content is at risk.
+// We deliberately use strings.Join instead of lipgloss.JoinVertical:
+// JoinVertical pads every line to the widest constituent's column count with
+// trailing spaces, which makes resize-shrink wrap every line and desync the
+// inline-renderer line accounting. strings.Join keeps each line at its
+// natural length so only genuinely-wide content is at risk.
 func (m *Model) liveView() string {
 	var parts []string
 	for _, b := range m.blocks {
@@ -1045,9 +1035,9 @@ func (m *Model) renderUserBubble(content string) string {
 // wrapPlain word-wraps non-markdown text to the safe live width (m.liveWidth)
 // so streaming text never sits at the terminal wrap boundary. We use
 // reflow's wordwrap (which only inserts \n at word boundaries) instead of
-// lipgloss.Style.Width(W).Render which also pads each line with trailing
-// spaces to W. Padding produces full-width lines that wrap on resize-shrink
-// and corrupt bubbletea's inline-renderer line accounting.
+// lipgloss.Style.Width(W).Render, which also pads every line to W with
+// trailing spaces — those full-width lines wrap on resize-shrink and desync
+// the inline-renderer line accounting.
 func (m *Model) wrapPlain(text string) string {
 	w := m.liveWidth()
 	if w <= 4 {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -745,37 +745,25 @@ func (m Model) View() string {
 	return strings.Join(parts, "\n")
 }
 
-// liveWidth returns the width to use when rendering live-frame content. We
-// cap at 80 cols (book-readable column count) and otherwise back off the
-// real terminal width by 10 cols.
+// liveWidth returns the width to use when rendering live-frame content:
+// the terminal width minus a small cushion that keeps glamour, lipgloss,
+// and the textinput off the wrap column. Tracks the terminal so wide
+// windows actually fill.
 //
-// bubbletea's inline renderer (v1.3.10 standard_renderer.go) uses logical
-// line counts, not visual rows, when issuing CursorUp(linesRendered-1)
-// before each frame. Any content that wraps to two visual rows on the new
-// terminal width — a lipgloss border at width-4, a glamour-wrapped paragraph
-// at width-4, a width-padded textinput — desyncs the cursor and stacks
-// stale frame fragments into scrollback during drag-resize.
-//
-// The 80-col cap matters because it makes resize a non-event for the
-// common case: any terminal ≥ 90 cols renders content at the same constant
-// 80 cols regardless of actual width, so dragging through that range
-// doesn't change what's on screen and the renderer never sees a wrap.
-// Below 90 cols liveWidth follows the terminal (with a 10-col cushion) so
-// content stays inside the viewport.
+// Resize-during-stream caveat: bubbletea v1.3.10's inline renderer uses
+// logical line counts, not visual rows, in CursorUp before each frame, so
+// drag-resizing while a live frame is in flight can stack stale fragments
+// into scrollback. Tracked separately; will be addressed via a bubbletea
+// upgrade or upstream fix.
 func (m *Model) liveWidth() int {
 	const (
-		maxLiveWidth   = 80
-		margin         = 10
+		margin         = 4  // small cushion so content doesn't end at the wrap column
 		minUsableWidth = 40 // below this, give up the cushion to keep something visible
 	)
-	w := m.width
-	if w > maxLiveWidth+margin {
-		return maxLiveWidth
+	if m.width > minUsableWidth {
+		return m.width - margin
 	}
-	if w > minUsableWidth {
-		return w - margin
-	}
-	return w
+	return m.width
 }
 
 // liveView renders only the in-flight blocks that should occupy the live
@@ -1046,7 +1034,7 @@ func (m *Model) renderApprovalChoice(b *block) {
 func (m *Model) renderUserBubble(content string) string {
 	prefix := promptStyle.Render("❯") + " " // visible width 2
 	padded := " " + content + " "
-	bubbleWidth := max(m.width-2, 8)
+	bubbleWidth := max(m.liveWidth()-2, 8)
 	style := userMsgBubble
 	if m.width > 4 && lipgloss.Width(padded) > bubbleWidth {
 		style = style.Width(bubbleWidth)

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1429,6 +1429,49 @@ func TestUserBubbleDoesNotPadShortMessages(t *testing.T) {
 	assert.Less(t, widths[0], 20, "short bubble line should hug content, not fill terminal; got width=%d", widths[0])
 }
 
+func TestUserBubbleWrapsAtWideTerminal(t *testing.T) {
+	t.Parallel()
+
+	// At a wide terminal the bubble must wrap against liveWidth (m.width-4),
+	// not raw m.width — otherwise wrapped lines sit on the terminal wrap
+	// column and desync the inline-renderer line accounting.
+	const termWidth = 200
+	m := &Model{width: termWidth}
+	long := strings.Repeat("word ", 60) // ~300 chars, forces wrap
+	got := m.renderUserBubble(long)
+
+	widths := visibleLines(got)
+	require.Greater(t, len(widths), 1, "long bubble at wide terminal must wrap; got: %q", got)
+	for i, w := range widths {
+		assert.LessOrEqual(t, w, m.liveWidth(), "bubble line %d sits past liveWidth: width=%d", i, w)
+	}
+}
+
+func TestLiveWidth_Boundaries(t *testing.T) {
+	t.Parallel()
+
+	// liveWidth contract: wide terminals back off by a 4-col cushion so
+	// rendered content stays inside the wrap column; at or below the
+	// minUsableWidth threshold (40) we hand back the raw width so something
+	// still renders on a degenerate terminal.
+	cases := []struct {
+		width int
+		want  int
+	}{
+		{width: 0, want: 0},
+		{width: 1, want: 1},
+		{width: 40, want: 40},  // boundary: not > minUsableWidth, no cushion
+		{width: 41, want: 37},  // first width that gets the cushion
+		{width: 80, want: 76},  // typical narrow terminal
+		{width: 100, want: 96}, // matches the welcome.termWidth assertion
+		{width: 200, want: 196},
+	}
+	for _, tc := range cases {
+		m := &Model{width: tc.width}
+		assert.Equal(t, tc.want, m.liveWidth(), "liveWidth(width=%d)", tc.width)
+	}
+}
+
 func TestResizeReRendersWidthDependentBlocks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -339,10 +339,9 @@ func TestModel_Update_WindowSize_TracksDimensionsAndBuildsRenderer(t *testing.T)
 
 	assert.Equal(t, 100, um.width)
 	assert.Equal(t, 30, um.height)
-	// welcome.termWidth is the safe live-frame width: capped at 80 once the
-	// terminal exceeds 90 cols, so the banner stays at a stable 80 cols
-	// across drag-resizes through that range. See liveWidth() for rationale.
-	assert.Equal(t, 80, um.welcome.termWidth)
+	// welcome.termWidth tracks liveWidth() = terminal width minus a 4-col
+	// margin so the banner fills the available width.
+	assert.Equal(t, 96, um.welcome.termWidth)
 	// The glamour renderer is lazily built on the first WindowSize so it can
 	// pick up the real terminal width for wrapping.
 	require.NotNil(t, um.mdRenderer)
@@ -1726,7 +1725,7 @@ func TestModel_WrapPlain_TinyWidthShortCircuits(t *testing.T) {
 	long := "a fairly long sentence that would otherwise wrap"
 
 	m := NewModel(ModelConfig{})
-	m.width = 1 // liveWidth returns m.width directly when below minUsableWidth
+	m.width = 1 // liveWidth returns m.width directly when at or below minUsableWidth
 	require.LessOrEqual(t, m.liveWidth(), 4, "test relies on tiny liveWidth path")
 	assert.Equal(t, long, m.wrapPlain(long), "tiny-width path must return input verbatim")
 

--- a/pkg/cmd/pulumi/neo/tui_welcome_test.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome_test.go
@@ -150,8 +150,8 @@ func TestWelcomeView_TildeForHomePath(t *testing.T) {
 
 	// Paths under $HOME are presented as "~/<rel>" so the user sees the
 	// shorter, familiar shell form rather than a long absolute path. The
-	// banner has limited horizontal real estate (capped at liveWidth ≤ 80
-	// cols) and the absolute home path is the dominant chunk on most setups.
+	// banner has limited horizontal real estate and the absolute home path
+	// is the dominant chunk on most setups.
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skipf("UserHomeDir unavailable: %v", err)


### PR DESCRIPTION
## Summary

- `liveWidth()` now returns `terminal_width - 4` (with the 40-col floor preserved) instead of capping at 80 cols. The conversation pane fills wide terminals instead of sitting at ~50% utilization.
- `renderUserBubble` now uses `liveWidth()` like the rest of the pane, so user bubbles align with assistant/tool blocks.
- 80-col cap was a workaround for bubbletea v1.3.10's inline-renderer cursor desync on drag-resize. That trade-off is deferred — drag-resizing during a live frame can still leak stale fragments into scrollback. Will be addressed later

Reported in pulumi/pulumi-service#42469 (dogfooders on iTerm2 with wide windows seeing the conversation pane occupy < 50% of the terminal).

## Test plan

- [x] `cd pkg && mise exec -- go test -count=1 -race ./cmd/pulumi/neo/...`
- [x] `mise exec -- make format`
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/neo/...`
- [ ] Manual: launch `pulumi neo` on a 200-col iTerm2 window and confirm content fills the width
- [ ] Manual: launch on a 60-col terminal and confirm content stays inside the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)