### PR TITLE
Eagerly error on schemas with unconstructable types

### DIFF
--- a/changelog/pending/20260507--sdkgen--eagerly-error-on-schemas-with-unconstructable-types.yaml
+++ b/changelog/pending/20260507--sdkgen--eagerly-error-on-schemas-with-unconstructable-types.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen
+  description: Eagerly error on schemas with unconstructable types

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -190,6 +190,8 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 		return nil, diags, err
 	}
 
+	diags = diags.Extend(validateNoRequiredObjectCycles(typeList))
+
 	parameterization, parameterizationDiags := bindParameterization(spec.Parameterization)
 	diags = diags.Extend(parameterizationDiags)
 
@@ -1397,6 +1399,89 @@ func (t *types) bindEnumType(token string, spec ComplexTypeSpec) (*EnumType, hcl
 		Comment:          spec.Description,
 		IsOverlay:        spec.IsOverlay,
 	}, diags
+}
+
+// validateNoRequiredObjectCycles reports a diagnostic for every object type
+// whose required-property graph contains a cycle returning to itself. Such a
+// schema describes a value of infinite size and so cannot be satisfied.
+//
+// Only direct ObjectType references count: Array, Map, and Union members all
+// have a finite empty form (or a non-recursive branch), so they break the
+// cycle. Optional properties also break the cycle.
+func validateNoRequiredObjectCycles(typeList []Type) hcl.Diagnostics {
+	// Each object is bound twice in typeList — once as a plain shape and once
+	// as an input shape — so dedupe by Token to report each logical cycle once.
+	// Visit objects in lexicographic Token order so that the chosen DFS root,
+	// and therefore the cycle text and diagnostic order, are deterministic.
+	objects := make([]*ObjectType, 0, len(typeList))
+	for _, t := range typeList {
+		if obj, ok := t.(*ObjectType); ok {
+			objects = append(objects, obj)
+		}
+	}
+	sort.Slice(objects, func(i, j int) bool { return objects[i].Token < objects[j].Token })
+
+	var diags hcl.Diagnostics
+	reported := map[string]bool{}
+	for _, obj := range objects {
+		if reported[obj.Token] {
+			continue
+		}
+		if cycle := findRequiredObjectCycle(obj, nil, map[*ObjectType]bool{}); cycle != nil {
+			tokens := make([]string, len(cycle))
+			for i, c := range cycle {
+				tokens[i] = c.Token
+				reported[c.Token] = true
+			}
+			diags = diags.Append(errorf(memberPath("types", obj.Token),
+				"object type has unsatisfiable required-property cycle: %s",
+				strings.Join(tokens, " -> ")))
+		}
+	}
+	return diags
+}
+
+// findRequiredObjectCycle DFSes the required-property graph rooted at obj.
+// If a cycle is found, it returns the slice of object types on that cycle,
+// starting at the first repeated node and ending with the same node again.
+func findRequiredObjectCycle(obj *ObjectType, path []*ObjectType, onPath map[*ObjectType]bool) []*ObjectType {
+	// walkRequiredType strips non-cycling wrappers (InputType) and recurses into
+	// ObjectType refs. Array, Map, Union, and Optional are not followed because
+	// they admit a non-recursive value. TokenType is also a leaf: it stands for
+	// a reference into another schema, which we treat as opaque — cycles cannot
+	// span schemas, and other schemas are assumed to have been validated.
+	var walkRequiredType func(typ Type, path []*ObjectType) []*ObjectType
+	walkRequiredType = func(typ Type, path []*ObjectType) []*ObjectType {
+		switch t := typ.(type) {
+		case *InputType:
+			return walkRequiredType(t.ElementType, path)
+		case *ObjectType:
+			return findRequiredObjectCycle(t, path, onPath)
+		}
+		return nil
+	}
+
+	if onPath[obj] {
+		idx := 0
+		for i, c := range path {
+			if c == obj {
+				idx = i
+				break
+			}
+		}
+		return append(append([]*ObjectType{}, path[idx:]...), obj)
+	}
+	onPath[obj] = true
+	defer delete(onPath, obj)
+	for _, p := range obj.Properties {
+		if !p.IsRequired() {
+			continue
+		}
+		if cycle := walkRequiredType(p.Type, append(path, obj)); cycle != nil {
+			return cycle
+		}
+	}
+	return nil
 }
 
 func (t *types) finishTypes(tokens []string, options ValidationOptions) ([]Type, hcl.Diagnostics, error) {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -3151,3 +3151,183 @@ func TestModuleFormatTokenCollisions(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestRequiredObjectCycles covers validateNoRequiredObjectCycles: object types
+// whose required-property graph reaches themselves through only direct object
+// references describe values of infinite size and must be rejected, while
+// cycles that pass through Array, Map, Union, or Optional are satisfiable and
+// must continue to bind.
+func TestRequiredObjectCycles(t *testing.T) {
+	t.Parallel()
+
+	stringSpec := TypeSpec{Type: "string"}
+	refSpec := func(token string) TypeSpec { return TypeSpec{Ref: "#/types/" + token} }
+	objType := func(props map[string]PropertySpec, required ...string) ComplexTypeSpec {
+		return ComplexTypeSpec{ObjectTypeSpec: ObjectTypeSpec{
+			Type:       "object",
+			Properties: props,
+			Required:   required,
+		}}
+	}
+	pkgWithTypes := func(types map[string]ComplexTypeSpec) PackageSpec {
+		return PackageSpec{Name: "test", Version: "1.0.0", Types: types}
+	}
+
+	t.Run("DirectRequiredCycleErrors", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"foo": {TypeSpec: refSpec("test:index:A")},
+			}, "foo"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Equal(t, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary: "#/types/test:index:A: object type has unsatisfiable required-property cycle: " +
+				"test:index:A -> test:index:A",
+		}}, diags)
+	})
+
+	t.Run("IndirectRequiredCycleErrorsOncePerCycle", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"b": {TypeSpec: refSpec("test:index:B")},
+			}, "b"),
+			"test:index:B": objType(map[string]PropertySpec{
+				"a": {TypeSpec: refSpec("test:index:A")},
+			}, "a"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Equal(t, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary: "#/types/test:index:A: object type has unsatisfiable required-property cycle: " +
+				"test:index:A -> test:index:B -> test:index:A",
+		}}, diags)
+	})
+
+	t.Run("ThreeNodeRequiredCycleErrorsOncePerCycle", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"b": {TypeSpec: refSpec("test:index:B")},
+			}, "b"),
+			"test:index:B": objType(map[string]PropertySpec{
+				"c": {TypeSpec: refSpec("test:index:C")},
+			}, "c"),
+			"test:index:C": objType(map[string]PropertySpec{
+				"a": {TypeSpec: refSpec("test:index:A")},
+			}, "a"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Equal(t, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary: "#/types/test:index:A: object type has unsatisfiable required-property cycle: " +
+				"test:index:A -> test:index:B -> test:index:C -> test:index:A",
+		}}, diags)
+	})
+
+	t.Run("OptionalSelfReferenceIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"foo": {TypeSpec: refSpec("test:index:A")},
+			}),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("RequiredSelfReferenceThroughArrayIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"foo": {TypeSpec: TypeSpec{
+					Type:  "array",
+					Items: &TypeSpec{Ref: "#/types/test:index:A"},
+				}},
+			}, "foo"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("RequiredSelfReferenceThroughMapIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"foo": {TypeSpec: TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &TypeSpec{Ref: "#/types/test:index:A"},
+				}},
+			}, "foo"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("RequiredSelfReferenceThroughUnionIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"foo": {TypeSpec: TypeSpec{
+					OneOf: []TypeSpec{stringSpec, refSpec("test:index:A")},
+				}},
+			}, "foo"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("AcyclicRequiredGraphIsAllowed", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:Leaf": objType(map[string]PropertySpec{
+				"name": {TypeSpec: stringSpec},
+			}, "name"),
+			"test:index:Branch": objType(map[string]PropertySpec{
+				"leaf": {TypeSpec: refSpec("test:index:Leaf")},
+			}, "leaf"),
+			"test:index:Root": objType(map[string]PropertySpec{
+				"branch": {TypeSpec: refSpec("test:index:Branch")},
+				"leaf":   {TypeSpec: refSpec("test:index:Leaf")},
+			}, "branch", "leaf"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("DisjointCyclesAreReportedSeparately", func(t *testing.T) {
+		t.Parallel()
+		spec := pkgWithTypes(map[string]ComplexTypeSpec{
+			"test:index:A": objType(map[string]PropertySpec{
+				"a": {TypeSpec: refSpec("test:index:A")},
+			}, "a"),
+			"test:index:B": objType(map[string]PropertySpec{
+				"b": {TypeSpec: refSpec("test:index:B")},
+			}, "b"),
+		})
+		_, diags, err := BindSpec(spec, nil, ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		assert.Equal(t, hcl.Diagnostics{
+			{
+				Severity: hcl.DiagError,
+				Summary: "#/types/test:index:A: object type has unsatisfiable required-property cycle: " +
+					"test:index:A -> test:index:A",
+			},
+			{
+				Severity: hcl.DiagError,
+				Summary: "#/types/test:index:B: object type has unsatisfiable required-property cycle: " +
+					"test:index:B -> test:index:B",
+			},
+		}, diags)
+	})
+}

--- a/scripts/check-registry-schemas.sh
+++ b/scripts/check-registry-schemas.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Download every package schema from the Pulumi registry and run
+# `pulumi schema check` against each one. Used to validate that bind-time
+# changes (e.g. the unconstructable-types check) don't break any existing
+# published schema.
+#
+# Requires:
+#   - the locally built pulumi at $REPO/bin/pulumi (so we use the version
+#     under test, not whatever is on $PATH)
+#   - jq, curl
+#   - logged in to Pulumi Cloud (`pulumi login`)
+#
+# Output: each line is one of OK / FAIL / DOWNLOAD_FAILED / SKIP, followed
+# by the package id. On FAIL the schema-check stderr is printed inline.
+# A summary is printed at the end. All artifacts (downloaded schemas and
+# per-package error logs) are kept in $WORK_DIR.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PULUMI_BIN="${PULUMI_BIN:-$REPO/bin/pulumi}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d -t pulumi-registry-check.XXXXXX)}"
+
+if [[ ! -x "$PULUMI_BIN" ]]; then
+  echo "pulumi binary not found at $PULUMI_BIN; build it with 'make build' or set PULUMI_BIN" >&2
+  exit 2
+fi
+
+mkdir -p "$WORK_DIR/schemas" "$WORK_DIR/errors"
+
+echo "pulumi:    $PULUMI_BIN"
+echo "work dir:  $WORK_DIR"
+
+make -C "$REPO" bin/pulumi
+
+# --- 1. Pull the package list. -----------------------------------------------
+# ListPackages is paginated (100 per page); --paginate follows the
+# continuationToken automatically and merges pages.
+PACKAGES_JSON="$WORK_DIR/packages.json"
+echo "Listing packages..."
+"$PULUMI_BIN" cloud api ListPackages --paginate >"$PACKAGES_JSON"
+TOTAL=$(jq '.packages | length' "$PACKAGES_JSON")
+echo "Found $TOTAL packages."
+
+# --- 2. Walk each package: download schema + run schema check. ---------------
+# schemaURL is a presigned S3 link with a short expiry (~5 minutes), so we
+# download and check each package back-to-back rather than batching.
+PASS=0
+FAIL=0
+SKIP=0
+DLERR=0
+FAIL_IDS=()
+
+# Read packages into a bash array so the counters in the loop survive
+# (a piped `while read` would run in a subshell). `mapfile` is bash 4+, so
+# stash NUL-delimited records in a tmp file and iterate that — works on
+# macOS's default bash 3.2 too.
+PKG_LIST="$WORK_DIR/packages.ndjson"
+jq -c '.packages[]' "$PACKAGES_JSON" >"$PKG_LIST"
+
+i=0
+while IFS= read -r pkg; do
+  i=$((i + 1))
+  source=$(jq -r '.source' <<<"$pkg")
+  publisher=$(jq -r '.publisher' <<<"$pkg")
+  name=$(jq -r '.name' <<<"$pkg")
+  version=$(jq -r '.version' <<<"$pkg")
+  schema_url=$(jq -r '.schemaURL // ""' <<<"$pkg")
+
+  id="${source}__${publisher}__${name}__${version}"
+  schema_file="$WORK_DIR/schemas/${id}.json"
+  err_file="$WORK_DIR/errors/${id}.txt"
+  prefix="[$i/$TOTAL]"
+
+  if [[ -z "$schema_url" ]]; then
+    echo "$prefix SKIP (no schemaURL): $id"
+    SKIP=$((SKIP + 1))
+    continue
+  fi
+
+  # The registry serves schemas with Content-Encoding: gzip unconditionally
+  # (see scripts/registry-content-encoding-bug.md), so we always send
+  # Accept-Encoding: gzip via --compressed and let curl decompress.
+  if ! curl -sSfL --compressed "$schema_url" -o "$schema_file" 2>"$err_file"; then
+    echo "$prefix DOWNLOAD_FAILED: $id"
+    cat "$err_file"
+    DLERR=$((DLERR + 1))
+    continue
+  fi
+
+  if "$PULUMI_BIN" schema check --allow-dangling-references "$schema_file" >"$err_file" 2>&1; then
+    echo "$prefix OK: $id"
+    PASS=$((PASS + 1))
+  else
+    echo "$prefix FAIL: $id"
+    sed 's/^/    /' "$err_file"
+    FAIL=$((FAIL + 1))
+    FAIL_IDS+=("$id")
+  fi
+done <"$PKG_LIST"
+
+echo
+echo "==================== summary ===================="
+echo "total:           $TOTAL"
+echo "passed:          $PASS"
+echo "failed:          $FAIL"
+echo "skipped:         $SKIP"
+echo "download errors: $DLERR"
+if (( FAIL > 0 )); then
+  echo
+  echo "Failed packages:"
+  for id in "${FAIL_IDS[@]}"; do
+    echo "  - $id"
+  done
+fi
+echo
+echo "Artifacts kept in: $WORK_DIR"

--- a/tests/testdata/codegen/cyclic-types/schema.yaml
+++ b/tests/testdata/codegen/cyclic-types/schema.yaml
@@ -6,19 +6,16 @@ types:
     properties:
       foo:
         $ref: "#/types/example::DirectCycle"
-    required: [ foo ]
   example::IndirectCycleS:
     type: object
     properties:
       foo2:
         $ref: "#/types/example::IndirectCycleT"
-    required: [ foo2 ]
   example::IndirectCycleT:
     type: object
     properties:
       foo3:
         $ref: "#/types/example::IndirectCycleS"
-    required: [ foo3 ]
   example::AcyclicReferent:
     type: object
     properties:


### PR DESCRIPTION
Originally pulled out of https://github.com/pulumi/pulumi/pull/22871, where the problem was discovered, after Claude spent 10 minutes trying to construct an infinitely recursive type.

This PR makes it a schema bind error to express a type who's construction requires a previously constructed instance of that type, since these types are unconstructable. This is spiritually similar to "infinitely sized type" errors in systems programming languages.

My goal here is to make it easier for bad AI written & auto-generated schemas to be discovered before they are given to users.

---

### Testing

I've tested this against every schema in the registry, and only one failed: https://github.com/pulumi/pulumi-google-native:

- google-native:bigquery/v2:ArgumentResponse → StandardSqlDataTypeResponse (self-referential, required)                                                                                                 
- google-native:bigquery/v2:QueryParameterResponse → QueryParameterTypeResponse (self-referential, required)                                                                                            
- google-native:bigquery/v2:QueryParameterTypeStructTypesItemResponse → QueryParameterTypeResponse                                                                                                      
- google-native:bigquery/v2:StandardSqlFieldResponse → StandardSqlDataTypeResponse                                                                                                                      

All discovered failures are valid. They are all failures to mark a type declared (in the doc comments) as optional as optional in the schema. IMO this check has found a genuine bug in google-native, filed as https://github.com/pulumi/pulumi-google-native/issues/1246.