### PR TITLE
display: close event logger's output channel on completion

### DIFF
--- a/changelog/pending/20260511--cli-display--close-event-logger-output-channel-on-completion.yaml
+++ b/changelog/pending/20260511--cli-display--close-event-logger-output-channel-on-completion.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/display
+  description: Close the event logger's output channel once the input stream ends, so consumers that drain via `range` terminate instead of deadlocking

--- a/changelog/pending/20260511--cli-display--close-event-logger-output-channel-on-completion.yaml
+++ b/changelog/pending/20260511--cli-display--close-event-logger-output-channel-on-completion.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: cli/display
-  description: Close the event logger's output channel once the input stream ends, so consumers that drain via `range` terminate instead of deadlocking

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -189,16 +189,15 @@ func startEventLogger(
 
 		client := pulumirpc.NewEventsClient(conn)
 
+		stream, err := client.StreamEvents(context.TODO())
+		if err != nil {
+			logging.V(7).Infof("failed to start event stream: %v", err)
+			return events, done
+		}
+
 		outEvents, outDone := make(chan engine.StampedEvent), make(chan bool)
 		go func() {
 			defer close(done)
-
-			stream, err := client.StreamEvents(context.TODO())
-			if err != nil {
-				logging.V(7).Infof("failed to start event stream: %v", err)
-				<-outDone
-				return
-			}
 
 			for e := range events {
 				var buf bytes.Buffer

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -228,6 +228,7 @@ func startEventLogger(
 				logging.V(7).Infof("failed to close event stream: %v", err)
 			}
 
+			close(outEvents)
 			<-outDone
 		}()
 
@@ -262,6 +263,7 @@ func startEventLogger(
 			}
 		}
 
+		close(outEvents)
 		<-outDone
 	}()
 

--- a/pkg/backend/display/display_test.go
+++ b/pkg/backend/display/display_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -75,6 +76,59 @@ func TestShowEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(read), "not-filtered")
 	assert.Contains(t, string(read), "this-is-filtered-from-display")
+}
+
+func TestStartEventLogger_ClosesOutputOnInputClose(t *testing.T) {
+	t.Parallel()
+
+	// startEventLogger must close its output channel when the input is exhausted,
+	// so consumers can rely on standard `for range` semantics rather than having
+	// to break on CancelEvent.
+	eventLog, err := os.CreateTemp(t.TempDir(), "event-log-")
+	require.NoError(t, err)
+
+	events := make(chan engine.StampedEvent, 1)
+	events <- engine.StampedEvent{Event: engine.NewCancelEvent()}
+	close(events)
+
+	done := make(chan bool)
+	outEvents, outDone := startEventLogger(events, done, Options{
+		EventLogPath: eventLog.Name(),
+	})
+
+	drained := make(chan struct{})
+	go func() {
+		for range outEvents { //nolint:revive // intentional drain
+		}
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(2 * time.Second):
+		t.Fatal("outEvents was not closed after the input was drained")
+	}
+
+	close(outDone)
+	<-done
+}
+
+func TestStartEventLogger_TCPFallsBackOnInvalidTarget(t *testing.T) {
+	t.Parallel()
+
+	// If the TCP target is unusable, startEventLogger must fall back to the
+	// original (events, done) so the rest of the display pipeline still runs.
+	// "tcp://" with an empty address makes grpc.NewClient fail synchronously.
+	events := make(chan engine.StampedEvent)
+	done := make(chan bool)
+
+	outEvents, outDone := startEventLogger(events, done, Options{
+		EventLogPath: "tcp://",
+	})
+
+	// The originals are returned unchanged — same channel identity.
+	assert.Equal(t, (<-chan engine.StampedEvent)(events), outEvents)
+	assert.Equal(t, (chan<- bool)(done), outDone)
 }
 
 func TestEscapeURN(t *testing.T) {


### PR DESCRIPTION
## Summary

`startEventLogger` returns a channel (`outEvents`) that is never closed when the input stream ends. The existing display consumers (`ShowDiffEvents`, `ShowJSONEvents`, `ShowProgressEvents`, `ShowWatchEvents`, `ShowPreviewDigest`) sidestep this by breaking on `CancelEvent` rather than waiting for closure, so the bug has stayed latent — but the invariant that an exhausted producer closes its output channel was being silently violated.

Surfaced while iterating on #22870: an earlier draft of the summary-JSON tap drained the upstream with `for range tapped`, and deadlocked waiting on a closure that never came. That PR has its own targeted fix (break on `CancelEvent`); this one fixes the underlying invariant so future consumers can rely on standard channel-close semantics.

Two related fixes in `startEventLogger`:

1. Close `outEvents` after the input loop exits, in both the file and TCP branches.
2. In the TCP branch, if `client.StreamEvents` fails, fall back to `return events, done` — matching the pattern already used when `grpc.NewClient` fails. The previous code created `outEvents`/`outDone` and then blocked the goroutine on `<-outDone` forever, since the consumer was waiting on a channel that would never receive.

## Test plan

- [x] `go test ./pkg/backend/display/...` passes
- [x] Manual: `pulumi up --event-log /tmp/events.log` writes 8 events to the log (ending with `cancelEvent`) and exits with code 0 in ~0.9s
- [x] Manual: `pulumi up --event-log tcp://127.0.0.1:1` (unreachable port) completes cleanly in ~0.4s with exit code 0 — no hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)