### PR TITLE
add `pulumi stack webhook ping`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-ping.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-ping.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook ping` to send a test ping to a stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -734,6 +734,17 @@ func (pc *Client) GetStackWebhook(
 	return resp, nil
 }
 
+// PingStackWebhook sends a test ping to the given webhook and returns the delivery result.
+func (pc *Client) PingStackWebhook(
+	ctx context.Context, stackID StackIdentifier, webhookName string,
+) (apitype.WebhookDelivery, error) {
+	var resp apitype.WebhookDelivery
+	if err := pc.restCall(ctx, "POST", getStackPath(stackID, "hooks", webhookName, "ping"), nil, nil, &resp); err != nil {
+		return apitype.WebhookDelivery{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -154,3 +154,57 @@ func TestGetStackWebhook(t *testing.T) {
 		assert.ErrorContains(t, err, "not found")
 	})
 }
+
+func TestPingStackWebhook(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.WebhookDelivery{
+			ID:           "delivery-123",
+			Kind:         "ping",
+			Payload:      `{"timestamp":1234567890,"message":"ping"}`,
+			Timestamp:    1234567890,
+			Duration:     42,
+			RequestURL:   "https://example.com/webhook",
+			ResponseCode: 200,
+			ResponseBody: "ok",
+		}
+
+		var gotPath, gotMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.PingStackWebhook(t.Context(), stackID, "deploy-hook")
+		require.NoError(t, err)
+
+		assert.Equal(t, "POST", gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks/deploy-hook/ping", gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.PingStackWebhook(t.Context(), stackID, "no-such-hook")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -153,28 +153,6 @@ func newStackWebhookRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23057]: Not yet implemented.
-func newStackWebhookPingCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "ping",
-		Short:  "Send a test ping to a stack webhook",
-		Long:   "[EXPERIMENTAL] Send a test ping to a stack webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23056]: Not yet implemented.
 func newStackWebhookDeliveryCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping.go
@@ -1,0 +1,172 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookPingClient is the interface the ping command needs from the API client.
+type stackWebhookPingClient interface {
+	PingStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+	) (apitype.WebhookDelivery, error)
+}
+
+// stackWebhookPingClientFactory builds a stackWebhookPingClient from the environment.
+type stackWebhookPingClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookPingClient, client.StackIdentifier, error)
+
+func newStackWebhookPingCmd() *cobra.Command {
+	return newStackWebhookPingCmdWith(nil)
+}
+
+func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Send a test ping to a stack webhook",
+		Long: "[EXPERIMENTAL] Send a test ping to a stack webhook.\n" +
+			"\n" +
+			"Issues a test ping event to the specified webhook to verify it is\n" +
+			"properly configured and reachable. Unlike normal webhook deliveries,\n" +
+			"this bypasses the message queue and sends the request directly to the\n" +
+			"webhook endpoint.\n" +
+			"\n" +
+			"The response includes the full delivery result: the HTTP request URL,\n" +
+			"response status code, response body, and request duration.\n" +
+			"\n" +
+			"Returns an error if the webhook does not exist.",
+		Example: "  # Ping a webhook to verify it works\n" +
+			"  pulumi stack webhook ping my-webhook\n\n" +
+			"  # Ping a webhook and get the full delivery details as JSON\n" +
+			"  pulumi stack webhook ping my-webhook --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackWebhookPingClientFactory
+			}
+			return runStackWebhookPing(cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], output)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable text) or json")
+
+	return cmd
+}
+
+// defaultStackWebhookPingClientFactory resolves the current Pulumi Cloud context and
+// returns a client and stack identifier.
+func defaultStackWebhookPingClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookPingClient, client.StackIdentifier, error) {
+	return RequireCloudStack(
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackWebhookPing(
+	ctx context.Context,
+	w io.Writer,
+	factory stackWebhookPingClientFactory,
+	stackFlag string,
+	webhookName string,
+	output string,
+) error {
+	renderer, err := webhookPingRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	delivery, err := c.PingStackWebhook(ctx, stackID, webhookName)
+	if err != nil {
+		return fmt.Errorf("pinging stack webhook: %w", err)
+	}
+
+	return renderer(w, delivery)
+}
+
+type webhookPingRenderFunc func(w io.Writer, d apitype.WebhookDelivery) error
+
+func webhookPingRenderer(output string) (webhookPingRenderFunc, error) {
+	switch output {
+	case "", "default":
+		return renderWebhookPingText, nil
+	case "json":
+		return renderWebhookPingJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
+	}
+}
+
+func renderWebhookPingJSON(w io.Writer, d apitype.WebhookDelivery) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(d)
+}
+
+func renderWebhookPingText(w io.Writer, d apitype.WebhookDelivery) error {
+	ts := time.Unix(d.Timestamp, 0).UTC().Format(time.RFC3339)
+
+	fmt.Fprintf(w, "ID:                %s\n", d.ID)
+	fmt.Fprintf(w, "Kind:              %s\n", d.Kind)
+	fmt.Fprintf(w, "URL:               %s\n", d.RequestURL)
+	fmt.Fprintf(w, "Timestamp:         %s\n", ts)
+	fmt.Fprintf(w, "Duration:          %dms\n", d.Duration)
+	if d.RequestHeaders != "" {
+		fmt.Fprintln(w, "Request headers:")
+		for _, line := range strings.Split(d.RequestHeaders, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				fmt.Fprintf(w, "  %s\n", line)
+			}
+		}
+	}
+	if d.Payload != "" {
+		fmt.Fprintf(w, "Payload:           %s\n", d.Payload)
+	}
+	fmt.Fprintf(w, "Response code:     %d\n", d.ResponseCode)
+	if d.ResponseBody != "" {
+		fmt.Fprintf(w, "Response body:     %s\n", d.ResponseBody)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWebhookPingClient struct {
+	delivery apitype.WebhookDelivery
+	err      error
+	gotName  string
+}
+
+func (m *mockWebhookPingClient) PingStackWebhook(
+	_ context.Context, _ client.StackIdentifier, name string,
+) (apitype.WebhookDelivery, error) {
+	m.gotName = name
+	return m.delivery, m.err
+}
+
+func stubPingFactory(c stackWebhookPingClient) stackWebhookPingClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookPingClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func sampleDelivery() apitype.WebhookDelivery {
+	return apitype.WebhookDelivery{
+		ID:              "delivery-abc",
+		Kind:            "ping",
+		Payload:         `{"timestamp":1715558400,"message":"ping"}`,
+		Timestamp:       1715558400,
+		Duration:        42,
+		RequestURL:      "https://example.com/webhook",
+		RequestHeaders:  "Content-Type: application/json",
+		ResponseCode:    200,
+		ResponseHeaders: "Content-Type: text/plain",
+		ResponseBody:    "ok",
+	}
+}
+
+func TestStackWebhookPing_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookPingClient{delivery: sampleDelivery()}
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", "default")
+	require.NoError(t, err)
+
+	assert.Equal(t, `ID:                delivery-abc
+Kind:              ping
+URL:               https://example.com/webhook
+Timestamp:         2024-05-13T00:00:00Z
+Duration:          42ms
+Request headers:
+  Content-Type: application/json
+Payload:           {"timestamp":1715558400,"message":"ping"}
+Response code:     200
+Response body:     ok
+`, buf.String())
+}
+
+func TestStackWebhookPing_TextOutput_NoBody(t *testing.T) {
+	t.Parallel()
+
+	d := sampleDelivery()
+	d.ResponseBody = ""
+
+	var buf bytes.Buffer
+	c := &mockWebhookPingClient{delivery: d}
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "default")
+	require.NoError(t, err)
+
+	assert.Equal(t, `ID:                delivery-abc
+Kind:              ping
+URL:               https://example.com/webhook
+Timestamp:         2024-05-13T00:00:00Z
+Duration:          42ms
+Request headers:
+  Content-Type: application/json
+Payload:           {"timestamp":1715558400,"message":"ping"}
+Response code:     200
+`, buf.String())
+}
+
+func TestStackWebhookPing_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookPingClient{delivery: sampleDelivery()}
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"id": "delivery-abc",
+		"kind": "ping",
+		"payload": "{\"timestamp\":1715558400,\"message\":\"ping\"}",
+		"timestamp": 1715558400,
+		"duration": 42,
+		"requestUrl": "https://example.com/webhook",
+		"requestHeaders": "Content-Type: application/json",
+		"responseCode": 200,
+		"responseHeaders": "Content-Type: text/plain",
+		"responseBody": "ok"
+	}`, buf.String())
+}
+
+func TestStackWebhookPing_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookPingClient{delivery: sampleDelivery()}
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+}
+
+func TestStackWebhookPing_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockWebhookPingClient{err: errors.New("connection refused")}
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pinging stack webhook")
+	assert.Contains(t, err.Error(), "connection refused")
+}

