### PR TITLE
cli/cloud: nudge users to `describe` before calling `pulumi cloud api`

### DIFF
--- a/changelog/pending/20260506--cli-cloud--recommend-describe-before-pulumi-cloud-api.yaml
+++ b/changelog/pending/20260506--cli-cloud--recommend-describe-before-pulumi-cloud-api.yaml
@@ -1,4 +1,4 @@
 changes:
-- type: improvement
-  scope: cli/cloud
+- type: feat
+  scope: cli
   description: Recommend `pulumi cloud api describe` in `pulumi cloud api --help` to verify operation parameters before calling

--- a/changelog/pending/20260506--cli-cloud--recommend-describe-before-pulumi-cloud-api.yaml
+++ b/changelog/pending/20260506--cli-cloud--recommend-describe-before-pulumi-cloud-api.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/cloud
+  description: Recommend `pulumi cloud api describe` in `pulumi cloud api --help` to verify operation parameters before calling

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -150,7 +150,9 @@ func newAPICmd() *cobra.Command {
 			"\n" +
 			"Exit codes: 0 success; 1 caller error; 2 invalid flags; 3 auth; 8 cancelled;\n" +
 			"255 internal.",
-		Example: "  # Inspect the currently authenticated user.\n" +
+		Example: "  # Verify an op's parameters and schemas with `describe` before calling it.\n" +
+			"  pulumi cloud api describe CreateStackTag\n\n" +
+			"  # Inspect the currently authenticated user.\n" +
 			"  pulumi cloud api /api/user\n\n" +
 			"  # Call by raw path with template variables filled from -F.\n" +
 			"  pulumi cloud api /api/orgs/{orgName}/members -F orgName=acme\n\n" +


### PR DESCRIPTION
## Summary

Adds a leading example to `pulumi cloud api --help` that points users (and agents) at `pulumi cloud api describe <op>` to verify field names, types, and required path variables before issuing a call.

closes #22879