### PR TITLE
Surface pulumi_preview/pulumi_up errors to the Neo agent

### DIFF
--- a/changelog/pending/20260511--cli-neo--include-the-failure-reason-in-pulumi-preview-and-pulumi-up-tool-results-when-they-fail.yaml
+++ b/changelog/pending/20260511--cli-neo--include-the-failure-reason-in-pulumi-preview-and-pulumi-up-tool-results-when-they-fail.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Include the failure reason in `pulumi_preview` and `pulumi_up` tool results when they fail, so the agent can react instead of seeing a blank error

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -570,6 +570,35 @@ func TestSession_InvokeToolCallHandlerErrorWithPartialValue(t *testing.T) {
 	assert.Equal(t, partial, item.Content)
 }
 
+// structResult stands in for pulumiResult — a non-map struct returned by a
+// handler — without pulling in the cross-package dependency.
+type structResult struct {
+	Status string
+	Logs   string
+}
+
+func TestSession_InvokeToolCallStructValueErrorPreservesContent(t *testing.T) {
+	t.Parallel()
+
+	// A struct returned alongside an error must reach the agent verbatim; the
+	// pulumi tool's failedResult strategy depends on it.
+	result := structResult{Status: "failed", Logs: "error: stack not found\n"}
+	s := &Session{
+		Handlers: map[string]ToolHandler{
+			"pulumi": &fakeHandler{
+				wantMethod: "pulumi_preview",
+				result:     result,
+				err:        errors.New("pulumi preview: stack not found"),
+			},
+		},
+	}
+	item := s.invokeToolCall(t.Context(),
+		apitype.AgentBackendEventToolCall{ToolCallID: "c", Name: "pulumi__pulumi_preview"})
+
+	assert.True(t, item.IsError)
+	assert.Equal(t, result, item.Content)
+}
+
 // errStreamer fails at StreamNeoTaskEvents so the Run loop returns immediately.
 type errStreamer struct{ err error }
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -198,22 +198,22 @@ func (p *Pulumi) Invoke(ctx context.Context, method string, args json.RawMessage
 
 func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiResult, error) {
 	if a.StackName == "" {
-		return pulumiResult{}, errors.New("stack_name is required")
+		return failedResult(a, "", errors.New("stack_name is required"))
 	}
 	if a.LocalPulumiDir == "" {
-		return pulumiResult{}, errors.New("local_pulumi_dir is required")
+		return failedResult(a, "", errors.New("local_pulumi_dir is required"))
 	}
 	if !filepath.IsAbs(a.LocalPulumiDir) {
-		return pulumiResult{}, errors.New("local_pulumi_dir must be an absolute path")
+		return failedResult(a, "", errors.New("local_pulumi_dir must be an absolute path"))
 	}
 
 	// Confine local_pulumi_dir to the Session sandbox.
 	dir, err := resolveUnderRoots([]string{p.Cwd}, a.LocalPulumiDir, false)
 	if err != nil {
-		return pulumiResult{}, err
+		return failedResult(a, "", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "Pulumi.yaml")); err != nil {
-		return pulumiResult{}, fmt.Errorf("local_pulumi_dir %q: Pulumi.yaml not found", a.LocalPulumiDir)
+		return failedResult(a, "", fmt.Errorf("local_pulumi_dir %q: Pulumi.yaml not found", a.LocalPulumiDir))
 	}
 
 	// Apply environment variables for the engine run. We snapshot and restore the
@@ -230,34 +230,34 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	// process-global — concurrent callers from outside the Session would race.
 	prevDir, err := os.Getwd()
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("recording working directory: %w", err)
+		return failedResult(a, "", fmt.Errorf("recording working directory: %w", err))
 	}
 	if err := os.Chdir(dir); err != nil {
-		return pulumiResult{}, fmt.Errorf("chdir %q: %w", dir, err)
+		return failedResult(a, "", fmt.Errorf("chdir %q: %w", dir, err))
 	}
 	defer func() { _ = os.Chdir(prevDir) }()
 
 	proj, root, err := p.Workspace.ReadProject()
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("reading project: %w", err)
+		return failedResult(a, "", fmt.Errorf("reading project: %w", err))
 	}
 
 	stackRef, err := p.Backend.ParseStackReference(a.StackName)
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("parsing stack reference: %w", err)
+		return failedResult(a, "", fmt.Errorf("parsing stack reference: %w", err))
 	}
 	s, err := p.Backend.GetStack(ctx, stackRef)
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("getting stack: %w", err)
+		return failedResult(a, "", fmt.Errorf("getting stack: %w", err))
 	}
 	if s == nil {
-		return pulumiResult{}, fmt.Errorf("stack %q not found", a.StackName)
+		return failedResult(a, "", fmt.Errorf("stack %q not found", a.StackName))
 	}
 
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("getting stack configuration: %w", err)
+		return failedResult(a, "", fmt.Errorf("getting stack configuration: %w", err))
 	}
 
 	decrypter := sm.Decrypter()
