### PR TITLE
Bump cron direct build to Go 1.25

### DIFF
--- a/.github/workflows/cron-direct-build.yml
+++ b/.github/workflows/cron-direct-build.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - uses: jdx/mise-action@v2
         with:
           experimental: true
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - uses: pulumi/actions@v6
         with:


### PR DESCRIPTION
## Summary

- `cron-direct-build.yml` pinned Go 1.24 in both `pkg` and `sdk` jobs, but the repo's `go.mod` now requires Go 1.25 — the cron job was failing with `go.mod requires go >= 1.25 (running go 1.24.13; GOTOOLCHAIN=local)`.
- Bump both jobs to Go 1.25.

Fixes #22924

## Test plan

- [ ] Workflow file syntax accepted by GitHub Actions
- [ ] CI passes