### PR TITLE
Change SETTINGS.outputs to a set instead of a deque

### DIFF
--- a/changelog/pending/20260511--sdk-python--speed-up-python-program-resolution-by-using-a-set-instead-of-deque-to-track-outputs.yaml
+++ b/changelog/pending/20260511--sdk-python--speed-up-python-program-resolution-by-using-a-set-instead-of-deque-to-track-outputs.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Speed up python program resolution by using a set instead of deque to track outputs

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -151,18 +151,18 @@ class Output(Generic[T_co]):
     def _track(self) -> None:
         """Register _data with SETTINGS.outputs for lifecycle tracking."""
         with SETTINGS.lock:
-            SETTINGS.outputs.append(self._data)
+            SETTINGS.outputs.add(self._data)
 
         def cleanup(fut: "asyncio.Future[_OutputData[T_co]]") -> None:
             if fut.cancelled() or (fut.exception() is not None):
-                # if cancelled or error'd leave it in the deque to pick up at program exit
+                # if cancelled or error'd leave it in the set to pick up at program exit
                 return
-            # else remove it from the deque
+            # else remove it from the set
             with SETTINGS.lock:
                 try:
                     SETTINGS.outputs.remove(fut)
-                except ValueError:
-                    # if it's not in the deque then it's already been removed in wait_for_rpcs
+                except KeyError:
+                    # if it's not in the set then it's already been removed in wait_for_rpcs
                     pass
 
         self._data.add_done_callback(cleanup)

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -23,7 +23,6 @@ from ._instrumentation import wrap_with_context
 import asyncio
 import os
 import threading
-from collections import deque
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union
 
@@ -61,7 +60,7 @@ class Settings:
         root_directory: Optional[str] = None,
     ):
         self.rpc_manager = RPCManager()
-        self.outputs = deque()
+        self.outputs = set()
         self.lock = threading.Lock()
 
         # Save the metadata information.
@@ -110,7 +109,7 @@ class Settings:
     def lock(self) -> threading.Lock: ...  # type: ignore
 
     @contextproperty
-    def outputs(self) -> deque[asyncio.Task]: ...  # type: ignore
+    def outputs(self) -> set[asyncio.Task]: ...  # type: ignore
 
     @contextproperty
     def monitor(self) -> Optional[resource_pb2_grpc.ResourceMonitorStub]: ...

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -164,7 +164,7 @@ async def wait_for_rpcs(await_all_outstanding_tasks=True) -> None:
                 if not_done:
                     with SETTINGS.lock:
                         for task in not_done:
-                            SETTINGS.outputs.append(task)
+                            SETTINGS.outputs.add(task)
 
             log.debug("All outstanding outputs completed.")
 


### PR DESCRIPTION
This updates the output tracking in python to use a set rather than a deque. Order of addition and removal doesn't actually matter, we just keep running the event loop till all outputs are resolved. But the set can do the removal operations in O(1) instead of O(n) time. This should make python programs with many outputs created much faster to shutdown at the end.