### PR TITLE
conformance: don't show engine log output in CI (or by default)

### DIFF
--- a/sdk/go/common/testing/util.go
+++ b/sdk/go/common/testing/util.go
@@ -30,14 +30,10 @@ func RandomStackName() string {
 	return "test" + hex.EncodeToString(b)
 }
 
-// LogTruncated logs a message, truncating it if it is too long.  PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT can be set to
-// "true" to see the full log message.
-func LogTruncated(t *testing.T, name, message string) {
+// LogIfVerbose logs a message only if PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT is set to "true".
+func LogIfVerbose(t *testing.T, name, message string) {
 	if os.Getenv("PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT") != "true" {
-		// Cut down logs so they don't overwhelm the test output
-		if len(message) > 2048 {
-			message = message[:2048] + "... (truncated, run with PULUMI_LANGUAGE_TEST_SHOW_FULL_OUTPUT=true to see full logs))"
-		}
+		return
 	}
 	t.Logf("%s: %s", name, message)
 }

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -287,8 +287,8 @@ func TestLanguage(t *testing.T) {
 					for _, msg := range result.Messages {
 						t.Log(msg)
 					}
-					ptesting.LogTruncated(t, "stdout", result.Stdout)
-					ptesting.LogTruncated(t, "stderr", result.Stderr)
+					ptesting.LogIfVerbose(t, "stdout", result.Stdout)
+					ptesting.LogIfVerbose(t, "stderr", result.Stderr)
 					assert.True(t, result.Success)
 				})
 			}

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -240,8 +240,8 @@ func testLanguage(t *testing.T, runtime string, forceTsc bool) {
 					for _, msg := range result.Messages {
 						t.Log(msg)
 					}
-					ptesting.LogTruncated(t, "stdout", result.Stdout)
-					ptesting.LogTruncated(t, "stderr", result.Stderr)
+					ptesting.LogIfVerbose(t, "stdout", result.Stdout)
+					ptesting.LogIfVerbose(t, "stderr", result.Stderr)
 					assert.True(t, result.Success)
 				})
 			}

--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -160,8 +160,8 @@ func TestLanguage(t *testing.T) {
 			for _, msg := range result.Messages {
 				t.Log(msg)
 			}
-			ptesting.LogTruncated(t, "stdout", result.Stdout)
-			ptesting.LogTruncated(t, "stderr", result.Stderr)
+			ptesting.LogIfVerbose(t, "stdout", result.Stdout)
+			ptesting.LogIfVerbose(t, "stderr", result.Stderr)
 			assert.True(t, result.Success)
 		})
 	}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -240,8 +240,8 @@ func testLanguageWithConfig(t *testing.T, config languageTestConfig) {
 					for _, msg := range result.Messages {
 						t.Log(msg)
 					}
-					ptesting.LogTruncated(t, "stdout", result.Stdout)
-					ptesting.LogTruncated(t, "stderr", result.Stderr)
+					ptesting.LogIfVerbose(t, "stdout", result.Stdout)
+					ptesting.LogIfVerbose(t, "stderr", result.Stderr)
 					assert.True(t, result.Success)
 				})
 			}


### PR DESCRIPTION
Engine logs in CI are quite overwhelming (there's a lot of log output) and of limited usefulness, because a) it's hard to associate them with a particular test, and b) it's so much output that it completely overwhelms the GHA output display.

They also obscure the actual test failures by just sheer volume of output.

We already have an env variable that truncates the largest log lines, change that to mean "show any logs at all", and don't set it in CI. This will make it so we just show the actual test failures in CI, but we can still see the full logs if it's necessary locally.
