### PR TITLE
add cloud subscope

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -9,6 +9,7 @@ scopes:
   ci: []
   cli:
     - about
+    - cloud
     - config
     - display
     - engine


### PR DESCRIPTION
For `pulumi cloud *`.  Suggested in https://github.com/pulumi/pulumi/pull/22874
