### PR TITLE
Add registerPackage helper to cache package references per deployment

### DIFF
--- a/changelog/pending/20260511--sdk-nodejs--add-per-deployment-caching-of-package-references-for-parameterized-providers.yaml
+++ b/changelog/pending/20260511--sdk-nodejs--add-per-deployment-caching-of-package-references-for-parameterized-providers.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: sdk/nodejs
+  description: Add registerPackage helper to cache package references per deployment

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -801,9 +801,7 @@ export function registerPackage(args: RegisterPackageArgs): Promise<string> {
         return existing;
     }
     if (!supportsParameterization()) {
-        throw new Error(
-            "The Pulumi CLI does not support parameterization. Please update the Pulumi CLI",
-        );
+        throw new Error("The Pulumi CLI does not support parameterization. Please update the Pulumi CLI");
     }
 
     const params = new resproto.Parameterization();

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -18,7 +18,7 @@ import * as path from "path";
 import { ComponentResource } from "../resource";
 import { CallbackServer, ICallbackServer } from "./callbacks";
 import { debuggablePromise } from "./debuggable";
-import { getLocalStore, getStore } from "./state";
+import { getLocalStore, getPackageRefs, getStore } from "./state";
 
 import * as engrpc from "../proto/engine_grpc_pb";
 import * as engproto from "../proto/engine_pb";
@@ -207,6 +207,7 @@ export function resetOptions(
     store.supportsInvokeTransforms = false;
     store.supportsParameterization = false;
     store.callbacks = undefined;
+    store.packageRefs = new Map<string, Promise<string>>();
 }
 
 export function setMockOptions(
@@ -764,6 +765,72 @@ export function rpcKeepAlive(): () => void {
  */
 export function supportsParameterization(): boolean {
     return getStore().supportsParameterization;
+}
+
+/**
+ * Arguments for {@link registerPackage}.
+ */
+export interface RegisterPackageArgs {
+    baseProviderName: string;
+    baseProviderVersion: string;
+    baseProviderDownloadUrl: string;
+    packageName: string;
+    packageVersion: string;
+    base64Parameter: string;
+}
+
+/**
+ * Registers a parameterized provider package with the resource monitor and
+ * returns its package reference. The result is cached per deployment so that
+ * concurrent inline programs each register against their own engine and
+ * receive distinct refs.
+ */
+export function registerPackage(args: RegisterPackageArgs): Promise<string> {
+    const key = [
+        args.baseProviderName,
+        args.baseProviderVersion,
+        args.baseProviderDownloadUrl,
+        args.packageName,
+        args.packageVersion,
+        args.base64Parameter,
+    ].join("\0");
+
+    const cache = getPackageRefs();
+    const existing = cache.get(key);
+    if (existing !== undefined) {
+        return existing;
+    }
+    if (!supportsParameterization()) {
+        throw new Error(
+            "The Pulumi CLI does not support parameterization. Please update the Pulumi CLI",
+        );
+    }
+
+    const params = new resproto.Parameterization();
+    params.setName(args.packageName);
+    params.setVersion(args.packageVersion);
+    params.setValue(Uint8Array.from(atob(args.base64Parameter), (c) => c.charCodeAt(0)));
+    const req = new resproto.RegisterPackageRequest();
+    req.setName(args.baseProviderName);
+    req.setVersion(args.baseProviderVersion);
+    req.setDownloadUrl(args.baseProviderDownloadUrl);
+    req.setParameterization(params);
+
+    const mon = getMonitor();
+    if (mon === undefined) {
+        throw new Error("No monitor available");
+    }
+    const promise = new Promise<string>((resolve, reject) => {
+        mon.registerPackage(req, (err, resp) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(resp.getRef());
+            }
+        });
+    });
+    cache.set(key, promise);
+    return promise;
 }
 
 /**

--- a/sdk/nodejs/runtime/state.ts
+++ b/sdk/nodejs/runtime/state.ts
@@ -214,6 +214,14 @@ export interface Store {
      * Tracks the list of resource modules that have been registered.
      */
     resourceModules: Map<string, ResourceModule[]>;
