### PR TITLE
Surface filesystem tool errors to the Neo agent

### DIFF
--- a/changelog/pending/20260512--cli-neo--surface-the-failure-reason-when-a-filesystem-tool-call-fails.yaml
+++ b/changelog/pending/20260512--cli-neo--surface-the-failure-reason-when-a-filesystem-tool-call-fails.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: Surface the failure reason when a `filesystem` tool call fails, instead of returning an empty result to the agent

--- a/pkg/cmd/pulumi/neo/tools/filesystem.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem.go
@@ -102,7 +102,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding read args: %w", err)
 		}
-		return f.read(p.FilePath, p.Offset, p.Limit)
+		return nilOnError(f.read(p.FilePath, p.Offset, p.Limit))
 	case "write":
 		var p struct {
 			FilePath string `json:"file_path"`
@@ -111,7 +111,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding write args: %w", err)
 		}
-		return f.write(p.FilePath, p.Content)
+		return nilOnError(f.write(p.FilePath, p.Content))
 	case "directory_tree":
 		var p struct {
 			Path  string `json:"path"`
@@ -120,13 +120,13 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding directory_tree args: %w", err)
 		}
-		return f.directoryTree(p.Path, p.Depth)
+		return nilOnError(f.directoryTree(p.Path, p.Depth))
 	case "edit":
 		var p editArgs
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding edit args: %w", err)
 		}
-		return f.edit(p)
+		return nilOnError(f.edit(p))
 	case "grep":
 		var p struct {
 			Pattern string `json:"pattern"`
@@ -136,7 +136,7 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding grep args: %w", err)
 		}
-		return f.grep(p.Pattern, p.Path, p.Include)
+		return nilOnError(f.grep(p.Pattern, p.Path, p.Include))
 	case "content_replace":
 		var p struct {
 			Pattern     string `json:"pattern"`
@@ -148,12 +148,24 @@ func (f *Filesystem) Invoke(_ context.Context, method string, args json.RawMessa
 		if err := json.Unmarshal(args, &p); err != nil {
 			return nil, fmt.Errorf("decoding content_replace args: %w", err)
 		}
-		return f.contentReplace(p.Pattern, p.Replacement, p.Path, p.FilePattern, p.DryRun)
+		return nilOnError(f.contentReplace(p.Pattern, p.Replacement, p.Path, p.FilePattern, p.DryRun))
 	case "grep_ast":
 		return nil, fmt.Errorf("filesystem method %q is not yet implemented in pulumi neo CLI mode", method)
 	default:
 		return nil, fmt.Errorf("unknown filesystem method %q", method)
 	}
+}
+
+// nilOnError drops a method's zero-valued result on the floor when it returns
+// an error, so Filesystem.Invoke yields an untyped-nil `any` instead of an
+// interface that wraps a zero struct. Without this Session.invokeToolCall keeps
+// the empty struct as Content (a zero struct boxed into any is non-nil), and
+// the agent sees IsError=true with no failure reason.
+func nilOnError[T any](v T, err error) (any, error) {
+	if err != nil {
+		return nil, err
+	}
+	return v, nil
 }
 
 // resolve safely interprets a path supplied by the agent. The agent sends absolute paths

--- a/pkg/cmd/pulumi/neo/tools/filesystem_test.go
+++ b/pkg/cmd/pulumi/neo/tools/filesystem_test.go
@@ -238,14 +238,19 @@ func TestFilesystem_ReadMissingFileReturnsError(t *testing.T) {
 	t.Parallel()
 
 	// Inside the sandbox, but the file itself doesn't exist — os.ReadFile should
-	// surface a clear error (not a silent empty-content result).
+	// surface a clear error (not a silent empty-content result). On the error
+	// path Invoke must also return a nil value: a zero readResult boxed into
+	// any is non-nil, so Session.invokeToolCall would keep it as Content and
+	// drop the err.Error() fallback that conveys the failure reason to the
+	// agent.
 	root := t.TempDir()
 	fs, err := NewFilesystem(root)
 	require.NoError(t, err)
 
-	_, err = fs.Invoke(t.Context(), "read",
+	value, err := fs.Invoke(t.Context(), "read",
 		json.RawMessage(fmt.Sprintf(`{"file_path":%q}`, filepath.Join(root, "missing.txt"))))
 	require.Error(t, err)
+	assert.Nil(t, value, "Invoke must return a nil value on error so session.go's err.Error() fallback fires")
 }
 
 func TestFilesystem_WriteRejectsPathOutsideRoot(t *testing.T) {


### PR DESCRIPTION
## Summary

- Every method in `Filesystem.Invoke` returned a zero-valued struct alongside its error (e.g. `readResult{}, err`). When that struct is boxed into the `any` returned from `Invoke`, `Session.invokeToolCall`'s `value != nil` guard at `session.go:205` is unconditionally true (interfaces wrapping struct values carry a type descriptor), so the empty struct stays as Content and the `err.Error()` fallback never fires — the agent sees `IsError=true` with a blank `readResult{}` / `writeResult{}` / `""` / etc., no failure reason.
- Wrap each switch arm with a tiny generic `nilOnError` helper that drops the value to an untyped `nil` when there's an error. `session.invokeToolCall` then populates Content with `{"error": err.Error()}` as intended.
- Same interface-nil quirk we just fixed for the pulumi tool in #22948; simpler fix here because the filesystem methods bail early without computing any useful partial result, so there's nothing to convey through the struct.

## Test plan

- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/tools/...` passes
- [x] `make format` / `make lint` clean
- [x] Tightened `TestFilesystem_ReadMissingFileReturnsError` to assert `Invoke` returns `(nil, err)` — locks in the contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)