### PR TITLE
fix(cli/neo): render ux__ask_user as a question, not an approval

### DIFF
--- a/changelog/pending/20260506--cli-neo--render-ask-user-clarifying-questions-as-questions-not-approval-prompts.yaml
+++ b/changelog/pending/20260506--cli-neo--render-ask-user-clarifying-questions-as-questions-not-approval-prompts.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/neo
-  description: Render `ux__ask_user` clarifying questions as questions in the TUI instead of as scary "⚠ Approval required / Approve? [y to approve / reason to deny]" prompts. The agent's free-form answer is sent through the existing `user_confirmation` channel.
+  description: Render `ux__ask_user` clarifying questions as questions instead of approval prompts

--- a/changelog/pending/20260506--cli-neo--render-ask-user-clarifying-questions-as-questions-not-approval-prompts.yaml
+++ b/changelog/pending/20260506--cli-neo--render-ask-user-clarifying-questions-as-questions-not-approval-prompts.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Render `ux__ask_user` clarifying questions as questions in the TUI instead of as scary "⚠ Approval required / Approve? [y to approve / reason to deny]" prompts. The agent's free-form answer is sent through the existing `user_confirmation` channel.

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -71,26 +71,18 @@ const (
 	// tool-approval rendering path.
 	approvalTypePlanExit = "plan_exit"
 
-	// toolNameAskUser is the suffix the CLI matches in context.tool_name to
-	// recognize the agent's ask-user tool — the agent isn't asking for
-	// approval, it's asking the user a clarifying question. Tool names on the
-	// wire are "<server>__<method>" (e.g. "ux__ask_user"); we match by suffix
-	// so the server prefix can change without a CLI rebuild. The agent uses
-	// approval_type "general" for these — there is no dedicated approval_type
-	// for ask_user, so the CLI dispatches on tool name alone.
+	// toolNameAskUser is the method name (the `<method>` half of
+	// `<server>__<method>`) for the agent's ask-user tool. The CLI matches
+	// by suffix so the server prefix can change without a CLI rebuild. The
+	// agent emits approval_type "general" for these, so the TUI must
+	// dispatch on tool name rather than approval_type alone.
 	toolNameAskUser = "ask_user"
 )
 
-// isAskUserToolName reports whether a tool name from
-// AgentBackendEventUserApprovalContext.ToolName identifies the ask-user tool.
-// Matches both the bare method ("ask_user") and the namespaced form
-// ("<server>__ask_user", e.g. "ux__ask_user").
+// isAskUserToolName reports whether `name` identifies the agent's ask-user
+// tool, in either bare ("ask_user") or namespaced ("ux__ask_user") form.
 func isAskUserToolName(name string) bool {
-	if name == toolNameAskUser {
-		return true
-	}
-	_, suffix, ok := strings.Cut(name, "__")
-	return ok && suffix == toolNameAskUser
+	return name == toolNameAskUser || strings.HasSuffix(name, "__"+toolNameAskUser)
 }
 
 // hasPendingCLIToolCalls reports whether any tool call in the list has

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -72,15 +72,14 @@ const (
 	approvalTypePlanExit = "plan_exit"
 
 	// toolNameAskUser is the method name (the `<method>` half of
-	// `<server>__<method>`) for the agent's ask-user tool. The CLI matches
-	// by suffix so the server prefix can change without a CLI rebuild. The
-	// agent emits approval_type "general" for these, so the TUI must
-	// dispatch on tool name rather than approval_type alone.
+	// `<server>__<method>`) for the agent's ask-user tool. The agent emits
+	// approval_type "general" for these, so the TUI must dispatch on tool
+	// name rather than approval_type alone.
 	toolNameAskUser = "ask_user"
 )
 
-// isAskUserToolName reports whether `name` identifies the agent's ask-user
-// tool, in either bare ("ask_user") or namespaced ("ux__ask_user") form.
+// isAskUserToolName matches by suffix so the server prefix can change
+// without a CLI rebuild ("ask_user" or "<server>__ask_user").
 func isAskUserToolName(name string) bool {
 	return name == toolNameAskUser || strings.HasSuffix(name, "__"+toolNameAskUser)
 }

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -20,7 +20,11 @@
 // helpers that operate on those wire types.
 package neo
 
-import "github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
 
 // Discriminator values for the AgentConsoleEvent envelope and the inner backend/user
 // events we care about.
