### PR TITLE
cli/neo: show CLI version in the welcome banner

### DIFF
--- a/changelog/pending/20260506--cli-neo--show-cli-version-in-the-welcome-banner.yaml
+++ b/changelog/pending/20260506--cli-neo--show-cli-version-in-the-welcome-banner.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/neo
+  description: Show the active CLI version in the `pulumi neo` welcome banner

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -197,6 +198,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		Org:           orgName,
 		WorkDir:       cwdFlag,
 		Username:      username,
+		Version:       version.Version,
 		EventCh:       uiCh,
 		OutCh:         outCh,
 		Busy:          prompt != "",

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -117,7 +117,10 @@ type ModelConfig struct {
 	Org      string
 	WorkDir  string
 	Username string
-	EventCh  <-chan UIEvent
+	// Version is the Pulumi CLI version stamped at build time (e.g. "v3.235.0").
+	// Empty in dev builds — the welcome banner omits it when blank.
+	Version string
+	EventCh <-chan UIEvent
 	// OutCh carries every TUI-originated user event (chat messages, approval
 	// answers, …) to the dispatcher in runNeo. Each send also carries the
 	// TUI's current planMode, which the dispatcher reads on the first
@@ -281,6 +284,7 @@ func NewModel(cfg ModelConfig) Model {
 			org:       cfg.Org,
 			workDir:   cfg.WorkDir,
 			username:  cfg.Username,
+			version:   cfg.Version,
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},

--- a/pkg/cmd/pulumi/neo/tui_welcome.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome.go
@@ -34,6 +34,7 @@ type welcomeModel struct {
 	org        string
 	workDir    string
 	username   string
+	version    string // CLI version, e.g. "v3.235.0"; empty in dev builds
 	consoleURL string
 	termWidth  int
 	greeting   string // cached greeting, picked once at creation
@@ -110,19 +111,22 @@ func (w welcomeModel) View() string {
 
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(magenta)
 
-	infoText := displayDir
+	suffix := ""
 	if w.org != "" {
-		infoText += " · org: " + w.org
+		suffix += " · org: " + w.org
 	}
-	if lipgloss.Width(infoText) > contentWidth && w.org != "" {
-		orgSuffix := " · org: " + w.org
-		maxPath := contentWidth - lipgloss.Width(orgSuffix)
+	if w.version != "" {
+		suffix += " · " + w.version
+	}
+	infoText := displayDir + suffix
+	if lipgloss.Width(infoText) > contentWidth && suffix != "" {
+		maxPath := contentWidth - lipgloss.Width(suffix)
 		if maxPath > 3 {
 			pathRunes := []rune(displayDir)
 			if len(pathRunes) > maxPath {
 				displayDir = string(pathRunes[:maxPath-3]) + "..."
 			}
-			infoText = displayDir + orgSuffix
+			infoText = displayDir + suffix
 		}
 	}
 

--- a/pkg/cmd/pulumi/neo/tui_welcome_test.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome_test.go
@@ -100,6 +100,64 @@ func TestWelcomeView_RendersCoreFields(t *testing.T) {
 	assert.Contains(t, out, "acme", "org must render")
 }
 
+func TestWelcomeView_RendersVersion(t *testing.T) {
+	t.Parallel()
+
+	// The CLI version is stamped at build time and shown in the info line so
+	// users can sanity-check which binary is talking to the backend without
+	// dropping out to `pulumi version`.
+	w := welcomeModel{
+		org:       "acme",
+		workDir:   "/tmp/proj",
+		username:  "alice",
+		version:   "v3.235.0",
+		termWidth: 120,
+		greeting:  "hi",
+	}
+	out := w.View()
+
+	assert.Contains(t, out, "v3.235.0", "version must render in the info line")
+}
+
+func TestWelcomeView_OmitsEmptyVersion(t *testing.T) {
+	t.Parallel()
+
+	// Dev builds leave version.Version empty. The banner must still render
+	// cleanly — no stray "·" separator from a half-built suffix.
+	w := welcomeModel{
+		org:       "acme",
+		workDir:   "/tmp/proj",
+		termWidth: 120,
+		greeting:  "hi",
+	}
+	out := w.View()
+
+	assert.Contains(t, out, "/tmp/proj · org: acme")
+	// The version separator must not appear when version is empty.
+	assert.NotContains(t, out, "/tmp/proj · org: acme · ")
+}
+
+func TestWelcomeView_NarrowTerminalPreservesVersion(t *testing.T) {
+	t.Parallel()
+
+	// When the path overflows, the version (like the org) is a fixed suffix:
+	// the path truncates and the version stays intact, so users keep seeing
+	// which CLI build is running even on narrow terminals.
+	longPath := "/" + strings.Repeat("verylongsegment/", 4)
+	w := welcomeModel{
+		org:       "acme",
+		workDir:   longPath,
+		version:   "v3.235.0",
+		termWidth: 60,
+		greeting:  "hi",
+	}
+	out := w.View()
+
+	assert.Contains(t, out, "...", "long path must be truncated")
+	assert.Contains(t, out, "v3.235.0", "version suffix must survive truncation")
+	assert.Contains(t, out, "acme", "org suffix must survive truncation")
+}
+
 func TestWelcomeView_RendersConsoleHyperlink(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Append the build-stamped CLI version to the info line of the `pulumi neo` welcome banner so users can sanity-check which binary is talking to the backend without dropping to `pulumi version`.
- Renders as a third `·`-separated suffix after the working directory and org (e.g. `~/code/pulumi1 · org: acme · v3.235.0`). Dev builds (`version.Version == ""`) still render cleanly with no stray separator.
- Path truncation on narrow terminals now treats the org and version as fixed suffixes — both stay intact and the path shortens.

## Why
Fixes pulumi/pulumi-service#42325 — Mark asked for the active CLI version to be visible on the Neo screen, similar to how Claude Code surfaces it.

## Test plan
- [x] `go test ./cmd/pulumi/neo/...`
- [x] `golangci-lint run ./cmd/pulumi/neo/...`
- [ ] Manually verify the banner renders the version line on a built binary (`make build` + `pulumi neo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)