### PR TITLE
Fix flaky TestFuzz: targeted update with refresh + deleted parent

### DIFF
--- a/pkg/engine/lifecycletest/fuzzing/exclude.go
+++ b/pkg/engine/lifecycletest/fuzzing/exclude.go
@@ -64,6 +64,8 @@ func DefaultExclusionRules() ExclusionRules {
 		ExcludePendingReplacementRegisteredInUpdate,
 		// TODO[pulumi/pulumi#22511]
 		ExcludeTargetedUpdateRefreshWithChildProvider,
+		// TODO[pulumi/pulumi#22923]
+		ExcludeTargetedUpdateRefreshWithDeletedParent,
 	}
 }
 
@@ -747,6 +749,47 @@ func ExcludeTargetedUpdateRefreshWithChildProvider(
 			if childProviderPkgs[resPkg] {
 				return true
 			}
+		}
+	}
+
+	return false
+}
+
+// ExcludeTargetedUpdateRefreshWithDeletedParent excludes scenarios where a
+// targeted update with refresh runs against a snapshot that contains a resource
+// marked for deletion (`Delete: true`) which is the parent of one or more other
+// snapshot resources. During such a run the engine can rebuild the snapshot
+// such that the deleted parent comes after its children, violating the
+// snapshot integrity invariant that parents precede their children.
+func ExcludeTargetedUpdateRefreshWithDeletedParent(
+	snap *SnapshotSpec,
+	_ *ProgramSpec,
+	_ *ProviderSpec,
+	plan *PlanSpec,
+) bool {
+	if plan.Operation != PlanOperationUpdate {
+		return false
+	}
+	if !plan.Refresh {
+		return false
+	}
+	if len(plan.TargetURNs) == 0 {
+		return false
+	}
+
+	deletedURNs := make(map[resource.URN]bool)
+	for _, res := range snap.Resources {
+		if res.Delete {
+			deletedURNs[res.URN()] = true
+		}
+	}
+	if len(deletedURNs) == 0 {
+		return false
+	}
+
+	for _, res := range snap.Resources {
+		if res.Parent != "" && deletedURNs[res.Parent] {
+			return true
 		}
 	}
 

--- a/pkg/engine/lifecycletest/update_test.go
+++ b/pkg/engine/lifecycletest/update_test.go
@@ -741,3 +741,137 @@ func TestTargetedUpdateRefreshUnknownChildProvider(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, snap), opts, false, p.BackendClient, nil, "1")
 	require.NoError(t, err)
 }
