### PR TITLE
cli/package: print docs pointers after `package add` and `gen-sdk`

### DIFF
--- a/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
+++ b/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/package
+  description: Print `pulumi cloud api` pointers to the version-pinned readme, doc tree, and per-resource docs after `pulumi package add` and `pulumi package gen-sdk`

--- a/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
+++ b/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/package
-  description: When invoked by an AI coding agent, print `pulumi cloud api` pointers after `pulumi package add` and `pulumi package gen-sdk`
+  description: When invoked by an AI coding agent, print `pulumi api` pointers after `pulumi package add` and `pulumi package gen-sdk`

--- a/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
+++ b/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/package
-  description: When invoked by an AI coding agent, print `pulumi cloud api` pointers to the version-pinned readme, doc tree, and per-resource docs after `pulumi package add` and `pulumi package gen-sdk`
+  description: When invoked by an AI coding agent, print `pulumi cloud api` pointers after `pulumi package add` and `pulumi package gen-sdk`

--- a/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
+++ b/changelog/pending/20260507--cli-package--print-registry-docs-pointer-after-package-add-and-gen-sdk.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: feat
   scope: cli/package
-  description: Print `pulumi cloud api` pointers to the version-pinned readme, doc tree, and per-resource docs after `pulumi package add` and `pulumi package gen-sdk`
+  description: When invoked by an AI coding agent, print `pulumi cloud api` pointers to the version-pinned readme, doc tree, and per-resource docs after `pulumi package add` and `pulumi package gen-sdk`

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -241,8 +241,9 @@ func addExecutionMetadataToEnvironment(env map[string]string, execKind, execAgen
 	}
 }
 
-// DetectAIAgent returns the AI agent driving the CLI, inferred from AI_AGENT
-// or well-known agent-specific environment variables, or "" if none is found.
+// DetectAIAgent returns a normalized name for the AI coding agent driving
+// the CLI (e.g. "claude", "cursor", "codex"), or "" if none is detected.
+// Detection is based on environment variables.
 func DetectAIAgent(getEnv func(string) string) string {
 	normalized := func(agent string) string {
 		agent = strings.TrimSpace(strings.ToLower(agent))

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -25,9 +25,7 @@ func NewPackageCmd() *cobra.Command {
 		Short: "Work with Pulumi packages",
 		Long: `Work with Pulumi packages
 
-Install and configure Pulumi packages and their plugins and SDKs.
-
-Browse the registry: pulumi cloud api '/api/registry/packages'`,
+Install and configure Pulumi packages and their plugins and SDKs.`,
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)

--- a/pkg/cmd/pulumi/packagecmd/package.go
+++ b/pkg/cmd/pulumi/packagecmd/package.go
@@ -25,7 +25,9 @@ func NewPackageCmd() *cobra.Command {
 		Short: "Work with Pulumi packages",
 		Long: `Work with Pulumi packages
 
-Install and configure Pulumi packages and their plugins and SDKs.`,
+Install and configure Pulumi packages and their plugins and SDKs.
+
+Browse the registry: pulumi cloud api '/api/registry/packages'`,
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -235,10 +235,12 @@ func printRegistryDocsHint(w io.Writer, ctx context.Context, reg registry.Regist
 	if pkg == nil || pkg.Name == "" || pkg.Version == nil || reg == nil {
 		return
 	}
-	if _, err := reg.GetPackage(ctx, "pulumi", "pulumi", pkg.Name, pkg.Version); err != nil {
+	meta, err := registry.ResolvePackageFromName(ctx, reg, pkg.Name, pkg.Version)
+	if err != nil {
 		return
 	}
-	base := fmt.Sprintf("/api/registry/packages/pulumi/pulumi/%s/versions/%s", pkg.Name, pkg.Version.String())
+	base := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s",
+		meta.Source, meta.Publisher, meta.Name, pkg.Version.String())
 	fmt.Fprintf(w, "Docs: pulumi cloud api --format=markdown '%s/readme'\n", base)
 	fmt.Fprintln(w, "      (or /nav for the doc tree, /docs/<token> for a specific resource)")
 }

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,6 +147,9 @@ from the parameters, as in:
 			)
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
+				if errors.Is(err, registry.ErrNotFound) {
+					return fmt.Errorf("%w\nSearch: pulumi cloud api '/api/registry/packages?search=<term>'", err)
+				}
 				return err
 			}
 
@@ -196,6 +200,7 @@ from the parameters, as in:
 			}
 
 			fmt.Fprintf(cmd.ErrOrStderr(), "Added package %s\n", schemaDisplayName(pkg))
