### PR TITLE
Neo auto-approve switch

### DIFF
--- a/changelog/pending/20260507--cli-neo--surface-approval-and-permission-modes.yaml
+++ b/changelog/pending/20260507--cli-neo--surface-approval-and-permission-modes.yaml
@@ -1,4 +1,4 @@
 changes:
-- type: improvement
+- type: feat
   scope: cli/neo
   description: Add `--approval-mode` and `--permission-mode` flags to `pulumi neo`, with Ctrl+A and Ctrl+R hotkeys to switch modes mid-session

--- a/changelog/pending/20260507--cli-neo--surface-approval-and-permission-modes.yaml
+++ b/changelog/pending/20260507--cli-neo--surface-approval-and-permission-modes.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: improvement
+  scope: cli/neo
+  description: Add `--approval-mode` and `--permission-mode` flags to `pulumi neo`, with Ctrl+A and Ctrl+R hotkeys to switch modes mid-session

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -58,11 +58,15 @@ const (
 )
 
 // NeoApprovalMode controls whether the agent requires user approval before executing tools.
+// Mirrors apitype.NeoApprovalMode in pulumi-service; the wire values must stay in sync.
 type NeoApprovalMode string
 
 const (
 	// NeoApprovalModeManual requires the agent to request user approval for each tool call.
 	NeoApprovalModeManual NeoApprovalMode = "manual"
+	// NeoApprovalModeBalanced auto-approves low-risk tool calls and prompts only on
+	// destructive operations. The cloud ApprovalHandler decides which calls qualify.
+	NeoApprovalModeBalanced NeoApprovalMode = "balanced"
 	// NeoApprovalModeAuto allows the agent to execute tools without user approval.
 	NeoApprovalModeAuto NeoApprovalMode = "auto"
 )
@@ -73,6 +77,19 @@ type NeoTaskSource string
 const (
 	// NeoTaskSourceCLI tags tasks created from the Pulumi CLI.
 	NeoTaskSourceCLI NeoTaskSource = "cli"
+)
+
+// NeoPermissionMode caps the capabilities granted to an agent task. Mirrors
+// apitype.NeoPermissionMode in pulumi-service; the wire values must stay in sync.
+type NeoPermissionMode string
+
+const (
+	// NeoPermissionModeDefault grants the agent the full set of capabilities permitted
+	// by the user's role. This is the server's default when the field is omitted.
+	NeoPermissionModeDefault NeoPermissionMode = "default"
+	// NeoPermissionModeReadOnly restricts the agent to read-only operations: no
+	// `pulumi up`, no PR creation, no state mutations.
+	NeoPermissionModeReadOnly NeoPermissionMode = "read-only"
 )
 
 // NeoTaskRequest represents a request to create a Neo task. This is a thin client-side
@@ -89,6 +106,9 @@ type NeoTaskRequest struct {
 	// ApprovalMode controls whether the agent requires user approval before executing tools.
 	// JSON tag is camelCase to match apitype.CreateAgentTaskRequest from pulumi-service.
 	ApprovalMode NeoApprovalMode `json:"approvalMode,omitempty"`
+	// PermissionMode caps the agent's capabilities (default vs read-only). Empty means
+	// inherit the org / server default. JSON tag is camelCase to match the service IDL.
+	PermissionMode NeoPermissionMode `json:"permissionMode,omitempty"`
 	// PlanMode, when true, creates the task in plan mode: the agent explores and asks
 	// questions but must not write files, run `pulumi up`, or open PRs. The server enforces
 	// this by activating PlanModeTracker for the task and gating the exit on an approved
@@ -1712,17 +1732,16 @@ func (pc *Client) ExplainPreviewWithNeo(
 }
 
 // CreateNeoTaskOptions bundles the optional knobs on CreateNeoTask. The zero value
-// corresponds to the defaults used by `--neo-task-on-failure`: cloud tool execution,
-// server-default approval policy, and plan mode off.
+// accepts the server-side defaults for every field.
 type CreateNeoTaskOptions struct {
 	ToolExecutionMode string
 	ApprovalMode      NeoApprovalMode
+	PermissionMode    NeoPermissionMode
 	PlanMode          bool
 }
 
 // CreateNeoTask creates a new Neo agent task via the Neo Tasks API. See
-// CreateNeoTaskOptions for the available knobs; pass a zero-value struct to accept
-// server defaults (the `--neo-task-on-failure` path).
+// CreateNeoTaskOptions for the available knobs.
 func (pc *Client) CreateNeoTask(
 	ctx context.Context,
 	orgName string,
@@ -1742,6 +1761,7 @@ func (pc *Client) CreateNeoTask(
 		},
 		ToolExecutionMode: opts.ToolExecutionMode,
 		ApprovalMode:      opts.ApprovalMode,
+		PermissionMode:    opts.PermissionMode,
 		PlanMode:          opts.PlanMode,
 		Source:            NeoTaskSourceCLI,
 	}
@@ -1762,6 +1782,31 @@ func (pc *Client) CreateNeoTask(
 	}
 
 	return &resp, nil
+}
+
+// UpdateNeoTaskOptions bundles the fields a CLI session can change on a live task.
+// Pointer fields let callers update one axis without resetting the other — matches
+// the apitype.UpdateTaskRequest shape on the cloud side.
+type UpdateNeoTaskOptions struct {
+	ApprovalMode   *NeoApprovalMode   `json:"approvalMode,omitempty"`
+	PermissionMode *NeoPermissionMode `json:"permissionMode,omitempty"`
+}
+
+// UpdateNeoTask PATCHes an existing Neo task with new approval / permission mode
+// values. Used by the TUI's mid-session toggles (Ctrl+A / Ctrl+R) so the cloud
+// ApprovalHandler picks up the change immediately. Fields left nil in opts are
+// not sent — the server preserves the existing value.
+func (pc *Client) UpdateNeoTask(
+	ctx context.Context, orgName, taskID string, opts UpdateNeoTaskOptions,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
+	defer cancel()
+
+	path := fmt.Sprintf("/api/preview/agents/%s/tasks/%s", orgName, taskID)
+	if err := pc.restCall(ctx, http.MethodPatch, path, nil, opts, nil); err != nil {
+		return fmt.Errorf("updating Neo task: %w", err)
+	}
+	return nil
 }
 
 // NeoStreamEvent is one item from a Neo task Server-Sent Events (SSE) stream. Exactly

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1064,6 +1064,124 @@ func TestCreateNeoTask(t *testing.T) {
 
 		assert.NotContains(t, gotBody, "planMode", "planMode must be omitted when false")
 	})
