### PR TITLE
Add producer workflow to export secrets to ESC

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [ workflow_dispatch ]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@9d6485759b6adff2538ae91f1b77cc96265c9dad # v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}


### PR DESCRIPTION
These changes add the standard `export-repo-secrets.yml` producer workflow. Adapted directly from [pulumi/pulumi-java's `export-repo-secrets.yml`](https://github.com/pulumi/pulumi-java/blob/main/.github/workflows/export-repo-secrets.yml); only the target env differs.

Writes to the org env `pulumi/imports/github-secrets`. The action discriminates between org-level and repo-level secrets and routes the repo-level ones into the per-repo env--same pattern as pulumi-java. The workflow runs on `workflow_dispatch` only.

Prerequisite for #20137 (Use ESC secrets), which needs repo-level secrets like `PULUMI_PROD_ACCESS_TOKEN`, `AZURE_CLIENT_*`, `GCP_SERVICE_ACCOUNT`, `OTEL_EXPORTER_OTLP_ENDPOINT`, and `PULUMI_BOT_HOMEBREW_TOKEN` to be available in ESC.

Required follow-up after merge:
1. Provision `EXPORT_SECRETS_PRIVATE_KEY` as a repo secret (private key for the Export Secrets GitHub App, id `1256780`)--match the pattern used by pulumi-service, pulumi-java, etc.
2. Dispatch the workflow once to populate the per-repo env.