### PR TITLE
cli/neo: render the agent's TODO list in the TUI

### DIFF
--- a/changelog/pending/20260506--cli-neo--render-the-agents-todo-list-in-the-tui.yaml
+++ b/changelog/pending/20260506--cli-neo--render-the-agents-todo-list-in-the-tui.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Render the agent's TODO list in the `pulumi neo` TUI

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -79,8 +79,7 @@ const (
 	toolNameAskUser = "ask_user"
 
 	// toolNameTodoWrite is the cloud-side tool the agent uses to publish its
-	// task list. The TUI peeks at the args to render the list; the call itself
-	// runs server-side and never enters the CLI dispatch path.
+	// task list. It runs server-side and never enters the CLI dispatch path.
 	toolNameTodoWrite = "todo__TodoWrite"
 )
 
@@ -103,21 +102,12 @@ func hasPendingCLIToolCalls(calls []apitype.AgentBackendEventToolCall) bool {
 	return false
 }
 
-// parseTodoWriteArgs decodes the args object of a todo__TodoWrite tool call
-// into a UITodoList payload. Returns ok=false (and no items) for malformed
-// or empty payloads so callers can skip the UI emit cleanly. The wire shape
-// is { "todos": [{"content","index","priority","status"}] }.
+// parseTodoWriteArgs decodes the args object of a todo__TodoWrite tool call.
+// Returns ok=false for malformed or empty payloads so callers can skip the
+// UI emit cleanly.
 func parseTodoWriteArgs(args json.RawMessage) ([]UITodoItem, bool) {
-	if len(args) == 0 {
-		return nil, false
-	}
 	var payload struct {
-		Todos []struct {
-			Content  string `json:"content"`
-			Index    int    `json:"index"`
-			Priority string `json:"priority"`
-			Status   string `json:"status"`
-		} `json:"todos"`
+		Todos []UITodoItem `json:"todos"`
 	}
 	if err := json.Unmarshal(args, &payload); err != nil {
 		return nil, false
@@ -125,14 +115,5 @@ func parseTodoWriteArgs(args json.RawMessage) ([]UITodoItem, bool) {
 	if len(payload.Todos) == 0 {
 		return nil, false
 	}
-	items := make([]UITodoItem, 0, len(payload.Todos))
-	for _, t := range payload.Todos {
-		items = append(items, UITodoItem{
-			Content:  t.Content,
-			Status:   t.Status,
-			Priority: t.Priority,
-			Index:    t.Index,
-		})
-	}
-	return items, true
+	return payload.Todos, true
 }

--- a/pkg/cmd/pulumi/neo/events.go
+++ b/pkg/cmd/pulumi/neo/events.go
@@ -21,6 +21,7 @@
 package neo
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -76,6 +77,11 @@ const (
 	// approval_type "general" for these, so the TUI must dispatch on tool
 	// name rather than approval_type alone.
 	toolNameAskUser = "ask_user"
+
+	// toolNameTodoWrite is the cloud-side tool the agent uses to publish its
+	// task list. The TUI peeks at the args to render the list; the call itself
+	// runs server-side and never enters the CLI dispatch path.
+	toolNameTodoWrite = "todo__TodoWrite"
 )
 
 // isAskUserToolName matches by suffix so the server prefix can change
@@ -95,4 +101,38 @@ func hasPendingCLIToolCalls(calls []apitype.AgentBackendEventToolCall) bool {
 		}
 	}
 	return false
+}
+
+// parseTodoWriteArgs decodes the args object of a todo__TodoWrite tool call
+// into a UITodoList payload. Returns ok=false (and no items) for malformed
+// or empty payloads so callers can skip the UI emit cleanly. The wire shape
+// is { "todos": [{"content","index","priority","status"}] }.
+func parseTodoWriteArgs(args json.RawMessage) ([]UITodoItem, bool) {
+	if len(args) == 0 {
+		return nil, false
+	}
+	var payload struct {
+		Todos []struct {
+			Content  string `json:"content"`
+			Index    int    `json:"index"`
+			Priority string `json:"priority"`
+			Status   string `json:"status"`
+		} `json:"todos"`
+	}
+	if err := json.Unmarshal(args, &payload); err != nil {
+		return nil, false
+	}
+	if len(payload.Todos) == 0 {
+		return nil, false
+	}
+	items := make([]UITodoItem, 0, len(payload.Todos))
+	for _, t := range payload.Todos {
+		items = append(items, UITodoItem{
+			Content:  t.Content,
+			Status:   t.Status,
+			Priority: t.Priority,
+			Index:    t.Index,
+		})
+	}
+	return items, true
 }

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -256,6 +256,17 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 			IsFinal:           msg.IsFinal,
 			HasPendingCLIWork: msg.IsFinal && hasPendingCLIToolCalls(msg.ToolCalls),
 		})
