### PR TITLE
Use `uv` for most python integration tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2447,6 +2447,8 @@ func (pt *ProgramTester) preparePythonProject(projinfo *engine.Projinfo) error {
 		if err = pt.preparePythonProjectWithPipenv(cwd); err != nil {
 			return err
 		}
+	} else if pythonToolchainIsUv(projinfo) {
+		return pt.preparePythonProjectWithUv(projinfo, cwd)
 	} else {
 		venvPath := "venv"
 		if cwd != projinfo.Root {
@@ -2490,6 +2492,55 @@ func (pt *ProgramTester) preparePythonProject(projinfo *engine.Projinfo) error {
 		}
 	}
 
+	return nil
+}
+
+func pythonToolchainIsUv(projinfo *engine.Projinfo) bool {
+	if projinfo == nil || projinfo.Proj == nil || projinfo.Proj.Runtime.Options() == nil {
+		return false
+	}
+	tc, _ := projinfo.Proj.Runtime.Options()["toolchain"].(string)
+	return tc == "uv"
+}
+
+// preparePythonProjectWithUv prepares a Python project that declares `toolchain: uv` in its Pulumi.yaml.
+// It runs `uv sync` against the fixture's pyproject.toml to create a `.venv` and a `uv.lock`, then
+// editable-installs any `Dependencies` (typically the local sdk/python) on top.
+func (pt *ProgramTester) preparePythonProjectWithUv(projinfo *engine.Projinfo, cwd string) error {
+	venvDir := ".venv"
+	venvPath := filepath.Join(cwd, venvDir)
+
+	syncArgs := []string{"uv", "sync"}
+	if pt.opts.InstallDevReleases {
+		syncArgs = append(syncArgs, "--prerelease=allow")
+	}
+	if err := pt.runCommand("uv-sync", syncArgs, cwd); err != nil {
+		return err
+	}
+
+	pt.opts.virtualEnvDir = venvDir
+	projinfo.Proj.Runtime.SetOption("virtualenv", venvPath)
+	projfile := filepath.Join(projinfo.Root, workspace.ProjectFile+".yaml")
+	if err := projinfo.Proj.Save(projfile); err != nil {
+		return fmt.Errorf("saving project: %w", err)
+	}
+
+	if pt.opts.RunUpdateTest {
+		return nil
+	}
+
+	for _, dep := range pt.opts.Dependencies {
+		if !filepath.IsAbs(dep) {
+			abs, err := filepath.Abs(dep)
+			if err != nil {
+				return err
+			}
+			dep = abs
+		}
+		if err := pt.runCommand("uv-add", []string{"uv", "add", "--editable", dep}, cwd); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -897,6 +897,7 @@ type ProgramTester struct {
 	goBin          string              // the `go` binary we are using.
 	pythonBin      string              // the `python` binary we are using.
 	pipenvBin      string              // The `pipenv` binary we are using.
+	uvBin          string              // the `uv` binary we are using.
 	dotNetBin      string              // the `dotnet` binary we are using.
 	updateEventLog string              // The path to the engine event log for `pulumi up` in this test.
 	maxStepTries   int                 // The maximum number of times to retry a failed pulumi step.
@@ -986,6 +987,11 @@ func (pt *ProgramTester) getPythonBin() (string, error) {
 // getPipenvBin returns a path to the currently-installed Pipenv tool, or an error if the tool could not be found.
 func (pt *ProgramTester) getPipenvBin() (string, error) {
 	return getCmdBin(&pt.pipenvBin, "pipenv", pt.opts.PipenvBin)
+}
+
+// getUvBin returns a path to the currently-installed `uv` tool, or an error if the tool could not be found.
+func (pt *ProgramTester) getUvBin() (string, error) {
+	return getCmdBin(&pt.uvBin, "uv", "")
 }
 
 func (pt *ProgramTester) getDotNetBin() (string, error) {
@@ -2507,10 +2513,15 @@ func pythonToolchainIsUv(projinfo *engine.Projinfo) bool {
 // It runs `uv sync` against the fixture's pyproject.toml to create a `.venv` and a `uv.lock`, then
 // editable-installs any `Dependencies` (typically the local sdk/python) on top.
 func (pt *ProgramTester) preparePythonProjectWithUv(projinfo *engine.Projinfo, cwd string) error {
+	uvBin, err := pt.getUvBin()
+	if err != nil {
+		return err
+	}
+
 	venvDir := ".venv"
 	venvPath := filepath.Join(cwd, venvDir)
 
-	syncArgs := []string{"uv", "sync"}
+	syncArgs := []string{uvBin, "sync"}
 	if pt.opts.InstallDevReleases {
 		syncArgs = append(syncArgs, "--prerelease=allow")
 	}
@@ -2537,7 +2548,7 @@ func (pt *ProgramTester) preparePythonProjectWithUv(projinfo *engine.Projinfo, c
 			}
 			dep = abs
 		}
-		if err := pt.runCommand("uv-add", []string{"uv", "add", "--editable", dep}, cwd); err != nil {
+		if err := pt.runCommand("uv-add", []string{uvBin, "add", "--editable", dep}, cwd); err != nil {
 			return err
 		}
 	}

--- a/sdk/python/toolchain/uv.go
+++ b/sdk/python/toolchain/uv.go
@@ -270,6 +270,12 @@ func (u *uv) LinkPackages(ctx context.Context, packages map[string]string) error
 func (u *uv) EnsureVenv(ctx context.Context, cwd string, useLanguageVersionTools, showOutput bool,
 	infoWriter, errorWriter io.Writer,
 ) error {
+	// Skip if the venv already exists. `uv venv --allow-existing` re-copies the launcher into `python.exe`, and on
+	// Windows that can fail with a file-lock error if any earlier process still holds the existing python.exe (e.g.
+	// recursive plugin installs that run multiple uv operations against the same venv).
+	if IsVirtualEnv(u.virtualenvPath) {
+		return nil
+	}
 	venvCmd := u.uvCommand(ctx, cwd, showOutput, infoWriter, errorWriter, "venv", "--quiet",
 		"--allow-existing", u.virtualenvPath)
 	if err := venvCmd.Run(); err != nil {

--- a/tests/integration/aliases/python/adopt_component_child/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/adopt_component_child/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_adopt_component_child
 description: A program that adopts a component child with an alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/adopt_component_child/step1/pyproject.toml
+++ b/tests/integration/aliases/python/adopt_component_child/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_adopt_component_child"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/adopt_into_component/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/adopt_into_component/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_adopt_into_component
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/adopt_into_component/step1/pyproject.toml
+++ b/tests/integration/aliases/python/adopt_into_component/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_adopt_into_component"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/Pulumi.yaml
@@ -1,2 +1,5 @@
 name: alias_after_failed_update
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/alias_after_failed_update/step1/pyproject.toml
+++ b/tests/integration/aliases/python/alias_after_failed_update/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "alias_after_failed_update"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/extract_component_child/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/extract_component_child/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_extract_component_child
 description: A program that extracts a component child with an alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/extract_component_child/step1/pyproject.toml
+++ b/tests/integration/aliases/python/extract_component_child/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_extract_component_child"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/rename/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/rename/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_rename
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/rename/step1/pyproject.toml
+++ b/tests/integration/aliases/python/rename/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_rename"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/rename_component/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/rename_component/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_rename_component
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/rename_component/step1/pyproject.toml
+++ b/tests/integration/aliases/python/rename_component/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_rename_component"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/rename_component_and_child/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/rename_component_and_child/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_rename_component_and_child
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/rename_component_and_child/step1/pyproject.toml
+++ b/tests/integration/aliases/python/rename_component_and_child/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_rename_component_and_child"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/rename_component_child/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/rename_component_child/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_rename_component_child
 description: A program that renames a component child with an alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/rename_component_child/step1/pyproject.toml
+++ b/tests/integration/aliases/python/rename_component_child/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_rename_component_child"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/retype_component/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/retype_component/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_retype_component
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/retype_component/step1/pyproject.toml
+++ b/tests/integration/aliases/python/retype_component/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_retype_component"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/retype_component_child/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/retype_component_child/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_retype_component_child
 description: A program that retypes a component child with an alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/retype_component_child/step1/pyproject.toml
+++ b/tests/integration/aliases/python/retype_component_child/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_retype_component_child"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/aliases/python/retype_parents/step1/Pulumi.yaml
+++ b/tests/integration/aliases/python/retype_parents/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aliases_retype_component
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/aliases/python/retype_parents/step1/pyproject.toml
+++ b/tests/integration/aliases/python/retype_parents/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "aliases_retype_component"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/call_component_failures/python/Pulumi.yaml
+++ b/tests/integration/call_component_failures/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_failures_py
 description: A program that constructs remote component resources with a constructor that returns an error.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/call_component_failures/python/pyproject.toml
+++ b/tests/integration/call_component_failures/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_failures_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/call_component_failures/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/call_component_failures/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/cancel/Pulumi.yaml
+++ b/tests/integration/cancel/Pulumi.yaml
@@ -3,4 +3,4 @@ description: A simple Python Pulumi program that sleeps for 30 seconds so we can
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv

--- a/tests/integration/cancel/pyproject.toml
+++ b/tests/integration/cancel/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "cancel"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
@@ -1,4 +1,1 @@
-runtime:
-  name: python
-  options:
-    toolchain: uv
+runtime: python

--- a/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/bootstrap-less/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/component-provider-host/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/component-provider-host/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/component-provider-host/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/component-provider-host/provider/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/component_provider/python/exception/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/exception/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/exception/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/exception/provider/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/component_provider/python/features/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/features/provider/PulumiPlugin.yaml
@@ -1,4 +1,1 @@
-runtime:
-  name: python
-  options:
-    toolchain: uv
+runtime: python

--- a/tests/integration/component_provider/python/features/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/features/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
@@ -1,4 +1,1 @@
-runtime:
-  name: python
-  options:
-    toolchain: uv
+runtime: python

--- a/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/package/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/recursive-types/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/recursive-types/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/recursive-types/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/recursive-types/provider/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/component_provider/python/resource-ref/provider/PulumiPlugin.yaml
+++ b/tests/integration/component_provider/python/resource-ref/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/component_provider/python/resource-ref/provider/pyproject.toml
+++ b/tests/integration/component_provider/python/resource-ref/provider/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = [
+    "pulumi-command==1.0.4",
+]

--- a/tests/integration/component_provider_schema/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/component_provider_schema/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/config_basic/python/Pulumi.yaml
+++ b/tests/integration/config_basic/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: config_basic_py
 description: A simple Python program that uses configuration.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/config_basic/python/pyproject.toml
+++ b/tests/integration/config_basic/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "config_basic_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/config_missing/python/Pulumi.yaml
+++ b/tests/integration/config_missing/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: config_missing_py
 description: A simple Python program that errors on missing configuration.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/config_missing/python/pyproject.toml
+++ b/tests/integration/config_missing/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "config_missing_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/config_secrets_warn/python/Pulumi.yaml
+++ b/tests/integration/config_secrets_warn/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: config_secrets_python
 description: A simple Python program that uses configuration secrets.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/config_secrets_warn/python/pyproject.toml
+++ b/tests/integration/config_secrets_warn/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "config_secrets_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component/python/Pulumi.yaml
+++ b/tests/integration/construct_component/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_py
 description: A program that constructs remote component resources.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component/python/pyproject.toml
+++ b/tests/integration/construct_component/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_failures/python/Pulumi.yaml
+++ b/tests/integration/construct_component_failures/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_failures_py
 description: A program that constructs remote component resources with a constructor that returns an error.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_failures/python/pyproject.toml
+++ b/tests/integration/construct_component_failures/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_failures_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_failures/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_failures/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_id_output/python/Pulumi.yaml
+++ b/tests/integration/construct_component_id_output/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_py
 description: A program that constructs remote component resources.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_id_output/python/pyproject.toml
+++ b/tests/integration/construct_component_id_output/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_methods_py
 description: A program that constructs remote component resources with methods.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_methods/python/pyproject.toml
+++ b/tests/integration/construct_component_methods/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_methods_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_methods/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_methods_errors/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_errors/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_methods_errors_py
 description: A program that constructs remote component resources with a method that returns an error.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_methods_errors/python/pyproject.toml
+++ b/tests/integration/construct_component_methods_errors/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_methods_errors_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods_errors/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_methods_errors/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_methods_provider/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_provider/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_methods_provider_py
 description: A program that constructs remote component resources with methods and an explicit provider set for another package.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_methods_provider/python/pyproject.toml
+++ b/tests/integration/construct_component_methods_provider/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_methods_provider_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods_provider/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_methods_provider/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_methods_resources/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_resources/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_methods_resources_py
 description: A program that constructs remote component resources with methods that create resources.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component_methods_resources/python/pyproject.toml
+++ b/tests/integration/construct_component_methods_resources/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_methods_resources_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods_resources/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_methods_resources/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_methods_unknown/python/Pulumi.yaml
+++ b/tests/integration/construct_component_methods_unknown/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_methods_unknown_py
 description: A program that constructs remote component resources with methods and unknowns.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component_methods_unknown/python/pyproject.toml
+++ b/tests/integration/construct_component_methods_unknown/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_methods_unknown_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_methods_unknown/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_methods_unknown/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_output_values/python/Pulumi.yaml
+++ b/tests/integration/construct_component_output_values/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_output_values_py
 description: A program that constructs remote component resources with output values.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_output_values/python/pyproject.toml
+++ b/tests/integration/construct_component_output_values/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_output_values_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_output_values/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_output_values/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_plain/python/Pulumi.yaml
+++ b/tests/integration/construct_component_plain/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_plain_py
 description: A program that constructs a remote component resource with prompt inputs.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component_plain/python/pyproject.toml
+++ b/tests/integration/construct_component_plain/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_plain_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_plain/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_plain/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_provider/python/Pulumi.yaml
+++ b/tests/integration/construct_component_provider/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_provider_py
 description: A program that constructs remote component resources with first class provider.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_provider/python/pyproject.toml
+++ b/tests/integration/construct_component_provider/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_provider_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_provider/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_provider/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/construct_component_provider_explicit/python/Pulumi.yaml
+++ b/tests/integration/construct_component_provider_explicit/python/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: construct_component_provider_py
 description: A program that constructs remote component resources with first class provider.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 config:
   pulumi:disable-default-providers: ["*"]

--- a/tests/integration/construct_component_provider_explicit/python/pyproject.toml
+++ b/tests/integration/construct_component_provider_explicit/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_provider_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_provider_propagation/python/Pulumi.yaml
+++ b/tests/integration/construct_component_provider_propagation/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_provider_propagation_py
 description: A program that constructs remote component resources with first class provider.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component_provider_propagation/python/pyproject.toml
+++ b/tests/integration/construct_component_provider_propagation/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_provider_propagation_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_slow/python/Pulumi.yaml
+++ b/tests/integration/construct_component_slow/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: construct_component_slow_py
 description: A program that constructs a remote component resource with a child resource that takes a long time to be created.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/construct_component_slow/python/pyproject.toml
+++ b/tests/integration/construct_component_slow/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_slow_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_unknown/python/Pulumi.yaml
+++ b/tests/integration/construct_component_unknown/python/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: construct_component_unknown_py
 description: A program that constructs remote component resources with unknowns during preview.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 plugins:
   providers:
     - name: testprovider

--- a/tests/integration/construct_component_unknown/python/pyproject.toml
+++ b/tests/integration/construct_component_unknown/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "construct_component_unknown_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/construct_component_unknown/testcomponent-python/PulumiPlugin.yaml
+++ b/tests/integration/construct_component_unknown/testcomponent-python/PulumiPlugin.yaml
@@ -1,4 +1,5 @@
 runtime:
   name: python
   options:
+    toolchain: uv
     virtualenv: venv

--- a/tests/integration/custom_timeouts/python/failure/Pulumi.yaml
+++ b/tests/integration/custom_timeouts/python/failure/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: custom_timeouts
 description: A program that instantiates a resource with a custom timeout
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/custom_timeouts/python/failure/pyproject.toml
+++ b/tests/integration/custom_timeouts/python/failure/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "custom_timeouts"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/custom_timeouts/python/success/Pulumi.yaml
+++ b/tests/integration/custom_timeouts/python/success/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: custom_timeouts
 description: A program that instantiates a resource with a custom timeout
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/custom_timeouts/python/success/pyproject.toml
+++ b/tests/integration/custom_timeouts/python/success/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "custom_timeouts"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/debug-plugin/python-plugin/PulumiPlugin.yaml
+++ b/tests/integration/debug-plugin/python-plugin/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/debug-plugin/python-plugin/pyproject.toml
+++ b/tests/integration/debug-plugin/python-plugin/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "python-plugin"
+version = "0.0.0"
+dependencies = [
+    "pulumi>=3.159.0,<4.0.0",
+]

--- a/tests/integration/deleted_with/python/Pulumi.yaml
+++ b/tests/integration/deleted_with/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: deleted_with_py
 description: A program that uses the DeletedWith resource option
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/deleted_with/python/pyproject.toml
+++ b/tests/integration/deleted_with/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "deleted_with_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-config-separate-module/Pulumi.yaml
+++ b/tests/integration/dynamic/python-config-separate-module/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic-provider-config-main-py
 description: test for dynamic provider configuration in a separate module from __main__
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-config-separate-module/pyproject.toml
+++ b/tests/integration/dynamic/python-config-separate-module/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic-provider-config-main-py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-config/Pulumi.yaml
+++ b/tests/integration/dynamic/python-config/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic-provider-config-main-py
 description: test for dynamic provider configuration within __main__
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-config/pyproject.toml
+++ b/tests/integration/dynamic/python-config/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic-provider-config-main-py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-disable-serialization-as-secret/Pulumi.yaml
+++ b/tests/integration/dynamic/python-disable-serialization-as-secret/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic_py_disable_serialization_as_secret
 description: A simple Python program that uses dynamic providers with serialization as secret disabled.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-disable-serialization-as-secret/pyproject.toml
+++ b/tests/integration/dynamic/python-disable-serialization-as-secret/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic_py_disable_serialization_as_secret"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-read-inputs/Pulumi.yaml
+++ b/tests/integration/dynamic/python-read-inputs/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic_python_read_inputs
 description: Tests that dynamic providers can return inputs from read() for accurate diffs after refresh.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-read-inputs/pyproject.toml
+++ b/tests/integration/dynamic/python-read-inputs/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic_python_read_inputs"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-resource-type-name/Pulumi.yaml
+++ b/tests/integration/dynamic/python-resource-type-name/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic_resource_type_name_py
 description: A simple Python program that uses dynamic providers with custom resource type name.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-resource-type-name/pyproject.toml
+++ b/tests/integration/dynamic/python-resource-type-name/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic_resource_type_name_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python-secrets/Pulumi.yaml
+++ b/tests/integration/dynamic/python-secrets/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic-provider-secret-py
 description: test for dynamic provider secret capture
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python-secrets/pyproject.toml
+++ b/tests/integration/dynamic/python-secrets/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic-provider-secret-py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/dynamic/python/Pulumi.yaml
+++ b/tests/integration/dynamic/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic_py
 description: A simple Python program that uses dynamic providers.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/dynamic/python/pyproject.toml
+++ b/tests/integration/dynamic/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/empty/python/Pulumi.yaml
+++ b/tests/integration/empty/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: emptypy
 description: An empty Python Pulumi program.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/empty/python/pyproject.toml
+++ b/tests/integration/empty/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "emptypy"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/enums/python/Pulumi.yaml
+++ b/tests/integration/enums/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: enum_outputs_python
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: Enum outputs in python

--- a/tests/integration/enums/python/pyproject.toml
+++ b/tests/integration/enums/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "enum_outputs_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/error_hooks/python/Pulumi.yaml
+++ b/tests/integration/error_hooks/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: error_hooks_python
 description: A program with error hooks
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/error_hooks/python/pyproject.toml
+++ b/tests/integration/error_hooks/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "error_hooks_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/gather_plugin/python/Pulumi.yaml
+++ b/tests/integration/gather_plugin/python/Pulumi.yaml
@@ -2,7 +2,7 @@ name: test-provider-url-python
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
 description: A minimal Python Pulumi program
 plugins:
   providers:

--- a/tests/integration/gather_plugin/python/pyproject.toml
+++ b/tests/integration/gather_plugin/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "test-provider-url-python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/get_resource/python/Pulumi.yaml
+++ b/tests/integration/get_resource/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: get_resource
 description: A simple Python program that gets an existing resource from the engine.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/get_resource/python/pyproject.toml
+++ b/tests/integration/get_resource/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "get_resource"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2510,6 +2510,17 @@ func installPythonProviderDependencies(t *testing.T, dir string) {
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "`%s` in %s failed with output: %s", cmd.String(), cmd.Dir, string(out))
 
+	coreSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk", "python"))
+	require.NoError(t, err)
+
+	if isUvPythonProject(dir) {
+		cmd := exec.Command("uv", "add", "--editable", coreSDK)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "`uv add --editable %s` in %s failed: %s", coreSDK, dir, string(out))
+		return
+	}
+
 	// Install the local development SDK
 	tc, err := toolchain.ResolveToolchain(toolchain.PythonOptions{
 		Root:       dir,
@@ -2518,12 +2529,22 @@ func installPythonProviderDependencies(t *testing.T, dir string) {
 	})
 	require.NoError(t, err)
 
-	coreSDK, err := filepath.Abs(filepath.Join("..", "..", "sdk", "python"))
-	require.NoError(t, err)
 	cmd, err = tc.ModuleCommand(t.Context(), "pip", "install", coreSDK)
 	require.NoError(t, err)
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, "output: %s", out)
+}
+
+// isUvPythonProject reports whether the Pulumi project at dir declares `toolchain: uv`.
+func isUvPythonProject(dir string) bool {
+	pattern := regexp.MustCompile(`(?m)^\s+toolchain:\s*uv\s*$`)
+	for _, fname := range []string{"PulumiPlugin.yaml", "Pulumi.yaml"} {
+		data, err := os.ReadFile(filepath.Join(dir, fname))
+		if err == nil && pattern.Match(data) {
+			return true
+		}
+	}
+	return false
 }
 
 // Regression test for https://github.com/pulumi/pulumi/issues/18768

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1342,7 +1342,6 @@ func TestPolicyPackInstallDependencies(t *testing.T) {
 	e.ImportDirectory("policy/python_policy_pack")
 	require.False(t, e.PathExists("venv"))
 	stdout, _ := e.RunCommand("pulumi", "install")
-	require.Contains(t, stdout, "Finished creating virtual environment")
 	require.Contains(t, stdout, "Finished installing dependencies")
 	require.True(t, e.PathExists("venv"))
 }

--- a/tests/integration/interrupt/provider/PulumiPlugin.yaml
+++ b/tests/integration/interrupt/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/interrupt/provider/pyproject.toml
+++ b/tests/integration/interrupt/provider/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/large_resource/python/Pulumi.yaml
+++ b/tests/integration/large_resource/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: large_resource_python
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program with a >4mb string resource

--- a/tests/integration/large_resource/python/pyproject.toml
+++ b/tests/integration/large_resource/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "large_resource_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/log_debug/python/Pulumi.yaml
+++ b/tests/integration/log_debug/python/Pulumi.yaml
@@ -1,2 +1,5 @@
 name: log_debug_py
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/log_debug/python/pyproject.toml
+++ b/tests/integration/log_debug/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "log_debug_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/new/python/random/Pulumi.yaml
+++ b/tests/integration/new/python/random/Pulumi.yaml
@@ -1,6 +1,3 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime:
-  name: python
-  options:
-    toolchain: uv
+runtime: python

--- a/tests/integration/new/python/random/Pulumi.yaml
+++ b/tests/integration/new/python/random/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: ${PROJECT}
 description: ${DESCRIPTION}
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/new/python/random/pyproject.toml
+++ b/tests/integration/new/python/random/pyproject.toml
@@ -1,7 +1,0 @@
-[project]
-name = "PROJECT"
-version = "0.0.0"
-dependencies = [
-    "pulumi>=3.0.0,<4.0.0",
-    "pulumi-random>=4.0.0,<5.0.0",
-]

--- a/tests/integration/new/python/random/pyproject.toml
+++ b/tests/integration/new/python/random/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "PROJECT"
+version = "0.0.0"
+dependencies = [
+    "pulumi>=3.0.0,<4.0.0",
+    "pulumi-random>=4.0.0,<5.0.0",
+]

--- a/tests/integration/otel_traces/python/Pulumi.yaml
+++ b/tests/integration/otel_traces/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: otel-traces-python
 description: A simple program to test OTEL tracing
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/otel_traces/python/pyproject.toml
+++ b/tests/integration/otel_traces/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "otel-traces-python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/packages-install-recursive/python-provider/PulumiPlugin.yaml
+++ b/tests/integration/packages-install-recursive/python-provider/PulumiPlugin.yaml
@@ -2,6 +2,6 @@ name: python-provider
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
 packages:
   typescript-a: ../ts-provider-a

--- a/tests/integration/packages-install-recursive/python-provider/pyproject.toml
+++ b/tests/integration/packages-install-recursive/python-provider/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "python-provider"
+version = "0.0.0"
+dependencies = [
+    "pulumi>=3.0.0,<4.0.0",
+    "pulumi_random==4.18.4",
+]

--- a/tests/integration/partial_values/python/Pulumi.yaml
+++ b/tests/integration/partial_values/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: dynamic_py
 description: A simple Python program that uses dynamic providers.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/partial_values/python/pyproject.toml
+++ b/tests/integration/partial_values/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/policy/python_policy_pack/PulumiPolicy.yaml
+++ b/tests/integration/policy/python_policy_pack/PulumiPolicy.yaml
@@ -2,5 +2,6 @@ runtime:
   name: python
   options:
     toolchain: uv
+    virtualenv: venv
 version: 0.0.1
 description: A policy that does nothing

--- a/tests/integration/policy/python_policy_pack/PulumiPolicy.yaml
+++ b/tests/integration/policy/python_policy_pack/PulumiPolicy.yaml
@@ -1,6 +1,6 @@
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
 version: 0.0.1
 description: A policy that does nothing

--- a/tests/integration/policy/python_policy_pack/pyproject.toml
+++ b/tests/integration/policy/python_policy_pack/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "python_policy_pack"
+version = "0.0.0"
+dependencies = [
+    "pulumi-policy>=1.3.0,<2.0.0",
+]

--- a/tests/integration/printf/python/Pulumi.yaml
+++ b/tests/integration/printf/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: printfpy
 description: A Pulumi program that printfs some stuff.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/printf/python/pyproject.toml
+++ b/tests/integration/printf/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "printfpy"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/program_error/python/step1/Pulumi.yaml
+++ b/tests/integration/program_error/python/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: program-error-python
 description: A program that throws an error
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/program_error/python/step1/pyproject.toml
+++ b/tests/integration/program_error/python/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "program-error-python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/config-getter-types/Pulumi.yaml
+++ b/tests/integration/python/config-getter-types/Pulumi.yaml
@@ -3,5 +3,5 @@ description: A simple Python Pulumi program that type checks with pyright.
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
     typechecker: pyright

--- a/tests/integration/python/config-getter-types/Pulumi.yaml
+++ b/tests/integration/python/config-getter-types/Pulumi.yaml
@@ -3,5 +3,5 @@ description: A simple Python Pulumi program that type checks with pyright.
 runtime:
   name: python
   options:
-    toolchain: uv
+    virtualenv: venv
     typechecker: pyright

--- a/tests/integration/python/config-getter-types/pyproject.toml
+++ b/tests/integration/python/config-getter-types/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pulumi-python-pyright"
+version = "0.0.0"
+dependencies = [
+    "pyright",
+]

--- a/tests/integration/python/config-getter-types/pyproject.toml
+++ b/tests/integration/python/config-getter-types/pyproject.toml
@@ -1,6 +1,0 @@
-[project]
-name = "pulumi-python-pyright"
-version = "0.0.0"
-dependencies = [
-    "pyright",
-]

--- a/tests/integration/python/duplicate-output/Pulumi.yaml
+++ b/tests/integration/python/duplicate-output/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-duplicate-output
 description: A Python program that tests returning the same output twice.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/duplicate-output/pyproject.toml
+++ b/tests/integration/python/duplicate-output/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-duplicate-output"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/dynamic-provider/uv/pyproject.toml
+++ b/tests/integration/python/dynamic-provider/uv/pyproject.toml
@@ -1,4 +1,0 @@
-[project]
-name = "dynamic-provider-uv"
-version = "0.0.0"
-dependencies = []

--- a/tests/integration/python/dynamic-provider/uv/pyproject.toml
+++ b/tests/integration/python/dynamic-provider/uv/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "dynamic-provider-uv"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/implicit-dependency-cycles/Pulumi.yaml
+++ b/tests/integration/python/implicit-dependency-cycles/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: complex_implicit_parent_child_dependencies
 description: A Python program that errors out due to implicitly created dependency cycles
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/implicit-dependency-cycles/pyproject.toml
+++ b/tests/integration/python/implicit-dependency-cycles/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "complex_implicit_parent_child_dependencies"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/missing-main/Pulumi.yaml
+++ b/tests/integration/python/missing-main/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-venv
 description: A simple Python Pulumi program that needs a venv to run.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/missing-main/pyproject.toml
+++ b/tests/integration/python/missing-main/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-venv"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/mypy/Pulumi.yaml
+++ b/tests/integration/python/mypy/Pulumi.yaml
@@ -3,5 +3,5 @@ description: A simple Python Pulumi program that type checks with mypy.
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
     typechecker: mypy

--- a/tests/integration/python/mypy/pyproject.toml
+++ b/tests/integration/python/mypy/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "pulumi-python-mypy"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+    "mypy",
+]

--- a/tests/integration/python/organization/Pulumi.yaml
+++ b/tests/integration/python/organization/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-organization
 description: A simple Python Pulumi program that expects the organization to be set
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/organization/pyproject.toml
+++ b/tests/integration/python/organization/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pulumi-python-organization"
+version = "0.0.0"
+dependencies = [
+    "pulumi==3.152.0",
+]

--- a/tests/integration/python/parameterized/Pulumi.yaml
+++ b/tests/integration/python/parameterized/Pulumi.yaml
@@ -1,5 +1,5 @@
-name: parameterized 
+name: parameterized
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv

--- a/tests/integration/python/parameterized/pyproject.toml
+++ b/tests/integration/python/parameterized/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "parameterized"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/python/parameterized/pyproject.toml
+++ b/tests/integration/python/parameterized/pyproject.toml
@@ -3,4 +3,8 @@ name = "parameterized"
 version = "0.0.0"
 dependencies = [
     "pulumi",
+    "pulumi-pkg",
 ]
+
+[tool.uv.sources]
+pulumi-pkg = { path = "./sdk/python", editable = true }

--- a/tests/integration/python/pylint/Pulumi.yaml
+++ b/tests/integration/python/pylint/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pylint
 description: A simple Python program that should be pylint clean.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/pylint/pyproject.toml
+++ b/tests/integration/python/pylint/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pylint"
+version = "0.0.0"
+dependencies = [
+    "pylint",
+]

--- a/tests/integration/python/pyright-missing/Pulumi.yaml
+++ b/tests/integration/python/pyright-missing/Pulumi.yaml
@@ -3,5 +3,5 @@ description: A simple Python Pulumi program that type checks with pyright but py
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
     typechecker: pyright

--- a/tests/integration/python/pyright-missing/pyproject.toml
+++ b/tests/integration/python/pyright-missing/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pulumi-python-pyright"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/python/pyright/Pulumi.yaml
+++ b/tests/integration/python/pyright/Pulumi.yaml
@@ -3,5 +3,5 @@ description: A simple Python Pulumi program that type checks with pyright.
 runtime:
   name: python
   options:
-    virtualenv: venv
+    toolchain: uv
     typechecker: pyright

--- a/tests/integration/python/pyright/pyproject.toml
+++ b/tests/integration/python/pyright/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "pulumi-python-pyright"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+    "pyright",
+]

--- a/tests/integration/python/resource_args/Pulumi.yaml
+++ b/tests/integration/python/resource_args/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-resource-args
 description: A Python program that uses a generated library from schema to test resource args
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/resource_args/pyproject.toml
+++ b/tests/integration/python/resource_args/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pulumi-python-resource-args"
+version = "0.0.0"
+dependencies = [
+    "setuptools",
+]

--- a/tests/integration/python/stack_truncate/main_dir_specified/Pulumi.yaml
+++ b/tests/integration/python/stack_truncate/main_dir_specified/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: pulumi-python-stack-truncate
 description: |
   A Python program that errors out
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 main: bar/

--- a/tests/integration/python/stack_truncate/main_dir_specified/pyproject.toml
+++ b/tests/integration/python/stack_truncate/main_dir_specified/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-stack-truncate"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/stack_truncate/main_specified/Pulumi.yaml
+++ b/tests/integration/python/stack_truncate/main_specified/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: pulumi-python-stack-truncate
 description: |
   A Python program that errors out
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 main: foo.py

--- a/tests/integration/python/stack_truncate/main_specified/pyproject.toml
+++ b/tests/integration/python/stack_truncate/main_specified/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-stack-truncate"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/stack_truncate/normal/Pulumi.yaml
+++ b/tests/integration/python/stack_truncate/normal/Pulumi.yaml
@@ -1,4 +1,7 @@
 name: pulumi-python-stack-truncate
 description: |
   A Python program that errors out
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/stack_truncate/normal/pyproject.toml
+++ b/tests/integration/python/stack_truncate/normal/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-stack-truncate"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/translation/Pulumi.yaml
+++ b/tests/integration/python/translation/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pylint
 description: A Python program that tests dict key translation.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python/translation/pyproject.toml
+++ b/tests/integration/python/translation/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pylint"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python/uv-with-error/pyproject.toml
+++ b/tests/integration/python/uv-with-error/pyproject.toml
@@ -2,5 +2,4 @@
 name = "uv"
 version = "0.1.0"
 description = "A Python project with an error that uses the uv toolchain."
-requires-python = ">=3.9"
 dependencies = ["pulumi>=3.0.0,<4.0.0", "pulumi-random>=4.0.0,<5.0.0"]

--- a/tests/integration/python/uv-workspace/infra/projects/some-project/pyproject.toml
+++ b/tests/integration/python/uv-workspace/infra/projects/some-project/pyproject.toml
@@ -2,5 +2,4 @@
 name = "some-project"
 version = "0.1.0"
 description = "A Python project inside a uv workspace"
-requires-python = ">=3.9"
 dependencies = []

--- a/tests/integration/python/uv-workspace/infra/pyproject.toml
+++ b/tests/integration/python/uv-workspace/infra/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "infra-workspace"
 version = "0.1.0"
-requires-python = ">=3.9"
 dependencies = ["some-package", "pulumi"]
 
 [tool.uv.workspace]

--- a/tests/integration/python/uv-workspace/packages/some-package/pyproject.toml
+++ b/tests/integration/python/uv-workspace/packages/some-package/pyproject.toml
@@ -2,7 +2,6 @@
 name = "some-package"
 version = "0.1.0"
 description = "A Python package"
-requires-python = ">=3.9"
 dependencies = []
 
 [build-system]

--- a/tests/integration/python_await/asyncio_tasks/Pulumi.yaml
+++ b/tests/integration/python_await/asyncio_tasks/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-asyncio-tasks
 description: A Python program that tests waiting for outputs and tasks.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python_await/asyncio_tasks/pyproject.toml
+++ b/tests/integration/python_await/asyncio_tasks/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-asyncio-tasks"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/create_inside_apply/Pulumi.yaml
+++ b/tests/integration/python_await/create_inside_apply/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: create_inside_apply
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: create a resource inside an apply in python

--- a/tests/integration/python_await/create_inside_apply/pyproject.toml
+++ b/tests/integration/python_await/create_inside_apply/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "create_inside_apply"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/error_handling/Pulumi.yaml
+++ b/tests/integration/python_await/error_handling/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await_error_handling
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if non-exported outputs are awaited

--- a/tests/integration/python_await/error_handling/pyproject.toml
+++ b/tests/integration/python_await/error_handling/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await_error_handling"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/failure/Pulumi.yaml
+++ b/tests/integration/python_await/failure/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if non-exported outputs are awaited

--- a/tests/integration/python_await/failure/pyproject.toml
+++ b/tests/integration/python_await/failure/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/failure_exported_output/Pulumi.yaml
+++ b/tests/integration/python_await/failure_exported_output/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if non-exported outputs are awaited

--- a/tests/integration/python_await/failure_exported_output/pyproject.toml
+++ b/tests/integration/python_await/failure_exported_output/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/failure_multiple_unexported_outputs/Pulumi.yaml
+++ b/tests/integration/python_await/failure_multiple_unexported_outputs/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if non-exported outputs are awaited

--- a/tests/integration/python_await/failure_multiple_unexported_outputs/pyproject.toml
+++ b/tests/integration/python_await/failure_multiple_unexported_outputs/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/multiple_outputs/Pulumi.yaml
+++ b/tests/integration/python_await/multiple_outputs/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if multiple non-exported outputs are awaited

--- a/tests/integration/python_await/multiple_outputs/pyproject.toml
+++ b/tests/integration/python_await/multiple_outputs/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/output_leak/Pulumi.yaml
+++ b/tests/integration/python_await/output_leak/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: pulumi-python-output-leak
 description: A Python program that tests waiting for outputs doesn't leak futures.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/python_await/output_leak/pyproject.toml
+++ b/tests/integration/python_await/output_leak/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pulumi-python-output-leak"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/python_await/success/Pulumi.yaml
+++ b/tests/integration/python_await/success/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: python_await
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv
 description: A python program to test if non-exported outputs are awaited

--- a/tests/integration/python_await/success/pyproject.toml
+++ b/tests/integration/python_await/success/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "python_await"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/resource_hooks/python/step-1/Pulumi.yaml
+++ b/tests/integration/resource_hooks/python/step-1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: resource_hooks_python
 description: A program with resource hooks
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/resource_hooks/python/step-1/pyproject.toml
+++ b/tests/integration/resource_hooks/python/step-1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "resource_hooks_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/resource_hooks/python_hook_decorator/Pulumi.yaml
+++ b/tests/integration/resource_hooks/python_hook_decorator/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: resource_hooks_python_hook_decorator
 description: A program with a resource hook for hook decorator testing
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/resource_hooks/python_hook_decorator/pyproject.toml
+++ b/tests/integration/resource_hooks/python_hook_decorator/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "resource_hooks_python_hook_decorator"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/resource_hooks/python_secret/Pulumi.yaml
+++ b/tests/integration/resource_hooks/python_secret/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: resource_hooks_python_secret
 description: A program with a resource hook that receives a secret
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/resource_hooks/python_secret/pyproject.toml
+++ b/tests/integration/resource_hooks/python_secret/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "resource_hooks_python_secret"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/resource_hooks/python_transform/Pulumi.yaml
+++ b/tests/integration/resource_hooks/python_transform/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: resource_hooks_python_transform
 description: A program with a resource hook set by a transform
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/resource_hooks/python_transform/pyproject.toml
+++ b/tests/integration/resource_hooks/python_transform/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "resource_hooks_python_transform"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/resource_refs_get_resource/python/Pulumi.yaml
+++ b/tests/integration/resource_refs_get_resource/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: resource_refs_get_resource_py
 description: A program that ensures invoking 'pulumi:pulumi:getResource' returns resource refs
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/resource_refs_get_resource/python/pyproject.toml
+++ b/tests/integration/resource_refs_get_resource/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "resource_refs_get_resource_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/run_plugin/provider-python/PulumiPlugin.yaml
+++ b/tests/integration/run_plugin/provider-python/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/run_plugin/provider-python/__main__.py
+++ b/tests/integration/run_plugin/provider-python/__main__.py
@@ -19,7 +19,7 @@ class Provider(provider.Provider):
 
 if __name__ == "__main__":
     provider_dir = Path(__file__).absolute().parent
-    expected_venv = provider_dir / "venv"
+    expected_venv = provider_dir / ".venv"
     venv = os.getenv("VIRTUAL_ENV", "")
     assert (
         Path(venv) == expected_venv

--- a/tests/integration/run_plugin/provider-python/pyproject.toml
+++ b/tests/integration/run_plugin/provider-python/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "provider-python"
+version = "0.0.0"
+dependencies = [
+    "pulumi>3.0.0,<4.0.0",
+]

--- a/tests/integration/secret_outputs/python/Pulumi.yaml
+++ b/tests/integration/secret_outputs/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: secret-outputs-py
 description: A simple Python program that tests secret outputs
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/secret_outputs/python/pyproject.toml
+++ b/tests/integration/secret_outputs/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "secret-outputs-py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/signal_cancellation/plugin_python/provider/PulumiPlugin.yaml
+++ b/tests/integration/signal_cancellation/plugin_python/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/signal_cancellation/plugin_python/provider/pyproject.toml
+++ b/tests/integration/signal_cancellation/plugin_python/provider/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = [
+    "pulumi>=3.230.0",
+]

--- a/tests/integration/signal_cancellation/plugin_python_ignore/provider/PulumiPlugin.yaml
+++ b/tests/integration/signal_cancellation/plugin_python_ignore/provider/PulumiPlugin.yaml
@@ -1,1 +1,4 @@
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/signal_cancellation/plugin_python_ignore/provider/pyproject.toml
+++ b/tests/integration/signal_cancellation/plugin_python_ignore/provider/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "provider"
+version = "0.0.0"
+dependencies = [
+    "pulumi>=3.230.0",
+]

--- a/tests/integration/signal_cancellation/python/pyproject.toml
+++ b/tests/integration/signal_cancellation/python/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "signal-cancellation-python"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/signal_cancellation/python_ignore/pyproject.toml
+++ b/tests/integration/signal_cancellation/python_ignore/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "signal-cancellation-python"
+version = "0.0.0"
+dependencies = [
+    "pulumi",
+]

--- a/tests/integration/stack_outputs/python/Pulumi.yaml
+++ b/tests/integration/stack_outputs/python/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: stack_outputs_py
 description: A simple Python program that has stack outputs.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/stack_outputs/python/pyproject.toml
+++ b/tests/integration/stack_outputs/python/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "stack_outputs_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/stack_outputs_program_error/python/step1/Pulumi.yaml
+++ b/tests/integration/stack_outputs_program_error/python/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: stack_outputs_program_error_py
 description: A program that exports some outputs and then errors in a later step.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/stack_outputs_program_error/python/step1/pyproject.toml
+++ b/tests/integration/stack_outputs_program_error/python/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "stack_outputs_program_error_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/stack_outputs_resource_error/python/step1/Pulumi.yaml
+++ b/tests/integration/stack_outputs_resource_error/python/step1/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: stack_outputs_resource_error_py
 description: A program that exports some outputs and then errors in a later step.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/stack_outputs_resource_error/python/step1/pyproject.toml
+++ b/tests/integration/stack_outputs_resource_error/python/step1/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "stack_outputs_resource_error_py"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/transformations/python/simple/Pulumi.yaml
+++ b/tests/integration/transformations/python/simple/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: transformations_simple
 description: A program that replaces a resource with a new name and alias.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/transformations/python/simple/pyproject.toml
+++ b/tests/integration/transformations/python/simple/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "transformations_simple"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/transforms/python/simple/Pulumi.yaml
+++ b/tests/integration/transforms/python/simple/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: transforms_simple
 description: A program with transforms
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/transforms/python/simple/pyproject.toml
+++ b/tests/integration/transforms/python/simple/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "transforms_simple"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/types/python/declared/Pulumi.yaml
+++ b/tests/integration/types/python/declared/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: types_python
 description: A program that uses input/output types with explicitly declared properties.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/types/python/declared/pyproject.toml
+++ b/tests/integration/types/python/declared/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "types_python"
+version = "0.0.0"
+dependencies = []

--- a/tests/integration/types/python/simple/Pulumi.yaml
+++ b/tests/integration/types/python/simple/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: types_python
 description: A program that uses input/output types.
-runtime: python
+runtime:
+  name: python
+  options:
+    toolchain: uv

--- a/tests/integration/types/python/simple/pyproject.toml
+++ b/tests/integration/types/python/simple/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "types_python"
+version = "0.0.0"
+dependencies = []


### PR DESCRIPTION
We’re seeing flakes during `pip install` because (I think) concurrent writes to the pip cache can cause errors. By switching to `uv` we bypass that potential error, and probably make the tests a little faster in the process.

