### PR TITLE
Change PluginInfo timestamps to be cached like size

### DIFF
--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -118,12 +118,14 @@ func formatPluginsJSON(plugins []workspace.PluginInfo) error {
 			Size:    plugin.Size(),
 		}
 
-		if !plugin.InstallTime.IsZero() {
-			jsonPluginInfo[idx].InstallTime = makeStringRef(cmd.FormatTime(plugin.InstallTime.UTC()))
+		installTime := plugin.InstallTime()
+		if !installTime.IsZero() {
+			jsonPluginInfo[idx].InstallTime = makeStringRef(cmd.FormatTime(installTime.UTC()))
 		}
 
-		if !plugin.LastUsedTime.IsZero() {
-			jsonPluginInfo[idx].LastUsedTime = makeStringRef(cmd.FormatTime(plugin.LastUsedTime.UTC()))
+		lastUsedTime := plugin.LastUsedTime()
+		if !lastUsedTime.IsZero() {
+			jsonPluginInfo[idx].LastUsedTime = makeStringRef(cmd.FormatTime(lastUsedTime.UTC()))
 		}
 	}
 
@@ -146,21 +148,23 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 		} else {
 			bytes = humanize.Bytes(plugin.Size())
 		}
-		var installTime string
-		if plugin.InstallTime.IsZero() {
-			installTime = naString
+		var installTimeStr string
+		installTime := plugin.InstallTime()
+		if installTime.IsZero() {
+			installTimeStr = naString
 		} else {
-			installTime = humanize.Time(plugin.InstallTime)
+			installTimeStr = humanize.Time(installTime)
 		}
-		var lastUsedTime string
-		if plugin.LastUsedTime.IsZero() {
-			lastUsedTime = humanNeverTime
+		var lastUsedTimeStr string
+		lastUsedTime := plugin.LastUsedTime()
+		if lastUsedTime.IsZero() {
+			lastUsedTimeStr = humanNeverTime
 		} else {
-			lastUsedTime = humanize.Time(plugin.LastUsedTime)
+			lastUsedTimeStr = humanize.Time(lastUsedTime)
 		}
 
 		rows = append(rows, cmdutil.TableRow{
-			Columns: []string{plugin.Name, string(plugin.Kind), version, bytes, installTime, lastUsedTime},
+			Columns: []string{plugin.Name, string(plugin.Kind), version, bytes, installTimeStr, lastUsedTimeStr},
 		})
 
 		totalSize += plugin.Size()

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -478,9 +478,15 @@ func (l *pluginLoader) loadSchemaBytes(
 	}
 
 	if schemaPath != "" {
-		schemaBytes, ok := l.loadCachedSchemaBytes(schemaPath, pluginInfo.InstallTime)
-		if ok {
-			return schemaBytes, nil, nil
+		installTime := pluginInfo.InstallTime()
+		if installTime.IsZero() {
+			// Non-fatal: log and proceed without file caching.
+			logging.V(3).Infof("failed to get install time for plugin %s@%v: %v", descriptor.Name, pluginVersion, err)
+		} else {
+			schemaBytes, ok := l.loadCachedSchemaBytes(schemaPath, installTime)
+			if ok {
+				return schemaBytes, nil, nil
+			}
 		}
 	}
 

--- a/pkg/codegen/schema/loader_caching_test.go
+++ b/pkg/codegen/schema/loader_caching_test.go
@@ -137,11 +137,12 @@ func TestSchemaCacheMissWritesFile(t *testing.T) {
 		},
 	}
 
+	pluginDir := t.TempDir()
 	pluginInfo := &workspace.PluginInfo{
-		Name:        "aws",
-		Kind:        apitype.ResourcePlugin,
-		Version:     &version,
-		InstallTime: time.Now().Add(-time.Hour),
+		Name:    "aws",
+		Kind:    apitype.ResourcePlugin,
+		Version: &version,
+		Path:    pluginDir,
 	}
 
 	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
@@ -172,7 +173,10 @@ func TestSchemaCacheHitSkipsPlugin(t *testing.T) {
 	version := semver.MustParse("1.0.0")
 	schema := minimalSchemaJSON("aws", "1.0.0")
 
-	// Write the cache file before creating the loader.
+	// Create the plugin dir first so its ctime is older than the cache file written next.
+	pluginDir := t.TempDir()
+
+	// Write the cache file after the plugin dir exists so its mtime >= plugin dir ctime.
 	schemaPath, err := schemaFilePath("aws", &version, "", nil)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(filepath.Dir(schemaPath), 0o700))
@@ -186,12 +190,12 @@ func TestSchemaCacheHitSkipsPlugin(t *testing.T) {
 		},
 	}
 
-	// Plugin install time is before the cache file was written.
+	// Plugin install time (derived from pluginDir ctime) is before the cache file was written.
 	pluginInfo := &workspace.PluginInfo{
-		Name:        "aws",
-		Kind:        apitype.ResourcePlugin,
-		Version:     &version,
-		InstallTime: time.Now().Add(-time.Hour),
+		Name:    "aws",
+		Kind:    apitype.ResourcePlugin,
+		Version: &version,
+		Path:    pluginDir,
 	}
 
 	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
@@ -222,7 +226,10 @@ func TestSchemaCacheStaleOnReinstall(t *testing.T) {
 	pastTime := time.Now().Add(-time.Hour)
 	require.NoError(t, os.Chtimes(schemaPath, pastTime, pastTime))
 
-	// Plugin was reinstalled after the cache was written.
+	// Plugin was reinstalled after the cache was written: create the plugin dir
+	// after backdating the cache so its ctime is newer than the cache mtime.
+	pluginDir := t.TempDir()
+
 	getCalled := 0
 	provider := &plugin.MockProvider{
 		GetSchemaF: func(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
@@ -232,10 +239,10 @@ func TestSchemaCacheStaleOnReinstall(t *testing.T) {
 	}
 
 	pluginInfo := &workspace.PluginInfo{
-		Name:        "aws",
-		Kind:        apitype.ResourcePlugin,
-		Version:     &version,
-		InstallTime: time.Now(), // newer than the backdated cache file
+		Name:    "aws",
+		Kind:    apitype.ResourcePlugin,
+		Version: &version,
+		Path:    pluginDir, // ctime is newer than the backdated cache file
 	}
 
 	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
@@ -319,12 +326,14 @@ func TestSchemaCacheParameterized(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, awsPath, azurePath, "different parameterizations must use distinct cache files")
 
-	installTime := time.Now().Add(-time.Hour)
+	// Create the plugin dir before priming the cache so its ctime is older than
+	// the cache files written by makeLoader below.
+	pluginDir := t.TempDir()
 	pluginInfo := &workspace.PluginInfo{
-		Name:        "terraform-bridge",
-		Kind:        apitype.ResourcePlugin,
-		Version:     &bridgeVersion,
-		InstallTime: installTime,
+		Name:    "terraform-bridge",
+		Kind:    apitype.ResourcePlugin,
+		Version: &bridgeVersion,
+		Path:    pluginDir,
 	}
 
 	// Helper: build a loader backed by a provider that always returns the given schema.

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -1363,14 +1363,45 @@ func (spec PluginDescriptor) String() string {
 // location, by default `~/.pulumi/plugins/<kind>-<name>-<version>/`.  A plugin may contain multiple files,
 // however the primary loadable executable must be named `pulumi-<kind>-<name>`.
 type PluginInfo struct {
-	Name         string             // the simple name of the plugin.
-	Path         string             // the path that a plugin was loaded from (this will always be a directory)
-	Kind         apitype.PluginKind // the kind of the plugin (language, resource, etc).
-	Version      *semver.Version    // the plugin's semantic version, if present.
-	InstallTime  time.Time          // the time the plugin was installed.
-	LastUsedTime time.Time          // the last time the plugin was used.
+	Name    string             // the simple name of the plugin.
+	Path    string             // the path that a plugin was loaded from (this will always be a directory)
+	Kind    apitype.PluginKind // the kind of the plugin (language, resource, etc).
+	Version *semver.Version    // the plugin's semantic version, if present.
+
+	installTime  time.Time // cached time the plugin was installed.
+	lastUsedTime time.Time // cached last time the plugin was used.
 
 	size uint64 // cached plugin size in bytes
+}
+
+// InstallTime returns the time the plugin was installed.
+func (info *PluginInfo) InstallTime() time.Time {
+	if !info.installTime.IsZero() {
+		return info.installTime
+	}
+
+	err := info.setFileMetadata()
+	if err != nil {
+		logging.V(6).Infof("unable to get plugin install time for %s: %v", info.Path, err)
+		return time.Time{}
+	}
+
+	return info.installTime
+}
+
+// LastUsedTime returns the last time the plugin was used.
+func (info *PluginInfo) LastUsedTime() time.Time {
+	if !info.lastUsedTime.IsZero() {
+		return info.lastUsedTime
+	}
+
+	err := info.setFileMetadata()
+	if err != nil {
+		logging.V(6).Infof("unable to get plugin last used time for %s: %v", info.Path, err)
+		return time.Time{}
+	}
+
+	return info.lastUsedTime
 }
 
 // Size calculates the size of the plugin, in bytes.
@@ -1415,9 +1446,13 @@ func (info *PluginInfo) Delete() error {
 }
 
 // setFileMetadata adds extra metadata from the given file, representing this plugin's directory.
-func (info *PluginInfo) setFileMetadata(path string) error {
+func (info *PluginInfo) setFileMetadata() error {
+	if info.Path == "" {
+		return nil
+	}
+
 	// Get the file info.
-	file, err := os.Stat(path)
+	file, err := os.Stat(info.Path)
 	if err != nil {
 		return err
 	}
@@ -1426,12 +1461,12 @@ func (info *PluginInfo) setFileMetadata(path string) error {
 	tinfo := times.Get(file)
 
 	if tinfo.HasChangeTime() {
-		info.InstallTime = tinfo.ChangeTime()
+		info.installTime = tinfo.ChangeTime()
 	} else {
-		info.InstallTime = tinfo.ModTime()
+		info.installTime = tinfo.ModTime()
 	}
 
-	info.LastUsedTime = tinfo.AccessTime()
+	info.lastUsedTime = tinfo.AccessTime()
 
 	return nil
 }
@@ -1961,9 +1996,6 @@ func GetPluginsFromDir(dir string) ([]PluginInfo, error) {
 			} else if !os.IsNotExist(err) {
 				return nil, err
 			}
-			if err = plugin.setFileMetadata(path); err != nil {
-				return nil, err
-			}
 			plugins = append(plugins, plugin)
 		}
 	}
@@ -1992,7 +2024,7 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 // possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
 func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (string, error) {
-	info, path, err := getPluginInfoAndPath(ctx, d, spec, true /* skipMetadata */, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins)
 	if err != nil {
 		return "", err
 	}
@@ -2004,7 +2036,7 @@ func GetPluginPath(ctx context.Context, d diag.Sink, spec PluginDescriptor, proj
 
 func GetPluginInfo(ctx context.Context, d diag.Sink, spec PluginDescriptor, projectPlugins []ProjectPlugin,
 ) (*PluginInfo, error) {
-	info, path, err := getPluginInfoAndPath(ctx, d, spec, false, projectPlugins)
+	info, path, err := getPluginInfoAndPath(ctx, d, spec, projectPlugins)
 	if err != nil {
 		return nil, err
 	}
@@ -2038,7 +2070,7 @@ func getPluginPath(info *PluginInfo) string {
 func getPluginInfoAndPath(
 	ctx context.Context,
 	d diag.Sink,
-	spec PluginDescriptor, skipMetadata bool,
+	spec PluginDescriptor,
 	projectPlugins []ProjectPlugin,
 ) (*PluginInfo, string, error) {
 	filename := spec.File()
@@ -2082,12 +2114,6 @@ func getPluginInfoAndPath(
 			Kind:    localSpec.Kind,
 			Version: localSpec.Version,
 			Path:    filepath.Clean(plugin.Path),
-		}
-		// computing plugin sizes can be very expensive (nested node_modules)
-		if !skipMetadata {
-			if err := info.setFileMetadata(info.Path); err != nil {
-				return nil, "", err
-			}
 		}
 		path := getPluginPath(info)
 		return info, path, nil
@@ -2162,12 +2188,6 @@ func getPluginInfoAndPath(
 			Kind: spec.Kind,
 			Name: spec.Name,
 			Path: filepath.Dir(pluginPath),
-		}
-		// computing plugin sizes can be very expensive (nested node_modules)
-		if !skipMetadata {
-			if err := info.setFileMetadata(info.Path); err != nil {
-				return nil, "", err
-			}
 		}
 		return info, pluginPath, nil
 	}

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -1775,7 +1775,7 @@ func TestPluginInfoShimless(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pluginPath, info.Path)
 	assert.Equal(t, uint64(23), info.Size())
-	assert.Equal(t, stat.ModTime(), info.InstallTime)
+	assert.Equal(t, stat.ModTime(), info.InstallTime())
 }
 
 func TestProjectPluginsWithUncleanPath(t *testing.T) {


### PR DESCRIPTION
This updates `PluginInfo` to internally calculate and cache its timestamps the same as we do for size. 

This means we can get rid of all the `skipMetadata` logic and we only make a `Stat` call for when these timestamps are needed (during `plugin ls` or when deciding if a plugin has invalidated its schema cache).

Only major refactor is the tests now need to make real files and fill in `Path` rather than just setting `InstallTime`.