### PR TITLE
implement `pulumi stack webhook get`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-get.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook get` to inspect a single stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -723,6 +723,17 @@ func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier
 	return resp, nil
 }
 
+// GetStackWebhook returns a single webhook by name for the given stack.
+func (pc *Client) GetStackWebhook(
+	ctx context.Context, stackID StackIdentifier, webhookName string,
+) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "hooks", webhookName), nil, nil, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -83,7 +83,7 @@ func TestListStackWebhooks(t *testing.T) {
 
 		c := newMockClient(srv)
 		_, err := c.ListStackWebhooks(t.Context(), stackID)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "internal error")
 	})
 
 	t.Run("empty list", func(t *testing.T) {
@@ -99,5 +99,58 @@ func TestListStackWebhooks(t *testing.T) {
 		got, err := c.ListStackWebhooks(t.Context(), stackID)
 		require.NoError(t, err)
 		assert.Empty(t, got)
+	})
+}
+
+func TestGetStackWebhook(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		format := "raw"
+		want := apitype.Webhook{
+			OrganizationName: "my-org",
+			Name:             "deploy-hook",
+			DisplayName:      "Deploy Hook",
+			PayloadURL:       "https://example.com/webhook",
+			Active:           true,
+			Format:           &format,
+			Filters:          []string{"stack_update"},
+			Groups:           []string{"stacks"},
+		}
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.GetStackWebhook(t.Context(), stackID, "deploy-hook")
+		require.NoError(t, err)
+
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks/deploy-hook", gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.GetStackWebhook(t.Context(), stackID, "no-such-hook")
+		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -55,30 +55,6 @@ func stackWebhookHookArg() *constrictor.Arguments {
 	}
 }
 
-// newStackWebhookListCmd is defined in stack_webhook_list.go.
-
-// TODO[https://github.com/pulumi/pulumi/issues/23061]: Not yet implemented.
-func newStackWebhookGetCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Get the details of a stack webhook",
-		Long:   "[EXPERIMENTAL] Get the details of a stack webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23060]: Not yet implemented.
 func newStackWebhookNewCmd() *cobra.Command {
 	var (

--- a/pkg/cmd/pulumi/stack/stack_webhook_get.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get.go
@@ -1,0 +1,223 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookGetClient is the interface the get command needs from the API client.
+type stackWebhookGetClient interface {
+	GetStackWebhook(ctx context.Context, stackID client.StackIdentifier, webhookName string) (apitype.Webhook, error)
+}
+
+// stackWebhookGetCmd holds the resolved dependencies for `pulumi stack webhook get`.
+type stackWebhookGetCmd struct {
+	client  stackWebhookGetClient
+	stackID client.StackIdentifier
+	output  string
+}
+
+func newStackWebhookGetCmd() *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the details of a stack webhook",
+		Long: "[EXPERIMENTAL] Get the details of a stack webhook.\n" +
+			"\n" +
+			"Displays the configuration of a single webhook including its ID, name,\n" +
+			"URL, format, event groups, events, and active status.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			c, stackID, err := RequireCloudStack(
+				ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stack)
+			if err != nil {
+				return err
+			}
+			get := &stackWebhookGetCmd{
+				client:  c,
+				stackID: stackID,
+				output:  output,
+			}
+			return get.run(ctx, cmd.OutOrStdout(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable text) or json")
+
+	return cmd
+}
+
+func (c *stackWebhookGetCmd) run(ctx context.Context, w io.Writer, webhookName string) error {
+	renderer, err := webhookGetRenderer(c.output)
+	if err != nil {
+		return err
+	}
+
+	webhook, err := c.client.GetStackWebhook(ctx, c.stackID, webhookName)
+	if err != nil {
+		return fmt.Errorf("reading stack webhook: %w", err)
+	}
+
+	return renderer(w, webhook)
+}
+
+type webhookGetRenderFunc func(w io.Writer, webhook apitype.Webhook) error
+
+func webhookGetRenderer(output string) (webhookGetRenderFunc, error) {
+	switch output {
+	case "", "default":
+		return renderWebhookGetText, nil
+	case "json":
+		return renderWebhookGetJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
+	}
+}
+
+// webhookGetJSON is the full JSON shape for `pulumi stack webhook get --output=json`.
+// It includes all fields returned by the API, unlike the list command's summary.
+type webhookGetJSON struct {
+	OrganizationName string   `json:"organizationName"`
+	ProjectName      string   `json:"projectName"`
+	StackName        string   `json:"stackName"`
+	EnvName          string   `json:"envName"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	URL              string   `json:"url"`
+	Format           string   `json:"format"`
+	Active           bool     `json:"active"`
+	Groups           []string `json:"eventGroups"`
+	Filters          []string `json:"events"`
+	HasSecret        bool     `json:"hasSecret"`
+	SecretCiphertext string   `json:"secretCiphertext"`
+}
+
+func toWebhookGetJSON(wh apitype.Webhook) webhookGetJSON {
+	format := ""
+	if wh.Format != nil {
+		format = *wh.Format
+	}
+	groups := wh.Groups
+	if groups == nil {
+		groups = []string{}
+	}
+	filters := wh.Filters
+	if filters == nil {
+		filters = []string{}
+	}
+	projectName := ""
+	if wh.ProjectName != nil {
+		projectName = *wh.ProjectName
+	}
+	stackName := ""
+	if wh.StackName != nil {
+		stackName = *wh.StackName
+	}
+	envName := ""
+	if wh.EnvName != nil {
+		envName = *wh.EnvName
+	}
+	return webhookGetJSON{
+		OrganizationName: wh.OrganizationName,
+		ProjectName:      projectName,
+		StackName:        stackName,
+		EnvName:          envName,
+		ID:               wh.Name,
+		Name:             wh.DisplayName,
+		URL:              wh.PayloadURL,
+		Format:           format,
+		Active:           wh.Active,
+		Groups:           groups,
+		Filters:          filters,
+		HasSecret:        wh.HasSecret,
+		SecretCiphertext: wh.SecretCiphertext,
+	}
+}
+
+func renderWebhookGetJSON(w io.Writer, webhook apitype.Webhook) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toWebhookGetJSON(webhook))
+}
+
+func renderWebhookGetText(w io.Writer, wh apitype.Webhook) error {
+	format := ""
+	if wh.Format != nil {
+		format = *wh.Format
+	}
+	active := "yes"
+	if !wh.Active {
+		active = "no"
+	}
+	hasSecret := "no"
+	if wh.HasSecret {
+		hasSecret = "yes"
+	}
+
+	fmt.Fprintf(w, "ID:                %s\n", wh.Name)
+	if wh.DisplayName != "" {
+		fmt.Fprintf(w, "Name:              %s\n", wh.DisplayName)
+	}
+	fmt.Fprintf(w, "Organization:      %s\n", wh.OrganizationName)
+	if wh.ProjectName != nil && *wh.ProjectName != "" {
+		fmt.Fprintf(w, "Project:           %s\n", *wh.ProjectName)
+	}
+	if wh.StackName != nil && *wh.StackName != "" {
+		fmt.Fprintf(w, "Stack:             %s\n", *wh.StackName)
+	}
+	if wh.EnvName != nil && *wh.EnvName != "" {
+		fmt.Fprintf(w, "Environment:       %s\n", *wh.EnvName)
+	}
+	fmt.Fprintf(w, "URL:               %s\n", wh.PayloadURL)
+	if format != "" {
+		fmt.Fprintf(w, "Format:            %s\n", format)
+	}
+	if len(wh.Groups) > 0 {
+		fmt.Fprintf(w, "Event groups:      %s\n", strings.Join(wh.Groups, ", "))
+	}
+	if len(wh.Filters) > 0 {
+		fmt.Fprintf(w, "Events:            %s\n", strings.Join(wh.Filters, ", "))
+	}
+	fmt.Fprintf(w, "Active:            %s\n", active)
+	fmt.Fprintf(w, "Has secret:        %s\n", hasSecret)
+	if wh.SecretCiphertext != "" {
+		fmt.Fprintf(w, "Secret ciphertext: %s\n", wh.SecretCiphertext)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
@@ -73,19 +73,19 @@ func TestStackWebhookGet_TextOutput(t *testing.T) {
 	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "deploy-hook")
 	require.NoError(t, err)
 
-	out := buf.String()
-	assert.Contains(t, out, "ID:                deploy-hook")
-	assert.Contains(t, out, "Name:              Deploy Hook")
-	assert.Contains(t, out, "Organization:      my-org")
-	assert.Contains(t, out, "Project:           my-project")
-	assert.Contains(t, out, "Stack:             dev")
-	assert.Contains(t, out, "URL:               https://example.com/webhook")
-	assert.Contains(t, out, "Format:            raw")
-	assert.Contains(t, out, "Event groups:      stacks")
-	assert.Contains(t, out, "Events:            stack_update")
-	assert.Contains(t, out, "Active:            yes")
-	assert.Contains(t, out, "Has secret:        yes")
-	assert.Contains(t, out, "Secret ciphertext: v1:abc123")
+	assert.Equal(t, `ID:                deploy-hook
+Name:              Deploy Hook
+Organization:      my-org
+Project:           my-project
+Stack:             dev
+URL:               https://example.com/webhook
+Format:            raw
+Event groups:      stacks
+Events:            stack_update
+Active:            yes
+Has secret:        yes
+Secret ciphertext: v1:abc123
+`, buf.String())
 }
 
 func TestStackWebhookGet_TextOutput_Minimal(t *testing.T) {
@@ -104,21 +104,12 @@ func TestStackWebhookGet_TextOutput_Minimal(t *testing.T) {
 	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "bare-hook")
 	require.NoError(t, err)
 
-	out := buf.String()
-	assert.Contains(t, out, "ID:                bare-hook")
-	assert.Contains(t, out, "URL:               https://example.com")
-	assert.Contains(t, out, "Active:            no")
-	assert.Contains(t, out, "Has secret:        no")
-
-	// Optional fields should be absent.
-	assert.NotContains(t, out, "Name:")
-	assert.NotContains(t, out, "Project:")
-	assert.NotContains(t, out, "Stack:")
-	assert.NotContains(t, out, "Environment:")
-	assert.NotContains(t, out, "Format:")
-	assert.NotContains(t, out, "Event groups:")
-	assert.NotContains(t, out, "Events:")
-	assert.NotContains(t, out, "Secret ciphertext:")
+	assert.Equal(t, `ID:                bare-hook
+Organization:      my-org
+URL:               https://example.com
+Active:            no
+Has secret:        no
+`, buf.String())
 }
 
 func TestStackWebhookGet_JSONOutput(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWebhookGetClient implements stackWebhookGetClient for tests.
+type mockWebhookGetClient struct {
+	webhook apitype.Webhook
+	err     error
+	gotName string
+}
+
+func (m *mockWebhookGetClient) GetStackWebhook(
+	_ context.Context, _ client.StackIdentifier, name string,
+) (apitype.Webhook, error) {
+	m.gotName = name
+	return m.webhook, m.err
+}
+
+func sampleWebhook() apitype.Webhook {
+	return apitype.Webhook{
+		OrganizationName: "my-org",
+		ProjectName:      ptr("my-project"),
+		StackName:        ptr("dev"),
+		Name:             "deploy-hook",
+		DisplayName:      "Deploy Hook",
+		PayloadURL:       "https://example.com/webhook",
+		Active:           true,
+		Format:           ptr("raw"),
+		Groups:           []string{"stacks"},
+		Filters:          []string{"stack_update"},
+		HasSecret:        true,
+		SecretCiphertext: "v1:abc123",
+	}
+}
+
+func newTestGetCmd(c *mockWebhookGetClient, output string) *stackWebhookGetCmd {
+	return &stackWebhookGetCmd{
+		client:  c,
+		stackID: testStackID,
+		output:  output,
+	}
+}
+
+func TestStackWebhookGet_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{webhook: sampleWebhook()}
+	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "deploy-hook")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID:                deploy-hook")
+	assert.Contains(t, out, "Name:              Deploy Hook")
+	assert.Contains(t, out, "Organization:      my-org")
+	assert.Contains(t, out, "Project:           my-project")
+	assert.Contains(t, out, "Stack:             dev")
+	assert.Contains(t, out, "URL:               https://example.com/webhook")
+	assert.Contains(t, out, "Format:            raw")
+	assert.Contains(t, out, "Event groups:      stacks")
+	assert.Contains(t, out, "Events:            stack_update")
+	assert.Contains(t, out, "Active:            yes")
+	assert.Contains(t, out, "Has secret:        yes")
+	assert.Contains(t, out, "Secret ciphertext: v1:abc123")
+}
+
+func TestStackWebhookGet_TextOutput_Minimal(t *testing.T) {
+	t.Parallel()
+
+	// Webhook with no display name, no format, no groups, no events.
+	wh := apitype.Webhook{
+		OrganizationName: "my-org",
+		Name:             "bare-hook",
+		PayloadURL:       "https://example.com",
+		Active:           false,
+	}
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{webhook: wh}
+	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "bare-hook")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID:                bare-hook")
+	assert.Contains(t, out, "URL:               https://example.com")
+	assert.Contains(t, out, "Active:            no")
+	assert.Contains(t, out, "Has secret:        no")
+
+	// Optional fields should be absent.
+	assert.NotContains(t, out, "Name:")
+	assert.NotContains(t, out, "Project:")
+	assert.NotContains(t, out, "Stack:")
+	assert.NotContains(t, out, "Environment:")
+	assert.NotContains(t, out, "Format:")
+	assert.NotContains(t, out, "Event groups:")
+	assert.NotContains(t, out, "Events:")
+	assert.NotContains(t, out, "Secret ciphertext:")
+}
+
+func TestStackWebhookGet_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{webhook: sampleWebhook()}
+	err := newTestGetCmd(c, "json").run(t.Context(), &buf, "deploy-hook")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organizationName": "my-org",
+		"projectName": "my-project",
+		"stackName": "dev",
+		"envName": "",
+		"id": "deploy-hook",
+		"name": "Deploy Hook",
+		"url": "https://example.com/webhook",
+		"format": "raw",
+		"active": true,
+		"eventGroups": ["stacks"],
+		"events": ["stack_update"],
+		"hasSecret": true,
+		"secretCiphertext": "v1:abc123"
+	}`, buf.String())
+}
+
+func TestStackWebhookGet_JSONOutput_NilFields(t *testing.T) {
+	t.Parallel()
+
+	wh := apitype.Webhook{
+		OrganizationName: "my-org",
+		Name:             "bare-hook",
+		PayloadURL:       "https://example.com",
+		Active:           true,
+	}
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{webhook: wh}
+	err := newTestGetCmd(c, "json").run(t.Context(), &buf, "bare-hook")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organizationName": "my-org",
+		"projectName": "",
+		"stackName": "",
+		"envName": "",
+		"id": "bare-hook",
+		"name": "",
+		"url": "https://example.com",
+		"format": "",
+		"active": true,
+		"eventGroups": [],
+		"events": [],
+		"hasSecret": false,
+		"secretCiphertext": ""
+	}`, buf.String())
+}
+
+func TestStackWebhookGet_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{webhook: sampleWebhook()}
+	err := newTestGetCmd(c, "yaml").run(t.Context(), &buf, "deploy-hook")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+}
+
+func TestStackWebhookGet_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookGetClient{err: errors.New("not found")}
+	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "no-such")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading stack webhook")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestStackWebhookGet_WebhookNamePropagation(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookGetClient{webhook: sampleWebhook()}
+	var buf bytes.Buffer
+	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "my-hook-name")
+	require.NoError(t, err)
+	assert.Equal(t, "my-hook-name", c.gotName)
+}

