### PR TITLE
`pulumi refresh --output json`

### DIFF
--- a/changelog/pending/20260508--cli--add-output-json-to-pulumi-refresh-for-a-structured-summary.yaml
+++ b/changelog/pending/20260508--cli--add-output-json-to-pulumi-refresh-for-a-structured-summary.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `--output json` to `pulumi refresh` for a structured JSON summary of the operation result

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -67,6 +67,7 @@ func NewRefreshCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
+	var output string
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int32
@@ -132,6 +133,16 @@ func NewRefreshCmd() *cobra.Command {
 					"must be passed in to proceed when running in non-interactive mode")
 			}
 
+			// Validate --output up front. We keep the existing --json flag (which
+			// emits a JSONL stream of engine events) backwards compatible, and
+			// only emit the structured operation summary when --output=json.
+			switch output {
+			case "default", "json":
+				// No-op.
+			default:
+				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
+			}
+
 			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
 			if err != nil {
 				return err
@@ -155,6 +166,7 @@ func NewRefreshCmd() *cobra.Command {
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
 				JSONDisplay:          jsonDisplay,
+				SummaryJSON:          output == "json",
 			}
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
@@ -393,6 +405,12 @@ func NewRefreshCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the refresh diffs, operations, and overall output as JSON")
+	cmd.Flags().StringVar(
+		&output, "output", "default",
+		"Output format. Supported values are: default, json")
+	// Hidden until --output is wired up across all operations.
+	_ = cmd.Flags().MarkHidden("output")
+	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),
 		"Allow P resource operations to run in parallel at once (1 for no parallelism).")

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -242,6 +242,8 @@ type ProgramTestOptions struct {
 	UpdateCommandlineFlags []string
 	// DestroyCommandlineFlags specifies flags to add to the `pulumi destroy` command line (e.g. "--output=json")
 	DestroyCommandlineFlags []string
+	// RefreshCommandlineFlags specifies flags to add to the `pulumi refresh` command line (e.g. "--output=json")
+	RefreshCommandlineFlags []string
 	// QueryCommandlineFlags specifies flags to add to the `pulumi query` command line (e.g. "--color=raw")
 	QueryCommandlineFlags []string
 	// RunBuild indicates that the build step should be run (e.g. run `yarn build` for `nodejs` programs)
@@ -600,6 +602,9 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	}
 	if overrides.DestroyCommandlineFlags != nil {
 		opts.DestroyCommandlineFlags = append(opts.DestroyCommandlineFlags, overrides.DestroyCommandlineFlags...)
+	}
+	if overrides.RefreshCommandlineFlags != nil {
+		opts.RefreshCommandlineFlags = append(opts.RefreshCommandlineFlags, overrides.RefreshCommandlineFlags...)
 	}
 	if overrides.QueryCommandlineFlags != nil {
 		opts.QueryCommandlineFlags = append(opts.QueryCommandlineFlags, overrides.QueryCommandlineFlags...)
@@ -1661,6 +1666,9 @@ func (pt *ProgramTester) TestPreviewUpdateAndEdits() error {
 		}
 		if !pt.opts.ExpectRefreshChanges {
 			refresh = append(refresh, "--expect-no-changes")
+		}
+		if pt.opts.RefreshCommandlineFlags != nil {
+			refresh = append(refresh, pt.opts.RefreshCommandlineFlags...)
 		}
 		if err := pt.runPulumiCommand("pulumi-refresh", refresh, dir, false); err != nil {
 			return err

--- a/tests/integration/refresh_output_summary_test.go
+++ b/tests/integration/refresh_output_summary_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:paralleltest // ProgramTest calls t.Parallel()
+func TestRefresh_OutputJSONSummary(t *testing.T) {
+	// Capture only `pulumi refresh`'s stdout. Like the symmetric up/destroy
+	// tests, we expect it to consist solely of the summary JSON object.
+	var refreshStdout bytes.Buffer
+	writer := &scopedWriter{buf: &refreshStdout}
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                     "single_resource",
+		Dependencies:            []string{"@pulumi/pulumi"},
+		Quick:                   true,
+		Verbose:                 true,
+		Stdout:                  writer,
+		Stderr:                  io.Discard, // human-readable progress goes here; we don't assert on it
+		RefreshCommandlineFlags: []string{"--output", "json"},
+		PrePulumiCommand: func(verb string) (func(err error) error, error) {
+			if verb != "refresh" {
+				return nil, nil
+			}
+
+			writer.SetActive(true)
+			return func(err error) error {
+				writer.SetActive(false)
+				return nil
+			}, nil
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			// Smoke check: the program actually ran and produced a deployment to refresh.
+			require.NotNil(t, stackInfo.Deployment)
+		},
+	})
+
+	// The whole of stdout should be a single JSON object. If parsing fails or
+	// fields are missing, the report includes the captured stdout to make
+	// debugging easy.
+	raw := bytes.TrimSpace(refreshStdout.Bytes())
+
+	var summary display.SummaryJSON
+	require.NoErrorf(t, json.Unmarshal(raw, &summary),
+		"expected stdout to be exactly one JSON summary object, got:\n%s", raw)
+
+	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+}


### PR DESCRIPTION
Stacked on top of #22870 — please merge that one first.

Mirrors the `--output <default|json>` flag introduced for `pulumi up` (#22870) and `pulumi destroy` (#22875) onto `pulumi refresh`. When `--output json` is passed, a single-line JSON object of the same shape is emitted on stdout once the refresh completes:

- `result` — `succeeded`, `failed`, or `canceled`
- `duration` — how long the operation took
- `summary` — count per operation kind (refresh, etc.)

`--json` and `--output` are mutually exclusive. The flag is `Hidden: true` for now and will be revealed once the remaining operations (`preview`, ...) reach parity.

## Implementation notes

- Reuses the parent PR's `display.SummaryJSON` option. The wiring on the refresh side is just `opts.Display.SummaryJSON = output == "json"` — the display layer handles emitting the summary via the `SummaryEvent` tap. Zero new types, zero CLI-side result computation.
- Unlike `destroy.go`, `refresh.go` has no human-friendly post-operation `fmt.Printf` messages gated on `!jsonDisplay`, so there was no need to introduce the `jsonOutput := jsonDisplay || output == "json"` helper from the destroy PR. If new such messages are added later they should follow the destroy pattern.
- Refresh sets `isRefresh=true` on the engine, so policy packs are skipped — but the `SummaryEvent` is emitted on the same code path as up/destroy, so no refresh-specific summary plumbing was needed.
- A `RefreshCommandlineFlags` field is added to `ProgramTestOptions`, mirroring the existing `UpdateCommandlineFlags` and the `DestroyCommandlineFlags` introduced in #22875, so the new integration test can inject `--output json` into the lifecycle's post-update refresh step.

## Test plan

- [x] Integration test `TestRefresh_OutputJSONSummary` runs `pulumi refresh --output json` against a single-resource program and asserts that the entire captured stdout is exactly the summary JSON object (mirrors the up/destroy tests' stricter assertion). The `summary` count assertion is omitted because a no-change refresh against a freshly-applied stack legitimately produces empty change counts
- [x] `go build`, `go vet`, and `golangci-lint` clean on `pkg/` and `tests/`
- [x] Existing `display` and `operations` unit tests still pass
- [ ] Manual smoke: `pulumi refresh --output json` on a real stack
- [ ] Manual smoke: `pulumi refresh --output json --json` errors with a mutual-exclusion message
- [ ] Manual smoke: `pulumi refresh --output garbage` errors with the validation message