### PR TITLE
ci: skip on-pr.yml for changelog-only changes

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -13,6 +13,7 @@ on:
     paths-ignore:
       - "sdk/.version"
       - "pkg/cmd/pulumi/neo/**"
+      - "changelog/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- Follow-up to #22822: add `changelog/**` to `paths-ignore` in `on-pr.yml` so changelog-only PRs skip the heavy default workflow, matching the no-op behavior already wired into `on-pr-default.yml`.

## Test plan
- [ ] Open a changelog-only PR and confirm `on-pr.yml` is skipped while `ci-ok` still resolves green via the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)