### PR TITLE
`pulumi preview --output json`

### DIFF
--- a/changelog/pending/20260508--cli--add-output-json-to-pulumi-preview-for-a-structured-summary.yaml
+++ b/changelog/pending/20260508--cli--add-output-json-to-pulumi-preview-for-a-structured-summary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--output json` to `pulumi preview` for a structured JSON summary of the operation result

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -297,6 +297,7 @@ func NewPreviewCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var output string
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -360,6 +361,16 @@ func NewPreviewCmd() *cobra.Command {
 				return err
 			}
 
+			// Validate --output up front. We keep the existing --json flag (which
+			// emits a JSONL stream of engine events) backwards compatible, and
+			// only emit the structured operation summary when --output=json.
+			switch output {
+			case "default", "json":
+				// No-op.
+			default:
+				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
+			}
+
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			displayType := display.DisplayProgress
 			if diffDisplay {
@@ -381,6 +392,7 @@ func NewPreviewCmd() *cobra.Command {
 				IsInteractive:          cmdutil.Interactive(),
 				Type:                   displayType,
 				JSONDisplay:            jsonDisplay,
+				SummaryJSON:            output == "json",
 				EventLogPath:           eventLogPath,
 				Debug:                  debug,
 			}
@@ -578,7 +590,7 @@ func NewPreviewCmd() *cobra.Command {
 					}
 
 					// Write out message on how to use the plan (if not writing out --json)
-					if !jsonDisplay {
+					if !jsonDisplay && output != "json" {
 						var buf bytes.Buffer
 						ui.Fprintf(&buf, "Update plan written to '%s'", planFilePath)
 						ui.Fprintf(
@@ -696,6 +708,12 @@ func NewPreviewCmd() *cobra.Command {
 		&jsonDisplay, "json", "j", false,
 		"Serialize the preview diffs, operations, and overall output as JSON."+
 			" Set PULUMI_ENABLE_STREAMING_JSON_PREVIEW to stream JSON events instead.")
+	cmd.Flags().StringVar(
+		&output, "output", "default",
+		"Output format. Supported values are: default, json")
+	// Hidden until --output is wired up across all operations.
+	_ = cmd.Flags().MarkHidden("output")
+	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")

--- a/tests/integration/preview_output_summary_test.go
+++ b/tests/integration/preview_output_summary_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestPreview_OutputJSONSummary(t *testing.T) {
+	// Capture only `pulumi preview`'s stdout. Like the symmetric up test, we
+	// expect it to consist solely of the summary JSON object.
+	//
+	// `pulumi preview` is only invoked explicitly when `SkipPreview` is false
+	// (i.e. not `Quick: true`). The internal preview that `pulumi up` runs is
+	// part of the `up` invocation, not a separate `preview` verb. We therefore
+	// run a minimal lifecycle that includes the explicit preview step.
+	var previewStdout bytes.Buffer
+	writer := &scopedWriter{buf: &previewStdout}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                     "single_resource",
+		Dependencies:            []string{"@pulumi/pulumi"},
+		SkipExportImport:        true,
+		SkipEmptyPreviewUpdate:  true,
+		SkipRefresh:             true,
+		Verbose:                 true,
+		Stdout:                  writer,
+		Stderr:                  io.Discard, // human-readable progress goes here; we don't assert on it
+		PreviewCommandlineFlags: []string{"--output", "json"},
+		PrePulumiCommand: func(verb string) (func(err error) error, error) {
+			if verb != "preview" {
+				return nil, nil
+			}
+
+			writer.SetActive(true)
+			return func(err error) error {
+				writer.SetActive(false)
+				return nil
+			}, nil
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// Smoke check: the program actually ran and produced a deployment.
+			require.NotNil(t, stackInfo.Deployment)
+		},
+	})
+
+	// The whole of stdout should be a single JSON object. If parsing fails or
+	// fields are missing, the report includes the captured stdout to make
+	// debugging easy.
+	raw := bytes.TrimSpace(previewStdout.Bytes())
+
+	var summary display.SummaryJSON
+	require.NoErrorf(t, json.Unmarshal(raw, &summary),
+		"expected stdout to be exactly one JSON summary object, got:\n%s", raw)
+
+	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
+}


### PR DESCRIPTION
Stacked on top of #22870 — please merge that one first.

Mirrors the `--output <default|json>` flag introduced for `pulumi up` onto `pulumi preview`. When `--output json` is passed, a single-line JSON object of the same shape is emitted on stdout once the preview completes:

- `result` — `succeeded`, `failed`, or `canceled`
- `duration` — how long the operation took
- `summary` — count per operation kind (create, update, etc.)

`--json` and `--output` are mutually exclusive. The flag is `Hidden: true` for now and will be revealed once the remaining operations (`refresh`, ...) reach parity.

## Implementation notes

- Reuses the parent PR's `display.SummaryJSON` option. The wiring on the preview side is just `opts.Display.SummaryJSON = output == "json"` — the display layer handles emitting the summary via the `SummaryEvent` tap. Zero new types, zero CLI-side result computation.
- `pulumi preview` already has a `--json` flag that emits diffs as JSON. Mutual exclusion with `--output` is enforced via `cmd.MarkFlagsMutuallyExclusive("json", "output")` and the new `--output` value is validated up front, before any other heavy work, so an invalid value fails fast.
- `preview.go` has one `!jsonDisplay` check that suppresses the human-friendly "Update plan written to..." message. It now also triggers when `--output json` is set, so stdout contains only the summary JSON line. Implemented via the same small `jsonOutput := jsonDisplay || output == "json"` helper as destroy.
- The integration test cannot use `Quick: true` because `Quick` implies `SkipPreview: true`, which means `PreviewAndUpdate` skips the explicit `pulumi preview` invocation and only runs an internal preview as part of `pulumi up` (different verb, doesn't match the `PrePulumiCommand` filter). The test instead skips the other lifecycle stages individually.

## Test plan

- [x] Integration test `TestPreview_OutputJSONSummary` runs `pulumi preview --output json` against a single-resource program and asserts that the entire captured stdout is exactly the summary JSON object (mirrors the up/destroy tests' stricter assertion)
- [x] `go build` and `go vet` clean on `pkg/` and `tests/integration/`
- [x] `golangci-lint` clean on `pkg/cmd/pulumi/operations/...` and `tests/integration/`
- [ ] Manual smoke: `pulumi preview --output json` on a real stack
- [ ] Manual smoke: `pulumi preview --output json --json` errors with a mutual-exclusion message
- [ ] Manual smoke: `pulumi preview --output garbage` errors with the validation message