### PR TITLE
exclude another nodejs language test for bun

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -203,7 +203,8 @@ func testLanguage(t *testing.T, runtime string, forceTsc bool) {
 					}
 
 					if runtime == "bun" {
-						if tt == "l2-external-enum" || tt == "l2-namespaced-provider" {
+						if tt == "l2-external-enum" || tt == "l2-namespaced-provider" ||
+							tt == "provider-replacement-trigger-component" {
 							t.Skip(
 								"On linux bun has trouble resolving indirect dependencies that point to a local file" +
 									"https://github.com/pulumi/pulumi/issues/22100")


### PR DESCRIPTION
This test also needs to resolve indirect dependencies, and thus can fail in the same way as the other two we're already skipping. Skip this one as well to avoid its flakyness.
