### PR TITLE
add continue-on-error to upload code coverage and upload codecov test results

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -381,6 +381,7 @@ jobs:
       - name: Upload code coverage
         uses: actions/upload-artifact@v7
         if: ${{ inputs.enable-coverage }}
+        continue-on-error: true
         with:
           name: coverage-${{ env.TEST_HASH_ID }}
           path: |
@@ -388,6 +389,7 @@ jobs:
             !coverage/.gitkeep
       - name: Upload codecov test results
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1
+        continue-on-error: true
         with:
           directory: junit/
           fail_ci_if_error: false


### PR DESCRIPTION

In https://github.com/pulumi/pulumi/pull/22914, we made it so we don't fail when we fail to merge code coverage results.  However that just pushed the failure path one level further, and we fail there.  Add `continue-on-error` to those steps as well.

Fixes https://github.com/pulumi/pulumi/issues/22933