@@ -66,7 +70,28 @@ const (
 	// exits in lockstep). Any other value (today: "general") takes the regular
 	// tool-approval rendering path.
 	approvalTypePlanExit = "plan_exit"
+
+	// toolNameAskUser is the suffix the CLI matches in context.tool_name to
+	// recognize the agent's ask-user tool — the agent isn't asking for
+	// approval, it's asking the user a clarifying question. Tool names on the
+	// wire are "<server>__<method>" (e.g. "ux__ask_user"); we match by suffix
+	// so the server prefix can change without a CLI rebuild. The agent uses
+	// approval_type "general" for these — there is no dedicated approval_type
+	// for ask_user, so the CLI dispatches on tool name alone.
+	toolNameAskUser = "ask_user"
 )
+
+// isAskUserToolName reports whether a tool name from
+// AgentBackendEventUserApprovalContext.ToolName identifies the ask-user tool.
+// Matches both the bare method ("ask_user") and the namespaced form
+// ("<server>__ask_user", e.g. "ux__ask_user").
+func isAskUserToolName(name string) bool {
+	if name == toolNameAskUser {
+		return true
+	}
+	_, suffix, ok := strings.Cut(name, "__")
+	return ok && suffix == toolNameAskUser
+}
 
 // hasPendingCLIToolCalls reports whether any tool call in the list has
 // execution_mode=="cli", meaning the CLI must run it locally before the agent

--- a/pkg/cmd/pulumi/neo/events_test.go
+++ b/pkg/cmd/pulumi/neo/events_test.go
@@ -46,18 +46,14 @@ func TestHasPendingCLIToolCalls(t *testing.T) {
 func TestIsAskUserToolName(t *testing.T) {
 	t.Parallel()
 
-	// Bare method form and the namespaced "<server>__<method>" form must
-	// both match — server prefixes can change without a CLI rebuild.
 	assert.True(t, isAskUserToolName("ask_user"))
 	assert.True(t, isAskUserToolName("ux__ask_user"))
 	assert.True(t, isAskUserToolName("anything__ask_user"))
 
-	// Unrelated tool names must not match.
 	assert.False(t, isAskUserToolName(""))
 	assert.False(t, isAskUserToolName("ask_user_other"))
 	assert.False(t, isAskUserToolName("filesystem__read"))
 	assert.False(t, isAskUserToolName("ux__notify"))
-	// A tool whose method merely contains "ask_user" must not match —
-	// suffix means the full method, not a substring.
+	// Suffix means the full method, not a substring.
 	assert.False(t, isAskUserToolName("ux__ask_user_v2"))
 }

--- a/pkg/cmd/pulumi/neo/events_test.go
+++ b/pkg/cmd/pulumi/neo/events_test.go
@@ -42,3 +42,22 @@ func TestHasPendingCLIToolCalls(t *testing.T) {
 		{ExecutionMode: toolExecutionModeCLI},
 	}))
 }
+
+func TestIsAskUserToolName(t *testing.T) {
+	t.Parallel()
+
+	// Bare method form and the namespaced "<server>__<method>" form must
+	// both match — server prefixes can change without a CLI rebuild.
+	assert.True(t, isAskUserToolName("ask_user"))
+	assert.True(t, isAskUserToolName("ux__ask_user"))
+	assert.True(t, isAskUserToolName("anything__ask_user"))
+
+	// Unrelated tool names must not match.
+	assert.False(t, isAskUserToolName(""))
+	assert.False(t, isAskUserToolName("ask_user_other"))
+	assert.False(t, isAskUserToolName("filesystem__read"))
+	assert.False(t, isAskUserToolName("ux__notify"))
+	// A tool whose method merely contains "ask_user" must not match —
+	// suffix means the full method, not a substring.
+	assert.False(t, isAskUserToolName("ux__ask_user_v2"))
+}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -290,6 +290,7 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 			Sensitivity:     req.Sensitivity,
 			ApprovalType:    req.ApprovalType,
 			PlanDescription: req.Context.PlanDescription,
