### PR TITLE
implement `pulumi stack webhook list`

### DIFF
--- a/changelog/pending/20260512--cli--add-pulumi-stack-webhook-list.yaml
+++ b/changelog/pending/20260512--cli--add-pulumi-stack-webhook-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook list` to list all webhooks configured for a stack

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -681,6 +681,15 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 	return stack, nil
 }
 
+// ListStackWebhooks returns all webhooks configured for the given stack.
+func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier) ([]apitype.Webhook, error) {
+	var resp []apitype.Webhook
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "hooks"), nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListStackWebhooks(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		format := "raw"
+		want := []apitype.Webhook{
+			{
+				OrganizationName: "my-org",
+				Name:             "deploy-hook",
+				DisplayName:      "Deploy Hook",
+				PayloadURL:       "https://example.com/webhook",
+				Active:           true,
+				Format:           &format,
+				Filters:          []string{"stack_update"},
+			},
+			{
+				OrganizationName: "my-org",
+				Name:             "slack-hook",
+				DisplayName:      "Slack Notifications",
+				PayloadURL:       "https://hooks.slack.com/services/T00/B00/xxx",
+				Active:           false,
+			},
+		}
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackWebhooks(t.Context(), stackID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks", gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusInternalServerError, `{"message":"internal error"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.ListStackWebhooks(t.Context(), stackID)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackWebhooks(t.Context(), stackID)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -54,26 +54,7 @@ func stackWebhookHookArg() *constrictor.Arguments {
 	}
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23062]: Not yet implemented.
-func newStackWebhookListCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List all webhooks configured for a stack",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
+// newStackWebhookListCmd is defined in stack_webhook_list.go.
 
 // TODO[https://github.com/pulumi/pulumi/issues/23061]: Not yet implemented.
 func newStackWebhookGetCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -1,0 +1,334 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookListClient is the interface the list command needs from the API client.