+		// todo__TodoWrite is cloud-marked, so it never reaches runBatch / the
+		// UIToolStarted path; surface it directly as a UITodoList so the TUI
+		// can render the agent's task list without needing to execute the call.
+		for _, tc := range msg.ToolCalls {
+			if tc.Name != toolNameTodoWrite {
+				continue
+			}
+			if items, ok := parseTodoWriteArgs(tc.Args); ok {
+				sendUI(s.UIEvents, UITodoList{Items: items})
+			}
+		}
 	case backendEventExecToolCallProgress:
 		var p apitype.AgentBackendEventExecToolCallProgress
 		if err := json.Unmarshal(eventBody, &p); err != nil {

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -257,8 +257,7 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 			HasPendingCLIWork: msg.IsFinal && hasPendingCLIToolCalls(msg.ToolCalls),
 		})
 		// todo__TodoWrite is cloud-marked, so it never reaches runBatch / the
-		// UIToolStarted path; surface it directly as a UITodoList so the TUI
-		// can render the agent's task list without needing to execute the call.
+		// UIToolStarted path — forward the args directly as a UITodoList.
 		for _, tc := range msg.ToolCalls {
 			if tc.Name != toolNameTodoWrite {
 				continue

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -337,6 +337,7 @@ func TestSession_ForwardsTodoWriteToolCallAsUITodoList(t *testing.T) {
 		UIEvents: uiCh,
 	}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	require.True(t, hasUIEvent[UITodoList](events), "todo__TodoWrite must emit UITodoList")
@@ -385,6 +386,7 @@ func TestSession_TodoWriteWithMalformedArgsEmitsNoTodoList(t *testing.T) {
 	uiCh := make(chan UIEvent, 16)
 	s := &Session{Client: streamer, Handlers: map[string]ToolHandler{}, OrgName: "o", TaskID: "t", UIEvents: uiCh}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	assert.False(t, hasUIEvent[UITodoList](events), "malformed todos payload must not emit UITodoList")

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -306,6 +306,90 @@ func TestSession_FinalAssistantMessageWithCliCallsDoesNotEmitTaskIdle(t *testing
 	assert.False(t, hasUIEvent[UITaskIdle](events), "pending cli tool calls must not emit UITaskIdle")
 }
 
+func TestSession_ForwardsTodoWriteToolCallAsUITodoList(t *testing.T) {
+	t.Parallel()
+
+	// todo__TodoWrite is cloud-marked: the agent runs it server-side, so it
+	// must never reach the CLI dispatch loop. It does, however, carry the
+	// task list the TUI wants to render — forwardToUI peeks at the args and
+	// emits a UITodoList alongside the regular UIAssistantMessage.
+	streamer := newFakeStreamer()
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{{
+			ToolCallID: "tc1",
+			Name:       toolNameTodoWrite,
+			Args: json.RawMessage(`{"todos":[
+				{"content":"first","index":0,"priority":"high","status":"pending"},
+				{"content":"second","index":1,"priority":"medium","status":"in_progress"},
+				{"content":"third","index":2,"priority":"low","status":"completed"}
+			]}`),
+		}},
+	})}
+	close(streamer.stream)
+
+	uiCh := make(chan UIEvent, 16)
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{},
+		OrgName:  "o",
+		TaskID:   "t",
+		UIEvents: uiCh,
+	}
+	require.NoError(t, s.Run(t.Context()))
+
+	events := collectUIEvents(uiCh)
+	require.True(t, hasUIEvent[UITodoList](events), "todo__TodoWrite must emit UITodoList")
+
+	// Verify the parsed payload preserves the wire content, ordering, and
+	// status strings so the renderer has everything it needs.
+	var got UITodoList
+	for _, e := range events {
+		if list, ok := e.(UITodoList); ok {
+			got = list
+			break
+		}
+	}
+	require.Len(t, got.Items, 3)
+	assert.Equal(t, "first", got.Items[0].Content)
+	assert.Equal(t, "pending", got.Items[0].Status)
+	assert.Equal(t, "high", got.Items[0].Priority)
+	assert.Equal(t, 0, got.Items[0].Index)
+	assert.Equal(t, "in_progress", got.Items[1].Status)
+	assert.Equal(t, "completed", got.Items[2].Status)
+
+	// Cloud-marked TodoWrite must never trigger CLI dispatch — no exec or
+	// tool_result posts should leave the session.
+	streamer.mu.Lock()
+	defer streamer.mu.Unlock()
+	assert.Empty(t, streamer.posted, "cloud-marked todo__TodoWrite must not produce CLI posts")
+}
+
+func TestSession_TodoWriteWithMalformedArgsEmitsNoTodoList(t *testing.T) {
+	t.Parallel()
+
+	// A malformed args payload must be silently skipped rather than crashing
+	// the forwarder. The session must keep going and process subsequent
+	// events normally.
+	streamer := newFakeStreamer()
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type: backendEventAssistantMessage,
+		ToolCalls: []apitype.AgentBackendEventToolCall{{
+			ToolCallID: "tc1",
+			Name:       toolNameTodoWrite,
+			Args:       json.RawMessage(`{"todos":"not-an-array"}`),
+		}},
+	})}
+	close(streamer.stream)
+
+	uiCh := make(chan UIEvent, 16)
+	s := &Session{Client: streamer, Handlers: map[string]ToolHandler{}, OrgName: "o", TaskID: "t", UIEvents: uiCh}
+	require.NoError(t, s.Run(t.Context()))
+
+	events := collectUIEvents(uiCh)
+	assert.False(t, hasUIEvent[UITodoList](events), "malformed todos payload must not emit UITodoList")
+}
+
 func TestSession_MultipleCliCallsEmitExecToolCallPerCallThenOneResult(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -83,10 +83,8 @@ type block struct {
 	// as UIPulumiResource / UIPulumiDiag / UIPulumiEnd events arrive, then
 	// re-rendered by renderBlock on every update.
 	pulumi *pulumiBlockState
-	// todos is populated for blockTodoList (the standalone, working-mode
-	// rendering) and for blockApprovalPlan when the buffered list captured
-	// during plan mode is attached at plan_exit time so renderBlock can
-	// fold it into the plan body as a Tasks: subsection.
+	// todos is populated for blockTodoList and folded into blockApprovalPlan
+	// as a Tasks: subsection.
 	todos []UITodoItem
 }
 
@@ -230,10 +228,8 @@ type Model struct {
 	// emissions prepend a blank line so each committed block has visual
 	// breathing room from whatever came before.
 	hasEmittedScrollback bool
-	// pendingTodos buffers the latest UITodoList while planMode is true.
-	// It is drained and attached to the next blockApprovalPlan when the
-	// plan_exit approval arrives, so the user sees the task list and the
-	// plan as a single visual unit rather than two separate blocks.
+	// pendingTodos buffers the latest UITodoList while planMode is true so
+	// the list lands inside the same block as the Proposed plan, not above it.
 	pendingTodos []UITodoItem
 }
 
@@ -251,8 +247,7 @@ var (
 	// and the "Proposed plan" block header so they read as the same visual cue.
 	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 	// Styles for in-progress and completed todo items. Pending items render
-	// in the default style so the visually-loud markers (cyan/green) are
-	// reserved for the rows the user actually cares about.
+	// in the default style — no entry here.
 	todoActiveStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
 	todoCompletedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Faint(true)
 	todoListHeader     = lipgloss.NewStyle().Bold(true).Render("⏺ TODO")
@@ -742,13 +737,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UITodoList:
-		// In plan mode, hold the list until plan_exit so the user sees the
-		// tasks alongside the plan in a single block. Outside plan mode we
-		// commit on every TodoWrite — the agent fires one per status change,
-		// which is exactly the "step completed / list edited" trigger.
+		// In plan mode, hold the list until plan_exit so the tasks land
+		// inside the same block as the plan. Outside plan mode commit
+		// immediately so status flips show up in scrollback.
 		if len(msg.Items) > 0 {
 			if m.planMode {
-				m.pendingTodos = append(m.pendingTodos[:0], msg.Items...)
+				m.pendingTodos = msg.Items
 			} else {
 				cmds = append(cmds, m.commitBlock(block{kind: blockTodoList, todos: msg.Items}))
 			}
@@ -768,9 +762,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case m.pendingApprovalType == approvalTypePlanExit:
 			// The plan body is authored as markdown and lives in
-			// PlanDescription; msg.Message is just a generic intro. Any
-			// TodoWrite buffered while in plan mode is folded into this
-			// same block as a Tasks: subsection by renderBlock below.
+			// PlanDescription; msg.Message is just a generic intro.
 			planBlock := block{kind: blockApprovalPlan, raw: msg.PlanDescription, todos: m.pendingTodos}
 			m.pendingTodos = nil
 			cmds = append(cmds, m.commitBlock(planBlock))
@@ -1148,9 +1140,6 @@ func (m *Model) renderBlock(b *block) {
 
 // renderTodoLines formats todos as one ASCII checkbox per line, sorted by
 // Index so the agent's intended ordering survives JSON round-tripping.
-// Pending items render in the default style; in_progress is bold cyan and
-// completed is faint green so a long list is scannable without dominating
-// the surrounding plan or transcript.
 func renderTodoLines(items []UITodoItem) string {
 	if len(items) == 0 {
 		return ""

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -15,6 +15,7 @@
 package neo
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -61,6 +62,7 @@ const (
 	blockQuestion
 	blockAnswerSubmitted
 	blockPulumiOp
+	blockTodoList
 )
 
 type block struct {
@@ -81,6 +83,11 @@ type block struct {
 	// as UIPulumiResource / UIPulumiDiag / UIPulumiEnd events arrive, then
 	// re-rendered by renderBlock on every update.
 	pulumi *pulumiBlockState
+	// todos is populated for blockTodoList (the standalone, working-mode
+	// rendering) and for blockApprovalPlan when the buffered list captured
+	// during plan mode is attached at plan_exit time so renderBlock can
+	// fold it into the plan body as a Tasks: subsection.
+	todos []UITodoItem
 }
 
 // pulumiBlockState accumulates the live state of a blockPulumiOp. Resources are
@@ -223,6 +230,11 @@ type Model struct {
 	// emissions prepend a blank line so each committed block has visual
 	// breathing room from whatever came before.
 	hasEmittedScrollback bool
+	// pendingTodos buffers the latest UITodoList while planMode is true.
+	// It is drained and attached to the next blockApprovalPlan when the
+	// plan_exit approval arrives, so the user sees the task list and the
+	// plan as a single visual unit rather than two separate blocks.
+	pendingTodos []UITodoItem
 }
 
 var (
@@ -238,6 +250,12 @@ var (
 	// planAccentStyle is a distinct cyan+bold used for both the footer banner
 	// and the "Proposed plan" block header so they read as the same visual cue.
 	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	// Styles for in-progress and completed todo items. Pending items render
+	// in the default style so the visually-loud markers (cyan/green) are
+	// reserved for the rows the user actually cares about.
+	todoActiveStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	todoCompletedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Faint(true)
+	todoListHeader     = lipgloss.NewStyle().Bold(true).Render("⏺ TODO")
 )
 
 // renderLeftBracket decorates content with a left-only bracket border: a
@@ -723,6 +741,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
+	case UITodoList:
+		// In plan mode, hold the list until plan_exit so the user sees the
+		// tasks alongside the plan in a single block. Outside plan mode we
+		// commit on every TodoWrite — the agent fires one per status change,
+		// which is exactly the "step completed / list edited" trigger.
+		if len(msg.Items) > 0 {
+			if m.planMode {
+				m.pendingTodos = append(m.pendingTodos[:0], msg.Items...)
+			} else {
+				cmds = append(cmds, m.commitBlock(block{kind: blockTodoList, todos: msg.Items}))
+			}
+		}
+		cmds = append(cmds, m.applyBusyForEvent(msg))
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
 	case UIApprovalRequest:
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		m.pendingApproval = true
@@ -735,8 +768,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case m.pendingApprovalType == approvalTypePlanExit:
 			// The plan body is authored as markdown and lives in
-			// PlanDescription; msg.Message is just a generic intro.
-			cmds = append(cmds, m.commitBlock(block{kind: blockApprovalPlan, raw: msg.PlanDescription}))
+			// PlanDescription; msg.Message is just a generic intro. Any
+			// TodoWrite buffered while in plan mode is folded into this
+			// same block as a Tasks: subsection by renderBlock below.
+			planBlock := block{kind: blockApprovalPlan, raw: msg.PlanDescription, todos: m.pendingTodos}
+			m.pendingTodos = nil
+			cmds = append(cmds, m.commitBlock(planBlock))
 			m.textInput.Prompt = "Approve plan? [y to approve / reason to deny]: "
 		case isAskUserToolName(msg.ToolName):
 			m.pendingIsQuestion = true
@@ -855,7 +892,7 @@ func isLiveKind(b block) bool {
 		return b.pulumi != nil && !b.pulumi.done
 	case blockToolComplete, blockAssistantFinal, blockError, blockWarning,
 		blockCancelled, blockUserMessage, blockApprovalPlan,
-		blockApprovalGeneral, blockApprovalChoice,
+		blockApprovalGeneral, blockApprovalChoice, blockTodoList,
 		blockQuestion, blockAnswerSubmitted:
 		return false
 	}
@@ -1060,6 +1097,10 @@ func (m *Model) renderBlock(b *block) {
 		b.rendered = m.renderPulumiBlock(b.pulumi)
 		return
 	}
+	if b.kind == blockTodoList {
+		b.rendered = renderHeaderedBlock(todoListHeader, renderTodoLines(b.todos))
+		return
+	}
 	if b.raw == "" {
 		return
 	}
@@ -1078,7 +1119,14 @@ func (m *Model) renderBlock(b *block) {
 		b.rendered = renderAssistantFinal(m.renderMarkdown(b.raw))
 	case blockApprovalPlan:
 		header := planAccentStyle.Render("⏺ Proposed plan")
-		b.rendered = renderHeaderedBlock(header, m.renderMarkdown(b.raw))
+		body := m.renderMarkdown(b.raw)
+		// Fold any todos buffered during plan mode into the plan body. A
+		// blank line separates them from the plan markdown so glamour's
+		// last paragraph doesn't visually run into the Tasks header.
+		if len(b.todos) > 0 {
+			body = strings.TrimRight(body, "\n") + "\n\nTasks:\n" + renderTodoLines(b.todos)
+		}
+		b.rendered = renderHeaderedBlock(header, body)
 	case blockApprovalGeneral:
 		header := warningStyle.Render("⚠ Approval required")
 		b.rendered = renderHeaderedBlock(header, m.wrapPlain(b.raw))
@@ -1093,9 +1141,36 @@ func (m *Model) renderBlock(b *block) {
 	case blockBusy, blockToolComplete:
 		// No raw: blockBusy renders live from label, blockToolComplete is
 		// pre-styled at event time.
-	case blockApprovalChoice, blockPulumiOp:
-		// Unreachable: both are handled by early returns above.
+	case blockApprovalChoice, blockPulumiOp, blockTodoList:
+		// Unreachable: handled by early returns above.
 	}
+}
+
+// renderTodoLines formats todos as one ASCII checkbox per line, sorted by
+// Index so the agent's intended ordering survives JSON round-tripping.
+// Pending items render in the default style; in_progress is bold cyan and
+// completed is faint green so a long list is scannable without dominating
+// the surrounding plan or transcript.
+func renderTodoLines(items []UITodoItem) string {
+	if len(items) == 0 {
+		return ""
+	}
+	sorted := append([]UITodoItem(nil), items...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Index < sorted[j].Index })
+	lines := make([]string, 0, len(sorted))
+	for _, it := range sorted {
+		var marker, content string
+		switch it.Status {
+		case "completed":
+			marker, content = "[x]", todoCompletedStyle.Render(it.Content)
+		case "in_progress":
+			marker, content = "[~]", todoActiveStyle.Render(it.Content)
+		default:
+			marker, content = "[ ]", it.Content
+		}
+		lines = append(lines, marker+" "+content)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m *Model) renderApprovalChoice(b *block) {

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -204,17 +204,16 @@ func (UIPulumiEnd) uiEvent() {}
 
 // UITodoItem is one entry in the agent's task list. Index preserves the
 // agent's intended ordering; Priority is carried for forward compatibility
-// but the renderer ignores it today.
+// but the renderer ignores it today. Field tags also let the wire decoder
+// in events.go unmarshal todo__TodoWrite args directly into this type.
 type UITodoItem struct {
-	Content  string
-	Status   string // "pending" | "in_progress" | "completed"
-	Priority string // "low" | "medium" | "high"
-	Index    int
+	Content  string `json:"content"`
+	Status   string `json:"status"`   // "pending" | "in_progress" | "completed"
+	Priority string `json:"priority"` // "low" | "medium" | "high"
+	Index    int    `json:"index"`
 }
 
-// UITodoList carries the agent's full task list. The TUI buffers it during
-// plan mode (rendering it as a Tasks: subsection of the next plan_exit
-// approval block) and renders it as its own block on every event otherwise.
+// UITodoList carries the agent's full task list.
 type UITodoList struct {
 	Items []UITodoItem
 }

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -201,3 +201,22 @@ type UIPulumiEnd struct {
 }
 
 func (UIPulumiEnd) uiEvent() {}
+
+// UITodoItem is one entry in the agent's task list. Index preserves the
+// agent's intended ordering; Priority is carried for forward compatibility
+// but the renderer ignores it today.
+type UITodoItem struct {
+	Content  string
+	Status   string // "pending" | "in_progress" | "completed"
+	Priority string // "low" | "medium" | "high"
+	Index    int
+}
+
+// UITodoList carries the agent's full task list. The TUI buffers it during
+// plan mode (rendering it as a Tasks: subsection of the next plan_exit
+// approval block) and renders it as its own block on every event otherwise.
+type UITodoList struct {
+	Items []UITodoItem
+}
+
+func (UITodoList) uiEvent() {}

--- a/pkg/cmd/pulumi/neo/tui_events_test.go
+++ b/pkg/cmd/pulumi/neo/tui_events_test.go
@@ -47,6 +47,7 @@ func TestUIEventSealedInterface(t *testing.T) {
 		UIPulumiResource{ToolName: "pulumi__pulumi_preview"},
 		UIPulumiDiag{ToolName: "pulumi__pulumi_preview"},
 		UIPulumiEnd{ToolName: "pulumi__pulumi_preview"},
+		UITodoList{Items: []UITodoItem{{Content: "do thing", Status: "pending"}}},
 	}
 
 	// Calling uiEvent() through the interface dispatches to each concrete impl —
@@ -54,5 +55,5 @@ func TestUIEventSealedInterface(t *testing.T) {
 	for _, e := range events {
 		e.uiEvent()
 	}
-	require.Len(t, events, 17, "bumped this when adding a new UIEvent variant")
+	require.Len(t, events, 18, "bumped this when adding a new UIEvent variant")
 }

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1639,6 +1639,162 @@ func TestQuestionWrapsToTerminalWidth(t *testing.T) {
 	}
 }
 
+func TestModel_Update_UITodoList_OutsidePlanModeCommitsBlock(t *testing.T) {
+	t.Parallel()
+
+	// Outside plan mode every TodoWrite is rendered immediately so the user
+	// sees status flips ("step completed") and edits land in scrollback.
+	m := NewModel(ModelConfig{})
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated, cmd := m.Update(UITodoList{Items: []UITodoItem{
+		{Content: "set up project", Index: 0, Status: "completed"},
+		{Content: "add lambda", Index: 1, Status: "in_progress"},
+		{Content: "run preview", Index: 2, Status: "pending"},
+	}})
+	um := updated.(Model)
+
+	idx := um.findBlockKind(blockTodoList)
+	require.NotEqual(t, -1, idx, "TodoWrite outside plan mode must commit a blockTodoList")
+	rendered := um.blocks[idx].rendered
+	assert.Contains(t, rendered, "TODO")
+	assert.Contains(t, rendered, "[x] ")
+	assert.Contains(t, rendered, "[~] ")
+	assert.Contains(t, rendered, "[ ] ")
+	// Index ordering is load-bearing: the agent communicates "next step"
+	// implicitly via priority order.
+	assert.Less(t, strings.Index(rendered, "set up project"), strings.Index(rendered, "add lambda"))
+	assert.Less(t, strings.Index(rendered, "add lambda"), strings.Index(rendered, "run preview"))
+
+	printed := collectPrintln(cmd)
+	require.Len(t, printed, 1, "outside plan mode the TODO block must be printed to scrollback")
+	assert.Contains(t, printed[0], "set up project")
+}
+
+func TestModel_Update_UITodoList_InPlanModeBuffersAndDoesNotCommit(t *testing.T) {
+	t.Parallel()
+
+	// In plan mode the list is held back so it can be folded into the
+	// upcoming Proposed plan block — committing now would split the visual
+	// unit the user picked the embedded layout for.
+	m := NewModel(ModelConfig{})
+	m.planMode = true
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated, cmd := m.Update(UITodoList{Items: []UITodoItem{
+		{Content: "draft plan", Index: 0, Status: "pending"},
+	}})
+	um := updated.(Model)
+
+	assert.Equal(t, -1, um.findBlockKind(blockTodoList),
+		"plan-mode TodoWrite must not commit a standalone block")
+	require.Len(t, um.pendingTodos, 1)
+	assert.Equal(t, "draft plan", um.pendingTodos[0].Content)
+	assert.Empty(t, collectPrintln(cmd), "plan-mode TodoWrite must not write to scrollback yet")
+}
+
+func TestModel_Update_PlanExitFoldsBufferedTodosIntoPlanBlock(t *testing.T) {
+	t.Parallel()
+
+	// The buffered list must surface as a Tasks: subsection inside the
+	// single Proposed plan block — that's the layout the user chose so the
+	// plan and the tasks read as one unit in scrollback.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.planMode = true
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated1, _ := m.Update(UITodoList{Items: []UITodoItem{
+		{Content: "alpha task", Index: 0, Status: "pending"},
+		{Content: "beta task", Index: 1, Status: "pending"},
+	}})
+	m = updated1.(Model)
+
+	updated2, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_plan",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\n- step one",
+	})
+	um := updated2.(Model)
+
+	assert.Empty(t, um.pendingTodos, "buffered todos must be drained on plan_exit")
+	idx := um.findBlockKind(blockApprovalPlan)
+	require.NotEqual(t, -1, idx)
+	rendered := um.blocks[idx].rendered
+	assert.Contains(t, rendered, "Proposed plan")
+	assert.Contains(t, rendered, "Tasks:")
+	assert.Contains(t, rendered, "alpha task")
+	assert.Contains(t, rendered, "beta task")
+	// Single block — no separate blockTodoList ever materialized.
+	assert.Equal(t, -1, um.findBlockKind(blockTodoList),
+		"plan-exit must not produce a separate TODO block")
+}
+
+func TestModel_Update_PlanModeUITodoList_OnlyLatestSnapshotIsRendered(t *testing.T) {
+	t.Parallel()
+
+	// Several TodoWrites can arrive in plan mode (the agent drafts and
+	// revises). The plan_exit block must reflect only the most recent
+	// snapshot so users don't see superseded work.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.planMode = true
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated1, _ := m.Update(UITodoList{Items: []UITodoItem{
+		{Content: "stale entry", Index: 0, Status: "pending"},
+	}})
+	m = updated1.(Model)
+	updated2, _ := m.Update(UITodoList{Items: []UITodoItem{
+		{Content: "latest entry", Index: 0, Status: "pending"},
+	}})
+	m = updated2.(Model)
+
+	updated3, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_plan2",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "Plan body.",
+	})
+	um := updated3.(Model)
+
+	idx := um.findBlockKind(blockApprovalPlan)
+	require.NotEqual(t, -1, idx)
+	rendered := um.blocks[idx].rendered
+	assert.Contains(t, rendered, "latest entry")
+	assert.NotContains(t, rendered, "stale entry",
+		"superseded list entries must not leak into the plan block")
+}
+
+func TestModel_Update_PlanExitWithoutBufferedTodosRendersCleanPlan(t *testing.T) {
+	t.Parallel()
+
+	// When no TodoWrite has fired during plan mode, the plan block must
+	// render exactly as before — no spurious Tasks: header attached.
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+	m.planMode = true
+	updated0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updated0.(Model)
+
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID:      "appr_plan3",
+		ApprovalType:    approvalTypePlanExit,
+		PlanDescription: "# Plan\n\nbody only",
+	})
+	um := updated.(Model)
+
+	idx := um.findBlockKind(blockApprovalPlan)
+	require.NotEqual(t, -1, idx)
+	rendered := um.blocks[idx].rendered
+	assert.Contains(t, rendered, "Proposed plan")
+	assert.NotContains(t, rendered, "Tasks:",
+		"a plan with no buffered todos must not advertise an empty Tasks: section")
+}
+
 func TestModel_RenderMarkdown_FallsBackWhenRendererNil(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Surface `todo__TodoWrite` calls in the `pulumi neo` TUI so the user can see
what the agent is tracking.

- **In plan mode**: every TodoWrite is buffered and folded into the next
  "Proposed plan" approval block as a `Tasks:` subsection, so the plan and
  the task list read as a single unit when the agent emits its plan.
- **Outside plan mode**: every TodoWrite renders as a standalone `⏺ TODO`
  block in scrollback, so status flips ("step completed") and edits land
  for the user as they happen.

Items render with ASCII checkboxes — `[ ]` pending, `[~]` in_progress,
`[x]` completed — sorted by their `index` field.

`todo__TodoWrite` is a cloud-side tool, so the parsing happens in
`session.forwardToUI` (alongside the `UIPulumi*` family), not in the CLI
dispatch loop.

Fixes pulumi/pulumi-service#42479

## Demo

[![asciicast](https://asciinema.org/a/L7nuifQB7iKmPDWj.svg)](https://asciinema.org/a/L7nuifQB7iKmPDWj)

## Test plan

- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/...`
- [x] `make format` / `golangci-lint run` clean
- [ ] Manual: `pulumi neo` with plan mode on → TODO list appears only
      embedded in the "Proposed plan" block, never on its own beforehand
- [ ] Manual: `pulumi neo` without plan mode → standalone `⏺ TODO` block
      re-renders into scrollback on each TodoWrite with the latest statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)