### PR TITLE
don't run merges on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
     secrets: inherit
 
   test-collect-reports:
-    needs: [unit-test, integration-test, acceptance-test-macos]
+    needs: [unit-test, integration-test]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -44,7 +44,6 @@ jobs:
       enable-coverage: true
       fail-fast: true
       test-retries: 2
-      acceptance-test-platforms: 'macos-latest'
       fuzz-test-optional: true
     secrets: inherit
 


### PR DESCRIPTION
MacOS runners are fairly limited in parallelism for the free open source tier.  We're running into limits for them (in addition to some other issues), which further slows down an already slow CI build.

Since the MacOS platform should be *very* close to linux platform in terms of behaviour for our purposes, let's stop running CI in the merge queue on MacOS.

We'll still run CI on MacOS in the daily jobs.