### PR TITLE
fix integration test

### DIFF
--- a/tests/integration/component_provider/python/component-provider-host/nodejs/index.ts
+++ b/tests/integration/component_provider/python/component-provider-host/nodejs/index.ts
@@ -29,7 +29,7 @@ let comp = new provider.MyComponent("comp", {
         },
         strInput: "world",
     },
-    assetInput: new pulumi.asset.StringAsset("Hello, World"),
+    assetInput: new pulumi.asset.StringAsset("Hello, World!"),
     archiveInput: new pulumi.asset.AssetArchive({
         asset1: new pulumi.asset.StringAsset("im inside an archive"),
     }),

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2103,13 +2103,13 @@ func TestPythonComponentProviderRun(t *testing.T) {
 						// We're expecting assetOutput = map[text:HELLO, WORLD!]
 						asset := stack.Outputs["assetOutput"].(map[string]any)
 						text := asset["text"].(string)
-						checkAssetText(t, runtime, "HELLO, WORLD!", text)
+						checkAssetText(t, "HELLO, WORLD!", text)
 
 						// We're expecting  archiveOutput = map[assets:map[asset1:map[text:IM INSIDE AN ARCHIVE]]
 						archive := stack.Outputs["archiveOutput"].(map[string]any)
 						asset1 := archive["assets"].(map[string]any)["asset1"].(map[string]any)
 						text = asset1["text"].(string)
-						checkAssetText(t, runtime, "IM INSIDE AN ARCHIVE", text)
+						checkAssetText(t, "IM INSIDE AN ARCHIVE", text)
 					}
 				},
 			})
@@ -2178,16 +2178,9 @@ func TestPythonComponentProviderFeatures(t *testing.T) {
 	})
 }
 
-func checkAssetText(t *testing.T, runtime, expected, actual string) {
+func checkAssetText(t *testing.T, expected, actual string) {
 	t.Helper()
-	switch runtime {
-	case "nodejs":
-		// Node.js replaces the asset text with "..." in the stack output.
-		// https://github.com/pulumi/pulumi/blob/a3c9fd948de150043a7e07aa82ca17ffaee0bddc/sdk/nodejs/runtime/stack.ts#L163
-		require.Equal(t, "...", actual)
-	default:
-		require.Equal(t, expected, actual)
-	}
+	require.Equal(t, expected, actual)
 }
 
 // Tests that we can get the schema for a Python component provider using component_provider_host.


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/22827 fixed how nodejs outputs are emitted. This test was still relying on on the old behaviour, which worked until we released a new version of the nodejs SDK (we're using the released version in this test presumably), so the test broke as soon as we released it yesterday.

Fix this test to unblock the tests.
