### PR TITLE
`pulumi up --output json`

### DIFF
--- a/changelog/pending/20260506--cli--add-output-json-to-pulumi-up-for-a-structured-summary.yaml
+++ b/changelog/pending/20260506--cli--add-output-json-to-pulumi-up-for-a-structured-summary.yaml
@@ -1,4 +1,4 @@
 changes:
-- type: feature
+- type: feat
   scope: cli
   description: Add `--output json` to `pulumi up` for a structured JSON summary of the operation result

--- a/changelog/pending/20260506--cli--add-output-json-to-pulumi-up-for-a-structured-summary.yaml
+++ b/changelog/pending/20260506--cli--add-output-json-to-pulumi-up-for-a-structured-summary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feature
+  scope: cli
+  description: Add `--output json` to `pulumi up` for a structured JSON summary of the operation result

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -122,9 +122,6 @@ func ShowEvents(
 			close(ch)
 		}()
 		rawEvents = ch
-		if opts.SummaryJSON {
-			rawEvents = tapSummaryJSON(rawEvents, opts)
-		}
 	}
 
 	if opts.JSONDisplay {
@@ -133,6 +130,20 @@ func ShowEvents(
 		} else {
 			ShowJSONEvents(stampedEvents, done, opts)
 		}
+		return
+	}
+
+	if opts.SummaryJSON {
+		// `--output json` mode: stdout must contain only the summary JSON line.
+		// Suppress all human-readable output (permalinks, progress, diffs); the
+		// tap drains the event stream and emits the summary on stdout when the
+		// SummaryEvent arrives.
+		tapped := tapSummaryJSON(rawEvents, opts)
+		go func() {
+			defer close(done)
+			for range tapped { //nolint:revive // intentional drain
+			}
+		}()
 		return
 	}
 

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -141,7 +141,10 @@ func ShowEvents(
 		tapped := tapSummaryJSON(rawEvents, opts)
 		go func() {
 			defer close(done)
-			for range tapped { //nolint:revive // intentional drain
+			for e := range tapped {
+				if e.Type == engine.CancelEvent {
+					return
+				}
 			}
 		}()
 		return

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -112,15 +112,19 @@ func ShowEvents(
 	// that we can consistently use `rawEvents` in both `ShowPreviewDigest` and the non-json display modes. We
 	// can't always create rawEvents because if we're in ShowJSONEvents we'll have two consumers competing for
 	// the stamped events.
-	var rawEvents chan engine.Event
+	var rawEvents <-chan engine.Event
 	if !opts.JSONDisplay || (isPreview && !streamPreview) {
-		rawEvents = make(chan engine.Event)
+		ch := make(chan engine.Event)
 		go func() {
 			for e := range stampedEvents {
-				rawEvents <- e.Event
+				ch <- e.Event
 			}
-			close(rawEvents)
+			close(ch)
 		}()
+		rawEvents = ch
+		if opts.SummaryJSON {
+			rawEvents = tapSummaryJSON(rawEvents, opts)
+		}
 	}
 
 	if opts.JSONDisplay {

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -49,6 +49,7 @@ type Options struct {
 	IsInteractive            bool                // true if we should display things interactively.
 	Type                     Type                // type of display (rich diff, progress, or query).
 	JSONDisplay              bool                // true if we should emit the entire diff as JSON.
+	SummaryJSON              bool                // true to emit a one-line JSON summary on stdout when the operation ends.
 	EventLogPath             string              // the path to the file to use for logging events, if any.
 	Debug                    bool                // true to enable debug output.
 	Stdin                    io.Reader           // the reader to use for stdin. Defaults to os.Stdin if unset.

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -87,6 +87,9 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 				}
 			}
 			out <- e
+			if e.Type == engine.CancelEvent {
+				return
+			}
 		}
 	}()
 	return out

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// SummaryJSON is a one-line JSON summary of a stack operation, intended for
+// programmatic / LLM consumers when `--output json` is set.
+//
+// The shape is intentionally narrower than `apitype.SummaryEvent`: it only
+// surfaces the fields that make sense as a final summary of the run (no
+// `isPreview`, no `policyPacks`, no `maybeCorrupt`).
+type SummaryJSON struct {
+	// Result is the high-level outcome of the operation.
+	Result apitype.OperationResult `json:"result"`
+	// Duration is how long the operation took.
+	Duration time.Duration `json:"duration"`
+	// Summary is the count per operation kind (create, update, etc).
+	Summary display.ResourceChanges `json:"summary,omitempty"`
+}
+
+// summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
+func summaryJSONFromEvent(p engine.SummaryEventPayload) SummaryJSON {
+	return SummaryJSON{
+		Result:   p.Result,
+		Duration: p.Duration,
+		Summary:  p.ResourceChanges,
+	}
+}
+
+// writeSummaryJSON encodes a SummaryJSON to w as a single line.
+func writeSummaryJSON(w io.Writer, s SummaryJSON) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(s); err != nil {
+		return err
+	}
+	// json.Encoder always appends a trailing newline; that's the line break we want.
+	_, err := io.Copy(w, &buf)
+	return err
+}
+
+// tapSummaryJSON returns a copy of the input channel that, in addition to
+// forwarding every event, watches for a SummaryEvent and writes its summary
+// to stdout as a single-line JSON object.
+//
+// The tap is only attached when Options.SummaryJSON is set; the rest of the
+// display pipeline is otherwise unaffected.
+func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
+	out := make(chan engine.Event)
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	go func() {
+		defer close(out)
+		for e := range in {
+			if e.Type == engine.SummaryEvent {
+				if payload, ok := e.Payload().(engine.SummaryEventPayload); ok {
+					if err := writeSummaryJSON(stdout, summaryJSONFromEvent(payload)); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: failed to write summary JSON: %v\n", err)
+					}
+				}
+			}
+			out <- e
+		}
+	}()
+	return out
+}

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -76,13 +76,17 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	if stdout == nil {
 		stdout = os.Stdout
 	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
 	go func() {
 		defer close(out)
 		for e := range in {
 			if e.Type == engine.SummaryEvent {
 				if payload, ok := e.Payload().(engine.SummaryEventPayload); ok {
 					if err := writeSummaryJSON(stdout, summaryJSONFromEvent(payload)); err != nil {
-						fmt.Fprintf(os.Stderr, "warning: failed to write summary JSON: %v\n", err)
+						fmt.Fprintf(stderr, "warning: failed to write summary JSON: %v\n", err)
 					}
 				}
 			}

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -17,6 +17,7 @@ package display
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -96,4 +97,29 @@ func TestTapSummaryJSON_EmitsOnSummaryEvent(t *testing.T) {
 	assert.Equal(t, apitype.OperationResultSucceeded, summary.Result)
 	assert.Equal(t, 1*time.Second, summary.Duration)
 	assert.Equal(t, 5, summary.Summary["same"])
+}
+
+func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {
+	t.Parallel()
+
+	// The input channel is intentionally never closed: the tap must terminate
+	// on CancelEvent alone. startEventLogger never closes its output channel,
+	// so a tap that waits for closure deadlocks the whole display pipeline.
+	in := make(chan engine.Event, 1)
+	in <- engine.NewCancelEvent()
+
+	out := tapSummaryJSON(in, Options{Stdout: io.Discard})
+
+	done := make(chan struct{})
+	go func() {
+		for range out { //nolint:revive // intentional drain
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tap did not return after CancelEvent")
+	}
 }

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/display"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryJSONFromEvent(t *testing.T) {
+	t.Parallel()
+
+	payload := engine.SummaryEventPayload{
+		Result:          apitype.OperationResultSucceeded,
+		Duration:        7 * time.Second,
+		ResourceChanges: display.ResourceChanges{"create": 2, "update": 1},
+	}
+
+	got := summaryJSONFromEvent(payload)
+
+	assert.Equal(t, apitype.OperationResultSucceeded, got.Result)
+	assert.Equal(t, 7*time.Second, got.Duration)
+	assert.Equal(t, 2, got.Summary["create"])
+	assert.Equal(t, 1, got.Summary["update"])
+}
+
+func TestWriteSummaryJSON(t *testing.T) {
+	t.Parallel()
+
+	s := SummaryJSON{
+		Result:   apitype.OperationResultFailed,
+		Duration: 3 * time.Second,
+		Summary:  display.ResourceChanges{"delete": 1},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeSummaryJSON(&buf, s))
+
+	// Output is a single line of JSON terminated by a newline.
+	out := buf.String()
+	assert.True(t, strings.HasSuffix(out, "\n"), "output should end with newline")
+	assert.Equal(t, 1, strings.Count(out, "\n"), "output should be a single line")
+
+	var roundTrip SummaryJSON
+	require.NoError(t, json.Unmarshal([]byte(out), &roundTrip))
+	assert.Equal(t, s, roundTrip)
+
+	// The wire shape uses our preferred keys.
+	assert.Contains(t, out, `"result":"failed"`)
+	assert.Contains(t, out, `"summary":`)
+	assert.NotContains(t, out, "changeSummary")
+	assert.NotContains(t, out, "resourceChanges")
+}
+
+func TestTapSummaryJSON_EmitsOnSummaryEvent(t *testing.T) {
+	t.Parallel()
+
+	in := make(chan engine.Event, 2)
+	in <- engine.NewEvent(engine.SummaryEventPayload{
+		Result:          apitype.OperationResultSucceeded,
+		Duration:        1 * time.Second,
+		ResourceChanges: display.ResourceChanges{"same": 5},
+	})
+	close(in)
+
+	var buf bytes.Buffer
+	out := tapSummaryJSON(in, Options{Stdout: &buf})
+
+	// Drain the output channel so the goroutine completes.
+	for range out { //nolint:revive // intentional drain
+	}
+
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+	assert.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+	assert.Equal(t, 1*time.Second, summary.Duration)
+	assert.Equal(t, 5, summary.Summary["same"])
+}

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1196,7 +1196,8 @@ func (b *diyBackend) apply(
 
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 
-	if !op.Opts.Display.JSONDisplay && op.Opts.Display.Type != display.DisplayWatch {
+	if !op.Opts.Display.JSONDisplay && !op.Opts.Display.SummaryJSON &&
+		op.Opts.Display.Type != display.DisplayWatch {
 		// We're about to print the first line of output, record the time it took to get here. This is more of a metric
 		// than a logical span, but this is a convenient way to record this information.
 		if startTime, ok := cmdutil.ProcessStartTimeFromContext(ctx); ok && cmdutil.IsOTelEnabled() {
@@ -1348,7 +1349,8 @@ func (b *diyBackend) apply(
 	}
 
 	// Make sure to print a link to the stack's checkpoint before exiting.
-	if !op.Opts.Display.SuppressPermalink && opts.ShowLink && !op.Opts.Display.JSONDisplay {
+	if !op.Opts.Display.SuppressPermalink && opts.ShowLink &&
+		!op.Opts.Display.JSONDisplay && !op.Opts.Display.SummaryJSON {
 		// Note we get a real signed link for aws/azure/gcp links.  But no such option exists for
 		// file:// links so we manually create the link ourselves.
 		var link string

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1679,7 +1679,8 @@ func (b *cloudBackend) apply(
 
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 
-	if !op.Opts.Display.JSONDisplay && op.Opts.Display.Type != display.DisplayWatch {
+	if !op.Opts.Display.JSONDisplay && !op.Opts.Display.SummaryJSON &&
+		op.Opts.Display.Type != display.DisplayWatch {
 		// We're about to print the first line of output, record the time it took to get here. This is more of a metric
 		// than a logical span, but this is a convenient way to record this information.
 		if startTime, ok := cmdutil.ProcessStartTimeFromContext(ctx); ok && cmdutil.IsOTelEnabled() {

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -98,6 +98,7 @@ func NewUpCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var output string
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -587,6 +588,16 @@ func NewUpCmd() *cobra.Command {
 				return err
 			}
 
+			// Validate --output up front. We keep the existing --json flag (which
+			// emits a JSONL stream of engine events) backwards compatible, and
+			// only emit the structured operation summary when --output=json.
+			switch output {
+			case "default", "json":
+				// No-op.
+			default:
+				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
+			}
+
 			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return err
@@ -617,6 +628,7 @@ func NewUpCmd() *cobra.Command {
 				EventLogPath:           eventLogPath,
 				Debug:                  debug,
 				JSONDisplay:            jsonDisplay,
+				SummaryJSON:            output == "json",
 				ShowSecrets:            showSecrets,
 			}
 
@@ -770,6 +782,12 @@ func NewUpCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the update diffs, operations, and overall output as JSON")
+	cmd.Flags().StringVar(
+		&output, "output", "default",
+		"Output format. Supported values are: default, json")
+	// Hidden until --output is wired up across all operations (destroy, preview, refresh, ...).
+	_ = cmd.Flags().MarkHidden("output")
+	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")

--- a/tests/integration/up_output_summary_test.go
+++ b/tests/integration/up_output_summary_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -27,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// scopedWriter captures writes only while it is active. Used by the integration
+// test below so that we record stdout from `pulumi up` and nothing else.
 type scopedWriter struct {
 	buf    *bytes.Buffer
 	active bool
@@ -45,9 +46,10 @@ func (w *scopedWriter) SetActive(active bool) {
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestUp_OutputJSONSummary(t *testing.T) {
-	// Avoid capturing output from commands other than `pulumi up`.
-	var upOut bytes.Buffer
-	writer := &scopedWriter{buf: &upOut}
+	// Capture only `pulumi up`'s stdout. We expect it to consist solely of the
+	// summary JSON object — see Frassle's review comment on #22870.
+	var upStdout bytes.Buffer
+	writer := &scopedWriter{buf: &upStdout}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:                    "single_resource",
@@ -55,7 +57,7 @@ func TestUp_OutputJSONSummary(t *testing.T) {
 		Quick:                  true,
 		Verbose:                true,
 		Stdout:                 writer,
-		Stderr:                 writer,
+		Stderr:                 io.Discard, // human-readable progress goes here; we don't assert on it
 		UpdateCommandlineFlags: []string{"--output", "json"},
 		PrePulumiCommand: func(verb string) (func(err error) error, error) {
 			if verb != "up" {
@@ -74,25 +76,15 @@ func TestUp_OutputJSONSummary(t *testing.T) {
 		},
 	})
 
-	// Find the JSON summary object inside the captured `pulumi up --output json` output.
-	for line := range strings.SplitSeq(upOut.String(), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
+	// The whole of stdout should be a single JSON object — no progress, no
+	// permalink, no banner. If parsing fails or fields are missing, the report
+	// includes the captured stdout to make debugging easy.
+	raw := bytes.TrimSpace(upStdout.Bytes())
 
-		var summary display.SummaryJSON
-		if err := json.Unmarshal([]byte(line), &summary); err != nil {
-			continue
-		}
-		if summary.Result != "" && len(summary.Summary) > 0 {
-			require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
-			require.NotEmpty(t, summary.Summary)
-			return
-		}
-	}
+	var summary display.SummaryJSON
+	require.NoErrorf(t, json.Unmarshal(raw, &summary),
+		"expected stdout to be exactly one JSON summary object, got:\n%s", raw)
 
-	t.Fatal("expected to find operation summary JSON in pulumi up output")
+	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
 }
-
-var _ io.Writer = (*scopedWriter)(nil)

--- a/tests/integration/up_output_summary_test.go
+++ b/tests/integration/up_output_summary_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+)
+
+type scopedWriter struct {
+	buf    *bytes.Buffer
+	active bool
+}
+
+func (w *scopedWriter) Write(p []byte) (n int, err error) {
+	if !w.active {
+		return len(p), nil
+	}
+	return w.buf.Write(p)
+}
+
+func (w *scopedWriter) SetActive(active bool) {
+	w.active = active
+}
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestUp_OutputJSONSummary(t *testing.T) {
+	// Avoid capturing output from commands other than `pulumi up`.
+	var upOut bytes.Buffer
+	writer := &scopedWriter{buf: &upOut}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                    "single_resource",
+		Dependencies:           []string{"@pulumi/pulumi"},
+		Quick:                  true,
+		Verbose:                true,
+		Stdout:                 writer,
+		Stderr:                 writer,
+		UpdateCommandlineFlags: []string{"--output", "json"},
+		PrePulumiCommand: func(verb string) (func(err error) error, error) {
+			if verb != "up" {
+				return nil, nil
+			}
+
+			writer.SetActive(true)
+			return func(err error) error {
+				writer.SetActive(false)
+				return nil
+			}, nil
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// Smoke check: the program actually ran and produced a deployment.
+			require.NotNil(t, stackInfo.Deployment)
+		},
+	})
+
+	// Find the JSON summary object inside the captured `pulumi up --output json` output.
+	for line := range strings.SplitSeq(upOut.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var summary display.SummaryJSON
+		if err := json.Unmarshal([]byte(line), &summary); err != nil {
+			continue
+		}
+		if summary.Result != "" && len(summary.Summary) > 0 {
+			require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+			require.NotEmpty(t, summary.Summary)
+			return
+		}
+	}
+
+	t.Fatal("expected to find operation summary JSON in pulumi up output")
+}
+
+var _ io.Writer = (*scopedWriter)(nil)


### PR DESCRIPTION
Stacked on top of #22883.

Adds a hidden `--output <default|json>` flag to `pulumi up`. With `--output json`, a single-line JSON object is emitted on stdout once the operation completes:

- `result` — `succeeded`, `failed`, or `canceled`
- `duration` — how long the operation took
- `summary` — a count per operation kind (create, update, etc.)

The format logic lives in `pkg/backend/display`, alongside the other display modes. `Options.SummaryJSON` flips on a tap that observes the existing `SummaryEvent` (now carrying `Result` thanks to #22883) and writes the summary to stdout. There is no parallel result computation in the CLI layer.

The flag is hidden until the same option is wired into the other operations (`destroy`, `preview`, `refresh`, ...), to avoid exposing a half-rolled-out surface.

`--json` and `--output` are mutually exclusive.

## Test plan

- [x] Unit tests in `pkg/backend/display/summary_json_test.go` cover `summaryJSONFromEvent`, JSON wire shape (round-trip + key names), and the `tapSummaryJSON` channel end-to-end
- [x] Integration test `TestUp_OutputJSONSummary` runs `pulumi up --output json` and asserts the summary line is emitted on stdout
- [x] `go build ./...` and `golangci-lint run` clean on `pkg/` and `tests/`
- [ ] Manual smoke: `pulumi up --output json` on a sample stack
- [ ] Manual smoke: `pulumi up --output json --json` errors with a mutual-exclusion message
- [ ] Manual smoke: `pulumi up --output garbage` errors with the validation message