+
+	t.Run("PermissionModeReadOnlySerializes", func(t *testing.T) {
+		t.Parallel()
+
+		// permissionMode is per-task and the cloud caps OBO token scopes when it
+		// reads "read-only". The wire tag is camelCase to match apitype.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_5"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "stack", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode: "cli",
+			PermissionMode:    NeoPermissionModeReadOnly,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "read-only", gotBody["permissionMode"])
+	})
+
+	t.Run("PermissionModeOmittedWhenEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		// An empty PermissionMode must not appear in the body so the server
+		// falls back to the org default rather than seeing an invalid value.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_6"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", CreateNeoTaskOptions{})
+		require.NoError(t, err)
+
+		assert.NotContains(t, gotBody, "permissionMode")
+	})
+}
+
+func TestUpdateNeoTask(t *testing.T) {
+	t.Parallel()
+
+	// UpdateNeoTask is the CLI's mid-session toggle path: it PATCHes /tasks/{id}
+	// with whichever mode fields the user just toggled. The pointer fields on
+	// UpdateNeoTaskOptions ensure that a single-axis toggle doesn't reset the
+	// other axis on the server side.
+
+	t.Run("ApprovalModeUpdate", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			gotPath   string
+			gotMethod string
+			gotBody   map[string]any
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			gotPath = req.URL.Path
+			gotMethod = req.Method
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		mode := NeoApprovalModeBalanced
+		err := c.UpdateNeoTask(t.Context(), "my-org", "task_1", UpdateNeoTaskOptions{
+			ApprovalMode: &mode,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPatch, gotMethod)
+		assert.Equal(t, "/api/preview/agents/my-org/tasks/task_1", gotPath)
+		assert.Equal(t, "balanced", gotBody["approvalMode"])
+		assert.NotContains(t, gotBody, "permissionMode",
+			"a single-axis toggle must not send the untouched axis")
+	})
+
+	t.Run("PermissionModeUpdate", func(t *testing.T) {
+		t.Parallel()
+
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		perm := NeoPermissionModeReadOnly
+		err := c.UpdateNeoTask(t.Context(), "my-org", "task_2", UpdateNeoTaskOptions{
+			PermissionMode: &perm,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, "read-only", gotBody["permissionMode"])
+		assert.NotContains(t, gotBody, "approvalMode")
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		t.Parallel()
+
+		errorServer := newMockServer(http.StatusBadRequest, `{"message": "bad"}`)
+		defer errorServer.Close()
+
+		c := newMockClient(errorServer)
+		mode := NeoApprovalModeAuto
+		err := c.UpdateNeoTask(t.Context(), "my-org", "task_x", UpdateNeoTaskOptions{
+			ApprovalMode: &mode,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "updating Neo task")
+	})
 }
 
 func TestPostNeoTaskUserEvent(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -76,13 +76,23 @@ func isInvalidEntitiesError(err error) bool {
 }
 
 // outboundEvent is the local envelope the TUI uses to dispatch user events to
-// runNeo's dispatcher loop. It wraps the wire-level AgentUserEvent and tacks on
-// planMode, which is only meaningful for the first user_message (the one that
-// triggers CreateNeoTask). Wrapping keeps planMode out of apitype and avoids a
-// second channel for a value that's always produced alongside a message.
+// runNeo's dispatcher loop. It carries either a wire-level AgentUserEvent (chat
+// messages, approval answers, cancels) or, when update is non-nil, a mid-session
+// approval/permission mode change. Wrapping keeps these out of apitype and avoids
+// a second channel for values produced alongside the user's keypresses.
+//
+// planMode, approvalMode, and permissionMode are only meaningful on the first
+// user_message — the one that triggers CreateNeoTask. The dispatcher snapshots
+// them into the create-task call. Later toggles surface through update instead.
 type outboundEvent struct {
-	event    apitype.AgentUserEvent
-	planMode bool
+	event          apitype.AgentUserEvent
+	planMode       bool
+	approvalMode   client.NeoApprovalMode
+	permissionMode client.NeoPermissionMode
+	// update, when non-nil, requests a PATCH against the live task instead of
+	// posting a user event. Used by Ctrl+A / Ctrl+R after the first message has
+	// been sent, so cloud ApprovalHandler picks up the new mode immediately.
+	update *client.UpdateNeoTaskOptions
 }
 
 // Indirection points for the integration test in neo_integration_test.go.
@@ -101,9 +111,11 @@ var (
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {
 	var (
-		stackName string
-		orgFlag   string
-		cwdFlag   string
+		stackName          string
+		orgFlag            string
+		cwdFlag            string
+		approvalModeFlag   string
+		permissionModeFlag string
 	)
 
 	cmd := &cobra.Command{
@@ -121,7 +133,15 @@ func NewNeoCmd() *cobra.Command {
 			if len(args) > 0 {
 				prompt = args[0]
 			}
-			return runNeo(ctx, prompt, stackName, orgFlag, cwdFlag)
+			approvalMode, err := parseApprovalMode(approvalModeFlag)
+			if err != nil {
+				return err
+			}
+			permissionMode, err := parsePermissionMode(permissionModeFlag)
+			if err != nil {
+				return err
+			}
+			return runNeo(ctx, prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode)
 		},
 	}
 
@@ -131,11 +151,45 @@ func NewNeoCmd() *cobra.Command {
 		"The organization that owns the Neo task (defaults to the user's default org)")
 	cmd.Flags().StringVar(&cwdFlag, "cwd", "",
 		"Working directory for local tool execution (defaults to the current directory)")
+	cmd.Flags().StringVar(&approvalModeFlag, "approval-mode", string(client.NeoApprovalModeManual),
+		"Approval mode for tool calls: 'manual' prompts on every call, 'balanced' "+
+			"auto-approves low-risk calls, 'auto' executes everything without prompting")
+	cmd.Flags().StringVar(&permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
+		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
+			"'read-only' blocks state-mutating operations")
 
 	return cmd
 }
 
-func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) error {
+// parseApprovalMode validates the --approval-mode flag value against the
+// NeoApprovalMode enum. The cloud rejects unknown values too, but a CLI-side
+// check produces a clearer error before any network round-trip.
+func parseApprovalMode(s string) (client.NeoApprovalMode, error) {
+	switch client.NeoApprovalMode(s) {
+	case client.NeoApprovalModeManual,
+		client.NeoApprovalModeBalanced,
+		client.NeoApprovalModeAuto:
+		return client.NeoApprovalMode(s), nil
+	}
+	return "", fmt.Errorf("invalid --approval-mode %q: expected one of manual, balanced, auto", s)
+}
+
+// parsePermissionMode validates the --permission-mode flag value against the
+// NeoPermissionMode enum.
+func parsePermissionMode(s string) (client.NeoPermissionMode, error) {
+	switch client.NeoPermissionMode(s) {
+	case client.NeoPermissionModeDefault, client.NeoPermissionModeReadOnly:
+		return client.NeoPermissionMode(s), nil
+	}
+	return "", fmt.Errorf("invalid --permission-mode %q: expected one of default, read-only", s)
+}
+
+func runNeo(
+	ctx context.Context,
+	prompt, stackName, orgFlag, cwdFlag string,
+	approvalMode client.NeoApprovalMode,
+	permissionMode client.NeoPermissionMode,
+) error {
 	if cwdFlag == "" {
 		var err error
 		cwdFlag, err = os.Getwd()
@@ -200,7 +254,8 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 		resp, err := createNeoTaskWithEntityRetry(
 			ctx, pc, orgName, prompt, stackRefName, projectName, client.CreateNeoTaskOptions{
 				ToolExecutionMode: "cli",
-				ApprovalMode:      client.NeoApprovalModeManual,
+				ApprovalMode:      approvalMode,
+				PermissionMode:    permissionMode,
 			}, nil)
 		if err != nil {
 			return err
@@ -230,14 +285,16 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
 	model := NewModel(ModelConfig{
-		Org:           orgName,
-		WorkDir:       cwdFlag,
-		Username:      username,
-		Version:       version.Version,
-		EventCh:       uiCh,
-		OutCh:         outCh,
-		Busy:          prompt != "",
-		InitialPrompt: prompt,
+		Org:                   orgName,
+		WorkDir:               cwdFlag,
+		Username:              username,
+		Version:               version.Version,
+		EventCh:               uiCh,
+		OutCh:                 outCh,
+		Busy:                  prompt != "",
+		InitialPrompt:         prompt,
+		InitialApprovalMode:   approvalMode,
+		InitialPermissionMode: permissionMode,
 	})
 
 	// Inline (non-alt-screen) so the transcript stays in the user's terminal
@@ -260,13 +317,20 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 
 			// createTask creates the Neo task with the given prompt and starts the session.
 			// Called immediately if a prompt was provided, or on the first user message.
-			// planMode is the value the TUI captured at the moment the first message was
-			// sent; the CLI-prompt path always passes false.
-			createTask := func(initialPrompt string, planMode bool) error {
+			// approvalMode / permissionMode / planMode are the values the TUI captured at
+			// the moment the first message was sent; the CLI-prompt path passes the values
+			// from the --approval-mode / --permission-mode flags and false for plan mode.
+			createTask := func(
+				initialPrompt string,
+				createApprovalMode client.NeoApprovalMode,
+				createPermissionMode client.NeoPermissionMode,
+				planMode bool,
+			) error {
 				resp, err := createNeoTaskWithEntityRetry(
 					gctx, pc, orgName, initialPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
 						ToolExecutionMode: "cli",
-						ApprovalMode:      client.NeoApprovalModeManual,
+						ApprovalMode:      createApprovalMode,
+						PermissionMode:    createPermissionMode,
 						PlanMode:          planMode,
 					}, func(originalErr error) {
 						sendUI(uiCh, UIWarning{Message: fmt.Sprintf(
@@ -300,9 +364,11 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 			}
 
 			if prompt != "" {
-				// The command-line prompt path always passes false for planMode.
+				// The command-line prompt path always passes false for planMode and
+				// uses the modes parsed from the CLI flags (which the TUI also seeds
+				// into its model). A subsequent toggle still routes through the TUI.
 				g.Go(func() error {
-					return createTask(prompt, false)
+					return createTask(prompt, approvalMode, permissionMode, false)
 				})
 			}
 
@@ -330,13 +396,16 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 						defer ts.mu.Unlock()
 						return ts.taskID
 					},
-					func(message string, planMode bool) {
+					func(message string, am client.NeoApprovalMode, pm client.NeoPermissionMode, planMode bool) {
 						g.Go(func() error {
-							return createTask(message, planMode)
+							return createTask(message, am, pm, planMode)
 						})
 					},
 					func(ctx context.Context, taskID string, body any) error {
 						return pc.PostNeoTaskUserEvent(ctx, orgName, taskID, body)
+					},
+					func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
+						return pc.UpdateNeoTask(ctx, orgName, taskID, opts)
 					},
 				)
 			})
@@ -397,8 +466,10 @@ func dispatchUserEvents(
 	uiCh chan<- UIEvent,
 	initialTaskCreated bool,
 	getTaskID func() string,
-	spawnCreateTask func(message string, planMode bool),
+	spawnCreateTask func(message string, approvalMode client.NeoApprovalMode,
+		permissionMode client.NeoPermissionMode, planMode bool),
 	postEvent func(ctx context.Context, taskID string, body any) error,
+	updateTask func(ctx context.Context, taskID string, opts client.UpdateNeoTaskOptions) error,
 ) error {
 	taskCreated := initialTaskCreated
 	for {
@@ -411,16 +482,29 @@ func dispatchUserEvents(
 			}
 			if msg, isMsg := ob.event.(apitype.AgentUserEventUserMessage); isMsg && !taskCreated {
 				taskCreated = true
-				spawnCreateTask(msg.Content, ob.planMode)
+				spawnCreateTask(msg.Content, ob.approvalMode, ob.permissionMode, ob.planMode)
 				continue
 			}
 			taskID := getTaskID()
 			if taskID == "" {
+				// A pre-task-creation mode toggle is a no-op: CreateNeoTask hasn't
+				// fired yet, so the next createTask call will pick up the latest
+				// values from the model snapshot. Drop silently — this is the
+				// expected path when the user toggles before sending a message.
+				if ob.update != nil {
+					continue
+				}
 				// Unreachable in normal use: the TUI gates Enter on busy state
 				// until UITaskIdle, and approvals only fire in response to backend
 				// events that imply the task exists. Surface instead of silently
 				// dropping.
 				sendUI(uiCh, UIWarning{Message: "dropped event: task not ready"})
+				continue
+			}
+			if ob.update != nil {
+				if err := updateTask(ctx, taskID, *ob.update); err != nil {
+					sendUI(uiCh, UIWarning{Message: "failed to update Neo task: " + err.Error()})
+				}
 				continue
 			}
 			if err := postEvent(ctx, taskID, ob.event); err != nil {

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -293,7 +293,8 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// rather than relying on `go test -timeout` to catch a hang.
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	}()
 
 	select {
@@ -378,7 +379,8 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	}()
 
 	select {
@@ -405,7 +407,8 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	srv := newNeoFakeServer(t)
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
-	err := runNeo(t.Context(), "" /*prompt*/, "", "test-org", t.TempDir())
+	err := runNeo(t.Context(), "" /*prompt*/, "", "test-org", t.TempDir(),
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
 
@@ -430,7 +433,8 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
 		"non-cloud backends must surface a clear error rather than panic on the type assertion")
@@ -460,7 +464,8 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// cwdFlag empty → runNeo calls os.Getwd. The test's own working
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
-		done <- runNeo(t.Context(), "do a thing", "", "test-org", "" /*cwd*/)
+		done <- runNeo(t.Context(), "do a thing", "", "test-org", "", /*cwd*/
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	}()
 
 	select {
@@ -483,7 +488,8 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	missing := t.TempDir() + "/does-not-exist"
-	err := runNeo(t.Context(), "do a thing", "", "test-org", missing)
+	err := runNeo(t.Context(), "do a thing", "", "test-org", missing,
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
 	// path should be referenced so the user can see what went wrong.
@@ -511,7 +517,8 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 		},
 	}
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
 	assert.Empty(t, srv.recordedPosts(),
@@ -555,7 +562,8 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	isInteractive = func() bool { return false }
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir())
+	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
@@ -627,7 +635,8 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir())
+		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
 	}()
 
 	select {

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -673,6 +673,14 @@ func TestRunWithTUI_ParentContextCancellationStopsWorkers(t *testing.T) {
 // test reached the post branch when it shouldn't have.
 func noopPostEvent(context.Context, string, any) error { return nil }
 
+// noopSpawn is the spawnCreateTask stub for dispatcher tests that aren't
+// exercising lazy task creation. Discards everything.
+func noopSpawn(string, client.NeoApprovalMode, client.NeoPermissionMode, bool) {}
+
+// noopUpdateTask is the updateTask stub for dispatcher tests that aren't
+// exercising the mid-session update path. Always succeeds.
+func noopUpdateTask(context.Context, string, client.UpdateNeoTaskOptions) error { return nil }
+
 func TestDispatchUserEvents_ContextCancelExits(t *testing.T) {
 	t.Parallel()
 
@@ -682,7 +690,7 @@ func TestDispatchUserEvents_ContextCancelExits(t *testing.T) {
 	go func() {
 		done <- dispatchUserEvents(ctx, out, nil, true,
 			func() string { return "task-1" },
-			func(string, bool) {}, noopPostEvent)
+			noopSpawn, noopPostEvent, noopUpdateTask)
 	}()
 
 	cancel()
@@ -702,7 +710,7 @@ func TestDispatchUserEvents_ChannelCloseExits(t *testing.T) {
 	go func() {
 		done <- dispatchUserEvents(t.Context(), out, nil, true,
 			func() string { return "task-1" },
-			func(string, bool) {}, noopPostEvent)
+			noopSpawn, noopPostEvent, noopUpdateTask)
 	}()
 
 	close(out)
@@ -722,9 +730,13 @@ func TestDispatchUserEvents_LazyTaskCreationOnFirstUserMessage(t *testing.T) {
 	// events should NOT spawn again — the dispatcher tracks taskCreated.
 	var spawned []string
 	var spawnedPlanMode []bool
-	spawn := func(msg string, planMode bool) {
+	var spawnedApproval []client.NeoApprovalMode
+	var spawnedPermission []client.NeoPermissionMode
+	spawn := func(msg string, am client.NeoApprovalMode, pm client.NeoPermissionMode, planMode bool) {
 		spawned = append(spawned, msg)
 		spawnedPlanMode = append(spawnedPlanMode, planMode)
+		spawnedApproval = append(spawnedApproval, am)
+		spawnedPermission = append(spawnedPermission, pm)
 	}
 
 	postCalls := 0
@@ -735,8 +747,10 @@ func TestDispatchUserEvents_LazyTaskCreationOnFirstUserMessage(t *testing.T) {
 
 	out := make(chan outboundEvent, 4)
 	out <- outboundEvent{
-		event:    apitype.AgentUserEventUserMessage{Type: userEventUserMessage, Content: "hello"},
-		planMode: true,
+		event:          apitype.AgentUserEventUserMessage{Type: userEventUserMessage, Content: "hello"},
+		planMode:       true,
+		approvalMode:   client.NeoApprovalModeBalanced,
+		permissionMode: client.NeoPermissionModeReadOnly,
 	}
 	// Second event arrives after taskCreated is true and a taskID is set —
 	// must take the post branch, not the spawn branch.
@@ -747,13 +761,17 @@ func TestDispatchUserEvents_LazyTaskCreationOnFirstUserMessage(t *testing.T) {
 
 	err := dispatchUserEvents(t.Context(), out, nil, false,
 		func() string { return "task-1" },
-		spawn, post)
+		spawn, post, noopUpdateTask)
 	require.NoError(t, err)
 
 	require.Len(t, spawned, 1, "only the first user_message must trigger lazy task creation")
 	assert.Equal(t, "hello", spawned[0])
 	assert.Equal(t, []bool{true}, spawnedPlanMode,
 		"planMode must be forwarded from the outboundEvent envelope")
+	assert.Equal(t, []client.NeoApprovalMode{client.NeoApprovalModeBalanced}, spawnedApproval,
+		"approvalMode must be forwarded from the outboundEvent envelope")
+	assert.Equal(t, []client.NeoPermissionMode{client.NeoPermissionModeReadOnly}, spawnedPermission,
+		"permissionMode must be forwarded from the outboundEvent envelope")
 	assert.Equal(t, 1, postCalls, "the second event must be posted to the live task")
 }
 
@@ -772,11 +790,14 @@ func TestDispatchUserEvents_WarnsWhenTaskNotReady(t *testing.T) {
 
 	err := dispatchUserEvents(t.Context(), out, uiCh, false,
 		func() string { return "" }, // no task yet
-		func(string, bool) { t.Fatal("spawn must not fire for non-user_message") },
+		func(string, client.NeoApprovalMode, client.NeoPermissionMode, bool) {
+			t.Fatal("spawn must not fire for non-user_message")
+		},
 		func(context.Context, string, any) error {
 			t.Fatal("post must not fire when taskID is empty")
 			return nil
-		})
+		},
+		noopUpdateTask)
 	require.NoError(t, err)
 
 	close(uiCh)
@@ -806,11 +827,12 @@ func TestDispatchUserEvents_PostsEventToBackend(t *testing.T) {
 
 	err := dispatchUserEvents(t.Context(), out, nil, true,
 		func() string { return "task-1" },
-		func(string, bool) {},
+		noopSpawn,
 		func(_ context.Context, taskID string, body any) error {
 			calls = append(calls, postCall{taskID: taskID, body: body})
 			return nil
-		})
+		},
+		noopUpdateTask)
 	require.NoError(t, err)
 
 	require.Len(t, calls, 1)
@@ -833,10 +855,11 @@ func TestDispatchUserEvents_WarnsOnPostFailure(t *testing.T) {
 
 	err := dispatchUserEvents(t.Context(), out, uiCh, true,
 		func() string { return "task-1" },
-		func(string, bool) {},
+		noopSpawn,
 		func(context.Context, string, any) error {
 			return errors.New("network down")
-		})
+		},
+		noopUpdateTask)
 	require.NoError(t, err, "post errors must be reported via UIWarning, not propagated")
 
 	close(uiCh)
@@ -938,5 +961,147 @@ func TestCreateNeoTaskWithEntityRetry(t *testing.T) {
 			func(error) { t.Fatal("onEntityDropped should not fire when no stack is attached") })
 		require.Error(t, err)
 		assert.Equal(t, 1, calls)
+	})
+}
+
+func TestDispatchUserEvents_RoutesUpdateToUpdateTask(t *testing.T) {
+	t.Parallel()
+
+	// An outboundEvent.update entry carries a mid-session approval/permission
+	// toggle. The dispatcher must route it to updateTask (not postEvent) and
+	// pass through the Options struct verbatim, so the cloud PATCH lands.
+	type updateCall struct {
+		taskID string
+		opts   client.UpdateNeoTaskOptions
+	}
+	var updates []updateCall
+	mode := client.NeoApprovalModeBalanced
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{update: &client.UpdateNeoTaskOptions{ApprovalMode: &mode}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, nil, true,
+		func() string { return "task-1" },
+		noopSpawn,
+		func(context.Context, string, any) error {
+			t.Fatal("postEvent must not fire for an update-only outboundEvent")
+			return nil
+		},
+		func(_ context.Context, taskID string, opts client.UpdateNeoTaskOptions) error {
+			updates = append(updates, updateCall{taskID: taskID, opts: opts})
+			return nil
+		})
+	require.NoError(t, err)
+
+	require.Len(t, updates, 1)
+	assert.Equal(t, "task-1", updates[0].taskID)
+	require.NotNil(t, updates[0].opts.ApprovalMode)
+	assert.Equal(t, client.NeoApprovalModeBalanced, *updates[0].opts.ApprovalMode)
+}
+
+func TestDispatchUserEvents_DropsUpdateSilentlyWhenTaskNotReady(t *testing.T) {
+	t.Parallel()
+
+	// A pre-task-creation toggle is the expected path when the user presses
+	// Ctrl+A or Ctrl+R before sending any message. The dispatcher must drop
+	// the update without warning — the next CreateNeoTask will pick up the
+	// snapshotted value from the user_message envelope.
+	uiCh := make(chan UIEvent, 4)
+	mode := client.NeoApprovalModeAuto
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{update: &client.UpdateNeoTaskOptions{ApprovalMode: &mode}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, uiCh, false,
+		func() string { return "" }, // no task yet
+		noopSpawn,
+		noopPostEvent,
+		func(context.Context, string, client.UpdateNeoTaskOptions) error {
+			t.Fatal("updateTask must not fire when taskID is empty")
+			return nil
+		})
+	require.NoError(t, err)
+
+	close(uiCh)
+	for evt := range uiCh {
+		if w, ok := evt.(UIWarning); ok {
+			t.Fatalf("pre-task update must drop silently, got UIWarning: %s", w.Message)
+		}
+	}
+}
+
+func TestDispatchUserEvents_WarnsOnUpdateFailure(t *testing.T) {
+	t.Parallel()
+
+	// PATCH errors must surface as a UIWarning so the user knows the toggle
+	// didn't take effect, but the dispatcher itself must keep running — a
+	// transient cloud blip shouldn't tear the session down.
+	uiCh := make(chan UIEvent, 4)
+	mode := client.NeoApprovalModeAuto
+
+	out := make(chan outboundEvent, 1)
+	out <- outboundEvent{update: &client.UpdateNeoTaskOptions{ApprovalMode: &mode}}
+	close(out)
+
+	err := dispatchUserEvents(t.Context(), out, uiCh, true,
+		func() string { return "task-1" },
+		noopSpawn,
+		noopPostEvent,
+		func(context.Context, string, client.UpdateNeoTaskOptions) error {
+			return errors.New("network down")
+		})
+	require.NoError(t, err)
+
+	close(uiCh)
+	var got []UIWarning
+	for evt := range uiCh {
+		if w, ok := evt.(UIWarning); ok {
+			got = append(got, w)
+		}
+	}
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Message, "failed to update Neo task")
+	assert.Contains(t, got[0].Message, "network down")
+}
+
+func TestParseApprovalMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidValues", func(t *testing.T) {
+		t.Parallel()
+		for _, s := range []string{"manual", "balanced", "auto"} {
+			got, err := parseApprovalMode(s)
+			require.NoErrorf(t, err, "value %q must parse", s)
+			assert.Equal(t, client.NeoApprovalMode(s), got)
+		}
+	})
+
+	t.Run("RejectsUnknown", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseApprovalMode("yolo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manual, balanced, auto")
+	})
+}
+
+func TestParsePermissionMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidValues", func(t *testing.T) {
+		t.Parallel()
+		for _, s := range []string{"default", "read-only"} {
+			got, err := parsePermissionMode(s)
+			require.NoErrorf(t, err, "value %q must parse", s)
+			assert.Equal(t, client.NeoPermissionMode(s), got)
+		}
+	})
+
+	t.Run("RejectsUnknown", func(t *testing.T) {
+		t.Parallel()
+		_, err := parsePermissionMode("admin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "default, read-only")
 	})
 }

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -318,17 +318,40 @@ func (s *Session) forwardToUI(eventBody json.RawMessage) {
 	}
 }
 
