### PR TITLE
cli/neo: show tool args and results in a ctrl+o overlay

### DIFF
--- a/changelog/pending/20260512--cli-neo--show-tool-details-overlay-ctrl-o.yaml
+++ b/changelog/pending/20260512--cli-neo--show-tool-details-overlay-ctrl-o.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Show tool call arguments and results in `pulumi neo` via a `ctrl+o` overlay

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -162,7 +162,21 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		result := s.invokeToolCall(ctx, call)
 		items = append(items, result)
 
-		sendUI(s.UIEvents, UIToolCompleted{Name: call.Name, Args: call.Args, IsError: result.IsError})
+		// Marshal a copy of the result so the TUI overlay can render the full
+		// payload. A marshal failure shouldn't abort the call (the upstream
+		// post still happens above with the original any value), so swallow it
+		// and surface an empty Result — the overlay treats that as "no detail
+		// available".
+		var resultRaw json.RawMessage
+		if b, err := json.Marshal(result.Content); err == nil {
+			resultRaw = b
+		}
+		sendUI(s.UIEvents, UIToolCompleted{
+			Name:    call.Name,
+			Args:    call.Args,
+			Result:  resultRaw,
+			IsError: result.IsError,
+		})
 	}
 
 	result := apitype.AgentUserEventToolResult{

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -162,11 +162,14 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		result := s.invokeToolCall(ctx, call)
 		items = append(items, result)
 
-		// Marshal a JSON copy for the overlay; swallow the error so the call
-		// itself isn't aborted on a display-only failure.
-		var resultRaw json.RawMessage
-		if b, err := json.Marshal(result.Content); err == nil {
-			resultRaw = b
+		// Marshal a JSON copy for the overlay. A failure shouldn't abort the
+		// call (the post above already happened with the original any value),
+		// so pack the error into a stub Result the overlay can render.
+		resultRaw, err := json.Marshal(result.Content)
+		if err != nil {
+			resultRaw, _ = json.Marshal(map[string]string{
+				"marshal_error": err.Error(),
+			})
 		}
 		sendUI(s.UIEvents, UIToolCompleted{
 			Name:    call.Name,

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -162,11 +162,8 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		result := s.invokeToolCall(ctx, call)
 		items = append(items, result)
 
-		// Marshal a copy of the result so the TUI overlay can render the full
-		// payload. A marshal failure shouldn't abort the call (the upstream
-		// post still happens above with the original any value), so swallow it
-		// and surface an empty Result — the overlay treats that as "no detail
-		// available".
+		// Marshal a JSON copy for the overlay; swallow the error so the call
+		// itself isn't aborted on a display-only failure.
 		var resultRaw json.RawMessage
 		if b, err := json.Marshal(result.Content); err == nil {
 			resultRaw = b

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -177,10 +177,8 @@ func TestSession_DispatchesCliMarkedToolCallsAndPostsResult(t *testing.T) {
 func TestSession_UIToolCompletedCarriesResult(t *testing.T) {
 	t.Parallel()
 
-	// The tool-details overlay (ctrl+o in the TUI) only has content because
-	// runBatch attaches the marshalled invokeToolCall result to the
-	// UIToolCompleted event. If that wiring drops, the overlay silently goes
-	// blank for every call — guard against the regression.
+	// Regression guard: runBatch must attach the marshalled invokeToolCall
+	// result to UIToolCompleted, otherwise the ctrl+o overlay goes blank.
 	streamer := newFakeStreamer()
 	handlers := map[string]ToolHandler{
 		"filesystem": &fakeHandler{wantMethod: "read", result: map[string]any{"content": "payload"}},

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -226,6 +226,56 @@ func TestSession_UIToolCompletedCarriesResult(t *testing.T) {
 	assert.JSONEq(t, `{"content":"payload"}`, string(completed.Result))
 }
 
+func TestSession_UIToolCompletedSurfacesMarshalError(t *testing.T) {
+	t.Parallel()
+
+	// A handler that returns an unmarshallable value (channels aren't JSON) —
+	// the overlay should still get a non-empty Result containing the
+	// marshal_error stub so the user sees why.
+	streamer := newFakeStreamer()
+	handlers := map[string]ToolHandler{
+		"filesystem": &fakeHandler{wantMethod: "read", result: map[string]any{"ch": make(chan int)}},
+	}
+
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{
+				ToolCallID:    "c1",
+				Name:          "filesystem__read",
+				Args:          json.RawMessage(`{}`),
+				ExecutionMode: "cli",
+			},
+		},
+	})}
+	close(streamer.stream)
+
+	uiCh := make(chan UIEvent, 32)
+	s := &Session{
+		Client:   streamer,
+		Handlers: handlers,
+		OrgName:  "org",
+		TaskID:   "task",
+		UIEvents: uiCh,
+	}
+	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
+
+	var completed UIToolCompleted
+	var found bool
+	for _, e := range collectUIEvents(uiCh) {
+		if c, ok := e.(UIToolCompleted); ok {
+			completed = c
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+	require.NotEmpty(t, completed.Result, "marshal failure must still surface a Result for the overlay")
+	assert.Contains(t, string(completed.Result), "marshal_error")
+}
+
 func TestSession_AssistantMessageWithoutCliCallsPostsNothing(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -174,6 +174,60 @@ func TestSession_DispatchesCliMarkedToolCallsAndPostsResult(t *testing.T) {
 	assert.NotContains(t, asMap, "timestamp")
 }
 
+func TestSession_UIToolCompletedCarriesResult(t *testing.T) {
+	t.Parallel()
+
+	// The tool-details overlay (ctrl+o in the TUI) only has content because
+	// runBatch attaches the marshalled invokeToolCall result to the
+	// UIToolCompleted event. If that wiring drops, the overlay silently goes
+	// blank for every call — guard against the regression.
+	streamer := newFakeStreamer()
+	handlers := map[string]ToolHandler{
+		"filesystem": &fakeHandler{wantMethod: "read", result: map[string]any{"content": "payload"}},
+	}
+
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+		ToolCalls: []apitype.AgentBackendEventToolCall{
+			{
+				ToolCallID:    "c1",
+				Name:          "filesystem__read",
+				Args:          json.RawMessage(`{}`),
+				ExecutionMode: "cli",
+			},
+		},
+	})}
+	close(streamer.stream)
+
+	uiCh := make(chan UIEvent, 32)
+	s := &Session{
+		Client:   streamer,
+		Handlers: handlers,
+		OrgName:  "org",
+		TaskID:   "task",
+		UIEvents: uiCh,
+	}
+	require.NoError(t, s.Run(t.Context()))
+	close(uiCh)
+
+	events := collectUIEvents(uiCh)
+	var completed UIToolCompleted
+	var found bool
+	for _, e := range events {
+		if c, ok := e.(UIToolCompleted); ok {
+			completed = c
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "session must emit UIToolCompleted for the cli call")
+	assert.Equal(t, "filesystem__read", completed.Name)
+	assert.False(t, completed.IsError)
+	require.NotEmpty(t, completed.Result, "UIToolCompleted.Result must carry the marshalled tool output")
+	assert.JSONEq(t, `{"content":"payload"}`, string(completed.Result))
+}
+
 func TestSession_AssistantMessageWithoutCliCallsPostsNothing(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -518,16 +518,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// While the overlay is open, swallow keys that aren't close / scroll /
-		// quit so they can't leak into the hidden input bar.
+		// While the overlay is open, ctrl+o / esc / ctrl+c / ctrl+d all close
+		// it; scroll keys go to the viewport; everything else is swallowed so
+		// it can't leak into the hidden input bar. Closing on ctrl+c/d means a
+		// reflexive "abort" tap dismisses the overlay rather than killing the
+		// session — the user can press ctrl+c again from the inline view to
+		// quit.
 		if m.overlayActive {
 			//exhaustive:ignore // explicit default below
 			switch msg.Type {
-			case tea.KeyCtrlO, tea.KeyEsc:
+			case tea.KeyCtrlO, tea.KeyEsc, tea.KeyCtrlC, tea.KeyCtrlD:
 				m.overlayActive = false
 				return m, tea.ExitAltScreen
-			case tea.KeyCtrlC, tea.KeyCtrlD:
-				// Fall through to the shared ctrl+c/d gate below.
 			case tea.KeyUp, tea.KeyDown,
 				tea.KeyPgUp, tea.KeyPgDown,
 				tea.KeyHome, tea.KeyEnd:

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -996,7 +996,8 @@ func (m Model) View() string {
 	if m.overlayActive {
 		return m.overlay.View()
 	}
-	hintText := "enter to send · shift+tab plan · ctrl+a auto-approval · ctrl+r read-only · ctrl+o tool details · ctrl+c to quit"
+	hintText := "enter to send · shift+tab plan · ctrl+a auto-approval · " +
+		"ctrl+r read-only · ctrl+o tool details · ctrl+c to quit"
 	if m.busy {
 		hintText = "agent is working · enter disabled · ctrl+o tool details · esc or ctrl+c to cancel"
 	}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -291,18 +291,10 @@ type Model struct {
 	hasEmittedScrollback bool
 	// pendingTodos buffers the latest UITodoList while planMode is true so
 	// the list lands inside the same block as the Proposed plan, not above it.
-	pendingTodos []UITodoItem
-	// toolHistory captures every tool call (up to maxToolHistory) so the
-	// ctrl+o overlay can render args/results after the fact. UIToolStarted
-	// appends a pending entry; UIToolCompleted completes it.
-	toolHistory []toolCallRecord
-	// overlayActive is true while the ctrl+o alt-screen overlay is open. The
-	// inline View(), input bar, and most key handling are suppressed until
-	// the user closes the overlay (ctrl+o or esc).
+	pendingTodos  []UITodoItem
+	toolHistory   []toolCallRecord
 	overlayActive bool
-	// overlay wraps the bubbles viewport used to scroll the tool-details
-	// alt-screen. Sized off m.width / m.height on WindowSizeMsg.
-	overlay overlayModel
+	overlay       overlayModel
 }
 
 var (
@@ -526,15 +518,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// When the tool-details overlay is open it takes priority over every
-		// other key handler: ctrl+o and esc close it, ctrl+c/ctrl+d still go
-		// through the arm-and-confirm quit gate below, scroll keys are
-		// forwarded to the viewport, and everything else is swallowed so it
-		// can't leak into the (currently hidden) input bar.
+		// While the overlay is open, swallow keys that aren't close / scroll /
+		// quit so they can't leak into the hidden input bar.
 		if m.overlayActive {
-			//exhaustive:ignore // We only act on a handful of keys; everything
-			// else falls through the default branch and is swallowed so it
-			// can't leak into the hidden input bar.
+			//exhaustive:ignore // explicit default below
 			switch msg.Type {
 			case tea.KeyCtrlO, tea.KeyEsc:
 				m.overlayActive = false
@@ -577,11 +564,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// will fire later but no-op because ctrlCArmed is already false.
 		m.ctrlCArmed = false
 
-		// Ctrl+O opens the tool-details overlay. Sits above the busy and
-		// approval gates so users can peek at args/results at any point in the
-		// session, even mid-turn or while waiting on an approval. Closing the
-		// overlay is handled by the overlayActive branch at the top of this
-		// case — once it's open, we never reach this handler.
+		// Ctrl+O opens the overlay. Sits above the busy/approval gates so
+		// users can peek mid-turn. Closing is handled by the overlayActive
+		// branch above.
 		if msg.Type == tea.KeyCtrlO {
 			m.overlayActive = true
 			m.overlay.SetSize(m.width, m.height)
@@ -1003,11 +988,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View returns the rendered live frame: live blocks (busy spinner, in-flight
 // streaming, in-flight pulumi op) above the input bar. Completed blocks aren't
 // drawn here — they were committed to terminal scrollback via tea.Println as
-// soon as they reached a terminal state.
-//
-// When the tool-details overlay is open, View returns its full-screen
-// rendering instead — the inline transcript is suspended (bubbletea switches
-// to the alt-screen) until the user closes the overlay.
+// soon as they reached a terminal state. When the overlay is open the
+// inline frame is suspended and we render the alt-screen view instead.
 func (m Model) View() string {
 	if m.overlayActive {
 		return m.overlay.View()

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -292,6 +292,17 @@ type Model struct {
 	// pendingTodos buffers the latest UITodoList while planMode is true so
 	// the list lands inside the same block as the Proposed plan, not above it.
 	pendingTodos []UITodoItem
+	// toolHistory captures every tool call (up to maxToolHistory) so the
+	// ctrl+o overlay can render args/results after the fact. UIToolStarted
+	// appends a pending entry; UIToolCompleted completes it.
+	toolHistory []toolCallRecord
+	// overlayActive is true while the ctrl+o alt-screen overlay is open. The
+	// inline View(), input bar, and most key handling are suppressed until
+	// the user closes the overlay (ctrl+o or esc).
+	overlayActive bool
+	// overlay wraps the bubbles viewport used to scroll the tool-details
+	// alt-screen. Sized off m.width / m.height on WindowSizeMsg.
+	overlay overlayModel
 }
 
 var (
@@ -411,6 +422,7 @@ func NewModel(cfg ModelConfig) Model {
 		taskCreated:    cfg.TaskCreated,
 		approvalMode:   cfg.InitialApprovalMode,
 		permissionMode: cfg.InitialPermissionMode,
+		overlay:        newOverlayModel(80, 24),
 	}
 	if cfg.InitialPrompt != "" {
 		// Render the initial-prompt block now so tests can find it via
@@ -450,6 +462,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		safeWidth := m.liveWidth()
 		m.welcome.termWidth = safeWidth
 		m.textInput.Width = max(safeWidth-lipgloss.Width(m.textInput.Prompt)-1, 1)
+		m.overlay.SetSize(m.width, m.height)
+		if m.overlayActive {
+			m.overlay.Refresh(m.toolHistory)
+		}
 
 		// Glamour's wrap width is baked in at construction, so rebuild on resize.
 		// Wrap at liveWidth-4 so glamour-rendered output (assistant finals, plan
@@ -510,6 +526,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// When the tool-details overlay is open it takes priority over every
+		// other key handler: ctrl+o and esc close it, ctrl+c/ctrl+d still go
+		// through the arm-and-confirm quit gate below, scroll keys are
+		// forwarded to the viewport, and everything else is swallowed so it
+		// can't leak into the (currently hidden) input bar.
+		if m.overlayActive {
+			//exhaustive:ignore // We only act on a handful of keys; everything
+			// else falls through the default branch and is swallowed so it
+			// can't leak into the hidden input bar.
+			switch msg.Type {
+			case tea.KeyCtrlO, tea.KeyEsc:
+				m.overlayActive = false
+				return m, tea.ExitAltScreen
+			case tea.KeyCtrlC, tea.KeyCtrlD:
+				// Fall through to the shared ctrl+c/d gate below.
+			case tea.KeyUp, tea.KeyDown,
+				tea.KeyPgUp, tea.KeyPgDown,
+				tea.KeyHome, tea.KeyEnd:
+				return m, m.overlay.Update(msg)
+			default:
+				return m, nil
+			}
+		}
+
 		// Ctrl+D mirrors Ctrl+C: same arm/quit gate, same cancel-when-busy
 		// semantics. Two bindings is friendlier than picking one and forcing
 		// users to discover it.
@@ -536,6 +576,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// presses goes back to needing two presses again. The pending tick
 		// will fire later but no-op because ctrlCArmed is already false.
 		m.ctrlCArmed = false
+
+		// Ctrl+O opens the tool-details overlay. Sits above the busy and
+		// approval gates so users can peek at args/results at any point in the
+		// session, even mid-turn or while waiting on an approval. Closing the
+		// overlay is handled by the overlayActive branch at the top of this
+		// case — once it's open, we never reach this handler.
+		if msg.Type == tea.KeyCtrlO {
+			m.overlayActive = true
+			m.overlay.SetSize(m.width, m.height)
+			m.overlay.Refresh(m.toolHistory)
+			return m, tea.EnterAltScreen
+		}
 
 		// Shift+Tab toggles plan mode. The toggle must run before the approval
 		// and busy guards so users can flip the indicator at any point in the
@@ -734,6 +786,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolStarted:
+		m.toolHistory = appendToolStart(m.toolHistory, msg.Name, msg.Args)
+		if m.overlayActive {
+			m.overlay.Refresh(m.toolHistory)
+		}
 		cmds = append(cmds, m.applyBusyForEvent(msg))
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
@@ -742,6 +798,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, waitForEvent(m.eventCh))
 
 	case UIToolCompleted:
+		completeToolCall(m.toolHistory, msg.Name, msg.Result, msg.IsError)
+		if m.overlayActive {
+			m.overlay.Refresh(m.toolHistory)
+		}
 		marker := toolOKMarker
 		if msg.IsError {
 			marker = toolErrMarker
@@ -944,10 +1004,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // streaming, in-flight pulumi op) above the input bar. Completed blocks aren't
 // drawn here — they were committed to terminal scrollback via tea.Println as
 // soon as they reached a terminal state.
+//
+// When the tool-details overlay is open, View returns its full-screen
+// rendering instead — the inline transcript is suspended (bubbletea switches
+// to the alt-screen) until the user closes the overlay.
 func (m Model) View() string {
-	hintText := "enter to send · shift+tab plan · ctrl+a auto-approval · ctrl+r read-only · ctrl+c to quit"
+	if m.overlayActive {
+		return m.overlay.View()
+	}
+	hintText := "enter to send · shift+tab plan · ctrl+a auto-approval · ctrl+r read-only · ctrl+o tool details · ctrl+c to quit"
 	if m.busy {
-		hintText = "agent is working · enter disabled · esc or ctrl+c to cancel"
+		hintText = "agent is working · enter disabled · ctrl+o tool details · esc or ctrl+c to cancel"
 	}
 	hint := "  "
 	chips := m.modeChips()

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -58,7 +58,8 @@ type UIToolProgress struct {
 func (UIToolProgress) uiEvent() {}
 
 // UIToolCompleted signals that a CLI tool call has finished. Result is the
-// JSON-marshalled tool output (empty when marshalling failed).
+// JSON-marshalled tool output, or a {"marshal_error": ...} stub when the
+// raw value couldn't be marshalled.
 type UIToolCompleted struct {
 	Name    string
 	Args    json.RawMessage

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -57,9 +57,8 @@ type UIToolProgress struct {
 
 func (UIToolProgress) uiEvent() {}
 
-// UIToolCompleted signals that a CLI tool call has finished. Result carries the
-// JSON-marshalled tool output (apitype.AgentUserEventToolResultItem.Content);
-// it is empty when marshalling failed and the overlay shows a fallback line.
+// UIToolCompleted signals that a CLI tool call has finished. Result is the
+// JSON-marshalled tool output (empty when marshalling failed).
 type UIToolCompleted struct {
 	Name    string
 	Args    json.RawMessage

--- a/pkg/cmd/pulumi/neo/tui_events.go
+++ b/pkg/cmd/pulumi/neo/tui_events.go
@@ -57,10 +57,13 @@ type UIToolProgress struct {
 
 func (UIToolProgress) uiEvent() {}
 
-// UIToolCompleted signals that a CLI tool call has finished.
+// UIToolCompleted signals that a CLI tool call has finished. Result carries the
+// JSON-marshalled tool output (apitype.AgentUserEventToolResultItem.Content);
+// it is empty when marshalling failed and the overlay shows a fallback line.
 type UIToolCompleted struct {
 	Name    string
 	Args    json.RawMessage
+	Result  json.RawMessage
 	IsError bool
 }
 

--- a/pkg/cmd/pulumi/neo/tui_overlay.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay.go
@@ -173,7 +173,7 @@ func formatJSON(raw json.RawMessage) string {
 	}
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {
-		return string(raw)
+		return "(could not parse as JSON: " + err.Error() + ")\n\n" + string(raw)
 	}
 	var b strings.Builder
 	formatValue(&b, v, 0)

--- a/pkg/cmd/pulumi/neo/tui_overlay.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay.go
@@ -1,0 +1,179 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/reflow/wordwrap"
+)
+
+// overlayHeader is the persistent first line of the overlay so users always
+// know how to dismiss it and scroll.
+const overlayHeader = "Tool details · ctrl+o or esc to close · ↑↓ pgup/pgdn to scroll · home/end for top/bottom"
+
+var (
+	overlayHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	overlayMetaStyle   = lipgloss.NewStyle().Faint(true)
+	overlaySubheadOK   = lipgloss.NewStyle().Bold(true)
+	overlayErrorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true)
+	overlayEmptyStyle  = lipgloss.NewStyle().Faint(true).Italic(true)
+)
+
+// overlayModel is the alt-screen viewer for tool-call args/results. The
+// viewport handles scrolling natively; the wrapper takes care of rebuilding
+// content from the Model's tool history and rendering the persistent header.
+type overlayModel struct {
+	vp     viewport.Model
+	width  int
+	height int
+}
+
+// newOverlayModel constructs an overlay sized to the current terminal. The
+// viewport reserves one row for the persistent header.
+func newOverlayModel(width, height int) overlayModel {
+	vp := viewport.New(width, max(height-1, 1))
+	return overlayModel{vp: vp, width: width, height: height}
+}
+
+// SetSize re-sizes the overlay (and its viewport) in response to a window
+// resize. Caller should call Refresh afterwards so wrapped content reflows.
+func (o *overlayModel) SetSize(width, height int) {
+	o.width = width
+	o.height = height
+	o.vp.Width = width
+	o.vp.Height = max(height-1, 1)
+}
+
+// Update forwards messages (key/mouse) to the viewport so it can scroll.
+func (o *overlayModel) Update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	o.vp, cmd = o.vp.Update(msg)
+	return cmd
+}
+
+// Refresh rebuilds the viewport content from history. The viewport is
+// scrolled to the bottom so the most recent tool call is on screen when the
+// overlay opens.
+func (o *overlayModel) Refresh(history []toolCallRecord) {
+	o.vp.SetContent(renderOverlayBody(history, o.width))
+	o.vp.GotoBottom()
+}
+
+// View renders the overlay as the persistent header on top of the viewport.
+func (o *overlayModel) View() string {
+	return overlayHeaderStyle.Render(overlayHeader) + "\n" + o.vp.View()
+}
+
+// renderOverlayBody composes one section per history record, separated by a
+// blank line. Long string values inside the pretty-printed JSON are
+// word-wrapped to the viewport width so the viewport never has to
+// horizontally scroll.
+func renderOverlayBody(history []toolCallRecord, width int) string {
+	if len(history) == 0 {
+		return overlayEmptyStyle.Render(
+			"No tool calls yet. Once the agent invokes a tool its arguments and result will appear here.")
+	}
+	sections := make([]string, 0, len(history))
+	for i := range history {
+		sections = append(sections, renderToolSection(&history[i], width))
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+// renderToolSection formats one tool call: title line + faint metadata line +
+// Arguments and Result subsections. Pending calls render an "(in flight)"
+// placeholder instead of a result block.
+func renderToolSection(rec *toolCallRecord, width int) string {
+	var b strings.Builder
+
+	b.WriteString(styledToolLabel(rec.Name, rec.Args))
+	b.WriteString("\n")
+
+	meta := "started " + rec.StartedAt.Format("15:04:05")
+	switch {
+	case rec.Pending:
+		meta += " · running"
+	default:
+		meta += " · " + rec.CompletedAt.Sub(rec.StartedAt).Round(1e6).String()
+		if rec.IsError {
+			meta += " · " + overlayErrorStyle.Render("error")
+		} else {
+			meta += " · ok"
+		}
+	}
+	b.WriteString(overlayMetaStyle.Render(meta))
+	b.WriteString("\n\n")
+
+	b.WriteString(overlaySubheadOK.Render("Arguments"))
+	b.WriteString("\n")
+	b.WriteString(indent(wrapForOverlay(formatJSON(rec.Args), width), "  "))
+	b.WriteString("\n\n")
+
+	b.WriteString(overlaySubheadOK.Render("Result"))
+	b.WriteString("\n")
+	if rec.Pending {
+		b.WriteString(indent(overlayEmptyStyle.Render("(in flight)"), "  "))
+	} else {
+		b.WriteString(indent(wrapForOverlay(formatJSON(rec.Result), width), "  "))
+	}
+
+	return b.String()
+}
+
+// formatJSON returns a pretty-printed representation of raw. If raw can't be
+// parsed as JSON it falls back to the raw bytes as a string so the user still
+// sees something. An empty payload renders as "(empty)" so consumers don't
+// have to special-case nil.
+func formatJSON(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return "(empty)"
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return string(raw)
+	}
+	return string(out)
+}
+
+// wrapForOverlay word-wraps content to width-2 so the 2-space indent in
+// renderToolSection still leaves us inside the terminal. Falls back to the
+// unwrapped string when the width is too small to be useful.
+func wrapForOverlay(s string, width int) string {
+	if width <= 4 {
+		return s
+	}
+	return wordwrap.String(s, width-2)
+}
+
+// indent prefixes every line of s with prefix.
+func indent(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/cmd/pulumi/neo/tui_overlay.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay.go
@@ -24,16 +24,39 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 )
 
-// overlayHeader is the persistent first line of the overlay so users always
-// know how to dismiss it and scroll.
-const overlayHeader = "Tool details · ctrl+o or esc to close · ↑↓ pgup/pgdn to scroll · home/end for top/bottom"
+// overlayHint is the persistent footer line of the overlay so users always
+// know how to dismiss it and scroll. It sits below the viewport rather than
+// above it so the eye lands on the tool detail content first.
+const overlayHint = "Tool details · ctrl+o or esc to close · ↑↓ pgup/pgdn to scroll · home/end for top/bottom"
 
 var (
-	overlayHeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
-	overlayMetaStyle   = lipgloss.NewStyle().Faint(true)
-	overlaySubheadOK   = lipgloss.NewStyle().Bold(true)
-	overlayErrorStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true)
-	overlayEmptyStyle  = lipgloss.NewStyle().Faint(true).Italic(true)
+	// overlayHintStyle is the dim cue at the bottom of the alt-screen. Faint
+	// (not bold) keeps it out of the way of the actual content.
+	overlayHintStyle = lipgloss.NewStyle().Faint(true)
+	// overlayTitleStyle styles the tool function name in cyan bold so each
+	// section's title pops out at a glance.
+	overlayTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	overlayMetaStyle  = lipgloss.NewStyle().Faint(true)
+	// overlayArgsHead is bold blue for the Arguments subhead. Distinct from
+	// the Result subhead so the eye can find the boundary at a glance even
+	// without indentation cues.
+	overlayArgsHead = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("4"))
+	// overlayResultHead is bold green for an ok result, bold red when the
+	// call returned an error — same color discipline as the inline tool
+	// markers (toolOKMarker / toolErrMarker) so the two surfaces stay
+	// visually consistent.
+	overlayResultHeadOK    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
+	overlayResultHeadError = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1"))
+	overlayErrorStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true)
+	overlayEmptyStyle      = lipgloss.NewStyle().Faint(true).Italic(true)
+	overlayDividerStyle    = lipgloss.NewStyle().Faint(true)
+	// Section title markers mirror the inline transcript: green ⏺ for ok,
+	// red for error, dim cyan for in-flight. Same glyph as toolOKMarker so
+	// users get the same visual cue whether they're reading scrollback or
+	// the overlay.
+	overlayMarkerOK      = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("⏺")
+	overlayMarkerError   = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
+	overlayMarkerPending = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Faint(true).Render("⏺")
 )
 
 // overlayModel is the alt-screen viewer for tool-call args/results. The
@@ -76,15 +99,17 @@ func (o *overlayModel) Refresh(history []toolCallRecord) {
 	o.vp.GotoBottom()
 }
 
-// View renders the overlay as the persistent header on top of the viewport.
+// View renders the viewport with the persistent hint pinned to the bottom of
+// the alt-screen. The hint is below the content so the eye lands on the tool
+// detail first and only drops to the hint when looking for the close key.
 func (o *overlayModel) View() string {
-	return overlayHeaderStyle.Render(overlayHeader) + "\n" + o.vp.View()
+	return o.vp.View() + "\n" + overlayHintStyle.Render(overlayHint)
 }
 
-// renderOverlayBody composes one section per history record, separated by a
-// blank line. Long string values inside the pretty-printed JSON are
-// word-wrapped to the viewport width so the viewport never has to
-// horizontally scroll.
+// renderOverlayBody composes one section per history record, joined by a
+// faint horizontal divider so the boundary between calls is unambiguous.
+// Long string values inside the pretty-printed JSON are word-wrapped to the
+// viewport width so the viewport never has to horizontally scroll.
 func renderOverlayBody(history []toolCallRecord, width int) string {
 	if len(history) == 0 {
 		return overlayEmptyStyle.Render(
@@ -94,7 +119,17 @@ func renderOverlayBody(history []toolCallRecord, width int) string {
 	for i := range history {
 		sections = append(sections, renderToolSection(&history[i], width))
 	}
-	return strings.Join(sections, "\n\n")
+	return strings.Join(sections, "\n\n"+sectionDivider(width)+"\n\n")
+}
+
+// sectionDivider renders the faint horizontal rule used between tool-call
+// sections. We use a box-drawing character so the line reads as a divider
+// even on terminals that render Faint as a subtle grey.
+func sectionDivider(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return overlayDividerStyle.Render(strings.Repeat("─", width))
 }
 
 // renderToolSection formats one tool call: title line + faint metadata line +
@@ -103,7 +138,13 @@ func renderOverlayBody(history []toolCallRecord, width int) string {
 func renderToolSection(rec *toolCallRecord, width int) string {
 	var b strings.Builder
 
-	b.WriteString(styledToolLabel(rec.Name, rec.Args))
+	funcName, argSummary := toolLabelParts(rec.Name, rec.Args)
+	b.WriteString(toolMarker(rec))
+	b.WriteString(" ")
+	b.WriteString(overlayTitleStyle.Render(funcName))
+	if argSummary != "" {
+		b.WriteString(overlayMetaStyle.Render(" (\"" + argSummary + "\")"))
+	}
 	b.WriteString("\n")
 
 	meta := "started " + rec.StartedAt.Format("15:04:05")
@@ -121,12 +162,12 @@ func renderToolSection(rec *toolCallRecord, width int) string {
 	b.WriteString(overlayMetaStyle.Render(meta))
 	b.WriteString("\n\n")
 
-	b.WriteString(overlaySubheadOK.Render("Arguments"))
+	b.WriteString(overlayArgsHead.Render("Arguments"))
 	b.WriteString("\n")
 	b.WriteString(indent(wrapForOverlay(formatJSON(rec.Args), width), "  "))
 	b.WriteString("\n\n")
 
-	b.WriteString(overlaySubheadOK.Render("Result"))
+	b.WriteString(resultHead(rec).Render("Result"))
 	b.WriteString("\n")
 	if rec.Pending {
 		b.WriteString(indent(overlayEmptyStyle.Render("(in flight)"), "  "))
@@ -135,6 +176,30 @@ func renderToolSection(rec *toolCallRecord, width int) string {
 	}
 
 	return b.String()
+}
+
+// toolMarker picks the ⏺ glyph color for the section title based on call
+// state: green for an ok completion, red for an error, dim cyan while the
+// call is still in flight.
+func toolMarker(rec *toolCallRecord) string {
+	switch {
+	case rec.Pending:
+		return overlayMarkerPending
+	case rec.IsError:
+		return overlayMarkerError
+	default:
+		return overlayMarkerOK
+	}
+}
+
+// resultHead picks the color of the "Result" subhead: green on ok, red on
+// error. Keeps the visual rhythm of the section consistent with the marker
+// at the top.
+func resultHead(rec *toolCallRecord) lipgloss.Style {
+	if rec.IsError {
+		return overlayResultHeadError
+	}
+	return overlayResultHeadOK
 }
 
 // formatJSON returns a pretty-printed representation of raw. If raw can't be

--- a/pkg/cmd/pulumi/neo/tui_overlay.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay.go
@@ -16,6 +16,9 @@ package neo
 
 import (
 	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -202,10 +205,14 @@ func resultHead(rec *toolCallRecord) lipgloss.Style {
 	return overlayResultHeadOK
 }
 
-// formatJSON returns a pretty-printed representation of raw. If raw can't be
-// parsed as JSON it falls back to the raw bytes as a string so the user still
-// sees something. An empty payload renders as "(empty)" so consumers don't
-// have to special-case nil.
+// formatJSON renders raw as a YAML-ish key/value block. Unlike pretty-printed
+// JSON, the output drops curly braces, square brackets, and key/value
+// quoting, and multi-line strings are expanded onto their own indented
+// lines rather than escaped with "\n". This is purely a display format —
+// the result is not meant to round-trip back to JSON.
+//
+// Empty input renders "(empty)" so consumers always see an explicit signal.
+// Invalid JSON falls back to the raw bytes so the user still gets *something*.
 func formatJSON(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return "(empty)"
@@ -214,11 +221,143 @@ func formatJSON(raw json.RawMessage) string {
 	if err := json.Unmarshal(raw, &v); err != nil {
 		return string(raw)
 	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return string(raw)
+	var b strings.Builder
+	formatValue(&b, v, 0)
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatValue dispatches on the dynamic type produced by json.Unmarshal.
+// Top-level scalars (string, number, bool, null) print verbatim; collections
+// recurse through formatMap / formatSlice.
+func formatValue(b *strings.Builder, v any, depth int) {
+	switch x := v.(type) {
+	case map[string]any:
+		formatMap(b, x, depth)
+	case []any:
+		formatSlice(b, x, depth)
+	case string:
+		// At the top level (or as a continuation body) a multi-line string
+		// is printed verbatim so file contents and shell output keep their
+		// real line breaks. The caller is responsible for any leading indent.
+		b.WriteString(x)
+	case bool:
+		b.WriteString(strconv.FormatBool(x))
+	case float64:
+		b.WriteString(formatNumber(x))
+	case nil:
+		b.WriteString("null")
+	default:
+		// json.Unmarshal into `any` only produces the cases above, but be
+		// defensive: print the Go default formatting.
+		fmt.Fprintf(b, "%v", x)
 	}
-	return string(out)
+}
+
+// formatMap emits sorted key/value pairs. A scalar value sits on the same
+// line as its key; a complex (map/array) or multi-line string value starts
+// on the next line, indented two spaces deeper than the key.
+func formatMap(b *strings.Builder, m map[string]any, depth int) {
+	if len(m) == 0 {
+		b.WriteString("(empty)")
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	pad := strings.Repeat(" ", depth)
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		v := m[k]
+		if isInlineScalar(v) {
+			b.WriteString(pad)
+			b.WriteString(k)
+			b.WriteString(": ")
+			formatValue(b, v, depth+2)
+			continue
+		}
+		// Block form: "key:" on its own line, value indented two further.
+		b.WriteString(pad)
+		b.WriteString(k)
+		b.WriteString(":\n")
+		writeBlock(b, v, depth+2)
+	}
+}
+
+// formatSlice emits one element per line, prefixed with "- ". Scalar
+// elements sit on the same line as the bullet; complex elements have their
+// rendered body indented two columns past the bullet.
+func formatSlice(b *strings.Builder, s []any, depth int) {
+	if len(s) == 0 {
+		b.WriteString("(empty)")
+		return
+	}
+	pad := strings.Repeat(" ", depth)
+	for i, v := range s {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(pad)
+		b.WriteString("- ")
+		if isInlineScalar(v) {
+			formatValue(b, v, depth+2)
+			continue
+		}
+		// Render the child, then re-indent its continuation lines so they
+		// align past the "- " marker. The first line of the child output
+		// has no leading pad (we just wrote the bullet); subsequent lines
+		// need the bullet's two-space offset added.
+		var child strings.Builder
+		formatValue(&child, v, 0)
+		rendered := child.String()
+		first, rest, hasRest := strings.Cut(rendered, "\n")
+		b.WriteString(strings.TrimLeft(first, " "))
+		if hasRest {
+			b.WriteString("\n")
+			b.WriteString(indent(rest, pad+"  "))
+		}
+	}
+}
+
+// writeBlock renders v as the body of a "key:" line, indented `depth`
+// spaces on every line so it lines up under the key. Strings are written
+// verbatim with their newlines preserved; maps and arrays defer to
+// formatValue, which threads `depth` down to formatMap / formatSlice so
+// their per-line padding lines up too.
+func writeBlock(b *strings.Builder, v any, depth int) {
+	if s, ok := v.(string); ok {
+		b.WriteString(indent(s, strings.Repeat(" ", depth)))
+		return
+	}
+	formatValue(b, v, depth)
+}
+
+// isInlineScalar reports whether v can be rendered on the same line as its
+// owning key or bullet. Multi-line strings, maps, and arrays cannot — they
+// need their own indented block.
+func isInlineScalar(v any) bool {
+	switch x := v.(type) {
+	case map[string]any, []any:
+		return false
+	case string:
+		return !strings.Contains(x, "\n")
+	default:
+		return true
+	}
+}
+
+// formatNumber prints a JSON number (always float64) without trailing zeros
+// or exponent form. Integer values print as e.g. "0", "42", "-7"; fractional
+// values use the shortest decimal form via strconv.FormatFloat 'g' precision -1.
+func formatNumber(x float64) string {
+	if x == float64(int64(x)) {
+		return strconv.FormatInt(int64(x), 10)
+	}
+	return strconv.FormatFloat(x, 'g', -1, 64)
 }
 
 // wrapForOverlay word-wraps content to width-2 so the 2-space indent in

--- a/pkg/cmd/pulumi/neo/tui_overlay.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay.go
@@ -16,7 +16,6 @@ package neo
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,59 +26,37 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 )
 
-// overlayHint is the persistent footer line of the overlay so users always
-// know how to dismiss it and scroll. It sits below the viewport rather than
-// above it so the eye lands on the tool detail content first.
 const overlayHint = "Tool details · ctrl+o or esc to close · ↑↓ pgup/pgdn to scroll · home/end for top/bottom"
 
 var (
-	// overlayHintStyle is the dim cue at the bottom of the alt-screen. Faint
-	// (not bold) keeps it out of the way of the actual content.
-	overlayHintStyle = lipgloss.NewStyle().Faint(true)
-	// overlayTitleStyle styles the tool function name in cyan bold so each
-	// section's title pops out at a glance.
-	overlayTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
-	overlayMetaStyle  = lipgloss.NewStyle().Faint(true)
-	// overlayArgsHead is bold blue for the Arguments subhead. Distinct from
-	// the Result subhead so the eye can find the boundary at a glance even
-	// without indentation cues.
-	overlayArgsHead = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("4"))
-	// overlayResultHead is bold green for an ok result, bold red when the
-	// call returned an error — same color discipline as the inline tool
-	// markers (toolOKMarker / toolErrMarker) so the two surfaces stay
-	// visually consistent.
+	overlayHintStyle       = lipgloss.NewStyle().Faint(true)
+	overlayTitleStyle      = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
+	overlayMetaStyle       = lipgloss.NewStyle().Faint(true)
+	overlayArgsHead        = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("4"))
 	overlayResultHeadOK    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("2"))
 	overlayResultHeadError = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("1"))
 	overlayErrorStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Bold(true)
 	overlayEmptyStyle      = lipgloss.NewStyle().Faint(true).Italic(true)
 	overlayDividerStyle    = lipgloss.NewStyle().Faint(true)
-	// Section title markers mirror the inline transcript: green ⏺ for ok,
-	// red for error, dim cyan for in-flight. Same glyph as toolOKMarker so
-	// users get the same visual cue whether they're reading scrollback or
-	// the overlay.
-	overlayMarkerOK      = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("⏺")
-	overlayMarkerError   = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
-	overlayMarkerPending = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Faint(true).Render("⏺")
+	overlayMarkerOK        = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("⏺")
+	overlayMarkerError     = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
+	overlayMarkerPending   = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Faint(true).Render("⏺")
 )
 
-// overlayModel is the alt-screen viewer for tool-call args/results. The
-// viewport handles scrolling natively; the wrapper takes care of rebuilding
-// content from the Model's tool history and rendering the persistent header.
 type overlayModel struct {
 	vp     viewport.Model
 	width  int
 	height int
 }
 
-// newOverlayModel constructs an overlay sized to the current terminal. The
-// viewport reserves one row for the persistent header.
 func newOverlayModel(width, height int) overlayModel {
-	vp := viewport.New(width, max(height-1, 1))
-	return overlayModel{vp: vp, width: width, height: height}
+	return overlayModel{
+		vp:     viewport.New(width, max(height-1, 1)),
+		width:  width,
+		height: height,
+	}
 }
 
-// SetSize re-sizes the overlay (and its viewport) in response to a window
-// resize. Caller should call Refresh afterwards so wrapped content reflows.
 func (o *overlayModel) SetSize(width, height int) {
 	o.width = width
 	o.height = height
@@ -87,32 +64,25 @@ func (o *overlayModel) SetSize(width, height int) {
 	o.vp.Height = max(height-1, 1)
 }
 
-// Update forwards messages (key/mouse) to the viewport so it can scroll.
 func (o *overlayModel) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	o.vp, cmd = o.vp.Update(msg)
 	return cmd
 }
 
-// Refresh rebuilds the viewport content from history. The viewport is
-// scrolled to the bottom so the most recent tool call is on screen when the
-// overlay opens.
+// Refresh rebuilds the viewport content and snaps to the bottom so the most
+// recent call is on screen when the overlay opens.
 func (o *overlayModel) Refresh(history []toolCallRecord) {
 	o.vp.SetContent(renderOverlayBody(history, o.width))
 	o.vp.GotoBottom()
 }
 
-// View renders the viewport with the persistent hint pinned to the bottom of
-// the alt-screen. The hint is below the content so the eye lands on the tool
-// detail first and only drops to the hint when looking for the close key.
+// View pins the hint below the viewport rather than above it so the eye
+// lands on the tool detail first.
 func (o *overlayModel) View() string {
 	return o.vp.View() + "\n" + overlayHintStyle.Render(overlayHint)
 }
 
-// renderOverlayBody composes one section per history record, joined by a
-// faint horizontal divider so the boundary between calls is unambiguous.
-// Long string values inside the pretty-printed JSON are word-wrapped to the
-// viewport width so the viewport never has to horizontally scroll.
 func renderOverlayBody(history []toolCallRecord, width int) string {
 	if len(history) == 0 {
 		return overlayEmptyStyle.Render(
@@ -125,9 +95,6 @@ func renderOverlayBody(history []toolCallRecord, width int) string {
 	return strings.Join(sections, "\n\n"+sectionDivider(width)+"\n\n")
 }
 
-// sectionDivider renders the faint horizontal rule used between tool-call
-// sections. We use a box-drawing character so the line reads as a divider
-// even on terminals that render Faint as a subtle grey.
 func sectionDivider(width int) string {
 	if width <= 0 {
 		return ""
@@ -135,9 +102,6 @@ func sectionDivider(width int) string {
 	return overlayDividerStyle.Render(strings.Repeat("─", width))
 }
 
-// renderToolSection formats one tool call: title line + faint metadata line +
-// Arguments and Result subsections. Pending calls render an "(in flight)"
-// placeholder instead of a result block.
 func renderToolSection(rec *toolCallRecord, width int) string {
 	var b strings.Builder
 
@@ -181,9 +145,6 @@ func renderToolSection(rec *toolCallRecord, width int) string {
 	return b.String()
 }
 
-// toolMarker picks the ⏺ glyph color for the section title based on call
-// state: green for an ok completion, red for an error, dim cyan while the
-// call is still in flight.
 func toolMarker(rec *toolCallRecord) string {
 	switch {
 	case rec.Pending:
@@ -195,9 +156,6 @@ func toolMarker(rec *toolCallRecord) string {
 	}
 }
 
-// resultHead picks the color of the "Result" subhead: green on ok, red on
-// error. Keeps the visual rhythm of the section consistent with the marker
-// at the top.
 func resultHead(rec *toolCallRecord) lipgloss.Style {
 	if rec.IsError {
 		return overlayResultHeadError
@@ -205,14 +163,10 @@ func resultHead(rec *toolCallRecord) lipgloss.Style {
 	return overlayResultHeadOK
 }
 
-// formatJSON renders raw as a YAML-ish key/value block. Unlike pretty-printed
-// JSON, the output drops curly braces, square brackets, and key/value
-// quoting, and multi-line strings are expanded onto their own indented
-// lines rather than escaped with "\n". This is purely a display format —
-// the result is not meant to round-trip back to JSON.
-//
-// Empty input renders "(empty)" so consumers always see an explicit signal.
-// Invalid JSON falls back to the raw bytes so the user still gets *something*.
+// formatJSON renders raw as a YAML-ish key/value block — no braces, brackets,
+// or key/value quoting, and multi-line strings are expanded onto their own
+// indented lines. Display-only; the output is not meant to round-trip back
+// to JSON.
 func formatJSON(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return "(empty)"
@@ -226,9 +180,6 @@ func formatJSON(raw json.RawMessage) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// formatValue dispatches on the dynamic type produced by json.Unmarshal.
-// Top-level scalars (string, number, bool, null) print verbatim; collections
-// recurse through formatMap / formatSlice.
 func formatValue(b *strings.Builder, v any, depth int) {
 	switch x := v.(type) {
 	case map[string]any:
@@ -236,9 +187,6 @@ func formatValue(b *strings.Builder, v any, depth int) {
 	case []any:
 		formatSlice(b, x, depth)
 	case string:
-		// At the top level (or as a continuation body) a multi-line string
-		// is printed verbatim so file contents and shell output keep their
-		// real line breaks. The caller is responsible for any leading indent.
 		b.WriteString(x)
 	case bool:
 		b.WriteString(strconv.FormatBool(x))
@@ -246,16 +194,9 @@ func formatValue(b *strings.Builder, v any, depth int) {
 		b.WriteString(formatNumber(x))
 	case nil:
 		b.WriteString("null")
-	default:
-		// json.Unmarshal into `any` only produces the cases above, but be
-		// defensive: print the Go default formatting.
-		fmt.Fprintf(b, "%v", x)
 	}
 }
 
-// formatMap emits sorted key/value pairs. A scalar value sits on the same
-// line as its key; a complex (map/array) or multi-line string value starts
-// on the next line, indented two spaces deeper than the key.
 func formatMap(b *strings.Builder, m map[string]any, depth int) {
 	if len(m) == 0 {
 		b.WriteString("(empty)")
@@ -273,24 +214,18 @@ func formatMap(b *strings.Builder, m map[string]any, depth int) {
 			b.WriteString("\n")
 		}
 		v := m[k]
+		b.WriteString(pad)
+		b.WriteString(k)
 		if isInlineScalar(v) {
-			b.WriteString(pad)
-			b.WriteString(k)
 			b.WriteString(": ")
 			formatValue(b, v, depth+2)
 			continue
 		}
-		// Block form: "key:" on its own line, value indented two further.
-		b.WriteString(pad)
-		b.WriteString(k)
 		b.WriteString(":\n")
 		writeBlock(b, v, depth+2)
 	}
 }
 
-// formatSlice emits one element per line, prefixed with "- ". Scalar
-// elements sit on the same line as the bullet; complex elements have their
-// rendered body indented two columns past the bullet.
 func formatSlice(b *strings.Builder, s []any, depth int) {
 	if len(s) == 0 {
 		b.WriteString("(empty)")
@@ -307,14 +242,12 @@ func formatSlice(b *strings.Builder, s []any, depth int) {
 			formatValue(b, v, depth+2)
 			continue
 		}
-		// Render the child, then re-indent its continuation lines so they
-		// align past the "- " marker. The first line of the child output
-		// has no leading pad (we just wrote the bullet); subsequent lines
-		// need the bullet's two-space offset added.
+		// Re-indent continuation lines so they align past the "- " marker:
+		// the first line has none (the bullet itself takes that slot), the
+		// rest get the bullet's two-space offset.
 		var child strings.Builder
 		formatValue(&child, v, 0)
-		rendered := child.String()
-		first, rest, hasRest := strings.Cut(rendered, "\n")
+		first, rest, hasRest := strings.Cut(child.String(), "\n")
 		b.WriteString(strings.TrimLeft(first, " "))
 		if hasRest {
 			b.WriteString("\n")
@@ -323,11 +256,6 @@ func formatSlice(b *strings.Builder, s []any, depth int) {
 	}
 }
 
-// writeBlock renders v as the body of a "key:" line, indented `depth`
-// spaces on every line so it lines up under the key. Strings are written
-// verbatim with their newlines preserved; maps and arrays defer to
-// formatValue, which threads `depth` down to formatMap / formatSlice so
-// their per-line padding lines up too.
 func writeBlock(b *strings.Builder, v any, depth int) {
 	if s, ok := v.(string); ok {
 		b.WriteString(indent(s, strings.Repeat(" ", depth)))
@@ -336,9 +264,6 @@ func writeBlock(b *strings.Builder, v any, depth int) {
 	formatValue(b, v, depth)
 }
 
-// isInlineScalar reports whether v can be rendered on the same line as its
-// owning key or bullet. Multi-line strings, maps, and arrays cannot — they
-// need their own indented block.
 func isInlineScalar(v any) bool {
 	switch x := v.(type) {
 	case map[string]any, []any:
@@ -350,9 +275,8 @@ func isInlineScalar(v any) bool {
 	}
 }
 
-// formatNumber prints a JSON number (always float64) without trailing zeros
-// or exponent form. Integer values print as e.g. "0", "42", "-7"; fractional
-// values use the shortest decimal form via strconv.FormatFloat 'g' precision -1.
+// formatNumber sidesteps strconv's default float formatting for integer-valued
+// floats so exit_code:0 doesn't print as "0e+00".
 func formatNumber(x float64) string {
 	if x == float64(int64(x)) {
 		return strconv.FormatInt(int64(x), 10)
@@ -360,9 +284,6 @@ func formatNumber(x float64) string {
 	return strconv.FormatFloat(x, 'g', -1, 64)
 }
 
-// wrapForOverlay word-wraps content to width-2 so the 2-space indent in
-// renderToolSection still leaves us inside the terminal. Falls back to the
-// unwrapped string when the width is too small to be useful.
 func wrapForOverlay(s string, width int) string {
 	if width <= 4 {
 		return s
@@ -370,7 +291,6 @@ func wrapForOverlay(s string, width int) string {
 	return wordwrap.String(s, width-2)
 }
 
-// indent prefixes every line of s with prefix.
 func indent(s, prefix string) string {
 	if s == "" {
 		return ""

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -25,12 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// cmdMsgTypeName runs cmd in a goroutine (see runCmd) and returns the
-// resolved message's reflect.Type.Name(). It's how we identify bubbletea's
-// internal enterAltScreenMsg / exitAltScreenMsg singletons from tests:
-// they're unexported, so the only reliable handle on them is their type
-// name. Returns "" when the command times out (blocking cmd like
-// waitForEvent) or produces a nil message.
+// cmdMsgTypeName resolves cmd via runCmd and returns the message's reflect
+// type name — the only reliable handle on bubbletea's unexported alt-screen
+// messages from outside the package.
 func cmdMsgTypeName(cmd tea.Cmd) string {
 	msg, ok := runCmd(cmd)
 	if !ok || msg == nil {
@@ -78,13 +75,13 @@ func TestCompleteToolCall_NoMatchIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	hist := appendToolStart(nil, "fs__read", nil)
-	// Mark the only entry as completed so there's no pending match anymore.
 	completeToolCall(hist, "fs__read", json.RawMessage(`"ok"`), false)
 	require.False(t, hist[0].Pending)
 
-	// Second completion for the same name finds no pending entry and is dropped.
+	// A second completion for the same name finds no pending entry; it must
+	// not stomp the already-completed record.
 	completeToolCall(hist, "fs__read", json.RawMessage(`"different"`), true)
-	assert.JSONEq(t, `"ok"`, string(hist[0].Result), "stale completion must not overwrite a completed entry")
+	assert.JSONEq(t, `"ok"`, string(hist[0].Result))
 	assert.False(t, hist[0].IsError)
 }
 
@@ -98,15 +95,12 @@ func TestFormatJSON(t *testing.T) {
 	t.Run("renders a flat map as key/value lines without JSON syntax", func(t *testing.T) {
 		t.Parallel()
 		got := formatJSON(json.RawMessage(`{"b":2,"a":1}`))
-		// Keys sorted, no braces, no quotes, no trailing comma — the whole
-		// point of the YAML-ish renderer.
 		assert.Equal(t, "a: 1\nb: 2", got)
 	})
 
 	t.Run("integer numbers render without decimals or exponent", func(t *testing.T) {
 		t.Parallel()
-		// JSON numbers come back as float64; without special-casing, exit_code:0
-		// could otherwise print "0e+00" depending on the format verb.
+		// Guards against "0e+00" for integer-valued float64s; see formatNumber.
 		got := formatJSON(json.RawMessage(`{"exit_code":0,"size":1234567890}`))
 		assert.Equal(t, "exit_code: 0\nsize: 1234567890", got)
 	})
@@ -119,9 +113,6 @@ func TestFormatJSON(t *testing.T) {
 
 	t.Run("multi-line string value expands onto indented lines", func(t *testing.T) {
 		t.Parallel()
-		// The classic shell-output case: without this expansion, stdout
-		// containing newlines would render as one long line with literal
-		// "\n" escapes.
 		got := formatJSON(json.RawMessage(`{"stdout":"a\nb\nc"}`))
 		assert.Equal(t, "stdout:\n  a\n  b\n  c", got)
 	})
@@ -134,8 +125,6 @@ func TestFormatJSON(t *testing.T) {
 
 	t.Run("top-level string prints verbatim with newlines preserved", func(t *testing.T) {
 		t.Parallel()
-		// A Read tool result is often just the file contents. Quoting and
-		// escaping that would defeat the entire purpose of the overlay.
 		got := formatJSON(json.RawMessage(`"line1\nline2\nline3"`))
 		assert.Equal(t, "line1\nline2\nline3", got)
 	})
@@ -197,12 +186,10 @@ func TestModel_Update_CtrlOClosesOverlay(t *testing.T) {
 	t.Parallel()
 
 	m := NewModel(ModelConfig{})
-	// Open it first.
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	um := updated.(Model)
 	require.True(t, um.overlayActive)
 
-	// A second ctrl+o closes it and exits alt-screen.
 	updated, cmd := um.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	um = updated.(Model)
 	assert.False(t, um.overlayActive)
@@ -212,8 +199,8 @@ func TestModel_Update_CtrlOClosesOverlay(t *testing.T) {
 func TestModel_Update_EscClosesOverlay_NoCancel(t *testing.T) {
 	t.Parallel()
 
-	// Esc in the overlay must close it WITHOUT posting a user_cancel — the
-	// agent's turn must keep running in the background while the user reviews.
+	// Esc in the overlay must close it WITHOUT posting user_cancel — the
+	// agent keeps running while the user reviews.
 	outCh := make(chan outboundEvent, 1)
 	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
@@ -236,9 +223,8 @@ func TestModel_Update_EscClosesOverlay_NoCancel(t *testing.T) {
 func TestModel_Update_OverlaySwallowsTyping(t *testing.T) {
 	t.Parallel()
 
-	// While the overlay is open, printable keys must NOT reach the input
-	// textarea — the input bar is hidden and any leaked text would surprise
-	// the user when they close the overlay.
+	// Printable keys must not reach the (hidden) input bar while the overlay
+	// is open, otherwise typed text shows up after the overlay closes.
 	m := NewModel(ModelConfig{})
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	um := updated.(Model)
@@ -254,10 +240,9 @@ func TestModel_Update_OverlaySwallowsTyping(t *testing.T) {
 func TestModel_Update_OverlayForwardsScrollKeys(t *testing.T) {
 	t.Parallel()
 
-	// Scroll keys (↑↓ pgup pgdn home end) must reach the viewport. We can't
-	// easily assert the viewport's internal scroll offset from outside, so
-	// we just verify the overlay stays open — i.e. those keys are NOT
-	// hitting the "swallow everything else" default branch that returns nil.
+	// Viewport offset isn't visible from outside, so the assertion is the
+	// negative one: scroll keys must not trip the swallow-everything-else
+	// default branch (which would close-or-no-op the overlay).
 	m := NewModel(ModelConfig{})
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	um := updated.(Model)
@@ -330,20 +315,14 @@ func TestRenderOverlayBody_IncludesArgsAndResult(t *testing.T) {
 func TestRenderOverlayBody_DividerBetweenCalls(t *testing.T) {
 	t.Parallel()
 
-	// Two completed calls must be visually separated by the box-drawing
-	// divider — without it the second section's title can run into the
-	// first call's result block and the boundary gets lost.
 	hist := appendToolStart(nil, "fs__read", json.RawMessage(`{"path":"a.txt"}`))
 	completeToolCall(hist, "fs__read", json.RawMessage(`"a"`), false)
 	hist = appendToolStart(hist, "fs__read", json.RawMessage(`{"path":"b.txt"}`))
 	completeToolCall(hist, "fs__read", json.RawMessage(`"b"`), false)
 
 	body := renderOverlayBody(hist, 40)
-	// 40 contiguous ─ characters is the divider; if join used a plain
-	// blank-line separator the substring would not appear.
 	assert.Contains(t, body, strings.Repeat("─", 40))
-	// Single-call rendering must NOT include the divider — it's strictly a
-	// between-sections affordance.
+	// Divider is strictly a between-sections affordance.
 	single := renderOverlayBody(hist[:1], 40)
 	assert.NotContains(t, single, strings.Repeat("─", 40))
 }
@@ -351,9 +330,6 @@ func TestRenderOverlayBody_DividerBetweenCalls(t *testing.T) {
 func TestOverlayView_HintAtBottom(t *testing.T) {
 	t.Parallel()
 
-	// The hint is the close/scroll cue and must be the LAST visible line
-	// so users instinctively look down for it (matching Claude Code,
-	// less, man, etc.).
 	o := newOverlayModel(80, 10)
 	o.Refresh(nil)
 	view := o.View()
@@ -371,8 +347,5 @@ func TestRenderOverlayBody_PendingShowsInFlight(t *testing.T) {
 
 	body := renderOverlayBody(hist, 80)
 	assert.Contains(t, body, "(in flight)")
-	// The "running" annotation in the metadata line tells the user the call
-	// hasn't completed yet — without it they might think the empty result is
-	// the actual output.
 	assert.Contains(t, strings.ToLower(body), "running")
 }

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -95,12 +95,73 @@ func TestCompleteToolCall_NoMatchIsNoOp(t *testing.T) {
 func TestFormatJSON(t *testing.T) {
 	t.Parallel()
 
-	t.Run("pretty prints valid JSON", func(t *testing.T) {
+	t.Run("renders a flat map as key/value lines without JSON syntax", func(t *testing.T) {
 		t.Parallel()
 		got := formatJSON(json.RawMessage(`{"b":2,"a":1}`))
-		// json.MarshalIndent gives deterministic key ordering via map sort,
-		// so the result is stable.
-		assert.Equal(t, "{\n  \"a\": 1,\n  \"b\": 2\n}", got)
+		// Keys sorted, no braces, no quotes, no trailing comma — the whole
+		// point of the YAML-ish renderer.
+		assert.Equal(t, "a: 1\nb: 2", got)
+	})
+
+	t.Run("integer numbers render without decimals or exponent", func(t *testing.T) {
+		t.Parallel()
+		// JSON numbers come back as float64; without special-casing, exit_code:0
+		// could otherwise print "0e+00" depending on the format verb.
+		got := formatJSON(json.RawMessage(`{"exit_code":0,"size":1234567890}`))
+		assert.Equal(t, "exit_code: 0\nsize: 1234567890", got)
+	})
+
+	t.Run("fractional numbers use the shortest decimal form", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`{"ratio":0.5}`))
+		assert.Equal(t, "ratio: 0.5", got)
+	})
+
+	t.Run("multi-line string value expands onto indented lines", func(t *testing.T) {
+		t.Parallel()
+		// The classic shell-output case: without this expansion, stdout
+		// containing newlines would render as one long line with literal
+		// "\n" escapes.
+		got := formatJSON(json.RawMessage(`{"stdout":"a\nb\nc"}`))
+		assert.Equal(t, "stdout:\n  a\n  b\n  c", got)
+	})
+
+	t.Run("nested map indents the child block", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`{"outer":{"inner":"val"}}`))
+		assert.Equal(t, "outer:\n  inner: val", got)
+	})
+
+	t.Run("top-level string prints verbatim with newlines preserved", func(t *testing.T) {
+		t.Parallel()
+		// A Read tool result is often just the file contents. Quoting and
+		// escaping that would defeat the entire purpose of the overlay.
+		got := formatJSON(json.RawMessage(`"line1\nline2\nline3"`))
+		assert.Equal(t, "line1\nline2\nline3", got)
+	})
+
+	t.Run("top-level array renders each element with a bullet", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`[1,2,"three"]`))
+		assert.Equal(t, "- 1\n- 2\n- three", got)
+	})
+
+	t.Run("array of maps continues each map under the bullet", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`[{"a":1,"b":2}]`))
+		assert.Equal(t, "- a: 1\n  b: 2", got)
+	})
+
+	t.Run("empty collection renders an explicit placeholder", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "(empty)", formatJSON(json.RawMessage(`{}`)))
+		assert.Equal(t, "(empty)", formatJSON(json.RawMessage(`[]`)))
+	})
+
+	t.Run("booleans and null stringify directly", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`{"ok":true,"bad":false,"none":null}`))
+		assert.Equal(t, "bad: false\nnone: null\nok: true", got)
 	})
 
 	t.Run("falls back to raw bytes when unmarshal fails", func(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cmdMsgTypeName runs cmd in a goroutine (see runCmd) and returns the
+// resolved message's reflect.Type.Name(). It's how we identify bubbletea's
+// internal enterAltScreenMsg / exitAltScreenMsg singletons from tests:
+// they're unexported, so the only reliable handle on them is their type
+// name. Returns "" when the command times out (blocking cmd like
+// waitForEvent) or produces a nil message.
+func cmdMsgTypeName(cmd tea.Cmd) string {
+	msg, ok := runCmd(cmd)
+	if !ok || msg == nil {
+		return ""
+	}
+	return reflect.TypeOf(msg).Name()
+}
+
+// -----------------------------------------------------------------------------
+// History bookkeeping
+// -----------------------------------------------------------------------------
+
+func TestAppendToolStart_BoundsHistory(t *testing.T) {
+	t.Parallel()
+
+	var hist []toolCallRecord
+	for range maxToolHistory + 5 {
+		hist = appendToolStart(hist, "shell__shell_execute", nil)
+	}
+	require.Len(t, hist, maxToolHistory,
+		"history must be capped at maxToolHistory; oldest entries dropped off the front")
+	for _, r := range hist {
+		assert.True(t, r.Pending, "every appended start record should begin Pending")
+	}
+}
+
+func TestCompleteToolCall_MatchesMostRecentPending(t *testing.T) {
+	t.Parallel()
+
+	hist := appendToolStart(nil, "fs__read", json.RawMessage(`{"path":"a.txt"}`))
+	hist = appendToolStart(hist, "fs__read", json.RawMessage(`{"path":"b.txt"}`))
+
+	completeToolCall(hist, "fs__read", json.RawMessage(`"content B"`), false)
+
+	require.Len(t, hist, 2)
+	// Most-recent matching pending entry (index 1) is completed first.
+	assert.False(t, hist[1].Pending)
+	assert.JSONEq(t, `"content B"`, string(hist[1].Result))
+	// Earlier matching entry remains pending — it will be completed by a
+	// subsequent UIToolCompleted.
+	assert.True(t, hist[0].Pending)
+}
+
+func TestCompleteToolCall_NoMatchIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	hist := appendToolStart(nil, "fs__read", nil)
+	// Mark the only entry as completed so there's no pending match anymore.
+	completeToolCall(hist, "fs__read", json.RawMessage(`"ok"`), false)
+	require.False(t, hist[0].Pending)
+
+	// Second completion for the same name finds no pending entry and is dropped.
+	completeToolCall(hist, "fs__read", json.RawMessage(`"different"`), true)
+	assert.JSONEq(t, `"ok"`, string(hist[0].Result), "stale completion must not overwrite a completed entry")
+	assert.False(t, hist[0].IsError)
+}
+
+// -----------------------------------------------------------------------------
+// JSON formatter
+// -----------------------------------------------------------------------------
+
+func TestFormatJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pretty prints valid JSON", func(t *testing.T) {
+		t.Parallel()
+		got := formatJSON(json.RawMessage(`{"b":2,"a":1}`))
+		// json.MarshalIndent gives deterministic key ordering via map sort,
+		// so the result is stable.
+		assert.Equal(t, "{\n  \"a\": 1,\n  \"b\": 2\n}", got)
+	})
+
+	t.Run("falls back to raw bytes when unmarshal fails", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`not-json{`)
+		assert.Equal(t, "not-json{", formatJSON(raw))
+	})
+
+	t.Run("empty input renders explicit placeholder", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "(empty)", formatJSON(nil))
+		assert.Equal(t, "(empty)", formatJSON(json.RawMessage{}))
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Overlay open / close / scroll
+// -----------------------------------------------------------------------------
+
+func TestModel_Update_CtrlOOpensOverlay(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um := updated.(Model)
+
+	assert.True(t, um.overlayActive, "ctrl+o must flip the overlay on")
+	assert.Equal(t, "enterAltScreenMsg", cmdMsgTypeName(cmd),
+		"ctrl+o must enter the alt-screen so the overlay can take over the frame")
+}
+
+func TestModel_Update_CtrlOClosesOverlay(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+	// Open it first.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um := updated.(Model)
+	require.True(t, um.overlayActive)
+
+	// A second ctrl+o closes it and exits alt-screen.
+	updated, cmd := um.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um = updated.(Model)
+	assert.False(t, um.overlayActive)
+	assert.Equal(t, "exitAltScreenMsg", cmdMsgTypeName(cmd))
+}
+
+func TestModel_Update_EscClosesOverlay_NoCancel(t *testing.T) {
+	t.Parallel()
+
+	// Esc in the overlay must close it WITHOUT posting a user_cancel — the
+	// agent's turn must keep running in the background while the user reviews.
+	outCh := make(chan outboundEvent, 1)
+	m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um := updated.(Model)
+	require.True(t, um.overlayActive)
+
+	updated, cmd := um.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	um = updated.(Model)
+	assert.False(t, um.overlayActive, "esc in overlay must close it")
+	assert.False(t, um.cancelling, "esc in overlay must NOT trigger agent cancellation")
+	assert.Equal(t, "exitAltScreenMsg", cmdMsgTypeName(cmd))
+
+	select {
+	case ev := <-outCh:
+		t.Fatalf("esc in overlay must not post any outbound event, got %T", ev.event)
+	default:
+	}
+}
+
+func TestModel_Update_OverlaySwallowsTyping(t *testing.T) {
+	t.Parallel()
+
+	// While the overlay is open, printable keys must NOT reach the input
+	// textarea — the input bar is hidden and any leaked text would surprise
+	// the user when they close the overlay.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um := updated.(Model)
+	require.True(t, um.overlayActive)
+
+	for _, r := range "hello" {
+		updated, _ = um.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		um = updated.(Model)
+	}
+	assert.Equal(t, "", um.textInput.Value(), "typing while overlay is open must not enter the input buffer")
+}
+
+func TestModel_Update_OverlayForwardsScrollKeys(t *testing.T) {
+	t.Parallel()
+
+	// Scroll keys (↑↓ pgup pgdn home end) must reach the viewport. We can't
+	// easily assert the viewport's internal scroll offset from outside, so
+	// we just verify the overlay stays open — i.e. those keys are NOT
+	// hitting the "swallow everything else" default branch that returns nil.
+	m := NewModel(ModelConfig{})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	um := updated.(Model)
+	require.True(t, um.overlayActive)
+
+	for _, k := range []tea.KeyType{tea.KeyDown, tea.KeyUp, tea.KeyPgDown, tea.KeyPgUp, tea.KeyHome, tea.KeyEnd} {
+		updated, _ = um.Update(tea.KeyMsg{Type: k})
+		um = updated.(Model)
+		assert.True(t, um.overlayActive, "scroll key %v must not close the overlay", k)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// History updates from events
+// -----------------------------------------------------------------------------
+
+func TestModel_ToolEventsAppendHistory(t *testing.T) {
+	t.Parallel()
+
+	m := NewModel(ModelConfig{})
+	args := json.RawMessage(`{"command":"echo hi"}`)
+	result := json.RawMessage(`{"stdout":"hi\n","exit_code":0}`)
+
+	updated, _ := m.Update(UIToolStarted{Name: "shell__shell_execute", Args: args})
+	um := updated.(Model)
+	require.Len(t, um.toolHistory, 1)
+	assert.True(t, um.toolHistory[0].Pending)
+	assert.Equal(t, "shell__shell_execute", um.toolHistory[0].Name)
+	assert.JSONEq(t, string(args), string(um.toolHistory[0].Args))
+
+	updated, _ = um.Update(UIToolCompleted{
+		Name:    "shell__shell_execute",
+		Args:    args,
+		Result:  result,
+		IsError: false,
+	})
+	um = updated.(Model)
+	require.Len(t, um.toolHistory, 1)
+	assert.False(t, um.toolHistory[0].Pending)
+	assert.JSONEq(t, string(result), string(um.toolHistory[0].Result))
+}
+
+// -----------------------------------------------------------------------------
+// Overlay body rendering
+// -----------------------------------------------------------------------------
+
+func TestRenderOverlayBody_EmptyState(t *testing.T) {
+	t.Parallel()
+
+	body := renderOverlayBody(nil, 80)
+	assert.Contains(t, body, "No tool calls yet")
+}
+
+func TestRenderOverlayBody_IncludesArgsAndResult(t *testing.T) {
+	t.Parallel()
+
+	hist := appendToolStart(nil, "fs__read",
+		json.RawMessage(`{"path":"/tmp/a.txt"}`))
+	completeToolCall(hist, "fs__read",
+		json.RawMessage(`{"content":"hello world"}`), false)
+
+	body := renderOverlayBody(hist, 80)
+	assert.Contains(t, body, "Arguments")
+	assert.Contains(t, body, "/tmp/a.txt")
+	assert.Contains(t, body, "Result")
+	assert.Contains(t, body, "hello world")
+	assert.NotContains(t, body, "(in flight)")
+}
+
+func TestRenderOverlayBody_PendingShowsInFlight(t *testing.T) {
+	t.Parallel()
+
+	hist := appendToolStart(nil, "shell__shell_execute",
+		json.RawMessage(`{"command":"sleep 100"}`))
+
+	body := renderOverlayBody(hist, 80)
+	assert.Contains(t, body, "(in flight)")
+	// The "running" annotation in the metadata line tells the user the call
+	// hasn't completed yet — without it they might think the empty result is
+	// the actual output.
+	assert.Contains(t, strings.ToLower(body), "running")
+}

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -153,10 +153,12 @@ func TestFormatJSON(t *testing.T) {
 		assert.Equal(t, "bad: false\nnone: null\nok: true", got)
 	})
 
-	t.Run("falls back to raw bytes when unmarshal fails", func(t *testing.T) {
+	t.Run("falls back to raw bytes and surfaces the parse error", func(t *testing.T) {
 		t.Parallel()
-		raw := json.RawMessage(`not-json{`)
-		assert.Equal(t, "not-json{", formatJSON(raw))
+		got := formatJSON(json.RawMessage(`not-json{`))
+		assert.Contains(t, got, "could not parse as JSON",
+			"parse failure must surface the error so the user knows why the block looks raw")
+		assert.Contains(t, got, "not-json{", "raw bytes still shown for inspection")
 	})
 
 	t.Run("empty input renders explicit placeholder", func(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -266,6 +266,42 @@ func TestRenderOverlayBody_IncludesArgsAndResult(t *testing.T) {
 	assert.NotContains(t, body, "(in flight)")
 }
 
+func TestRenderOverlayBody_DividerBetweenCalls(t *testing.T) {
+	t.Parallel()
+
+	// Two completed calls must be visually separated by the box-drawing
+	// divider — without it the second section's title can run into the
+	// first call's result block and the boundary gets lost.
+	hist := appendToolStart(nil, "fs__read", json.RawMessage(`{"path":"a.txt"}`))
+	completeToolCall(hist, "fs__read", json.RawMessage(`"a"`), false)
+	hist = appendToolStart(hist, "fs__read", json.RawMessage(`{"path":"b.txt"}`))
+	completeToolCall(hist, "fs__read", json.RawMessage(`"b"`), false)
+
+	body := renderOverlayBody(hist, 40)
+	// 40 contiguous ─ characters is the divider; if join used a plain
+	// blank-line separator the substring would not appear.
+	assert.Contains(t, body, strings.Repeat("─", 40))
+	// Single-call rendering must NOT include the divider — it's strictly a
+	// between-sections affordance.
+	single := renderOverlayBody(hist[:1], 40)
+	assert.NotContains(t, single, strings.Repeat("─", 40))
+}
+
+func TestOverlayView_HintAtBottom(t *testing.T) {
+	t.Parallel()
+
+	// The hint is the close/scroll cue and must be the LAST visible line
+	// so users instinctively look down for it (matching Claude Code,
+	// less, man, etc.).
+	o := newOverlayModel(80, 10)
+	o.Refresh(nil)
+	view := o.View()
+	lines := strings.Split(view, "\n")
+	last := lines[len(lines)-1]
+	assert.Contains(t, last, "ctrl+o or esc to close",
+		"hint must be on the last line; got last line %q", last)
+}
+
 func TestRenderOverlayBody_PendingShowsInFlight(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_overlay_test.go
+++ b/pkg/cmd/pulumi/neo/tui_overlay_test.go
@@ -222,6 +222,34 @@ func TestModel_Update_EscClosesOverlay_NoCancel(t *testing.T) {
 	}
 }
 
+func TestModel_Update_CtrlCAndCtrlDCloseOverlay(t *testing.T) {
+	t.Parallel()
+
+	// A reflexive ctrl+c (or ctrl+d) while the overlay is open should dismiss
+	// the overlay rather than arm the quit gate or cancel the agent. Once
+	// back in the inline view a second ctrl+c can still quit normally.
+	for _, key := range []tea.KeyType{tea.KeyCtrlC, tea.KeyCtrlD} {
+		outCh := make(chan outboundEvent, 1)
+		m := NewModel(ModelConfig{OutCh: outCh, Busy: true})
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+		um := updated.(Model)
+		require.True(t, um.overlayActive)
+
+		updated, cmd := um.Update(tea.KeyMsg{Type: key})
+		um = updated.(Model)
+		assert.False(t, um.overlayActive, "%v in overlay must close it", key)
+		assert.False(t, um.ctrlCArmed, "%v in overlay must not arm the quit gate", key)
+		assert.False(t, um.cancelling, "%v in overlay must not trigger cancellation", key)
+		assert.Equal(t, "exitAltScreenMsg", cmdMsgTypeName(cmd))
+
+		select {
+		case ev := <-outCh:
+			t.Fatalf("%v in overlay must not post any outbound event, got %T", key, ev.event)
+		default:
+		}
+	}
+}
+
 func TestModel_Update_OverlaySwallowsTyping(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_tool_history.go
+++ b/pkg/cmd/pulumi/neo/tui_tool_history.go
@@ -1,0 +1,72 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// maxToolHistory bounds the number of records kept in Model.toolHistory so a
+// very long session can't grow the slice without limit. The oldest entries
+// drop off the front when this is exceeded.
+const maxToolHistory = 50
+
+// toolCallRecord is one entry in the overlay's tool-call history. Args are
+// captured at start time; Result and CompletedAt land when the matching
+// UIToolCompleted arrives. While Pending is true, Result is empty and the
+// overlay renders an "(in flight)" placeholder.
+type toolCallRecord struct {
+	Name        string
+	Args        json.RawMessage
+	Result      json.RawMessage
+	IsError     bool
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Pending     bool
+}
+
+// appendToolStart records a new in-flight tool call. The caller drops the
+// oldest entry when the slice exceeds maxToolHistory.
+func appendToolStart(history []toolCallRecord, name string, args json.RawMessage) []toolCallRecord {
+	rec := toolCallRecord{
+		Name:      name,
+		Args:      args,
+		StartedAt: time.Now(),
+		Pending:   true,
+	}
+	history = append(history, rec)
+	if len(history) > maxToolHistory {
+		history = history[len(history)-maxToolHistory:]
+	}
+	return history
+}
+
+// completeToolCall mutates the most recent pending entry that matches name to
+// reflect a completed call. runBatch dispatches calls serially so matching on
+// (name, most-recent-pending) is unambiguous in practice. If no match is
+// found (e.g. completed event with no matching start) the history is left
+// untouched.
+func completeToolCall(history []toolCallRecord, name string, result json.RawMessage, isError bool) {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Pending && history[i].Name == name {
+			history[i].Result = result
+			history[i].IsError = isError
+			history[i].CompletedAt = time.Now()
+			history[i].Pending = false
+			return
+		}
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui_tool_history.go
+++ b/pkg/cmd/pulumi/neo/tui_tool_history.go
@@ -19,15 +19,8 @@ import (
 	"time"
 )
 
-// maxToolHistory bounds the number of records kept in Model.toolHistory so a
-// very long session can't grow the slice without limit. The oldest entries
-// drop off the front when this is exceeded.
 const maxToolHistory = 50
 
-// toolCallRecord is one entry in the overlay's tool-call history. Args are
-// captured at start time; Result and CompletedAt land when the matching
-// UIToolCompleted arrives. While Pending is true, Result is empty and the
-// overlay renders an "(in flight)" placeholder.
 type toolCallRecord struct {
 	Name        string
 	Args        json.RawMessage
@@ -38,27 +31,22 @@ type toolCallRecord struct {
 	Pending     bool
 }
 
-// appendToolStart records a new in-flight tool call. The caller drops the
-// oldest entry when the slice exceeds maxToolHistory.
 func appendToolStart(history []toolCallRecord, name string, args json.RawMessage) []toolCallRecord {
-	rec := toolCallRecord{
+	history = append(history, toolCallRecord{
 		Name:      name,
 		Args:      args,
 		StartedAt: time.Now(),
 		Pending:   true,
-	}
-	history = append(history, rec)
+	})
 	if len(history) > maxToolHistory {
 		history = history[len(history)-maxToolHistory:]
 	}
 	return history
 }
 
-// completeToolCall mutates the most recent pending entry that matches name to
-// reflect a completed call. runBatch dispatches calls serially so matching on
-// (name, most-recent-pending) is unambiguous in practice. If no match is
-// found (e.g. completed event with no matching start) the history is left
-// untouched.
+// completeToolCall mutates the most-recent pending entry that matches name.
+// Session.runBatch dispatches calls serially, so that entry is unambiguously
+// the one to complete.
 func completeToolCall(history []toolCallRecord, name string, result json.RawMessage, isError bool) {
 	for i := len(history) - 1; i >= 0; i-- {
 		if history[i].Pending && history[i].Name == name {


### PR DESCRIPTION
## Summary

Adds a `ctrl+o` keybinding to the `pulumi neo` TUI that opens an alt-screen overlay listing every tool call in the session — arguments the agent sent and the result the tool returned. The agent keeps running while the overlay is open; `ctrl+o` or `esc` returns to the inline transcript.

Result content from `Session.invokeToolCall` is now plumbed into `UIToolCompleted` (it was previously dropped on the way to the TUI). Args and results render as pretty-printed JSON in the overlay; per-tool friendly formatters (e.g. split `stdout`/`stderr` for shell, diffs for `edit`) can be added incrementally without changing the data model.

Fixes pulumi/pulumi-service#41514

## Test plan

- [ ] `mise exec -- make build` builds clean.
- [ ] `mise exec -- make lint` passes (`go vet`, `golangci-lint`, requiredfield).
- [ ] Unit tests cover overlay open/close, esc-vs-cancel disambiguation, key swallowing while open, history bounds, and `UIToolCompleted.Result` plumbing.
- [ ] Manual smoke test in a sample stack:
  - [ ] Ask the agent to read a file, run a shell command, and edit a file.
  - [ ] `ctrl+o` mid-turn opens the overlay; scrolling and `↑↓ pgup pgdn home end` work.
  - [ ] Agent keeps streaming behind the overlay; new tool calls appear when toggled back.
  - [ ] `ctrl+o` again returns to the inline transcript with prior scrollback intact.
  - [ ] `esc` from inside the overlay closes it WITHOUT cancelling the agent's turn.

<img width="1281" height="1266" alt="Screenshot 2026-05-13 at 18 39 33" src="https://github.com/user-attachments/assets/23176402-0f8d-4b95-a326-7eae587247ed" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)