### PR TITLE
deal with symlinks more correctly

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
@@ -120,13 +120,21 @@ func newRepoLookup(wd string) (repoLookup, error) {
 		return nil, err
 	}
 
+	// Resolve symlinks so that filepath.Rel works correctly when the caller-provided
+	// paths and the worktree root go through different symlink chains (e.g. on macOS
+	// where /var is a symlink to /private/var).
+	repoRoot, err := filepath.EvalSymlinks(worktree.Filesystem.Root())
+	if err != nil {
+		return nil, err
+	}
+
 	h, err := repo.Head()
 	if err != nil {
 		return nil, err
 	}
 
 	return &repoLookupImpl{
-		RepoRoot: worktree.Filesystem.Root(),
+		RepoRoot: repoRoot,
 		Repo:     repo,
 		Head:     h,
 	}, nil
@@ -139,12 +147,34 @@ type repoLookupImpl struct {
 }
 
 func (r *repoLookupImpl) GetRootDirectory(wd string) (string, error) {
+	// Resolve symlinks so that filepath.Rel works correctly when wd and RepoRoot
+	// go through different symlink chains (e.g. on macOS where /var -> /private/var).
+	// Use evalSymlinksPrefix to handle paths where trailing components may not exist.
+	wd = evalSymlinksPrefix(wd)
+
 	dir, err := filepath.Rel(r.RepoRoot, wd)
 	if err != nil {
 		return "", err
 	}
 
 	return dir, err
+}
+
+// evalSymlinksPrefix resolves symlinks on the longest existing prefix of path,
+// then appends any remaining non-existent components. This handles cases like
+// macOS where /var is a symlink to /private/var but the full path may not exist yet.
+func evalSymlinksPrefix(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+
+	parent := filepath.Dir(path)
+	if parent == path {
+		return path
+	}
+
+	return filepath.Join(evalSymlinksPrefix(parent), filepath.Base(path))
 }
 
 func (r *repoLookupImpl) GetBranchName() string {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils_test.go
@@ -78,7 +78,10 @@ func TestRepoLookup(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://github.com/pulumi/test-repo.git", remote)
 
-		assert.Equal(t, filepath.Dir(workDir), rl.GetRepoRoot())
+		// Resolve symlinks so the comparison works on macOS where /var -> /private/var.
+		expectedRoot, err := filepath.EvalSymlinks(filepath.Dir(workDir))
+		require.NoError(t, err)
+		assert.Equal(t, expectedRoot, rl.GetRepoRoot())
 	})
 }
 

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -437,11 +437,24 @@ func addGitRemoteMetadataToMap(repo *git.Repository, projectRoot string, env map
 	if err != nil {
 		allErrors = multierror.Append(allErrors, fmt.Errorf("detecting VCS root: %w", err))
 	} else {
-		rel, err := filepath.Rel(tree.Filesystem.Root(), projectRoot)
+		// Resolve symlinks on both paths so filepath.Rel works correctly when
+		// they go through different symlink chains (e.g. on macOS where /var
+		// is a symlink to /private/var).
+		repoRoot, err := filepath.EvalSymlinks(tree.Filesystem.Root())
 		if err != nil {
-			allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
-		} else if !strings.HasPrefix(rel, "..") {
-			env[backend.VCSRepoRoot] = filepath.ToSlash(rel)
+			allErrors = multierror.Append(allErrors, fmt.Errorf("detecting VCS root: %w", err))
+		} else {
+			resolvedProjectRoot, err := filepath.EvalSymlinks(projectRoot)
+			if err != nil {
+				allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
+			} else {
+				rel, err := filepath.Rel(repoRoot, resolvedProjectRoot)
+				if err != nil {
+					allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
+				} else if !strings.HasPrefix(rel, "..") {
+					env[backend.VCSRepoRoot] = filepath.ToSlash(rel)
+				}
+			}
 		}
 	}
 
@@ -584,12 +597,23 @@ func addHgRemoteMetadataToMap(repo *hgutil.Repository, projectRoot string, env m
 		}
 	}
 
-	// Add the repository root path.
-	rel, err := filepath.Rel(repo.Root, projectRoot)
+	// Add the repository root path. Resolve symlinks so filepath.Rel works correctly
+	// when paths go through different symlink chains.
+	resolvedRepoRoot, err := filepath.EvalSymlinks(repo.Root)
 	if err != nil {
-		allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
-	} else if !strings.HasPrefix(rel, "..") {
-		env[backend.VCSRepoRoot] = filepath.ToSlash(rel)
+		allErrors = multierror.Append(allErrors, fmt.Errorf("detecting VCS root: %w", err))
+	} else {
+		resolvedProjectRoot, err := filepath.EvalSymlinks(projectRoot)
+		if err != nil {
+			allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
+		} else {
+			rel, err := filepath.Rel(resolvedRepoRoot, resolvedProjectRoot)
+			if err != nil {
+				allErrors = multierror.Append(allErrors, fmt.Errorf("detecting project root: %w", err))
+			} else if !strings.HasPrefix(rel, "..") {
+				env[backend.VCSRepoRoot] = filepath.ToSlash(rel)
+			}
+		}
 	}
 
 	return allErrors.ErrorOrNil()


### PR DESCRIPTION
Currently our tests on MacOS are broken because apparently `/var` is now a symlink to `/var/private`, and the test suite ends up with some files in there. When go-git opens the repository, it returns the real path, while `os.Getwd()` and friends still return the unresolved path.

This leads to mismatches in CI, and can lead to mismatches when we're checking the directories.  Always resolve the symlinks, so the paths work correctly, and we always have a consistent view of them.