-// forwardUserInputToUI parses a userInput event body and sends a UIUserMessage to the TUI.
+// forwardUserInputToUI parses a userInput event body and routes it to the TUI:
+// user_message → UIUserMessage (echo of a chat message, possibly from another
+// client) and user_confirmation → UIApprovalResolved (the cloud's signal that a
+// pending approval has been settled, either by the user clicking approve in the
+// console or by the auto-approval handler under ApprovalMode=auto/balanced).
 func (s *Session) forwardUserInputToUI(eventBody json.RawMessage) {
 	if s.UIEvents == nil {
 		return
 	}
 
-	var evt apitype.AgentUserEventUserMessage
-	if err := json.Unmarshal(eventBody, &evt); err != nil {
+	// Peek at the inner type; we reuse AgentBackendEventHeader because it's just
+	// a Type field and the JSON shape on the user-input side matches.
+	var head apitype.AgentBackendEventHeader
+	if err := json.Unmarshal(eventBody, &head); err != nil {
 		return
 	}
-	if evt.Content != "" {
-		sendUI(s.UIEvents, UIUserMessage{Content: evt.Content})
+
+	switch head.Type {
+	case userEventUserMessage:
+		var evt apitype.AgentUserEventUserMessage
+		if err := json.Unmarshal(eventBody, &evt); err != nil {
+			return
+		}
+		if evt.Content != "" {
+			sendUI(s.UIEvents, UIUserMessage{Content: evt.Content})
+		}
+	case userEventUserConfirmation:
+		var evt apitype.AgentUserEventUserConfirmation
+		if err := json.Unmarshal(eventBody, &evt); err != nil {
+			return
+		}
+		sendUI(s.UIEvents, UIApprovalResolved{
+			ApprovalID: evt.ApprovalID,
+			Approved:   evt.Approved,
+		})
 	}
 }

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -955,7 +955,10 @@ func TestSession_ForwardUserInputToUI_EmitsUserMessage(t *testing.T) {
 
 	ch := make(chan UIEvent, 4)
 	s := &Session{UIEvents: ch}
-	body, err := json.Marshal(map[string]any{"content": "hello there"})
+	body, err := json.Marshal(map[string]any{
+		"type":    userEventUserMessage,
+		"content": "hello there",
+	})
 	require.NoError(t, err)
 
 	s.forwardUserInputToUI(body)
@@ -974,7 +977,10 @@ func TestSession_ForwardUserInputToUI_EmptyContentDropped(t *testing.T) {
 	// UIUserMessage would draw an empty user bubble in the TUI.
 	ch := make(chan UIEvent, 4)
 	s := &Session{UIEvents: ch}
-	body, err := json.Marshal(map[string]any{"content": ""})
+	body, err := json.Marshal(map[string]any{
+		"type":    userEventUserMessage,
+		"content": "",
+	})
 	require.NoError(t, err)
 
 	s.forwardUserInputToUI(body)
@@ -985,9 +991,76 @@ func TestSession_ForwardUserInputToUI_NilChannelIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	s := &Session{UIEvents: nil}
-	body, err := json.Marshal(map[string]any{"content": "hi"})
+	body, err := json.Marshal(map[string]any{
+		"type":    userEventUserMessage,
+		"content": "hi",
+	})
 	require.NoError(t, err)
 	s.forwardUserInputToUI(body) // must not panic
+}
+
+func TestSession_ForwardUserInputToUI_UserConfirmationEmitsResolved(t *testing.T) {
+	t.Parallel()
+
+	// The cloud emits a user_confirmation event on the userInput side of the
+	// stream — both as an echo of our own confirmation and (synthetically)
+	// when ApprovalMode=auto/balanced auto-resolves a request. Either way the
+	// TUI needs UIApprovalResolved so it can clear the pending prompt.
+	ch := make(chan UIEvent, 4)
+	s := &Session{UIEvents: ch}
+	body, err := json.Marshal(map[string]any{
+		"type":                userEventUserConfirmation,
+		"approval_request_id": "sys-approval-abc",
+		"ok":                  true,
+	})
+	require.NoError(t, err)
+
+	s.forwardUserInputToUI(body)
+
+	events := drainUIEvents(ch)
+	require.Len(t, events, 1)
+	res, ok := events[0].(UIApprovalResolved)
+	require.Truef(t, ok, "expected UIApprovalResolved, got %T", events[0])
+	assert.Equal(t, "sys-approval-abc", res.ApprovalID)
+	assert.True(t, res.Approved, "ok=true must round-trip as Approved=true")
+}
+
+func TestSession_ForwardUserInputToUI_UserConfirmationDeniedRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// Defensive: today's cloud never auto-denies, but the wire format supports
+	// ok=false (manual deny path), and the TUI's renderApprovalAuto branches
+	// on Approved. Make sure the wire flag rides through unchanged.
+	ch := make(chan UIEvent, 4)
+	s := &Session{UIEvents: ch}
+	body, err := json.Marshal(map[string]any{
+		"type":                userEventUserConfirmation,
+		"approval_request_id": "sys-approval-xyz",
+		"ok":                  false,
+	})
+	require.NoError(t, err)
+
+	s.forwardUserInputToUI(body)
+
+	events := drainUIEvents(ch)
+	require.Len(t, events, 1)
+	res := events[0].(UIApprovalResolved)
+	assert.False(t, res.Approved)
+}
+
+func TestSession_ForwardUserInputToUI_UnknownTypeDropped(t *testing.T) {
+	t.Parallel()
+
+	// An unknown user-input subtype must not panic, must not emit an event.
+	// The cloud has historically added new userInput types (tool_result, etc.)
+	// that the TUI has no rendering for.
+	ch := make(chan UIEvent, 4)
+	s := &Session{UIEvents: ch}
+	body, err := json.Marshal(map[string]any{"type": "tool_result"})
+	require.NoError(t, err)
+
+	s.forwardUserInputToUI(body)
+	assert.Empty(t, drainUIEvents(ch))
 }
 
 func TestSession_ForwardUserInputToUI_MalformedJSONIgnored(t *testing.T) {
@@ -1007,7 +1080,10 @@ func TestSession_HandleEvent_UserInputEnvelope_EmitsUIUserMessage(t *testing.T) 
 	// 92.9% coverage) and the path the TUI depends on to show what the user
 	// typed — if this regresses, the user's own messages vanish from the log.
 	streamer := newFakeStreamer()
-	inner, err := json.Marshal(map[string]any{"content": "typed by user"})
+	inner, err := json.Marshal(map[string]any{
+		"type":    userEventUserMessage,
+		"content": "typed by user",
+	})
 	require.NoError(t, err)
 	envelope, err := json.Marshal(apitype.AgentConsoleEvent{
 		Type:      consoleEventUserInput,

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -45,6 +45,25 @@ type ctrlCDisarmMsg struct {
 	gen int
 }
 
+// modeToggleDebounce is the trailing-edge window for Ctrl+A / Ctrl+R: each
+// press updates local state immediately but only schedules a PATCH against the
+// live task after the user stops pressing for this long. Rapid mashing
+// collapses to one PATCH carrying the final value, so the cloud and the
+// dispatcher both see the user's intent instead of a noisy burst of updates.
+const modeToggleDebounce = 250 * time.Millisecond
+
+// approvalDebounceTickMsg / permissionDebounceTickMsg fire `modeToggleDebounce`
+// after each Ctrl+A / Ctrl+R press. They carry the generation they were
+// scheduled under so a newer press (which advances the generation) cancels the
+// stale tick by gen-mismatch.
+type approvalDebounceTickMsg struct {
+	gen int
+}
+
+type permissionDebounceTickMsg struct {
+	gen int
+}
+
 // blockKind identifies the type of rendered block in the output log.
 type blockKind int
 
@@ -160,6 +179,10 @@ type ModelConfig struct {
 	// that want to exercise the Shift+Tab post-send warning path without
 	// having to simulate a full Enter-driven send first.
 	MessageSent bool
+	// TaskCreated seeds the post-task-creation gate. Set it to true in tests
+	// that want to exercise the post-task Ctrl+A / Ctrl+R path without driving
+	// a UISessionURL through the event channel.
+	TaskCreated bool
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
@@ -217,10 +240,26 @@ type Model struct {
 	// permissionMode is the current capability scope, toggled via Ctrl+R. Same
 	// pre/post-send semantics as approvalMode.
 	permissionMode client.NeoPermissionMode
+	// approvalDebounceGen / permissionDebounceGen increment on every post-send
+	// Ctrl+A / Ctrl+R press. Each press schedules a tea.Tick carrying the
+	// current generation; the tick handler dispatches the PATCH only if the
+	// gen still matches, so rapid presses collapse to a single update with the
+	// final mode value.
+	approvalDebounceGen   int
+	permissionDebounceGen int
 	// messageSent flips to true when the TUI successfully dispatches its
 	// first user_message on outCh. From that point on, Shift+Tab emits the
 	// "plan mode is task-level" warning instead of toggling.
 	messageSent bool
+	// taskCreated flips to true when UISessionURL arrives — the dispatcher
+	// emits that immediately after CreateNeoTask returns OK, so it's the
+	// natural signal that the task is now addressable for PATCH. The window
+	// between messageSent and taskCreated is the race the Ctrl+A / Ctrl+R
+	// handlers gate on: in that window the dispatcher would silently drop a
+	// UpdateNeoTaskOptions event (no taskID yet), leaving the local mode out
+	// of sync with the cloud. Swallow the keypress instead so the status bar
+	// can't lie about what the cloud is enforcing.
+	taskCreated bool
 	// pendingApprovalType is the raw wire approval_type for the currently
 	// pending approval (empty when none). The Enter handler checks for
 	// approvalTypePlanExit so it can auto-clear planMode on approval.
@@ -369,6 +408,7 @@ func NewModel(cfg ModelConfig) Model {
 		width:          80,
 		height:         24,
 		messageSent:    cfg.MessageSent,
+		taskCreated:    cfg.TaskCreated,
 		approvalMode:   cfg.InitialApprovalMode,
 		permissionMode: cfg.InitialPermissionMode,
 	}
@@ -446,6 +486,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case approvalDebounceTickMsg:
+		// Trailing-edge debounce: dispatch the PATCH only if the user hasn't
+		// pressed Ctrl+A again since this tick was scheduled. A newer press
+		// advances approvalDebounceGen, so a stale tick is silently dropped
+		// here. taskCreated is guaranteed by the Ctrl+A handler that
+		// scheduled this tick.
+		if msg.gen == m.approvalDebounceGen {
+			next := m.approvalMode
+			m.sendOut(outboundEvent{
+				update: &client.UpdateNeoTaskOptions{ApprovalMode: &next},
+			})
+		}
+		return m, nil
+
+	case permissionDebounceTickMsg:
+		if msg.gen == m.permissionDebounceGen {
+			next := m.permissionMode
+			m.sendOut(outboundEvent{
+				update: &client.UpdateNeoTaskOptions{PermissionMode: &next},
+			})
+		}
+		return m, nil
+
 	case tea.KeyMsg:
 		// Ctrl+D mirrors Ctrl+C: same arm/quit gate, same cancel-when-busy
 		// semantics. Two bindings is friendlier than picking one and forcing
@@ -492,29 +555,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Ctrl+A cycles the approval mode (manual → balanced → auto → manual).
-		// Pre-message the value just updates the local snapshot; post-message we
-		// also dispatch an outboundEvent.update so the dispatcher PATCHes the
-		// live task and the cloud ApprovalHandler picks up the change.
+		// Pre-message the value just updates the local snapshot; post-message
+		// each press updates local state immediately but the PATCH against the
+		// live task is debounced via approvalDebounceTickMsg so rapid mashing
+		// collapses to one UpdateNeoTask carrying the final value (the cloud
+		// would otherwise see a noisy burst).
+		//
+		// The window between messageSent and taskCreated is a separate race:
+		// the dispatcher has no taskID to PATCH against yet and would silently
+		// drop the update. Swallow the keypress in that window so the status
+		// bar can't get out of sync with the cloud — the user can press again
+		// once the task URL arrives.
 		if msg.Type == tea.KeyCtrlA {
+			if m.messageSent && !m.taskCreated {
+				return m, nil
+			}
 			m.approvalMode = nextApprovalMode(m.approvalMode)
 			if m.messageSent {
-				next := m.approvalMode
-				m.sendOut(outboundEvent{
-					update: &client.UpdateNeoTaskOptions{ApprovalMode: &next},
-				})
+				return m, m.scheduleApprovalDebounce()
 			}
 			return m, nil
 		}
 
 		// Ctrl+R toggles the permission mode (default ↔ read-only). Same
-		// pre/post-send semantics as the approval-mode cycle above.
+		// pre/post-send semantics — and the same create-task race window and
+		// debounce mechanics — as the approval-mode cycle above.
 		if msg.Type == tea.KeyCtrlR {
+			if m.messageSent && !m.taskCreated {
+				return m, nil
+			}
 			m.permissionMode = nextPermissionMode(m.permissionMode)
 			if m.messageSent {
-				next := m.permissionMode
-				m.sendOut(outboundEvent{
-					update: &client.UpdateNeoTaskOptions{PermissionMode: &next},
-				})
+				return m, m.schedulePermissionDebounce()
 			}
 			return m, nil
 		}
@@ -707,6 +779,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// arrives, so emit the URL as its own line rather than re-rendering.
 		// OSC 8 wraps the URL so supporting terminals render it as clickable.
 		m.welcome.consoleURL = msg.URL
+		// CreateNeoTask sends UISessionURL immediately after taskID is set,
+		// so this is the natural moment to lift the post-Enter toggle freeze.
+		m.taskCreated = true
 		cmds = append(cmds, m.printlnBlock("  "+inputHintStyle.Render("⟡ "+osc8Hyperlink(msg.URL, msg.URL))))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -921,7 +996,7 @@ func (m Model) modeChips() string {
 		// Manual is the default — no chip, the status bar stays uncluttered.
 	}
 	if m.permissionMode == client.NeoPermissionModeReadOnly {
-		chips = append(chips, planAccentStyle.Render("🔒 read-only"))
+		chips = append(chips, planAccentStyle.Render("⊘ read-only"))
 	}
 	return strings.Join(chips, " ")
 }
@@ -1133,6 +1208,29 @@ func (m *Model) scheduleCtrlCDisarm() tea.Cmd {
 	gen := m.ctrlCArmGen
 	return tea.Tick(ctrlCArmTimeout, func(time.Time) tea.Msg {
 		return ctrlCDisarmMsg{gen: gen}
+	})
+}
+
+// scheduleApprovalDebounce advances the approval-debounce generation and
+// returns a tea.Cmd that posts an approvalDebounceTickMsg after
+// modeToggleDebounce. The Update handler dispatches the PATCH only if the
+// tick's gen still matches the current one — a subsequent Ctrl+A press
+// advances the gen and silently retires the stale tick.
+func (m *Model) scheduleApprovalDebounce() tea.Cmd {
+	m.approvalDebounceGen++
+	gen := m.approvalDebounceGen
+	return tea.Tick(modeToggleDebounce, func(time.Time) tea.Msg {
+		return approvalDebounceTickMsg{gen: gen}
+	})
+}
+
+// schedulePermissionDebounce is the permission-mode counterpart to
+// scheduleApprovalDebounce.
+func (m *Model) schedulePermissionDebounce() tea.Cmd {
+	m.permissionDebounceGen++
+	gen := m.permissionDebounceGen
+	return tea.Tick(modeToggleDebounce, func(time.Time) tea.Msg {
+		return permissionDebounceTickMsg{gen: gen}
 	})
 }
 

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/wordwrap"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
@@ -142,6 +143,12 @@ type ModelConfig struct {
 	// which is sent to the backend via CreateNeoTask rather than outCh and
 	// would otherwise only appear once the SSE stream echoes it back.
 	InitialPrompt string
+	// InitialApprovalMode and InitialPermissionMode seed the TUI's view of the
+	// task's approval / permission policy. These come from the --approval-mode /
+	// --permission-mode flags (or their defaults) and are sent on the first
+	// user_message; subsequent toggles via Ctrl+A / Ctrl+R PATCH the live task.
+	InitialApprovalMode   client.NeoApprovalMode
+	InitialPermissionMode client.NeoPermissionMode
 	// MessageSent seeds the post-first-message gate. Set it to true in tests
 	// that want to exercise the Shift+Tab post-send warning path without
 	// having to simulate a full Enter-driven send first.
@@ -194,6 +201,15 @@ type Model struct {
 	// true, Shift+Tab stops toggling and planMode is effectively frozen
 	// (further changes happen only via plan-approval auto-clear below).
 	planMode bool
+	// approvalMode is the current approval policy, cycled via Ctrl+A. Pre-first-
+	// message it's purely local — the value is snapshotted into CreateNeoTask on
+	// the first user_message. Post-send toggles dispatch an outboundEvent.update
+	// that the runNeo dispatcher routes through UpdateNeoTask, so cloud
+	// ApprovalHandler picks up the change without restarting the session.
+	approvalMode client.NeoApprovalMode
+	// permissionMode is the current capability scope, toggled via Ctrl+R. Same
+	// pre/post-send semantics as approvalMode.
+	permissionMode client.NeoPermissionMode
 	// messageSent flips to true when the TUI successfully dispatches its
 	// first user_message on outCh. From that point on, Shift+Tab emits the
 	// "plan mode is task-level" warning instead of toggling.
@@ -278,6 +294,30 @@ func renderLeftBracket(borderStyle lipgloss.Style, content string) string {
 	return strings.Join(out, "\n")
 }
 
+// nextApprovalMode returns the next value in the manual → balanced → auto →
+// manual cycle. Empty input is treated as manual so cycling from the zero value
+// lands on a real first state.
+func nextApprovalMode(m client.NeoApprovalMode) client.NeoApprovalMode {
+	switch m {
+	case client.NeoApprovalModeManual:
+		return client.NeoApprovalModeBalanced
+	case client.NeoApprovalModeBalanced:
+		return client.NeoApprovalModeAuto
+	case client.NeoApprovalModeAuto:
+		return client.NeoApprovalModeManual
+	}
+	return client.NeoApprovalModeManual
+}
+
+// nextPermissionMode flips between default and read-only. Anything else
+// (including empty) collapses back to default.
+func nextPermissionMode(m client.NeoPermissionMode) client.NeoPermissionMode {
+	if m == client.NeoPermissionModeReadOnly {
+		return client.NeoPermissionModeDefault
+	}
+	return client.NeoPermissionModeReadOnly
+}
+
 // renderIndented word-wraps content (ANSI-safe) to termWidth minus the
 // 2-space transcript gutter, or returns un-wrapped if the width is too
 // small to wrap into. URLs in the post-wrap output are wrapped in OSC 8
@@ -314,14 +354,16 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		textInput:   ti,
-		eventCh:     cfg.EventCh,
-		outCh:       cfg.OutCh,
-		busy:        cfg.Busy,
-		spinner:     sp,
-		width:       80,
-		height:      24,
-		messageSent: cfg.MessageSent,
+		textInput:      ti,
+		eventCh:        cfg.EventCh,
+		outCh:          cfg.OutCh,
+		busy:           cfg.Busy,
+		spinner:        sp,
+		width:          80,
+		height:         24,
+		messageSent:    cfg.MessageSent,
+		approvalMode:   cfg.InitialApprovalMode,
+		permissionMode: cfg.InitialPermissionMode,
 	}
 	if cfg.InitialPrompt != "" {
 		// Render the initial-prompt block now so tests can find it via
@@ -442,6 +484,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Ctrl+A cycles the approval mode (manual → balanced → auto → manual).
+		// Pre-message the value just updates the local snapshot; post-message we
+		// also dispatch an outboundEvent.update so the dispatcher PATCHes the
+		// live task and the cloud ApprovalHandler picks up the change.
+		if msg.Type == tea.KeyCtrlA {
+			m.approvalMode = nextApprovalMode(m.approvalMode)
+			if m.messageSent {
+				next := m.approvalMode
+				m.sendOut(outboundEvent{
+					update: &client.UpdateNeoTaskOptions{ApprovalMode: &next},
+				})
+			}
+			return m, nil
+		}
+
+		// Ctrl+R toggles the permission mode (default ↔ read-only). Same
+		// pre/post-send semantics as the approval-mode cycle above.
+		if msg.Type == tea.KeyCtrlR {
+			m.permissionMode = nextPermissionMode(m.permissionMode)
+			if m.messageSent {
+				next := m.permissionMode
+				m.sendOut(outboundEvent{
+					update: &client.UpdateNeoTaskOptions{PermissionMode: &next},
+				})
+			}
+			return m, nil
+		}
+
 		// ESC asks the agent to abort the current turn. Posts user_cancel
 		// upstream and flips the local cancelling flag so the spinner label
 		// switches to "Cancelling..." until the backend acknowledges via
@@ -538,7 +608,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						Type:    userEventUserMessage,
 						Content: text,
 					},
-					planMode: m.planMode,
+					planMode:       m.planMode,
+					approvalMode:   m.approvalMode,
+					permissionMode: m.permissionMode,
 				})
 				if sent {
 					// Render optimistically so the user sees their message in
@@ -773,13 +845,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // drawn here — they were committed to terminal scrollback via tea.Println as
 // soon as they reached a terminal state.
 func (m Model) View() string {
-	hintText := "enter to send · shift+tab to toggle plan mode · ctrl+c to quit"
+	hintText := "enter to send · shift+tab plan · ctrl+a approval · ctrl+r read-only · ctrl+c to quit"
 	if m.busy {
 		hintText = "agent is working · enter disabled · esc or ctrl+c to cancel"
 	}
 	hint := "  "
-	if m.planMode {
-		hint += planAccentStyle.Render("⏸ plan mode")
+	chips := m.modeChips()
+	if chips != "" {
+		hint += chips
 		hintText = " · " + hintText
 	}
 	if m.ctrlCArmed {
@@ -804,6 +877,28 @@ func (m Model) View() string {
 	}
 	parts = append(parts, m.textInput.View(), hint)
 	return strings.Join(parts, "\n")
+}
+
+// modeChips renders the status-bar chips for the three independent mode axes
+// (plan, approval, permission). Default values are omitted so the status bar
+// stays uncluttered until the user opts into something non-default.
+func (m Model) modeChips() string {
+	var chips []string
+	if m.planMode {
+		chips = append(chips, planAccentStyle.Render("⏸ plan mode"))
+	}
+	switch m.approvalMode {
+	case client.NeoApprovalModeBalanced:
+		chips = append(chips, planAccentStyle.Render("⚖ balanced"))
+	case client.NeoApprovalModeAuto:
+		chips = append(chips, planAccentStyle.Render("⚡ auto-approve"))
+	case client.NeoApprovalModeManual:
+		// Manual is the default — no chip, the status bar stays uncluttered.
+	}
+	if m.permissionMode == client.NeoPermissionModeReadOnly {
+		chips = append(chips, planAccentStyle.Render("🔒 read-only"))
+	}
+	return strings.Join(chips, " ")
 }
 
 // liveWidth returns the width to use when rendering live-frame content:

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -50,7 +50,7 @@ type ctrlCDisarmMsg struct {
 // live task after the user stops pressing for this long. Rapid mashing
 // collapses to one PATCH carrying the final value, so the cloud and the
 // dispatcher both see the user's intent instead of a noisy burst of updates.
-const modeToggleDebounce = 250 * time.Millisecond
+const modeToggleDebounce = 500 * time.Millisecond
 
 // approvalDebounceTickMsg / permissionDebounceTickMsg fire `modeToggleDebounce`
 // after each Ctrl+A / Ctrl+R press. They carry the generation they were

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -59,6 +59,7 @@ const (
 	blockApprovalPlan
 	blockApprovalGeneral
 	blockApprovalChoice
+	blockApprovalAuto
 	blockQuestion
 	blockAnswerSubmitted
 	blockPulumiOp
@@ -77,8 +78,14 @@ type block struct {
 	// label and shimmer apply to blockBusy only.
 	label   string
 	shimmer shimmerKind
-	// approved applies to blockApprovalChoice only.
+	// approved applies to blockApprovalChoice and blockApprovalAuto. For
+	// blockApprovalAuto it carries the "ok" field from the cloud's
+	// user_confirmation (true=auto-approved, false=auto-denied).
 	approved bool
+	// autoIsQuestion applies to blockApprovalAuto only — true if the underlying
+	// request was an ask-user call (so the renderer says "Auto-answered" rather
+	// than "Auto-approved").
+	autoIsQuestion bool
 	// pulumi carries per-block state for blockPulumiOp. It is mutated in place
 	// as UIPulumiResource / UIPulumiDiag / UIPulumiEnd events arrive, then
 	// re-rendered by renderBlock on every update.
@@ -830,6 +837,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
+	case UIApprovalResolved:
+		// Discriminator: pendingApproval is still true iff the cloud auto-
+		// resolved this request server-side (under ApprovalMode=auto/balanced).
+		// The manual path clears state locally on Enter before sending its
+		// user_confirmation upstream, so when the cloud echoes that back here
+		// pendingApproval is already false — and we no-op, which is correct.
+		// The ID match guards against a stale resolved event arriving after
+		// the user has already moved on to a different approval.
+		if m.pendingApproval && msg.ApprovalID == m.pendingApprovalID {
+			cmds = append(cmds, m.commitBlock(block{
+				kind:           blockApprovalAuto,
+				approved:       msg.Approved,
+				autoIsQuestion: m.pendingIsQuestion,
+			}))
+			m.clearPendingPrompt()
+		}
+		cmds = append(cmds, waitForEvent(m.eventCh))
+
 	default:
 		// Pass unhandled messages to textinput (e.g. blink).
 		var tiCmd tea.Cmd
@@ -959,8 +984,8 @@ func isLiveKind(b block) bool {
 		return b.pulumi != nil && !b.pulumi.done
 	case blockToolComplete, blockAssistantFinal, blockError, blockWarning,
 		blockCancelled, blockUserMessage, blockApprovalPlan,
-		blockApprovalGeneral, blockApprovalChoice, blockTodoList,
-		blockQuestion, blockAnswerSubmitted:
+		blockApprovalGeneral, blockApprovalChoice, blockApprovalAuto,
+		blockTodoList, blockQuestion, blockAnswerSubmitted:
 		return false
 	}
 	return false
@@ -1153,11 +1178,16 @@ func (m *Model) findBlockKind(kind blockKind) int {
 }
 
 // renderBlock recomputes b.rendered from b.raw using the current terminal
-// width and markdown renderer. blockApprovalChoice is the one kind that
-// still renders when raw is empty (its verdict is carried by b.approved).
+// width and markdown renderer. blockApprovalChoice and blockApprovalAuto are
+// the two kinds that still render when raw is empty (their state is carried
+// by b.approved / b.autoIsQuestion instead).
 func (m *Model) renderBlock(b *block) {
 	if b.kind == blockApprovalChoice {
 		m.renderApprovalChoice(b)
+		return
+	}
+	if b.kind == blockApprovalAuto {
+		m.renderApprovalAuto(b)
 		return
 	}
 	if b.kind == blockPulumiOp {
@@ -1206,7 +1236,7 @@ func (m *Model) renderBlock(b *block) {
 	case blockBusy, blockToolComplete:
 		// No raw: blockBusy renders live from label, blockToolComplete is
 		// pre-styled at event time.
-	case blockApprovalChoice, blockPulumiOp, blockTodoList:
+	case blockApprovalChoice, blockApprovalAuto, blockPulumiOp, blockTodoList:
 		// Unreachable: handled by early returns above.
 	}
 }
@@ -1233,6 +1263,23 @@ func renderTodoLines(items []UITodoItem) string {
 		lines = append(lines, marker+" "+content)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// renderApprovalAuto renders a feedback block committed when the cloud
+// auto-resolves a pending approval/question under ApprovalMode=auto or
+// balanced. The verb depends on what was asked (approval vs ask-user) and
+// whether the cloud reported ok=true; today auto-deny doesn't exist on the
+// cloud side but we render it anyway in case that changes.
+func (m *Model) renderApprovalAuto(b *block) {
+	verb := "Auto-approved"
+	switch {
+	case !b.approved:
+		verb = "Auto-denied"
+	case b.autoIsQuestion:
+		verb = "Auto-answered"
+	}
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	b.rendered = "  " + style.Render("⚡ "+verb)
 }
 
 func (m *Model) renderApprovalChoice(b *block) {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -945,7 +945,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // drawn here — they were committed to terminal scrollback via tea.Println as
 // soon as they reached a terminal state.
 func (m Model) View() string {
-	hintText := "enter to send · shift+tab plan · ctrl+a approval · ctrl+r read-only · ctrl+c to quit"
+	hintText := "enter to send · shift+tab plan · ctrl+a auto-approval · ctrl+r read-only · ctrl+c to quit"
 	if m.busy {
 		hintText = "agent is working · enter disabled · esc or ctrl+c to cancel"
 	}

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -124,6 +124,25 @@ type UIApprovalRequest struct {
 
 func (UIApprovalRequest) uiEvent() {}
 
+// UIApprovalResolved signals that a user_approval_request has been settled. The
+// cloud emits the underlying user_confirmation event in two cases: as an echo of
+// the user's own manual confirmation, and as a synthetic event when the auto-
+// approval handler resolves the request server-side under ApprovalMode=auto or
+// balanced. The TUI matches ApprovalID to its own pendingApprovalID and uses
+// the still-pending vs already-cleared state to discriminate auto-resolve from
+// echo (manual Enter clears the pending state locally before sending upstream,
+// so an echo arriving here lands with pendingApproval already false).
+type UIApprovalResolved struct {
+	ApprovalID string
+	// Approved mirrors the "ok" field on the wire: true for approved/answered,
+	// false for denied. Auto-resolve under the current cloud policy always
+	// emits Approved=true, but we carry the flag through so a future auto-deny
+	// path renders correctly.
+	Approved bool
+}
+
+func (UIApprovalResolved) uiEvent() {}
+
 // UIAwaitingApprovals is an interim backend signal that the agent is pausing before
 // it will emit a UIApprovalRequest. The declarative busy rule treats it as non-final
 // and shows an "Awaiting approvals" label until the approval request arrives.

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -2582,3 +2582,157 @@ func TestModel_Update_KeyEnter_FirstMessageCarriesAllModes(t *testing.T) {
 		t.Fatal("Enter must post the input to outCh")
 	}
 }
+
+// newQuestionPendingModel returns a Model that has just received a question
+// (ask-user) request — analogous to newApprovalPendingModel but routes through
+// the isAskUserToolName branch so pendingIsQuestion gets set.
+func newQuestionPendingModel(t *testing.T) Model {
+	t.Helper()
+	m := NewModel(ModelConfig{EventCh: make(chan UIEvent, 4), Busy: true})
+	updated, _ := m.Update(UIApprovalRequest{
+		ApprovalID: "appr_q",
+		Message:    "What region?",
+		ToolName:   "ux__ask_user",
+	})
+	return updated.(Model)
+}
+
+func TestModel_Update_UIApprovalResolved_AutoApprovedCommitsBlockAndClears(t *testing.T) {
+	t.Parallel()
+
+	// The cloud auto-resolved a pending approval. The TUI must commit an
+	// "Auto-approved" feedback block to scrollback and reset the prompt — the
+	// agent has already moved on, so the question prompt is no longer relevant.
+	m := newApprovalPendingModel(t, make(chan outboundEvent, 1))
+	require.True(t, m.pendingApproval, "precondition: approval is pending")
+
+	updated, cmd := m.Update(UIApprovalResolved{ApprovalID: "appr_1", Approved: true})
+	m = updated.(Model)
+
+	assert.False(t, m.pendingApproval, "matching resolved must clear pendingApproval")
+	assert.Empty(t, m.pendingApprovalID, "pendingApprovalID must reset")
+	assert.False(t, m.pendingIsQuestion)
+	assert.Equal(t, "❯ ", m.textInput.Prompt, "prompt must return to default")
+	assert.Equal(t, "Send a message...", m.textInput.Placeholder)
+
+	idx := m.findBlockKind(blockApprovalAuto)
+	require.GreaterOrEqual(t, idx, 0, "a blockApprovalAuto must be appended")
+	assert.True(t, m.blocks[idx].approved, "approved flag must round-trip from msg.Approved")
+	assert.False(t, m.blocks[idx].autoIsQuestion, "approval (not question) path must set autoIsQuestion=false")
+
+	// The commit also queues a tea.Println so the block lands in terminal
+	// scrollback. Verify the rendered string carries the "Auto-approved" verb.
+	printed := collectPrintln(cmd)
+	require.NotEmpty(t, printed, "auto-resolved block must be emitted to scrollback")
+	assert.Contains(t, printed[len(printed)-1], "Auto-approved")
+}
+
+func TestModel_Update_UIApprovalResolved_AutoApprovedQuestionRendersAnsweredVerb(t *testing.T) {
+	t.Parallel()
+
+	// Question (ask-user) path: pendingIsQuestion=true. The auto-resolved block
+	// must carry that flag through so the renderer says "Auto-answered" instead
+	// of "Auto-approved" — auto-approving an ask-user is conceptually answering
+	// with the default, not approving.
+	m := newQuestionPendingModel(t)
+	require.True(t, m.pendingApproval)
+	require.True(t, m.pendingIsQuestion)
+
+	updated, cmd := m.Update(UIApprovalResolved{ApprovalID: "appr_q", Approved: true})
+	m = updated.(Model)
+
+	assert.False(t, m.pendingApproval)
+	idx := m.findBlockKind(blockApprovalAuto)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.True(t, m.blocks[idx].autoIsQuestion, "question path must carry autoIsQuestion=true")
+
+	printed := collectPrintln(cmd)
+	require.NotEmpty(t, printed)
+	assert.Contains(t, printed[len(printed)-1], "Auto-answered")
+}
+
+func TestModel_Update_UIApprovalResolved_AutoDeniedRendersDeniedVerb(t *testing.T) {
+	t.Parallel()
+
+	// Defensive: ApprovalMode=auto never denies today, but the wire format
+	// supports it (ok=false) and a future cloud policy could exercise this
+	// path. The TUI must render "Auto-denied" so the user sees what happened.
+	m := newApprovalPendingModel(t, make(chan outboundEvent, 1))
+
+	updated, cmd := m.Update(UIApprovalResolved{ApprovalID: "appr_1", Approved: false})
+	m = updated.(Model)
+
+	idx := m.findBlockKind(blockApprovalAuto)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.False(t, m.blocks[idx].approved)
+
+	printed := collectPrintln(cmd)
+	require.NotEmpty(t, printed)
+	assert.Contains(t, printed[len(printed)-1], "Auto-denied")
+}
+
+func TestModel_Update_UIApprovalResolved_EchoOfManualIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Manual confirmation already clears pendingApproval locally (the Enter
+	// handler does that before sending upstream). When the cloud later echoes
+	// our own user_confirmation back on the stream, the TUI must NOT render an
+	// auto-approved block — pendingApproval is already false, so the handler
+	// silently no-ops.
+	m := NewModel(ModelConfig{EventCh: make(chan UIEvent, 4)})
+	require.False(t, m.pendingApproval, "precondition: no pending approval")
+
+	updated, _ := m.Update(UIApprovalResolved{ApprovalID: "appr_1", Approved: true})
+	m = updated.(Model)
+
+	assert.False(t, m.pendingApproval)
+	assert.Equal(t, -1, m.findBlockKind(blockApprovalAuto),
+		"echo of our own confirmation must not commit a blockApprovalAuto")
+}
+
+func TestModel_Update_UIApprovalResolved_MismatchedIDIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// A resolved event arriving with a different approval ID than the one the
+	// TUI is currently waiting on must be ignored — it's either stale or for a
+	// different request. The current pending state must survive.
+	m := newApprovalPendingModel(t, make(chan outboundEvent, 1))
+	require.True(t, m.pendingApproval)
+	require.Equal(t, "appr_1", m.pendingApprovalID)
+
+	updated, _ := m.Update(UIApprovalResolved{ApprovalID: "appr_other", Approved: true})
+	m = updated.(Model)
+
+	assert.True(t, m.pendingApproval, "mismatched ID must not clear pending state")
+	assert.Equal(t, "appr_1", m.pendingApprovalID)
+	assert.Equal(t, -1, m.findBlockKind(blockApprovalAuto),
+		"mismatched ID must not commit a blockApprovalAuto")
+}
+
+func TestRenderApprovalAuto_VerbVariants(t *testing.T) {
+	t.Parallel()
+
+	// Direct render-helper checks for the three string variants. lipgloss may
+	// embed ANSI in the rendered output, so we assert on Contains.
+	m := NewModel(ModelConfig{})
+
+	cases := []struct {
+		name           string
+		approved       bool
+		autoIsQuestion bool
+		want           string
+	}{
+		{name: "auto-approved", approved: true, autoIsQuestion: false, want: "Auto-approved"},
+		{name: "auto-answered", approved: true, autoIsQuestion: true, want: "Auto-answered"},
+		{name: "auto-denied-approval", approved: false, autoIsQuestion: false, want: "Auto-denied"},
+		{name: "auto-denied-question", approved: false, autoIsQuestion: true, want: "Auto-denied"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			b := &block{kind: blockApprovalAuto, approved: tc.approved, autoIsQuestion: tc.autoIsQuestion}
+			m.renderApprovalAuto(b)
+			assert.Contains(t, b.rendered, tc.want)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -2385,4 +2386,199 @@ func TestLiveView_BlankBetweenLiveBlocks(t *testing.T) {
 	require.Less(t, pulumiIdx, thinkingIdx)
 	assert.Contains(t, live[pulumiIdx:thinkingIdx], "\n\n",
 		"pulumi-op → busy gap must be a full blank line")
+}
+
+func TestModel_Update_CtrlA_CyclesApprovalMode(t *testing.T) {
+	t.Parallel()
+
+	// Ctrl+A advances the approval mode through manual → balanced → auto →
+	// manual. Pre-first-message there is no PATCH dispatch — the value lives
+	// purely in the TUI snapshot until the user sends their first message.
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoApprovalModeBalanced, m.approvalMode)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoApprovalModeAuto, m.approvalMode)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoApprovalModeManual, m.approvalMode,
+		"third Ctrl+A must wrap back to manual")
+
+	// Pre-message toggles must not put anything on outCh — the snapshot is
+	// only committed on the first user_message.
+	select {
+	case ev := <-outCh:
+		t.Fatalf("pre-message Ctrl+A must not dispatch an outbound event, got %#v", ev)
+	default:
+	}
+}
+
+func TestModel_Update_CtrlA_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
+	t.Parallel()
+
+	// Once the first message has been sent, Ctrl+A must both flip the local
+	// snapshot AND dispatch an outboundEvent.update so the runNeo dispatcher
+	// PATCHes the live task. Without that, cloud ApprovalHandler would still
+	// see the original mode and prompt at the wrong cadence.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		MessageSent:         true,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoApprovalModeBalanced, m.approvalMode)
+
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update, "Ctrl+A after send must dispatch an update")
+		require.NotNil(t, got.update.ApprovalMode, "update must carry the new approvalMode")
+		assert.Equal(t, client.NeoApprovalModeBalanced, *got.update.ApprovalMode)
+		assert.Nil(t, got.update.PermissionMode,
+			"approval-mode toggle must not include permissionMode")
+	default:
+		t.Fatal("Ctrl+A after send must post an outboundEvent.update on outCh")
+	}
+}
+
+func TestModel_Update_CtrlR_TogglesPermissionMode(t *testing.T) {
+	t.Parallel()
+
+	// Ctrl+R flips read-only on and off. Like Ctrl+A, pre-message it's a
+	// purely local flip; post-message it dispatches an update.
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{
+		OutCh:                 outCh,
+		InitialPermissionMode: client.NeoPermissionModeDefault,
+	})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoPermissionModeReadOnly, m.permissionMode)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoPermissionModeDefault, m.permissionMode,
+		"second Ctrl+R must flip back to default")
+
+	select {
+	case ev := <-outCh:
+		t.Fatalf("pre-message Ctrl+R must not dispatch, got %#v", ev)
+	default:
+	}
+}
+
+func TestModel_Update_CtrlR_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
+	t.Parallel()
+
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:                 outCh,
+		MessageSent:           true,
+		InitialPermissionMode: client.NeoPermissionModeDefault,
+	})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoPermissionModeReadOnly, m.permissionMode)
+
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update)
+		require.NotNil(t, got.update.PermissionMode)
+		assert.Equal(t, client.NeoPermissionModeReadOnly, *got.update.PermissionMode)
+		assert.Nil(t, got.update.ApprovalMode,
+			"permission-mode toggle must not include approvalMode")
+	default:
+		t.Fatal("Ctrl+R after send must post an outboundEvent.update on outCh")
+	}
+}
+
+func TestModel_View_ModeChips(t *testing.T) {
+	t.Parallel()
+
+	// Default modes (manual approval, default permission) collapse to no chips
+	// so the status bar stays uncluttered. Each non-default value gets its own
+	// chip; multiple chips concatenate with a space separator. We assert on
+	// modeChips() directly rather than View() because the hint line itself
+	// mentions "read-only" / "approval" in its keybindings legend.
+	t.Run("DefaultsRenderNoChips", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{
+			InitialApprovalMode:   client.NeoApprovalModeManual,
+			InitialPermissionMode: client.NeoPermissionModeDefault,
+		})
+		assert.Empty(t, m.modeChips(), "manual+default must render no chips")
+	})
+
+	t.Run("BalancedRendersChip", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{InitialApprovalMode: client.NeoApprovalModeBalanced})
+		assert.Contains(t, m.modeChips(), "balanced")
+	})
+
+	t.Run("AutoRendersChip", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{InitialApprovalMode: client.NeoApprovalModeAuto})
+		assert.Contains(t, m.modeChips(), "auto-approve")
+	})
+
+	t.Run("ReadOnlyRendersChip", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{InitialPermissionMode: client.NeoPermissionModeReadOnly})
+		assert.Contains(t, m.modeChips(), "read-only")
+	})
+
+	t.Run("MultipleChipsCoexist", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{
+			InitialApprovalMode:   client.NeoApprovalModeAuto,
+			InitialPermissionMode: client.NeoPermissionModeReadOnly,
+		})
+		m.planMode = true
+		chips := m.modeChips()
+		assert.Contains(t, chips, "plan mode")
+		assert.Contains(t, chips, "auto-approve")
+		assert.Contains(t, chips, "read-only")
+	})
+}
+
+func TestModel_Update_KeyEnter_FirstMessageCarriesAllModes(t *testing.T) {
+	t.Parallel()
+
+	// The first user message must snapshot all three axes (planMode,
+	// approvalMode, permissionMode) into the outboundEvent envelope. The
+	// dispatcher uses these to seed CreateNeoTask; if the snapshot is wrong
+	// the cloud task is created with the wrong policy.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:                 outCh,
+		InitialApprovalMode:   client.NeoApprovalModeBalanced,
+		InitialPermissionMode: client.NeoPermissionModeReadOnly,
+	})
+	m.planMode = true
+	m.textInput.SetValue("kick off")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = updated
+
+	select {
+	case got := <-outCh:
+		assert.True(t, got.planMode)
+		assert.Equal(t, client.NeoApprovalModeBalanced, got.approvalMode)
+		assert.Equal(t, client.NeoPermissionModeReadOnly, got.permissionMode)
+	default:
+		t.Fatal("Enter must post the input to outCh")
+	}
 }

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -2433,6 +2433,7 @@ func TestModel_Update_CtrlA_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
 	m := NewModel(ModelConfig{
 		OutCh:               outCh,
 		MessageSent:         true,
+		TaskCreated:         true,
 		InitialApprovalMode: client.NeoApprovalModeManual,
 	})
 
