### PR TITLE
avoid npm install flakes

### DIFF
--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -274,13 +274,42 @@ func RunCommandWithOptions(
 	opts *integration.ProgramTestOptions,
 	name string, cwd string, exec string, args ...string,
 ) {
+	stdout, stderr, err := tryRunCommand(t, opts, name, cwd, exec, args...)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+}
+
+// RunCommandWithRetries is like RunCommand but retries the command up to maxRetries times on failure.
+// This is useful for commands that may fail due to transient network errors (e.g. npm install).
+func RunCommandWithRetries(t *testing.T, name string, cwd string, maxRetries int, exec string, args ...string) {
+	opts := &integration.ProgramTestOptions{}
+	var stdout, stderr string
+	var err error
+	for attempt := range maxRetries {
+		stdout, stderr, err = tryRunCommand(t, opts, name, cwd, exec, args...)
+		if err == nil {
+			return
+		}
+		if attempt < maxRetries-1 {
+			t.Logf("Command %q failed (attempt %d/%d), retrying: %v", name, attempt+1, maxRetries, err)
+		}
+	}
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+}
+
+// tryRunCommand runs a command and returns stdout, stderr, and any error without failing the test.
+func tryRunCommand(
+	t *testing.T,
+	opts *integration.ProgramTestOptions,
+	name string, cwd string, exec string, args ...string,
+) (string, string, error) {
 	exec, err := executable.FindExecutable(exec)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		return "", "", err
 	}
 	wd, err := filepath.Abs(cwd)
-	require.NoError(t, err)
+	if err != nil {
+		return "", "", err
+	}
 	var stdout, stderr bytes.Buffer
 	opts.Stdout = &stdout
 	opts.Stderr = &stderr
@@ -290,18 +319,7 @@ func RunCommandWithOptions(
 		append([]string{exec}, args...),
 		wd,
 		opts)
-	//nolint:forbidigo // We enhance the error message show if the test fails
-	if !assert.NoError(t, err) {
-		stdout := stdout.String()
-		stderr := stderr.String()
-		if len(stdout) > 0 {
-			t.Logf("stdout: %s", stdout)
-		}
-		if len(stderr) > 0 {
-			t.Logf("stderr: %s", stderr)
-		}
-		t.FailNow()
-	}
+	return stdout.String(), stderr.String(), err
 }
 
 type SchemaVersion = string

--- a/pkg/codegen/testing/test/nodejs.go
+++ b/pkg/codegen/testing/test/nodejs.go
@@ -106,7 +106,7 @@ func typeCheckNodeJS(t *testing.T, path string, _ codegen.StringSet, linkLocal b
 }
 
 func TypeCheckNodeJSPackage(t *testing.T, pwd string, linkLocal bool) {
-	RunCommand(t, "npm_install", pwd, "npm", "install")
+	RunCommandWithRetries(t, "npm_install", pwd, 3, "npm", "install")
 	if linkLocal {
 		RunCommand(t, "yarn_link", pwd, "yarn", "link", "@pulumi/pulumi")
 	}


### PR DESCRIPTION
npm install sometimes flakes because of network issues, as for example seen in https://github.com/pulumi/pulumi/actions/runs/25431522957/job/74599111401.

Update this helper function to retry `npm install` a few times before actually giving up, to give us a better chance to deal with such flakes.
