### PR TITLE
only don't run CI if changelog/config.yaml changes

### DIFF
--- a/.github/workflows/on-pr-default.yml
+++ b/.github/workflows/on-pr-default.yml
@@ -12,14 +12,14 @@ on:
     paths-ignore:
       - "**" # Skip all files…
       - "!sdk/.version" # …except if only this file changes and nothing else.
-      - "!changelog/**" # or if only files in this directory changed
+      - "!changelog/config.yaml" # or if only this file changes.
 jobs:
   no-op:
     name: Skip CI on .version changes
     runs-on: ubuntu-latest
     steps:
       - name: Skip CI on .version changes
-        run: echo 'No need to run CI tests when only .version changes'
+        run: echo 'No need to run CI tests when only .version or changelog/config.yaml changes'
 
   ci-ok:
     name: ci-ok


### PR DESCRIPTION
Otherwise this job will always run whenever anything in changelog changes. So all PRs that have a changelog entry will automatically get added to the merge queue, whether they are passing tests or not, which is obviously incorrect.

We never really have changelog only changes, except when `changelog/config.yaml` changes, so only mark ci-ok green when that happens.

I misunderstood how this works in https://github.com/pulumi/pulumi/pull/22913 apparently.  I believe this is how https://github.com/pulumi/pulumi/pull/22864 made it to the merge queue even though CI was not green.