@@ -265,13 +265,13 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	if err := workspace.ValidateStackConfigAndApplyProjectConfig(
 		ctx, s.Ref().Name().String(), proj, cfg.Environment, cfg.Config, encrypter, decrypter,
 	); err != nil {
-		return pulumiResult{}, fmt.Errorf("validating stack config: %w", err)
+		return failedResult(a, "", fmt.Errorf("validating stack config: %w", err))
 	}
 
 	autonamer, err := autonaming.ParseAutonamingConfig(
 		autonamingStackContextFor(proj, s), cfg.Config, decrypter)
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("getting autonaming config: %w", err)
+		return failedResult(a, "", fmt.Errorf("getting autonaming config: %w", err))
 	}
 
 	// Pass nil for flags: GetUpdateMetadata only uses them to record
@@ -279,7 +279,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	m, err := metadata.GetUpdateMetadata("" /*message*/, root,
 		"neo" /*execKind*/, "" /*execAgent*/, false /*updatePlan*/, cfg, nil)
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("gathering metadata: %w", err)
+		return failedResult(a, "", fmt.Errorf("gathering metadata: %w", err))
 	}
 
 	opts := backend.UpdateOptions{
@@ -304,7 +304,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 
 	eventsFile, err := os.CreateTemp("", "pulumi-neo-events-*.ndjson")
 	if err != nil {
-		return pulumiResult{}, fmt.Errorf("creating events file: %w", err)
+		return failedResult(a, "", fmt.Errorf("creating events file: %w", err))
 	}
 	// We deliberately do NOT delete the file on exit — the agent may read it via
 	// the filesystem tool after the handler returns. Callers accept the OS temp-dir
@@ -392,7 +392,11 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		if isPreview {
 			label = "preview"
 		}
-		return res, fmt.Errorf("pulumi %s: %w", label, runErr)
+		// Prepend the error so the agent sees the reason even when the engine
+		// returned without emitting any DiagEvents (host crash, plugin
+		// discovery, marshalling).
+		res.Logs = fmt.Sprintf("error: pulumi %s: %s\n", label, runErr) + res.Logs
+		return res, errToolFailed
 	}
 	return res, nil
 }
@@ -644,6 +648,25 @@ func newPulumiResult(proj *workspace.Project, stackRef backend.StackReference, e
 		StackName:   stackRef.Name().String(),
 		EventsFile:  eventsPath,
 	}
+}
+
+// errToolFailed is the sentinel returned by failedResult. Its content is unread:
+// Session.invokeToolCall reads only err != nil to flip IsError.
+var errToolFailed = errors.New("pulumi tool failed")
+
+// failedResult builds the (pulumiResult, error) pair for every failure path in
+// run(). Session.invokeToolCall keeps the handler's value as Content (a zero
+// pulumiResult boxed into any is non-nil because the interface carries a type
+// descriptor, so the err.Error() fallback never fires), so Status and Logs are
+// the only channels through which the failure reason reaches the agent.
+func failedResult(a pulumiArgs, eventsPath string, err error) (pulumiResult, error) {
+	return pulumiResult{
+		Status:      "failed",
+		Logs:        "error: " + err.Error() + "\n",
+		ProjectName: a.ProjectName,
+		StackName:   a.StackName,
+		EventsFile:  eventsPath,
+	}, errToolFailed
 }
 
 // autonamingStackContextFor mirrors operations.autonamingStackContext without pulling in

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -17,6 +17,7 @@ package tools
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -98,34 +99,44 @@ func TestPulumi_InvokeRejectsBadJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "decoding")
 }
 
