### PR TITLE
Thread workspace.Context to ProviderFromSource

### DIFF
--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -565,6 +565,7 @@ func generateAndLinkSdksForPackages(
 		}
 
 		pkgSpec, _, err := packages.SchemaFromSchemaSource(
+			pkgWorkspace.Instance,
 			pctx,
 			pkg.Name,
 			&plugin.ParameterizeValue{Value: pkg.Parameterization.Value},

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -108,6 +108,7 @@ from the parameters, as in:
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 
 			pkg, packageSpec, diags, err := packages.InstallPackage(
+				pkgWorkspace.Instance,
 				pluginOrProject.proj,
 				pctx,
 				pluginOrProject.proj.RuntimeInfo().Name(),

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -67,7 +67,8 @@ empty string.`,
 
 			registry := cmdCmd.NewDefaultRegistry(
 				cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, sink, env.Global())
-			p, _, err := packages.ProviderFromSource(pctx, source, registry, env.Global(), 0 /* unbounded concurrency */)
+			p, _, err := packages.ProviderFromSource(
+				pkgWorkspace.Instance, pctx, source, registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return fmt.Errorf("load provider: %w", err)
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -60,7 +60,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			registry := cmdCmd.NewDefaultRegistry(
 				cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, sink, env.Global())
-			spec, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
+			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
 				registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -68,7 +68,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			registry := cmdCmd.NewDefaultRegistry(
 				cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, sink, env.Global())
-			spec, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
+			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
 				registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -71,7 +71,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 			registry := cmdCmd.NewDefaultRegistry(
 				cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, sink, env.Global())
-			spec, _, err := packages.SchemaFromSchemaSource(pctx, args[0], parameters,
+			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, args[0], parameters,
 				registry, env.Global(), 0 /* unbounded concurrency */)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -61,7 +61,7 @@ type publishPackageArgs struct {
 
 type packagePublishCmd struct {
 	extractSchema func(
-		pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
+		ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
 		registry registry.Registry, e env.Env, concurrency int,
 	) (*schema.PackageSpec, *workspace.PackageSpec, error)
 }
@@ -163,7 +163,7 @@ func (cmd *packagePublishCmd) Run(
 	}
 	defer contract.IgnoreClose(pctx)
 
-	pkg, _, err := cmd.extractSchema(pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry(),
+	pkg, _, err := cmd.extractSchema(pkgWorkspace.Instance, pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry(),
 		env.Global(), 0 /* unbounded concurrency */)
 	if err != nil {
 		return fmt.Errorf("failed to get schema: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -373,6 +373,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 
 			cmd := &packagePublishCmd{
 				extractSchema: func(
+					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
 					registry registry.Registry, _ env.Env, _ int,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
@@ -470,6 +471,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 
 			cmd := &packagePublishCmd{
 				extractSchema: func(
+					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
 					registry registry.Registry, _ env.Env, _ int,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
@@ -529,6 +531,7 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 
 			cmd := &packagePublishCmd{
 				extractSchema: func(
+					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
 					registry registry.Registry, _ env.Env, _ int,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
@@ -561,6 +564,7 @@ func newMockTemplateWorkspace(readProjectErr error) pkgWorkspace.Context {
 func TestPackagePublishCmd_Run_ReadProjectError(t *testing.T) {
 	cmd := packagePublishCmd{
 		extractSchema: func(
+			ws pkgWorkspace.Context,
 			pctx *plugin.Context,
 			packageSource string,
 			parameters plugin.ParameterizeParameters,

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -66,11 +66,11 @@ func BindSpec(spec schema.PackageSpec) (*schema.Package, error) {
 
 // InstallPackage installs a package to the project by generating an SDK and linking it.
 // It returns the path to the installed package.
-func InstallPackage(proj workspace.BaseProject, pctx *plugin.Context, language, root,
-	schemaSource string, parameters plugin.ParameterizeParameters,
+func InstallPackage(ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *plugin.Context,
+	language, root, schemaSource string, parameters plugin.ParameterizeParameters,
 	registry registry.Registry, e env.Env, concurrency int,
 ) (*schema.Package, *workspace.PackageSpec, hcl.Diagnostics, error) {
-	pkgSpec, specOverride, err := SchemaFromSchemaSource(pctx, schemaSource, parameters, registry, e, concurrency)
+	pkgSpec, specOverride, err := SchemaFromSchemaSource(ws, pctx, schemaSource, parameters, registry, e, concurrency)
 	if err != nil {
 		var diagErr hcl.Diagnostics
 		if errors.As(err, &diagErr) {
@@ -356,6 +356,7 @@ func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginDescr
 // The returned workspace.PackageSpec will be non-nil if and only if the schema is sourced
 // from a plugin.
 func SchemaFromSchemaSource(
+	ws pkgWorkspace.Context,
 	pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters, registry registry.Registry,
 	env env.Env, concurrency int,
 ) (*schema.PackageSpec, *workspace.PackageSpec, error) {
@@ -389,7 +390,7 @@ func SchemaFromSchemaSource(
 		return &spec, nil, nil
 	}
 
-	p, packageSpec, err := ProviderFromSource(pctx, packageSource, registry, env, concurrency)
+	p, packageSpec, err := ProviderFromSource(ws, pctx, packageSource, registry, env, concurrency)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -437,6 +438,7 @@ func SchemaFromSchemaSource(
 //
 // PLUGIN[@VERSION] | PATH_TO_PLUGIN
 func ProviderFromSource(
+	ws pkgWorkspace.Context,
 	pctx *plugin.Context, packageSource string, reg registry.Registry,
 	e env.Env, concurrency int,
 ) (plugin.Provider, workspace.PackageSpec, error) {
@@ -447,7 +449,7 @@ func ProviderFromSource(
 	}
 	packageSpec := workspace.PackageSpec{Source: packageSource, Version: version}
 	{
-		proj, _, err := pkgWorkspace.Instance.LoadBaseProjectFrom(pctx.Request(), pctx.Pwd)
+		proj, _, err := ws.LoadBaseProjectFrom(pctx.Request(), pctx.Pwd)
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return nil, workspace.PackageSpec{}, fmt.Errorf("error loading Pulumi Project: %w", err)
 		}
@@ -465,7 +467,7 @@ func ProviderFromSource(
 			AllowNonInvertableLocalWorkspaceResolution: true,
 		},
 		Concurrency: concurrency,
-	}, reg, packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance, pctx.Host, os.Stderr, os.Stderr,
+	}, reg, packageworkspace.New(pluginstorage.Instance, ws, pctx.Host, os.Stderr, os.Stderr,
 		nil, packageworkspace.Options{}))
 	if err != nil {
 		return nil, workspace.PackageSpec{}, fmt.Errorf("unable to install %s: %w", packageSpec, err)

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
@@ -103,6 +104,8 @@ func TestProviderFromSource(t *testing.T) {
 			},
 		}
 
+		mws := &pkgWorkspace.MockContext{}
+
 		pctx, err := plugin.NewContext(
 			t.Context(),
 			nil,
@@ -118,7 +121,7 @@ func TestProviderFromSource(t *testing.T) {
 		require.NoError(t, err)
 		defer pctx.Close()
 
-		provider, _, err := ProviderFromSource(pctx, inputSource, mockRegistry, env.NewEnv(env.MapStore{
+		provider, _, err := ProviderFromSource(mws, pctx, inputSource, mockRegistry, env.NewEnv(env.MapStore{
 			"PULUMI_EXPERIMENTAL": "true",
 		}), 0)
 		require.NoError(t, err)

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -118,7 +118,7 @@ func schemaFromSourceOrStdin(cmd *cobra.Command, source string, extraArgs []stri
 	parameters := &plugin.ParameterizeArgs{Args: extraArgs}
 	registry := cmdCmd.NewDefaultRegistry(
 		cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global())
-	spec, _, err := packages.SchemaFromSchemaSource(pctx, source, parameters,
+	spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
 		registry, env.Global(), 0 /* unbounded concurrency */)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Bit more of trying to move `pkgWorkspace.Instance` calls up the call stack so commands are more testable.