### PR TITLE
stop installing winget manually

### DIFF
--- a/.github/workflows/download-pulumi-cron.yml
+++ b/.github/workflows/download-pulumi-cron.yml
@@ -115,10 +115,6 @@ jobs:
             echo "Deleting Pulumi"
             rm -v "$PULUMI_INSTALL_DIR"/pulumi*
           fi
-      - name: Install winget
-        uses: Cyberboss/install-winget@1c6f189175e9f015bf1aa113cd1cc6c73efb9d47 # v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Pulumi Using WinGet
         run: winget install pulumi --disable-interactivity --accept-source-agreements --verbose
       - run: echo "C:/Program Files (x86)/Pulumi" >> "${GITHUB_PATH}"


### PR DESCRIPTION
Winget (in a newer version) is supposed to be installed on the GitHub runner images already (according to Claude).  Again according to claude, this newer version should fix the install error we've been having in CI (see https://github.com/pulumi/pulumi/actions/runs/25485947161/job/74781423355).

Probably worth a try since I don't know any better than this either.

Fixes https://github.com/pulumi/pulumi/issues/18948