### PR TITLE
fix pip flakyness

### DIFF
--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -52,12 +52,6 @@ func RunCommandPulumiHome(
 	env = append(env, "PULUMI_DEBUG_COMMANDS=true")
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
-	// Disable pip's HTTP cache to work around pypa/pip#13979: pip 26.1's upgraded urllib3
-	// advertises zstd encoding, changing the Vary header. Cache entries written by one pip
-	// version (e.g. the system pip upgraded in CI setup) become unreadable by another (e.g.
-	// the venv pip), causing "Cache entry deserialization failed" → "Content-Type: Unknown"
-	// → package resolution failures.
-	env = append(env, "PIP_NO_CACHE_DIR=1")
 	if coverdir := os.Getenv("PULUMI_GOCOVERDIR"); coverdir != "" {
 		env = append(env, "GOCOVERDIR="+coverdir)
 	}

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -52,6 +52,12 @@ func RunCommandPulumiHome(
 	env = append(env, "PULUMI_DEBUG_COMMANDS=true")
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
+	// Disable pip's HTTP cache to work around pypa/pip#13979: pip 26.1's upgraded urllib3
+	// advertises zstd encoding, changing the Vary header. Cache entries written by one pip
+	// version (e.g. the system pip upgraded in CI setup) become unreadable by another (e.g.
+	// the venv pip), causing "Cache entry deserialization failed" → "Content-Type: Unknown"
+	// → package resolution failures.
+	env = append(env, "PIP_NO_CACHE_DIR=1")
 	if coverdir := os.Getenv("PULUMI_GOCOVERDIR"); coverdir != "" {
 		env = append(env, "GOCOVERDIR="+coverdir)
 	}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -733,6 +733,14 @@ func init() {
 
 	mutexPath := filepath.Join(os.TempDir(), "pip-mutex.lock")
 	pipMutex = fsutil.NewFileMutex(mutexPath)
+
+	// Disable pip's HTTP cache to work around pypa/pip#13979: pip 26.1's upgraded urllib3
+	// advertises zstd encoding, changing the Vary header. Cache entries written by one pip
+	// version (e.g. the system pip upgraded in CI setup) become unreadable by another (e.g.
+	// the venv pip), causing "Cache entry deserialization failed" → "Content-Type: Unknown"
+	// → package resolution failures. Setting this process-wide ensures all subprocesses
+	// (including component_setup.sh and language host plugins) inherit it.
+	os.Setenv("PIP_NO_CACHE_DIR", "1")
 }
 
 // GetLogs retrieves the logs for a given stack in a particular region making the query provided.

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1211,17 +1211,16 @@ func (pt *ProgramTester) runPythonCommand(name string, args []string, wd string)
 }
 
 func (pt *ProgramTester) runVirtualEnvCommand(name string, args []string, wd string) error {
-	// When installing with `pip install -e`, a PKG-INFO file is created. If two packages are being installed
-	// this way simultaneously (which happens often, when running tests), both installations will be writing the
-	// same file simultaneously. If one process catches "PKG-INFO" in a half-written state, the one process that
-	// observed the torn write will fail to install the package.
+	// Serialize all pip install operations using pipMutex. This avoids two problems:
+	// 1. When installing with `pip install -e`, a PKG-INFO file is created. Concurrent editable
+	//    installs of the same package can produce torn writes that corrupt the PKG-INFO file.
+	// 2. Concurrent pip installs share the same HTTP cache. Simultaneous writes to the cache can
+	//    corrupt entries (Content-Type: Unknown), causing pip to skip PyPI pages and fail to
+	//    resolve packages like setuptools.
 	//
-	// To avoid this problem, we use pipMutex to explicitly serialize installation operations. Doing so avoids
-	// the problem of multiple processes stomping on the same files in the source tree. Note that pipMutex is a
-	// file mutex, so this strategy works even if the go test runner chooses to split up text execution across
-	// multiple processes. (Furthermore, each test gets an instance of ProgramTester and thus the mutex, so we'd
-	// need to be sharing the mutex globally in each test process if we weren't using the file system to lock.)
-	if name == "virtualenv-pip-install-package" {
+	// pipMutex is a file mutex, so this strategy works even if the go test runner splits test
+	// execution across multiple processes.
+	if strings.HasPrefix(name, "virtualenv-pip-") {
 		if err := pipMutex.Lock(); err != nil {
 			panic(err)
 		}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1211,16 +1211,17 @@ func (pt *ProgramTester) runPythonCommand(name string, args []string, wd string)
 }
 
 func (pt *ProgramTester) runVirtualEnvCommand(name string, args []string, wd string) error {
-	// Serialize all pip install operations using pipMutex. This avoids two problems:
-	// 1. When installing with `pip install -e`, a PKG-INFO file is created. Concurrent editable
-	//    installs of the same package can produce torn writes that corrupt the PKG-INFO file.
-	// 2. Concurrent pip installs share the same HTTP cache. Simultaneous writes to the cache can
-	//    corrupt entries (Content-Type: Unknown), causing pip to skip PyPI pages and fail to
-	//    resolve packages like setuptools.
+	// When installing with `pip install -e`, a PKG-INFO file is created. If two packages are being installed
+	// this way simultaneously (which happens often, when running tests), both installations will be writing the
+	// same file simultaneously. If one process catches "PKG-INFO" in a half-written state, the one process that
+	// observed the torn write will fail to install the package.
 	//
-	// pipMutex is a file mutex, so this strategy works even if the go test runner splits test
-	// execution across multiple processes.
-	if strings.HasPrefix(name, "virtualenv-pip-") {
+	// To avoid this problem, we use pipMutex to explicitly serialize installation operations. Doing so avoids
+	// the problem of multiple processes stomping on the same files in the source tree. Note that pipMutex is a
+	// file mutex, so this strategy works even if the go test runner chooses to split up text execution across
+	// multiple processes. (Furthermore, each test gets an instance of ProgramTester and thus the mutex, so we'd
+	// need to be sharing the mutex globally in each test process if we weren't using the file system to lock.)
+	if name == "virtualenv-pip-install-package" {
 		if err := pipMutex.Lock(); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Another attempt at fixing the pip flakyness we've been seeing recently, and that's one of our major causes of flakes right now.  The approach we (claude) takes here is to just disable the cache globally, which surprisingly doesn't seem to add any additional time to the CI run (still around 36-40min in this PR).  So it's probably worth a try, to see if this solves that flakiness.  

This has survived 6 retries without seeing the usual flakiness, so it might be worth a try. It’s still a little bit of a shot in the dark, but maybe it works.

I don't know if claude is correct with the explanation, but it seems somewhat plausible at least.