+
+// TestTargetedUpdateRefreshWithDeletedParent reproduces a fuzz-found snapshot
+// integrity error where a targeted update with refresh runs against a snapshot
+// that contains a top-level component resource marked for deletion which has
+// children. The rebuilt snapshot orders the deleted parent after its children,
+// violating the invariant that a parent resource must precede its children.
+//
+// Reproducer for the fuzz failure at:
+//
+//	cd pkg && PULUMI_LIFECYCLE_TEST_FUZZ=1 go test ./engine/lifecycletest \
+//	  -run '^TestFuzz$' -tags all -rapid.seed=11828830533255979657 -count=1 -v
+func TestTargetedUpdateRefreshWithDeletedParent(t *testing.T) {
+	t.Parallel()
+
+	// TODO[pulumi/pulumi#22923]: Fix the underlying issue and re-enable this test.
+	t.Skip("Skipping: targeted update with refresh reorders a deleted parent after its children")
+
+	p := &lt.TestPlan{
+		Project: "test-project",
+		Stack:   "test-stack",
+	}
+
+	snap := func() *deploy.Snapshot {
+		s := &deploy.Snapshot{}
+
+		prov := &resource.State{
+			Type:   "pulumi:providers:pkgA",
+			URN:    "urn:pulumi:test-stack::test-project::pulumi:providers:pkgA::prov",
+			Custom: true,
+			ID:     "id-prov",
+		}
+		s.Resources = append(s.Resources, prov)
+
+		provRef, err := providers.NewReference(prov.URN, prov.ID)
+		require.NoError(t, err)
+
+		// A top-level custom resource that the target component is parented under.
+		parentA := &resource.State{
+			Type:           "pkgA:m:TypeA",
+			URN:            "urn:pulumi:test-stack::test-project::pkgA:m:TypeA::res-shared",
+			Custom:         true,
+			ID:             "id-parentA",
+			Provider:       provRef.String(),
+			RetainOnDelete: true,
+		}
+		s.Resources = append(s.Resources, parentA)
+
+		// The targeted component resource, parented under parentA.
+		target := &resource.State{
+			Type:           "pkgA:m:TypeB",
+			URN:            "urn:pulumi:test-stack::test-project::pkgA:m:TypeA$pkgA:m:TypeB::res-target",
+			Custom:         false,
+			Provider:       provRef.String(),
+			Parent:         parentA.URN,
+			RetainOnDelete: true,
+		}
+		s.Resources = append(s.Resources, target)
+
+		// A separate, top-level component resource marked for deletion. This
+		// shares a name with the target but has a different URN.
+		deletedParent := &resource.State{
+			Type:           "pkgA:m:TypeB",
+			URN:            "urn:pulumi:test-stack::test-project::pkgA:m:TypeB::res-target",
+			Custom:         false,
+			Delete:         true,
+			Provider:       provRef.String(),
+			RetainOnDelete: true,
+		}
+		s.Resources = append(s.Resources, deletedParent)
+
+		// A child of the deleted parent that is also marked for deletion. This
+		// shares a name with parentA but has a different URN.
+		deletedChild := &resource.State{
+			Type:     "pkgA:m:TypeA",
+			URN:      "urn:pulumi:test-stack::test-project::pkgA:m:TypeB$pkgA:m:TypeA::res-shared",
+			Custom:   true,
+			Delete:   true,
+			ID:       "id-deletedChild",
+			Provider: provRef.String(),
+			Parent:   deletedParent.URN,
+		}
+		s.Resources = append(s.Resources, deletedChild)
+
+		return s
+	}()
+	require.NoError(t, snap.VerifyIntegrity(), "initial snapshot is not valid")
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		prov, err := monitor.RegisterResource("pulumi:providers:pkgA", "prov", true, deploytest.ResourceOptions{})
+		require.NoError(t, err)
+
+		provRef, err := providers.NewReference(prov.URN, prov.ID)
+		require.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:m:TypeA", "res-shared", true, deploytest.ResourceOptions{
+			Provider:       provRef.String(),
+			RetainOnDelete: ptr(true),
+		})
+		require.NoError(t, err)
+
+		// Re-register the resource that matches the deleted top-level component
+		// in the snapshot. The targeted nested component is not re-registered
+		// and so will be marked for deletion during the targeted update.
+		_, err = monitor.RegisterResource("pkgA:m:TypeB", "res-target", false, deploytest.ResourceOptions{
+			Provider:       provRef.String(),
+			RetainOnDelete: ptr(true),
+		})
+		require.NoError(t, err)
+
+		return nil
+	})
+
+	targetURN := "urn:pulumi:test-stack::test-project::pkgA:m:TypeA$pkgA:m:TypeB::res-target"
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	opts := lt.TestUpdateOptions{
+		T:                t,
+		HostF:            hostF,
+		SkipDisplayTests: true,
+		UpdateOptions: engine.UpdateOptions{
+			Refresh: true,
+			Targets: deploy.NewUrnTargets([]string{targetURN}),
+		},
+	}
+
+	_, err := lt.TestOp(engine.Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), opts, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds a narrow exclusion rule (`ExcludeTargetedUpdateRefreshWithDeletedParent`) to the lifecycle fuzz test that skips scenarios combining a targeted update with refresh and a snapshot containing a resource marked for deletion that is the parent of another snapshot resource. In such scenarios the engine can rebuild the snapshot so that the deleted parent comes after its children, violating the snapshot integrity invariant that parents precede their children.
- Adds a deterministic reproduction test (`TestTargetedUpdateRefreshWithDeletedParent`) that demonstrates the underlying engine bug — currently skipped pending fix.
- Tracks the engine bug in pulumi/pulumi#22923.

## Investigation

This was discovered via the failing fuzz job at https://github.com/pulumi/pulumi/actions/runs/25549844356/job/74995686905, where `TestFuzz` failed with a snapshot integrity error (`child resource …'s parent … comes after it`) and reported reproducer seed `11828830533255979657`.

## Reproduction

```
cd pkg && PULUMI_LIFECYCLE_TEST_FUZZ=1 go test ./engine/lifecycletest \
  -run '^TestFuzz$' -tags all -rapid.seed=11828830533255979657 -count=1 -v
```

With this PR applied, the same seed completes cleanly.

## Root cause

When a targeted update with refresh runs against a snapshot that contains a top-level component resource marked for deletion which has children, the engine's snapshot rebuild can place the deleted parent after its children, producing an invalid snapshot.

## Test plan

- [x] `TestTargetedUpdateRefreshWithDeletedParent` reproduces the bug (fails when unskipped) with the same `child resource X's parent Y comes after it` error wording.
- [x] Exclusion rule prevents the fuzz test from generating the broken scenario.
- [x] `TestFuzz` with the original failing seed now passes.
- [x] Three back-to-back `rapid.checks=10000` runs all pass.
- [x] `make lint` passes.