+type stackWebhookListClient interface {
+	ListStackWebhooks(ctx context.Context, stackID client.StackIdentifier) ([]apitype.Webhook, error)
+}
+
+// stackWebhookListClientFactory builds a stackWebhookListClient from the environment.
+// It returns the client, the resolved StackIdentifier, and any error.
+type stackWebhookListClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookListClient, client.StackIdentifier, error)
+
+func newStackWebhookListCmd() *cobra.Command {
+	return newStackWebhookListCmdWith(nil)
+}
+
+func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all webhooks configured for a stack",
+		Long: "List all webhooks configured for a stack.\n" +
+			"\n" +
+			"Displays the ID, name, payload URL, format, event groups, events, and active\n" +
+			"status of each webhook. By default the output is a human-readable table;\n" +
+			"pass --output=json for a stable, machine-readable JSON envelope.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackWebhookListClientFactory
+			}
+			return runStackWebhookList(cmd.Context(), cmd.OutOrStdout(), factory, stack, output)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable table) or json")
+
+	return cmd
+}
+
+// defaultStackWebhookListClientFactory resolves the current Pulumi Cloud context and
+// returns a client and stack identifier.
+func defaultStackWebhookListClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookListClient, client.StackIdentifier, error) {
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	s, err := RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
+		stackFlag, LoadOnly, opts)
+	if err != nil {
+		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
+	}
+
+	cloudStack, ok := s.(httpstate.Stack)
+	if !ok {
+		return nil, client.StackIdentifier{}, fmt.Errorf("stack webhooks require the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	ref := cloudStack.Ref()
+	project := ""
+	if p, ok := ref.Project(); ok {
+		project = string(p)
+	}
+	stackID := client.StackIdentifier{
+		Owner:   cloudStack.OrgName(),
+		Project: project,
+		Stack:   ref.Name(),
+	}
+
+	be := cloudStack.Backend().(httpstate.Backend)
+	return be.Client(), stackID, nil
+}
+
+func runStackWebhookList(
+	ctx context.Context,
+	w io.Writer,
+	factory stackWebhookListClientFactory,
+	stackFlag string,
+	output string,
+) error {
+	renderer, err := webhookListRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	webhooks, err := c.ListStackWebhooks(ctx, stackID)
+	if err != nil {
+		return fmt.Errorf("listing stack webhooks: %w", err)
+	}
+
+	return renderer(w, webhooks)
+}
+
+type webhookListRenderFunc func(w io.Writer, webhooks []apitype.Webhook) error
+
+func webhookListRenderer(output string) (webhookListRenderFunc, error) {
+	switch output {
+	case "", "default", "table":
+		return renderWebhookListTable, nil
+	case "json":
+		return renderWebhookListJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q: expected \"default\", \"table\", or \"json\"", output)
+	}
+}
+
+// webhookListEnvelope is the JSON shape emitted by `pulumi stack webhook list --output=json`.
+type webhookListEnvelope struct {
+	Webhooks []webhookJSON `json:"webhooks"`
+	Count    int           `json:"count"`
+}
+
+type webhookJSON struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	URL      string   `json:"url"`
+	Format   string   `json:"format"`
+	Active   bool     `json:"active"`
+	Groups   []string `json:"eventGroups"`
+	Filters  []string `json:"events"`
+}
+
+func toWebhookJSON(wh apitype.Webhook) webhookJSON {
+	format := ""
+	if wh.Format != nil {
+		format = *wh.Format
+	}
+	groups := wh.Groups
+	if groups == nil {
+		groups = []string{}
+	}
+	filters := wh.Filters
+	if filters == nil {
+		filters = []string{}
+	}
+	return webhookJSON{
+		ID:       wh.Name,
+		Name:     wh.DisplayName,
+		URL:      wh.PayloadURL,
+		Format:   format,
+		Active:   wh.Active,
+		Groups:   groups,
+		Filters:  filters,
+	}
+}
+
+func renderWebhookListJSON(w io.Writer, webhooks []apitype.Webhook) error {
+	items := make([]webhookJSON, 0, len(webhooks))
+	for _, wh := range webhooks {
+		items = append(items, toWebhookJSON(wh))
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(webhookListEnvelope{
+		Webhooks: items,
+		Count:    len(items),
+	})
+}
+
+const webhookTableFallbackCols = 120
+
+// webhookTableRow holds the formatted string values for a single table row.
+type webhookTableRow struct {
+	id, name, url, format, groups, events, active string
+}
+
+func buildTableRows(webhooks []apitype.Webhook) []webhookTableRow {
+	rows := make([]webhookTableRow, len(webhooks))
+	for i, wh := range webhooks {
+		format := ""
+		if wh.Format != nil {
+			format = *wh.Format
+		}
+		groups := ""
+		if len(wh.Groups) > 0 {
+			groups = strings.Join(wh.Groups, ", ")
+		}
+		events := ""
+		if len(wh.Filters) > 0 {
+			events = strings.Join(wh.Filters, ", ")
+		}
+		active := "yes"
+		if !wh.Active {
+			active = "no"
+		}
+		rows[i] = webhookTableRow{
+			id:     wh.Name,
+			name:   wh.DisplayName,
+			url:    wh.PayloadURL,
+			format: format,
+			groups: groups,
+			events: events,
+			active: active,
+		}
+	}
+	return rows
+}
+
+func renderWebhookListTable(w io.Writer, webhooks []apitype.Webhook) error {
+	if len(webhooks) == 0 {
+		fmt.Fprintln(w, "No webhooks configured for this stack.")
+		return nil
+	}
+
+	rows := buildTableRows(webhooks)
+
+	// Detect which optional columns have at least one non-empty value.
+	hasName, hasFormat, hasGroups, hasEvents := false, false, false, false
+	for _, r := range rows {
+		hasName = hasName || r.name != ""
+		hasFormat = hasFormat || r.format != ""
+		hasGroups = hasGroups || r.groups != ""
+		hasEvents = hasEvents || r.events != ""
+	}
+
+	// Build header and rows dynamically, skipping empty columns.
+	header := table.Row{"ID"}
+	if hasName {
+		header = append(header, "NAME")
+	}
+	header = append(header, "URL")
+	if hasFormat {
+		header = append(header, "FORMAT")
+	}
+	if hasGroups {
+		header = append(header, "EVENT GROUPS")
+	}
+	if hasEvents {
+		header = append(header, "EVENTS")
+	}
+	header = append(header, "ACTIVE")
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(header)
+
+	for _, r := range rows {
+		row := table.Row{r.id}
+		if hasName {
+			row = append(row, r.name)
+		}
+		row = append(row, r.url)
+		if hasFormat {
+			row = append(row, r.format)
+		}
+		if hasGroups {
+			row = append(row, r.groups)
+		}
+		if hasEvents {
+			row = append(row, r.events)
+		}
+		row = append(row, r.active)
+		t.AppendRow(row)
+	}
+
+	// Let URL absorb remaining width.
+	cols := termWidth(webhookTableFallbackCols)
+	// 3 chars per column separator + 1 outer border each side = 3*ncols + 1.
+	borderWidth := 3*len(header) + 1
+	fixedColsWidth := 40 // rough room for the non-URL columns
+	urlWidth := cols - borderWidth - fixedColsWidth
+	if urlWidth < 20 {
+		urlWidth = 20
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "URL", WidthMax: urlWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d webhook(s)\n", len(webhooks))
+	return nil
+}
+
+func termWidth(fallback int) int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return fallback
+	}
+	return w
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -17,6 +17,7 @@ package stack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -100,7 +101,8 @@ func defaultStackWebhookListClientFactory(
 
 	cloudStack, ok := s.(httpstate.Stack)
 	if !ok {
-		return nil, client.StackIdentifier{}, fmt.Errorf("stack webhooks require the Pulumi Cloud backend; run `pulumi login`")
+		return nil, client.StackIdentifier{},
+			errors.New("stack webhooks require the Pulumi Cloud backend; run `pulumi login`")
 	}
 
 	ref := cloudStack.Ref()
@@ -163,13 +165,13 @@ type webhookListEnvelope struct {
 }
 
 type webhookJSON struct {
-	ID       string   `json:"id"`
-	Name     string   `json:"name"`
-	URL      string   `json:"url"`
-	Format   string   `json:"format"`
-	Active   bool     `json:"active"`
-	Groups   []string `json:"eventGroups"`
-	Filters  []string `json:"events"`
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	URL     string   `json:"url"`
+	Format  string   `json:"format"`
+	Active  bool     `json:"active"`
+	Groups  []string `json:"eventGroups"`
+	Filters []string `json:"events"`
 }
 
 func toWebhookJSON(wh apitype.Webhook) webhookJSON {
@@ -186,13 +188,13 @@ func toWebhookJSON(wh apitype.Webhook) webhookJSON {
 		filters = []string{}
 	}
 	return webhookJSON{
-		ID:       wh.Name,
-		Name:     wh.DisplayName,
-		URL:      wh.PayloadURL,
-		Format:   format,
-		Active:   wh.Active,
-		Groups:   groups,
-		Filters:  filters,
+		ID:      wh.Name,
+		Name:    wh.DisplayName,
+		URL:     wh.PayloadURL,
+		Format:  format,
+		Active:  wh.Active,
+		Groups:  groups,
+		Filters: filters,
 	}
 }
 

--- a/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
@@ -1,0 +1,363 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWebhookClient implements stackWebhookListClient for tests.
+type mockWebhookClient struct {
+	webhooks []apitype.Webhook
+	err      error
+}
+
+func (m *mockWebhookClient) ListStackWebhooks(_ context.Context, _ client.StackIdentifier) ([]apitype.Webhook, error) {
+	return m.webhooks, m.err
+}
+
+var testStackID = client.StackIdentifier{
+	Owner:   "my-org",
+	Project: "my-project",
+	Stack:   tokens.MustParseStackName("dev"),
+}
+
+func stubFactory(c stackWebhookListClient) stackWebhookListClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookListClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func failingFactory(err error) stackWebhookListClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookListClient, client.StackIdentifier, error) {
+		return nil, client.StackIdentifier{}, err
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func sampleWebhooks() []apitype.Webhook {
+	return []apitype.Webhook{
+		{
+			OrganizationName: "my-org",
+			Name:             "deploy-hook",
+			DisplayName:      "Deploy Hook",
+			PayloadURL:       "https://example.com/webhook",
+			Active:           true,
+			Format:           ptr("raw"),
+			Groups:           []string{"stacks"},
+			Filters:          []string{"stack_update"},
+		},
+		{
+			OrganizationName: "my-org",
+			Name:             "slack-hook",
+			DisplayName:      "Slack Notifications",
+			PayloadURL:       "https://hooks.slack.com/services/T00/B00/xxx",
+			Active:           false,
+			Format:           ptr("slack"),
+			Groups:           []string{"stacks", "deployments"},
+			Filters:          []string{"stack_update", "drift_detected"},
+		},
+	}
+}
+
+func TestStackWebhookList_TableOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: sampleWebhooks()}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Table should contain column headers
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "URL")
+	assert.Contains(t, out, "FORMAT")
+	assert.Contains(t, out, "EVENT GROUPS")
+	assert.Contains(t, out, "EVENTS")
+	assert.Contains(t, out, "ACTIVE")
+
+	// Table should contain data
+	assert.Contains(t, out, "deploy-hook")
+	assert.Contains(t, out, "Deploy Hook")
+	assert.Contains(t, out, "https://example.com/webhook")
+	assert.Contains(t, out, "raw")
+	assert.Contains(t, out, "stacks")
+	assert.Contains(t, out, "stack_update")
+	assert.Contains(t, out, "yes")
+
+	assert.Contains(t, out, "slack-hook")
+	assert.Contains(t, out, "Slack Notifications")
+	assert.Contains(t, out, "deployments")
+	assert.Contains(t, out, "no")
+
+	// Footer count
+	assert.Contains(t, out, "2 webhook(s)")
+}
+
+func TestStackWebhookList_TableOutput_DropsEmptyColumns(t *testing.T) {
+	t.Parallel()
+
+	// Webhooks with no name, no format, no groups, and no events
+	// should produce a table that omits those columns entirely.
+	webhooks := []apitype.Webhook{
+		{
+			OrganizationName: "my-org",
+			Name:             "hook-a",
+			PayloadURL:       "https://example.com/a",
+			Active:           true,
+		},
+		{
+			OrganizationName: "my-org",
+			Name:             "hook-b",
+			PayloadURL:       "https://example.com/b",
+			Active:           false,
+		},
+	}
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: webhooks}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Only ID, URL, and ACTIVE should be present.
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "URL")
+	assert.Contains(t, out, "ACTIVE")
+
+	// These columns should be absent since all values are empty.
+	// NAME header would appear between ID and URL if present.
+	assert.NotContains(t, out, "FORMAT")
+	assert.NotContains(t, out, "EVENT GROUPS")
+	assert.NotContains(t, out, "EVENTS")
+
+	assert.Contains(t, out, "hook-a")
+	assert.Contains(t, out, "hook-b")
+	assert.Contains(t, out, "2 webhook(s)")
+}
+
+func TestStackWebhookList_TableOutput_PartialColumns(t *testing.T) {
+	t.Parallel()
+
+	// One webhook has groups, neither has events — only EVENT GROUPS column should appear.
+	webhooks := []apitype.Webhook{
+		{
+			OrganizationName: "my-org",
+			Name:             "hook-a",
+			PayloadURL:       "https://example.com/a",
+			Active:           true,
+			Groups:           []string{"stacks"},
+		},
+		{
+			OrganizationName: "my-org",
+			Name:             "hook-b",
+			PayloadURL:       "https://example.com/b",
+			Active:           true,
+		},
+	}
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: webhooks}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "EVENT GROUPS")
+	assert.Contains(t, out, "stacks")
+	assert.NotContains(t, out, "EVENTS")
+	assert.NotContains(t, out, "FORMAT")
+}
+
+func TestStackWebhookList_TableOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: []apitype.Webhook{}}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "No webhooks configured for this stack.")
+}
+
+func TestStackWebhookList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: sampleWebhooks()}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.JSONEq(t, `{
+		"webhooks": [
+			{
+				"id": "deploy-hook",
+				"name": "Deploy Hook",
+				"url": "https://example.com/webhook",
+				"format": "raw",
+				"active": true,
+				"eventGroups": ["stacks"],
+				"events": ["stack_update"]
+			},
+			{
+				"id": "slack-hook",
+				"name": "Slack Notifications",
+				"url": "https://hooks.slack.com/services/T00/B00/xxx",
+				"format": "slack",
+				"active": false,
+				"eventGroups": ["stacks", "deployments"],
+				"events": ["stack_update", "drift_detected"]
+			}
+		],
+		"count": 2
+	}`, out)
+}
+
+func TestStackWebhookList_JSONOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: []apitype.Webhook{}}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"webhooks": [], "count": 0}`, buf.String())
+}
+
+func TestStackWebhookList_JSONOutput_NilFormat(t *testing.T) {
+	t.Parallel()
+
+	// Webhook with nil Format pointer and nil Groups should render as empty values in JSON.
+	webhooks := []apitype.Webhook{
+		{
+			OrganizationName: "my-org",
+			Name:             "no-format",
+			DisplayName:      "No Format",
+			PayloadURL:       "https://example.com",
+			Active:           true,
+		},
+	}
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: webhooks}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"webhooks": [
+			{
+				"id": "no-format",
+				"name": "No Format",
+				"url": "https://example.com",
+				"format": "",
+				"active": true,
+				"eventGroups": [],
+				"events": []
+			}
+		],
+		"count": 1
+	}`, buf.String())
+}
+
+func TestStackWebhookList_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{webhooks: sampleWebhooks()}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestStackWebhookList_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookClient{err: errors.New("server error")}
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing stack webhooks")
+	assert.Contains(t, err.Error(), "server error")
+}
+
+func TestStackWebhookList_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := runStackWebhookList(t.Context(), &buf, failingFactory(errors.New("not logged in")), "", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestStackWebhookList_StackFlagPropagation(t *testing.T) {
+	t.Parallel()
+
+	var capturedStack string
+	factory := func(_ context.Context, stackFlag string) (stackWebhookListClient, client.StackIdentifier, error) {
+		capturedStack = stackFlag
+		return &mockWebhookClient{webhooks: []apitype.Webhook{}}, testStackID, nil
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookList(t.Context(), &buf, factory, "org/proj/my-stack", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "org/proj/my-stack", capturedStack)
+}
+
+func TestStackWebhookList_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookClient{webhooks: sampleWebhooks()}
+	cmd := newStackWebhookListCmdWith(stubFactory(c))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"count": 2`)
+}
+
+func TestStackWebhookList_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	// Verify that newStackWebhookListCmd() returns a well-formed command.
+	cmd := newStackWebhookListCmd()
+	assert.Equal(t, "list", cmd.Use)
+	assert.NotNil(t, cmd.RunE)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "o", f.Shorthand)
+	assert.Equal(t, "default", f.DefValue)
+
+	sf := cmd.Flags().Lookup("stack")
+	require.NotNil(t, sf)
+	assert.Equal(t, "s", sf.Shorthand)
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
@@ -350,7 +350,7 @@ func TestStackWebhookList_DefaultCmd(t *testing.T) {
 	// Verify that newStackWebhookListCmd() returns a well-formed command.
 	cmd := newStackWebhookListCmd()
 	assert.Equal(t, "list", cmd.Use)
-	assert.NotNil(t, cmd.RunE)
+	require.NotNil(t, cmd.RunE)
 
 	f := cmd.Flags().Lookup("output")
 	require.NotNil(t, f)

--- a/sdk/go/common/apitype/webhooks.go
+++ b/sdk/go/common/apitype/webhooks.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// Webhook describes a webhook returned by the Pulumi Cloud REST API.
+type Webhook struct {
+	OrganizationName string   `json:"organizationName"`
+	ProjectName      *string  `json:"projectName,omitempty"`
+	StackName        *string  `json:"stackName,omitempty"`
+	Name             string   `json:"name"`
+	DisplayName      string   `json:"displayName"`
+	PayloadURL       string   `json:"payloadUrl"`
+	Active           bool     `json:"active"`
+	Format           *string  `json:"format,omitempty"`
+	Filters          []string `json:"filters,omitempty"`
+	Groups           []string `json:"groups,omitempty"`
+}


### PR DESCRIPTION
Implement the `pulumi stack webhook list` command, which wraps the ListStackWebhooks endpoint.

Output examples:

```
$ pulumi stack webhook list -s pulumi/pulumi-service-review-stacks/tgummerer --output default
┌──────────┬──────────┬─────────────────────────┬────────┬─────────────────────┬────────────────────────────┬────────┐
│ ID       │ NAME     │ URL                     │ FORMAT │ EVENT GROUPS        │ EVENTS                     │ ACTIVE │
├──────────┼──────────┼─────────────────────────┼────────┼─────────────────────┼────────────────────────────┼────────┤
│ 96edc9f1 │ whatever │ https://localhost.local │ raw    │ deployments, stacks │ policy_violation_mandatory │ yes    │
└──────────┴──────────┴─────────────────────────┴────────┴─────────────────────┴────────────────────────────┴────────┘

1 webhook(s)
```

```
$ pulumi stack webhook list -s pulumi/pulumi-service-review-stacks/tgummerer --output json
{
  "webhooks": [
    {
      "id": "96edc9f1",
      "name": "whatever",
      "url": "https://localhost.local",
      "format": "raw",
      "active": true,
      "groups": [
        "deployments",
        "stacks"
      ],
      "filters": [
        "policy_violation_mandatory"
      ]
    }
  ],
  "count": 1
}
```

Note that the naming differs a little from API naming, but it matches the naming in the UI, which imo is clearer.

Fixes https://github.com/pulumi/pulumi/issues/23062

