### PR TITLE
importer: preserve `__`-prefixed keys in generated PCL

### DIFF
--- a/changelog/pending/20260505--cli-import--preserve-prefixed-keys-in-imported-resource-state.yaml
+++ b/changelog/pending/20260505--cli-import--preserve-prefixed-keys-in-imported-resource-state.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/import
-  description: Preserve `__`-prefixed keys (e.g. `__type` discriminators) when generating PCL for imported resource state, so provider-defined payloads round-trip correctly
+  description: Preserve `__`-prefixed keys when generating PCL for imported resource state, so provider-defined payloads round-trip correctly

--- a/changelog/pending/20260505--cli-import--preserve-prefixed-keys-in-imported-resource-state.yaml
+++ b/changelog/pending/20260505--cli-import--preserve-prefixed-keys-in-imported-resource-state.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Preserve `__`-prefixed keys (e.g. `__type` discriminators) when generating PCL for imported resource state, so provider-defined payloads round-trip correctly

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
@@ -880,10 +879,11 @@ func generateValue(
 			}
 
 			for k, v := range obj.AllStable {
-				// Ignore internal properties.
-				if strings.HasPrefix(k, "__") {
-					continue
-				}
+				// Provider schemas are free to use `__`-prefixed keys as
+				// discriminators (e.g. `__type`) inside freeform map payloads,
+				// so we preserve them here. Stripping silently dropped values
+				// that were then required as inputs to dependent resources;
+				// see https://github.com/pulumi/pulumi/issues/22738.
 
 				x, err := generateValue(elementType, v, importState, onReferenceFound)
 				if err != nil {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -879,12 +879,6 @@ func generateValue(
 			}
 
 			for k, v := range obj.AllStable {
-				// Provider schemas are free to use `__`-prefixed keys as
-				// discriminators (e.g. `__type`) inside freeform map payloads,
-				// so we preserve them here. Stripping silently dropped values
-				// that were then required as inputs to dependent resources;
-				// see https://github.com/pulumi/pulumi/issues/22738.
-
 				x, err := generateValue(elementType, v, importState, onReferenceFound)
 				if err != nil {
 					return nil, err

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1111,6 +1111,39 @@ func TestStructuralTypeChecks(t *testing.T) {
 	})
 }
 
+// TestGenerateValuePreservesProviderDiscriminators verifies that values destined for a
+// freeform map-typed (or untyped) property keep their `__`-prefixed keys. Some providers
+// use `__type` (or similar) as discriminators inside such payloads; stripping them is a
+// silent data-loss bug at import time. See https://github.com/pulumi/pulumi/issues/22738.
+func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {
+	t.Parallel()
+
+	value := property.New(map[string]property.Value{
+		"__type": property.New("PermissionDescriptorGroup"),
+		"name":   property.New("root"),
+		"items": property.New([]property.Value{
+			property.New(map[string]property.Value{
+				"__type": property.New("PermissionDescriptorCondition"),
+				"name":   property.New("child"),
+			}),
+		}),
+	})
+
+	expr, err := generateValue(
+		&schema.MapType{ElementType: schema.AnyType},
+		value,
+		ImportState{},
+		func(string) {},
+	)
+	require.NoError(t, err)
+
+	// Generated HCL renders map keys quoted (`fmt.Sprintf("%q", k)`) so they survive
+	// non-identifier characters; the test asserts on the formatted text directly.
+	formatted := fmt.Sprintf("%v", expr)
+	assert.Contains(t, formatted, `"__type" = "PermissionDescriptorGroup"`)
+	assert.Contains(t, formatted, `"__type" = "PermissionDescriptorCondition"`)
+}
+
 func TestReduceUnionTypeEliminatesUnionsBasicCase(t *testing.T) {
 	t.Parallel()
 	value := property.New("hello")

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1133,8 +1133,6 @@ func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Generated HCL renders map keys quoted (`fmt.Sprintf("%q", k)`) so they survive
-	// non-identifier characters; the test asserts on the formatted text directly.
 	formatted := fmt.Sprintf("%v", expr)
 	assert.Contains(t, formatted, `"__type" = "PermissionDescriptorGroup"`)
 	assert.Contains(t, formatted, `"__type" = "PermissionDescriptorCondition"`)

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1111,10 +1111,6 @@ func TestStructuralTypeChecks(t *testing.T) {
 	})
 }
 
-// TestGenerateValuePreservesProviderDiscriminators verifies that values destined for a
-// freeform map-typed (or untyped) property keep their `__`-prefixed keys. Some providers
-// use `__type` (or similar) as discriminators inside such payloads; stripping them is a
-// silent data-loss bug at import time. See https://github.com/pulumi/pulumi/issues/22738.
 func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Follow-up to [#22834](https://github.com/pulumi/pulumi/pull/22834), which fixed the same class of bug in the Python SDK. The HCL2 importer's `generateValue` was unconditionally stripping every `__`-prefixed key when emitting code for a freeform map-typed (or untyped) property:

```go
default:
    elementType := schema.AnyType
    if mapType, ok := typ.(*schema.MapType); ok {
        elementType = mapType.ElementType
    }

    for k, v := range obj.AllStable {
        // Ignore internal properties.
        if strings.HasPrefix(k, "__") {
            continue
        }
        ...
    }
```

Provider schemas can use `__type` (or similar) as discriminators inside such payloads. `pulumi import` was silently dropping them and the generated code wouldn't round-trip — the resource would be re-imported with the same problem on every refresh, and dependent resources fed from the imported value would fail backend validation. See [#22738](https://github.com/pulumi/pulumi/issues/22738) for the original Python-side report; the importer is the same bug shape on the codegen side.

## Changes

- `pkg/importer/hcl2.go` — drop the `strings.HasPrefix(k, \"__\")` strip in the `MapType` / `AnyType` branch of `generateValue`. The `ObjectType` branch is unchanged: it iterates declared schema properties by name, so `__` keys can never appear there.
- `pkg/importer/hcl2_test.go` — new unit test `TestGenerateValuePreservesProviderDiscriminators` that exercises `generateValue` directly with a `MapType<AnyType>` schema and nested `__type` keys, asserting the generated HCL contains them.

## Test plan

- [x] New test fails without the fix and passes with it (verified red → green)
- [x] `go test ./importer/...` — all tests pass
- [x] `go build ./...` — clean
- [ ] CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)