### PR TITLE
use absolute paths for typescript require strings

### DIFF
--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -90,6 +90,7 @@
         "automation/workspace.ts",
         "tests/cmd/dynamic/config.spec.ts",
         "tests/cmd/run/error.spec.ts",
+        "tests/tsutils.spec.ts",
         "tests/config.spec.ts",
         "tests/constants.ts",
         "tests/init.spec.ts",

--- a/sdk/nodejs/tsutils.ts
+++ b/sdk/nodejs/tsutils.ts
@@ -42,24 +42,29 @@ export function loadTypeScriptCompilerOptions(tsConfigPath: string): object {
  * @internal
  */
 export function typeScriptRequireStrings(): { typescriptRequire: string; tsnodeRequire: string } {
-    let typescriptRequire = "typescript";
-    let tsnodeRequire = "ts-node";
+    let typescriptRequire: string;
+    let tsnodeRequire: string;
 
     try {
-        // Try loading typescript from node_modules
+        // Try loading typescript from node_modules.
+        // Use require.resolve to get the absolute path so that the same
+        // TypeScript installation is used regardless of which module later
+        // calls require(typescriptRequire) (e.g. the vendored ts-node
+        // resolves from a different directory than tsutils).
         const ts: typeof typescript = require("typescript");
-        const tsPath = require.resolve("typescript");
-        log.debug(`Found typescript version ${ts.version} at ${tsPath}`);
+        typescriptRequire = require.resolve("typescript");
+        log.debug(`Found typescript version ${ts.version} at ${typescriptRequire}`);
     } catch (error) {
         // Fallback to the vendored version
         typescriptRequire = path.join(__dirname, "vendor", "typescript@3.8.3", "typescript.js");
         log.debug(`Using vendored typescript@3.8.3`);
     }
     try {
-        // Try loading ts-node from node_modules
-        const tsn: typeof tsnode = require(tsnodeRequire);
-        const tsnPath = require.resolve("ts-node");
-        log.debug(`Found ts-node version: ${tsn.VERSION} at ${tsnPath}`);
+        // Try loading ts-node from node_modules.
+        // Use require.resolve for the same reason as above.
+        const tsn: typeof tsnode = require("ts-node");
+        tsnodeRequire = require.resolve("ts-node");
+        log.debug(`Found ts-node version: ${tsn.VERSION} at ${tsnodeRequire}`);
     } catch (error) {
         // Fallback to the vendored version
         tsnodeRequire = path.join(__dirname, "vendor", "ts-node@7.0.1");


### PR DESCRIPTION
Currently, when we manage to load a typescript from node_modules, we don't return the full absolute path from the function, but just "typescript"/"ts-node". This (according to claude) means that we may later pick up a different version for the version detection than for the actual usage, as the version check ends up using the global version, but we end up using the locally installed version.

This leads to errors such as https://github.com/pulumi/cli-performance-metrics/actions/runs/25394476087/job/74477422558.

I'm not entirely sure this is the right fix, but something about the version detection needs fixing I think.

Fixes: https://github.com/pulumi/cli-performance-metrics/issues/95

(opening this as draft as a reminder for myself to make sure I don't loose track of this)