--- a/sdk/go/common/apitype/webhooks.go
+++ b/sdk/go/common/apitype/webhooks.go
@@ -19,6 +19,7 @@ type Webhook struct {
 	OrganizationName string   `json:"organizationName"`
 	ProjectName      *string  `json:"projectName,omitempty"`
 	StackName        *string  `json:"stackName,omitempty"`
+	EnvName          *string  `json:"envName,omitempty"`
 	Name             string   `json:"name"`
 	DisplayName      string   `json:"displayName"`
 	PayloadURL       string   `json:"payloadUrl"`
@@ -26,4 +27,6 @@ type Webhook struct {
 	Format           *string  `json:"format,omitempty"`
 	Filters          []string `json:"filters,omitempty"`
 	Groups           []string `json:"groups,omitempty"`
+	HasSecret        bool     `json:"hasSecret"`
+	SecretCiphertext string   `json:"secretCiphertext"`
 }


### PR DESCRIPTION
Implement the `pulumi stack webhook get` command.  In addition to what `list` shows, this adds some extra information about the webhook.

Example output:
```
$ pulumi stack webhook get -s pulumi/pulumi-service-review-stacks/tgummerer 96edc9f1 --output default
ID:                96edc9f1
Name:              whatever
Organization:      pulumi
Project:           pulumi-service-review-stacks
Stack:             tgummerer
URL:               https://localhost.local
Format:            raw
Event groups:      deployments, stacks
Events:            policy_violation_mandatory
Active:            yes
Has secret:        yes
Secret ciphertext: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
```

```
$ pulumi stack webhook get -s pulumi/pulumi-service-review-stacks/tgummerer 96edc9f1 --output json
{
  "organizationName": "pulumi",
  "projectName": "pulumi-service-review-stacks",
  "stackName": "tgummerer",
  "envName": "",
  "id": "96edc9f1",
  "name": "whatever",
  "url": "https://localhost.local",
  "format": "raw",
  "active": true,
  "eventGroups": [
    "deployments",
    "stacks"
  ],
  "events": [
    "policy_violation_mandatory"
  ],
  "hasSecret": true,
  "secretCiphertext": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
}
```

Fixes https://github.com/pulumi/pulumi/issues/23061
