### PR TITLE
mark ci-ok green when only files in the changelog directory changed

### DIFF
--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -12,6 +12,7 @@ on:
     paths-ignore:
       - "**" # Skip all files…
       - "!sdk/.version" # …except if only this file changes and nothing else.
+      - "!changelog/**" # or if only files in this directory changed
 jobs:
   no-op:
     name: Skip CI on .version changes


### PR DESCRIPTION
This shouldn't need a re-run of CI, and since
https://github.com/pulumi/pulumi/pull/22842, we don't run CI on changelog only changes.  So if a PR only changes something in `changelog/` it can never be merged as things are.

This is my bad, as I told @VenelinMartinov we probably don't need this (but I'm now eating my words, as I made https://github.com/pulumi/pulumi/pull/22896 unmergeable :facepalm: )