### PR TITLE
cli/neo: fix panic on cancellation

### DIFF
--- a/changelog/pending/20260507--cli-neo--fix-panic-on-cancellation.yaml
+++ b/changelog/pending/20260507--cli-neo--fix-panic-on-cancellation.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Fix a panic when cancelling a `pulumi neo` session

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -188,6 +188,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	}
 
 	uiCh := make(chan UIEvent, 64)
+	defer close(uiCh)
 	outCh := make(chan outboundEvent, 8)
 
 	pu.Sink = newPulumiSinkForUI(uiCh)
@@ -209,10 +210,7 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := newTeaProgram(model)
 
-	// runNeo owns uiCh: runWithTUI's g.Wait() joins every writer before
-	// returning, so closing afterward is safe and lets bubbletea's leftover
-	// waitForEvent goroutines exit instead of leaking.
-	err = runWithTUI(
+	return runWithTUI(
 		ctx,
 		func() error {
 			_, err := p.Run()
@@ -304,8 +302,6 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 			})
 		},
 	)
-	close(uiCh)
-	return err
 }
 
 // runWithTUI runs the bubbletea program alongside caller-registered worker

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -209,11 +209,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := newTeaProgram(model)
 
-	// runNeo owns uiCh's lifecycle. runWithTUI's g.Wait() joins every worker
-	// (Session.Run, dispatchUserEvents, createTask, the gctx→p.Quit watcher,
-	// and the TUI goroutine) before returning, so by the time we close here
-	// no writer is live. Closing also unblocks any leftover waitForEvent
-	// goroutines spawned by bubbletea so they don't leak.
+	// runNeo owns uiCh: runWithTUI's g.Wait() joins every writer before
+	// returning, so closing afterward is safe and lets bubbletea's leftover
+	// waitForEvent goroutines exit instead of leaking.
 	err = runWithTUI(
 		ctx,
 		func() error {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -209,7 +209,12 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	// scrollback after exit.
 	p := newTeaProgram(model)
 
-	return runWithTUI(
+	// runNeo owns uiCh's lifecycle. runWithTUI's g.Wait() joins every worker
+	// (Session.Run, dispatchUserEvents, createTask, the gctx→p.Quit watcher,
+	// and the TUI goroutine) before returning, so by the time we close here
+	// no writer is live. Closing also unblocks any leftover waitForEvent
+	// goroutines spawned by bubbletea so they don't leak.
+	err = runWithTUI(
 		ctx,
 		func() error {
 			_, err := p.Run()
@@ -301,6 +306,8 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 			})
 		},
 	)
+	close(uiCh)
+	return err
 }
 
 // runWithTUI runs the bubbletea program alongside caller-registered worker

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -52,18 +52,16 @@ type Session struct {
 	// likes (stderr today, a TUI tomorrow). nil disables logging.
 	Log io.Writer
 	// UIEvents, when non-nil, receives parsed events for the bubbletea TUI to display.
-	// The Session closes this channel when Run() exits.
+	// The caller owns the channel's lifecycle — Session.Run never closes it. uiCh
+	// has multiple writers in production (dispatchUserEvents, createTask, the
+	// pulumi sink), so closing here would race with them and panic with
+	// "send on closed channel" during cancellation (pulumi/pulumi-service#42773).
 	UIEvents chan<- UIEvent
 }
 
 // Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil)
-// or the SSE stream errors out (returns the error). If UIEvents is set, it is closed
-// when Run returns.
+// or the SSE stream errors out (returns the error).
 func (s *Session) Run(ctx context.Context) error {
-	if s.UIEvents != nil {
-		defer close(s.UIEvents)
-	}
-
 	stream, err := s.Client.StreamNeoTaskEvents(ctx, s.OrgName, s.TaskID)
 	if err != nil {
 		return fmt.Errorf("opening event stream: %w", err)

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -52,10 +52,9 @@ type Session struct {
 	// likes (stderr today, a TUI tomorrow). nil disables logging.
 	Log io.Writer
 	// UIEvents, when non-nil, receives parsed events for the bubbletea TUI to display.
-	// The caller owns the channel's lifecycle — Session.Run never closes it. uiCh
-	// has multiple writers in production (dispatchUserEvents, createTask, the
-	// pulumi sink), so closing here would race with them and panic with
-	// "send on closed channel" during cancellation (pulumi/pulumi-service#42773).
+	// The caller owns the channel — Session.Run never closes it. The channel has
+	// other writers (dispatchUserEvents, createTask, the pulumi sink), and closing
+	// from here races them (pulumi/pulumi-service#42773).
 	UIEvents chan<- UIEvent
 }
 

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -198,8 +198,7 @@ func TestSession_AssistantMessageWithoutCliCallsPostsNothing(t *testing.T) {
 }
 
 // collectUIEvents drains a UIEvents channel until it is closed, returning everything seen.
-// Session.Run no longer closes UIEvents — tests own the channel and must close it
-// after Run returns before calling this helper.
+// Tests own the channel and must close it after Run returns before calling this.
 func collectUIEvents(ch <-chan UIEvent) []UIEvent {
 	var out []UIEvent
 	for evt := range ch {
@@ -899,11 +898,7 @@ func TestSession_HandleEvent_UserInputEnvelope_EmitsUIUserMessage(t *testing.T) 
 	require.True(t, hasUIEvent[UIUserMessage](events), "userInput envelope must emit UIUserMessage")
 }
 
-// Regression test for pulumi/pulumi-service#42773: Session.Run must not close
-// UIEvents on exit. uiCh has multiple writers in production
-// (dispatchUserEvents, createTask, the pulumi sink); closing it from inside
-// Session.Run races with those writers and panics with "send on closed
-// channel" during cancellation. The caller owns the channel's lifecycle.
+// Regression test for pulumi/pulumi-service#42773.
 func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
 	t.Parallel()
 
@@ -921,6 +916,6 @@ func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
 	require.NoError(t, s.Run(t.Context()))
 
 	require.NotPanics(t, func() {
-		sendUI(uiCh, UIWarning{Message: "post-run write must not panic"})
-	}, "Session.Run must not close UIEvents — caller owns the channel")
+		sendUI(uiCh, UIWarning{Message: "x"})
+	})
 }

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -198,7 +198,8 @@ func TestSession_AssistantMessageWithoutCliCallsPostsNothing(t *testing.T) {
 }
 
 // collectUIEvents drains a UIEvents channel until it is closed, returning everything seen.
