### PR TITLE
Bump the version of pulumi-hcl to v0.2.0

### DIFF
--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -56,7 +56,7 @@ LANGUAGES=(
   # renovate: datasource=github-releases depName=pulumi/pulumi-yaml
   "yaml v1.33.0"
   # renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl
-  "hcl v0.0.2 pulumi-labs"
+  "hcl v0.2.0 pulumi-labs"
 )
 
 for i in "${LANGUAGES[@]}"; do


### PR DESCRIPTION
Consume the new upstream release.

No changelog since this is currently in very early (pre-anncounce) beta. 