### PR TITLE
cli/cloud: rename `--format` flag to `--output` on `pulumi api`

### DIFF
--- a/changelog/pending/20260512--cli-cloud--rename-pulumi-api-format-flag-to-output.yaml
+++ b/changelog/pending/20260512--cli-cloud--rename-pulumi-api-format-flag-to-output.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Rename the `--format` flag to `--output` on `pulumi api` and its subcommands

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -61,7 +61,7 @@ type apiCommand struct {
 	silent          bool
 	verbose         bool
 	dryRun          bool
-	format          string
+	output          string
 	envelopeVersion int
 }
 
@@ -99,7 +99,7 @@ func bindFlags(cmd *cobra.Command, api *apiCommand) {
 		"Dump full request and response to stderr")
 	pf.BoolVar(&api.dryRun, "dry-run", false,
 		"Print the resolved request without sending it")
-	pf.StringVar(&api.format, "format", "",
+	pf.StringVar(&api.output, "output", "",
 		"Drive content negotiation and rendering. Default uses the op's primary "+
 			"response content type (usually JSON). `json` or `markdown` request that "+
 			"format via the Accept header — rejected if the op's spec doesn't declare it. "+
@@ -181,7 +181,7 @@ func NewAPICmd() *cobra.Command {
 			"  pulumi api UpdateStackTag --input ./tag.json\n" +
 			"  cat tag.json | pulumi api UpdateStackTag --input -\n\n" +
 			"  # Filter the JSON response with jq.\n" +
-			"  pulumi api /api/user --format=json | jq '.githubLogin'\n\n" +
+			"  pulumi api /api/user --output=json | jq '.githubLogin'\n\n" +
 			"  # Follow pagination cursors and stream the combined result to jq.\n" +
 			"  pulumi api ListStacks --paginate | jq '.stacks[].name'\n\n" +
 			"  # Extract just the status line + headers without the body.\n" +
@@ -270,7 +270,7 @@ func runAPI(cmd *cobra.Command, args []string, api *apiCommand) error {
 
 	query := mergeQuery(rawQuery, queryExtras)
 
-	accept, err := negotiateAccept(mr.Op, api.format)
+	accept, err := negotiateAccept(mr.Op, api.output)
 	if err != nil {
 		return err
 	}
@@ -444,13 +444,13 @@ func writeStatusAndHeaders(w io.Writer, resp *http.Response) {
 }
 
 // negotiateAccept picks the Accept header value to send for op based on the
-// user's --format flag. When --format is unset we use the op's primary
+// user's --output flag. When --output is unset we use the op's primary
 // response content type (historically JSON for Pulumi Cloud). When the user
 // explicitly asks for JSON or markdown we validate against the op's declared
 // response content types so the call fails fast with a helpful message
 // instead of surprising the caller with a 406 from the server.
-func negotiateAccept(op *Operation, format string) (string, error) {
-	switch strings.ToLower(format) {
+func negotiateAccept(op *Operation, output string) (string, error) {
+	switch strings.ToLower(output) {
 	case "", "raw", "auto", "default":
 		if op.ResponseContentType != "" {
 			return op.ResponseContentType, nil
@@ -462,34 +462,34 @@ func negotiateAccept(op *Operation, format string) (string, error) {
 				return ct, nil
 			}
 		}
-		return "", unsupportedFormatError(op, "json", "application/json")
+		return "", unsupportedOutputError(op, "json", "application/json")
 	case "markdown", "md":
 		for _, ct := range op.SuccessContentTypes {
 			if strings.EqualFold(ct, "text/markdown") {
 				return ct, nil
 			}
 		}
-		return "", unsupportedFormatError(op, "markdown", "text/markdown")
+		return "", unsupportedOutputError(op, "markdown", "text/markdown")
 	default:
 		return "", NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
-			"invalid --format value: "+format).
-			WithField("format").
-			WithSuggestions("--format=json", "--format=markdown", "--format=raw")
+			"invalid --output value: "+output).
+			WithField("output").
+			WithSuggestions("--output=json", "--output=markdown", "--output=raw")
 	}
 }
 
-// unsupportedFormatError returns a caller-actionable error when the user
-// asks for a format the op doesn't declare. The suggestions surface the
-// content types the op does declare so the user can pick one that works.
-func unsupportedFormatError(op *Operation, want, mediaType string) error {
+// unsupportedOutputError returns a caller-actionable error when the user
+// asks for an output format the op doesn't declare. The suggestions surface
+// the content types the op does declare so the user can pick one that works.
+func unsupportedOutputError(op *Operation, want, mediaType string) error {
 	msg := fmt.Sprintf("operation %s does not declare a %s response", op.OperationID, mediaType)
-	suggestions := []string{"omit --format to use the op's default content type"}
+	suggestions := []string{"omit --output to use the op's default content type"}
 	if len(op.SuccessContentTypes) > 0 {
 		suggestions = append(suggestions,
 			"declared response content types: "+strings.Join(op.SuccessContentTypes, ", "))
 	}
 	return NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags, msg).
-		WithField("format").
+		WithField("output").
 		WithSuggestions(suggestions...)
 }
 

--- a/pkg/cmd/pulumi/cloud/api_test.go
+++ b/pkg/cmd/pulumi/cloud/api_test.go
@@ -227,7 +227,7 @@ func TestNegotiateAccept_MarkdownNotDeclared(t *testing.T) {
 	assert.Contains(t, joined, "application/json")
 }
 
-// TestNegotiateAccept_InvalidValue rejects unknown --format values.
+// TestNegotiateAccept_InvalidValue rejects unknown --output values.
 func TestNegotiateAccept_InvalidValue(t *testing.T) {
 	t.Parallel()
 	_, err := negotiateAccept(&Operation{}, "yaml")

--- a/pkg/cmd/pulumi/cloud/describe.go
+++ b/pkg/cmd/pulumi/cloud/describe.go
@@ -30,7 +30,7 @@ import (
 // parent command's persistent flags (--refresh-spec).
 func newDescribeCmd(api *apiCommand) *cobra.Command {
 	var method string
-	var format string
+	var output string
 
 	cmd := &cobra.Command{
 		Use:   "describe",
@@ -42,7 +42,7 @@ func newDescribeCmd(api *apiCommand) *cobra.Command {
 			"`/api/stacks/{orgName}`) or an operation ID as shown in `list` (e.g.\n" +
 			"`ListAccounts`). Operation IDs are matched case-insensitively.\n" +
 			"\n" +
-			"Default output is a human-readable schema render. Pass --format=json for the\n" +
+			"Default output is a human-readable schema render. Pass --output=json for the\n" +
 			"stable agent envelope, including the inlined JSON schema.",
 		Example: "  # Describe an operation by its ID.\n" +
 			"  pulumi api describe ListOrgMembers\n\n" +
@@ -51,9 +51,9 @@ func newDescribeCmd(api *apiCommand) *cobra.Command {
 			"  # Paste-friendly: copy a METHOD + path row from `list` verbatim.\n" +
 			"  pulumi api describe 'GET /api/user'\n\n" +
 			"  # Extract just the request body schema.\n" +
-			"  pulumi api describe CreateStackTag --format=json | jq '.operation.requestBody.jsonSchema'\n\n" +
+			"  pulumi api describe CreateStackTag --output=json | jq '.operation.requestBody.jsonSchema'\n\n" +
 			"  # Pull the parameter list for scripting.\n" +
-			"  pulumi api describe GetStack --format=json | jq '.operation.parameters[] | {name, in, required}'",
+			"  pulumi api describe GetStack --output=json | jq '.operation.parameters[] | {name, in, required}'",
 	}
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
 		Arguments: []constrictor.Argument{{Name: "path-or-operation-id"}},
@@ -61,14 +61,14 @@ func newDescribeCmd(api *apiCommand) *cobra.Command {
 	})
 	cmd.Flags().StringVarP(&method, "method", "X", "GET",
 		"HTTP method to look up (a path can map to multiple ops by method)")
-	cmd.Flags().StringVar(&format, "format", "",
+	cmd.Flags().StringVar(&output, "output", "",
 		"Output format: default is a human-readable schema render; "+
 			"`markdown` emits a markdown document (piping friendly, renders in IDEs/glow); "+
 			"`json` emits the stable agent envelope")
 
 	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
 		return runDescribe(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), args, method,
-			cmd.Flags().Changed("method"), format, api.refreshSpec)
+			cmd.Flags().Changed("method"), output, api.refreshSpec)
 	})
 	return cmd
 }
@@ -76,9 +76,9 @@ func newDescribeCmd(api *apiCommand) *cobra.Command {
 func runDescribe(
 	ctx context.Context,
 	w, warnW io.Writer,
-	args []string, method string, methodExplicit bool, format string, refresh bool,
+	args []string, method string, methodExplicit bool, output string, refresh bool,
 ) error {
-	mode, err := resolveOutput(format)
+	mode, err := resolveOutput(output)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/cloud/describe_markdown.go
+++ b/pkg/cmd/pulumi/cloud/describe_markdown.go
@@ -26,7 +26,7 @@ import (
 // laid out to mirror pulumi/docs' OpenAPI rendering (method + path header,
 // admonitions for preview/deprecated, description, a parameters table, request
 // body, and a bucketed list of responses). The output is plain GitHub-flavored
-// markdown suitable for `describe --format=markdown`; callers piping to a
+// markdown suitable for `describe --output=markdown`; callers piping to a
 // terminal may further pass it through glow or similar for ANSI rendering.
 func RenderDescribeMarkdown(op *Operation) string {
 	var b strings.Builder

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -184,14 +184,14 @@ func writeErrorText(w io.Writer, d ErrorDetail) error {
 	return err
 }
 
-// Command-output envelopes. Each top-level `--format=json` payload gets a
+// Command-output envelopes. Each top-level `--output=json` payload gets a
 // dedicated envelope type here so the wire format is reviewable in one place.
 
 // orderedByDesc describes the sort order `ls` commits to. Agents can key off
 // this so they skip defensive resorting.
 const orderedByDesc = "tag asc, path asc, method precedence (GET, POST, PUT, PATCH, DELETE, HEAD)"
 
-// lsOperation is the per-row shape of the `list --format=json` payload.
+// lsOperation is the per-row shape of the `list --output=json` payload.
 // Summary and Description both appear: Pulumi's spec generator fills Summary
 // from the same Java annotation value as OperationID (so the two often match),
 // while Description holds the long-form prose. Both are emitted as "" when
@@ -209,7 +209,7 @@ type lsOperation struct {
 }
 
 // lsEnvelope is the top-level JSON shape emitted by `ls` on stdout when
-// piped or when --format=json is set.
+// piped or when --output=json is set.
 type lsEnvelope struct {
 	SchemaVersion int           `json:"schemaVersion"`
 	OrderedBy     string        `json:"orderedBy"`
@@ -218,7 +218,7 @@ type lsEnvelope struct {
 	Operations    []lsOperation `json:"operations"`
 }
 
-// describedOp is the per-operation payload emitted by `describe --format=json`.
+// describedOp is the per-operation payload emitted by `describe --output=json`.
 // It's a view over Operation with stable JSON names so the envelope remains
 // usable across CLI versions.
 type describedOp struct {
@@ -246,7 +246,7 @@ type bodyJSON struct {
 	JSONSchema  json.RawMessage `json:"jsonSchema,omitempty"`
 }
 
-// describeEnvelope is the top-level `describe --format=json` shape.
+// describeEnvelope is the top-level `describe --output=json` shape.
 type describeEnvelope struct {
 	SchemaVersion int         `json:"schemaVersion"`
 	Operation     describedOp `json:"operation"`

--- a/pkg/cmd/pulumi/cloud/envelope_test.go
+++ b/pkg/cmd/pulumi/cloud/envelope_test.go
@@ -62,9 +62,9 @@ func TestWriteErrorEnvelope_NonInteractiveIsCompactJSON(t *testing.T) {
 
 func TestWriteErrorEnvelope_InteractiveIsHumanReadable(t *testing.T) {
 	t.Parallel()
-	apiErr := NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags, "--format=yaml is not supported").
-		WithField("format").
-		WithSuggestions("--format=json", "--format=table")
+	apiErr := NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags, "--output=yaml is not supported").
+		WithField("output").
+		WithSuggestions("--output=json", "--output=table")
 
 	var buf bytes.Buffer
 	require.NoError(t, WriteErrorEnvelope(&buf, apiErr, true))
@@ -73,11 +73,11 @@ func TestWriteErrorEnvelope_InteractiveIsHumanReadable(t *testing.T) {
 	// Plain text — must NOT be JSON.
 	assert.False(t, strings.HasPrefix(strings.TrimSpace(out), "{"),
 		"interactive output should be human text, not JSON")
-	assert.Contains(t, out, "error: --format=yaml is not supported")
-	assert.Contains(t, out, "field: format")
+	assert.Contains(t, out, "error: --output=yaml is not supported")
+	assert.Contains(t, out, "field: output")
 	assert.Contains(t, out, "Suggestions:")
-	assert.Contains(t, out, "- --format=json")
-	assert.Contains(t, out, "- --format=table")
+	assert.Contains(t, out, "- --output=json")
+	assert.Contains(t, out, "- --output=table")
 }
 
 func TestWriteErrorEnvelope_InteractiveHTTPStatus(t *testing.T) {

--- a/pkg/cmd/pulumi/cloud/ls.go
+++ b/pkg/cmd/pulumi/cloud/ls.go
@@ -34,7 +34,7 @@ import (
 // every operation exposed by the embedded OpenAPI spec. api carries the
 // parent command's persistent flags (--refresh-spec).
 func newLsCmd(api *apiCommand) *cobra.Command {
-	var format string
+	var output string
 	includePreview := true
 	includeDeprecated := false
 
@@ -47,23 +47,23 @@ func newLsCmd(api *apiCommand) *cobra.Command {
 			"Output is sorted by (tag asc, path asc, method precedence). The default is a\n" +
 			"human-readable table when interactive; when non-interactive, list switches to\n" +
 			"the JSON envelope so downstream parsers don't have to deal with the table's\n" +
-			"box-drawing characters. Pass --format=json to request JSON explicitly, or\n" +
-			"--format=table to keep the table when redirecting.\n" +
+			"box-drawing characters. Pass --output=json to request JSON explicitly, or\n" +
+			"--output=table to keep the table when redirecting.\n" +
 			"\n" +
 			"Preview endpoints are listed by default; deprecated endpoints are hidden. Use\n" +
 			"--include-preview=false or --include-deprecated to change that.",
 		Example: "  # Print the table of stable endpoints.\n" +
 			"  pulumi api list\n\n" +
 			"  # Grab every operation as JSON (the default when piped).\n" +
-			"  pulumi api list --format=json\n\n" +
+			"  pulumi api list --output=json\n\n" +
 			"  # Count endpoints per tag with jq.\n" +
-			"  pulumi api list --format=json | jq '[.operations[] | .tag] | group_by(.) |\n" +
+			"  pulumi api list --output=json | jq '[.operations[] | .tag] | group_by(.) |\n" +
 			"    map({tag: .[0], count: length})'\n\n" +
 			"  # Find all stack-related GETs.\n" +
-			"  pulumi api list --format=json | jq '.operations[] |\n" +
+			"  pulumi api list --output=json | jq '.operations[] |\n" +
 			"    select(.method==\"GET\" and (.path | contains(\"/stacks\"))) | .operationId'\n\n" +
 			"  # Full-text search descriptions for deployment-related endpoints.\n" +
-			"  pulumi api list --format=json | jq '.operations[] |\n" +
+			"  pulumi api list --output=json | jq '.operations[] |\n" +
 			"    select(.description | test(\"deployment\"; \"i\")) |\n" +
 			"    {operationId, path, description}'\n\n" +
 			"  # Include deprecated endpoints (hidden by default).\n" +
@@ -72,9 +72,9 @@ func newLsCmd(api *apiCommand) *cobra.Command {
 			"  pulumi api list --include-preview=false",
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-	cmd.Flags().StringVar(&format, "format", "",
+	cmd.Flags().StringVar(&output, "output", "",
 		"Output format: `table` (human-readable, default when interactive), `json` "+
-			"(stable agent envelope, default when non-interactive). Use --format=table "+
+			"(stable agent envelope, default when non-interactive). Use --output=table "+
 			"to keep the table when redirecting.")
 	cmd.Flags().BoolVar(&includePreview, "include-preview", true,
 		"Include endpoints marked as preview")
@@ -82,7 +82,7 @@ func newLsCmd(api *apiCommand) *cobra.Command {
 		"Include endpoints marked as deprecated")
 
 	cmd.RunE = runWithEnvelope(func(cmd *cobra.Command, args []string) error {
-		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), format,
+		return runLs(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), output,
 			includePreview, includeDeprecated, api.refreshSpec)
 	})
 	return cmd
@@ -91,10 +91,10 @@ func newLsCmd(api *apiCommand) *cobra.Command {
 func runLs(
 	ctx context.Context,
 	w, warnW io.Writer,
-	format string,
+	output string,
 	includePreview, includeDeprecated, refresh bool,
 ) error {
-	mode, err := resolveOutput(format)
+	mode, err := resolveOutput(output)
 	if err != nil {
 		return err
 	}
@@ -102,9 +102,9 @@ func runLs(
 	// `describe` and the raw dispatcher, so reject them here explicitly.
 	if mode == outputRaw || mode == outputMarkdown {
 		return NewAPIError(cmdutil.ExitConfigurationError, ErrInvalidFlags,
-			"--format="+format+" is not supported for list").
-			WithField("format").
-			WithSuggestions("--format=json", "--format=table")
+			"--output="+output+" is not supported for list").
+			WithField("output").
+			WithSuggestions("--output=json", "--output=table")
 	}
 
 	if mode == outputDefault && !cmdutil.Interactive() {
@@ -218,14 +218,14 @@ func emitLsTable(w io.Writer, idx *Index) error {
 		{Name: "SUMMARY", WidthMax: summaryWidth, WidthMaxEnforcer: text.WrapText},
 	})
 	t.Render()
-	fmt.Fprintf(w, "\n%d operations. Pass --format=json for a stable, scriptable contract.\n",
+	fmt.Fprintf(w, "\n%d operations. Pass --output=json for a stable, scriptable contract.\n",
 		len(idx.Operations))
 	return nil
 }
 
 // stdoutWidth reports the column count of stdout, falling back to fallback
 // when stdout isn't a terminal or the size can't be determined (e.g. when
-// the user piped --format=table to a file but still wants the table).
+// the user piped --output=table to a file but still wants the table).
 func stdoutWidth(fallback int) int {
 	w, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil || w <= 0 {

--- a/pkg/cmd/pulumi/cloud/ls_test.go
+++ b/pkg/cmd/pulumi/cloud/ls_test.go
@@ -85,8 +85,8 @@ func TestResolveOutputAcceptsTable(t *testing.T) {
 	assert.Equal(t, outputTable, m)
 }
 
-// TestRunLs_RejectsRawAndMarkdown pins that ls refuses --format=raw and
-// --format=markdown up front, rather than silently rendering the table.
+// TestRunLs_RejectsRawAndMarkdown pins that ls refuses --output=raw and
+// --output=markdown up front, rather than silently rendering the table.
 // These modes are accepted globally by resolveOutput for describe and the
 // raw dispatcher.
 func TestRunLs_RejectsRawAndMarkdown(t *testing.T) {
@@ -100,7 +100,7 @@ func TestRunLs_RejectsRawAndMarkdown(t *testing.T) {
 			require.True(t, errors.As(err, &apiErr))
 			assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
 			assert.Equal(t, cmdutil.ExitConfigurationError, apiErr.ExitCode)
-			assert.Equal(t, "format", apiErr.Envelope.Error.Field)
+			assert.Equal(t, "output", apiErr.Envelope.Error.Field)
 		})
 	}
 }

--- a/pkg/cmd/pulumi/cloud/output.go
+++ b/pkg/cmd/pulumi/cloud/output.go
@@ -22,7 +22,7 @@ import (
 type outputFormat int
 
 const (
-	// outputDefault is "no --format passed" — the command picks its own
+	// outputDefault is "no --output passed" — the command picks its own
 	// human-friendly format and may auto-switch when non-interactive
 	// (e.g. `list` flips to JSON).
 	outputDefault outputFormat = iota
@@ -36,7 +36,7 @@ const (
 	outputMarkdown
 )
 
-// resolveOutput decides the effective output mode given the --format flag.
+// resolveOutput decides the effective output mode given the --output flag.
 func resolveOutput(explicit string) (outputFormat, error) {
 	switch explicit {
 	case "", "auto", "default":
@@ -51,7 +51,7 @@ func resolveOutput(explicit string) (outputFormat, error) {
 		return outputMarkdown, nil
 	default:
 		return outputDefault, NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
-			"invalid --format value: "+explicit).
-			WithSuggestions("--format=json", "--format=markdown", "--format=table", "--format=raw")
+			"invalid --output value: "+explicit).
+			WithSuggestions("--output=json", "--output=markdown", "--output=table", "--output=raw")
 	}
 }

--- a/pkg/cmd/pulumi/cloud/spec.go
+++ b/pkg/cmd/pulumi/cloud/spec.go
@@ -32,7 +32,7 @@ import (
 )
 
 // ParamSpec describes a single parameter for an API operation.
-// JSON tags are part of the `describe --format=json` envelope contract
+// JSON tags are part of the `describe --output=json` envelope contract
 // (SchemaVersion 1).
 type ParamSpec struct {
 	Name        string   `json:"name"`
@@ -78,22 +78,22 @@ type Operation struct {
 	// SuccessContentTypes lists every content type declared on the primary
 	// 2xx response, in spec order. An endpoint that offers both
 	// `application/json` and `text/markdown` will carry both, which lets the
-	// dispatcher drive content negotiation via --format. The legacy
+	// dispatcher drive content negotiation via --output. The legacy
 	// ResponseContentType field is still populated with the first preferred
 	// entry so human/JSON describe output stays stable.
 	SuccessContentTypes []string
 	BodySchemaText      string
 	ResponseSchemaText  string
-	// Request/response schemas serialized with all $refs inlined, so `describe --format=json`
+	// Request/response schemas serialized with all $refs inlined, so `describe --output=json`
 	// consumers can walk the structure programmatically.
 	BodySchemaJSON     json.RawMessage
 	ResponseSchemaJSON json.RawMessage
-	// Markdown-rendered request body schema for --format=markdown and the TUI.
+	// Markdown-rendered request body schema for --output=markdown and the TUI.
 	BodySchemaMarkdown string
 	// InlineResponses carries every response that has a schema (both success and
 	// error). The primary success response is duplicated into the flat
 	// ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields above so
-	// the text and `--format=json` outputs both keep a stable primary body.
+	// the text and `--output=json` outputs both keep a stable primary body.
 	InlineResponses []ResponseSpec
 	// StockErrors lists response codes with no schema — docs renders these as a
 	// compact chip row.
@@ -112,7 +112,7 @@ type Operation struct {
 type Index struct {
 	Operations  []*Operation
 	ByKey       map[string]*Operation // "GET /api/user" -> op
-	SpecVersion string                // the spec's own info.version, surfaced in `list --format=json`
+	SpecVersion string                // the spec's own info.version, surfaced in `list --output=json`
 	// router is a gorilla/mux router with one named route per operation
 	// (route name == op.Key()). Routes are registered in specificity order
 	// consistent with the pulumi-service codegen
@@ -278,7 +278,7 @@ func parseOperation(path, method string, op *v3high.Operation, renderer *schemaR
 // `InlineResponses` (has a schema) vs `StockErrors` (no schema). The first
 // 2xx success response is also duplicated into the flat
 // ResponseContentType/ResponseSchemaText/ResponseSchemaJSON fields so the
-// `describe` text and `--format=json` outputs both have a primary body.
+// `describe` text and `--output=json` outputs both have a primary body.
 func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRenderer) {
 	if op.Responses == nil {
 		return
@@ -341,9 +341,9 @@ func populateResponses(out *Operation, op *v3high.Operation, renderer *schemaRen
 		out.InlineResponses = append(out.InlineResponses, spec)
 
 		// Mirror the first success response into the flat fields so the text
-		// and `--format=json` outputs both still see the "primary" body.
+		// and `--output=json` outputs both still see the "primary" body.
 		// Also snapshot the full list of content types the spec declares for
-		// that response — the dispatcher uses it to drive --format-based
+		// that response — the dispatcher uses it to drive --output-based
 		// content negotiation.
 		if out.ResponseSchemaText == "" && isSuccessStatus(e.status) {
 			out.ResponseContentType = spec.ContentType

--- a/pkg/cmd/pulumi/cloud/spec_test.go
+++ b/pkg/cmd/pulumi/cloud/spec_test.go
@@ -99,7 +99,7 @@ func TestInternalOpsFiltered(t *testing.T) {
 
 // TestSuccessContentTypesCaptured asserts the parser records every content
 // type the spec declares on the primary 2xx response — the dispatcher uses
-// this list to drive --format-based content negotiation, so dropping
+// this list to drive --output-based content negotiation, so dropping
 // alternatives at parse time would silently defeat the feature.
 func TestSuccessContentTypesCaptured(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Rename the `--format` flag to `--output` across `pulumi api`, `pulumi api list`, and `pulumi api describe`.

This aligns with the existing `pulumi org search --output/-o` convention and reads more naturally than "format" when the value also drives content negotiation (e.g. `--output=raw` keeps the op's default Accept header and writes the response body through unchanged — which isn't really a "format" decision).

This is a breaking change to a recently-added command, made now while the surface is still marked `[EXPERIMENTAL]` (see #22970) and has not yet shipped in a stable release.

## Test plan
- [x] Existing unit tests in `pkg/cmd/pulumi/cloud/...` updated and pass
- [x] Verified `pulumi api --help`, `list --help`, `describe --help` all show `--output` and example snippets use `--output=...`
- [x] Verified `pulumi api list --format=json` now errors with `unknown flag: --format`
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [x] `make lint` — clean (`golangci-lint run ./cmd/pulumi/cloud/...` → 0 issues; `make lint_changelog` clean)
- [x] `go test ./cmd/pulumi/cloud/...` — pass
- [x] `go build ./...` (pkg) — clean
- [x] `gofumpt -l` on the package — no changes needed
- [ ] `make tidy_fix` — clean — N/A (no go.mod changes)
- [ ] `make check_proto` — clean (if proto changes) — N/A

## Changelog
- [x] Changelog entry added: `Rename the \`--format\` flag to \`--output\` on \`pulumi api\` and its subcommands`

## Risk

Breaking change to a recently-added, `[EXPERIMENTAL]`-tagged command. Doing the rename now (alongside the `pulumi cloud api` → `pulumi api` move in #22970) avoids carrying a permanent alias. No internal callers reference the old flag — every `--format` mention in source/tests/help text/examples has been migrated to `--output`. The `WithField("format")` envelope identifier also moves to `"output"` for consistency with the flag name.