### PR TITLE
Remove ListAnalyzers from Host

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -166,6 +166,10 @@ type deploymentOptions struct {
 	// true if this deployment is a dry run, such as a preview action or a preview
 	// operation preceding e.g. a refresh or destroy.
 	DryRun bool
+
+	// LoadedAnalyzers is populated by loadPolicyPlugins after policy packs are loaded
+	// and configured. This is the list that the step generator will run for policy checks.
+	LoadedAnalyzers []plugin.Analyzer
 }
 
 // deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
@@ -232,8 +236,6 @@ func newDeployment(
 		return nil, err
 	}
 
-	localPolicyPackPaths := ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks)
-
 	deplOpts := &deploy.Options{
 		ParallelDiff:              opts.ParallelDiff,
 		DryRun:                    opts.DryRun,
@@ -255,13 +257,14 @@ func newDeployment(
 		ContinueOnError:           opts.ContinueOnError,
 		Autonamer:                 opts.Autonamer,
 		ShowSecrets:               opts.ShowSecrets,
+		Analyzers:                 opts.LoadedAnalyzers,
 	}
 
 	var depl *deploy.Deployment
 	if !opts.isImport {
 		depl, err = deploy.NewDeployment(
 			plugctx, deplOpts, actions, target, target.Snapshot, opts.Plan, source,
-			localPolicyPackPaths, ctx.BackendClient, resourceHooks)
+			ctx.BackendClient, resourceHooks)
 	} else {
 		_, defaultProviderInfo, pluginErr := installPlugins(
 			cancelCtx,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -611,8 +611,8 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 	}
 
 	var (
-		wg           sync.WaitGroup
-		analyzersMu  sync.Mutex
+		wg              sync.WaitGroup
+		analyzersMu     sync.Mutex
 		loadedAnalyzers []plugin.Analyzer
 	)
 	addAnalyzer := func(a plugin.Analyzer) {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -610,7 +610,16 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 		}
 	}
 
-	var wg sync.WaitGroup
+	var (
+		wg           sync.WaitGroup
+		analyzersMu  sync.Mutex
+		loadedAnalyzers []plugin.Analyzer
+	)
+	addAnalyzer := func(a plugin.Analyzer) {
+		analyzersMu.Lock()
+		loadedAnalyzers = append(loadedAnalyzers, a)
+		analyzersMu.Unlock()
+	}
 	errs := make(chan error, len(deployOpts.RequiredPolicies)+len(deployOpts.LocalPolicyPacks))
 
 	// Load required policy packs (installation already completed above).
@@ -670,6 +679,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 				if len(mergedConfig) > 0 {
 					logging.V(7).Infof("policy pack %q does not support config; skipping configure", analyzerInfo.Name)
 				}
+				addAnalyzer(analyzer)
 				return
 			}
 			configFromAPI, err := resourceanalyzer.ParsePolicyPackConfigFromAPI(mergedConfig)
@@ -688,6 +698,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 				errs <- fmt.Errorf("configuring policy pack %q: %w", analyzerInfo.Name, err)
 				return
 			}
+			addAnalyzer(analyzer)
 		}(policy)
 	}
 
@@ -768,6 +779,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 					errs <- fmt.Errorf("policy pack %q at %q does not support config", analyzerInfo.Name, pack.Path)
 					return
 				}
+				addAnalyzer(analyzer)
 				return
 			}
 
@@ -797,6 +809,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 				errs <- fmt.Errorf("configuring policy pack %q at %q: %w", analyzerInfo.Name, pack.Path, err)
 				return
 			}
+			addAnalyzer(analyzer)
 		}(i, pack)
 	}
 
@@ -817,6 +830,7 @@ func loadPolicyPlugins(plugctx *plugin.Context,
 		return errors.New("validating policy config")
 	}
 
+	deployOpts.LoadedAnalyzers = loadedAnalyzers
 	return nil
 }
 

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -109,6 +109,8 @@ type Options struct {
 	Autonamer autonaming.Autonamer
 	// true if the engine should display secrets in diagnostic messages.
 	ShowSecrets bool
+	// Analyzers is the list of policy analyzers to run during this deployment.
+	Analyzers []plugin.Analyzer
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the
@@ -329,8 +331,8 @@ type Deployment struct {
 	schemaLoader schema.Loader
 	// the source of new resources.
 	source Source
-	// the policy packs to run during this deployment's generation.
-	localPolicyPackPaths []string
+	// the policy analyzers to run during this deployment.
+	analyzers []plugin.Analyzer
 	// the dependency graph of the old snapshot.
 	depGraph *graph.DependencyGraph
 	// the provider registry for this deployment.
@@ -532,7 +534,6 @@ func NewDeployment(
 	prev *Snapshot,
 	plan *Plan,
 	source Source,
-	localPolicyPackPaths []string,
 	backendClient BackendClient,
 	resourceHooks *ResourceHooks,
 ) (*Deployment, error) {
@@ -586,7 +587,7 @@ func NewDeployment(
 		allOlds:                         allOlds,
 		oldViews:                        oldViews,
 		source:                          source,
-		localPolicyPackPaths:            localPolicyPackPaths,
+		analyzers:                       opts.Analyzers,
 		depGraph:                        depGraph,
 		providers:                       reg,
 		goals:                           newGoals,

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -59,7 +59,7 @@ func TestPendingOperationsDeployment(t *testing.T) {
 		},
 	})
 
-	_, err := NewDeployment(&plugin.Context{}, &Options{}, nil, &Target{}, snap, nil, NewNullSource("test"), nil, nil, nil)
+	_, err := NewDeployment(&plugin.Context{}, &Options{}, nil, &Target{}, snap, nil, NewNullSource("test"), nil, nil)
 	require.NoError(t, err)
 }
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -604,4 +604,3 @@ func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string,
 	}
 	return plug.(plugin.Analyzer), nil
 }