+			printRegistryDocsHint(cmd.ErrOrStderr(), cmd.Context(), pluginOrProject.reg, pkg)
 			return nil
 		},
 	}
@@ -224,6 +229,18 @@ type addTarget struct {
 	projectFilePath *string
 	reg             registry.Registry
 	proj            workspace.BaseProject
+}
+
+func printRegistryDocsHint(w io.Writer, ctx context.Context, reg registry.Registry, pkg *schema.Package) {
+	if pkg == nil || pkg.Name == "" || pkg.Version == nil || reg == nil {
+		return
+	}
+	if _, err := reg.GetPackage(ctx, "pulumi", "pulumi", pkg.Name, pkg.Version); err != nil {
+		return
+	}
+	base := fmt.Sprintf("/api/registry/packages/pulumi/pulumi/%s/versions/%s", pkg.Name, pkg.Version.String())
+	fmt.Fprintf(w, "Docs: pulumi cloud api --format=markdown '%s/readme'\n", base)
+	fmt.Fprintln(w, "      (or /nav for the doc tree, /docs/<token> for a specific resource)")
 }
 
 func schemaDisplayName(schema *schema.Package) string {

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -151,7 +151,7 @@ from the parameters, as in:
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
 				if errors.Is(err, registry.ErrNotFound) && agent != "" {
-					return fmt.Errorf("%w\nSearch: pulumi cloud api '/api/registry/packages?search=<term>'", err)
+					return fmt.Errorf("%w\nSearch: pulumi api '/api/registry/packages?search=<term>'", err)
 				}
 				return err
 			}
@@ -203,7 +203,7 @@ from the parameters, as in:
 			}
 
 			fmt.Fprintf(cmd.ErrOrStderr(), "Added package %s\n", schemaDisplayName(pkg))
-			printRegistryDocsHint(cmd.ErrOrStderr(), agent, cmd.Context(), pluginOrProject.reg, pkg)
+			printRegistryDocsHint(cmd.ErrOrStderr(), agent, cmd.Context(), target.reg, pkg)
 			return nil
 		},
 	}
