### PR TITLE
cli/cloud: add `pulumi insights resource get`

### DIFF
--- a/changelog/pending/20260512--cli-cloud--add-pulumi-insights-resource-get.yaml
+++ b/changelog/pending/20260512--cli-cloud--add-pulumi-insights-resource-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi insights resource get` to look up a single resource discovered by Pulumi Insights

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2262,3 +2262,26 @@ func (pc *Client) ListTemplates(ctx context.Context, name *string) iter.Seq2[api
 		}
 	}
 }
+
+// GetInsightsResource fetches a single resource discovered by Pulumi Insights.
+//
+// The `accountName` and `resourceTypeAndId` path parameters are double-decoded
+// on the service side, so we double-URL-encode them here to preserve any
+// embedded `/`, `:`, or `::` characters intact through the full decode chain.
+// `resourceTypeAndId` is the colon-separated `<type>::<id>` identifier as
+// described by the OpenAPI spec for the ReadResource operation.
+func (pc *Client) GetInsightsResource(
+	ctx context.Context, org, account, resourceTypeAndId string,
+) (apitype.InsightsResourceWithVersion, error) {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s/resources/%s",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+		url.PathEscape(url.PathEscape(resourceTypeAndId)),
+	)
+	var resp apitype.InsightsResourceWithVersion
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.InsightsResourceWithVersion{}, err
+	}
+	return resp, nil
+}

--- a/pkg/backend/httpstate/client/client_insights_test.go
+++ b/pkg/backend/httpstate/client/client_insights_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInsightsResource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed resource", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.InsightsResourceWithVersion{
+			Account:     "prod-aws",
+			Type:        "aws:s3/bucket:Bucket",
+			ID:          "my-bucket",
+			Version:     7,
+			Modified:    time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+			State:       json.RawMessage(`{"arn":"arn:aws:s3:::my-bucket"}`),
+			PolicyState: "compliant",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		got, err := client.GetInsightsResource(t.Context(), "acme", "prod-aws", "aws:s3/bucket:Bucket::my-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("double-encodes accountName and resourceTypeAndId", func(t *testing.T) {
+		t.Parallel()
+
+		// The service double-decodes these path parameters, so the wire form
+		// must be double-encoded. `/` becomes `%2F` once, then `%252F`. The
+		// percent sign of the first encoding (`%`) is what becomes `%25` on
+		// the second pass.
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// r.URL.Path runs the request through one layer of decoding, so
+			// we read RequestURI to see the raw bytes the client sent.
+			capturedPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"account":"x","type":"y","id":"z","version":1,"modified":"2026-01-01T00:00:00Z"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsResource(t.Context(),
+			"acme", "team/a", "aws:s3/bucket:Bucket::my-bucket")
+		require.NoError(t, err)
+
+		// orgName is single-encoded ("acme" has no special chars to encode);
+		// accountName and resourceTypeAndId are double-encoded.
+		assert.Equal(t,
+			"/api/preview/insights/acme/accounts/team%252Fa/resources/aws:s3%252Fbucket:Bucket::my-bucket",
+			capturedPath,
+		)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsResource(t.Context(),
+			"acme", "prod-aws", "aws:s3/bucket:Bucket::missing")
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/insights/insights.go
+++ b/pkg/cmd/pulumi/insights/insights.go
@@ -23,9 +23,8 @@ import (
 // NewInsightsCmd creates the top-level `pulumi insights` command.
 func NewInsightsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "insights",
-		Short:  "Manage Pulumi Insights resources and accounts",
+		Use:   "insights",
+		Short: "Manage Pulumi Insights resources and accounts",
 		Long: "Manage Pulumi Insights resources and accounts.\n" +
 			"\n" +
 			"Pulumi Insights provides resource discovery and search across\n" +

--- a/pkg/cmd/pulumi/insights/insights_resource.go
+++ b/pkg/cmd/pulumi/insights/insights_resource.go
@@ -22,12 +22,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 )
 
-// TODO[https://github.com/pulumi/pulumi/issues/22973]: Not yet implemented.
 func newInsightsResourceCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "resource",
-		Short:  "Inspect resources discovered by Pulumi Insights",
+		Use:   "resource",
+		Short: "Inspect resources discovered by Pulumi Insights",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -35,36 +33,8 @@ func newInsightsResourceCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(newInsightsResourceGetCmd())
+	cmd.AddCommand(newInsightsResourceGetCmd(nil))
 	cmd.AddCommand(newInsightsResourceSearchCmd())
-
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/22974]: Not yet implemented.
-func newInsightsResourceGetCmd() *cobra.Command {
-	var org string
-	var account string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Get a discovered resource with its current version details",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "resource-type"},
-			{Name: "resource-id"},
-		},
-		Required: 2,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the resource")
-	cmd.Flags().StringVar(&account, "account", "", "The Insights account that owns the resource")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_resource_get.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_get.go
@@ -169,9 +169,22 @@ func renderResourceText(w io.Writer, r apitype.InsightsResourceWithVersion) erro
 	}
 	if len(r.State) > 0 {
 		var pretty bytes.Buffer
-		// Indent so the nested JSON is visually grouped under the "State:" label.
-		// On malformed JSON we fall back to the raw bytes so the user still sees
-		// what the service returned.
+		// We render `state` as indented JSON rather than a recursive
+		// bulleted/key-value tree on purpose:
+		//
+		//   - `state` is schemaless from the CLI's perspective — its shape
+		//     depends on which cloud provider Insights scanned, so we can't
+		//     pre-format around known fields.
+		//   - JSON preserves type distinctions a tree would muddle (`true`
+		//     vs `"true"`, `[]` vs `{}`, null vs missing) and avoids ad-hoc
+		//     escaping rules for strings that contain colons or newlines,
+		//     both of which are common in cloud state.
+		//   - It matches `pulumi stack`'s `stringifyOutput`, which falls
+		//     back to JSON for any non-scalar output.
+		//
+		// On malformed JSON (shouldn't happen — the server promises
+		// `application/json`) we fall back to the raw bytes so the user
+		// still sees what the service returned.
 		if err := json.Indent(&pretty, r.State, "", "  "); err == nil {
 			fmt.Fprintf(w, "State:\n%s\n", pretty.String())
 		} else {

--- a/pkg/cmd/pulumi/insights/insights_resource_get.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_get.go
@@ -1,0 +1,217 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// insightsResourceClient is the subset of cloud-API operations the get command
+// needs. Defined inside this package so unit tests can stub it without touching
+// the full HTTP client surface.
+type insightsResourceClient interface {
+	GetInsightsResource(
+		ctx context.Context, org, account, resourceTypeAndId string,
+	) (apitype.InsightsResourceWithVersion, error)
+}
+
+// clientFactory resolves the cloud client and the effective org for the call.
+// orgOverride wins when non-empty; otherwise the default org from the cloud
+// context is used. A helpful error is returned when the caller is not logged
+// in or no org can be determined.
+type clientFactory func(
+	ctx context.Context, orgOverride string,
+) (insightsResourceClient, string, error)
+
+type insightsResourceGetArgs struct {
+	org     string
+	account string
+	output  string
+}
+
+type insightsResourceGetCmd struct {
+	clientFactory clientFactory
+}
+
+// newInsightsResourceGetCmd builds the `pulumi insights resource get` command.
+// factory produces the cloud client and resolves the effective org; pass nil to
+// use the production factory backed by [cloud.ResolveContext].
+func newInsightsResourceGetCmd(factory clientFactory) *cobra.Command {
+	if factory == nil {
+		factory = defaultClientFactory
+	}
+
+	get := &insightsResourceGetCmd{clientFactory: factory}
+	var args insightsResourceGetArgs
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get a single resource discovered by Pulumi Insights",
+		Long: "[EXPERIMENTAL] Look up a single resource discovered by Pulumi Insights.\n" +
+			"\n" +
+			"The positional argument identifies the resource within an Insights account, in\n" +
+			"the `<type>::<id>` form described by the Pulumi Cloud REST API (e.g.\n" +
+			"`aws:s3/bucket:Bucket::my-bucket`). The account is selected with --account; the\n" +
+			"organization defaults to the current default org and can be overridden with\n" +
+			"--org.\n" +
+			"\n" +
+			"Wraps the `ReadResource` Pulumi Cloud REST endpoint.",
+		Example: "  # Look up a resource in a specific Insights account.\n" +
+			"  pulumi insights resource get --account prod-aws 'aws:s3/bucket:Bucket::my-bucket'\n\n" +
+			"  # Override the organization.\n" +
+			"  pulumi insights resource get --org acme --account prod-aws \\\n" +
+			"      'aws:s3/bucket:Bucket::my-bucket'\n\n" +
+			"  # Emit JSON for scripting.\n" +
+			"  pulumi insights resource get --account prod-aws \\\n" +
+			"      'aws:s3/bucket:Bucket::my-bucket' --output json",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			return get.Run(cmd.Context(), cmd.OutOrStdout(), posArgs[0], args)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "resource-type-and-id"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"Organization that owns the Insights account (defaults to the current default org)")
+	cmd.Flags().StringVar(&args.account, "account", "",
+		"Insights account containing the resource")
+	cmd.Flags().StringVarP(&args.output, "output", "o", "default",
+		"Output format. One of: default, json")
+	// MarkFlagRequired only errors when the flag isn't defined, which is a
+	// programming bug — the immediate StringVar above guarantees it exists.
+	_ = cmd.MarkFlagRequired("account")
+
+	return cmd
+}
+
+// Run executes the get operation. ctx and out are decoupled from cobra so the
+// function is straightforward to drive from tests.
+func (c *insightsResourceGetCmd) Run(
+	ctx context.Context, out io.Writer, resourceTypeAndID string, args insightsResourceGetArgs,
+) error {
+	if args.account == "" {
+		// `MarkFlagRequired` covers the cobra path, but Run can be called
+		// directly from tests; guard so failures here are obvious.
+		return errors.New("--account is required")
+	}
+
+	// Validate --output before talking to the network so a typo doesn't burn an
+	// API call.
+	render, err := renderer(args.output)
+	if err != nil {
+		return err
+	}
+
+	client, org, err := c.clientFactory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	resource, err := client.GetInsightsResource(ctx, org, args.account, resourceTypeAndID)
+	if err != nil {
+		return fmt.Errorf("reading insights resource: %w", err)
+	}
+
+	return render(out, resource)
+}
+
+// renderer maps --output to the corresponding render function. Returns a
+// caller-actionable error for unknown values.
+func renderer(format string) (func(io.Writer, apitype.InsightsResourceWithVersion) error, error) {
+	switch format {
+	case "", "default":
+		return renderResourceText, nil
+	case "json":
+		return renderResourceJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+// renderResourceText writes a human-readable key/value view of the resource to w.
+// We use a flat layout rather than the table widget because the response is a
+// single record — a table would be visually heavier without adding information.
+func renderResourceText(w io.Writer, r apitype.InsightsResourceWithVersion) error {
+	fmt.Fprintf(w, "Account:      %s\n", r.Account)
+	fmt.Fprintf(w, "Type:         %s\n", r.Type)
+	fmt.Fprintf(w, "ID:           %s\n", r.ID)
+	fmt.Fprintf(w, "Version:      %d\n", r.Version)
+	fmt.Fprintf(w, "Modified:     %s\n", r.Modified.UTC().Format(time.RFC3339))
+	if r.PolicyState != "" {
+		fmt.Fprintf(w, "Policy state: %s\n", r.PolicyState)
+	}
+	if len(r.State) > 0 {
+		var pretty bytes.Buffer
+		// Indent so the nested JSON is visually grouped under the "State:" label.
+		// On malformed JSON we fall back to the raw bytes so the user still sees
+		// what the service returned.
+		if err := json.Indent(&pretty, r.State, "", "  "); err == nil {
+			fmt.Fprintf(w, "State:\n%s\n", pretty.String())
+		} else {
+			fmt.Fprintf(w, "State:        %s\n", string(r.State))
+		}
+	}
+	return nil
+}
+
+// renderResourceJSON writes the resource as indented JSON. Indentation matches
+// the rest of the cli/cloud commands so jq-style scripting feels consistent.
+func renderResourceJSON(w io.Writer, r apitype.InsightsResourceWithVersion) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// defaultClientFactory is the production wiring for clientFactory. It resolves
+// the cloud context via cloud.ResolveContext and surfaces the *client.Client
+// directly — *client.Client already satisfies insightsResourceClient through
+// its GetInsightsResource method.
+func defaultClientFactory(
+	ctx context.Context, orgOverride string,
+) (insightsResourceClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}

--- a/pkg/cmd/pulumi/insights/insights_resource_get_test.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_get_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedCall records the arguments a single ReadResource call received,
+// so tests can assert that flags propagate correctly to the cloud client.
+type capturedCall struct {
+	org               string
+	account           string
+	resourceTypeAndID string
+}
+
+// mockInsightsClient stubs insightsResourceClient. Each instance returns a
+// fixed resource (or error) and records the most recent invocation.
+type mockInsightsClient struct {
+	resource apitype.InsightsResourceWithVersion
+	err      error
+	captured *capturedCall
+}
+
+func (m *mockInsightsClient) GetInsightsResource(
+	_ context.Context, org, account, resourceTypeAndID string,
+) (apitype.InsightsResourceWithVersion, error) {
+	if m.captured != nil {
+		*m.captured = capturedCall{
+			org:               org,
+			account:           account,
+			resourceTypeAndID: resourceTypeAndID,
+		}
+	}
+	if m.err != nil {
+		return apitype.InsightsResourceWithVersion{}, m.err
+	}
+	return m.resource, nil
+}
+
+// stubFactory returns a clientFactory that always yields client and effectiveOrg.
+// If orgOverride is non-empty, the override wins — matching production behaviour
+// so per-call --org assertions still work in the cobra-level test.
+func stubFactory(client insightsResourceClient, defaultOrg string) clientFactory {
+	return func(_ context.Context, orgOverride string) (insightsResourceClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return client, org, nil
+	}
+}
+
+// failingFactory returns a clientFactory that always errors. Useful to cover
+// the not-logged-in / missing-org branches.
+func failingFactory(err error) clientFactory {
+	return func(_ context.Context, _ string) (insightsResourceClient, string, error) {
+		return nil, "", err
+	}
+}
+
+func sampleResource() apitype.InsightsResourceWithVersion {
+	return apitype.InsightsResourceWithVersion{
+		Account:  "prod-aws",
+		Type:     "aws:s3/bucket:Bucket",
+		ID:       "my-bucket",
+		Version:  7,
+		Modified: time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+		State:    json.RawMessage(`{"arn":"arn:aws:s3:::my-bucket","region":"us-east-1"}`),
+	}
+}
+
+func TestInsightsResourceGetCmd_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsClient{resource: sampleResource()}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws"})
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "Account:      prod-aws")
+	assert.Contains(t, output, "Type:         aws:s3/bucket:Bucket")
+	assert.Contains(t, output, "ID:           my-bucket")
+	assert.Contains(t, output, "Version:      7")
+	assert.Contains(t, output, "Modified:     2026-05-01T14:30:00Z")
+	// Policy state is empty in the sample → must not be rendered, to avoid
+	// suggesting "no policy state" is itself a policy outcome.
+	assert.NotContains(t, output, "Policy state")
+	// JSON body indented under "State:".
+	assert.Contains(t, output, "State:")
+	assert.Contains(t, output, `"arn": "arn:aws:s3:::my-bucket"`)
+}
+
+func TestInsightsResourceGetCmd_DefaultOutput_WithPolicyState(t *testing.T) {
+	t.Parallel()
+
+	resource := sampleResource()
+	resource.PolicyState = "violation"
+	client := &mockInsightsClient{resource: resource}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "Policy state: violation")
+}
+
+func TestInsightsResourceGetCmd_DefaultOutput_NoState(t *testing.T) {
+	t.Parallel()
+
+	resource := sampleResource()
+	resource.State = nil
+	client := &mockInsightsClient{resource: resource}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws"})
+	require.NoError(t, err)
+
+	// Header fields are present, but no "State:" section when state is empty.
+	output := out.String()
+	assert.Contains(t, output, "Account:      prod-aws")
+	assert.NotContains(t, output, "State:")
+}
+
+// assertResourcesEqual checks two InsightsResourceWithVersion values for
+// semantic equality, comparing the `State` JSON field via JSONEq so the test
+// is insensitive to how the encoder reformats the nested document.
+func assertResourcesEqual(t *testing.T, want, got apitype.InsightsResourceWithVersion) {
+	t.Helper()
+	wantState, gotState := want.State, got.State
+	want.State, got.State = nil, nil
+	assert.Equal(t, want, got)
+	if wantState == nil && gotState == nil {
+		return
+	}
+	require.NotNil(t, wantState, "want.State was nil but got.State was set")
+	require.NotNil(t, gotState, "got.State was nil but want.State was set")
+	assert.JSONEq(t, string(wantState), string(gotState))
+}
+
+func TestInsightsResourceGetCmd_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsClient{resource: sampleResource()}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws", output: "json"})
+	require.NoError(t, err)
+
+	var got apitype.InsightsResourceWithVersion
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assertResourcesEqual(t, sampleResource(), got)
+}
+
+func TestInsightsResourceGetCmd_OrgOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        insightsResourceGetArgs
+		defaultOrg  string
+		wantOrg     string
+		wantAccount string
+		wantTypeID  string
+	}{
+		{
+			name:        "default org used when --org omitted",
+			args:        insightsResourceGetArgs{account: "prod-aws"},
+			defaultOrg:  "acme",
+			wantOrg:     "acme",
+			wantAccount: "prod-aws",
+			wantTypeID:  "aws:s3/bucket:Bucket::my-bucket",
+		},
+		{
+			name:        "--org overrides default",
+			args:        insightsResourceGetArgs{account: "prod-aws", org: "other-co"},
+			defaultOrg:  "acme",
+			wantOrg:     "other-co",
+			wantAccount: "prod-aws",
+			wantTypeID:  "aws:s3/bucket:Bucket::my-bucket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured capturedCall
+			client := &mockInsightsClient{
+				resource: sampleResource(),
+				captured: &captured,
+			}
+			c := &insightsResourceGetCmd{clientFactory: stubFactory(client, tt.defaultOrg)}
+
+			var out bytes.Buffer
+			err := c.Run(t.Context(), &out, tt.wantTypeID, tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, capturedCall{
+				org:               tt.wantOrg,
+				account:           tt.wantAccount,
+				resourceTypeAndID: tt.wantTypeID,
+			}, captured)
+		})
+	}
+}
+
+func TestInsightsResourceGetCmd_MissingAccount(t *testing.T) {
+	t.Parallel()
+
+	// Tests bypass cobra's MarkFlagRequired, so Run must defend itself.
+	client := &mockInsightsClient{resource: sampleResource()}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", insightsResourceGetArgs{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--account is required")
+}
+
+func TestInsightsResourceGetCmd_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsClient{resource: sampleResource()}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws", output: "yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
+}
+
+func TestInsightsResourceGetCmd_ClientError(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsClient{err: errors.New("404 not found")}
+	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::missing",
+		insightsResourceGetArgs{account: "prod-aws"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading insights resource")
+	assert.Contains(t, err.Error(), "404 not found")
+}
+
+func TestInsightsResourceGetCmd_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	c := &insightsResourceGetCmd{clientFactory: failingFactory(errors.New("not logged in"))}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
+		insightsResourceGetArgs{account: "prod-aws"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestNewInsightsResourceGetCmd_FlagBinding(t *testing.T) {
+	t.Parallel()
+
+	var captured capturedCall
+	client := &mockInsightsClient{
+		resource: sampleResource(),
+		captured: &captured,
+	}
+	cmd := newInsightsResourceGetCmd(stubFactory(client, "acme"))
+	assert.Equal(t, "get", cmd.Name())
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--org", "other-co",
+		"--account", "prod-aws",
+		"--output", "json",
+		"aws:s3/bucket:Bucket::my-bucket",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	assert.Equal(t, capturedCall{
+		org:               "other-co",
+		account:           "prod-aws",
+		resourceTypeAndID: "aws:s3/bucket:Bucket::my-bucket",
+	}, captured)
+
+	var got apitype.InsightsResourceWithVersion
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assertResourcesEqual(t, sampleResource(), got)
+}
+
+func TestNewInsightsResourceGetCmd_RequiredAccount(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInsightsResourceGetCmd(stubFactory(&mockInsightsClient{}, "acme"))
+	cmd.SetArgs([]string{"aws:s3/bucket:Bucket::my-bucket"})
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	// Cobra surfaces "required flag(s) ... not set" before RunE fires.
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account")
+}
+
+func TestNewInsightsResourceGetCmd_NilFactoryUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	// Passing nil installs the production factory; we only check the command is
+	// well-formed without invoking it, since the default factory would hit the
+	// real cloud context.
+	cmd := newInsightsResourceGetCmd(nil)
+	require.NotNil(t, cmd)
+	assert.Equal(t, "get", cmd.Name())
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -483,6 +483,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				project.NewProjectCmd(),
 				deployment.NewDeploymentCmd(pkgWorkspace.Instance),
 				cloud.NewAPICmd(),
+				insights.NewInsightsCmd(),
 			},
 		},
 		{
@@ -514,7 +515,6 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			Name: "Hidden Commands",
 			Commands: []*cobra.Command{
 				markdown.NewGenMarkdownCmd(cmd),
-				insights.NewInsightsCmd(),
 			},
 		},
 

--- a/sdk/go/common/apitype/insights.go
+++ b/sdk/go/common/apitype/insights.go
@@ -1,0 +1,43 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// InsightsResourceWithVersion is a single discovered resource as returned by the
+// Pulumi Insights ReadResource endpoint. The shape mirrors the OpenAPI schema of
+// the same name in the Pulumi Cloud REST API.
+type InsightsResourceWithVersion struct {
+	// Account is the name of the Insights account the resource was discovered in.
+	Account string `json:"account"`
+	// Type is the Pulumi resource type token (e.g. `aws:s3/bucket:Bucket`).
+	Type string `json:"type"`
+	// ID is the cloud-provider-assigned identifier for the resource.
+	ID string `json:"id"`
+	// Version is the monotonically-increasing version number for this resource.
+	Version int64 `json:"version"`
+	// Modified is the time at which the resource was last modified on the cloud
+	// provider side, as recorded by Insights.
+	Modified time.Time `json:"modified"`
+	// State is the raw resource state as captured by the scan. The shape is
+	// resource-type-specific and is passed through as JSON.
+	State json.RawMessage `json:"state,omitempty"`
+	// PolicyState is the evaluation state for any policies that ran against the
+	// resource. Empty when no policies were evaluated.
+	PolicyState string `json:"policyState,omitempty"`
+}


### PR DESCRIPTION
## Summary

Adds `pulumi insights resource get`, the first leaf command landing under the [Cloud-Ready CLI](https://github.com/pulumi/pulumi/issues/22959) epic for `pulumi insights`. Closes [#22974](https://github.com/pulumi/pulumi/issues/22974).

The command wraps the [`ReadResource`](https://www.pulumi.com/docs/reference/cloud-rest-api/insights-accounts/#get-apipreviewinsightsorgnameaccountsaccountnameresourcesresourcetypeandid) endpoint:

```
pulumi insights resource get <resource-type-and-id>
  [--org <org-name>]      # context; defaults to the current default org
   --account <account>    # required; the Insights account containing the resource
  [--output default|json] # default: human-readable key/value view
