### PR TITLE
codegen/pcl: skip options-block property-name attributes in dep walker

### DIFF
--- a/changelog/pending/20260508--codegen-pcl--make-pcl-dep-walker-aware-of-options-block-property-name-attributes.yaml
+++ b/changelog/pending/20260508--codegen-pcl--make-pcl-dep-walker-aware-of-options-block-property-name-attributes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: codegen/pcl
+  description: Stop reporting spurious circular references when an `ignoreChanges`, `hideDiffs`, `replaceOnChanges`, or `additionalSecretOutputs` entry shares a name with a top-level node

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -133,7 +133,7 @@ func (b *binder) bindNode(ctx context.Context, node Node) hcl.Diagnostics {
 func (b *binder) getDependencies(node Node) []Node {
 	depSet := codegen.Set{}
 	var deps []Node
-	diags := hclsyntax.VisitAll(node.SyntaxNode(), func(node hclsyntax.Node) hcl.Diagnostics {
+	visit := func(node hclsyntax.Node) hcl.Diagnostics {
 		var depName string
 		switch node := node.(type) {
 		case *hclsyntax.FunctionCallExpr:
@@ -152,9 +152,59 @@ func (b *binder) getDependencies(node Node) []Node {
 			deps = append(deps, node)
 		}
 		return nil
-	})
-	contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
+	}
+
+	if body := resourceSyntaxBody(node); body != nil {
+		walkResourceBodyForDeps(body, visit)
+	} else {
+		diags := hclsyntax.VisitAll(node.SyntaxNode(), visit)
+		contract.Assertf(len(diags) == 0, "unexpected diagnostics: %v", diags)
+	}
 	return SourceOrderNodes(deps)
+}
+
+func resourceSyntaxBody(node Node) *hclsyntax.Body {
+	switch n := node.(type) {
+	case *Resource:
+		if n.syntax != nil {
+			return n.syntax.Body
+		}
+	case *ReadResource:
+		if n.syntax != nil {
+			return n.syntax.Body
+		}
+	}
+	return nil
+}
+
+// walkResourceBodyForDeps mirrors optionsScopes.GetScopeForAttribute: the four
+// property-name attributes resolve identifiers against the resource's own
+// inputs, not the root scope, so the dep walker must skip them or it will
+// report spurious circular references.
+func walkResourceBodyForDeps(body *hclsyntax.Body, visit hclsyntax.VisitFunc) {
+	for _, attr := range body.Attributes {
+		_ = hclsyntax.VisitAll(attr.Expr, visit)
+	}
+	for _, block := range body.Blocks {
+		if block.Type == "options" {
+			walkOptionsBlockForDeps(block.Body, visit)
+			continue
+		}
+		_ = hclsyntax.VisitAll(block, visit)
+	}
+}
+
+func walkOptionsBlockForDeps(body *hclsyntax.Body, visit hclsyntax.VisitFunc) {
+	for _, attr := range body.Attributes {
+		switch attr.Name {
+		case "ignoreChanges", "hideDiffs", "replaceOnChanges", "additionalSecretOutputs":
+			continue
+		}
+		_ = hclsyntax.VisitAll(attr.Expr, visit)
+	}
+	for _, block := range body.Blocks {
+		_ = hclsyntax.VisitAll(block, visit)
+	}
 }
 
 func expressionIsLiteralNull(expr model.Expression) bool {

--- a/pkg/codegen/pcl/binder_nodes.go
+++ b/pkg/codegen/pcl/binder_nodes.go
@@ -177,7 +177,7 @@ func resourceSyntaxBody(node Node) *hclsyntax.Body {
 	return nil
 }
 
-// walkResourceBodyForDeps mirrors optionsScopes.GetScopeForAttribute: the four
+// walkResourceBodyForDeps mirrors optionsScopes.GetScopeForAttribute: the
 // property-name attributes resolve identifiers against the resource's own
 // inputs, not the root scope, so the dep walker must skip them or it will
 // report spurious circular references.

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -319,6 +319,166 @@ func TestBindReadComponentResourceFails(t *testing.T) {
 	require.Contains(t, diags.Error(), "Component")
 }
 
+func TestBindResourceIgnoreChangesNameCollision(t *testing.T) {
+	t.Parallel()
+
+	pkgSpec := schema.PackageSpec{
+		Name:    "foo",
+		Version: "1.0.0",
+		Provider: schema.ResourceSpec{
+			ObjectTypeSpec: schema.ObjectTypeSpec{Type: "object"},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"foo:index:Foo": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"property": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{"property"},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"property": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				RequiredInputs: []string{"property"},
+			},
+			// Input named "ignoreChanges" so the user-attribute subtest can
+			// exercise the top-level case where the name collides.
+			"foo:index:Bar": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"ignoreChanges": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					Required: []string{"ignoreChanges"},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"ignoreChanges": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				RequiredInputs: []string{"ignoreChanges"},
+			},
+		},
+	}
+	pkg, diags, err := schema.BindSpec(pkgSpec, nil, schema.ValidationOptions{})
+	require.NoError(t, err, "BindSpec failed")
+	require.False(t, diags.HasErrors(), "BindSpec diagnostics: %v", diags.Error())
+
+	tests := []struct {
+		name     string
+		src      string
+		subject  string
+		wantDeps []string
+	}{
+		{
+			name: "ignoreChanges entry shadows the resource's own name",
+			src: `
+resource property "foo:index:Foo" {
+	property = "p"
+	options {
+		ignoreChanges = [property]
+	}
+}`,
+			subject: "property",
+		},
+		{
+			name: "ignoreChanges entry shadows a sibling resource's name",
+			src: `
+resource property "foo:index:Foo" {
+	property = "s"
+}
+resource other "foo:index:Foo" {
+	property = "p"
+	options {
+		ignoreChanges = [property]
+	}
+}`,
+			subject: "other",
+		},
+		{
+			name: "all four shadowing attributes are suppressed",
+			src: `resource property "foo:index:Foo" {
+	property = "p"
+	options {
+		ignoreChanges           = [property]
+		hideDiffs               = [property]
+		replaceOnChanges        = [property]
+		additionalSecretOutputs = [property]
+	}
+}`,
+			subject: "property",
+		},
+		{
+			// Top-level "ignoreChanges" is a user property, not the options
+			// attribute, so its references must still resolve at root scope.
+			name: "user attribute named ignoreChanges still tracks deps",
+			src: `target = "t"
+resource bar "foo:index:Bar" {
+	ignoreChanges = target
+}`,
+			subject:  "bar",
+			wantDeps: []string{"target"},
+		},
+		{
+			// Guards against an over-broad fix that would suppress every
+			// options-block lookup; dependsOn is not a property-name attribute.
+			name: "options.dependsOn still registers root references",
+			src: `resource target "foo:index:Foo" {
+	property = "t"
+}
+resource property "foo:index:Foo" {
+	property = "p"
+	options {
+		dependsOn     = [target]
+		ignoreChanges = [property]
+	}
+}`,
+			subject:  "property",
+			wantDeps: []string{"target"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if t.Failed() {
+					t.Logf("source:\n%s", tt.src)
+				}
+			}()
+
+			parser := syntax.NewParser()
+			require.NoError(t,
+				parser.ParseFile(strings.NewReader(tt.src), "test.pp"),
+				"parse failed")
+
+			prog, bindDiags, err := BindProgram(parser.Files, Loader(&stubSchemaLoader{
+				Package: pkg,
+			}))
+			require.NoError(t, err, "bind returned error")
+			require.Falsef(t, bindDiags.HasErrors(), "bind diagnostics: %v", bindDiags.Error())
+			require.NotNil(t, prog)
+
+			var subject Node
+			for _, n := range prog.Nodes {
+				if n.Name() == tt.subject {
+					subject = n
+					break
+				}
+			}
+			require.NotNilf(t, subject, "no node named %q in program", tt.subject)
+
+			deps := subject.GetDependencies()
+			gotDeps := make([]string, 0, len(deps))
+			for _, d := range deps {
+				gotDeps = append(gotDeps, d.Name())
+			}
+			require.ElementsMatch(t, tt.wantDeps, gotDeps,
+				"unexpected dependency set for %q", subject.Name())
+		})
+	}
+}
+
 type stubSchemaLoader struct {
 	Package *schema.Package
 }

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -396,7 +396,8 @@ resource other "foo:index:Foo" {
 		},
 		{
 			name: "all four shadowing attributes are suppressed",
-			src: `resource property "foo:index:Foo" {
+			src: `
+resource property "foo:index:Foo" {
 	property = "p"
 	options {
 		ignoreChanges           = [property]
@@ -411,7 +412,8 @@ resource other "foo:index:Foo" {
 			// Top-level "ignoreChanges" is a user property, not the options
 			// attribute, so its references must still resolve at root scope.
 			name: "user attribute named ignoreChanges still tracks deps",
-			src: `target = "t"
+			src: `
+target = "t"
 resource bar "foo:index:Bar" {
 	ignoreChanges = target
 }`,
@@ -422,7 +424,8 @@ resource bar "foo:index:Bar" {
 			// Guards against an over-broad fix that would suppress every
 			// options-block lookup; dependsOn is not a property-name attribute.
 			name: "options.dependsOn still registers root references",
-			src: `resource target "foo:index:Foo" {
+			src: `
+resource target "foo:index:Foo" {
 	property = "t"
 }
 resource property "foo:index:Foo" {

--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -110,21 +110,6 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 		loader := &stubSchemaLoader{pkg: pkg}
 		importState := buildImportState(sample)
 
-		if ignoreChangesShadowsBoundName(sample, importState) {
-			// PCL binder bug: getDependencies (pkg/codegen/pcl/binder_nodes.go:133)
-			// walks the AST and resolves every identifier against the program's
-			// root scope, ignoring the per-attribute scope override that
-			// optionsScopes.GetScopeForAttribute installs for `ignoreChanges`
-			// (and friends). When an entry's bare-identifier name happens to
-			// match a top-level node (the resource itself or a snapshot
-			// resource), the walker registers a spurious dependency that
-			// bindNode then reports as "circular reference". Until the binder
-			// is fixed (see TestBindIgnoreChangesNameCollision when restored),
-			// skip cases the rapid generator constructs but a hand-written
-			// program would never produce.
-			t.Skip("ignoreChanges entry shadows a bound node name; PCL dep walker reports a spurious cycle")
-		}
-
 		block, _, err := GenerateHCL2Definition(loader, sample.State, importState)
 		require.NoError(t, err)
 
@@ -204,27 +189,6 @@ func renderInputs(t require.TestingT, r *pcl.Resource) resource.PropertyMap {
 func hasSelectableResource(pkg *schema.Package) bool {
 	for _, r := range pkg.Resources {
 		if !r.IsProvider && !r.IsComponent {
-			return true
-		}
-	}
-	return false
-}
-
-// ignoreChangesShadowsBoundName reports whether any entry in
-// state.IgnoreChanges names a top-level bound node — either the state's own
-// resource or any snapshot resource that lives in the names table. Such
-// names are exactly the ones the PCL dep walker would resolve in the root
-// scope and turn into a spurious dependency edge.
-func ignoreChangesShadowsBoundName(sample *rapidimporter.Sample, importState ImportState) bool {
-	if len(sample.State.IgnoreChanges) == 0 {
-		return false
-	}
-	bound := map[string]bool{sample.State.URN.Name(): true}
-	for _, n := range importState.Names {
-		bound[n] = true
-	}
-	for _, c := range sample.State.IgnoreChanges {
-		if bound[c] {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- The PCL binder's `getDependencies` (`pkg/codegen/pcl/binder_nodes.go`) walked the entire resource AST and resolved every identifier against the program root scope, ignoring the per-attribute scope override that `optionsScopes.GetScopeForAttribute` installs for `ignoreChanges`, `hideDiffs`, `replaceOnChanges`, and `additionalSecretOutputs`. When an entry's bare-identifier name matched a top-level node, the walker registered a spurious dependency that `bindNode` then reported as a "circular reference".
- Make the dep walker resource-shape aware: for `*Resource` and `*ReadResource` nodes, skip the four property-name attributes inside an `options` block. Top-level user attributes named `ignoreChanges` (etc.) are still walked normally, as are `options.dependsOn` and the other options-block attributes.
- Removes the corresponding skip in `TestRapidGenerateHCL2Definition`, which had been catching this bug at high probability.

## Test plan

- [x] New `TestBindResourceIgnoreChangesNameCollision` in `pkg/codegen/pcl/binder_resource_test.go` covers self-shadowing, sibling-shadowing, all four shadowing attributes, a top-level user attribute named `ignoreChanges` (must still register deps), and `options.dependsOn` (must still register deps).
- [x] Verified the new test fails 4/5 with the fix reverted.
- [x] `go test ./codegen/pcl/...` (full pcl suite) passes.
- [x] `go test -run TestRapidGenerateHCL2Definition ./importer/ -args -rapid.checks=2000` passes.