@@ -254,7 +254,7 @@ func printRegistryDocsHint(
 	}
 	fmt.Fprintln(w, "Documentation:")
 	for _, h := range hints {
-		fmt.Fprintf(w, "  pulumi cloud api --format=markdown '%s%s'%s\n", base, h.suffix, h.comment)
+		fmt.Fprintf(w, "  pulumi api --format=markdown '%s%s'%s\n", base, h.suffix, h.comment)
 	}
 }
 

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -27,6 +27,7 @@ import (
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -147,7 +148,7 @@ from the parameters, as in:
 			)
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
-				if errors.Is(err, registry.ErrNotFound) {
+				if errors.Is(err, registry.ErrNotFound) && metadata.DetectAIAgent(os.Getenv) != "" {
 					return fmt.Errorf("%w\nSearch: pulumi cloud api '/api/registry/packages?search=<term>'", err)
 				}
 				return err
@@ -232,6 +233,9 @@ type addTarget struct {
 }
 
 func printRegistryDocsHint(w io.Writer, ctx context.Context, reg registry.Registry, pkg *schema.Package) {
+	if metadata.DetectAIAgent(os.Getenv) == "" {
+		return
+	}
 	if pkg == nil || pkg.Name == "" || pkg.Version == nil || reg == nil {
 		return
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -92,6 +92,8 @@ from the parameters, as in:
   pulumi package add <provider> -- --provider-parameter-flag value
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			agent := metadata.DetectAIAgent(os.Getenv)
+
 			wd, err := os.Getwd()
 			if err != nil {
 				return err
@@ -148,7 +150,7 @@ from the parameters, as in:
 			)
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
-				if errors.Is(err, registry.ErrNotFound) && metadata.DetectAIAgent(os.Getenv) != "" {
+				if errors.Is(err, registry.ErrNotFound) && agent != "" {
 					return fmt.Errorf("%w\nSearch: pulumi cloud api '/api/registry/packages?search=<term>'", err)
 				}
 				return err
@@ -201,7 +203,7 @@ from the parameters, as in:
 			}
 
 			fmt.Fprintf(cmd.ErrOrStderr(), "Added package %s\n", schemaDisplayName(pkg))
-			printRegistryDocsHint(cmd.ErrOrStderr(), cmd.Context(), pluginOrProject.reg, pkg)
+			printRegistryDocsHint(cmd.ErrOrStderr(), agent, cmd.Context(), pluginOrProject.reg, pkg)
 			return nil
 		},
 	}
@@ -232,11 +234,10 @@ type addTarget struct {
 	proj            workspace.BaseProject
 }
 
-func printRegistryDocsHint(w io.Writer, ctx context.Context, reg registry.Registry, pkg *schema.Package) {
-	if metadata.DetectAIAgent(os.Getenv) == "" {
-		return
-	}
-	if pkg == nil || pkg.Name == "" || pkg.Version == nil || reg == nil {
+func printRegistryDocsHint(
+	w io.Writer, agent string, ctx context.Context, reg registry.Registry, pkg *schema.Package,
+) {
+	if agent == "" || pkg == nil || pkg.Name == "" || pkg.Version == nil || reg == nil {
 		return
 	}
 	meta, err := registry.ResolvePackageFromName(ctx, reg, pkg.Name, pkg.Version)
@@ -245,8 +246,16 @@ func printRegistryDocsHint(w io.Writer, ctx context.Context, reg registry.Regist
 	}
 	base := fmt.Sprintf("/api/registry/packages/%s/%s/%s/versions/%s",
 		meta.Source, meta.Publisher, meta.Name, pkg.Version.String())
-	fmt.Fprintf(w, "Docs: pulumi cloud api --format=markdown '%s/readme'\n", base)
-	fmt.Fprintln(w, "      (or /nav for the doc tree, /docs/<token> for a specific resource)")
+	hints := []struct{ suffix, comment string }{
+		{"/readme", "                    # package readme"},
+		{"/nav", "                       # doc tree (modules)"},
+		{"/nav?q=<term>&depth=full", "   # search for resources/functions"},
+		{"/docs/<token>", "              # one resource or function (token from /nav)"},
+	}
+	fmt.Fprintln(w, "Documentation:")
+	for _, h := range hints {
+		fmt.Fprintf(w, "  pulumi cloud api --format=markdown '%s%s'%s\n", base, h.suffix, h.comment)
+	}
 }
 
 func schemaDisplayName(schema *schema.Package) string {

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -243,7 +243,7 @@ func TestPrintRegistryDocsHint(t *testing.T) {
 
 	expectedBase := "/api/registry/packages/pulumi/pulumi/random/versions/4.19.1"
 	cmdLine := func(suffix, comment string) string {
-		return "  pulumi cloud api --format=markdown '" + expectedBase + suffix + "'" + comment + "\n"
+		return "  pulumi api --format=markdown '" + expectedBase + suffix + "'" + comment + "\n"
 	}
 	expectedOutput := "Documentation:\n" +
 		cmdLine("/readme", "                    # package readme") +

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -15,11 +15,19 @@
 package packagecmd
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"iter"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -190,6 +198,116 @@ func TestLoadEnclosingTarget(t *testing.T) {
 				}
 			}
 			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestPrintRegistryDocsHint(t *testing.T) {
+	t.Parallel()
+
+	ver := semver.MustParse("4.19.1")
+	pkgFor := func(name string, version *semver.Version) *schema.Package {
+		return &schema.Package{Name: name, Version: version}
+	}
+
+	matchingMeta := apitype.PackageMetadata{
+		Source: "pulumi", Publisher: "pulumi", Name: "random", Version: ver,
+	}
+	resolverFromMatching := func(meta apitype.PackageMetadata) registry.Mock {
+		return registry.Mock{
+			ListPackagesF: func(_ context.Context, _ *string) iter.Seq2[apitype.PackageMetadata, error] {
+				return func(yield func(apitype.PackageMetadata, error) bool) {
+					yield(meta, nil)
+				}
+			},
+			GetPackageF: func(
+				_ context.Context, source, publisher, name string, _ *semver.Version,
+			) (apitype.PackageMetadata, error) {
+				if source == meta.Source && publisher == meta.Publisher && name == meta.Name {
+					return meta, nil
+				}
+				return apitype.PackageMetadata{}, registry.ErrNotFound
+			},
+		}
+	}
+	notFoundResolver := registry.Mock{
+		ListPackagesF: func(_ context.Context, _ *string) iter.Seq2[apitype.PackageMetadata, error] {
+			return func(yield func(apitype.PackageMetadata, error) bool) {}
+		},
+		GetPackageF: func(
+			_ context.Context, _, _, _ string, _ *semver.Version,
+		) (apitype.PackageMetadata, error) {
+			return apitype.PackageMetadata{}, registry.ErrNotFound
+		},
+	}
+
+	expectedBase := "/api/registry/packages/pulumi/pulumi/random/versions/4.19.1"
+	cmdLine := func(suffix, comment string) string {
+		return "  pulumi cloud api --format=markdown '" + expectedBase + suffix + "'" + comment + "\n"
+	}
+	expectedOutput := "Documentation:\n" +
+		cmdLine("/readme", "                    # package readme") +
+		cmdLine("/nav", "                       # doc tree (modules)") +
+		cmdLine("/nav?q=<term>&depth=full", "   # search for resources/functions") +
+		cmdLine("/docs/<token>", "              # one resource or function (token from /nav)")
+
+	tests := []struct {
+		name  string
+		agent string
+		reg   registry.Registry
+		pkg   *schema.Package
+		want  string
+	}{
+		{
+			name:  "agent on, happy path",
+			agent: "claude",
+			reg:   resolverFromMatching(matchingMeta),
+			pkg:   pkgFor("random", &ver),
+			want:  expectedOutput,
+		},
+		{
+			name:  "agent off skips output",
+			agent: "",
+			reg:   resolverFromMatching(matchingMeta),
+			pkg:   pkgFor("random", &ver),
+			want:  "",
+		},
+		{
+			name:  "nil package skips output",
+			agent: "claude",
+			reg:   resolverFromMatching(matchingMeta),
+			pkg:   nil,
+			want:  "",
+		},
+		{
+			name:  "missing version skips output",
+			agent: "claude",
+			reg:   resolverFromMatching(matchingMeta),
+			pkg:   pkgFor("random", nil),
+			want:  "",
+		},
+		{
+			name:  "nil registry skips output",
+			agent: "claude",
+			reg:   nil,
+			pkg:   pkgFor("random", &ver),
+			want:  "",
+		},
+		{
+			name:  "resolver not found skips output",
+			agent: "claude",
+			reg:   notFoundResolver,
+			pkg:   pkgFor("random", &ver),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			printRegistryDocsHint(&buf, tt.agent, t.Context(), tt.reg, tt.pkg)
+			assert.Equal(t, tt.want, buf.String())
 		})
 	}
 }

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -99,6 +99,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 					}
 				}
 				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
+				printRegistryDocsHint(os.Stderr, cmd.Context(), registry, pkg)
 				return nil
 			}
 			diags, err := packages.GenSDK(cmd.Context(), language, out, pkg, overlays, local)
