### PR TITLE
cli/neo: keep prior streaming text when the agent emits a new turn

### DIFF
--- a/changelog/pending/20260507--cli-neo--keep-prior-streaming-text-when-the-agent-emits-a-new-turn.yaml
+++ b/changelog/pending/20260507--cli-neo--keep-prior-streaming-text-when-the-agent-emits-a-new-turn.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Keep the agent's prior commentary visible when it emits a new streaming turn before finalizing the previous one

--- a/changelog/pending/20260507--cli-neo--keep-prior-streaming-text-when-the-agent-emits-a-new-turn.yaml
+++ b/changelog/pending/20260507--cli-neo--keep-prior-streaming-text-when-the-agent-emits-a-new-turn.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/neo
-  description: Keep the agent's prior commentary visible when it emits a new streaming turn before finalizing the previous one
+  description: Render every assistant message in the TUI scrollback so multi-turn commentary no longer disappears between tool calls

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -563,12 +563,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case UIAssistantMessage:
-		// Every assistant_message with text content is a complete utterance
-		// for that turn and must be committed to scrollback. The backend does
-		// not chunk a single turn into multiple messages, so each non-empty
-		// payload — final, hand-off (HasPendingCLIWork=true), or non-final
-		// commentary preceding a tool call — gets its own final block.
-		// IsFinal only feeds the busy-state rule via applyBusyForEvent.
+		// Each assistant_message carries the full content for one agent turn —
+		// the backend never chunks a turn across multiple events. Commit any
+		// non-empty payload to scrollback; IsFinal feeds only the busy-state
+		// rule via applyBusyForEvent.
 		if msg.Content != "" {
 			cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
 		}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -579,7 +579,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
 			}
 		} else if msg.Content != "" {
-			if idx := m.findBlockKind(blockAssistantStreaming); idx >= 0 {
+			idx := m.findBlockKind(blockAssistantStreaming)
+			if idx >= 0 && m.blocks[idx].raw != "" && !strings.HasPrefix(msg.Content, m.blocks[idx].raw) {
+				// New turn: the agent moved on without an is_final=true marker
+				// (it emits commentary before each tool call, and a tool call
+				// at is_final=false ends the turn implicitly). Commit the prior
+				// streaming text as a final block so it lands in scrollback —
+				// otherwise the next assignment to raw silently overwrites it.
+				prior := m.blocks[idx].raw
+				m.removeBlockKind(blockAssistantStreaming)
+				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: prior}))
+				idx = -1
+			}
+			if idx >= 0 {
 				m.blocks[idx].raw = msg.Content
 				m.renderBlock(&m.blocks[idx])
 			} else {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -49,7 +49,6 @@ type blockKind int
 const (
 	blockBusy blockKind = iota
 	blockToolComplete
-	blockAssistantStreaming
 	blockAssistantFinal
 	blockError
 	blockWarning
@@ -564,39 +563,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case UIAssistantMessage:
-		// Any IsFinal=true assistant_message is a complete utterance and must be
-		// committed to scrollback — including hand-offs (HasPendingCLIWork=true),
-		// where the agent's commentary precedes a CLI tool call. HasPendingCLIWork
-		// only governs busy-state management (see applyBusyForEvent); it must not
-		// gate commit, otherwise hand-off commentary lives only in the live frame
-		// and is overwritten by the next hand-off / final message.
-		// The empty-content guard avoids a phantom marker for is_final=true
-		// messages that arrive with no text (e.g. a server-side hand-off finalized
-		// once tool calls were reconciled).
-		if msg.IsFinal {
-			m.removeBlockKind(blockAssistantStreaming)
-			if msg.Content != "" {
-				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
-			}
-		} else if msg.Content != "" {
-			idx := m.findBlockKind(blockAssistantStreaming)
-			if idx >= 0 && m.blocks[idx].raw != "" && !strings.HasPrefix(msg.Content, m.blocks[idx].raw) {
-				// New turn: the agent moved on without an is_final=true marker
-				// (it emits commentary before each tool call, and a tool call
-				// at is_final=false ends the turn implicitly). Commit the prior
-				// streaming text as a final block so it lands in scrollback —
-				// otherwise the next assignment to raw silently overwrites it.
-				prior := m.blocks[idx].raw
-				m.removeBlockKind(blockAssistantStreaming)
-				cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: prior}))
-				idx = -1
-			}
-			if idx >= 0 {
-				m.blocks[idx].raw = msg.Content
-				m.renderBlock(&m.blocks[idx])
-			} else {
-				m.appendRenderedBlock(block{kind: blockAssistantStreaming, raw: msg.Content})
-			}
+		// Every assistant_message with text content is a complete utterance
+		// for that turn and must be committed to scrollback. The backend does
+		// not chunk a single turn into multiple messages, so each non-empty
+		// payload — final, hand-off (HasPendingCLIWork=true), or non-final
+		// commentary preceding a tool call — gets its own final block.
+		// IsFinal only feeds the busy-state rule via applyBusyForEvent.
+		if msg.Content != "" {
+			cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
 		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		cmds = append(cmds, waitForEvent(m.eventCh))
@@ -861,7 +835,7 @@ func (m *Model) liveView() string {
 // been committed to terminal scrollback (false).
 func isLiveKind(b block) bool {
 	switch b.kind {
-	case blockBusy, blockAssistantStreaming:
+	case blockBusy:
 		return true
 	case blockPulumiOp:
 		return b.pulumi != nil && !b.pulumi.done
@@ -1084,8 +1058,6 @@ func (m *Model) renderBlock(b *block) {
 		b.rendered = renderIndented(cancelledStyle, m.width, b.raw)
 	case blockUserMessage:
 		b.rendered = m.renderUserBubble(b.raw)
-	case blockAssistantStreaming:
-		b.rendered = renderAssistantStreaming(m.wrapPlain(b.raw))
 	case blockAssistantFinal:
 		b.rendered = renderAssistantFinal(m.renderMarkdown(b.raw))
 	case blockApprovalPlan:
@@ -1151,11 +1123,6 @@ func (m *Model) wrapPlain(text string) string {
 	return linkifyURLs(wordwrap.String(text, w-4))
 }
 
-func (m *Model) appendRenderedBlock(b block) {
-	m.renderBlock(&b)
-	m.appendBlock(b)
-}
-
 // renderMarkdown renders text through glamour, falling back to plain text.
 // URLs in the rendered output are wrapped in OSC 8 escapes so terminals that
 // support hyperlinks render them as clickable.
@@ -1191,14 +1158,6 @@ func renderAssistantFinal(rendered string) string {
 	}
 	firstLine, rest, _ := strings.Cut(trimmed, "\n")
 	return renderHeaderedBlock(finalMarker+" "+firstLine, rest)
-}
-
-// renderAssistantStreaming renders streaming text with a dim indicator.
-func renderAssistantStreaming(text string) string {
-	if text == "" {
-		return ""
-	}
-	return "  " + text
 }
 
 // waitForEvent returns a tea.Cmd that reads from the UIEvent channel.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -563,10 +563,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case UIAssistantMessage:
-		// Each assistant_message carries the full content for one agent turn —
-		// the backend never chunks a turn across multiple events. Commit any
-		// non-empty payload to scrollback; IsFinal feeds only the busy-state
-		// rule via applyBusyForEvent.
 		if msg.Content != "" {
 			cmds = append(cmds, m.commitBlock(block{kind: blockAssistantFinal, raw: msg.Content}))
 		}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -792,10 +792,10 @@ func (m *Model) liveWidth() int {
 }
 
 // liveView renders only the in-flight blocks that should occupy the live
-// frame: busy spinner (always pinned at the bottom of the live region), an
-// in-flight streaming assistant message, and an open pulumi op block. The
-// busy block's spinner glyph is read from m.spinner.View() at render time so
-// the animation tracks the current frame without re-caching per block.
+// frame: busy spinner (always pinned at the bottom of the live region) and
+// an open pulumi op block. The busy block's spinner glyph is read from
+// m.spinner.View() at render time so the animation tracks the current frame
+// without re-caching per block.
 //
 // We deliberately use strings.Join instead of lipgloss.JoinVertical:
 // JoinVertical pads every line to the widest constituent's column count with

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -107,28 +107,29 @@ func TestBusy_NoFlickerOnCLIToolHandoff(t *testing.T) {
 	assert.GreaterOrEqual(t, m.findBlockKind(blockAssistantFinal), 0)
 }
 
-// TestBusy_NonFinalStreamingKeepsSpinnerOn — under the old rule, a non-final
+// TestBusy_NonFinalKeepsSpinnerOn — under the old rule, a non-final
 // assistant_message explicitly removed the busy block. The declarative rule
-// keeps the spinner on throughout streaming so there is no gap before the
-// next tool or the truly-final message.
-func TestBusy_NonFinalStreamingKeepsSpinnerOn(t *testing.T) {
+// keeps the spinner on across non-final messages so there is no gap before
+// the next tool or the truly-final message.
+func TestBusy_NonFinalKeepsSpinnerOn(t *testing.T) {
 	t.Parallel()
 
 	ch := make(chan UIEvent, 4)
 	model := tea.Model(NewModel(ModelConfig{EventCh: ch, Busy: true}))
 
-	model, _ = model.Update(UIAssistantMessage{Content: "thinking...", IsFinal: false})
+	model, _ = model.Update(UIAssistantMessage{Content: "first turn", IsFinal: false})
 	assert.True(t, model.(Model).busy, "non-final assistant_message must leave spinner on")
 	m := model.(Model)
-	assert.GreaterOrEqual(t, m.findBlockKind(blockAssistantStreaming), 0, "streaming content renders as a streaming block")
+	assert.GreaterOrEqual(t, m.findBlockKind(blockAssistantFinal), 0,
+		"non-final content commits as a final block")
 	assert.GreaterOrEqual(t, m.findBlockKind(blockBusy), 0, "spinner block is still present")
 
-	// More streaming text — still non-final, still busy.
-	model, _ = model.Update(UIAssistantMessage{Content: "thinking harder", IsFinal: false})
+	// Another non-final turn — still busy.
+	model, _ = model.Update(UIAssistantMessage{Content: "second turn", IsFinal: false})
 	assert.True(t, model.(Model).busy)
 
 	// Truly final — spinner off.
-	model, _ = model.Update(UIAssistantMessage{Content: "thinking harder. Done.", IsFinal: true})
+	model, _ = model.Update(UIAssistantMessage{Content: "Done.", IsFinal: true})
 	assert.False(t, model.(Model).busy)
 }
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -134,16 +134,6 @@ func TestRenderAssistantFinal(t *testing.T) {
 	assert.Contains(t, multi, "\n")
 }
 
-func TestRenderAssistantStreaming(t *testing.T) {
-	t.Parallel()
-
-	assert.Empty(t, renderAssistantStreaming(""))
-	// The streaming indent is two spaces — matches the marker column in the
-	// final render so tokens don't visually jump when streaming transitions to
-	// final.
-	assert.Equal(t, "  hi", renderAssistantStreaming("hi"))
-}
-
 func TestWaitForEvent_DeliversEvent(t *testing.T) {
 	t.Parallel()
 
@@ -257,13 +247,13 @@ func TestFindBlockKind(t *testing.T) {
 
 	m := &Model{blocks: []block{
 		{kind: blockUserMessage},
-		{kind: blockAssistantStreaming},
+		{kind: blockAssistantFinal},
 		{kind: blockUserMessage},
 	}}
-	// Returns the *last* index — matters for streaming: we need to update the
-	// latest assistant bubble, not an earlier one.
+	// Returns the *last* index — matters when multiple blocks of the same
+	// kind exist and we need to act on the most recent one.
 	assert.Equal(t, 2, m.findBlockKind(blockUserMessage))
-	assert.Equal(t, 1, m.findBlockKind(blockAssistantStreaming))
+	assert.Equal(t, 1, m.findBlockKind(blockAssistantFinal))
 	assert.Equal(t, -1, m.findBlockKind(blockError))
 }
 
@@ -917,53 +907,82 @@ func TestModel_Update_SpinnerTick_IgnoredWhenIdle(t *testing.T) {
 	assert.Nil(t, cmd, "idle TickMsg must not schedule another tick")
 }
 
-func TestModel_Update_UIAssistantMessage_Streaming_AppendsThenUpdates(t *testing.T) {
+// TestModel_Update_UIAssistantMessage_CommitsEachContentMessage pins the
+// "no chunking" assumption: every assistant_message with non-empty content,
+// final or not, commits its own blockAssistantFinal to scrollback. The
+// backend does not split a single turn into multiple events, so each
+// payload is a complete utterance.
+func TestModel_Update_UIAssistantMessage_CommitsEachContentMessage(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan UIEvent, 4)
-	m := NewModel(ModelConfig{EventCh: ch})
+	m := NewModel(ModelConfig{})
 
-	// First streaming chunk: must append a new blockAssistantStreaming.
-	updated, _ := m.Update(UIAssistantMessage{Content: "one"})
+	updated, _ := m.Update(UIAssistantMessage{Content: "first turn"})
 	m1 := updated.(Model)
-	idx := m1.findBlockKind(blockAssistantStreaming)
-	require.NotEqual(t, -1, idx, "first streaming msg must append a streaming block")
-
-	// Second streaming chunk: same block kind; the rendered text must change
-	// but the number of streaming blocks must not grow.
-	updated2, _ := m1.Update(UIAssistantMessage{Content: "one two"})
+	updated2, _ := m1.Update(UIAssistantMessage{Content: "second turn"})
 	m2 := updated2.(Model)
-	count := 0
-	for _, b := range m2.blocks {
-		if b.kind == blockAssistantStreaming {
-			count++
+	updated3, _ := m2.Update(UIAssistantMessage{Content: "final reply", IsFinal: true})
+	m3 := updated3.(Model)
+
+	finals := 0
+	for _, b := range m3.blocks {
+		if b.kind == blockAssistantFinal {
+			finals++
 		}
 	}
-	assert.Equal(t, 1, count, "second streaming msg must update in place, not append")
+	assert.Equal(t, 3, finals, "three messages with content must produce three final blocks")
 }
 
-func TestModel_Update_UIAssistantMessage_Final_ReplacesStreaming(t *testing.T) {
+// TestModel_Update_UIAssistantMessage_EmptyContentSkipsCommit guards the
+// empty-content branch: a tool-call-only message (no text) must not produce
+// a phantom final block.
+func TestModel_Update_UIAssistantMessage_EmptyContentSkipsCommit(t *testing.T) {
 	t.Parallel()
 
-	ch := make(chan UIEvent, 4)
-	m := NewModel(ModelConfig{EventCh: ch})
-	// Seed a streaming block so the final msg has something to replace.
-	updated, _ := m.Update(UIAssistantMessage{Content: "streaming"})
-	m1 := updated.(Model)
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(UIAssistantMessage{Content: "", IsFinal: true})
+	um := updated.(Model)
 
-	updated2, _ := m1.Update(UIAssistantMessage{Content: "done", IsFinal: true})
+	assert.Equal(t, -1, um.findBlockKind(blockAssistantFinal),
+		"empty content must not commit a final block")
+}
+
+// TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorTurn is a
+// regression for pulumi-service#42775: two consecutive non-final messages
+// (a multi-turn flow where the agent comments before each tool call) must
+// each reach scrollback. Previously the second silently overwrote the
+// first.
+func TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorTurn(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+
+	updated, _ := m.Update(UIAssistantMessage{Content: "I've explored the project."})
+	m1 := updated.(Model)
+	updated2, cmd := m1.Update(UIAssistantMessage{Content: "Got it — keep the existing bucket."})
 	m2 := updated2.(Model)
 
-	assert.Equal(t, -1, m2.findBlockKind(blockAssistantStreaming), "final msg must drop any streaming block")
-	assert.GreaterOrEqual(t, m2.findBlockKind(blockAssistantFinal), 0, "final msg must leave a final block")
+	var raws []string
+	for _, b := range m2.blocks {
+		if b.kind == blockAssistantFinal {
+			raws = append(raws, b.raw)
+		}
+	}
+	assert.Equal(t, []string{
+		"I've explored the project.",
+		"Got it — keep the existing bucket.",
+	}, raws, "each non-final turn with content must commit its own final block")
+
+	// And both must reach the user via tea.Println, not just sit in m.blocks.
+	printed := strings.Join(collectPrintln(cmd), "\n")
+	assert.Contains(t, printed, "Got it — keep the existing bucket.",
+		"second turn must reach scrollback via tea.Println")
 }
 
 // TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback is a
 // regression for a bug where hand-off messages (IsFinal=true,
-// HasPendingCLIWork=true) carrying assistant commentary were rendered as a
-// streaming live-frame block and then silently overwritten by the next
-// hand-off, so the commentary never reached scrollback. Each IsFinal=true
-// message — hand-off or terminal — must commit a final block.
+// HasPendingCLIWork=true) carrying assistant commentary were dropped before
+// reaching scrollback. Each hand-off must commit its own final block.
 func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T) {
 	t.Parallel()
 
@@ -976,12 +995,6 @@ func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T
 	})
 	m1 := updated.(Model)
 
-	// The streaming block is the live-frame holding pen; a hand-off must
-	// flush it and append a committed final block instead. Otherwise the
-	// next hand-off's content overwrites the streaming raw and the prior
-	// commentary is lost from scrollback.
-	assert.Equal(t, -1, m1.findBlockKind(blockAssistantStreaming),
-		"hand-off must not leave a streaming block behind")
 	idx := m1.findBlockKind(blockAssistantFinal)
 	require.GreaterOrEqual(t, idx, 0, "hand-off must commit a final assistant block")
 	assert.Equal(t, "I'll read the file", m1.blocks[idx].raw)
@@ -1000,69 +1013,6 @@ func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T
 		}
 	}
 	assert.Equal(t, 2, finals, "two hand-offs must produce two committed final blocks")
-}
-
-// TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorStreaming guards
-// against the bug where a second is_final=false message with content that
-// is not an extension of the prior streaming text silently overwrote that
-// text — losing the agent's earlier commentary entirely. The fix detects
-// the turn boundary (no shared prefix) and commits the prior streaming
-// block to scrollback before starting the fresh streaming block.
-// Regression for pulumi-service#42775.
-func TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorStreaming(t *testing.T) {
-	t.Parallel()
-
-	ch := make(chan UIEvent, 4)
-	m := NewModel(ModelConfig{EventCh: ch})
-
-	// Turn 1: streaming commentary that ends with a tool call (is_final=false).
-	updated, _ := m.Update(UIAssistantMessage{Content: "I've explored the project."})
-	m1 := updated.(Model)
-	require.NotEqual(t, -1, m1.findBlockKind(blockAssistantStreaming))
-
-	// Turn 2: brand-new commentary, not a prefix-extension of turn 1.
-	updated2, cmd := m1.Update(UIAssistantMessage{Content: "Got it — keep the existing bucket."})
-	m2 := updated2.(Model)
-
-	// The prior streaming text must have been committed as a final block,
-	// and a fresh streaming block must hold the new content.
-	idx := m2.findBlockKind(blockAssistantFinal)
-	require.GreaterOrEqual(t, idx, 0, "prior streaming text must be committed to scrollback")
-	assert.Equal(t, "I've explored the project.", m2.blocks[idx].raw)
-
-	streamIdx := m2.findBlockKind(blockAssistantStreaming)
-	require.NotEqual(t, -1, streamIdx, "new turn must seed a fresh streaming block")
-	assert.Equal(t, "Got it — keep the existing bucket.", m2.blocks[streamIdx].raw)
-
-	// And the committed text must reach the user via tea.Println, not just
-	// sit in m.blocks. collectPrintln walks the returned cmd batch.
-	printed := collectPrintln(cmd)
-	joined := strings.Join(printed, "\n")
-	assert.Contains(t, joined, "I've explored the project.",
-		"prior turn must reach scrollback via tea.Println")
-}
-
-// TestModel_Update_UIAssistantMessage_PrefixExtension_UpdatesInPlace pins the
-// other half of the contract: when the new content extends the existing
-// streaming text (the normal incremental-streaming case), the prior block
-// must be updated in place — not committed as a phantom final.
-func TestModel_Update_UIAssistantMessage_PrefixExtension_UpdatesInPlace(t *testing.T) {
-	t.Parallel()
-
-	ch := make(chan UIEvent, 4)
-	m := NewModel(ModelConfig{EventCh: ch})
-
-	updated, _ := m.Update(UIAssistantMessage{Content: "Hello"})
-	m1 := updated.(Model)
-
-	updated2, _ := m1.Update(UIAssistantMessage{Content: "Hello world"})
-	m2 := updated2.(Model)
-
-	assert.Equal(t, -1, m2.findBlockKind(blockAssistantFinal),
-		"prefix extension is one continuous turn, not a turn boundary")
-	streamIdx := m2.findBlockKind(blockAssistantStreaming)
-	require.NotEqual(t, -1, streamIdx)
-	assert.Equal(t, "Hello world", m2.blocks[streamIdx].raw)
 }
 
 func TestModel_Update_UIToolStarted_ShowsBusyBlock(t *testing.T) {
@@ -1886,20 +1836,18 @@ func TestModel_LiveView_OnlyShowsLiveBlocks(t *testing.T) {
 		{kind: blockToolComplete, rendered: "TOOLCOMPLETESCROLLBACK"},
 		{kind: blockAssistantFinal, rendered: "FINALSCROLLBACK"},
 		{kind: blockWarning, rendered: "WARNSCROLLBACK"},
-		{kind: blockAssistantStreaming, rendered: "STREAMING_LIVE", raw: "STREAMING_LIVE"},
 		{kind: blockBusy, label: "Thinking...", shimmer: shimmerVerb},
 	}
 
 	view := m.View()
 	// Live blocks are visible.
-	assert.Contains(t, view, "STREAMING_LIVE", "in-flight streaming must appear in View")
 	assert.Contains(t, view, "Thinking", "busy label must appear in View")
 	// Committed blocks are NOT visible — they were emitted to scrollback.
 	assert.NotContains(t, view, "USERSCROLLBACK")
 	assert.NotContains(t, view, "TOOLCOMPLETESCROLLBACK")
 	assert.NotContains(t, view, "FINALSCROLLBACK")
 	assert.NotContains(t, view, "WARNSCROLLBACK")
-	require.Len(t, m.blocks, 6, "View must not mutate the blocks slice")
+	require.Len(t, m.blocks, 5, "View must not mutate the blocks slice")
 }
 
 func TestApprovalGeneralWrapsToTerminalWidth(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -908,10 +908,8 @@ func TestModel_Update_SpinnerTick_IgnoredWhenIdle(t *testing.T) {
 }
 
 // TestModel_Update_UIAssistantMessage_CommitsEachContentMessage pins the
-// "no chunking" assumption: every assistant_message with non-empty content,
-// final or not, commits its own blockAssistantFinal to scrollback. The
-// backend does not split a single turn into multiple events, so each
-// payload is a complete utterance.
+// "no chunking" assumption: every assistant_message with non-empty content
+// — final or not — commits its own blockAssistantFinal to scrollback.
 func TestModel_Update_UIAssistantMessage_CommitsEachContentMessage(t *testing.T) {
 	t.Parallel()
 
@@ -949,9 +947,8 @@ func TestModel_Update_UIAssistantMessage_EmptyContentSkipsCommit(t *testing.T) {
 
 // TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorTurn is a
 // regression for pulumi-service#42775: two consecutive non-final messages
-// (a multi-turn flow where the agent comments before each tool call) must
-// each reach scrollback. Previously the second silently overwrote the
-// first.
+// must each reach scrollback. Previously the second silently overwrote
+// the first.
 func TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorTurn(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -2206,34 +2206,27 @@ func TestView_LeadingBlankLine_Busy_SpinnerFlushWithPrompt(t *testing.T) {
 }
 
 // TestLiveView_BlankBetweenLiveBlocks pins the inter-block gap inside the live
-// frame, for the rare case where a streaming assistant message and an open
-// pulumi op are both pending under the busy spinner.
+// frame when an open pulumi op is pending under the busy spinner.
 func TestLiveView_BlankBetweenLiveBlocks(t *testing.T) {
 	t.Parallel()
 
 	m := NewModel(ModelConfig{})
 	m.width = 80
 	m.blocks = []block{
-		{kind: blockAssistantStreaming, rendered: "STREAM_LIVE", raw: "STREAM_LIVE"},
 		{kind: blockPulumiOp, rendered: "PULUMI_LIVE", pulumi: &pulumiBlockState{done: false}},
 		{kind: blockBusy, label: "Thinking...", shimmer: shimmerVerb},
 	}
 
 	live := m.liveView()
-	require.Contains(t, live, "STREAM_LIVE")
 	require.Contains(t, live, "PULUMI_LIVE")
 	require.Contains(t, live, "Thinking")
 
-	// Each adjacent pair must be separated by a blank line. We can't anchor
-	// on exact line counts (the busy line and rendered strings may wrap or
-	// embed ANSI), so check that "\n\n" appears between each pair in order.
-	streamIdx := strings.Index(live, "STREAM_LIVE")
+	// The pulumi-op → busy pair must be separated by a blank line. We can't
+	// anchor on exact line counts (the busy line and rendered string may wrap
+	// or embed ANSI), so check that "\n\n" appears between them.
 	pulumiIdx := strings.Index(live, "PULUMI_LIVE")
 	thinkingIdx := strings.Index(live, "Thinking")
-	require.Less(t, streamIdx, pulumiIdx)
 	require.Less(t, pulumiIdx, thinkingIdx)
-	assert.Contains(t, live[streamIdx:pulumiIdx], "\n\n",
-		"streaming → pulumi-op gap must be a full blank line")
 	assert.Contains(t, live[pulumiIdx:thinkingIdx], "\n\n",
 		"pulumi-op → busy gap must be a full blank line")
 }

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -1002,6 +1002,69 @@ func TestModel_Update_UIAssistantMessage_HandoffCommitsToScrollback(t *testing.T
 	assert.Equal(t, 2, finals, "two hand-offs must produce two committed final blocks")
 }
 
+// TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorStreaming guards
+// against the bug where a second is_final=false message with content that
+// is not an extension of the prior streaming text silently overwrote that
+// text — losing the agent's earlier commentary entirely. The fix detects
+// the turn boundary (no shared prefix) and commits the prior streaming
+// block to scrollback before starting the fresh streaming block.
+// Regression for pulumi-service#42775.
+func TestModel_Update_UIAssistantMessage_NewTurn_CommitsPriorStreaming(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	// Turn 1: streaming commentary that ends with a tool call (is_final=false).
+	updated, _ := m.Update(UIAssistantMessage{Content: "I've explored the project."})
+	m1 := updated.(Model)
+	require.NotEqual(t, -1, m1.findBlockKind(blockAssistantStreaming))
+
+	// Turn 2: brand-new commentary, not a prefix-extension of turn 1.
+	updated2, cmd := m1.Update(UIAssistantMessage{Content: "Got it — keep the existing bucket."})
+	m2 := updated2.(Model)
+
+	// The prior streaming text must have been committed as a final block,
+	// and a fresh streaming block must hold the new content.
+	idx := m2.findBlockKind(blockAssistantFinal)
+	require.GreaterOrEqual(t, idx, 0, "prior streaming text must be committed to scrollback")
+	assert.Equal(t, "I've explored the project.", m2.blocks[idx].raw)
+
+	streamIdx := m2.findBlockKind(blockAssistantStreaming)
+	require.NotEqual(t, -1, streamIdx, "new turn must seed a fresh streaming block")
+	assert.Equal(t, "Got it — keep the existing bucket.", m2.blocks[streamIdx].raw)
+
+	// And the committed text must reach the user via tea.Println, not just
+	// sit in m.blocks. collectPrintln walks the returned cmd batch.
+	printed := collectPrintln(cmd)
+	joined := strings.Join(printed, "\n")
+	assert.Contains(t, joined, "I've explored the project.",
+		"prior turn must reach scrollback via tea.Println")
+}
+
+// TestModel_Update_UIAssistantMessage_PrefixExtension_UpdatesInPlace pins the
+// other half of the contract: when the new content extends the existing
+// streaming text (the normal incremental-streaming case), the prior block
+// must be updated in place — not committed as a phantom final.
+func TestModel_Update_UIAssistantMessage_PrefixExtension_UpdatesInPlace(t *testing.T) {
+	t.Parallel()
+
+	ch := make(chan UIEvent, 4)
+	m := NewModel(ModelConfig{EventCh: ch})
+
+	updated, _ := m.Update(UIAssistantMessage{Content: "Hello"})
+	m1 := updated.(Model)
+
+	updated2, _ := m1.Update(UIAssistantMessage{Content: "Hello world"})
+	m2 := updated2.(Model)
+
+	assert.Equal(t, -1, m2.findBlockKind(blockAssistantFinal),
+		"prefix extension is one continuous turn, not a turn boundary")
+	streamIdx := m2.findBlockKind(blockAssistantStreaming)
+	require.NotEqual(t, -1, streamIdx)
+	assert.Equal(t, "Hello world", m2.blocks[streamIdx].raw)
+}
+
 func TestModel_Update_UIToolStarted_ShowsBusyBlock(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When the `pulumi neo` agent emits commentary across multiple turns (typical of a flow where the agent narrates each step before invoking a tool), only the final turn's text was reaching the user. The earlier commentary lived in a live-frame "streaming" block that got silently overwritten on the next message.

Two-step change:

1. Always commit assistant messages to scrollback. Any `assistant_message` with non-empty content — final, hand-off, or non-final commentary preceding a tool call — now commits its own `blockAssistantFinal`. `IsFinal` only governs the busy-state rule.
2. Drop the streaming-block infrastructure. The backend doesn't chunk a single turn into multiple `is_final=false` events, so the in-place "streaming update" path was dead. Removed `blockAssistantStreaming` and its renderer, plus the unused `renderAssistantStreaming` and `appendRenderedBlock` helpers, and the tests that pinned chunked streaming.

Net effect: every piece of agent commentary is preserved in scrollback and there's one fewer block kind to reason about.

Fixes pulumi/pulumi-service#42775

## Test plan

- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/...` (regression test for the multi-turn case + tests for the empty-content guard, hand-off case, and "every content message commits" contract)
- [x] `make format` / `golangci-lint run` clean
- [ ] Manual: `pulumi neo` with a multi-turn plan-mode prompt → both pieces of commentary remain visible across the approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)