-

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -605,9 +605,3 @@ func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string,
 	return plug.(plugin.Analyzer), nil
 }
 
-func (host *pluginHost) ListAnalyzers() []plugin.Analyzer {
-	host.m.Lock()
-	defer host.m.Unlock()
-
-	return host.analyzers
-}

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -81,10 +81,6 @@ func (host *testPluginHost) PolicyAnalyzer(name tokens.QName, path string,
 	return nil, errors.New("unsupported")
 }
 
-func (host *testPluginHost) ListAnalyzers() []plugin.Analyzer {
-	return nil
-}
-
 func (host *testPluginHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 	return host.provider(descriptor)
 }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1275,7 +1275,7 @@ func (sg *stepGenerator) continueStepsFromImport(event ContinueResourceImportEve
 
 	// Send the resource off to any Analyzers before being operated on. We do two passes: first we perform
 	// remediations, and *then* we do analysis, since we want analyzers to run on the final resource states.
-	analyzers := sg.deployment.ctx.Host.ListAnalyzers()
+	analyzers := sg.deployment.analyzers
 
 	// First pass: perform remediations sequentially. Each remediation can transform the resource
 	// properties, so subsequent analyzers must see the transformed state.
@@ -3191,7 +3191,7 @@ func (sg *stepGenerator) analyzeAll(
 }
 
 func (sg *stepGenerator) AnalyzeResources() error {
-	analyzers := sg.deployment.ctx.Host.ListAnalyzers()
+	analyzers := sg.deployment.analyzers
 
 	var resources []plugin.AnalyzerStackResource
 	// Don't bother building the resources slice if there are no analyzers.

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -121,10 +121,6 @@ func (h *testHost) PolicyAnalyzer(
 	return analyzer, nil
 }
 
-func (h *testHost) ListAnalyzers() []plugin.Analyzer {
-	return h.policies
-}
-
 func (h *testHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 	// If we've not been given a version, we'll try and find the provider by name alone, picking the latest if there are
 	// multiple versions of the named provider. Otherwise, we can attempt to find an exact match.

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -68,9 +67,6 @@ type Host interface {
 	// set of policies that are required to be run during an update, so they tend to be in a
 	// well-known place.
 	PolicyAnalyzer(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
-
-	// ListAnalyzers returns a list of all analyzer plugins known to the plugin host.
-	ListAnalyzers() []Analyzer
 
 	// Provider loads a new copy of the provider for a given package.  If a provider for this package could not be
 	// found, or an error occurs while creating it, a non-nil error is returned.
@@ -494,14 +490,6 @@ func (host *defaultHost) PolicyAnalyzer(name tokens.QName, path string, opts *Po
 		return nil, err
 	}
 	return plugin.(Analyzer), nil
-}
-
-func (host *defaultHost) ListAnalyzers() []Analyzer {
-	analyzers := slice.Prealloc[Analyzer](len(host.analyzerPlugins))
-	for _, analyzer := range host.analyzerPlugins {
-		analyzers = append(analyzers, analyzer.Plugin)
-	}
-	return analyzers
 }
 
 func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -33,7 +33,6 @@ type MockHost struct {
 	LogStatusF          func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
 	AnalyzerF           func(nm tokens.QName) (Analyzer, error)
 	PolicyAnalyzerF     func(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
-	ListAnalyzersF      func() []Analyzer
 	ProviderF           func(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
 	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
 	EnsurePluginsF      func(plugins []workspace.PluginDescriptor, kinds Flags) error
@@ -85,13 +84,6 @@ func (m *MockHost) PolicyAnalyzer(name tokens.QName, path string, opts *PolicyAn
 		return m.PolicyAnalyzerF(name, path, opts)
 	}
 	return nil, errors.New("PolicyAnalyzer not implemented")
-}
-
-func (m *MockHost) ListAnalyzers() []Analyzer {
-	if m.ListAnalyzersF != nil {
-		return m.ListAnalyzersF()
-	}
-	return nil
 }
 
 func (m *MockHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {


### PR DESCRIPTION
This removes `ListAnalyzers` from the `Host` interface. Instead when we load the policy packs in the deployment startup we just keep a list of what we've loaded and pass that directly down to the step_generator. 