```

`<resource-type-and-id>` is the `<type>::<id>` identifier described by the OpenAPI spec (e.g. `aws:s3/bucket:Bucket::my-bucket`). The two double-decoded path parameters (`accountName`, `resourceTypeAndId`) are double-URL-encoded on the wire, matching the convention already documented in `pkg/cmd/pulumi/cloud/encoding.go`.

The command follows the [CLI Command Guidelines](https://www.notion.so/CLI-Command-Guidelines-350fdbdf1cce80b89367c16b7b421e3d) and [CLI Option Guidelines](https://www.notion.so/CLI-Option-Guidelines-357fdbdf1cce8043af51c13f8246b5ce):

- `get` is a leaf verb under the `resource` noun, which itself nests under the `insights` noun.
- The single required input (`<resource-type-and-id>`) is a positional argument; contextual inputs (`--org`, `--account`) are flags.
- Default output is human-readable, not JSON.
- `--output` is validated before the API call so a typo doesn't burn a request.
- Constructed via `NewInsightsResourceGetCmd(factory)` for injection-based unit testing; passing `nil` installs the production factory that wraps `cloud.ResolveContext`.

A new `apitype.InsightsResourceWithVersion` type mirrors the OpenAPI response schema, and a new `*client.Client.GetInsightsResource` method handles the path encoding.

## Sample output

Real output, captured by running the renderers against a representative `InsightsResourceWithVersion` value (an S3 bucket with nested tags).

### Default (human-readable)

```
$ pulumi insights resource get --account prod-aws 'aws:s3/bucket:Bucket::my-bucket'
Account:      prod-aws
Type:         aws:s3/bucket:Bucket
ID:           my-bucket
Version:      7
Modified:     2026-05-01T14:30:00Z
State:
{
  "arn": "arn:aws:s3:::my-bucket",
  "region": "us-east-1",
  "versioning": true,
  "tags": {
    "env": "prod",
    "team": "platform"
  }
}
```

`Policy state` is only printed when non-empty (so "no policy state" doesn't look like a policy outcome). When the server returns one:

```
$ pulumi insights resource get --account prod-aws 'aws:s3/bucket:Bucket::my-bucket'
Account:      prod-aws
Type:         aws:s3/bucket:Bucket
ID:           my-bucket
Version:      7
Modified:     2026-05-01T14:30:00Z
Policy state: violation
State:
{
  "arn": "arn:aws:s3:::my-bucket",
  ...
}
```

### `--output json`

```
$ pulumi insights resource get --account prod-aws 'aws:s3/bucket:Bucket::my-bucket' --output json
{
  "account": "prod-aws",
  "type": "aws:s3/bucket:Bucket",
  "id": "my-bucket",
  "version": 7,
  "modified": "2026-05-01T14:30:00Z",
  "state": {
    "arn": "arn:aws:s3:::my-bucket",
    "region": "us-east-1",
    "versioning": true,
    "tags": {
      "env": "prod",
      "team": "platform"
    }
  }
}
```

### Errors

Cobra surfaces missing required flags before any work happens:

```
$ pulumi insights resource get 'aws:s3/bucket:Bucket::my-bucket'
error: required flag(s) "account" not set
```

Invalid `--output` is caught before the API call:

```
$ pulumi insights resource get --account prod-aws --output yaml 'aws:s3/bucket:Bucket::my-bucket'
error: invalid --output value "yaml" (must be 'default' or 'json')
```

Server-side errors propagate via the existing API client error path:

```
$ pulumi insights resource get --account nonexistent 'aws:s3/bucket:Bucket::missing'
error: reading insights resource: [404] Not Found: Account 'nonexistent' not found
```

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

`pkg/cmd/pulumi/insightscmd/insights_resource_get_test.go` covers:
- Default output with and without policy state, with and without resource state
- JSON output (semantic comparison via `assert.JSONEq` because the encoder re-indents the nested `state` document)
- Default org vs `--org` override propagation
- Missing `--account` (direct `Run` path) and Cobra's `MarkFlagRequired` path
- Invalid `--output` value rejected before the API call
- Client error propagation and factory error propagation
- Full cobra-level flag binding and `NewInsightsResourceGetCmd(nil)` defaulting

`pkg/backend/httpstate/client/client_insights_test.go` covers `GetInsightsResource` against a `httptest.NewServer`:
- Round-trip of a populated response
- Path encoding: `accountName` and `resourceTypeAndId` are double-encoded on the wire (asserts the literal request URI)
- HTTP error propagation

Smoke-tested against the live Pulumi Cloud API: a non-existent account surfaces a clean `[404] Not Found: Account '...' not found` error (the third "Errors" example above is from that run).

## Validation

- [x] `make lint` — clean (`golangci-lint run --tests` over the affected packages reports 0 issues)
- [x] `make test_fast` — relevant package tests pass (`insightscmd`, `httpstate/client`, plus a broader `-short` sweep of `./cmd/pulumi/...` and `./backend/httpstate/client/...`)
- [x] `make tidy_fix` — clean (no `go.mod` changes; only existing in-tree imports)
- [x] `make format` — clean (`gofmt -l` reports no diffs on touched files)
- [x] Relevant SDK tests pass (if SDK changes) — `sdk/go/common/apitype` tests pass
- [ ] `make check_proto` — n/a, no proto changes

## Changelog

- [x] Changelog entry added: `cli/cloud: Add \`pulumi insights resource get\` to look up a single resource discovered by Pulumi Insights`

## Risk

Strictly additive: new package `pkg/cmd/pulumi/insightscmd`, new apitype `InsightsResourceWithVersion`, new method `*client.Client.GetInsightsResource`, and two wiring lines in `pulumi.go`. No existing surfaces change shape.

The endpoint is marked `Preview` server-side (`x-pulumi-route-property.Visibility: Preview`), so the command's `--help` text labels the tree `[EXPERIMENTAL]` to match. The shape may evolve before stabilising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)