+			ToolName:        req.Context.ToolName,
 		})
 	case backendEventAwaitingApprovals:
 		sendUI(s.UIEvents, UIAwaitingApprovals{})

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -754,9 +754,8 @@ func TestSession_ForwardToUI_EmitsAllEventTypes(t *testing.T) {
 			},
 		},
 		{
-			// context.tool_name must be forwarded so the TUI can recognize
-			// ask-user tools and render them as questions instead of
-			// approvals (see isAskUserToolName).
+			// context.tool_name must reach the TUI so it can dispatch
+			// ask-user tools to question rendering.
 			"user_approval_request_forwards_tool_name",
 			map[string]any{
 				"type":          backendEventUserApprovalRequest,

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -753,6 +753,27 @@ func TestSession_ForwardToUI_EmitsAllEventTypes(t *testing.T) {
 					m.Message == "Run pulumi up?" && m.Sensitivity == "high"
 			},
 		},
+		{
+			// context.tool_name must be forwarded so the TUI can recognize
+			// ask-user tools and render them as questions instead of
+			// approvals (see isAskUserToolName).
+			"user_approval_request_forwards_tool_name",
+			map[string]any{
+				"type":          backendEventUserApprovalRequest,
+				"id":            "appr_q",
+				"message":       "Which region?",
+				"approval_type": "general",
+				"context": map[string]any{
+					"tool_name":    "ux__ask_user",
+					"tool_call_id": "call_1",
+				},
+			},
+			func(e UIEvent) bool {
+				m, ok := e.(UIApprovalRequest)
+				return ok && m.ApprovalID == "appr_q" &&
+					m.ApprovalType == "general" && m.ToolName == "ux__ask_user"
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -195,11 +195,10 @@ type Model struct {
 	// pending approval (empty when none). The Enter handler checks for
 	// approvalTypePlanExit so it can auto-clear planMode on approval.
 	pendingApprovalType string
-	// pendingIsQuestion is true when the pending request is a question from
-	// the agent's ask-user tool (see isAskUserToolName). The Enter handler
-	// uses it to treat the typed text as a free-form answer instead of
-	// running the y/yes-or-deny parsing. Set when the request arrives,
-	// cleared on submit alongside pendingApproval.
+	// pendingIsQuestion is true when the pending request is an ask-user
+	// question (see isAskUserToolName) rather than an approval. Tells the
+	// Enter handler to take the typed text as a free-form answer instead of
+	// running the y/yes-or-deny parsing.
 	pendingIsQuestion bool
 	// cancelling is true from the moment the user presses ESC (the TUI posts an
 	// AgentUserEventCancel upstream) until the next final event arrives. While
@@ -441,12 +440,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Type == tea.KeyEnter {
 				text := strings.TrimSpace(m.textInput.Value())
 				if m.pendingIsQuestion {
-					// Free-form answer to an ask-user question. Empty input is
-					// a no-op — questions can't be answered with nothing; ESC
-					// remains the abort path. The wire reply is
-					// Approved=false, Message=<answer> to match the backend's
-					// existing ask_user tool wrapper, which converts it into a
-					// tool_response delivering the answer to the agent.
+					// Empty input is a no-op — "no answer" is meaningless for
+					// a question; ESC remains the abort path.
 					if text == "" {
 						return m, nil
 					}
@@ -459,14 +454,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						},
 						planMode: m.planMode,
 					})
-					m.pendingApproval = false
-					m.pendingApprovalID = ""
-					m.pendingApprovalType = ""
-					m.pendingIsQuestion = false
-					m.textInput.Prompt = "❯ "
-					m.textInput.PromptStyle = promptStyle
-					m.textInput.Placeholder = "Send a message..."
-					m.textInput.Reset()
+					m.clearPendingPrompt()
 					answerCmd := m.commitBlock(block{kind: blockAnswerSubmitted, raw: text})
 					return m, tea.Batch(answerCmd, m.showBusy(thinkingLabel, shimmerVerb))
 				}
@@ -485,9 +473,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					},
 					planMode: m.planMode,
 				})
-				m.pendingApproval = false
-				m.pendingApprovalID = ""
-				m.pendingApprovalType = ""
 				// Approving a plan exits plan mode server-side (the PlanModeTracker
 				// stops gating writes), so mirror that locally. Denial leaves the
 				// mode on — the agent will re-plan and gate-out again on the next
@@ -495,10 +480,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if wasPlanApproval && approved {
 					m.planMode = false
 				}
