### PR TITLE
get per request spans for API calls

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -251,6 +251,40 @@ type httpClient interface {
 	Do(req *http.Request, policy retryPolicy) (*http.Response, error)
 }
 
+// tracingTransport wraps an http.RoundTripper to create a span for each individual HTTP attempt,
+// making retries visible in traces.
+type tracingTransport struct {
+	base    http.RoundTripper
+	attempt int
+}
+
+func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.attempt++
+	ctx := req.Context()
+	tracer := otel.Tracer("pulumi-cli")
+	ctx, span := cmdutil.StartSpan(ctx, tracer, "HTTP attempt",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.Int("http.attempt", t.attempt),
+			attribute.String("http.method", req.Method),
+			attribute.String("http.url", req.URL.String()),
+		))
+	defer span.End()
+
+	req = req.WithContext(ctx)
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		span.RecordError(err)
+	} else {
+		span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+		if resp.StatusCode >= 400 {
+			span.SetStatus(codes.Error, resp.Status)
+		}
+	}
+	return resp, err
+}
+
 // defaultHTTPClient is an implementation of httpClient that provides a basic implementation of Do
 // using the specified *http.Client, with retry support.
 type defaultHTTPClient struct {
@@ -282,6 +316,14 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 	// Add a User-Agent header to distinguish the pulumi CLI from other clients.
 	req.Header.Set("User-Agent", UserAgent())
 
+	// Wrap the transport to get per-attempt spans.
+	transport := c.client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	tracingClient := *c.client
+	tracingClient.Transport = &tracingTransport{base: transport}
+
 	// Wait 1s before retrying on failure. Then increase by 2x until the
 	// maximum delay is reached. Stop after maxRetryCount requests have
 	// been made.
@@ -293,7 +335,7 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 		MaxRetryCount:         intPtr(4),
 		HandshakeTimeoutsOnly: !policy.shouldRetry(req),
 	}
-	return httputil.DoWithRetryOpts(req, c.client, opts)
+	return httputil.DoWithRetryOpts(req, &tracingClient, opts)
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -280,6 +280,8 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 		if resp.StatusCode >= 400 {
 			span.SetStatus(codes.Error, resp.Status)
+		} else {
+			span.SetStatus(codes.Ok, "")
 		}
 	}
 	return resp, err

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -20,11 +20,15 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -263,4 +267,123 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 
 		assert.True(t, errors.Is(err, backenderr.LoginRequiredError{}))
 	})
+}
+
+//nolint:paralleltest //  subtests mutate the global otel tracer provider.
+func TestDoCreatesPerAttemptSpans(t *testing.T) {
+	t.Run("single successful request", func(t *testing.T) {
+		recorder := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(tp)
+		t.Cleanup(func() {
+			otel.SetTracerProvider(prev)
+		})
+
+		client := &defaultHTTPClient{
+			&http.Client{
+				Transport: &errorTransport{
+					roundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: 200,
+							Status:     "200 OK",
+							Body:       io.NopCloser(bytes.NewReader(nil)),
+						}, nil
+					},
+				},
+			},
+		}
+
+		req, err := http.NewRequest("GET", "https://api.example.com/test", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req, retryAllMethods)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		tp.ForceFlush(t.Context())
+		spans := recorder.Ended()
+
+		// Should have an "HTTP attempt" span nested under an "HTTP request" span.
+		attemptSpans := filterSpansByName(spans, "HTTP attempt")
+		require.Len(t, attemptSpans, 1)
+		assertSpanAttribute(t, attemptSpans[0], "http.attempt", int64(1))
+		assertSpanAttribute(t, attemptSpans[0], "http.status_code", int64(200))
+	})
+
+	t.Run("retries on 500", func(t *testing.T) {
+		recorder := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(tp)
+		t.Cleanup(func() {
+			otel.SetTracerProvider(prev)
+		})
+
+		var callCount atomic.Int32
+		client := &defaultHTTPClient{
+			&http.Client{
+				Transport: &errorTransport{
+					roundTripFunc: func(req *http.Request) (*http.Response, error) {
+						n := callCount.Add(1)
+						if n <= 2 {
+							return &http.Response{
+								StatusCode: 500,
+								Status:     "500 Internal Server Error",
+								Body:       io.NopCloser(bytes.NewReader(nil)),
+							}, nil
+						}
+						return &http.Response{
+							StatusCode: 200,
+							Status:     "200 OK",
+							Body:       io.NopCloser(bytes.NewReader(nil)),
+						}, nil
+					},
+				},
+			},
+		}
+
+		req, err := http.NewRequest("GET", "https://api.example.com/test", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req, retryAllMethods)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		tp.ForceFlush(t.Context())
+		spans := recorder.Ended()
+
+		attemptSpans := filterSpansByName(spans, "HTTP attempt")
+		require.Len(t, attemptSpans, 3, "expected 2 failed + 1 successful attempt")
+
+		// Verify attempt numbers are sequential.
+		for i, span := range attemptSpans {
+			assertSpanAttribute(t, span, "http.attempt", int64(i+1))
+		}
+		// First two should have 500 status, last should have 200.
+		assertSpanAttribute(t, attemptSpans[0], "http.status_code", int64(500))
+		assertSpanAttribute(t, attemptSpans[1], "http.status_code", int64(500))
+		assertSpanAttribute(t, attemptSpans[2], "http.status_code", int64(200))
+	})
+}
+
+func filterSpansByName(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var result []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func assertSpanAttribute(t *testing.T, span sdktrace.ReadOnlySpan, key string, want int64) {
+	t.Helper()
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			require.Equal(t, want, attr.Value.AsInt64(), "attribute %s", key)
+			return
+		}
+	}
+	require.Failf(t, "attribute not found", "attribute %q not found on span %q", key, span.Name())
 }


### PR DESCRIPTION
Currently we only get one span from the http client, that includes all of its retries.  However if there are retries, that is interesting to know, and we should have individual spans for that.  Add those, so we have better granularity seeing what happens with http requests between the client and the service.