-// Use with a Session that sets s.UIEvents — Run closes the channel when it exits.
+// Session.Run no longer closes UIEvents — tests own the channel and must close it
+// after Run returns before calling this helper.
 func collectUIEvents(ch <-chan UIEvent) []UIEvent {
 	var out []UIEvent
 	for evt := range ch {
@@ -238,6 +239,7 @@ func TestSession_FinalAssistantMessageWithoutCliCallsEmitsTaskIdle(t *testing.T)
 		UIEvents: uiCh,
 	}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	assert.True(t, hasUIEvent[UITaskIdle](events), "expected UITaskIdle after final assistant_message with no cli calls")
@@ -264,6 +266,7 @@ func TestSession_StreamingAssistantMessageDoesNotEmitTaskIdle(t *testing.T) {
 		UIEvents: uiCh,
 	}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	assert.False(t, hasUIEvent[UITaskIdle](events), "streaming chunks must not emit UITaskIdle")
@@ -298,6 +301,7 @@ func TestSession_FinalAssistantMessageWithCliCallsDoesNotEmitTaskIdle(t *testing
 		UIEvents: uiCh,
 	}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	assert.False(t, hasUIEvent[UITaskIdle](events), "pending cli tool calls must not emit UITaskIdle")
@@ -889,7 +893,34 @@ func TestSession_HandleEvent_UserInputEnvelope_EmitsUIUserMessage(t *testing.T) 
 		UIEvents: uiCh,
 	}
 	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
 
 	events := collectUIEvents(uiCh)
 	require.True(t, hasUIEvent[UIUserMessage](events), "userInput envelope must emit UIUserMessage")
+}
+
+// Regression test for pulumi/pulumi-service#42773: Session.Run must not close
+// UIEvents on exit. uiCh has multiple writers in production
+// (dispatchUserEvents, createTask, the pulumi sink); closing it from inside
+// Session.Run races with those writers and panics with "send on closed
+// channel" during cancellation. The caller owns the channel's lifecycle.
+func TestSession_RunDoesNotCloseUIEvents(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+	close(streamer.stream)
+
+	uiCh := make(chan UIEvent, 4)
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{},
+		OrgName:  "o",
+		TaskID:   "t",
+		UIEvents: uiCh,
+	}
+	require.NoError(t, s.Run(t.Context()))
+
+	require.NotPanics(t, func() {
+		sendUI(uiCh, UIWarning{Message: "post-run write must not panic"})
+	}, "Session.Run must not close UIEvents — caller owns the channel")
 }


### PR DESCRIPTION
## Summary

`uiCh` has multiple writers (`Session`, `dispatchUserEvents`, `createTask`, the pulumi sink) but only `Session.Run` was closing it via `defer`. During cancellation `Session.Run` could exit and close the channel while another writer was mid-`sendUI`, panicking with `send on closed channel`. The non-blocking select in `sendUI` only protects against a slow reader — sending on a closed channel still panics.

Move ownership of `uiCh`'s lifecycle to `runNeo`: `runWithTUI`'s `g.Wait()` joins every worker before returning, so closing afterward is panic-free.

Fixes pulumi/pulumi-service#42773.

## Test plan

- [x] Added `TestSession_RunDoesNotCloseUIEvents` — confirmed it reproduces the panic on unfixed code, passes after the fix
- [x] `go test -race ./pkg/cmd/pulumi/neo/...`
- [x] `golangci-lint run ./pkg/cmd/pulumi/neo/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)