@@ -107,6 +108,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "SDK has been written to %s\n", filepath.Join(out, language))
+			printRegistryDocsHint(os.Stderr, cmd.Context(), registry, pkg)
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -26,6 +26,7 @@ import (
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -52,6 +53,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			` or it must have a PulumiPlugin.yaml file specifying the runtime to use.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			source := args[0]
+			agent := metadata.DetectAIAgent(os.Getenv)
 
 			wd, err := os.Getwd()
 			if err != nil {
@@ -99,7 +101,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 					}
 				}
 				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
-				printRegistryDocsHint(os.Stderr, cmd.Context(), registry, pkg)
+				printRegistryDocsHint(os.Stderr, agent, cmd.Context(), registry, pkg)
 				return nil
 			}
 			diags, err := packages.GenSDK(cmd.Context(), language, out, pkg, overlays, local)
@@ -108,7 +110,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "SDK has been written to %s\n", filepath.Join(out, language))
-			printRegistryDocsHint(os.Stderr, cmd.Context(), registry, pkg)
+			printRegistryDocsHint(os.Stderr, agent, cmd.Context(), registry, pkg)
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary

When invoked by an AI coding agent, `pulumi package add` and `pulumi package gen-sdk` now print a short `pulumi api` block pointing at the package's version-pinned docs:

```
Added package aws
Docs: pulumi api --format=markdown '/api/registry/packages/pulumi/pulumi/aws/versions/6.0.0/readme'
      (or /nav for the doc tree, /docs/<token> for a specific resource)
```

The first line is copy-pasteable; the second annotates the alternate suffixes (doc tree, per-resource docs by token). Source/publisher are resolved via `registry.ResolvePackageFromName` — the same primitive the install flow already uses — so private and community packages get their actual canonical path rather than a hardcoded `pulumi/pulumi`. If the resolver returns `ErrNotFound` (parameterized providers, or names the cloud registry doesn't know about), the hint is skipped silently.

`registry.ErrNotFound` from `package add` is also wrapped with a one-line `pulumi api ?search=<term>` hint when the agent gate is on.

Detection uses the existing `metadata.DetectAIAgent` matrix (Claude Code, Cursor, Codex, Aider, etc.) — promoted from unexported `detectAIAgent` to a public function. Humans see the unchanged success/error output.

Mirrors the strategy in pulumi/docs#18821: the cloud registry API is the canonical, version-aware surface for agents.

Fixes https://github.com/pulumi/pulumi-service/issues/41500

## Test plan

Manually verified against a built binary in a throwaway nodejs project:

- [x] agent + `package add random` → docs block printed with `pulumi/pulumi/random/versions/4.19.1/readme`
- [x] clean env + `package add random` → only "Added package random", no extra output
- [x] agent + `package add this-package-does-not-exist` → search hint after the not-found error
- [x] clean env + `package add this-package-does-not-exist` → unmodified not-found error
- [x] agent + `package gen-sdk random` → docs block follows "SDK has been written"
- [x] `make lint`, `make test_fast` for `pkg/cmd/pulumi/{packagecmd,metadata}`

## Risk

The hint runs `registry.ResolvePackageFromName` once after each successful install — additive HTTP round-trip vs. existing install behavior, no functional change to the install itself. For ambiguous names (e.g., a private package that shadows a public one), the second resolution could in theory land on a different match than the install picked, producing a misleading docs URL. Threading the install's `apitype.PackageMetadata` through to the printing site would close that gap and is a clean follow-up if it matters in practice.