--- a/sdk/go/common/apitype/webhooks.go
+++ b/sdk/go/common/apitype/webhooks.go
@@ -30,3 +30,18 @@ type Webhook struct {
 	HasSecret        bool     `json:"hasSecret"`
 	SecretCiphertext string   `json:"secretCiphertext"`
 }
+
+// WebhookDelivery describes the result of delivering a webhook event,
+// returned by the ping and delivery endpoints.
+type WebhookDelivery struct {
+	ID              string `json:"id"`
+	Kind            string `json:"kind"`
+	Payload         string `json:"payload"`
+	Timestamp       int64  `json:"timestamp"`
+	Duration        int    `json:"duration"`
+	RequestURL      string `json:"requestUrl"`
+	RequestHeaders  string `json:"requestHeaders"`
+	ResponseCode    int    `json:"responseCode"`
+	ResponseHeaders string `json:"responseHeaders"`
+	ResponseBody    string `json:"responseBody"`
+}


### PR DESCRIPTION
Output examples:

```
$ pulumi stack webhook ping -s pulumi/pulumi-service-review-stacks/tgummerer 96edc9f1 --output default
ID:                78b505ba-d533-4e1d-a855-2b4d903c87aa
Kind:              ping
URL:               https://localhost.local
Timestamp:         2026-05-13T06:19:04Z
Duration:          39ms
Request headers:
  Accept: */*
  Content-Type: application/json
  Pulumi-Webhook-Id: 78b505ba-d533-4e1d-a855-2b4d903c87aa
  Pulumi-Webhook-Kind: ping
  Pulumi-Webhook-Signature: d56b77df4dd68e623988b326d5e3c13d62906ba54d45f497aebb8347f24dec13
Payload:           {"timestamp":1778653144,"message":"🍹 Just a friendly ping from Pulumi 🍹"}
Response code:     0
Response body:     URL error with webhook

$ pulumi stack webhook ping -s pulumi/pulumi-service-review-stacks/tgummerer 96edc9f1 --output json
{
  "id": "c64dd9a8-be18-4e6a-8208-2bb2efbbd13a",
  "kind": "ping",
  "payload": "{\"timestamp\":1778653205,\"message\":\"🍹 Just a friendly ping from Pulumi 🍹\"}",
  "timestamp": 1778653205,
  "duration": 7,
  "requestUrl": "https://localhost.local",
  "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: c64dd9a8-be18-4e6a-8208-2bb2efbbd13a\r\nPulumi-Webhook-Kind: ping\r\nPulumi-Webhook-Signature: 95d20970c78cf451a50c415e699d71ab2e98199ebd4389e36695852b0964925e\r\n",
  "responseCode": 0,
  "responseHeaders": "",
  "responseBody": "URL error with webhook"
}
```

Fixes https://github.com/pulumi/pulumi/issues/23057

Built on top of https://github.com/pulumi/pulumi/pull/23088.