-				m.textInput.Prompt = "❯ "
-				m.textInput.PromptStyle = promptStyle
-				m.textInput.Placeholder = "Send a message..."
-				m.textInput.Reset()
+				m.clearPendingPrompt()
 				choiceCmd := m.commitBlock(block{
 					kind:     blockApprovalChoice,
 					approved: approved,
@@ -730,17 +712,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingApprovalID = msg.ApprovalID
 		m.pendingApprovalType = msg.ApprovalType
 		m.pendingIsQuestion = false
+		m.textInput.PromptStyle = warningStyle
+		m.textInput.Placeholder = ""
+		m.textInput.Reset()
 		switch {
 		case m.pendingApprovalType == approvalTypePlanExit:
 			// The plan body is authored as markdown and lives in
 			// PlanDescription; msg.Message is just a generic intro.
 			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription}))
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
-			m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		case isAskUserToolName(msg.ToolName):
-			// The agent's ask-user tool reuses user_approval_request to ask
-			// a clarifying question. Render as a question, not an approval —
-			// no warning header, free-form answer prompt.
+			// Render as a question, not an approval.
 			m.pendingIsQuestion = true
 			cmds = append(cmds, m.commitBlock(block{kind: blockQuestion, raw: msg.Message}))
 			m.textInput.Prompt = "Your answer: "
@@ -748,10 +730,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalGeneral, raw: msg.Message}))
 			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
-			m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		}
-		m.textInput.Placeholder = ""
-		m.textInput.Reset()
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	default:
@@ -949,6 +928,20 @@ func (m *Model) appendWarningBlock(msg string) tea.Cmd {
 
 func (m *Model) appendUserMessageBlock(content string) tea.Cmd {
 	return m.commitBlock(block{kind: blockUserMessage, raw: content})
+}
+
+// clearPendingPrompt resets all pendingApproval/pendingIsQuestion state and
+// returns the text input to its default "send a message" appearance. Called
+// after the user submits a confirmation or an answer.
+func (m *Model) clearPendingPrompt() {
+	m.pendingApproval = false
+	m.pendingApprovalID = ""
+	m.pendingApprovalType = ""
+	m.pendingIsQuestion = false
+	m.textInput.Prompt = "❯ "
+	m.textInput.PromptStyle = promptStyle
+	m.textInput.Placeholder = "Send a message..."
+	m.textInput.Reset()
 }
 
 // appendBlock appends a non-busy block, keeping any existing blockBusy

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -440,8 +440,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.Type == tea.KeyEnter {
 				text := strings.TrimSpace(m.textInput.Value())
 				if m.pendingIsQuestion {
-					// Empty input is a no-op — "no answer" is meaningless for
-					// a question; ESC remains the abort path.
 					if text == "" {
 						return m, nil
 					}
@@ -722,7 +720,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription}))
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
 		case isAskUserToolName(msg.ToolName):
-			// Render as a question, not an approval.
 			m.pendingIsQuestion = true
 			cmds = append(cmds, m.commitBlock(block{kind: blockQuestion, raw: msg.Message}))
 			m.textInput.Prompt = "Your answer: "
@@ -931,8 +928,7 @@ func (m *Model) appendUserMessageBlock(content string) tea.Cmd {
 }
 
 // clearPendingPrompt resets all pendingApproval/pendingIsQuestion state and