@@ -2440,15 +2441,171 @@ func TestModel_Update_CtrlA_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
 	m = updated.(Model)
 	assert.Equal(t, client.NeoApprovalModeBalanced, m.approvalMode)
 
+	// The keypress only schedules the debounce tick; nothing is on outCh yet.
+	select {
+	case ev := <-outCh:
+		t.Fatalf("Ctrl+A must defer the dispatch behind the debounce tick, got %#v", ev)
+	default:
+	}
+
+	// Deliver the debounce tick with the current gen — that's what tea.Tick
+	// would do after modeToggleDebounce — and assert the PATCH lands.
+	updated, _ = m.Update(approvalDebounceTickMsg{gen: m.approvalDebounceGen})
+	_ = updated
+
 	select {
 	case got := <-outCh:
-		require.NotNil(t, got.update, "Ctrl+A after send must dispatch an update")
+		require.NotNil(t, got.update, "the debounce tick must dispatch an update")
 		require.NotNil(t, got.update.ApprovalMode, "update must carry the new approvalMode")
 		assert.Equal(t, client.NeoApprovalModeBalanced, *got.update.ApprovalMode)
 		assert.Nil(t, got.update.PermissionMode,
 			"approval-mode toggle must not include permissionMode")
 	default:
-		t.Fatal("Ctrl+A after send must post an outboundEvent.update on outCh")
+		t.Fatal("the debounce tick at the current gen must dispatch")
+	}
+}
+
+func TestModel_Update_CtrlA_RapidPressesCollapseToOneDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Three Ctrl+A presses in quick succession (faster than the debounce
+	// window) must collapse to a single PATCH carrying the FINAL mode value.
+	// Each press advances the debounce gen, so only the last-scheduled tick
+	// fires the dispatch — the earlier two are gen-mismatched and silently
+	// dropped.
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		MessageSent:         true,
+		TaskCreated:         true,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+
+	// Three presses: manual → balanced → auto → manual.
+	for range 3 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+		m = updated.(Model)
+	}
+	require.Equal(t, client.NeoApprovalModeManual, m.approvalMode,
+		"three presses must wrap back to manual")
+	require.Equal(t, 3, m.approvalDebounceGen, "each press advances the debounce gen")
+
+	// Stale ticks from the first two presses arrive — both must no-op.
+	updated, _ := m.Update(approvalDebounceTickMsg{gen: 1})
+	m = updated.(Model)
+	updated, _ = m.Update(approvalDebounceTickMsg{gen: 2})
+	m = updated.(Model)
+	select {
+	case ev := <-outCh:
+		t.Fatalf("stale-gen ticks must not dispatch, got %#v", ev)
+	default:
+	}
+
+	// The latest tick fires the dispatch with the final mode value.
+	updated, _ = m.Update(approvalDebounceTickMsg{gen: 3})
+	_ = updated
+
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update)
+		require.NotNil(t, got.update.ApprovalMode)
+		assert.Equal(t, client.NeoApprovalModeManual, *got.update.ApprovalMode,
+			"the collapsed dispatch must carry the FINAL mode after all presses")
+	default:
+		t.Fatal("the current-gen tick must dispatch")
+	}
+
+	// And no further events on outCh.
+	select {
+	case ev := <-outCh:
+		t.Fatalf("only one dispatch must land for three rapid presses, got extra %#v", ev)
+	default:
+	}
+}
+
+func TestModel_Update_ApprovalDebounceTick_StaleGenDoesNotDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Defensive: a debounce tick whose gen no longer matches must be a no-op
+	// even when there's no other pending press. This guards the case where a
+	// late tea.Tick fires after the user has already moved past the toggle.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		MessageSent:         true,
+		TaskCreated:         true,
+		InitialApprovalMode: client.NeoApprovalModeAuto,
+	})
+	m.approvalDebounceGen = 5
+
+	updated, _ := m.Update(approvalDebounceTickMsg{gen: 4})
+	_ = updated
+	select {
+	case ev := <-outCh:
+		t.Fatalf("stale-gen tick must not dispatch, got %#v", ev)
+	default:
+	}
+}
+
+func TestModel_Update_CtrlA_DuringTaskCreationIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Between Enter and the task URL arriving (the create-task in-flight
+	// window), Ctrl+A would race the dispatcher: getTaskID() returns "" and
+	// the update event is silently dropped. The fix swallows the keypress
+	// instead so the status bar never lies about what the cloud is enforcing.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		MessageSent:         true,
+		TaskCreated:         false,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+
+	assert.Equal(t, client.NeoApprovalModeManual, m.approvalMode,
+		"Ctrl+A during the create-task window must not change the local mode")
+	select {
+	case ev := <-outCh:
+		t.Fatalf("Ctrl+A during the create-task window must not dispatch, got %#v", ev)
+	default:
+	}
+}
+
+func TestModel_Update_UISessionURL_UnfreezesPostMessageToggles(t *testing.T) {
+	t.Parallel()
+
+	// UISessionURL is the dispatcher's signal that CreateNeoTask succeeded —
+	// from that moment on, Ctrl+A / Ctrl+R must work again. The status-bar
+	// indicator also flips here.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{
+		OutCh:               outCh,
+		EventCh:             make(chan UIEvent, 4),
+		MessageSent:         true,
+		InitialApprovalMode: client.NeoApprovalModeManual,
+	})
+	require.False(t, m.taskCreated, "precondition: task not yet created")
+
+	updated, _ := m.Update(UISessionURL{URL: "https://app.pulumi.com/x/neo/tasks/t1"})
+	m = updated.(Model)
+	require.True(t, m.taskCreated, "UISessionURL must flip taskCreated")
+
+	// Toggle now works — schedules a debounced PATCH.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlA})
+	m = updated.(Model)
+	assert.Equal(t, client.NeoApprovalModeBalanced, m.approvalMode)
+
+	// Fire the debounce tick so the PATCH actually lands.
+	updated, _ = m.Update(approvalDebounceTickMsg{gen: m.approvalDebounceGen})
+	_ = updated
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update)
+	default:
+		t.Fatal("debounce tick after UISessionURL must dispatch an update")
 	}
 }
 