+
+    /**
+     * Caches package references returned by `RegisterPackage` for
+     * parameterized providers. Scoped to the deployment so concurrent inline
+     * programs each register against their own engine and receive distinct
+     * refs.
+     */
+    packageRefs: Map<string, Promise<string>>;
 }
 
 /**
@@ -266,6 +274,7 @@ export class LocalStore implements Store {
     supportsErrorHooks = false;
     resourcePackages = new Map<string, ResourcePackage[]>();
     resourceModules = new Map<string, ResourceModule[]>();
+    packageRefs = new Map<string, Promise<string>>();
 }
 
 /**
@@ -306,6 +315,21 @@ export function getResourceModules(): Map<string, ResourceModule[]> {
         store.resourceModules = new Map<string, ResourceModule[]>();
     }
     return store.resourceModules;
+}
+
+/**
+ * Get the package reference cache for the current stack deployment.
+ *
+ * @internal
+ */
+export function getPackageRefs(): Map<string, Promise<string>> {
+    const store = getStore();
+    if (store.packageRefs === undefined) {
+        // packageRefs may be undefined if the Store was created by an older
+        // copy of the SDK runtime that didn't define this field.
+        store.packageRefs = new Map<string, Promise<string>>();
+    }
+    return store.packageRefs;
 }
 
 /**

--- a/sdk/nodejs/tests/runtime/registerPackage.spec.ts
+++ b/sdk/nodejs/tests/runtime/registerPackage.spec.ts
@@ -1,0 +1,115 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as runtime from "../../runtime";
+import * as state from "../../runtime/state";
+import * as resproto from "../../proto/resource_pb";
+
+function setMockMonitor(result: string | Error): void {
+    const store = state.getStore();
+    store.settings.monitor = {
+        registerPackage(_req: any, cb: (err: any, resp: any) => void) {
+            if (result instanceof Error) {
+                cb(result, undefined);
+                return;
+            }
+            const resp = new resproto.RegisterPackageResponse();
+            resp.setRef(result);
+            cb(null, resp);
+        },
+    } as any;
+    store.supportsParameterization = true;
+}
+
+const baseArgs: runtime.RegisterPackageArgs = {
+    baseProviderName: "base",
+    baseProviderVersion: "1.2.3",
+    baseProviderDownloadUrl: "",
+    packageName: "mypackage",
+    packageVersion: "2.0.0",
+    base64Parameter: "aGVsbG8=",
+};
+
+describe("runtime/registerPackage", () => {
+    it("registers and caches the ref", async () => {
+        await state.withLocalStorage(async () => {
+            setMockMonitor("uuid-1");
+            const ref = await runtime.registerPackage(baseArgs);
+            assert.strictEqual(ref, "uuid-1");
+            const cache = state.getPackageRefs();
+            assert.strictEqual(cache.size, 1);
+            assert.strictEqual(await [...cache.values()][0], "uuid-1");
+        });
+    });
+
+    it("returns the same ref for the same args", async () => {
+        await state.withLocalStorage(async () => {
+            setMockMonitor("uuid-1");
+            const a = await runtime.registerPackage(baseArgs);
+            const b = await runtime.registerPackage(baseArgs);
+            assert.strictEqual(a, b);
+            assert.strictEqual(state.getPackageRefs().size, 1);
+        });
+    });
+
+    it("uses a distinct cache entry per identifying field", async () => {
+        await state.withLocalStorage(async () => {
+            setMockMonitor("uuid");
+            await runtime.registerPackage(baseArgs);
+            await runtime.registerPackage({ ...baseArgs, packageVersion: "3.0.0" });
+            await runtime.registerPackage({ ...baseArgs, base64Parameter: "T3RoZXI=" });
+            await runtime.registerPackage({ ...baseArgs, baseProviderDownloadUrl: "https://example/x" });
+            assert.strictEqual(state.getPackageRefs().size, 4);
+        });
+    });
+
+    it("caches errors so failed registrations are not retried", async () => {
+        const expected = new Error("registration failed");
+        await state.withLocalStorage(async () => {
+            setMockMonitor(expected);
+            await assert.rejects(runtime.registerPackage(baseArgs), expected);
+            await assert.rejects(runtime.registerPackage(baseArgs), expected);
+            assert.strictEqual(state.getPackageRefs().size, 1);
+        });
+    });
+
+    it("isolates refs between deployments", async () => {
+        const refA = await state.withLocalStorage(async () => {
+            setMockMonitor("uuid-A");
+            return runtime.registerPackage(baseArgs);
+        });
+        const refB = await state.withLocalStorage(async () => {
+            setMockMonitor("uuid-B");
+            return runtime.registerPackage(baseArgs);
+        });
+        assert.strictEqual(refA, "uuid-A");
+        assert.strictEqual(refB, "uuid-B");
+    });
+
+    it("throws when the engine does not support parameterization", async () => {
+        await state.withLocalStorage(async () => {
+            setMockMonitor("uuid");
+            state.getStore().supportsParameterization = false;
+            assert.throws(() => runtime.registerPackage(baseArgs), /does not support parameterization/);
+        });
+    });
+
+    it("throws when there is no monitor", async () => {
+        await state.withLocalStorage(async () => {
+            state.getStore().supportsParameterization = true;
+            assert.throws(() => runtime.registerPackage(baseArgs), /No monitor available/);
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -105,6 +105,7 @@
         "tests/runtime/dependsOn.spec.ts",
         "tests/runtime/findWorkspaceRoot.spec.ts",
         "tests/runtime/manifest.spec.ts",
+        "tests/runtime/registerPackage.spec.ts",
         "tests/runtime/registrations.spec.ts",
         "tests/runtime/pack.ts",
         "tests/runtime/rpc.spec.ts",


### PR DESCRIPTION
Adds a `registerPackage` helper that we can use in codegen to register a package. This will allow us to cache package references per deployment instead of globally, which breaks repeated automation API runs.

In a follow up PR we'll update codegen to use this helper.

Ref https://github.com/pulumi/pulumi/issues/23017