### PR TITLE
ci: add CODEOWNERS entry for pkg/cmd/pulumi/neo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @pulumi/platform
+/pkg/cmd/pulumi/neo/ @pulumi/ai


### PR DESCRIPTION
## Summary
- Add `/pkg/cmd/pulumi/neo/ @pulumi/ai` to `.github/CODEOWNERS` so the AI team owns code review for the neo CLI subtree.
- The more-specific path overrides the existing `* @pulumi/platform` default for that directory.

## Test plan
- [ ] CODEOWNERS syntax validated by GitHub on PR open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)