### PR TITLE
Generate correct .NET property names when the schema version contains a hyphen

### DIFF
--- a/pkg/codegen/testing/test/sdk_driver.go
+++ b/pkg/codegen/testing/test/sdk_driver.go
@@ -350,7 +350,7 @@ var PulumiPulumiSDKTests = []*SDKTest{
 	{
 		Directory:   "hyphenated-symbols",
 		Description: "Test that types can have names with hyphens in them",
-		Skip:        allLanguages.Except("go/any").Except("python/any"),
+		Skip:        allLanguages.Except("go/any").Except("python/any").Except("dotnet/any"),
 	},
 	{
 		Directory:   "provider-type-schema",


### PR DESCRIPTION
Covers the dotnet case for #15874
Requires https://github.com/pulumi/pulumi-dotnet/pull/1005