-// returns the text input to its default "send a message" appearance. Called
-// after the user submits a confirmation or an answer.
+// returns the text input to its default "send a message" appearance.
 func (m *Model) clearPendingPrompt() {
 	m.pendingApproval = false
 	m.pendingApprovalID = ""

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -58,6 +58,8 @@ const (
 	blockApprovalPlan
 	blockApprovalGeneral
 	blockApprovalChoice
+	blockQuestion
+	blockAnswerSubmitted
 	blockPulumiOp
 )
 
@@ -193,6 +195,12 @@ type Model struct {
 	// pending approval (empty when none). The Enter handler checks for
 	// approvalTypePlanExit so it can auto-clear planMode on approval.
 	pendingApprovalType string
+	// pendingIsQuestion is true when the pending request is a question from
+	// the agent's ask-user tool (see isAskUserToolName). The Enter handler
+	// uses it to treat the typed text as a free-form answer instead of
+	// running the y/yes-or-deny parsing. Set when the request arrives,
+	// cleared on submit alongside pendingApproval.
+	pendingIsQuestion bool
 	// cancelling is true from the moment the user presses ESC (the TUI posts an
 	// AgentUserEventCancel upstream) until the next final event arrives. While
 	// it is true the busy label is overridden to "Cancelling..." so the user
@@ -432,6 +440,36 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.pendingApproval {
 			if msg.Type == tea.KeyEnter {
 				text := strings.TrimSpace(m.textInput.Value())
+				if m.pendingIsQuestion {
+					// Free-form answer to an ask-user question. Empty input is
+					// a no-op — questions can't be answered with nothing; ESC
+					// remains the abort path. The wire reply is
+					// Approved=false, Message=<answer> to match the backend's
+					// existing ask_user tool wrapper, which converts it into a
+					// tool_response delivering the answer to the agent.
+					if text == "" {
+						return m, nil
+					}
+					m.sendOut(outboundEvent{
+						event: apitype.AgentUserEventUserConfirmation{
+							Type:       userEventUserConfirmation,
+							ApprovalID: m.pendingApprovalID,
+							Approved:   false,
+							Message:    text,
+						},
+						planMode: m.planMode,
+					})
+					m.pendingApproval = false
+					m.pendingApprovalID = ""
+					m.pendingApprovalType = ""
+					m.pendingIsQuestion = false
+					m.textInput.Prompt = "❯ "
+					m.textInput.PromptStyle = promptStyle
+					m.textInput.Placeholder = "Send a message..."
+					m.textInput.Reset()
+					answerCmd := m.commitBlock(block{kind: blockAnswerSubmitted, raw: text})
+					return m, tea.Batch(answerCmd, m.showBusy(thinkingLabel, shimmerVerb))
+				}
 				approved := strings.EqualFold(text, "y") || strings.EqualFold(text, "yes")
 				var denialMsg string
 				if !approved {
@@ -691,16 +729,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.pendingApproval = true
 		m.pendingApprovalID = msg.ApprovalID
 		m.pendingApprovalType = msg.ApprovalType
-		if m.pendingApprovalType == approvalTypePlanExit {
+		m.pendingIsQuestion = false
+		switch {
+		case m.pendingApprovalType == approvalTypePlanExit:
 			// The plan body is authored as markdown and lives in
 			// PlanDescription; msg.Message is just a generic intro.
 			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription}))
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
-		} else {
+			m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+		case isAskUserToolName(msg.ToolName):
+			// The agent's ask-user tool reuses user_approval_request to ask
+			// a clarifying question. Render as a question, not an approval —
+			// no warning header, free-form answer prompt.
+			m.pendingIsQuestion = true
+			cmds = append(cmds, m.commitBlock(block{kind: blockQuestion, raw: msg.Message}))
+			m.textInput.Prompt = "Your answer: "
+			m.textInput.PromptStyle = promptStyle
+		default:
 			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalGeneral, raw: msg.Message}))
 			m.textInput.Prompt = "Approve? [y to approve / reason to deny]: "
+			m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		}
-		m.textInput.PromptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 		m.textInput.Placeholder = ""
 		m.textInput.Reset()
 		cmds = append(cmds, waitForEvent(m.eventCh))
@@ -798,7 +847,8 @@ func isLiveKind(b block) bool {
 		return b.pulumi != nil && !b.pulumi.done
 	case blockToolComplete, blockAssistantFinal, blockError, blockWarning,
 		blockCancelled, blockUserMessage, blockApprovalPlan,
-		blockApprovalGeneral, blockApprovalChoice:
+		blockApprovalGeneral, blockApprovalChoice,
+		blockQuestion, blockAnswerSubmitted:
 		return false
 	}
 	return false
