### PR TITLE
[Neo] Return bare stack name from pulumi_preview/pulumi_up tool results

### DIFF
--- a/changelog/pending/20260507--cli-neo--return-bare-stack-name-from-pulumi-tool-results.yaml
+++ b/changelog/pending/20260507--cli-neo--return-bare-stack-name-from-pulumi-tool-results.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Return the bare stack name and canonical project name from `pulumi_preview` and `pulumi_up` tool results instead of echoing the raw input

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -364,14 +364,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	close(eventsCh)
 	<-drainDone
 
-	res := pulumiResult{
-		ProjectName: a.ProjectName,
-		StackName:   a.StackName,
-		EventsFile:  eventsPath,
-	}
-	if res.ProjectName == "" {
-		res.ProjectName = proj.Name.String()
-	}
+	res := newPulumiResult(proj, s.Ref(), eventsPath)
 
 	switch {
 	case runErr != nil && errors.Is(ctx.Err(), context.Canceled):
@@ -634,6 +627,22 @@ func silenceStd() func() {
 	return func() {
 		os.Stdout, os.Stderr = origStdout, origStderr
 		_ = null.Close()
+	}
+}
+
+// newPulumiResult returns a pulumiResult populated with the canonical project
+// name and bare stack name from the parsed StackReference. ParseStackReference
+// accepts both bare names and fully-qualified "<org>/<project>/<stack>" forms,
+// but downstream consumers (the Neo agent's entity extraction in particular)
+// treat the returned stack_name as a bare name. Echoing the raw input back
+// would cause the agent to construct entities with malformed names whenever
+// the LLM passes an FQSN — a phrasing the CLI itself encourages via some of
+// its own error messages.
+func newPulumiResult(proj *workspace.Project, stackRef backend.StackReference, eventsPath string) pulumiResult {
+	return pulumiResult{
+		ProjectName: proj.Name.String(),
+		StackName:   stackRef.Name().String(),
+		EventsFile:  eventsPath,
 	}
 }
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -698,6 +698,25 @@ func TestPulumi_DrainEvents_NDJSONIsValidEngineEvent(t *testing.T) {
 	assert.Equal(t, "warning", apiEv.DiagnosticEvent.Severity)
 }
 
+func TestNewPulumiResultUsesParsedNames(t *testing.T) {
+	t.Parallel()
+
+	// Regression: pulumiResult must echo the canonical project name and the
+	// bare stack name back to callers, not the raw input strings. The Neo
+	// agent's entity extraction treats the returned stack_name as a bare
+	// name; if we returned the input verbatim a fully-qualified
+	// "<org>/<project>/<stack>" form would propagate into a malformed
+	// StackEntity.
+	proj := &workspace.Project{Name: tokens.PackageName("real-proj")}
+	stackRef := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	res := newPulumiResult(proj, stackRef, "/tmp/events.ndjson")
+
+	assert.Equal(t, "real-proj", res.ProjectName)
+	assert.Equal(t, "dev", res.StackName)
+	assert.Equal(t, "/tmp/events.ndjson", res.EventsFile)
+}
+
 func TestAutonamingStackContextFor_NonHTTPStateStack(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The Neo agent runtime extracts a `StackEntity` from `PulumiOperationResult` by reading `stack_name` and `project_name` verbatim. The CLI's local implementation of `pulumi_preview` / `pulumi_up` was echoing whatever the LLM passed in, which meant a fully-qualified `<org>/<project>/<stack>` input — a phrasing the CLI's own error messages explicitly encourage (e.g. *"parsing stack reference: no current project found, pass the fully qualified stack name (org/project/stack)"*) — propagated as the `name` of the entity. Downstream the service then tried to look up a stack named `<org>/<project>/<stack>` inside the project, found nothing, and the agent's `change_entities` event failed.

Observed in production: a CLI-mode Neo task spent ~10 minutes setting up an S3-static-website project, switched to passing the FQSN to `pulumi_preview` after one of its retries hit the "fully qualified" error, succeeded on the 5th attempt, and then crashed when posting a `change_entities` event the service couldn't resolve. (Trace [`8b8125f8c5cb03ee66b0489243f36f39`](https://ui.honeycomb.io/pulumi-service/environments/production/datasets/pulumi-service/trace?trace_id=8b8125f8c5cb03ee66b0489243f36f39); pulumi-service-side fix in [pulumi-service#42765](https://github.com/pulumi/pulumi-service/pull/42765) handles the 500→400 surfacing, this PR fixes the root cause.)

The fix is to build the result from the parsed `StackReference` and `Project` instead of the raw input strings. The contract is now: the result always carries the bare stack name and the canonical project name regardless of how the input was phrased. ` ParseStackReference` already accepts both forms, so behaviour for callers passing bare names is unchanged.

## Test plan

- [x] New unit test `TestNewPulumiResultUsesParsedNames` asserts the helper returns `proj.Name.String()` and `stackRef.Name().String()` rather than echoing input strings.
- [x] Existing tests still pass: `go test ./pkg/cmd/pulumi/neo/...` clean.
- [x] `go build ./pkg/cmd/pulumi/neo/tools/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)