### PR TITLE
Render URLs in `pulumi neo` output as clickable OSC 8 hyperlinks

### DIFF
--- a/changelog/pending/20260506--cli-neo--render-urls-as-clickable-osc-8-hyperlinks-in-the-tui.yaml
+++ b/changelog/pending/20260506--cli-neo--render-urls-as-clickable-osc-8-hyperlinks-in-the-tui.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/neo
+  description: Render URLs in `pulumi neo` output as clickable OSC 8 hyperlinks in terminals that support them

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -254,12 +254,15 @@ func renderLeftBracket(borderStyle lipgloss.Style, content string) string {
 
 // renderIndented word-wraps content (ANSI-safe) to termWidth minus the
 // 2-space transcript gutter, or returns un-wrapped if the width is too
-// small to wrap into.
+// small to wrap into. URLs in the post-wrap output are wrapped in OSC 8
+// escapes so terminals that support hyperlinks render them as clickable.
+// We linkify after wrapping so a URL split across lines simply stays
+// non-clickable rather than producing a broken escape sequence.
 func renderIndented(style lipgloss.Style, termWidth int, content string) string {
 	if termWidth <= 4 {
-		return "  " + style.Render(content)
+		return "  " + linkifyURLs(style.Render(content))
 	}
-	return "  " + style.Width(termWidth-2).Render(content)
+	return "  " + linkifyURLs(style.Width(termWidth-2).Render(content))
 }
 
 // NewModel creates a new TUI Model.
@@ -597,8 +600,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case UISessionURL:
 		// The welcome banner is already in scrollback by the time the task URL
 		// arrives, so emit the URL as its own line rather than re-rendering.
+		// OSC 8 wraps the URL so supporting terminals render it as clickable.
 		m.welcome.consoleURL = msg.URL
-		cmds = append(cmds, tea.Println("  "+inputHintStyle.Render("⟡ "+msg.URL)))
+		cmds = append(cmds, tea.Println("  "+inputHintStyle.Render("⟡ "+osc8Hyperlink(msg.URL, msg.URL))))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIUserMessage:
@@ -1041,9 +1045,9 @@ func (m *Model) renderUserBubble(content string) string {
 func (m *Model) wrapPlain(text string) string {
 	w := m.liveWidth()
 	if w <= 4 {
-		return text
+		return linkifyURLs(text)
 	}
-	return wordwrap.String(text, w-4)
+	return linkifyURLs(wordwrap.String(text, w-4))
 }
 
 func (m *Model) appendRenderedBlock(b block) {
@@ -1052,15 +1056,17 @@ func (m *Model) appendRenderedBlock(b block) {
 }
 
 // renderMarkdown renders text through glamour, falling back to plain text.
+// URLs in the rendered output are wrapped in OSC 8 escapes so terminals that
+// support hyperlinks render them as clickable.
 func (m *Model) renderMarkdown(text string) string {
 	if m.mdRenderer == nil {
-		return text
+		return linkifyURLs(text)
 	}
 	rendered, err := m.mdRenderer.Render(text)
 	if err != nil {
-		return text
+		return linkifyURLs(text)
 	}
-	return strings.TrimRight(rendered, "\n")
+	return linkifyURLs(strings.TrimRight(rendered, "\n"))
 }
 
 // renderHeaderedBlock renders "  header" followed by body indented by 4 spaces,

--- a/pkg/cmd/pulumi/neo/tui_links.go
+++ b/pkg/cmd/pulumi/neo/tui_links.go
@@ -43,10 +43,21 @@ var urlPattern = regexp.MustCompile(`https?://[^\s\x1b<>"']+`)
 // clickable.
 var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\[^\x1b]*\x1b\]8;;\x1b\\`)
 
-// urlTrailingPunct lists characters we strip from the tail of a matched URL.
-// These almost always belong to the surrounding sentence rather than the URL
-// itself (e.g. "see https://example.com." or "(see https://example.com)").
-const urlTrailingPunct = ".,:;!?)]}"
+// urlAlwaysStripPunct lists characters we unconditionally strip from the tail
+// of a matched URL — they're sentence punctuation that practically never
+// appears at the end of a real URL (e.g. "see https://example.com.").
+const urlAlwaysStripPunct = ".,:;!?"
+
+// urlTrailingBrackets maps each closing bracket we may need to peel off the
+// tail of a matched URL to its matching opener. We only strip a trailing
+// closer when it's unmatched inside the URL — that way "(see https://x.com)"
+// loses the outer ")" but "https://en.wikipedia.org/wiki/Foo_(bar)" keeps
+// the balanced one.
+var urlTrailingBrackets = map[byte]byte{
+	')': '(',
+	']': '[',
+	'}': '{',
+}
 
 // linkifyURLs scans text for bare http/https URLs and wraps each one in an
 // OSC 8 hyperlink so terminals that support it render the URL as clickable.
@@ -76,14 +87,40 @@ func linkifyURLs(text string) string {
 // "https://example.com." doesn't try to open "example.com.".
 func linkifyPlain(s string) string {
 	return urlPattern.ReplaceAllStringFunc(s, func(match string) string {
-		trail := ""
-		for len(match) > 0 && strings.ContainsRune(urlTrailingPunct, rune(match[len(match)-1])) {
-			trail = string(match[len(match)-1]) + trail
-			match = match[:len(match)-1]
-		}
+		match, trail := trimURLTail(match)
 		if match == "" {
 			return trail
 		}
 		return osc8Hyperlink(match, match) + trail
 	})
+}
+
+// trimURLTail peels sentence punctuation off the end of a URL match. Plain
+// punctuation (.,:;!?) always strips. A closing bracket only strips if it's
+// unmatched inside what remains of the URL — so balanced brackets stay part
+// of the link target (e.g. Wikipedia disambiguation URLs like
+// "https://en.wikipedia.org/wiki/Foo_(bar)") while orphan closers from the
+// surrounding prose ("(see https://x.com)") get pushed back out.
+func trimURLTail(url string) (link, trail string) {
+	for len(url) > 0 {
+		last := url[len(url)-1]
+		if strings.IndexByte(urlAlwaysStripPunct, last) >= 0 {
+			trail = string(last) + trail
+			url = url[:len(url)-1]
+			continue
+		}
+		if opener, ok := urlTrailingBrackets[last]; ok {
+			// Count both brackets in the full current match (which still
+			// includes the trailing closer). closes > opens means the closer
+			// at the end has no partner inside the URL, so it belongs to the
+			// surrounding text.
+			if strings.Count(url, string(last)) > strings.Count(url, string(opener)) {
+				trail = string(last) + trail
+				url = url[:len(url)-1]
+				continue
+			}
+		}
+		break
+	}
+	return url, trail
 }

--- a/pkg/cmd/pulumi/neo/tui_links.go
+++ b/pkg/cmd/pulumi/neo/tui_links.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"regexp"
+	"strings"
+)
+
+// osc8Hyperlink wraps displayText as a clickable hyperlink to url using the
+// OSC 8 escape sequence. Terminals that support OSC 8 render displayText as
+// a click target; terminals that don't strip the escapes and show displayText
+// as plain text.
+//
+// The wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
+func osc8Hyperlink(url, displayText string) string {
+	if url == "" {
+		return displayText
+	}
+	return "\x1b]8;;" + url + "\x1b\\" + displayText + "\x1b]8;;\x1b\\"
+}
+
+// urlPattern matches bare http/https URLs in text. It excludes whitespace,
+// ANSI escape (so we never split a URL across an escape boundary), and
+// angle/quote characters that commonly bound URLs in prose.
+var urlPattern = regexp.MustCompile(`https?://[^\s\x1b<>"']+`)
+
+// osc8Pattern matches a complete OSC 8 hyperlink sequence — the opener with
+// its URL, the visible text, and the closer. linkifyURLs uses it to skip
+// past existing hyperlinks rather than re-wrapping URLs that are already
+// clickable.
+var osc8Pattern = regexp.MustCompile(`\x1b\]8;;[^\x1b]*\x1b\\[^\x1b]*\x1b\]8;;\x1b\\`)
+
+// urlTrailingPunct lists characters we strip from the tail of a matched URL.
+// These almost always belong to the surrounding sentence rather than the URL
+// itself (e.g. "see https://example.com." or "(see https://example.com)").
+const urlTrailingPunct = ".,:;!?)]}"
+
+// linkifyURLs scans text for bare http/https URLs and wraps each one in an
+// OSC 8 hyperlink so terminals that support it render the URL as clickable.
+// Existing OSC 8 sequences are passed through untouched, so calling this on
+// already-linkified output is safe.
+func linkifyURLs(text string) string {
+	if text == "" {
+		return text
+	}
+	// Walk the string, splitting on existing OSC 8 sequences so we only
+	// linkify the gaps between them. Without this, a URL already wrapped
+	// upstream (e.g. by the welcome banner or a future glamour version)
+	// would get a second, nested set of escapes.
+	var b strings.Builder
+	idx := 0
+	for _, span := range osc8Pattern.FindAllStringIndex(text, -1) {
+		b.WriteString(linkifyPlain(text[idx:span[0]]))
+		b.WriteString(text[span[0]:span[1]])
+		idx = span[1]
+	}
+	b.WriteString(linkifyPlain(text[idx:]))
+	return b.String()
+}
+
+// linkifyPlain wraps every bare URL in s with an OSC 8 hyperlink. Trailing
+// sentence punctuation is left outside the hyperlink so a click on
+// "https://example.com." doesn't try to open "example.com.".
+func linkifyPlain(s string) string {
+	return urlPattern.ReplaceAllStringFunc(s, func(match string) string {
+		trail := ""
+		for len(match) > 0 && strings.ContainsRune(urlTrailingPunct, rune(match[len(match)-1])) {
+			trail = string(match[len(match)-1]) + trail
+			match = match[:len(match)-1]
+		}
+		if match == "" {
+			return trail
+		}
+		return osc8Hyperlink(match, match) + trail
+	})
+}

--- a/pkg/cmd/pulumi/neo/tui_links_test.go
+++ b/pkg/cmd/pulumi/neo/tui_links_test.go
@@ -126,3 +126,120 @@ func TestLinkifyURLs_EmptyString(t *testing.T) {
 
 	assert.Equal(t, "", linkifyURLs(""))
 }
+
+// hyperlink is a test helper that builds the exact OSC 8 envelope we expect
+// linkifyURLs to emit for a given target URL and display text. Pinning the
+// full byte sequence in each assertion catches regressions where one of the
+// escape terminators gets dropped — a common refactor mistake that produces
+// visible garbage rather than a silent wrong-link bug.
+func hyperlink(target, display string) string {
+	return "\x1b]8;;" + target + "\x1b\\" + display + "\x1b]8;;\x1b\\"
+}
+
+func TestLinkifyURLs_PreservesBalancedTrailingParens(t *testing.T) {
+	t.Parallel()
+
+	// Wikipedia disambiguation URLs end in a real ")" that closes a "(" inside
+	// the URL. Stripping it would point clicks at a 404 — the bracket-balance
+	// logic must keep balanced closers as part of the link target.
+	const url = "https://en.wikipedia.org/wiki/Foo_(bar)"
+	got := linkifyURLs("see " + url + " for more")
+	assert.Contains(t, got, hyperlink(url, url))
+}
+
+func TestLinkifyURLs_PreservesParensInMiddleOfURL(t *testing.T) {
+	t.Parallel()
+
+	// Mid-URL parens have nothing to do with trailing-punct stripping, but
+	// pin the case so a future change can't accidentally consume them while
+	// scanning the tail.
+	const url = "https://example.com/path(with)parens/more"
+	assert.Equal(t, hyperlink(url, url), linkifyURLs(url))
+}
+
+func TestLinkifyURLs_PreservesMultipleBalancedGroups(t *testing.T) {
+	t.Parallel()
+
+	// Two balanced "()" groups: opens=2, closes=2, so the trailing ")" is
+	// balanced and must stay in the URL.
+	const url = "https://example.com/(a)/(b)"
+	assert.Equal(t, hyperlink(url, url), linkifyURLs(url))
+}
+
+func TestLinkifyURLs_PreservesBalancedBracketsInURL(t *testing.T) {
+	t.Parallel()
+
+	// Same balance rule applies to "[]" — square brackets are rarer in URLs
+	// (mostly IPv6 hosts in literal form) but the trim logic treats them
+	// uniformly with parens, so pin the behavior.
+	const url = "https://example.com/x[y]"
+	assert.Equal(t, hyperlink(url, url), linkifyURLs(url))
+}
+
+func TestLinkifyURLs_StripsUnbalancedTrailingParen(t *testing.T) {
+	t.Parallel()
+
+	// The inner "(bar)" is balanced inside the URL and stays put; only the
+	// outer ")" — opened by the prose's leading "(" — gets pushed back out.
+	const url = "https://en.wikipedia.org/wiki/Foo_(bar)"
+	got := linkifyURLs("(see " + url + ")")
+	assert.Contains(t, got, hyperlink(url, url)+")")
+	assert.NotContains(t, got, url+")\x1b\\", "outer paren must not be inside the link target")
+}
+
+func TestLinkifyURLs_StripsMultipleUnbalancedCloses(t *testing.T) {
+	t.Parallel()
+
+	// No "(" inside the URL means both trailing ")"s are unmatched and peel
+	// off into the prose one at a time.
+	got := linkifyURLs("https://example.com/foo))")
+	assert.Contains(t, got, hyperlink("https://example.com/foo", "https://example.com/foo")+"))")
+}
+
+func TestLinkifyURLs_StripsCombinedTrailingPunct_PeriodInside(t *testing.T) {
+	t.Parallel()
+
+	// Strip order matters: outer ")" is unbalanced and goes first, then the
+	// "." that's now exposed at the tail. Both end up in the trailing prose
+	// in their original order.
+	got := linkifyURLs("(https://example.com.)")
+	assert.Contains(t, got, hyperlink("https://example.com", "https://example.com")+".)")
+}
+
+func TestLinkifyURLs_StripsCombinedTrailingPunct_PeriodAfterParen(t *testing.T) {
+	t.Parallel()
+
+	// "." strips first (always-strip punct), exposing a balanced ")" that
+	// must stay in the URL. Naive "strip every trailing punct char" logic
+	// would peel the ")" off here and break the link.
+	const url = "https://example.com/(foo)"
+	got := linkifyURLs(url + ".")
+	assert.Contains(t, got, hyperlink(url, url)+".")
+}
+
+func TestLinkifyURLs_HandlesMixedPunctWithBalancedInner(t *testing.T) {
+	t.Parallel()
+
+	// Combined case: outer ")" peels first (closes=2 > opens=1), then ".",
+	// leaving the inner "(foo)" balanced and intact. Exercises the loop's
+	// recount-after-each-strip behavior.
+	const url = "https://example.com/(foo)"
+	got := linkifyURLs("(" + url + ".)")
+	assert.Contains(t, got, hyperlink(url, url)+".)")
+}
+
+func TestLinkifyURLs_MultipleURLsBalanceIndependently(t *testing.T) {
+	t.Parallel()
+
+	// Two URLs in one line: the first must keep its balanced trailing ")",
+	// the second must drop its trailing ".". This guards against a future
+	// refactor that accidentally hoists trim state across matches.
+	const wiki = "https://en.wikipedia.org/wiki/Foo_(bar)"
+	const ex = "https://example.com"
+	got := linkifyURLs("Compare " + wiki + " and " + ex + ".")
+	assert.Contains(t, got, hyperlink(wiki, wiki))
+	assert.Contains(t, got, hyperlink(ex, ex)+".")
+	// 2 hyperlinks * (opener + closer) = 4 OSC 8 marker sequences. More
+	// would mean a URL got double-wrapped; fewer would mean one got dropped.
+	assert.Equal(t, 4, strings.Count(got, "\x1b]8;;"))
+}

--- a/pkg/cmd/pulumi/neo/tui_links_test.go
+++ b/pkg/cmd/pulumi/neo/tui_links_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOSC8Hyperlink_WrapsURL(t *testing.T) {
+	t.Parallel()
+
+	got := osc8Hyperlink("https://example.com", "click me")
+	// The OSC 8 wire format is `ESC ] 8 ; ; <url> ESC \ <text> ESC ] 8 ; ; ESC \`.
+	// Pinning the exact bytes here so a refactor that drops one of the escape
+	// terminators (a common mistake) gets caught immediately rather than
+	// silently producing visible garbage in scrollback.
+	assert.Equal(t, "\x1b]8;;https://example.com\x1b\\click me\x1b]8;;\x1b\\", got)
+}
+
+func TestOSC8Hyperlink_EmptyURLPassesText(t *testing.T) {
+	t.Parallel()
+
+	// With no URL we have nothing to hyperlink to — return the display text
+	// unchanged rather than emitting an empty-target escape, which some
+	// terminals render as a broken link.
+	assert.Equal(t, "plain", osc8Hyperlink("", "plain"))
+}
+
+func TestLinkifyURLs_WrapsBareURL(t *testing.T) {
+	t.Parallel()
+
+	got := linkifyURLs("see https://example.com for details")
+	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\")
+	assert.Contains(t, got, "https://example.com\x1b]8;;\x1b\\")
+	assert.Contains(t, got, "for details")
+}
+
+func TestLinkifyURLs_StripsTrailingPunctuation(t *testing.T) {
+	t.Parallel()
+
+	// Sentence punctuation that follows a URL almost never belongs to it —
+	// "see https://example.com." should hyperlink "https://example.com" and
+	// leave the period outside, otherwise clicking opens the wrong URL.
+	got := linkifyURLs("see https://example.com.")
+	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\.")
+	assert.NotContains(t, got, "https://example.com.\x1b\\", "period must not be inside the hyperlink target")
+}
+
+func TestLinkifyURLs_HandlesParenthesizedURL(t *testing.T) {
+	t.Parallel()
+
+	got := linkifyURLs("(see https://example.com)")
+	// The trailing ")" belongs to the surrounding prose, not the URL, so it
+	// must land outside the hyperlink — otherwise terminals try to open
+	// "example.com)" which 404s.
+	assert.Contains(t, got, "\x1b]8;;https://example.com\x1b\\https://example.com\x1b]8;;\x1b\\)")
+}
+
+func TestLinkifyURLs_WrapsMultipleURLs(t *testing.T) {
+	t.Parallel()
+
+	got := linkifyURLs("first https://a.example and second https://b.example")
+	// Each URL gets its own complete OSC 8 envelope (opener + closer), so two
+	// URLs means four `\x1b]8;;` occurrences — confirms we didn't accidentally
+	// fuse the two URLs into one nested hyperlink or drop a closer.
+	assert.Equal(t, 4, strings.Count(got, "\x1b]8;;"))
+	assert.Contains(t, got, "https://a.example")
+	assert.Contains(t, got, "https://b.example")
+}
+
+func TestLinkifyURLs_LeavesExistingOSC8Alone(t *testing.T) {
+	t.Parallel()
+
+	// If the text is already a hyperlink (e.g. the welcome banner already ran
+	// it through osc8Hyperlink) we must not add a second pair of escapes —
+	// nested OSC 8 sequences confuse some terminals into rendering nothing
+	// clickable at all.
+	already := osc8Hyperlink("https://example.com", "https://example.com")
+	got := linkifyURLs(already)
+	assert.Equal(t, already, got)
+}
+
+func TestLinkifyURLs_MixesPlainAndExisting(t *testing.T) {
+	t.Parallel()
+
+	// A line containing a pre-wrapped URL plus a bare URL should end up with
+	// the pre-wrapped one untouched and the bare one freshly wrapped — two
+	// hyperlinks total, not three (no double-wrapping).
+	already := osc8Hyperlink("https://a.example", "a")
+	input := already + " then https://b.example"
+	got := linkifyURLs(input)
+	// Two complete hyperlinks = 4 `\x1b]8;;` occurrences (each has an opener
+	// and a closer). If linkify re-wrapped the existing one we'd see 6.
+	assert.Equal(t, 4, strings.Count(got, "\x1b]8;;"))
+	assert.Contains(t, got, already)
+	assert.Contains(t, got, "\x1b]8;;https://b.example\x1b\\https://b.example\x1b]8;;\x1b\\")
+}
+
+func TestLinkifyURLs_NoURLs(t *testing.T) {
+	t.Parallel()
+
+	// Plain text without any URLs passes through unchanged. This is the hot
+	// path for the vast majority of streamed assistant tokens, so it must
+	// not introduce spurious escapes.
+	const plain = "no urls here, just words"
+	assert.Equal(t, plain, linkifyURLs(plain))
+}
+
+func TestLinkifyURLs_EmptyString(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", linkifyURLs(""))
+}

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1023,10 +1023,21 @@ func TestModel_Update_UISessionURL_UpdatesWelcomeConsoleURL(t *testing.T) {
 
 	ch := make(chan UIEvent, 4)
 	m := NewModel(ModelConfig{EventCh: ch})
-	updated, _ := m.Update(UISessionURL{URL: "https://app.pulumi.com/x"})
+	updated, cmd := m.Update(UISessionURL{URL: "https://app.pulumi.com/x"})
 	um := updated.(Model)
 
 	assert.Equal(t, "https://app.pulumi.com/x", um.welcome.consoleURL)
+
+	// The session URL is also dropped to terminal scrollback so it survives
+	// re-renders. It must arrive wrapped in an OSC 8 hyperlink — without the
+	// escape, supporting terminals show plain text and the user can't click
+	// through to the task in the console.
+	prints := collectPrintln(cmd)
+	require.NotEmpty(t, prints, "UISessionURL must emit a tea.Println line")
+	joined := strings.Join(prints, "\n")
+	assert.Contains(t, joined, "\x1b]8;;https://app.pulumi.com/x\x1b\\",
+		"session URL must be wrapped in an OSC 8 hyperlink opener")
+	assert.Contains(t, joined, "https://app.pulumi.com/x")
 }
 
 func TestModel_Update_UIUserMessage_AppendsUserBlock(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_welcome.go
+++ b/pkg/cmd/pulumi/neo/tui_welcome.go
@@ -142,8 +142,7 @@ func (w welcomeModel) View() string {
 		if len([]rune(linkText)) > maxLink && maxLink > 3 {
 			linkText = string([]rune(linkText)[:maxLink-3]) + "..."
 		}
-		hyperlink := fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", w.consoleURL, linkText)
-		parts = append(parts, dim.Render("⟡ "+hyperlink))
+		parts = append(parts, dim.Render("⟡ "+osc8Hyperlink(w.consoleURL, linkText)))
 	}
 
 	return renderLeftBracket(bracketStyle, strings.Join(parts, "\n"))


### PR DESCRIPTION
## Summary

URLs that `pulumi neo` printed (session URL, agent-final markdown, plan blocks, warnings/errors, streaming text) landed as plain text. Only the welcome banner was OSC 8.

Adds `osc8Hyperlink` and `linkifyURLs` helpers and wires them into `renderMarkdown`, `wrapPlain`, `renderIndented`, the `UISessionURL` `tea.Println`, and the welcome banner. `linkifyURLs` strips trailing sentence punctuation off the hyperlink target and skips text already inside an OSC 8 sequence so we don't nest.

Fixes pulumi/pulumi-service#42474

## Test plan

- [x] `go test ./pkg/cmd/pulumi/neo/...` and `golangci-lint` pass
- [x] Unit tests for both helpers; `UISessionURL` test asserts the OSC 8 opener
- [ ] Manual click-through in iTerm2 / WezTerm / Ghostty

🤖 Generated with [Claude Code](https://claude.com/claude-code)