@@ -997,6 +1047,14 @@ func (m *Model) renderBlock(b *block) {
 	case blockApprovalGeneral:
 		header := warningStyle.Render("⚠ Approval required")
 		b.rendered = renderHeaderedBlock(header, m.wrapPlain(b.raw))
+	case blockQuestion:
+		// Cyan promptStyle (matches the ❯ input prompt) so the header reads
+		// as an input affordance, not a warning.
+		header := promptStyle.Render("◆ Question")
+		b.rendered = renderHeaderedBlock(header, m.wrapPlain(b.raw))
+	case blockAnswerSubmitted:
+		answered := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("✎ Answered")
+		b.rendered = renderIndented(lipgloss.NewStyle(), m.width, answered+" — "+b.raw)
 	case blockBusy, blockToolComplete:
 		// No raw: blockBusy renders live from label, blockToolComplete is
 		// pre-styled at event time.

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -117,6 +117,12 @@ type UIApprovalRequest struct {
 	// PlanDescription is the markdown plan body, populated only for plan_exit
 	// approvals. The TUI renders it through the glamour markdown renderer.
 	PlanDescription string
+	// ToolName is context.tool_name from the wire. ApprovalType alone is
+	// insufficient to distinguish a question (ux__ask_user) from a real
+	// approval — the agent emits "general" for both. The TUI uses ToolName
+	// (matched as a suffix; see isAskUserToolName) to route ask-user calls
+	// to the question rendering path instead of "⚠ Approval required".
+	ToolName string
 }
 
 func (UIApprovalRequest) uiEvent() {}

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -117,11 +117,8 @@ type UIApprovalRequest struct {
 	// PlanDescription is the markdown plan body, populated only for plan_exit
 	// approvals. The TUI renders it through the glamour markdown renderer.
 	PlanDescription string
-	// ToolName is context.tool_name from the wire. ApprovalType alone is
-	// insufficient to distinguish a question (ux__ask_user) from a real
-	// approval — the agent emits "general" for both. The TUI uses ToolName
-	// (matched as a suffix; see isAskUserToolName) to route ask-user calls
-	// to the question rendering path instead of "⚠ Approval required".
+	// ToolName is context.tool_name from the wire. Used by the TUI to route
+	// ask-user calls to the question rendering (see isAskUserToolName).
 	ToolName string
 }
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1353,8 +1353,7 @@ func TestModel_Update_UIApprovalRequest_AskUser_RendersAsQuestion(t *testing.T) 
 
 	// The agent's ux__ask_user tool reuses user_approval_request to ask
 	// clarifying questions. The TUI must NOT render this as an approval —
-	// no warning header, no "Approve?" prompt. Discriminator is the wire
-	// tool_name (the agent emits approval_type "general" for these too).
+	// no warning header, no "Approve?" prompt.
 	ch := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{EventCh: ch})
 
@@ -1389,9 +1388,6 @@ func TestModel_Update_UIApprovalRequest_AskUser_RendersAsQuestion(t *testing.T) 
 func TestModel_Update_UIApprovalRequest_AskUser_BareToolName(t *testing.T) {
 	t.Parallel()
 
-	// Tool names on the wire are "<server>__<method>"; the suffix matcher
-	// must also recognize the bare method form so a server rename doesn't
-	// require a CLI rebuild.
 	ch := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{EventCh: ch})
 