@@ -2486,12 +2643,23 @@ func TestModel_Update_CtrlR_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
 	m := NewModel(ModelConfig{
 		OutCh:                 outCh,
 		MessageSent:           true,
+		TaskCreated:           true,
 		InitialPermissionMode: client.NeoPermissionModeDefault,
 	})
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
 	m = updated.(Model)
 	assert.Equal(t, client.NeoPermissionModeReadOnly, m.permissionMode)
+
+	// Debounced — nothing on outCh until the tick fires.
+	select {
+	case ev := <-outCh:
+		t.Fatalf("Ctrl+R must defer the dispatch behind the debounce tick, got %#v", ev)
+	default:
+	}
+
+	updated, _ = m.Update(permissionDebounceTickMsg{gen: m.permissionDebounceGen})
+	_ = updated
 
 	select {
 	case got := <-outCh:
@@ -2501,7 +2669,51 @@ func TestModel_Update_CtrlR_AfterFirstMessage_DispatchesUpdate(t *testing.T) {
 		assert.Nil(t, got.update.ApprovalMode,
 			"permission-mode toggle must not include approvalMode")
 	default:
-		t.Fatal("Ctrl+R after send must post an outboundEvent.update on outCh")
+		t.Fatal("the debounce tick at the current gen must dispatch")
+	}
+}
+
+func TestModel_Update_CtrlR_RapidPressesCollapseToOneDispatch(t *testing.T) {
+	t.Parallel()
+
+	// Mirror of TestModel_Update_CtrlA_RapidPressesCollapseToOneDispatch for
+	// the permission axis. Two rapid Ctrl+R presses must net out to the
+	// starting state (default → read-only → default), so the only dispatch
+	// that fires carries permission=default.
+	outCh := make(chan outboundEvent, 2)
+	m := NewModel(ModelConfig{
+		OutCh:                 outCh,
+		MessageSent:           true,
+		TaskCreated:           true,
+		InitialPermissionMode: client.NeoPermissionModeDefault,
+	})
+
+	for range 2 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+		m = updated.(Model)
+	}
+	require.Equal(t, client.NeoPermissionModeDefault, m.permissionMode)
+	require.Equal(t, 2, m.permissionDebounceGen)
+
+	// Stale tick: gen mismatch, no dispatch.
+	updated, _ := m.Update(permissionDebounceTickMsg{gen: 1})
+	m = updated.(Model)
+	select {
+	case ev := <-outCh:
+		t.Fatalf("stale-gen tick must not dispatch, got %#v", ev)
+	default:
+	}
+
+	// Current tick: one dispatch with the netted-out final value.
+	updated, _ = m.Update(permissionDebounceTickMsg{gen: 2})
+	_ = updated
+	select {
+	case got := <-outCh:
+		require.NotNil(t, got.update)
+		require.NotNil(t, got.update.PermissionMode)
+		assert.Equal(t, client.NeoPermissionModeDefault, *got.update.PermissionMode)
+	default:
+		t.Fatal("the current-gen tick must dispatch the final value")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds the Neo TUI affordances for the cloud's approval / permission modes and fixes the stuck-prompt bug that fell out of the first slice.

- `--approval-mode` (`manual` / `balanced` / `auto`) and `--permission-mode` (`default` / `read-only`) flags on `pulumi neo`, hot-toggleable mid-session via Ctrl+A and Ctrl+R; status-bar chips reflect any non-default value. Mid-session toggles PATCH the live task so the cloud `ApprovalHandler` picks up the change without restarting.
- Wires the synthetic `user_confirmation` event the cloud emits on auto-resolve through `forwardUserInputToUI` → a new `UIApprovalResolved` event. The TUI now clears its pending question/approval prompt and commits an `Auto-approved` / `Auto-answered` / `Auto-denied` breadcrumb to scrollback. The manual path already clears state locally on Enter, so echoes of our own confirmation no-op.

Fixes https://github.com/pulumi/pulumi-service/issues/41318
Fixes https://github.com/pulumi/pulumi-service/issues/41323

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

New tests cover: `UpdateNeoTask` PATCH shape, parser validation for both new flags, Ctrl+A / Ctrl+R cycling pre- and post-message, `outboundEvent.update` routing in the dispatcher, the new `UIApprovalResolved` wire-routing path (including unknown-type drop and denied case), the `blockApprovalAuto` handler (auto-approved / question / denied / echo-noop / mismatched-id), and the renderer verb variants.

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — `pkg/cmd/pulumi/neo/...` and `pkg/backend/httpstate/client/...` clean (full sweep blocked locally by a Go toolchain cache mismatch unrelated to this PR; verified on focused packages after `go clean -cache`)
- [ ] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
- [x] Changelog entry added — `changelog/pending/20260507--cli-neo--surface-approval-and-permission-modes.yaml`.

## Risk

CLI-only change, gated behind the experimental `pulumi neo` command. The mode plumbing reuses the existing `apitype.CreateAgentTaskRequest` / `apitype.UpdateTaskRequest` wire shapes — empty mode fields are `omitempty` so existing call sites are unaffected. The new `forwardUserInputToUI` discriminator drops unknown user-input subtypes silently, matching the previous "empty content" behaviour, so no other inbound paths regress.