### PR TITLE
add continue-on-error flag to merge integration test coverage

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -402,6 +402,7 @@ jobs:
           fi
       - name: Merge integration test code coverage
         if: ${{ inputs.enable-coverage }}
+        continue-on-error: true
         run: |
           # Merge coverage data from coverage-instrumented binaries
           # if available.


### PR DESCRIPTION
We've tried to fix this job before, but it's still the top flaky environment issue.  Coverage is nice, but it's less important than our sanity, so let's continue if there are any errors in this step.