+// assertFailedResult checks that the handler's returned value is a pulumiResult
+// that self-describes the failure — Status="failed" plus the error text in Logs.
+func assertFailedResult(t *testing.T, value any, errSubstr string) {
+	t.Helper()
+	res, ok := value.(pulumiResult)
+	require.True(t, ok, "expected pulumiResult, got %T", value)
+	assert.Equal(t, "failed", res.Status)
+	assert.Contains(t, res.Logs, errSubstr)
+}
+
 func TestPulumi_RunRejectsMissingStackName(t *testing.T) {
 	t.Parallel()
 
 	p := &Pulumi{Cwd: t.TempDir()}
-	_, err := p.Invoke(t.Context(), "pulumi_preview",
+	value, err := p.Invoke(t.Context(), "pulumi_preview",
 		json.RawMessage(`{"project_name":"p","local_pulumi_dir":"/tmp"}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "stack_name is required")
+	assertFailedResult(t, value, "stack_name is required")
 }
 
 func TestPulumi_RunRejectsMissingLocalDir(t *testing.T) {
 	t.Parallel()
 
 	p := &Pulumi{Cwd: t.TempDir()}
-	_, err := p.Invoke(t.Context(), "pulumi_preview",
+	value, err := p.Invoke(t.Context(), "pulumi_preview",
 		json.RawMessage(`{"project_name":"p","stack_name":"dev"}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "local_pulumi_dir is required")
+	assertFailedResult(t, value, "local_pulumi_dir is required")
 }
 
 func TestPulumi_RunRejectsRelativeLocalDir(t *testing.T) {
 	t.Parallel()
 
 	p := &Pulumi{Cwd: t.TempDir()}
-	_, err := p.Invoke(t.Context(), "pulumi_preview",
+	value, err := p.Invoke(t.Context(), "pulumi_preview",
 		json.RawMessage(`{"project_name":"p","stack_name":"dev","local_pulumi_dir":"relative/path"}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be an absolute path")
+	assertFailedResult(t, value, "must be an absolute path")
 }
 
 func TestPulumi_RunRejectsEscapingLocalDir(t *testing.T) {
@@ -144,9 +155,9 @@ func TestPulumi_RunRejectsEscapingLocalDir(t *testing.T) {
 		"local_pulumi_dir": outside,
 	})
 	require.NoError(t, err)
-	_, err = p.Invoke(t.Context(), "pulumi_preview", args)
+	value, err := p.Invoke(t.Context(), "pulumi_preview", args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "outside")
+	assertFailedResult(t, value, "outside")
 }
 
 func TestPulumi_RunRejectsMissingPulumiYaml(t *testing.T) {
@@ -162,9 +173,25 @@ func TestPulumi_RunRejectsMissingPulumiYaml(t *testing.T) {
 		"local_pulumi_dir": root,
 	})
 	require.NoError(t, err)
-	_, err = p.Invoke(t.Context(), "pulumi_preview", args)
+	value, err := p.Invoke(t.Context(), "pulumi_preview", args)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Pulumi.yaml not found")
+	assertFailedResult(t, value, "Pulumi.yaml not found")
+}
+
+func TestFailedResult(t *testing.T) {
+	t.Parallel()
+
+	res, err := failedResult(
+		pulumiArgs{ProjectName: "proj", StackName: "dev"},
+		"/tmp/events.ndjson",
+		errors.New("kaboom"),
+	)
+	require.ErrorIs(t, err, errToolFailed)
+	assert.Equal(t, "failed", res.Status)
+	assert.Equal(t, "proj", res.ProjectName)
+	assert.Equal(t, "dev", res.StackName)
+	assert.Equal(t, "/tmp/events.ndjson", res.EventsFile)
+	assert.Equal(t, "error: kaboom\n", res.Logs)
 }
 
 func TestEnvValUnmarshal(t *testing.T) {
@@ -317,10 +344,9 @@ func TestOpSortRank(t *testing.T) {
 }
 
 // TestPulumi_InvokeRoutesPreviewAndUp confirms the method dispatch in Invoke
-// reaches both run() entry points. Both methods get past JSON decoding and
-// hit the same arg-validation rule (`local_pulumi_dir is required`) — the
-// fact that both succeed at decoding and produce that same downstream error
-// proves the switch wires both arms, not a single method via a fallthrough.
+// reaches both run() entry points. Observing the same downstream
+// arg-validation failure from each arm proves the switch wires both, not a
+// single method via a fallthrough.
 func TestPulumi_InvokeRoutesPreviewAndUp(t *testing.T) {
 	t.Parallel()
 
@@ -328,10 +354,10 @@ func TestPulumi_InvokeRoutesPreviewAndUp(t *testing.T) {
 		t.Run(method, func(t *testing.T) {
 			t.Parallel()
 			p := &Pulumi{Cwd: t.TempDir()}
-			_, err := p.Invoke(t.Context(), method,
+			value, err := p.Invoke(t.Context(), method,
 				json.RawMessage(`{"project_name":"p","stack_name":"dev"}`))
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "local_pulumi_dir is required")
+			assertFailedResult(t, value, "local_pulumi_dir is required")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- `Pulumi.run` returned `(pulumiResult{}, err)` on every preflight failure. When that empty struct is boxed into the `any` returned from `Pulumi.Invoke`, `Session.invokeToolCall`'s `value != nil` guard always wins — the `err.Error()` fallback is dead code, so the agent sees `IsError=true` with a blank result and no failure reason. Engine errors that don't emit diagnostics hit the same hole.
- New `failedResult` helper builds a `pulumiResult` with `Status="failed"` and `Logs="error: <msg>"` for every error path. Engine-failure branch prepends the wrapped error to `Logs` the same way. Handler now matches the self-describe contract `shell.go` already follows.

Fixes pulumi/pulumi-service#42969

## Test plan

- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/...` passes
- [x] `make format` / `make lint` clean
- [x] Existing preflight tests tightened to assert `Status="failed"` and the error substring in `Logs`
- [x] New `TestFailedResult` covers the helper directly
- [x] New `TestSession_InvokeToolCallStructValueErrorPreservesContent` locks in the struct-vs-map dispatch contract so a future refactor can't silently regress it

🤖 Generated with [Claude Code](https://claude.com/claude-code)