### PR TITLE
skip more signal cancellation tests

### DIFF
--- a/tests/integration/signal_cancellation/signal_cancellation_test.go
+++ b/tests/integration/signal_cancellation/signal_cancellation_test.go
@@ -142,6 +142,8 @@ func TestPluginSignalCancellation(t *testing.T) {
 		t.Skip("Sending SIGINT to a process is not supported on Windows")
 	}
 	t.Parallel()
+	// TODO[pulumi/pulumi#22683]: Re-enable when we fix the underlying issue
+	t.Skip("flaky test, see pulumi/pulumi#22683")
 	for _, lang := range []string{"plugin_go", "plugin_python", "plugin_nodejs"} {
 		t.Run(lang, func(t *testing.T) {
 			t.Parallel()
@@ -203,6 +205,8 @@ func TestPluginSignalCancellationForceKill(t *testing.T) {
 		t.Skip("Sending SIGINT to a process is not supported on Windows")
 	}
 	t.Parallel()
+	// TODO[pulumi/pulumi#22683]: Re-enable when we fix the underlying issue
+	t.Skip("flaky test, see pulumi/pulumi#22683")
 	for _, lang := range []string{"plugin_go_ignore", "plugin_python_ignore", "plugin_nodejs_ignore"} {
 		t.Run(lang, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
These tests are flaky, similar to the other ones we have for this, that are also skipped.  Skip this set as well to avoid the flakyness in CI.

Fixes https://github.com/pulumi/pulumi/issues/22581