### PR TITLE
Test on Node.js 26 and drop 20

### DIFF
--- a/changelog/pending/20260506--sdk-nodejs--test-on-node-js-26-and-drop-20.yaml
+++ b/changelog/pending/20260506--sdk-nodejs--test-on-node-js-26-and-drop-20.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Test on Node.js 26 and drop 20

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -144,7 +144,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 ALL_VERSION_SET = {
     "dotnet": ["8", "9"],
     "go": ["1.25.x", "1.26.x"],
-    "nodejs": ["20.x", "22.x", "24.x", "25.x"],
+    "nodejs": ["22.x", "24.x", "25.x", "26.x"],
     # When updating the minimum Python version here, also update `pyproject.toml`, including the
     # `mypy` and `ruff` sections.
     "python": ["3.10.x", "3.11.x", "3.12.x", "3.13.x", "3.14.x"],

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -34,10 +34,10 @@ async function writePackageJSON(
         license: "Apache-2.0",
         dependencies: {
             "@pulumi/pulumi": pulumiPackagePath,
-            "@types/mocha": "^9.0.0",
+            "@types/mocha": "^10.0.0",
             "@types/node": nodeTypesVersion,
             "@types/semver": "^7.5.6",
-            mocha: "^9.0.0",
+            mocha: "^11.0.0",
             "mocha-suppress-logs": "^0.5.1",
             mockpackage: "file:mockpackage-src",
             semver: "^7.5.4",


### PR DESCRIPTION
Node.js 26 is out and 20 is now EOL.