### PR TITLE
extend changelog message guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ All commands assume you're at the repo root.
 - **Tidy fix:** `mise exec -- make tidy_fix`
 - **Proto generation:** `mise exec -- make build_proto`
 - **Proto check:** `mise exec -- make check_proto`
-- **Changelog entry:** `mise exec -- make changelog` (interactive)
+- **Changelog entry:** `mise exec -- make changelog` (interactive) (See also the changelog messages guidelines in CONTRIBUTING.md)
 - **Go workspace:** `mise exec -- make work`
 
 ## Key invariants

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ Here's some examples of what we're trying to avoid:
 - Adds a feature
 - Feature now does something
 
+Keep changelog messages short and to the point, one sentence is usually enough. Don't overdescribe a feature in the changelog, to keep the whole log scanneable quickly by end users.
+
 ### Downloading Pulumi from contributed pull requests
 
 Artifacts built during pull request workflows can be downloaded by running the following command (note that the artifacts expire 7 days after CI has been run):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Here's some examples of what we're trying to avoid:
 - Adds a feature
 - Feature now does something
 
-Keep changelog messages short and to the point, one sentence is usually enough. Don't overdescribe a feature in the changelog, to keep the whole log scanneable quickly by end users.
+Keep changelog messages short and to the point, one sentence is usually enough. Don't overdescribe a feature in the changelog, to keep the whole log scannable quickly by end users.
 
 ### Downloading Pulumi from contributed pull requests
 


### PR DESCRIPTION
Extend the guidelines for changelog messages a bit.  Robots seem to want to write an essay for each changelog entry, but that's not what we generally want the changelog to look like, as it otherwise quickly becomes overwhelming for end users to actually read the changelog.