@@ -1511,9 +1507,7 @@ func TestModel_Update_AnswerQuestion_EmptyInputIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	// Empty input + Enter must not produce an outbound event and must
-	// leave the question pending. (For real approvals, empty Enter is a
-	// denial with empty reason — we deliberately diverge here because
-	// "no answer" is meaningless for a question.)
+	// leave the question pending.
 	outCh := make(chan outboundEvent, 1)
 	evCh := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1460,8 +1460,7 @@ func TestModel_Update_AnswerQuestion_SendsConfirmationWithAnswer(t *testing.T) {
 	// Pressing Enter on a question must send the typed text as the answer.
 	// Wire reply is Approved=false, Message=<answer> — the backend's
 	// ask_user tool wrapper converts ok=false+instructions into a
-	// tool_response delivering the answer to the agent. See captured
-	// events at /tmp/task-d390ca33-…events.json:584-619.
+	// tool_response delivering the answer to the agent.
 	outCh := make(chan outboundEvent, 1)
 	evCh := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1348,6 +1348,226 @@ func TestModel_Update_DenyPlan_LeavesPlanModeOn(t *testing.T) {
 	assert.True(t, m.planMode, "denied plan must leave planMode on")
 }
 
+func TestModel_Update_UIApprovalRequest_AskUser_RendersAsQuestion(t *testing.T) {
+	t.Parallel()
+
+	// The agent's ux__ask_user tool reuses user_approval_request to ask
+	// clarifying questions. The TUI must NOT render this as an approval —
+	// no warning header, no "Approve?" prompt. Discriminator is the wire
+	// tool_name (the agent emits approval_type "general" for these too).
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q",
+		Message:      "Which region should I deploy to?",
+		ApprovalType: "general",
+		ToolName:     "ux__ask_user",
+	})
+	um := updated.(Model)
+
+	assert.True(t, um.pendingIsQuestion, "ask_user must set pendingIsQuestion")
+	assert.Equal(t, -1, um.findBlockKind(blockApprovalGeneral),
+		"ask_user must NOT route to the general-approval block")
+	idx := um.findBlockKind(blockQuestion)
+	require.NotEqual(t, -1, idx, "ask_user must commit a blockQuestion")
+	rendered := um.blocks[idx].rendered
+	assert.NotContains(t, rendered, "Approval required",
+		"question rendering must not use the approval-required header")
+	assert.NotContains(t, rendered, "⚠",
+		"question rendering must not use the warning glyph")
+	assert.Contains(t, rendered, "Question",
+		"question rendering must include a question header")
+	assert.Contains(t, rendered, "Which region should I deploy to?",
+		"question body must be rendered verbatim")
+	assert.Contains(t, um.textInput.Prompt, "Your answer",
+		"prompt must invite a free-form answer, not an approval")
+	assert.NotContains(t, um.textInput.Prompt, "Approve",
+		"prompt must not say 'Approve?' for a question")
+}
+
+func TestModel_Update_UIApprovalRequest_AskUser_BareToolName(t *testing.T) {
+	t.Parallel()
+
+	// Tool names on the wire are "<server>__<method>"; the suffix matcher
+	// must also recognize the bare method form so a server rename doesn't
+	// require a CLI rebuild.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q2",
+		Message:      "Pick a runtime.",
+		ApprovalType: "general",
+		ToolName:     "ask_user",
+	})
+	um := updated.(Model)
+
+	assert.True(t, um.pendingIsQuestion)
+	assert.NotEqual(t, -1, um.findBlockKind(blockQuestion))
+}
+
+func TestModel_Update_UIApprovalRequest_AskUser_PlanExitWinsOverToolName(t *testing.T) {
+	t.Parallel()
+
+	// approval_type "plan_exit" is the highest-priority discriminator: a
+	// hypothetical plan_exit request that also carries a ux__ask_user tool
+	// name must render as a plan, never a question.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_p",
+		Message:         "intro",
+		ApprovalType:    approvalTypePlanExit,
+		ToolName:        "ux__ask_user", // ignored when approval_type is plan_exit
+		PlanDescription: "# Plan\n\n- step",
+	})
+	um := updated.(Model)
+
+	assert.False(t, um.pendingIsQuestion, "plan_exit must not be treated as a question")
+	assert.Equal(t, -1, um.findBlockKind(blockQuestion),
+		"plan_exit must not produce a blockQuestion")
+	assert.NotEqual(t, -1, um.findBlockKind(blockApprovalPlan),
+		"plan_exit must produce a blockApprovalPlan")
+}
+
+func TestModel_Update_UIApprovalRequest_GeneralWithoutAskUser_StillApproval(t *testing.T) {
+	t.Parallel()
+
+	// Sanity check that real "general" approvals (no ask_user tool name)
+	// still take the existing approval path. Guards against a regression
+	// where the new branch over-matches.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_real",
+		Message:      "Run pulumi up?",
+		ApprovalType: "general",
+		// no ToolName at all — represents a real approval-gated tool
+	})
+	um := updated.(Model)
+
+	assert.False(t, um.pendingIsQuestion)
+	assert.NotEqual(t, -1, um.findBlockKind(blockApprovalGeneral))
+	assert.Contains(t, um.textInput.Prompt, "Approve?")
+}
+
+func TestModel_Update_AnswerQuestion_SendsConfirmationWithAnswer(t *testing.T) {
+	t.Parallel()
+
+	// Pressing Enter on a question must send the typed text as the answer.
+	// Wire reply is Approved=false, Message=<answer> — the backend's
+	// ask_user tool wrapper converts ok=false+instructions into a
+	// tool_response delivering the answer to the agent. See captured
+	// events at /tmp/task-d390ca33-…events.json:584-619.
+	outCh := make(chan outboundEvent, 1)
+	evCh := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q3",
+		Message:      "Which region?",
+		ApprovalType: "general",
+		ToolName:     "ux__ask_user",
+	})
+	m = updated.(Model)
+	require.True(t, m.pendingIsQuestion)
+
+	answer := "us-west-2 with a hot spare in eu-central-1"
+	m.textInput.SetValue(answer)
+
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated2.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected AgentUserEventUserConfirmation, got %T", got.event)
+		assert.False(t, conf.Approved,
+			"answer is sent with Approved=false to match the backend ask_user wrapper contract")
+		assert.Equal(t, "appr_q3", conf.ApprovalID)
+		assert.Equal(t, answer, conf.Message,
+			"the typed text must be sent verbatim as instructions")
+	default:
+		t.Fatal("answering a question must post a confirmation event")
+	}
+
+	assert.False(t, m.pendingApproval, "submitting an answer must clear pendingApproval")
+	assert.False(t, m.pendingIsQuestion, "pendingIsQuestion must be cleared on submit")
+	assert.Empty(t, m.pendingApprovalType)
+
+	idx := m.findBlockKind(blockAnswerSubmitted)
+	require.NotEqual(t, -1, idx, "submitting must commit a blockAnswerSubmitted")
+	rendered := m.blocks[idx].rendered
+	assert.Contains(t, rendered, "Answered",
+		"the post-submit block must read 'Answered', not 'Denied'")
+	assert.NotContains(t, rendered, "Denied",
+		"the post-submit block must NOT read 'Denied' for a question answer")
+	assert.Contains(t, rendered, answer)
+}
+
+func TestModel_Update_AnswerQuestion_EmptyInputIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// Empty input + Enter must not produce an outbound event and must
+	// leave the question pending. (For real approvals, empty Enter is a
+	// denial with empty reason — we deliberately diverge here because
+	// "no answer" is meaningless for a question.)
+	outCh := make(chan outboundEvent, 1)
+	evCh := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh, EventCh: evCh})
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q4",
+		Message:      "Pick a region.",
+		ApprovalType: "general",
+		ToolName:     "ux__ask_user",
+	})
+	m = updated.(Model)
+
+	updated2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated2.(Model)
+
+	select {
+	case got := <-outCh:
+		t.Fatalf("empty Enter must not post a confirmation event; got %#v", got.event)
+	default:
+	}
+
+	assert.True(t, m.pendingApproval, "empty Enter must leave the question pending")
+	assert.True(t, m.pendingIsQuestion, "pendingIsQuestion must remain set")
+}
+
+func TestQuestionWrapsToTerminalWidth(t *testing.T) {
+	t.Parallel()
+
+	// Long question bodies wrap rather than clipping at the viewport edge.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
+	m = updated0.(Model)
+
+	long := strings.Repeat("word ", 25) // ~125 chars
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:   "appr_q5",
+		Message:      long,
+		ApprovalType: "general",
+		ToolName:     "ux__ask_user",
+	})
+	um := updated.(Model)
+
+	idx := um.findBlockKind(blockQuestion)
+	require.NotEqual(t, -1, idx)
+	widths := visibleLines(um.blocks[idx].rendered)
+	require.Greater(t, len(widths), 1,
+		"long question body must wrap; got: %q", um.blocks[idx].rendered)
+	for i, w := range widths {
+		assert.LessOrEqual(t, w, 40, "line %d exceeds terminal width: width=%d", i, w)
+	}
+}
+
 func TestModel_RenderMarkdown_FallsBackWhenRendererNil(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The agent's `ux__ask_user` tool reuses `user_approval_request` to ask clarifying questions. The `pulumi neo` TUI was rendering these as scary "⚠ Approval required / Approve? [y to approve / reason to deny]" prompts.

This PR routes ask_user calls to a new `blockQuestion` rendering with a "Your answer: " input prompt. The typed answer is submitted via the existing `user_confirmation` channel that the backend already handles (`ok=false, instructions=<answer>` — confirmed against captured task events). Discriminator is `context.tool_name`, matched as a suffix so `ux__ask_user` and a future bare `ask_user` both work.

Fixes pulumi/pulumi-service#42335

## Test plan

- [x] Unit tests for question rendering, suffix matching, plan-exit precedence, answer submission, empty-input no-op, and width wrapping (`pkg/cmd/pulumi/neo/tui_test.go`, `events_test.go`, `session_test.go`)
- [x] `cd pkg && go test -count=1 -tags all ./cmd/pulumi/neo/...`
- [x] `mise exec -- make lint` (clean)
- [ ] Manual smoke: trigger `ux__ask_user` in a real Neo session and confirm the rendered "◆ Question" / "Your answer: " UX, plus that the agent acts on the typed answer