### PR TITLE
cli: scaffold hidden cobra commands for the Cloud-Ready CLI

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -44,6 +44,10 @@ func NewDeploymentCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd.AddCommand(newDeploymentSettingsCmd())
 	cmd.AddCommand(newDeploymentRunCmd(ws))
+	cmd.AddCommand(newDeploymentListCmd())
+	cmd.AddCommand(newDeploymentGetCmd())
+	cmd.AddCommand(newDeploymentCancelCmd())
+	cmd.AddCommand(newDeploymentLogCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_cmds.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cmds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22988]: Not yet implemented.
 func newDeploymentListCmd() *cobra.Command {
 	var (
 		stack    string
@@ -52,6 +53,7 @@ func newDeploymentListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22987]: Not yet implemented.
 func newDeploymentGetCmd() *cobra.Command {
 	var stack string
 
@@ -77,6 +79,7 @@ func newDeploymentGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22985]: Not yet implemented.
 func newDeploymentCancelCmd() *cobra.Command {
 	var stack string
 
@@ -106,6 +109,7 @@ func newDeploymentCancelCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22986]: Not yet implemented.
 func newDeploymentLogCmd() *cobra.Command {
 	var (
 		stack  string
@@ -143,6 +147,7 @@ func newDeploymentLogCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22984]: Not yet implemented.
 func newDeploymentSettingsGetCmd() *cobra.Command {
 	var stack string
 
@@ -163,6 +168,7 @@ func newDeploymentSettingsGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22983]: Not yet implemented.
 func newDeploymentSettingsEditCmd() *cobra.Command {
 	var (
 		stack string

--- a/pkg/cmd/pulumi/deployment/deployment_cmds.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cmds.go
@@ -1,0 +1,193 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newDeploymentListCmd() *cobra.Command {
+	var (
+		stack    string
+		page     int
+		pageSize int
+		sort     string
+		asc      bool
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List deployments for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().IntVar(&page, "page", 1, "The page of results to return")
+	cmd.Flags().IntVar(&pageSize, "page-size", 10, "The number of results per page (1-100)")
+	cmd.Flags().StringVar(&sort, "sort", "", "The field to sort results by")
+	cmd.Flags().BoolVar(&asc, "asc", false, "Sort in ascending order")
+
+	return cmd
+}
+
+func newDeploymentGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get details for a specific deployment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "deployment-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newDeploymentCancelCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "cancel",
+		Short:  "Cancel an in-progress deployment",
+		Long: "Cancel an in-progress deployment.\n" +
+			"\n" +
+			"Canceling a deployment is a dangerous action and may leave the stack in\n" +
+			"an inconsistent state if canceled during the execution of a Pulumi operation.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "deployment-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newDeploymentLogCmd() *cobra.Command {
+	var (
+		stack  string
+		job    int
+		step   int
+		offset int
+		count  int
+		token  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "log",
+		Short:  "Retrieve execution logs for a deployment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "deployment-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().IntVar(&job, "job", -1, "The job index to fetch step-level logs for")
+	cmd.Flags().IntVar(&step, "step", -1, "The step index within the job (requires --job)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "The byte offset within the step's logs")
+	cmd.Flags().IntVar(&count, "count", 100, "The number of log lines to fetch (1-499 in step mode)")
+	cmd.Flags().StringVar(&token, "continuation-token", "", "The continuation token for streaming mode")
+
+	return cmd
+}
+
+func newDeploymentSettingsGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Retrieve the deployment settings for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newDeploymentSettingsEditCmd() *cobra.Command {
+	var (
+		stack string
+		file  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Create or update deployment settings for a stack",
+		Long: "Create or update deployment settings for a stack.\n" +
+			"\n" +
+			"If no settings exist, they are created. If settings already exist, the\n" +
+			"request body is merged with the current settings.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&file, "file", "f", "",
+		"Read settings patch from file; `-` reads stdin")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -79,6 +79,8 @@ func newDeploymentSettingsCmd() *cobra.Command {
 	cmd.AddCommand(newDeploymentSettingsDestroyCmd())
 	cmd.AddCommand(newDeploymentSettingsEnvCmd())
 	cmd.AddCommand(newDeploymentSettingsConfigureCmd())
+	cmd.AddCommand(newDeploymentSettingsGetCmd())
+	cmd.AddCommand(newDeploymentSettingsEditCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/env/env.go
+++ b/pkg/cmd/pulumi/env/env.go
@@ -37,5 +37,11 @@ func NewEnvCmd() *cobra.Command {
 	envCommand := escCLI.Commands()[0]
 	envCommand.Aliases = append(envCommand.Aliases, "esc")
 
+	envCommand.AddCommand(newEnvNewCmd())
+	envCommand.AddCommand(newEnvReferrerCmd())
+	envCommand.AddCommand(newEnvScheduleCmd())
+	envCommand.AddCommand(newEnvWebhookCmd())
+	envCommand.AddCommand(newEnvProviderCmd())
+
 	return envCommand
 }

--- a/pkg/cmd/pulumi/env/env_new.go
+++ b/pkg/cmd/pulumi/env/env_new.go
@@ -1,0 +1,51 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newEnvNewCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new Pulumi ESC environment",
+		Long: "Create a new Pulumi ESC environment.\n" +
+			"\n" +
+			"The environment starts with an empty YAML definition.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the environment in")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/env/env_new.go
+++ b/pkg/cmd/pulumi/env/env_new.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23042]: Not yet implemented.
 func newEnvNewCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/env/env_provider.go
+++ b/pkg/cmd/pulumi/env/env_provider.go
@@ -1,0 +1,170 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newEnvProviderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "provider",
+		Short:  "Manage environment OIDC providers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newEnvProviderNewCmd())
+	return cmd
+}
+
+func newEnvProviderNewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Register a new OIDC issuer for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newEnvProviderNewAWSCmd())
+	cmd.AddCommand(newEnvProviderNewAWSSSOCmd())
+	cmd.AddCommand(newEnvProviderNewAzureCmd())
+	cmd.AddCommand(newEnvProviderNewGCPCmd())
+	return cmd
+}
+
+func newEnvProviderNewAWSCmd() *cobra.Command {
+	var (
+		org    string
+		issuer string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "aws",
+		Short:  "Register an AWS OIDC issuer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to register the issuer in")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "The OIDC issuer URL")
+
+	return cmd
+}
+
+func newEnvProviderNewAWSSSOCmd() *cobra.Command {
+	var (
+		org    string
+		issuer string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "aws-sso",
+		Short:  "Register an AWS SSO OIDC issuer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to register the issuer in")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "The OIDC issuer URL")
+
+	return cmd
+}
+
+func newEnvProviderNewAzureCmd() *cobra.Command {
+	var (
+		org    string
+		issuer string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "azure",
+		Short:  "Register an Azure OIDC issuer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to register the issuer in")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "The OIDC issuer URL")
+
+	return cmd
+}
+
+func newEnvProviderNewGCPCmd() *cobra.Command {
+	var (
+		org    string
+		issuer string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "gcp",
+		Short:  "Register a Google Cloud OIDC issuer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to register the issuer in")
+	cmd.Flags().StringVar(&issuer, "issuer", "", "The OIDC issuer URL")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/env/env_provider.go
+++ b/pkg/cmd/pulumi/env/env_provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23043]: Not yet implemented.
 func newEnvProviderCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -57,6 +58,7 @@ func newEnvProviderNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23040]: Not yet implemented.
 func newEnvProviderNewAWSCmd() *cobra.Command {
 	var (
 		org    string
@@ -85,6 +87,7 @@ func newEnvProviderNewAWSCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23039]: Not yet implemented.
 func newEnvProviderNewAWSSSOCmd() *cobra.Command {
 	var (
 		org    string
@@ -113,6 +116,7 @@ func newEnvProviderNewAWSSSOCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23038]: Not yet implemented.
 func newEnvProviderNewAzureCmd() *cobra.Command {
 	var (
 		org    string
@@ -141,6 +145,7 @@ func newEnvProviderNewAzureCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23037]: Not yet implemented.
 func newEnvProviderNewGCPCmd() *cobra.Command {
 	var (
 		org    string

--- a/pkg/cmd/pulumi/env/env_referrer.go
+++ b/pkg/cmd/pulumi/env/env_referrer.go
@@ -1,0 +1,77 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newEnvReferrerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "referrer",
+		Short:  "Inspect entities that reference an environment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newEnvReferrerListCmd())
+	return cmd
+}
+
+func newEnvReferrerListCmd() *cobra.Command {
+	var (
+		org                    string
+		count                  int
+		allRevisions           bool
+		latestStackVersionOnly bool
+		token                  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List entities that reference an environment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().IntVar(&count, "count", 0, "The maximum number of results to return (1-500)")
+	cmd.Flags().BoolVar(&allRevisions, "all-revisions", false,
+		"Include references across all revisions")
+	cmd.Flags().BoolVar(&latestStackVersionOnly, "latest-stack-version-only", false,
+		"Return only the latest stack version for each referring stack")
+	cmd.Flags().StringVar(&token, "continuation-token", "",
+		"The continuation token for paginated retrieval")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/env/env_referrer.go
+++ b/pkg/cmd/pulumi/env/env_referrer.go
@@ -38,6 +38,7 @@ func newEnvReferrerCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23041]: Not yet implemented.
 func newEnvReferrerListCmd() *cobra.Command {
 	var (
 		org                    string

--- a/pkg/cmd/pulumi/env/env_schedule.go
+++ b/pkg/cmd/pulumi/env/env_schedule.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23036]: Not yet implemented.
 func newEnvScheduleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -63,6 +64,7 @@ func envScheduleEnvWithIDArg() *constrictor.Arguments {
 	}
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23035]: Not yet implemented.
 func newEnvScheduleListCmd() *cobra.Command {
 	var org string
 
@@ -82,6 +84,7 @@ func newEnvScheduleListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23034]: Not yet implemented.
 func newEnvScheduleNewCmd() *cobra.Command {
 	var (
 		org    string
@@ -109,6 +112,7 @@ func newEnvScheduleNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23033]: Not yet implemented.
 func newEnvSchedulePauseCmd() *cobra.Command {
 	var org string
 
@@ -128,6 +132,7 @@ func newEnvSchedulePauseCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23032]: Not yet implemented.
 func newEnvScheduleResumeCmd() *cobra.Command {
 	var org string
 
@@ -147,6 +152,7 @@ func newEnvScheduleResumeCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23031]: Not yet implemented.
 func newEnvScheduleRemoveCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/env/env_schedule.go
+++ b/pkg/cmd/pulumi/env/env_schedule.go
@@ -1,0 +1,167 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newEnvScheduleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "schedule",
+		Short:  "Manage environment scheduled actions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newEnvScheduleListCmd())
+	cmd.AddCommand(newEnvScheduleNewCmd())
+	cmd.AddCommand(newEnvSchedulePauseCmd())
+	cmd.AddCommand(newEnvScheduleResumeCmd())
+	cmd.AddCommand(newEnvScheduleRemoveCmd())
+	return cmd
+}
+
+func envScheduleEnvArg() *constrictor.Arguments {
+	return &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+		},
+		Required: 2,
+	}
+}
+
+func envScheduleEnvWithIDArg() *constrictor.Arguments {
+	return &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+			{Name: "schedule-id"},
+		},
+		Required: 3,
+	}
+}
+
+func newEnvScheduleListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List scheduled actions configured for an environment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envScheduleEnvArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvScheduleNewCmd() *cobra.Command {
+	var (
+		org    string
+		cron   string
+		once   string
+		action string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new scheduled action for an environment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envScheduleEnvArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVar(&cron, "cron", "", "The cron expression for recurring executions")
+	cmd.Flags().StringVar(&once, "once", "", "The ISO 8601 timestamp for a one-time execution")
+	cmd.Flags().StringVar(&action, "action", "", "The action to perform on each execution")
+
+	return cmd
+}
+
+func newEnvSchedulePauseCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "pause",
+		Short:  "Pause a scheduled action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvScheduleResumeCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "resume",
+		Short:  "Resume a previously paused scheduled action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvScheduleRemoveCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Permanently delete a scheduled action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/env/env_webhook.go
+++ b/pkg/cmd/pulumi/env/env_webhook.go
@@ -1,0 +1,228 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newEnvWebhookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "webhook",
+		Short:  "Manage environment webhooks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newEnvWebhookListCmd())
+	cmd.AddCommand(newEnvWebhookNewCmd())
+	cmd.AddCommand(newEnvWebhookEditCmd())
+	cmd.AddCommand(newEnvWebhookRemoveCmd())
+	cmd.AddCommand(newEnvWebhookPingCmd())
+	cmd.AddCommand(newEnvWebhookDeliveryCmd())
+
+	return cmd
+}
+
+func envWebhookEnvArg() *constrictor.Arguments {
+	return &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+		},
+		Required: 2,
+	}
+}
+
+func envWebhookEnvWithHookArg() *constrictor.Arguments {
+	return &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+			{Name: "webhook"},
+		},
+		Required: 3,
+	}
+}
+
+func newEnvWebhookListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List all webhooks configured for an environment",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvWebhookNewCmd() *cobra.Command {
+	var (
+		org     string
+		url     string
+		format  string
+		filters []string
+		active  bool
+		secret  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new environment webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "raw",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+
+	return cmd
+}
+
+func newEnvWebhookEditCmd() *cobra.Command {
+	var (
+		org     string
+		url     string
+		format  string
+		filters []string
+		active  bool
+		secret  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update an environment webhook's configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+
+	return cmd
+}
+
+func newEnvWebhookRemoveCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Delete an environment webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvWebhookPingCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "ping",
+		Short:  "Send a test ping to an environment webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}
+
+func newEnvWebhookDeliveryCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "delivery",
+		Short:  "Inspect environment webhook deliveries",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	cmd.AddCommand(newEnvWebhookDeliveryListCmd())
+	return cmd
+}
+
+func newEnvWebhookDeliveryListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List recent deliveries for an environment webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/env/env_webhook.go
+++ b/pkg/cmd/pulumi/env/env_webhook.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23030]: Not yet implemented.
 func newEnvWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -65,6 +66,7 @@ func envWebhookEnvWithHookArg() *constrictor.Arguments {
 	}
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23029]: Not yet implemented.
 func newEnvWebhookListCmd() *cobra.Command {
 	var org string
 
@@ -84,6 +86,7 @@ func newEnvWebhookListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23028]: Not yet implemented.
 func newEnvWebhookNewCmd() *cobra.Command {
 	var (
 		org     string
@@ -117,6 +120,7 @@ func newEnvWebhookNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23027]: Not yet implemented.
 func newEnvWebhookEditCmd() *cobra.Command {
 	var (
 		org     string
@@ -150,6 +154,7 @@ func newEnvWebhookEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23026]: Not yet implemented.
 func newEnvWebhookRemoveCmd() *cobra.Command {
 	var org string
 
@@ -169,6 +174,7 @@ func newEnvWebhookRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23025]: Not yet implemented.
 func newEnvWebhookPingCmd() *cobra.Command {
 	var org string
 
@@ -188,6 +194,7 @@ func newEnvWebhookPingCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23024]: Not yet implemented.
 func newEnvWebhookDeliveryCmd() *cobra.Command {
 	var org string
 
@@ -208,6 +215,7 @@ func newEnvWebhookDeliveryCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23023]: Not yet implemented.
 func newEnvWebhookDeliveryListCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/insights/insights.go
+++ b/pkg/cmd/pulumi/insights/insights.go
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,27 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package templatecmd
+package insights
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
-func NewTemplateCmd() *cobra.Command {
+// NewInsightsCmd creates the top-level `pulumi insights` command.
+func NewInsightsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "template",
-		Short: "Work with Pulumi templates",
-		Long: `Work with Pulumi templates
-
-Publish and manage Pulumi templates.`,
+		Hidden: true,
+		Use:    "insights",
+		Short:  "Manage Pulumi Insights resources and accounts",
+		Long: "Manage Pulumi Insights resources and accounts.\n" +
+			"\n" +
+			"Pulumi Insights provides resource discovery and search across\n" +
+			"cloud provider accounts.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(
-		newTemplatePublishCmd(),
-		newTemplateListCmd(),
-	)
+	cmd.AddCommand(newInsightsResourceCmd())
+	cmd.AddCommand(newInsightsAccountCmd())
+
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_account.go
+++ b/pkg/cmd/pulumi/insights/insights_account.go
@@ -1,0 +1,152 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newInsightsAccountCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "account",
+		Short:  "Manage Pulumi Insights accounts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newInsightsAccountNewCmd())
+	cmd.AddCommand(newInsightsAccountListCmd())
+	cmd.AddCommand(newInsightsAccountScanCmd())
+
+	return cmd
+}
+
+func newInsightsAccountNewCmd() *cobra.Command {
+	var (
+		org      string
+		provider string
+		parent   string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new Insights account",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the account in")
+	cmd.Flags().StringVar(&provider, "provider", "", "The cloud provider (e.g. aws, azure, gcp)")
+	cmd.Flags().StringVar(&parent, "parent", "", "The parent account, if any")
+
+	return cmd
+}
+
+func newInsightsAccountListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List Insights accounts available to the authenticated user",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list accounts for")
+
+	return cmd
+}
+
+func newInsightsAccountScanCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "scan",
+		Short:  "Trigger a resource discovery scan for an Insights account",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "account"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the account")
+
+	cmd.AddCommand(newInsightsAccountScanLogCmd())
+
+	return cmd
+}
+
+func newInsightsAccountScanLogCmd() *cobra.Command {
+	var (
+		org   string
+		job   int
+		step  int
+		count int
+		token string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "log",
+		Short:  "Retrieve logs for an Insights scan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "account"},
+			{Name: "scan-id"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the account")
+	cmd.Flags().IntVar(&job, "job", -1, "The job index to fetch step-level logs for")
+	cmd.Flags().IntVar(&step, "step", -1, "The step index within the job (requires --job)")
+	cmd.Flags().IntVar(&count, "count", 0, "The number of log lines to fetch")
+	cmd.Flags().StringVar(&token, "continuation-token", "", "The continuation token for paginated retrieval")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/insights/insights_account.go
+++ b/pkg/cmd/pulumi/insights/insights_account.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22976]: Not yet implemented.
 func newInsightsAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -41,6 +42,7 @@ func newInsightsAccountCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22979]: Not yet implemented.
 func newInsightsAccountNewCmd() *cobra.Command {
 	var (
 		org      string
@@ -71,6 +73,7 @@ func newInsightsAccountNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22980]: Not yet implemented.
 func newInsightsAccountListCmd() *cobra.Command {
 	var org string
 
@@ -90,6 +93,7 @@ func newInsightsAccountListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22978]: Not yet implemented.
 func newInsightsAccountScanCmd() *cobra.Command {
 	var org string
 
@@ -116,6 +120,7 @@ func newInsightsAccountScanCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22977]: Not yet implemented.
 func newInsightsAccountScanLogCmd() *cobra.Command {
 	var (
 		org   string

--- a/pkg/cmd/pulumi/insights/insights_resource.go
+++ b/pkg/cmd/pulumi/insights/insights_resource.go
@@ -1,0 +1,103 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newInsightsResourceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "resource",
+		Short:  "Inspect resources discovered by Pulumi Insights",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newInsightsResourceGetCmd())
+	cmd.AddCommand(newInsightsResourceSearchCmd())
+
+	return cmd
+}
+
+func newInsightsResourceGetCmd() *cobra.Command {
+	var org string
+	var account string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get a discovered resource with its current version details",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "resource-type"},
+			{Name: "resource-id"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the resource")
+	cmd.Flags().StringVar(&account, "account", "", "The Insights account that owns the resource")
+
+	return cmd
+}
+
+func newInsightsResourceSearchCmd() *cobra.Command {
+	var (
+		org        string
+		query      string
+		sort       string
+		page       int
+		size       int
+		cursor     string
+		properties bool
+		collapse   bool
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "search",
+		Short:  "Search for resources within an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to search within")
+	cmd.Flags().StringVarP(&query, "query", "q", "", "The query string to filter resources by")
+	cmd.Flags().StringVar(&sort, "sort", "", "The field to sort results by")
+	cmd.Flags().IntVar(&page, "page", 0, "The page of results to return (max 10,000 total)")
+	cmd.Flags().IntVar(&size, "page-size", 0, "The number of results per page")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "The cursor to continue pagination from (Enterprise only)")
+	cmd.Flags().BoolVar(&properties, "properties", false, "Include resource input/output values in results")
+	cmd.Flags().BoolVar(&collapse, "collapse", false, "Consolidate resources that exist in multiple sources")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/insights/insights_resource.go
+++ b/pkg/cmd/pulumi/insights/insights_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22973]: Not yet implemented.
 func newInsightsResourceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -40,6 +41,7 @@ func newInsightsResourceCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22974]: Not yet implemented.
 func newInsightsResourceGetCmd() *cobra.Command {
 	var org string
 	var account string
@@ -67,6 +69,7 @@ func newInsightsResourceGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22975]: Not yet implemented.
 func newInsightsResourceSearchCmd() *cobra.Command {
 	var (
 		org        string

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -81,6 +81,11 @@ func NewOrgCmd() *cobra.Command {
 	cmd.AddCommand(newOrgSetDefaultCmd())
 	cmd.AddCommand(newOrgGetDefaultCmd())
 	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newOrgWebhookCmd())
+	cmd.AddCommand(newOrgRoleCmd())
+	cmd.AddCommand(newOrgMemberCmd())
+	cmd.AddCommand(newOrgAuditLogCmd())
+	cmd.AddCommand(newOrgUsageCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/org/org_audit_log.go
+++ b/pkg/cmd/pulumi/org/org_audit_log.go
@@ -39,6 +39,7 @@ func newOrgAuditLogCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23001]: Not yet implemented.
 func newOrgAuditLogListCmd() *cobra.Command {
 	var (
 		org       string
@@ -70,6 +71,7 @@ func newOrgAuditLogListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23000]: Not yet implemented.
 func newOrgAuditLogExportCmd() *cobra.Command {
 	var (
 		org       string

--- a/pkg/cmd/pulumi/org/org_audit_log.go
+++ b/pkg/cmd/pulumi/org/org_audit_log.go
@@ -1,0 +1,104 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newOrgAuditLogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "audit-log",
+		Short:  "Inspect organization audit logs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgAuditLogListCmd())
+	cmd.AddCommand(newOrgAuditLogExportCmd())
+	return cmd
+}
+
+func newOrgAuditLogListCmd() *cobra.Command {
+	var (
+		org       string
+		eventType string
+		userLogin string
+		startTime string
+		token     string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List audit log events for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list audit logs for")
+	cmd.Flags().StringVar(&eventType, "event-type", "", "Filter by event type")
+	cmd.Flags().StringVar(&userLogin, "user", "", "Filter by user login")
+	cmd.Flags().StringVar(&startTime, "start-time", "",
+		"The upper bound of the time range (V1 semantics)")
+	cmd.Flags().StringVar(&token, "continuation-token", "",
+		"The continuation token for paginated retrieval")
+
+	return cmd
+}
+
+func newOrgAuditLogExportCmd() *cobra.Command {
+	var (
+		org       string
+		format    string
+		eventType string
+		userLogin string
+		startTime string
+		token     string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "export",
+		Short:  "Export audit log events for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to export audit logs for")
+	cmd.Flags().StringVar(&format, "format", "csv", "The export format: csv or cef")
+	cmd.Flags().StringVar(&eventType, "event-type", "", "Filter by event type")
+	cmd.Flags().StringVar(&userLogin, "user", "", "Filter by user login")
+	cmd.Flags().StringVar(&startTime, "start-time", "",
+		"The upper bound of the time range (V1 semantics)")
+	cmd.Flags().StringVar(&token, "continuation-token", "",
+		"The continuation token for paginated retrieval")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/org/org_member.go
+++ b/pkg/cmd/pulumi/org/org_member.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23009]: Not yet implemented.
 func newOrgMemberCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -41,6 +42,7 @@ func newOrgMemberCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23013]: Not yet implemented.
 func newOrgMemberListCmd() *cobra.Command {
 	var (
 		org  string
@@ -65,6 +67,7 @@ func newOrgMemberListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23011]: Not yet implemented.
 func newOrgMemberGetCmd() *cobra.Command {
 	var org string
 
@@ -89,6 +92,7 @@ func newOrgMemberGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23012]: Not yet implemented.
 func newOrgMemberEditCmd() *cobra.Command {
 	var (
 		org       string
@@ -121,6 +125,7 @@ func newOrgMemberEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23010]: Not yet implemented.
 func newOrgMemberRemoveCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/org/org_member.go
+++ b/pkg/cmd/pulumi/org/org_member.go
@@ -1,0 +1,146 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newOrgMemberCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "member",
+		Short:  "Manage organization members",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgMemberListCmd())
+	cmd.AddCommand(newOrgMemberGetCmd())
+	cmd.AddCommand(newOrgMemberEditCmd())
+	cmd.AddCommand(newOrgMemberRemoveCmd())
+	return cmd
+}
+
+func newOrgMemberListCmd() *cobra.Command {
+	var (
+		org  string
+		mode string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List members of an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list members for")
+	cmd.Flags().StringVar(&mode, "mode", "frontend",
+		"Member list mode: frontend or backend")
+
+	return cmd
+}
+
+func newOrgMemberGetCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get a member of an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "user-login"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the member")
+
+	return cmd
+}
+
+func newOrgMemberEditCmd() *cobra.Command {
+	var (
+		org       string
+		role      string
+		fgaRoleID string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Modify a member's role within an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "user-login"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the member")
+	cmd.Flags().StringVar(&role, "role", "",
+		"The built-in role to assign: member, admin, or billingManager")
+	cmd.Flags().StringVar(&fgaRoleID, "fga-role-id", "",
+		"The custom role to assign (takes precedence over --role)")
+
+	return cmd
+}
+
+func newOrgMemberRemoveCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Remove a member from an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "user-login"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the member")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -1,0 +1,188 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newOrgRoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "role",
+		Short:  "Manage organization custom roles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgRoleListCmd())
+	cmd.AddCommand(newOrgRoleNewCmd())
+	cmd.AddCommand(newOrgRoleEditCmd())
+	cmd.AddCommand(newOrgRoleRemoveCmd())
+	cmd.AddCommand(newOrgRoleAssignCmd())
+	return cmd
+}
+
+func newOrgRoleListCmd() *cobra.Command {
+	var (
+		org     string
+		purpose string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List custom roles for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list roles for")
+	cmd.Flags().StringVar(&purpose, "purpose", "",
+		"The UX purpose to filter by: organization, team, or token")
+
+	return cmd
+}
+
+func newOrgRoleNewCmd() *cobra.Command {
+	var (
+		org         string
+		description string
+		permissions []string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new custom role for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the role in")
+	cmd.Flags().StringVar(&description, "description", "", "A description for the role")
+	cmd.Flags().StringArrayVar(&permissions, "permission", nil,
+		"A permission scope for the role (repeatable)")
+
+	return cmd
+}
+
+func newOrgRoleEditCmd() *cobra.Command {
+	var (
+		org         string
+		newName     string
+		description string
+		permissions []string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update a custom role's name, description, or permissions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
+	cmd.Flags().StringVar(&newName, "new-name", "", "Rename the role")
+	cmd.Flags().StringVar(&description, "description", "", "Update the role's description")
+	cmd.Flags().StringArrayVar(&permissions, "permission", nil,
+		"Set the role's permission scopes (repeatable)")
+
+	return cmd
+}
+
+func newOrgRoleRemoveCmd() *cobra.Command {
+	var (
+		org   string
+		force bool
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Delete a custom role from an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Force deletion even if the role is currently assigned")
+
+	return cmd
+}
+
+func newOrgRoleAssignCmd() *cobra.Command {
+	var (
+		org  string
+		team string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "assign",
+		Short:  "Assign a role to a team",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
+	cmd.Flags().StringVar(&team, "team", "", "The team to assign the role to")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23003]: Not yet implemented.
 func newOrgRoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -42,6 +43,7 @@ func newOrgRoleCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23008]: Not yet implemented.
 func newOrgRoleListCmd() *cobra.Command {
 	var (
 		org     string
@@ -66,6 +68,7 @@ func newOrgRoleListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23007]: Not yet implemented.
 func newOrgRoleNewCmd() *cobra.Command {
 	var (
 		org         string
@@ -97,6 +100,7 @@ func newOrgRoleNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23006]: Not yet implemented.
 func newOrgRoleEditCmd() *cobra.Command {
 	var (
 		org         string
@@ -130,6 +134,7 @@ func newOrgRoleEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23005]: Not yet implemented.
 func newOrgRoleRemoveCmd() *cobra.Command {
 	var (
 		org   string
@@ -159,6 +164,7 @@ func newOrgRoleRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23004]: Not yet implemented.
 func newOrgRoleAssignCmd() *cobra.Command {
 	var (
 		org  string

--- a/pkg/cmd/pulumi/org/org_usage.go
+++ b/pkg/cmd/pulumi/org/org_usage.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newOrgUsageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "usage",
+		Short:  "Inspect organization resource usage",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgUsageGetCmd())
+	return cmd
+}
+
+func newOrgUsageGetCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Fetch the resources-under-management summary for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to fetch usage for")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/org/org_usage.go
+++ b/pkg/cmd/pulumi/org/org_usage.go
@@ -38,6 +38,7 @@ func newOrgUsageCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23002]: Not yet implemented.
 func newOrgUsageGetCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -1,0 +1,232 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newOrgWebhookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "webhook",
+		Short:  "Manage organization-level webhooks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgWebhookListCmd())
+	cmd.AddCommand(newOrgWebhookNewCmd())
+	cmd.AddCommand(newOrgWebhookEditCmd())
+	cmd.AddCommand(newOrgWebhookRemoveCmd())
+	cmd.AddCommand(newOrgWebhookPingCmd())
+	cmd.AddCommand(newOrgWebhookDeliveryCmd())
+
+	return cmd
+}
+
+func newOrgWebhookListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List all webhooks configured at the organization level",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list webhooks for")
+
+	return cmd
+}
+
+func newOrgWebhookNewCmd() *cobra.Command {
+	var (
+		org         string
+		url         string
+		format      string
+		filters     []string
+		active      bool
+		secret      string
+		displayName string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new organization webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the webhook in")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "raw",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
+
+	return cmd
+}
+
+func newOrgWebhookEditCmd() *cobra.Command {
+	var (
+		org         string
+		url         string
+		format      string
+		filters     []string
+		active      bool
+		secret      string
+		displayName string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update an organization webhook's configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "",
+		"The webhook format: raw, slack, or ms_teams")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
+
+	return cmd
+}
+
+func newOrgWebhookRemoveCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Permanently delete an organization webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
+
+	return cmd
+}
+
+func newOrgWebhookPingCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "ping",
+		Short:  "Send a test ping to an organization webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
+
+	return cmd
+}
+
+func newOrgWebhookDeliveryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "delivery",
+		Short:  "Inspect organization webhook deliveries",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newOrgWebhookDeliveryListCmd())
+	return cmd
+}
+
+func newOrgWebhookDeliveryListCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List recent deliveries for an organization webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "webhook"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22964]: Not yet implemented.
 func newOrgWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -44,6 +45,7 @@ func newOrgWebhookCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22965]: Not yet implemented.
 func newOrgWebhookListCmd() *cobra.Command {
 	var org string
 
@@ -63,6 +65,7 @@ func newOrgWebhookListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22966]: Not yet implemented.
 func newOrgWebhookNewCmd() *cobra.Command {
 	var (
 		org         string
@@ -103,6 +106,7 @@ func newOrgWebhookNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22967]: Not yet implemented.
 func newOrgWebhookEditCmd() *cobra.Command {
 	var (
 		org         string
@@ -143,6 +147,7 @@ func newOrgWebhookEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22968]: Not yet implemented.
 func newOrgWebhookRemoveCmd() *cobra.Command {
 	var org string
 
@@ -167,6 +172,7 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22969]: Not yet implemented.
 func newOrgWebhookPingCmd() *cobra.Command {
 	var org string
 
@@ -207,6 +213,7 @@ func newOrgWebhookDeliveryCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22997]: Not yet implemented.
 func newOrgWebhookDeliveryListCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/policy/policy.go
+++ b/pkg/cmd/pulumi/policy/policy.go
@@ -42,6 +42,8 @@ func NewPolicyCmd() *cobra.Command {
 	cmd.AddCommand(newPolicyPublishCmd())
 	cmd.AddCommand(newPolicyRmCmd())
 	cmd.AddCommand(newPolicyValidateCmd())
+	cmd.AddCommand(newPolicyComplianceCmd())
+	cmd.AddCommand(newPolicyIssueCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/policy/policy_compliance.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance.go
@@ -38,6 +38,7 @@ func newPolicyComplianceCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22994]: Not yet implemented.
 func newPolicyComplianceListCmd() *cobra.Command {
 	var (
 		org     string

--- a/pkg/cmd/pulumi/policy/policy_compliance.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance.go
@@ -1,0 +1,63 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newPolicyComplianceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "compliance",
+		Short:  "Inspect policy compliance results",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newPolicyComplianceListCmd())
+	return cmd
+}
+
+func newPolicyComplianceListCmd() *cobra.Command {
+	var (
+		org     string
+		groupBy string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List compliance results grouped by entity",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to fetch compliance results for")
+	cmd.Flags().StringVar(&groupBy, "group-by", "stack",
+		"How to group results: stack, account, or severity")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/policy/policy_group_cmds.go
+++ b/pkg/cmd/pulumi/policy/policy_group_cmds.go
@@ -1,0 +1,139 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newPolicyGroupNewCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new Policy Group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the Policy Group in")
+
+	return cmd
+}
+
+func newPolicyGroupGetCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get the details of a Policy Group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the Policy Group")
+
+	return cmd
+}
+
+func newPolicyGroupEditCmd() *cobra.Command {
+	var (
+		org                   string
+		newName               string
+		addStack              []string
+		removeStack           []string
+		addPolicyPack         []string
+		removePolicyPack      []string
+		addInsightsAccount    []string
+		removeInsightsAccount []string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update a Policy Group's configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the Policy Group")
+	cmd.Flags().StringVar(&newName, "new-name", "", "Rename the Policy Group")
+	cmd.Flags().StringArrayVar(&addStack, "add-stack", nil, "Add a stack to the Policy Group (repeatable)")
+	cmd.Flags().StringArrayVar(&removeStack, "remove-stack", nil, "Remove a stack from the Policy Group (repeatable)")
+	cmd.Flags().StringArrayVar(&addPolicyPack, "add-policy-pack", nil,
+		"Add a Policy Pack to the Policy Group (repeatable)")
+	cmd.Flags().StringArrayVar(&removePolicyPack, "remove-policy-pack", nil,
+		"Remove a Policy Pack from the Policy Group (repeatable)")
+	cmd.Flags().StringArrayVar(&addInsightsAccount, "add-insights-account", nil,
+		"Add an Insights account to the Policy Group (repeatable)")
+	cmd.Flags().StringArrayVar(&removeInsightsAccount, "remove-insights-account", nil,
+		"Remove an Insights account from the Policy Group (repeatable)")
+
+	return cmd
+}
+
+func newPolicyGroupRemoveCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Delete a Policy Group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the Policy Group")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/policy/policy_group_cmds.go
+++ b/pkg/cmd/pulumi/policy/policy_group_cmds.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22993]: Not yet implemented.
 func newPolicyGroupNewCmd() *cobra.Command {
 	var org string
 
@@ -46,6 +47,7 @@ func newPolicyGroupNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22992]: Not yet implemented.
 func newPolicyGroupGetCmd() *cobra.Command {
 	var org string
 
@@ -70,6 +72,7 @@ func newPolicyGroupGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22991]: Not yet implemented.
 func newPolicyGroupEditCmd() *cobra.Command {
 	var (
 		org                   string
@@ -114,6 +117,7 @@ func newPolicyGroupEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22990]: Not yet implemented.
 func newPolicyGroupRemoveCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/policy/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_group_ls.go
@@ -42,6 +42,10 @@ func newPolicyGroupCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newPolicyGroupLsCmd())
+	cmd.AddCommand(newPolicyGroupNewCmd())
+	cmd.AddCommand(newPolicyGroupGetCmd())
+	cmd.AddCommand(newPolicyGroupEditCmd())
+	cmd.AddCommand(newPolicyGroupRemoveCmd())
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/policy/policy_issue.go
+++ b/pkg/cmd/pulumi/policy/policy_issue.go
@@ -39,6 +39,7 @@ func newPolicyIssueCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22995]: Not yet implemented.
 func newPolicyIssueListCmd() *cobra.Command {
 	var (
 		org      string
@@ -64,6 +65,7 @@ func newPolicyIssueListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/22996]: Not yet implemented.
 func newPolicyIssueGetCmd() *cobra.Command {
 	var org string
 

--- a/pkg/cmd/pulumi/policy/policy_issue.go
+++ b/pkg/cmd/pulumi/policy/policy_issue.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newPolicyIssueCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "issue",
+		Short:  "Inspect policy issues",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newPolicyIssueListCmd())
+	cmd.AddCommand(newPolicyIssueGetCmd())
+	return cmd
+}
+
+func newPolicyIssueListCmd() *cobra.Command {
+	var (
+		org      string
+		page     int
+		pageSize int
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List all policy issues for an organization",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to list policy issues for")
+	cmd.Flags().IntVar(&page, "page", 1, "The page of results to return")
+	cmd.Flags().IntVar(&pageSize, "page-size", 0, "The number of results per page")
+
+	return cmd
+}
+
+func newPolicyIssueGetCmd() *cobra.Command {
+	var org string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get the details of a specific policy issue",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "issue-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the issue")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -59,6 +59,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/deployment"
 	cmdEnv "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/env"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/events"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/insights"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/install"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/logs"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/markdown"
@@ -513,6 +514,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			Name: "Hidden Commands",
 			Commands: []*cobra.Command{
 				markdown.NewGenMarkdownCmd(cmd),
+				insights.NewInsightsCmd(),
 			},
 		},
 

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -114,6 +114,11 @@ func NewStackCmd() *cobra.Command {
 	cmd.AddCommand(newStackChangeSecretsProviderCmd())
 	cmd.AddCommand(newStackHistoryCmd())
 	cmd.AddCommand(newStackUnselectCmd())
+	cmd.AddCommand(newStackNewCmd())
+	cmd.AddCommand(newStackGetCmd())
+	cmd.AddCommand(newStackDriftCmd())
+	cmd.AddCommand(newStackScheduleCmd())
+	cmd.AddCommand(newStackWebhookCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -1,0 +1,86 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newStackDriftCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "drift",
+		Short:  "Inspect stack drift detection results",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newStackDriftListCmd())
+	cmd.AddCommand(newStackDriftGetCmd())
+	return cmd
+}
+
+func newStackDriftListCmd() *cobra.Command {
+	var (
+		stack    string
+		page     int
+		pageSize int
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List drift detection runs for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().IntVar(&page, "page", 1, "The page of results to return")
+	cmd.Flags().IntVar(&pageSize, "page-size", 10, "The number of results per page (1-100)")
+
+	return cmd
+}
+
+func newStackDriftGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Retrieve the current drift detection status for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23053]: Not yet implemented.
 func newStackDriftCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -39,6 +40,7 @@ func newStackDriftCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23051]: Not yet implemented.
 func newStackDriftListCmd() *cobra.Command {
 	var (
 		stack    string
@@ -65,6 +67,7 @@ func newStackDriftListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23052]: Not yet implemented.
 func newStackDriftGetCmd() *cobra.Command {
 	var stack string
 

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -129,6 +129,9 @@ This command displays data about previous updates for a stack.`,
 		&pageSize, "page-size", 10, "Used with 'page' to control number of results returned")
 	cmd.PersistentFlags().IntVar(
 		&page, "page", 1, "Used with 'page-size' to paginate results")
+
+	cmd.AddCommand(newStackHistoryEventsCmd())
+
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23064]: Not yet implemented.
 func newStackHistoryEventsCmd() *cobra.Command {
 	var (
 		stack               string

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -1,0 +1,61 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newStackHistoryEventsCmd() *cobra.Command {
+	var (
+		stack               string
+		eventTypes          []string
+		resourceURN         string
+		includeNonActivated bool
+		token               string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "events",
+		Short:  "Retrieve engine events for an update",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "update-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringArrayVar(&eventTypes, "event-type", nil,
+		"Filter by engine event type code (repeatable)")
+	cmd.Flags().StringVar(&resourceURN, "urn", "", "Filter by resource URN")
+	cmd.Flags().BoolVar(&includeNonActivated, "include-non-activated", false,
+		"Include events not yet marked as activated")
+	cmd.Flags().StringVar(&token, "continuation-token", "",
+		"The continuation token for paginated retrieval")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23066]: Not yet implemented.
 func newStackNewCmd() *cobra.Command {
 	var (
 		org             string
@@ -65,6 +66,7 @@ func newStackNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23065]: Not yet implemented.
 func newStackGetCmd() *cobra.Command {
 	var stack string
 

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -1,0 +1,86 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newStackNewCmd() *cobra.Command {
+	var (
+		org             string
+		environment     string
+		secretsProvider string
+		encryptedKey    string
+		encryptionSalt  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new stack",
+		Long: "Create a new stack.\n" +
+			"\n" +
+			"A stack is an isolated, independently configurable instance of a Pulumi\n" +
+			"program, typically representing a deployment environment.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "project"},
+			{Name: "name"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "", "The organization to create the stack in")
+	cmd.Flags().StringVar(&environment, "environment", "",
+		"Reference to an ESC environment for storing stack configuration")
+	cmd.Flags().StringVar(&secretsProvider, "secrets-provider", "",
+		"The secrets provider for the stack")
+	cmd.Flags().StringVar(&encryptedKey, "encrypted-key", "",
+		"KMS-encrypted ciphertext for the data key (cloud-based secrets providers)")
+	cmd.Flags().StringVar(&encryptionSalt, "encryption-salt", "",
+		"Base64-encoded encryption salt (passphrase-based secrets providers)")
+
+	return cmd
+}
+
+func newStackGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Retrieve detailed information about a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -1,0 +1,180 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newStackScheduleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "schedule",
+		Short:  "Manage scheduled deployment actions for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newStackScheduleListCmd())
+	cmd.AddCommand(newStackScheduleNewCmd())
+	cmd.AddCommand(newStackScheduleGetCmd())
+	cmd.AddCommand(newStackScheduleEditCmd())
+	cmd.AddCommand(newStackScheduleRemoveCmd())
+	return cmd
+}
+
+func newStackScheduleListCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List all scheduled actions configured for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackScheduleNewCmd() *cobra.Command {
+	var (
+		stack     string
+		cron      string
+		once      string
+		operation string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a custom deployment schedule for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&cron, "cron", "",
+		"A cron expression for recurring executions (e.g. '0 */4 * * *')")
+	cmd.Flags().StringVar(&once, "once", "",
+		"An ISO 8601 timestamp for a one-time execution")
+	cmd.Flags().StringVar(&operation, "operation", "",
+		"The Pulumi operation to perform: update, preview, refresh, or destroy")
+
+	return cmd
+}
+
+func newStackScheduleGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Retrieve the configuration of a scheduled action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "schedule-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackScheduleEditCmd() *cobra.Command {
+	var (
+		stack     string
+		cron      string
+		once      string
+		operation string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update the configuration of a custom deployment schedule",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "schedule-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&cron, "cron", "",
+		"A cron expression for recurring executions")
+	cmd.Flags().StringVar(&once, "once", "",
+		"An ISO 8601 timestamp for a one-time execution")
+	cmd.Flags().StringVar(&operation, "operation", "",
+		"The Pulumi operation to perform: update, preview, refresh, or destroy")
+
+	return cmd
+}
+
+func newStackScheduleRemoveCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Permanently delete a scheduled deployment action",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "schedule-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23050]: Not yet implemented.
 func newStackScheduleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -42,6 +43,7 @@ func newStackScheduleCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23049]: Not yet implemented.
 func newStackScheduleListCmd() *cobra.Command {
 	var stack string
 
@@ -62,6 +64,7 @@ func newStackScheduleListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23048]: Not yet implemented.
 func newStackScheduleNewCmd() *cobra.Command {
 	var (
 		stack     string
@@ -93,6 +96,7 @@ func newStackScheduleNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23047]: Not yet implemented.
 func newStackScheduleGetCmd() *cobra.Command {
 	var stack string
 
@@ -118,6 +122,7 @@ func newStackScheduleGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23046]: Not yet implemented.
 func newStackScheduleEditCmd() *cobra.Command {
 	var (
 		stack     string
@@ -154,6 +159,7 @@ func newStackScheduleEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23045]: Not yet implemented.
 func newStackScheduleRemoveCmd() *cobra.Command {
 	var stack string
 

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -1,0 +1,269 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newStackWebhookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "webhook",
+		Short:  "Manage stack webhooks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newStackWebhookListCmd())
+	cmd.AddCommand(newStackWebhookGetCmd())
+	cmd.AddCommand(newStackWebhookNewCmd())
+	cmd.AddCommand(newStackWebhookEditCmd())
+	cmd.AddCommand(newStackWebhookRemoveCmd())
+	cmd.AddCommand(newStackWebhookPingCmd())
+	cmd.AddCommand(newStackWebhookDeliveryCmd())
+	return cmd
+}
+
+func stackWebhookHookArg() *constrictor.Arguments {
+	return &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+		},
+		Required: 1,
+	}
+}
+
+func newStackWebhookListCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List all webhooks configured for a stack",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackWebhookGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Get the details of a stack webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackWebhookNewCmd() *cobra.Command {
+	var (
+		stack       string
+		url         string
+		format      string
+		filters     []string
+		active      bool
+		secret      string
+		displayName string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new",
+		Short:  "Create a new stack webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "raw",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
+
+	return cmd
+}
+
+func newStackWebhookEditCmd() *cobra.Command {
+	var (
+		stack       string
+		url         string
+		format      string
+		filters     []string
+		active      bool
+		secret      string
+		displayName string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit",
+		Short:  "Update a stack webhook's configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&format, "format", "",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "filter", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
+
+	return cmd
+}
+
+func newStackWebhookRemoveCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove",
+		Short:  "Delete a stack webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackWebhookPingCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "ping",
+		Short:  "Send a test ping to a stack webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackWebhookDeliveryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "delivery",
+		Short:  "Inspect stack webhook deliveries",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.AddCommand(newStackWebhookDeliveryListCmd())
+	cmd.AddCommand(newStackWebhookDeliveryGetCmd())
+	return cmd
+}
+
+func newStackWebhookDeliveryListCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List recent deliveries for a stack webhook",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}
+
+func newStackWebhookDeliveryGetCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "get",
+		Short:  "Redeliver a specific webhook event",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "webhook"},
+			{Name: "event-id"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/23063]: Not yet implemented.
 func newStackWebhookCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -53,6 +54,7 @@ func stackWebhookHookArg() *constrictor.Arguments {
 	}
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23062]: Not yet implemented.
 func newStackWebhookListCmd() *cobra.Command {
 	var stack string
 
@@ -73,6 +75,7 @@ func newStackWebhookListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23061]: Not yet implemented.
 func newStackWebhookGetCmd() *cobra.Command {
 	var stack string
 
@@ -93,6 +96,7 @@ func newStackWebhookGetCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23060]: Not yet implemented.
 func newStackWebhookNewCmd() *cobra.Command {
 	var (
 		stack       string
@@ -129,6 +133,7 @@ func newStackWebhookNewCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23059]: Not yet implemented.
 func newStackWebhookEditCmd() *cobra.Command {
 	var (
 		stack       string
@@ -165,6 +170,7 @@ func newStackWebhookEditCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23058]: Not yet implemented.
 func newStackWebhookRemoveCmd() *cobra.Command {
 	var stack string
 
@@ -185,6 +191,7 @@ func newStackWebhookRemoveCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23057]: Not yet implemented.
 func newStackWebhookPingCmd() *cobra.Command {
 	var stack string
 
@@ -205,6 +212,7 @@ func newStackWebhookPingCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23056]: Not yet implemented.
 func newStackWebhookDeliveryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -222,6 +230,7 @@ func newStackWebhookDeliveryCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23055]: Not yet implemented.
 func newStackWebhookDeliveryListCmd() *cobra.Command {
 	var stack string
 
@@ -242,6 +251,7 @@ func newStackWebhookDeliveryListCmd() *cobra.Command {
 	return cmd
 }
 
+// TODO[https://github.com/pulumi/pulumi/issues/23054]: Not yet implemented.
 func newStackWebhookDeliveryGetCmd() *cobra.Command {
 	var stack string
 

--- a/pkg/cmd/pulumi/templatecmd/template_list.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatecmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+)
+
+func newTemplateListCmd() *cobra.Command {
+	var (
+		org    string
+		search string
+		token  string
+	)
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List registry-backed templates",
+		Long: "List registry-backed templates.\n" +
+			"\n" +
+			"Results can be filtered by template name and owning organization,\n" +
+			"and searched by name, description, metadata, and runtime.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("not yet implemented")
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "", "Filter templates by owning organization")
+	cmd.Flags().StringVar(&search, "search", "", "Case-insensitive partial match against template metadata")
+	cmd.Flags().StringVar(&token, "continuation-token", "", "The continuation token for paginated retrieval")
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/templatecmd/template_list.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
+// TODO[https://github.com/pulumi/pulumi/issues/22961]: Not yet implemented.
 func newTemplateListCmd() *cobra.Command {
 	var (
 		org    string


### PR DESCRIPTION
## Summary

Scaffolds the cobra command tree described in #22959 and its sub-issues so the structure is in place ahead of implementation. Every new command is `Hidden: true` and its `RunE` returns `not yet implemented`. Flags reflect the rough shape of each endpoint but no API calls are wired up.

The tree adds:

- `pulumi template list` (#22961)
- `pulumi insights resource {get,search}` (#22974, #22975)
- `pulumi insights account {new,list,scan {log}}` (#22978, #22977, #22979, #22980)
- `pulumi deployment {cancel,log,get,list}` (#22985, #22986, #22987, #22988)
- `pulumi deployment settings {get,edit}` (#22983, #22984)
- `pulumi policy group {new,get,edit,remove}` (#22990, #22991, #22992, #22993)
- `pulumi policy compliance list` (#22994)
- `pulumi policy issue {list,get}` (#22995, #22996)
- `pulumi org webhook {list,new,edit,remove,ping,delivery list}` (#22964-#22969, #22997)
- `pulumi org role {list,new,edit,remove,assign}` (#23003-#23008)
- `pulumi org member {list,get,edit,remove}` (#23009-#23013)
- `pulumi org audit-log {list,export}` (#23000, #23001)
- `pulumi org usage get` (#23002)
- `pulumi env new` (#23042)
- `pulumi env referrer list` (#23041)
- `pulumi env schedule {list,new,pause,resume,remove}` (#23031-#23035)
- `pulumi env webhook {list,new,edit,remove,ping,delivery list}` (#23023-#23029)
- `pulumi env provider new {aws,aws-sso,azure,gcp}` (#23037-#23040)
- `pulumi stack {new,get}` (#23065, #23066)
- `pulumi stack history events` (#23064)
- `pulumi stack drift {list,get}` (#23051, #23052)
- `pulumi stack schedule {list,new,get,edit,remove}` (#23045-#23049)
- `pulumi stack webhook {list,get,new,edit,remove,ping,delivery {list,get}}` (#23054-#23062)

## Test plan

- [x] `go build ./cmd/pulumi/...` succeeds
- [x] `golangci-lint run ./cmd/pulumi/...` clean
- [x] Each new leaf resolves via `--help` and prints its short description
- [ ] No changelog entry — this PR only adds hidden scaffolding