### PR TITLE
Fix PCL binder panic on conditional mixing Promise with try()

### DIFF
--- a/changelog/pending/20260507--programgen-pcl--fix-binder-panic-on-conditional-mixing-promise-and-try.yaml
+++ b/changelog/pending/20260507--programgen-pcl--fix-binder-panic-on-conditional-mixing-promise-and-try.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: programgen/pcl
+  description: Fix PCL binder panic when a conditional mixes a Promise-typed branch with a try() branch

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -110,6 +110,16 @@ func (t *PromiseType) conversionFrom(
 		if src, ok := src.(*PromiseType); ok {
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		}
+		if src, ok := src.(*OutputType); ok {
+			// An Output may carry unknowns or dependencies that a Promise cannot represent,
+			// so converting from output(U) to promise(T) is at best unsafe even when U is
+			// safely convertible to T.
+			kind, why := t.ElementType.conversionFrom(src.ElementType, unifying, seen)
+			if kind == SafeConversion {
+				kind = UnsafeConversion
+			}
+			return kind, why
+		}
 		return t.ElementType.conversionFrom(src, unifying, seen)
 	})
 }
@@ -130,8 +140,8 @@ func (t *PromiseType) unify(other Type) (Type, ConversionKind) {
 			elementType, conversionKind := t.ElementType.unify(other.ElementType)
 			return NewPromiseType(elementType), conversionKind
 		case *OutputType:
-			// If the other type is an output type, prefer the optional type, but unify the element type.
-			elementType, conversionKind := t.unify(other.ElementType)
+			// If the other type is an output type, prefer the output type, but unify the element types.
+			elementType, conversionKind := t.ElementType.unify(other.ElementType)
 			return NewOutputType(elementType), conversionKind
 		default:
 			// Prefer the promise type.

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -110,15 +110,11 @@ func (t *PromiseType) conversionFrom(
 		if src, ok := src.(*PromiseType); ok {
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		}
-		if src, ok := src.(*OutputType); ok {
+		if _, ok := src.(*OutputType); ok {
 			// An Output may carry unknowns or dependencies that a Promise cannot represent,
-			// so converting from output(U) to promise(T) is at best unsafe even when U is
-			// safely convertible to T.
-			kind, why := t.ElementType.conversionFrom(src.ElementType, unifying, seen)
-			if kind == SafeConversion {
-				kind = UnsafeConversion
-			}
-			return kind, why
+			// and there is no SDK-level operation that recovers a Promise from an Output, so
+			// there is no valid conversion from output(U) to promise(T).
+			return NoConversion, func() hcl.Diagnostics { return hcl.Diagnostics{typeNotConvertible(t, src)} }
 		}
 		return t.ElementType.conversionFrom(src, unifying, seen)
 	})

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -1459,6 +1459,22 @@ output "result" {
 	require.Nil(t, program)
 }
 
+// Test binding a conditional whose branches mix a promise-typed value (from an
+// invoke().result) with a try() expression.
+func TestBindConditionalMixingPromiseWithTry(t *testing.T) {
+	t.Parallel()
+	source := `
+config "x" "any" {}
+isOne = invoke("std:index:Abs", {a = 1, b = 1}).result == 1
+a = isOne ? x : null
+b = true ? a : try(x, null)
+`
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	require.NoError(t, err)
+	assert.False(t, diags.HasErrors(), "binding should not panic or error: %v", diags)
+	require.NotNil(t, program)
+}
+
 func TestStackReferenceGetToken(t *testing.T) {
 	t.Parallel()
 	source := `

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -1459,6 +1459,69 @@ output "result" {
 	require.Nil(t, program)
 }
 
+func TestBindInvokePicksOutputForm(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "resource output at property",
+			source: `
+resource "rng" "random:index/randomInteger:RandomInteger" {
+	min = 0
+	max = 100
+}
+result = invoke("std:index:Abs", {a = rng.result, b = 1})
+`,
+		},
+		{
+			name: "resource output mixed with dynamic",
+			source: `
+config "y" "any" {}
+resource "rng" "random:index/randomInteger:RandomInteger" {
+	min = 0
+	max = 100
+}
+result = invoke("std:index:Abs", {a = rng.result, b = y})
+`,
+		},
+		{
+			name: "whole-output args",
+			source: `
+args = secret({a = 1, b = 2})
+result = invoke("std:index:Abs", args)
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			program, diags, err := ParseAndBindProgram(t, tc.source, "program.pp")
+			require.NoError(t, err)
+			require.False(t, diags.HasErrors(), "binding should not error: %v", diags)
+			require.NotNil(t, program)
+
+			var call *model.FunctionCallExpression
+			for _, n := range program.Nodes {
+				lv, ok := n.(*pcl.LocalVariable)
+				if !ok || lv.Name() != "result" {
+					continue
+				}
+				call, _ = lv.Definition.Value.(*model.FunctionCallExpression)
+			}
+			require.NotNil(t, call, "expected 'result' bound to an invoke call")
+			require.GreaterOrEqual(t, len(call.Signature.Parameters), 2)
+			assert.True(t, model.ContainsOutputs(call.Signature.Parameters[1].Type),
+				"args param type should be the Input<T>-shaped output form; got %v",
+				call.Signature.Parameters[1].Type)
+		})
+	}
+}
+
 // Test binding a conditional whose branches mix a promise-typed value (from an
 // invoke().result) with a try() expression.
 func TestBindConditionalMixingPromiseWithTry(t *testing.T) {

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -221,6 +221,7 @@ func (b *binder) signatureForArgs(fn *schema.Function, args model.Expression) (m
 
 // Heuristic to decide when to use `fnOutput` form of a function. Will
 // conservatively prefer `false` unless bind option choose to prefer otherwise.
+//
 // It decides to return `true` if doing so avoids the need to introduce an `apply` form to
 // accommodate `Output` args (`Promise` args do not count).
 func (b *binder) useOutputVersion(fn *schema.Function, args model.Expression) bool {
@@ -242,9 +243,15 @@ func (b *binder) useOutputVersion(fn *schema.Function, args model.Expression) bo
 	regularFormParamType := b.schemaTypeToType(fn.Inputs)
 	argsType := args.Type()
 
+	// If we can't convert to the plain type, but we can convert to the output type, do that.
 	if regularFormParamType.ConversionFrom(argsType) == model.NoConversion &&
-		outputFormParamType.ConversionFrom(argsType) == model.SafeConversion &&
+		outputFormParamType.ConversionFrom(argsType) != model.NoConversion &&
 		model.ContainsOutputs(argsType) {
+		return true
+	}
+
+	// If the args themselves represent an output, we need to use the outputty version.
+	if _, ok := argsType.(*model.OutputType); ok {
 		return true
 	}
 

--- a/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
+++ b/tests/testdata/codegen/invoke-inside-conditional-range-pp/nodejs/invoke-inside-conditional-range.ts
@@ -38,11 +38,11 @@ export = async () => {
             enableDns64: enableIpv6 && publicSubnetEnableDns64,
             enableResourceNameDnsAaaaRecordOnLaunch: enableIpv6 && publicSubnetEnableResourceNameDnsAaaaRecordOnLaunch,
             enableResourceNameDnsARecordOnLaunch: !publicSubnetIpv6Native && publicSubnetEnableResourceNameDnsARecordOnLaunch,
-            ipv6CidrBlock: enableIpv6 && publicSubnetIpv6Prefixes.length > 0 ? currentVpc.ipv6CidrBlock.apply(ipv6CidrBlock => std.cidrsubnetOutput({
-                input: ipv6CidrBlock,
+            ipv6CidrBlock: enableIpv6 && publicSubnetIpv6Prefixes.length > 0 ? std.cidrsubnetOutput({
+                input: currentVpc.ipv6CidrBlock,
                 newbits: 8,
                 netnum: Number(publicSubnetIpv6Prefixes[range.value]),
-            })).apply(invoke => invoke.result) : null,
+            }).apply(invoke => invoke.result) : null,
             ipv6Native: enableIpv6 && publicSubnetIpv6Native,
             vpcId: currentVpc.id,
         }));


### PR DESCRIPTION
Binding a PCL conditional whose branches mixed a promise-typed value (from `invoke(...).result`) with a `try()` expression panicked in `unify` with `conversionKind (1) < conversionFrom (2)`.

The pre-checks in `unify` reported `SafeConversion` in both directions between `promise(union(null, dynamic))` and `output(dynamic)`: the `promise.conversionFrom(output)` path fell through to checking the promise's element type, where the inner `dest == DynamicType -> SafeConversion` shortcut on the `dynamic` element optimistically returned Safe. Converting an Output to a Promise is genuinely unsafe — an Output may carry unknowns or dependencies that a Promise cannot represent — so the closure inside `unify` produced an `UnsafeConversion` result, tripping the assertion.

Two fixes in `pkg/codegen/hcl2/model/type_promise.go`:

  1. `PromiseType.conversionFrom` now has an explicit `*OutputType` case that downgrades a `SafeConversion` from the inner element check to `UnsafeConversion`, mirroring `OutputType`'s explicit `*PromiseType` case.
  2. `PromiseType.unify`'s `*OutputType` case now unifies `t.ElementType` with `other.ElementType` (matching the `*PromiseType` case and `OutputType.unify`'s `*PromiseType` case) instead of unifying the whole promise with the output's element type.

Fixes https://github.com/pulumi/pulumi/issues/22905