### PR TITLE
Generate PCL for asset and archive inputs in importer

### DIFF
--- a/changelog/pending/20260508--cli-import--generate-pcl-for-asset-and-archive-inputs.yaml
+++ b/changelog/pending/20260508--cli-import--generate-pcl-for-asset-and-archive-inputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Generate PCL for asset and archive inputs when importing resources, instead of returning a "NYI" error

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -817,7 +819,7 @@ func generateValue(
 
 	switch {
 	case value.IsArchive():
-		return nil, errors.New("NYI: archives")
+		return generateArchive(value.AsArchive())
 	case value.IsArray():
 		elementType := schema.AnyType
 		if typ, ok := typ.(*schema.ArrayType); ok {
@@ -838,7 +840,7 @@ func generateValue(
 			Expressions: exprs,
 		}, nil
 	case value.IsAsset():
-		return nil, errors.New("NYI: assets")
+		return generateAsset(value.AsAsset())
 	case value.IsBool():
 		return &model.LiteralValueExpression{
 			Value: cty.BoolVal(value.AsBool()),
@@ -948,4 +950,82 @@ func generateValue(
 		contract.Failf("unexpected property value %v", value)
 		return nil, nil
 	}
+}
+
+// stringLiteralCall builds an HCL call to fn with a single string argument.
+func stringLiteralCall(fn, s string) *model.FunctionCallExpression {
+	return &model.FunctionCallExpression{
+		Name: fn,
+		Args: []model.Expression{
+			&model.TemplateExpression{
+				Parts: []model.Expression{
+					&model.LiteralValueExpression{
+						Value: cty.StringVal(s),
+					},
+				},
+			},
+		},
+	}
+}
+
+// generateAsset emits a PCL function call that constructs the given asset.
+func generateAsset(a *asset.Asset) (model.Expression, error) {
+	switch {
+	case a.IsText():
+		text, _ := a.GetText()
+		return stringLiteralCall("stringAsset", text), nil
+	case a.IsPath():
+		path, _ := a.GetPath()
+		return stringLiteralCall("fileAsset", path), nil
+	case a.IsURI():
+		uri, _ := a.GetURI()
+		return stringLiteralCall("remoteAsset", uri), nil
+	}
+	return nil, errors.New("asset has no text, path, or uri")
+}
+
+// generateArchive emits a PCL function call that constructs the given archive.
+func generateArchive(a *archive.Archive) (model.Expression, error) {
+	switch {
+	case a.IsAssets():
+		assets, _ := a.GetAssets()
+		items := slice.Prealloc[model.ObjectConsItem](len(assets))
+		for k, v := range assets {
+			var elem model.Expression
+			var err error
+			switch v := v.(type) {
+			case *asset.Asset:
+				elem, err = generateAsset(v)
+			case *archive.Archive:
+				elem, err = generateArchive(v)
+			default:
+				return nil, fmt.Errorf("unexpected archive entry type %T", v)
+			}
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, model.ObjectConsItem{
+				Key: &model.LiteralValueExpression{
+					Value: cty.StringVal(fmt.Sprintf("%q", k)),
+				},
+				Value: elem,
+			})
+		}
+		return &model.FunctionCallExpression{
+			Name: "assetArchive",
+			Args: []model.Expression{
+				&model.ObjectConsExpression{
+					Tokens: syntax.NewObjectConsTokens(len(items)),
+					Items:  items,
+				},
+			},
+		}, nil
+	case a.IsPath():
+		path, _ := a.GetPath()
+		return stringLiteralCall("fileArchive", path), nil
+	case a.IsURI():
+		uri, _ := a.GetURI()
+		return stringLiteralCall("remoteArchive", uri), nil
+	}
+	return nil, errors.New("archive has no assets, path, or uri")
 }

--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -62,13 +62,22 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 			if v.IsString() && !norm.NFC.IsNormalString(v.AsString()) {
 				return true
 			}
-			if !v.IsMap() {
+			if v.IsMap() {
+				for k := range v.AsMap().All {
+					if !norm.NFC.IsNormalString(k) {
+						return true
+					}
+				}
 				return false
 			}
-			for k := range v.AsMap().All {
-				if !norm.NFC.IsNormalString(k) {
-					return true
-				}
+			if v.IsAsset() {
+				a := v.AsAsset()
+				return !norm.NFC.IsNormalString(a.Text) ||
+					!norm.NFC.IsNormalString(a.Path) ||
+					!norm.NFC.IsNormalString(a.URI)
+			}
+			if v.IsArchive() {
+				return archiveHasNonNFC(v.AsArchive())
 			}
 			return false
 		}) {
@@ -78,12 +87,6 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 			// and the spec doesn't mandate normalization, so this loses
 			// information silently. Skip non-NFC inputs until that is fixed.
 			t.Skip("inputs contain a non-NFC string; HCL round-trip silently NFC-normalizes")
-		}
-
-		if checkPropertyMap(sample.State.Inputs, func(p property.Value) bool {
-			return p.IsArchive() || p.IsAsset()
-		}) {
-			t.Skip("Assets & archives are not yet implemented")
 		}
 
 		if checkPropertyMap(sample.State.Inputs, func(p property.Value) bool {
@@ -140,6 +143,33 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 		require.Truef(t, sample.State.Inputs.DeepEquals(gotInputs),
 			"inputs differ\nwant: %#v\ngot:  %#v\nblock:\n%s", sample.State.Inputs, gotInputs, text)
 	})
+}
+
+// archiveHasNonNFC reports whether a contains, transitively, any string that
+// is not in Unicode NFC form (asset text/path/uri, archive path/uri, or
+// archive entry keys).
+func archiveHasNonNFC(a property.Archive) bool {
+	if !norm.NFC.IsNormalString(a.Path) || !norm.NFC.IsNormalString(a.URI) {
+		return true
+	}
+	for k, entry := range a.Assets {
+		if !norm.NFC.IsNormalString(k) {
+			return true
+		}
+		switch entry := entry.(type) {
+		case property.Asset:
+			if !norm.NFC.IsNormalString(entry.Text) ||
+				!norm.NFC.IsNormalString(entry.Path) ||
+				!norm.NFC.IsNormalString(entry.URI) {
+				return true
+			}
+		case property.Archive:
+			if archiveHasNonNFC(entry) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func checkPropertyMap(m resource.PropertyMap, check func(property.Value) bool) bool {

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
@@ -167,6 +169,58 @@ func renderFunctionCall(t require.TestingT, x *model.FunctionCallExpression) pro
 			return property.New(property.Null)
 		}
 		return expr
+	case "stringAsset":
+		require.Len(t, x.Args, 1)
+		expr := renderExpr(t, x.Args[0])
+		if !assert.True(t, expr.IsString()) {
+			return property.New(property.Null)
+		}
+		a, err := asset.FromText(expr.AsString())
+		require.NoError(t, err)
+		return property.New(a)
+	case "remoteAsset":
+		require.Len(t, x.Args, 1)
+		expr := renderExpr(t, x.Args[0])
+		if !assert.True(t, expr.IsString()) {
+			return property.New(property.Null)
+		}
+		a, err := asset.FromURI(expr.AsString())
+		require.NoError(t, err)
+		return property.New(a)
+	case "remoteArchive":
+		require.Len(t, x.Args, 1)
+		expr := renderExpr(t, x.Args[0])
+		if !assert.True(t, expr.IsString()) {
+			return property.New(property.Null)
+		}
+		a, err := archive.FromURI(expr.AsString())
+		require.NoError(t, err)
+		return property.New(a)
+	case "assetArchive":
+		require.Len(t, x.Args, 1)
+		obj, ok := x.Args[0].(*model.ObjectConsExpression)
+		if !assert.True(t, ok, "assetArchive arg must be an object cons") {
+			return property.New(property.Null)
+		}
+		assets := map[string]any{}
+		for _, item := range obj.Items {
+			kv := renderExpr(t, item.Key)
+			if !assert.True(t, kv.IsString()) {
+				continue
+			}
+			v := renderExpr(t, item.Value)
+			switch {
+			case v.IsAsset():
+				assets[kv.AsString()] = v.AsAsset()
+			case v.IsArchive():
+				assets[kv.AsString()] = v.AsArchive()
+			default:
+				assert.Failf(t, "", "assetArchive entry %q is %v, want asset or archive", kv.AsString(), v)
+			}
+		}
+		a, err := archive.FromAssets(assets)
+		require.NoError(t, err)
+		return property.New(a)
 	case "secret":
 		require.Len(t, x.Args, 1)
 		return renderExpr(t, x.Args[0]).WithSecret(true)


### PR DESCRIPTION
## Summary
- Replaces the `NYI: assets` / `NYI: archives` errors in `generateValue` with emission of the PCL builtins (`stringAsset`, `fileAsset`, `remoteAsset`, `assetArchive`, `fileArchive`, `remoteArchive`). `assetArchive` recurses so nested archives serialize correctly.
- Drops the asset/archive skip in `TestRapidGenerateHCL2Definition` and extends the existing non-NFC skip (and a new `archiveHasNonNFC` walker) to also cover strings stored inside asset text/path/URI and archive keys, since the same upstream HCL/cty NFC normalization bug applies there.
- Extends the test renderer to round-trip `stringAsset`, `remoteAsset`, `remoteArchive`, and `assetArchive` back into `*asset.Asset`/`*archive.Archive` values.

## Test plan
- [x] \`go test -count=1 -tags all ./importer/...\`
- [x] \`go test -count=1 -tags all -run TestRapidGenerateHCL2Definition ./importer -v -args -rapid.checks=10000\`
- [x] \`golangci-lint run ./importer/...\`