### PR TITLE
Ignore invalid array values during imports

### DIFF
--- a/changelog/pending/20260512--cli-import--ignore-property-values-that-do-not-conform-to-the-schema-in-maps.yaml
+++ b/changelog/pending/20260512--cli-import--ignore-property-values-that-do-not-conform-to-the-schema-in-maps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Ignore property values that do not conform to the schema in maps

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -77,6 +78,8 @@ func filterReferences(resourceName string, importState ImportState) ImportState 
 }
 
 // GenerateHCL2Definition generates a Pulumi HCL2 definition for a given resource.
+//
+// GenerateHCL2Definition will drop map entries who's type doesn't conform to the schema type.
 func GenerateHCL2Definition(
 	loader schema.Loader,
 	state *resource.State,
@@ -578,6 +581,8 @@ func zeroValue(t schema.Type) model.Expression {
 // generatePropertyValue generates the value for the given property. If the value is absent and the property is
 // required, a zero value for the property's type is generated. If the value is absent and the property is not
 // required, no value is generated (i.e. this function returns nil).
+//
+// If the property represents a map and a value doesn't conform to the map shape, it is omitted.
 func generatePropertyValue(
 	property *schema.Property,
 	value property.Value,
@@ -596,8 +601,19 @@ func generatePropertyValue(
 
 // valueStructurallyTypedAs returns true if the given value is structurally typed as the given schema type.
 func valueStructurallyTypedAs(value property.Value, schemaType schema.Type) bool {
+	for {
+		if input, ok := schemaType.(*schema.InputType); ok {
+			schemaType = input.ElementType
+		} else {
+			break
+		}
+	}
 	if union, ok := schemaType.(*schema.UnionType); ok {
 		schemaType = reduceUnionType(union, value)
+	}
+
+	if schemaType == schema.AnyType {
+		return true
 	}
 
 	switch {
@@ -879,6 +895,11 @@ func generateValue(
 			}
 
 			for k, v := range obj.AllStable {
+				if !valueStructurallyTypedAs(v, elementType) {
+					slog.Info("dropped non-conforming value from object type",
+						slog.Any("expected-type", elementType), slog.Any("found-value", v))
+					continue
+				}
 				x, err := generateValue(elementType, v, importState, onReferenceFound)
 				if err != nil {
 					return nil, err

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1141,6 +1141,34 @@ func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {
 	assert.Contains(t, formatted, `"__type" = "PermissionDescriptorCondition"`)
 }
 
+func TestGenerateValueDropsNonConformingMapEntries(t *testing.T) {
+	t.Parallel()
+
+	value := property.New(map[string]property.Value{
+		"good1": property.New("hello"),
+		"good2": property.New("world"),
+		"bad1":  property.New(42.0),
+		"bad2":  property.New(true),
+		"bad3":  property.New(property.Array{}),
+	})
+
+	expr, err := generateValue(
+		&schema.MapType{ElementType: schema.StringType},
+		value,
+		ImportState{},
+		func(string) {},
+	)
+	require.NoError(t, err)
+
+	rendered := renderExpr(t, expr)
+	require.True(t, rendered.IsMap())
+
+	assert.Equal(t, map[string]property.Value{
+		"\"good1\"": property.New("hello"),
+		"\"good2\"": property.New("world"),
+	}, rendered.AsMap().AsMap())
+}
+
 func TestReduceUnionTypeEliminatesUnionsBasicCase(t *testing.T) {
 	t.Parallel()
 	value := property.New("hello")


### PR DESCRIPTION
For example, a resource like `aws:s3:Bucket` with a tags map:

Instead of attempting to generate code like this (and then failing to bind):

```hcl
tags = {
  __defaults = []
  TestTag    = "b"
}
```

We now instead generate code like this:

```hcl
tags = {
  TestTag    = "b"
}
```

We observe that `[]` is not a valid value for a `map<string>`, so we drop it.

Fixes https://github.com/pulumi/pulumi/issues/23069