### PR TITLE
print the correct error if cmd in StackOutputs

### DIFF
--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -813,7 +813,7 @@ func (l *LocalWorkspace) StackOutputs(ctx context.Context, stackName string) (Ou
 		"stack", "output", "--json", "--show-secrets", "--stack", stackName,
 	)
 	if err != nil {
-		return nil, newAutoError(fmt.Errorf("could not get secret outputs: %w", err), outStdout, outStderr, code)
+		return nil, newAutoError(fmt.Errorf("could not get secret outputs: %w", err), secretStdout, secretStderr, code)
 	}
 
 	var outputs map[string]any


### PR DESCRIPTION
If the second command in this function fails, we still add the errors for the first one to the error string. This is of course wrong, and prents debugging when things go wrong.

Add the right error outputs to the error, so we avoid this issue.

Noticed while investigating a flake (obviously won't fix the flake).
