### PR TITLE
changelog: add neo scope under cli

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,5 +82,6 @@ All commands assume you're at the repo root.
 - `proto/*.proto` → `mise exec -- make build_proto && mise exec -- make check_proto` and commit generated files
 - `go.mod` or `go.sum` in any module → `mise exec -- make tidy`
 - `pkg/codegen/schema/pulumi.json` → `mise exec -- make lint_pulumi_json`
+- Anything under `pkg/cmd/pulumi/neo/` (the `pulumi neo` TUI/agent) → use the `cli/neo` changelog scope.
 
 See subdirectory `AGENTS.md` files (`pkg/`, `sdk/nodejs/`, `sdk/python/`, `sdk/go/`) for package-specific instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,5 @@ All commands assume you're at the repo root.
 - `proto/*.proto` → `mise exec -- make build_proto && mise exec -- make check_proto` and commit generated files
 - `go.mod` or `go.sum` in any module → `mise exec -- make tidy`
 - `pkg/codegen/schema/pulumi.json` → `mise exec -- make lint_pulumi_json`
-- Anything under `pkg/cmd/pulumi/neo/` (the `pulumi neo` TUI/agent) → use the `cli/neo` changelog scope.
 
 See subdirectory `AGENTS.md` files (`pkg/`, `sdk/nodejs/`, `sdk/python/`, `sdk/go/`) for package-specific instructions.

--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -15,6 +15,7 @@ scopes:
     - env
     - import
     - install
+    - neo
     - new
     - plugin
     - package

--- a/pkg/cmd/pulumi/neo/AGENTS.md
+++ b/pkg/cmd/pulumi/neo/AGENTS.md
@@ -1,0 +1,7 @@
+# `pulumi neo` (`pkg/cmd/pulumi/neo/`)
+
+The `pulumi neo` TUI/agent command.
+
+## Changelog
+
+- Use the `cli/neo` scope for changelog entries that touch this directory.


### PR DESCRIPTION
## Summary
- Adds `neo` to the list of `cli` sub-scopes in `changelog/config.yaml` so go-change recognizes it.

## Test plan
- [ ] `mise exec -- make changelog` shows `neo` as a selectable sub-scope under `cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)