### PR TITLE
fix(cli/neo): no longer print "error: context canceled" on TUI quit

### DIFF
--- a/changelog/pending/20260505--cli-neo--no-longer-prints-error-context-canceled-on-quit.yaml
+++ b/changelog/pending/20260505--cli-neo--no-longer-prints-error-context-canceled-on-quit.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli
-  description: Fix `pulumi neo` printing `error: context canceled` when the user quits the TUI. The session loop now treats caller-initiated context cancellation as a clean shutdown rather than surfacing it as an error.
+  description: Fix `pulumi neo` printing `error: context canceled` when the user quits the TUI

--- a/changelog/pending/20260505--cli-neo--no-longer-prints-error-context-canceled-on-quit.yaml
+++ b/changelog/pending/20260505--cli-neo--no-longer-prints-error-context-canceled-on-quit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `pulumi neo` printing `error: context canceled` when the user quits the TUI. The session loop now treats caller-initiated context cancellation as a clean shutdown rather than surfacing it as an error.

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -56,8 +56,9 @@ type Session struct {
 	UIEvents chan<- UIEvent
 }
 
-// Run drives the loop. It blocks until ctx is cancelled or the SSE stream errors out.
-// If UIEvents is set, it is closed when Run returns.
+// Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil)
+// or the SSE stream errors out (returns the error). If UIEvents is set, it is closed
+// when Run returns.
 func (s *Session) Run(ctx context.Context) error {
 	if s.UIEvents != nil {
 		defer close(s.UIEvents)
@@ -71,7 +72,9 @@ func (s *Session) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			// Caller-initiated shutdown (e.g. TUI quit) is not an error — surfacing
+			// context.Canceled here would print "error: context canceled" on a normal exit.
+			return nil
 		case evt, ok := <-stream:
 			if !ok {
 				return nil

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -515,9 +515,12 @@ func TestSession_RunReturnsStreamError(t *testing.T) {
 	require.EqualError(t, err, "stream died")
 }
 
-func TestSession_RunHonorsContextCancel(t *testing.T) {
+func TestSession_RunReturnsNilOnContextCancel(t *testing.T) {
 	t.Parallel()
 
+	// Caller-initiated cancellation (e.g. TUI quit) must be treated as a clean
+	// shutdown — returning context.Canceled here causes cobra to print
+	// "error: context canceled" on a normal `pulumi neo` quit.
 	streamer := newFakeStreamer() // stream is never closed, never fed
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -525,7 +528,7 @@ func TestSession_RunHonorsContextCancel(t *testing.T) {
 
 	s := &Session{Client: streamer, OrgName: "o", TaskID: "t"}
 	err := s.Run(ctx)
-	assert.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, err)
 }
 
 func TestSession_MalformedConsoleEventIsIgnored(t *testing.T) {


### PR DESCRIPTION
## Summary

When the user quits the `pulumi neo` TUI (Ctrl+C, `/quit`, ESC), the process prints:

```
error: context canceled
```

before exiting. This change makes the quit silent.

## Root cause

#22821 added explicit `cancelAll()` in `runWithTUI` so the SSE poller and outbound dispatcher unblock on quit (otherwise the second Ctrl+C still hung). That cancellation exposed a latent bug in `Session.Run`: its `<-ctx.Done()` branch returned `ctx.Err()` (`context.Canceled`), which propagated through `errgroup.Wait` → `runNeo` → cobra's `RunE` → the diag sink, which prepended `"error: "` and wrote it to stderr on a normal exit.

The sibling loop `dispatchUserEvents` (`pkg/cmd/pulumi/neo/neo.go:351`) already returns `nil` from its `<-ctx.Done()` branch — `Session.Run` was the outlier.

## Change

- `Session.Run` returns `nil` on `<-ctx.Done()` instead of `ctx.Err()`. Real stream failures still surface via the `evt.Err` arm.
- Updated `TestSession_RunHonorsContextCancel` (which asserted the buggy behavior) → `TestSession_RunReturnsNilOnContextCancel` asserting clean shutdown.
- Doc comment on `Session.Run` updated to spell out the contract.

## Test plan

- [x] `cd pkg && mise exec -- go test -count=1 -tags all ./cmd/pulumi/neo/...` — passes
- [x] `mise exec -- golangci-lint run ./cmd/pulumi/neo/...` — clean
- [ ] Manual: build, run `pulumi neo`, quit via Ctrl+C twice → process exits silently (no `error: context canceled`)
- [ ] Manual: same, quit via `/quit` slash command → silent exit
- [ ] Manual sanity: kill network mid-stream → real error still surfaces (it goes through the `evt.Err` arm, not the `ctx.Done()` arm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)