### PR TITLE
`pulumi destroy --output json`

### DIFF
--- a/changelog/pending/20260513--cli--add-output-json-to-pulumi-destroy-for-a-structured-summary.yaml
+++ b/changelog/pending/20260513--cli--add-output-json-to-pulumi-destroy-for-a-structured-summary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--output json` to `pulumi destroy` for a structured JSON summary of the operation result

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -67,6 +67,7 @@ func NewDestroyCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var output string
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int32
@@ -127,6 +128,16 @@ func NewDestroyCmd() *cobra.Command {
 				return backenderr.NoConfirmationInNonInteractiveError{}
 			}
 
+			// Validate --output up front. We keep the existing --json flag (which
+			// emits a JSONL stream of engine events) backwards compatible, and
+			// only emit the structured operation summary when --output=json.
+			switch output {
+			case "default", "json":
+				// No-op.
+			default:
+				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
+			}
+
 			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
 			if err != nil {
 				return err
@@ -151,6 +162,7 @@ func NewDestroyCmd() *cobra.Command {
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
 				JSONDisplay:          jsonDisplay,
+				SummaryJSON:          output == "json",
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -294,7 +306,7 @@ func NewDestroyCmd() *cobra.Command {
 				if err != nil {
 					return err
 				} else if protectedCount == len(snapshot.Resources) {
-					if !jsonDisplay {
+					if !jsonDisplay && output != "json" {
 						fmt.Printf("There were no unprotected resources to destroy. There are still %d"+
 							" protected resources associated with this stack.\n", protectedCount)
 					}
@@ -337,11 +349,11 @@ func NewDestroyCmd() *cobra.Command {
 				Scopes:             backend.CancellationScopes,
 			})
 
-			if destroyErr == nil && protectedCount > 0 && !jsonDisplay {
+			if destroyErr == nil && protectedCount > 0 && !jsonDisplay && output != "json" {
 				fmt.Printf("All unprotected resources were destroyed. There are still %d protected resources"+
 					" associated with this stack.\n", protectedCount)
 			} else if destroyErr == nil && len(*targets) == 0 {
-				if !jsonDisplay && !remove && !previewOnly {
+				if !jsonDisplay && output != "json" && !remove && !previewOnly {
 					fmt.Printf("The resources in the stack have been deleted, but the history and configuration "+
 						"associated with the stack are still maintained. \nIf you want to remove the stack "+
 						"completely, run `pulumi stack rm %s`.\n", s.Ref())
@@ -354,7 +366,7 @@ func NewDestroyCmd() *cobra.Command {
 					if _, path, detectErr := workspace.DetectProjectStackPath(s.Ref().Name().Q()); detectErr == nil {
 						if detectErr = os.Remove(path); detectErr != nil && !os.IsNotExist(detectErr) {
 							return detectErr
-						} else if !jsonDisplay {
+						} else if !jsonDisplay && output != "json" {
 							fmt.Printf("The resources in the stack have been deleted, and the history and " +
 								"configuration removed.\n")
 						}
@@ -428,6 +440,12 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the destroy diffs, operations, and overall output as JSON")
+	cmd.Flags().StringVar(
+		&output, "output", "default",
+		"Output format. Supported values are: default, json")
+	// Hidden until --output is wired up across all operations (preview, refresh, ...).
+	_ = cmd.Flags().MarkHidden("output")
+	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -240,6 +240,8 @@ type ProgramTestOptions struct {
 	PreviewCommandlineFlags []string
 	// UpdateCommandlineFlags specifies flags to add to the `pulumi up` command line (e.g. "--color=raw")
 	UpdateCommandlineFlags []string
+	// DestroyCommandlineFlags specifies flags to add to the `pulumi destroy` command line (e.g. "--output=json")
+	DestroyCommandlineFlags []string
 	// QueryCommandlineFlags specifies flags to add to the `pulumi query` command line (e.g. "--color=raw")
 	QueryCommandlineFlags []string
 	// RunBuild indicates that the build step should be run (e.g. run `yarn build` for `nodejs` programs)
@@ -595,6 +597,9 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	}
 	if overrides.UpdateCommandlineFlags != nil {
 		opts.UpdateCommandlineFlags = append(opts.UpdateCommandlineFlags, overrides.UpdateCommandlineFlags...)
+	}
+	if overrides.DestroyCommandlineFlags != nil {
+		opts.DestroyCommandlineFlags = append(opts.DestroyCommandlineFlags, overrides.DestroyCommandlineFlags...)
 	}
 	if overrides.QueryCommandlineFlags != nil {
 		opts.QueryCommandlineFlags = append(opts.QueryCommandlineFlags, overrides.QueryCommandlineFlags...)
@@ -1568,6 +1573,9 @@ func (pt *ProgramTester) TestLifeCycleDestroy() error {
 		}
 		if pt.opts.DestroyExcludeProtected {
 			destroy = append(destroy, "--exclude-protected")
+		}
+		if pt.opts.DestroyCommandlineFlags != nil {
+			destroy = append(destroy, pt.opts.DestroyCommandlineFlags...)
 		}
 		if err := pt.runPulumiCommand("pulumi-destroy", destroy, pt.projdir, false); err != nil {
 			return err

--- a/tests/integration/destroy_output_summary_test.go
+++ b/tests/integration/destroy_output_summary_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestDestroy_OutputJSONSummary(t *testing.T) {
+	// Capture only `pulumi destroy`'s stdout. We expect it to consist solely of
+	// the summary JSON object — same contract as the symmetric up test.
+	var destroyStdout bytes.Buffer
+	writer := &scopedWriter{buf: &destroyStdout}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                     "single_resource",
+		Dependencies:            []string{"@pulumi/pulumi"},
+		Quick:                   true,
+		Verbose:                 true,
+		Stdout:                  writer,
+		Stderr:                  io.Discard, // human-readable progress goes here; we don't assert on it
+		DestroyCommandlineFlags: []string{"--output", "json"},
+		PrePulumiCommand: func(verb string) (func(err error) error, error) {
+			if verb != "destroy" {
+				return nil, nil
+			}
+
+			writer.SetActive(true)
+			return func(err error) error {
+				writer.SetActive(false)
+				return nil
+			}, nil
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// Smoke check: the program actually ran and produced a deployment to destroy.
+			require.NotNil(t, stackInfo.Deployment)
+		},
+	})
+
+	// The whole of stdout should be a single JSON object — no progress, no
+	// permalink, no banner.
+	raw := bytes.TrimSpace(destroyStdout.Bytes())
+
+	var summary display.SummaryJSON
+	require.NoErrorf(t, json.Unmarshal(raw, &summary),
+		"expected stdout to be exactly one JSON summary object, got:\n%s", raw)
+
+	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
+}


### PR DESCRIPTION
Follow-up to #22870 — adds the same `--output json` flag to `pulumi destroy`.

When `--output json` is passed, a single-line JSON object of the same shape is emitted on stdout once the destroy completes:

- `result` — `succeeded`, `failed`, or `canceled`
- `duration` — how long the operation took
- `summary` — count per operation kind (delete, etc.)

`--json` and `--output` are mutually exclusive. The flag is `Hidden: true` for now and will be revealed once the remaining operations (`preview`, `refresh`, ...) reach parity.

## Implementation notes

- Reuses `display.SummaryJSON` from #22870. The wiring on the destroy side is just `opts.Display.SummaryJSON = output == "json"` — the display layer handles emitting the summary via the `SummaryEvent` tap. Zero new types, zero CLI-side result computation.
- `destroy.go` has four `!jsonDisplay` checks that suppress human-friendly stdout messages (`"The resources in the stack have been deleted..."`, etc.) that `up.go` doesn't have. These now also trigger when `--output json` is set, so stdout contains only the summary JSON line. Implemented inline (`&& output != "json"`) — no helper, four sites.
- The early-return path for "all resources are protected" still doesn't produce a JSON summary — we exit before `DestroyStack` runs and so the engine never emits a `SummaryEvent`. Known gap; happy to handle in a follow-up if reviewers want.
- A `DestroyCommandlineFlags` field is added to `ProgramTestOptions`, mirroring `UpdateCommandlineFlags`, so the new integration test can inject `--output json` into the destroy step.

## Test plan

- [x] Integration test \`TestDestroy_OutputJSONSummary\` runs \`pulumi destroy --output json\` against a single-resource program and asserts that the entire captured stdout is exactly the summary JSON object (mirrors the up test's stricter assertion)
- [x] \`go build\` and \`golangci-lint\` clean on \`pkg/\` and \`tests/\`
- [ ] Manual smoke: \`pulumi destroy --output json\` on a real stack
- [ ] Manual smoke: \`pulumi destroy --output json --json\` errors with a mutual-exclusion message
- [ ] Manual smoke: \`pulumi destroy --output garbage\` errors with the validation message