### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/ci-dev-release.yml
+++ b/.github/workflows/ci-dev-release.yml
@@ -1,3 +1,9 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Create dev release
 
 permissions:
@@ -151,6 +157,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.sdk-check-release.outputs.nodejs-release == 'true' }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout
         uses: actions/checkout@v6
       - name: Make artifacts directory
@@ -177,24 +186,26 @@ jobs:
           registry-url: https://registry.npmjs.org
           always-auth: true
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
       - name: Publish nodejs release
         run: |
           find artifacts
           make -C sdk/nodejs publish
         env:
           PULUMI_VERSION: ${{ needs.gather-info.outputs.dev-version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
+          NPM_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
           GIT_REF: ${{ inputs.ref }}
-
 
   python-dev-sdk-release:
     needs: [gather-info, build-sdks, sdk-check-release, matrix]
     runs-on: ubuntu-latest
     if: ${{ needs.sdk-check-release.outputs.python-release == 'true' }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Python ${{ fromJson(needs.matrix.outputs.version-set).python }}
@@ -230,13 +241,16 @@ jobs:
           make -C sdk/python publish
         env:
           PYPI_USERNAME: __token__
-          PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          PYPI_PASSWORD: ${{ steps.esc-secrets.outputs.PYPI_API_TOKEN }}
 
   s3-blobs:
     name: s3 blobs
     runs-on: ubuntu-latest
     needs: [sign, gather-info]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
@@ -246,7 +260,7 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Make artifacts directory
         run: |
           mkdir -p artifacts.tmp

--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -10,6 +10,7 @@ name: Performance Gate
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -2,6 +2,7 @@ name: Test
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:
@@ -74,7 +75,6 @@ env:
   PULUMI_VERSION: ${{ inputs.version }}
   PULUMI_TEST_OWNER: "moolumi"
   PULUMI_TEST_ORG: "moolumi"
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   # Release builds use the service, PR checks and snapshots will use the local backend if possible.
   PULUMI_TEST_USE_SERVICE: ${{ !contains(inputs.version, '-') }}
   # We're hitting a lot of github limits because of deploytest trying to auto install plugins, skip that for now.
@@ -88,6 +88,11 @@ env:
   DOTNET_ROLL_FORWARD: "Major"
   SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
   OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN=PULUMI_PROD_ACCESS_TOKEN
 
 jobs:
   test:
@@ -111,6 +116,9 @@ jobs:
     timeout-minutes: 70
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - if: contains(inputs.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -119,9 +127,6 @@ jobs:
           swap-storage: false
           large-packages: false
           dotnet: false
-
-      # Create a coverage file to register a testing job was started.
-      # This artifact will be overwritten with "OK" at the end of the job.
       - name: Write test started file
         shell: bash
         run: |
@@ -286,9 +291,6 @@ jobs:
         shell: bash
         run: |
           echo "CLI-TARGET=$(go env GOOS)-$(go env GOARCH)" >> "${GITHUB_OUTPUT}"
-
-      # Ensure tests do not rely on pre-installed packages in CI. Unit tests must run absent a local
-      # Pulumi install, and integration tests must only test the version built by CI.
       - name: Remove Pre-installed Pulumi
         env:
           RUNNER_OS: ${{ runner.os }}
@@ -303,8 +305,6 @@ jobs:
             echo "Deleting Pulumi"
             rm -v "$PULUMI_INSTALL_DIR"/pulumi*
           fi
-
-      # Integration and performance test only steps:
       - name: Download pulumi-${{ steps.goenv.outputs.cli-target }}
         if: ${{ inputs.is-integration-test }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -379,16 +379,16 @@ jobs:
         run: ${{ inputs.test-command }}
         continue-on-error: ${{ inputs.continue-on-error }}
         env:
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
+          AZURE_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_CLIENT_SECRET }}
+          AZURE_STORAGE_SAS_TOKEN: ${{ steps.esc-secrets.outputs.AZURE_STORAGE_SAS_TOKEN }}
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/application_default_credentials.json
-          AWS_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_SECRET }}
+          AWS_ACCESS_KEY: ${{ steps.esc-secrets.outputs.AWS_CI_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.esc-secrets.outputs.AWS_CI_ACCESS_SECRET }}
           DOTNET_VERSION: ${{ fromJson(inputs.version-set).dotnet }}
       - name: Convert Node coverage data
         if: ${{ inputs.platform != 'windows-latest' }}
@@ -439,7 +439,7 @@ jobs:
           fail_ci_if_error: false
           override_branch: ${{ github.event_name == 'merge_group' && 'master' || github.head_ref }}
           verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
       - name: Summarize Test Time by Package
         continue-on-error: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,9 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: CI
 
 permissions:
@@ -494,6 +500,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check that there are no failed tests.
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Check tests completed successfully.
         run: |
           JSON='${{ toJson(needs) }}'
@@ -513,7 +522,6 @@ jobs:
           pattern: coverage-*
           merge-multiple: true
           path: coverage
-      # For PRs we need to set the merge base manually, otherwise it is sometimes incorrect.  See https://github.com/pulumi/pulumi/pull/17204#issuecomment-2405599310
       - name: Set codecov PR base
         if: github.event_name == 'pull_request'
         run: |
@@ -530,7 +538,7 @@ jobs:
           # TODO: stop pinning to v10.0.1 when https://github.com/codecov/codecov-cli/issues/651 is fixed.
           # At that point, we should consider switching to codecov/codecov-action@v5
           version: v10.0.1
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
   build-release-binaries:
     # This overwrites the previously built testing binaries with versions without coverage.
     name: Rebuild binaries

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Command Dispatch for PR events
 on:
   issue_comment:
@@ -9,10 +16,13 @@ jobs:
   command-dispatch:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Dispatch command
         uses: peter-evans/slash-command-dispatch@40877f718dce0101edfc7aea2b3800cc192f9ed5 # v2
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           permission: write
           issue-type: pull-request

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,8 +1,15 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: On Push
 
 permissions:
   # To push the tag
   contents: write
+  id-token: write
 
 on:
   push:
@@ -38,6 +45,9 @@ jobs:
     needs: [dev-release, info]
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
@@ -54,7 +64,7 @@ jobs:
         uses: proudust/gh-describe@v1
       - name: Dispatch event to docs repo
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         # Always prefix the short_sha with a letter to ensure it's a valid semver prerelease,
         # see https://github.com/pulumi/pulumi/issues/15471 for context.
         run: |

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -4,6 +4,7 @@ permissions:
   # To create the follow-up PR.
   contents: write
   pull-requests: write
+  id-token: write
 
 on:
   release:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,8 +1,15 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Automatic Rebase
 on:
   issue_comment:
     types: [created]
-jobs:  
+jobs:
   rebase:
     name: Rebase
     runs-on: ubuntu-latest
@@ -14,14 +21,17 @@ jobs:
         contains(github.event.comment.body, '/autosquash')
       )
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout the latest code
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@50007412be906b9cc222db3dfc469f325031f1b2
         with:
           autosquash: ${{ contains(github.event.comment.body, '/autosquash') || contains(github.event.comment.body, '/rebase-autosquash') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}

--- a/.github/workflows/release-homebrew-tap.yml
+++ b/.github/workflows/release-homebrew-tap.yml
@@ -2,6 +2,7 @@ name: Post-Release Homebrew Tap
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   workflow_call:
@@ -37,13 +38,20 @@ on:
 
 env:
   PULUMI_VERSION: ${{ inputs.version }}
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   update-homebrew-tap:
     name: Update Homebrew Tap
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -54,7 +62,7 @@ jobs:
         with:
           repository: pulumi/homebrew-tap
           path: homebrew-tap
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Update Homebrew Tap
         run: |
           set -euo pipefail

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,9 +1,16 @@
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Post-Release PR
 
 permissions:
   # To create a PR
   contents: write
   pull-requests: write
+  id-token: write
 
 on:
   workflow_call:
@@ -35,6 +42,9 @@ jobs:
     name: version bump
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
@@ -46,7 +56,7 @@ jobs:
           PULUMI_VERSION: ${{ inputs.version }}
           RELEASE_NOTES: ${{ inputs.release-notes }}
           QUEUE_MERGE: ${{ inputs.queue-merge }}
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         run: |
           set -euo pipefail
           git switch --create "automation/release-v${PULUMI_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ permissions:
   # To create a PR
   contents: write
   pull-requests: write
+  id-token: write
 
 on:
   workflow_call:
@@ -51,13 +52,13 @@ on:
 env:
   PULUMI_VERSION: ${{ inputs.version }}
   GIT_REF: ${{ inputs.ref }}
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN=PULUMI_PROD_ACCESS_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NPM_TOKEN,PYPI_PASSWORD=PYPI_API_TOKEN
 
 jobs:
   sdks:
@@ -68,6 +69,9 @@ jobs:
       matrix:
         language: ["nodejs", "python", "go"]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -104,6 +108,9 @@ jobs:
     name: s3 blobs
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -117,7 +124,7 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Download release artifacts
         run: |
           mkdir -p artifacts
@@ -164,6 +171,9 @@ jobs:
           - name: Docker containers
             run-command: pulumictl dispatch -r pulumi/pulumi-docker-containers -c release-build "${PULUMI_VERSION}"
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
@@ -171,14 +181,13 @@ jobs:
       - name: Install Pulumictl
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         with:
           repo: pulumi/pulumictl
           tag: v0.0.42
           cache: enable
       - name: Repository Dispatch
         run: ${{ matrix.job.run-command }}
-
 
   update-homebrew-tap:
     name: Update Homebrew Tap

--- a/.github/workflows/trigger-homebrew-event.yml
+++ b/.github/workflows/trigger-homebrew-event.yml
@@ -1,7 +1,12 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   VERSION: ${{ github.event.client_payload.ref }}
   COMMIT_SHA: ${{ github.event.client_payload.commitSha }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 on:
   repository_dispatch:
@@ -13,12 +18,15 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Add Homebrew to the PATH
         run: |
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> "${GITHUB_PATH}"
       - uses: dawidd6/action-homebrew-bump-formula@1446dca236b0440c6f02723a3f14f13be2c04ab0 # v7
         with:
-          token: ${{secrets.PULUMI_BOT_HOMEBREW_TOKEN}}
+          token: ${{steps.esc-secrets.outputs.PULUMI_BOT_HOMEBREW_TOKEN}}
           formula: pulumi
           tag: v${{env.VERSION}}
           revision: ${{env.COMMIT_SHA}}

--- a/.github/workflows/trigger-release-docs-event.yml
+++ b/.github/workflows/trigger-release-docs-event.yml
@@ -1,7 +1,12 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   VERSION: ${{ github.event.client_payload.ref }}
   COMMIT_SHA: ${{ github.event.client_payload.commitSha }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-pulumi
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 on:
   repository_dispatch:
@@ -13,6 +18,9 @@ jobs:
     name: Build Package Docs
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1
       - name: Checkout
         uses: actions/checkout@v6
       - name: Checkout Scripts Repo
@@ -25,5 +33,5 @@ jobs:
           ./ci-scripts/ci/build-package-docs.sh "pulumi"
         env:
           TRAVIS: true
-          PULUMI_BOT_GITHUB_API_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          PULUMI_BOT_GITHUB_API_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           TRAVIS_TAG: ${{ env.VERSION }}


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.