### PR TITLE
cli/cloud: add `pulumi insights account scan log`

### DIFF
--- a/changelog/pending/20260513--cli-cloud--add-pulumi-insights-account-scan-log.yaml
+++ b/changelog/pending/20260513--cli-cloud--add-pulumi-insights-account-scan-log.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi insights account scan log` to fetch log output for a Pulumi Insights scan

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -145,6 +145,9 @@ func init() {
 
 	// APIs for managing Pulumi Insights
 	addEndpoint("GET", "/api/preview/insights/{orgName}/accounts", "listInsightsAccounts")
+	addEndpoint("GET",
+		"/api/preview/insights/{orgName}/accounts/{accountName}/scans/{scanId}/logs",
+		"getScanLogs")
 
 	// APIs for interacting with the Package Registry
 	addEndpoint("POST", "/api/registry/packages/{source}/{publisher}/{name}/versions", "publishPackage")

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2567,3 +2567,23 @@ func (pc *Client) ListInsightsAccounts(
 	}
 	return resp, nil
 }
+
+// GetInsightsScanLogs wraps the GetScanLogs endpoint. See
+// [apitype.InsightsScanLogsParams] for mode and per-field semantics.
+//
+// `accountName` is double-decoded server-side, hence the double encoding here.
+func (pc *Client) GetInsightsScanLogs(
+	ctx context.Context, org, account, scanID string, params apitype.InsightsScanLogsParams,
+) (apitype.InsightsScanLogs, error) {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s/scans/%s/logs",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+		url.PathEscape(scanID),
+	)
+	var resp apitype.InsightsScanLogs
+	if err := pc.restCall(ctx, "GET", path, &params, nil, &resp); err != nil {
+		return apitype.InsightsScanLogs{}, err
+	}
+	return resp, nil
+}

--- a/pkg/backend/httpstate/client/client_insights_test.go
+++ b/pkg/backend/httpstate/client/client_insights_test.go
@@ -339,3 +339,184 @@ func TestListInsightsAccounts(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestGetInsightsScanLogs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns continuation-token response", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.InsightsScanLogs{
+			Type: "continuation",
+			Lines: []apitype.InsightsScanLogLine{
+				{
+					Header:    "scan",
+					Timestamp: time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+					Line:      "starting scan",
+				},
+				{
+					Timestamp: time.Date(2026, 5, 1, 14, 30, 1, 0, time.UTC),
+					Line:      "finished scan",
+				},
+			},
+			ContinuationToken: "next-page",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		got, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "scan-123", apitype.InsightsScanLogsParams{Count: 50})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns step response", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.InsightsScanLogs{
+			Type:       "step",
+			Output:     "scan output text\n",
+			NextOffset: 1024,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		job, step := 0, 0
+		offset := int64(0)
+		got, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "scan-123",
+			apitype.InsightsScanLogsParams{Job: &job, Step: &step, Offset: &offset})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("encodes query parameters", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			capturedPath  string
+			capturedQuery url.Values
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.EscapedPath()
+			capturedQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		job, step := 2, 3
+		offset := int64(4096)
+		_, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "scan-123",
+			apitype.InsightsScanLogsParams{
+				Job:    &job,
+				Step:   &step,
+				Offset: &offset,
+			})
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"/api/preview/insights/acme/accounts/prod-aws/scans/scan-123/logs",
+			capturedPath,
+		)
+		assert.Equal(t, "2", capturedQuery.Get("job"))
+		assert.Equal(t, "3", capturedQuery.Get("step"))
+		assert.Equal(t, "4096", capturedQuery.Get("offset"))
+	})
+
+	t.Run("encodes continuation-mode parameters", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedQuery url.Values
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "scan-123",
+			apitype.InsightsScanLogsParams{
+				ContinuationToken: "cursor",
+				Count:             100,
+			})
+		require.NoError(t, err)
+
+		assert.Equal(t, "cursor", capturedQuery.Get("continuationToken"))
+		assert.Equal(t, "100", capturedQuery.Get("count"))
+		assert.False(t, capturedQuery.Has("job"))
+		assert.False(t, capturedQuery.Has("step"))
+		assert.False(t, capturedQuery.Has("offset"))
+	})
+
+	t.Run("omits zero-valued parameters", func(t *testing.T) {
+		t.Parallel()
+
+		// Empty query string lets the server apply its own defaults.
+		var capturedQuery url.Values
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "scan-123", apitype.InsightsScanLogsParams{})
+		require.NoError(t, err)
+		assert.Empty(t, capturedQuery)
+	})
+
+	t.Run("double-encodes accountName in path", func(t *testing.T) {
+		t.Parallel()
+
+		// `/` becomes `%2F` once, then `%252F` for the server-side double-decode.
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "team/a", "scan-123", apitype.InsightsScanLogsParams{})
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"/api/preview/insights/acme/accounts/team%252Fa/scans/scan-123/logs",
+			capturedPath,
+		)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsScanLogs(t.Context(),
+			"acme", "prod-aws", "missing-scan", apitype.InsightsScanLogsParams{})
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/insights/insights_account.go
+++ b/pkg/cmd/pulumi/insights/insights_account.go
@@ -78,10 +78,9 @@ func newInsightsAccountScanCmd() *cobra.Command {
 	var org string
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "scan",
-		Short:  "Trigger a resource discovery scan for an Insights account",
-		Long:   "[EXPERIMENTAL] Trigger a resource discovery scan for an Insights account.",
+		Use:   "scan",
+		Short: "Trigger a resource discovery scan for an Insights account",
+		Long:  "[EXPERIMENTAL] Trigger a resource discovery scan for an Insights account.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -96,44 +95,7 @@ func newInsightsAccountScanCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the account")
 
-	cmd.AddCommand(newInsightsAccountScanLogCmd())
-
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/22977]: Not yet implemented.
-func newInsightsAccountScanLogCmd() *cobra.Command {
-	var (
-		org   string
-		job   int
-		step  int
-		count int
-		token string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "log",
-		Short:  "Retrieve logs for an Insights scan",
-		Long:   "[EXPERIMENTAL] Retrieve logs for an Insights scan.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "account"},
-			{Name: "scan-id"},
-		},
-		Required: 2,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the account")
-	cmd.Flags().IntVar(&job, "job", -1, "The job index to fetch step-level logs for")
-	cmd.Flags().IntVar(&step, "step", -1, "The step index within the job (requires --job)")
-	cmd.Flags().IntVar(&count, "count", 0, "The number of log lines to fetch")
-	cmd.Flags().StringVar(&token, "continuation-token", "", "The continuation token for paginated retrieval")
+	cmd.AddCommand(newInsightsAccountScanLogCmd(nil))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log.go
@@ -1,0 +1,334 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// insightsScanLogClient narrows the *client.Client surface so tests can stub
+// it without faking the whole HTTP client.
+type insightsScanLogClient interface {
+	GetInsightsScanLogs(
+		ctx context.Context, org, account, scanID string,
+		params apitype.InsightsScanLogsParams,
+	) (apitype.InsightsScanLogs, error)
+}
+
+// scanLogClientFactory resolves the client and effective org. orgOverride
+// wins when non-empty.
+type scanLogClientFactory func(
+	ctx context.Context, orgOverride string,
+) (insightsScanLogClient, string, error)
+
+type scanLogRender func(c *insightsAccountScanLogCmd, logs apitype.InsightsScanLogs) error
+
+type insightsAccountScanLogCmd struct {
+	org    string
+	job    int
+	jobSet bool
+	step   int
+	count  int
+	all    bool
+	output outputflag.OutputFlag[scanLogRender]
+
+	w io.Writer
+}
+
+// newInsightsAccountScanLogCmd builds the `pulumi insights account scan log`
+// command. Pass nil for factory to use the production wiring.
+func newInsightsAccountScanLogCmd(factory scanLogClientFactory) *cobra.Command {
+	if factory == nil {
+		factory = defaultScanLogClientFactory
+	}
+
+	logCmd := &insightsAccountScanLogCmd{
+		output: outputflag.OutputFlag[scanLogRender]{
+			RenderForTerminal: (*insightsAccountScanLogCmd).renderText,
+			RenderJSON:        (*insightsAccountScanLogCmd).renderJSON,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "log <account> <scan-id>",
+		Short: "Retrieve log output for an Insights scan",
+		Long: "[EXPERIMENTAL] Retrieve log output for an Insights scan.\n" +
+			"\n" +
+			"By default, a single page of log entries is returned. Use --count\n" +
+			"to request more, or --all to fetch every entry.\n" +
+			"\n" +
+			"Passing --job switches to step mode and returns the raw text\n" +
+			"output of a single step. --step selects the step within the job,\n" +
+			"and --all fetches the full step output.",
+		Example: "  # Show the first page of a scan's logs.\n" +
+			"  pulumi insights account scan log prod-aws scan-123\n\n" +
+			"  # Show the last 100 entries.\n" +
+			"  pulumi insights account scan log prod-aws scan-123 --count 100\n\n" +
+			"  # Fetch every entry as JSON.\n" +
+			"  pulumi insights account scan log prod-aws scan-123 --all --output json\n\n" +
+			"  # Read step 0 of job 0 in full.\n" +
+			"  pulumi insights account scan log prod-aws scan-123 --job 0 --step 0 --all",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			// Zero is a legitimate job/step index, so we can't use it as a
+			// sentinel for "unset".
+			logCmd.jobSet = cmd.Flags().Changed("job")
+			logCmd.w = cmd.OutOrStdout()
+			return logCmd.run(cmd.Context(), factory, posArgs[0], posArgs[1])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "account"},
+			{Name: "scan-id"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&logCmd.org, "org", "",
+		"Organization that owns the Insights account (defaults to the current default org)")
+	cmd.Flags().IntVar(&logCmd.count, "count", 0,
+		"Number of log entries to display")
+	cmd.Flags().BoolVar(&logCmd.all, "all", false,
+		"Fetch every entry (mutually exclusive with --count)")
+	cmd.Flags().IntVar(&logCmd.job, "job", 0,
+		"Switch to step mode and select this job index (combine with --step)")
+	cmd.Flags().IntVar(&logCmd.step, "step", 0,
+		"Step index within --job whose log output to fetch")
+	outputflag.VarP(cmd.Flags(), &logCmd.output)
+
+	cmd.MarkFlagsMutuallyExclusive("all", "count")
+
+	return cmd
+}
+
+// run is decoupled from cobra so tests can drive it directly.
+func (c *insightsAccountScanLogCmd) run(
+	ctx context.Context, factory scanLogClientFactory, account, scanID string,
+) error {
+	// --all and --count are handled by MarkFlagsMutuallyExclusive on the
+	// cobra command; --step requires --job is one-way so we catch it here.
+	if !c.jobSet && c.step != 0 {
+		return errors.New("--step requires --job")
+	}
+
+	client, org, err := factory(ctx, c.org)
+	if err != nil {
+		return err
+	}
+
+	logs, err := c.fetch(ctx, client, org, account, scanID)
+	if err != nil {
+		return fmt.Errorf("reading insights scan logs: %w", err)
+	}
+	return c.output.Get()(c, logs)
+}
+
+func (c *insightsAccountScanLogCmd) fetch(
+	ctx context.Context, client insightsScanLogClient,
+	org, account, scanID string,
+) (apitype.InsightsScanLogs, error) {
+	if c.jobSet {
+		return c.fetchStepMode(ctx, client, org, account, scanID)
+	}
+	return c.fetchContinuationMode(ctx, client, org, account, scanID)
+}
+
+func (c *insightsAccountScanLogCmd) fetchContinuationMode(
+	ctx context.Context, client insightsScanLogClient,
+	org, account, scanID string,
+) (apitype.InsightsScanLogs, error) {
+	// Target entry count: positive = exact, -1 = unlimited (--all), 0 =
+	// one page only (default).
+	want := 0
+	switch {
+	case c.count > 0:
+		want = c.count
+	case c.all:
+		want = -1
+	}
+
+	// API limit per request, documented 1-500.
+	const maxPageCount = 500
+
+	var acc apitype.InsightsScanLogs
+	var token string
+	for {
+		params := apitype.InsightsScanLogsParams{ContinuationToken: token}
+		switch {
+		case want == -1:
+			// Max out the page to minimise round-trips.
+			params.Count = maxPageCount
+		case want > 0:
+			// Cap to the remaining count so the last page doesn't
+			// over-fetch.
+			remaining := want - len(acc.Lines)
+			if remaining < maxPageCount {
+				params.Count = remaining
+			} else {
+				params.Count = maxPageCount
+			}
+		}
+
+		resp, err := client.GetInsightsScanLogs(ctx, org, account, scanID, params)
+		if err != nil {
+			return apitype.InsightsScanLogs{}, err
+		}
+		if acc.Type == "" {
+			acc.Type = resp.Type
+		}
+		acc.Lines = append(acc.Lines, resp.Lines...)
+		acc.ContinuationToken = resp.ContinuationToken
+
+		if want > 0 && len(acc.Lines) >= want {
+			acc.Lines = acc.Lines[:want]
+			break
+		}
+		if resp.ContinuationToken == "" || len(resp.Lines) == 0 || want == 0 {
+			break
+		}
+		token = resp.ContinuationToken
+	}
+	return acc, nil
+}
+
+func (c *insightsAccountScanLogCmd) fetchStepMode(
+	ctx context.Context, client insightsScanLogClient,
+	org, account, scanID string,
+) (apitype.InsightsScanLogs, error) {
+	job, step := c.job, c.step
+	params := apitype.InsightsScanLogsParams{Job: &job, Step: &step}
+	resp, err := client.GetInsightsScanLogs(ctx, org, account, scanID, params)
+	if err != nil {
+		return apitype.InsightsScanLogs{}, err
+	}
+
+	// --count doesn't apply in step mode (the API paginates by bytes, not
+	// by entries), so default and --count behave identically.
+	if !c.all {
+		return resp, nil
+	}
+
+	acc := resp
+	for acc.NextOffset > 0 {
+		offset := acc.NextOffset
+		more, err := client.GetInsightsScanLogs(ctx, org, account, scanID,
+			apitype.InsightsScanLogsParams{Job: &job, Step: &step, Offset: &offset})
+		if err != nil {
+			return apitype.InsightsScanLogs{}, err
+		}
+		acc.Output += more.Output
+		acc.NextOffset = more.NextOffset
+		if more.Output == "" && more.NextOffset == 0 {
+			break
+		}
+	}
+	return acc, nil
+}
+
+// renderText dispatches by mode: step mode emits a raw text blob, continuation
+// mode emits structured records.
+func (c *insightsAccountScanLogCmd) renderText(r apitype.InsightsScanLogs) error {
+	if c.jobSet {
+		return c.renderStepText(r)
+	}
+	return c.renderContinuationText(r)
+}
+
+func (c *insightsAccountScanLogCmd) renderStepText(r apitype.InsightsScanLogs) error {
+	if _, err := io.WriteString(c.w, r.Output); err != nil {
+		return err
+	}
+	// Force a trailing newline so the hint below sits on its own line.
+	if len(r.Output) > 0 && r.Output[len(r.Output)-1] != '\n' {
+		fmt.Fprintln(c.w)
+	}
+	if r.NextOffset > 0 {
+		fmt.Fprintf(c.w,
+			"More output available. Re-run with --all to fetch the rest.\n")
+	}
+	return nil
+}
+
+func (c *insightsAccountScanLogCmd) renderContinuationText(r apitype.InsightsScanLogs) error {
+	if len(r.Lines) == 0 {
+		fmt.Fprintln(c.w, "No log entries.")
+		return nil
+	}
+
+	for _, line := range r.Lines {
+		ts := ""
+		if !line.Timestamp.IsZero() {
+			ts = line.Timestamp.UTC().Format(time.RFC3339)
+		}
+		switch {
+		case ts != "" && line.Header != "":
+			fmt.Fprintf(c.w, "%s [%s] %s\n", ts, line.Header, line.Line)
+		case ts != "":
+			fmt.Fprintf(c.w, "%s %s\n", ts, line.Line)
+		case line.Header != "":
+			fmt.Fprintf(c.w, "[%s] %s\n", line.Header, line.Line)
+		default:
+			fmt.Fprintln(c.w, line.Line)
+		}
+	}
+	if r.ContinuationToken != "" {
+		fmt.Fprintln(c.w,
+			"\nMore entries available. Re-run with --count <N> or --all to fetch more.")
+	}
+	return nil
+}
+
+func (c *insightsAccountScanLogCmd) renderJSON(r apitype.InsightsScanLogs) error {
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+func defaultScanLogClientFactory(
+	ctx context.Context, orgOverride string,
+) (insightsScanLogClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -281,19 +282,22 @@ func (c *insightsAccountScanLogCmd) renderContinuationText(r apitype.InsightsSca
 	}
 
 	for _, line := range r.Lines {
+		// The server's Line field already ends in a newline; strip it so we
+		// don't double-space the output when we add our own.
+		text := strings.TrimRight(line.Line, "\n")
 		ts := ""
 		if !line.Timestamp.IsZero() {
 			ts = line.Timestamp.UTC().Format(time.RFC3339)
 		}
 		switch {
 		case ts != "" && line.Header != "":
-			fmt.Fprintf(c.w, "%s [%s] %s\n", ts, line.Header, line.Line)
+			fmt.Fprintf(c.w, "%s [%s] %s\n", ts, line.Header, text)
 		case ts != "":
-			fmt.Fprintf(c.w, "%s %s\n", ts, line.Line)
+			fmt.Fprintf(c.w, "%s %s\n", ts, text)
 		case line.Header != "":
-			fmt.Fprintf(c.w, "[%s] %s\n", line.Header, line.Line)
+			fmt.Fprintf(c.w, "[%s] %s\n", line.Header, text)
 		default:
-			fmt.Fprintln(c.w, line.Line)
+			fmt.Fprintln(c.w, text)
 		}
 	}
 	if r.ContinuationToken != "" {

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
@@ -1,0 +1,497 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturedScanLogCall struct {
+	org     string
+	account string
+	scanID  string
+	params  apitype.InsightsScanLogsParams
+}
+
+// mockScanLogClient consumes one response per call, so multi-page tests can
+// script a paginated stream.
+type mockScanLogClient struct {
+	responses []apitype.InsightsScanLogs
+	err       error
+	calls     []capturedScanLogCall
+}
+
+func (m *mockScanLogClient) GetInsightsScanLogs(
+	_ context.Context, org, account, scanID string,
+	params apitype.InsightsScanLogsParams,
+) (apitype.InsightsScanLogs, error) {
+	m.calls = append(m.calls, capturedScanLogCall{
+		org: org, account: account, scanID: scanID, params: params,
+	})
+	if m.err != nil {
+		return apitype.InsightsScanLogs{}, m.err
+	}
+	if len(m.calls) > len(m.responses) {
+		return apitype.InsightsScanLogs{}, nil
+	}
+	return m.responses[len(m.calls)-1], nil
+}
+
+// stubScanLogFactory mirrors production's orgOverride-wins behaviour so
+// per-call --org assertions reflect reality.
+func stubScanLogFactory(client insightsScanLogClient, defaultOrg string) scanLogClientFactory {
+	return func(_ context.Context, orgOverride string) (insightsScanLogClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return client, org, nil
+	}
+}
+
+func failingScanLogFactory(err error) scanLogClientFactory {
+	return func(_ context.Context, _ string) (insightsScanLogClient, string, error) {
+		return nil, "", err
+	}
+}
+
+// newTestScanLogCmd wires up the same renderer table the production
+// constructor installs.
+func newTestScanLogCmd() (*insightsAccountScanLogCmd, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &insightsAccountScanLogCmd{
+		output: outputflag.OutputFlag[scanLogRender]{
+			RenderForTerminal: (*insightsAccountScanLogCmd).renderText,
+			RenderJSON:        (*insightsAccountScanLogCmd).renderJSON,
+		},
+		w: &buf,
+	}, &buf
+}
+
+func continuationPage(lines int, token string) apitype.InsightsScanLogs {
+	var entries []apitype.InsightsScanLogLine
+	for i := 0; i < lines; i++ {
+		entries = append(entries, apitype.InsightsScanLogLine{
+			Header:    "scan",
+			Timestamp: time.Date(2026, 5, 1, 14, 30, i, 0, time.UTC),
+			Line:      "line " + string(rune('0'+i)),
+		})
+	}
+	return apitype.InsightsScanLogs{
+		Type:              "continuation",
+		Lines:             entries,
+		ContinuationToken: token,
+	}
+}
+
+func TestScanLog_ContinuationDefault(t *testing.T) {
+	t.Parallel()
+
+	// Default: one server page even when more pages are available.
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{
+			continuationPage(3, "next-page"),
+		},
+	}
+	cmd, buf := newTestScanLogCmd()
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	require.Len(t, client.calls, 1)
+	assert.Equal(t, "", client.calls[0].params.ContinuationToken)
+	assert.Equal(t, 0, client.calls[0].params.Count)
+
+	out := buf.String()
+	assert.Contains(t, out, "2026-05-01T14:30:00Z [scan] line 0")
+	assert.Contains(t, out, "2026-05-01T14:30:02Z [scan] line 2")
+	assert.Contains(t, out, "--count <N> or --all")
+}
+
+func TestScanLog_ContinuationEmpty(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{{}},
+	}
+	cmd, buf := newTestScanLogCmd()
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+	assert.Equal(t, "No log entries.\n", buf.String())
+}
+
+func TestScanLog_ContinuationLastPage(t *testing.T) {
+	t.Parallel()
+
+	// Empty continuation token → no follow-up hint.
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{continuationPage(2, "")},
+	}
+	cmd, buf := newTestScanLogCmd()
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "More entries available")
+}
+
+func TestScanLog_ContinuationCount(t *testing.T) {
+	t.Parallel()
+
+	// --count 4 spans two pages (3 + 1).
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{
+			continuationPage(3, "tok-1"),
+			continuationPage(3, "tok-2"),
+		},
+	}
+	cmd, buf := newTestScanLogCmd()
+	cmd.count = 4
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	require.Len(t, client.calls, 2)
+	assert.Equal(t, "", client.calls[0].params.ContinuationToken)
+	assert.Equal(t, 4, client.calls[0].params.Count)
+	// Second call asks only for the remaining 1 entry.
+	assert.Equal(t, "tok-1", client.calls[1].params.ContinuationToken)
+	assert.Equal(t, 1, client.calls[1].params.Count)
+
+	out := buf.String()
+	assert.Contains(t, out, "2026-05-01T14:30:00Z [scan] line 0")
+	assert.Equal(t, 4, bytesLineCount(out, "[scan] line"))
+}
+
+func TestScanLog_ContinuationAll(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{
+			continuationPage(2, "tok-1"),
+			continuationPage(2, "tok-2"),
+			continuationPage(1, ""),
+		},
+	}
+	cmd, buf := newTestScanLogCmd()
+	cmd.all = true
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	require.Len(t, client.calls, 3)
+	// --all maxes out per-page count to minimise round-trips.
+	for _, call := range client.calls {
+		assert.Equal(t, 500, call.params.Count)
+	}
+	assert.Equal(t, "", client.calls[0].params.ContinuationToken)
+	assert.Equal(t, "tok-1", client.calls[1].params.ContinuationToken)
+	assert.Equal(t, "tok-2", client.calls[2].params.ContinuationToken)
+
+	out := buf.String()
+	assert.Equal(t, 5, bytesLineCount(out, "[scan] line"))
+	assert.NotContains(t, out, "More entries available")
+}
+
+func TestScanLog_AllAndCountMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{}
+	cmd := newInsightsAccountScanLogCmd(stubScanLogFactory(client, "acme"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--all", "--count", "5", "prod-aws", "scan-123"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[all count]")
+	assert.Empty(t, client.calls)
+}
+
+func TestScanLog_StepDefault(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{{
+			Type:       "step",
+			Output:     "step output chunk 1\n",
+			NextOffset: 1024,
+		}},
+	}
+	cmd, buf := newTestScanLogCmd()
+	cmd.jobSet = true
+	cmd.job = 0
+	cmd.step = 0
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	// Zero values must reach the wire as non-nil pointers.
+	require.Len(t, client.calls, 1)
+	require.NotNil(t, client.calls[0].params.Job)
+	require.NotNil(t, client.calls[0].params.Step)
+	assert.Equal(t, 0, *client.calls[0].params.Job)
+	assert.Equal(t, 0, *client.calls[0].params.Step)
+	assert.Nil(t, client.calls[0].params.Offset, "default mode never sets offset")
+
+	out := buf.String()
+	assert.Contains(t, out, "step output chunk 1")
+	assert.Contains(t, out, "More output available. Re-run with --all")
+}
+
+func TestScanLog_StepAll(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{
+			{Type: "step", Output: "chunk-1\n", NextOffset: 1024},
+			{Type: "step", Output: "chunk-2\n", NextOffset: 2048},
+			{Type: "step", Output: "chunk-3\n", NextOffset: 0},
+		},
+	}
+	cmd, buf := newTestScanLogCmd()
+	cmd.jobSet = true
+	cmd.job = 1
+	cmd.step = 2
+	cmd.all = true
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	require.Len(t, client.calls, 3)
+	assert.Nil(t, client.calls[0].params.Offset)
+	require.NotNil(t, client.calls[1].params.Offset)
+	assert.Equal(t, int64(1024), *client.calls[1].params.Offset)
+	require.NotNil(t, client.calls[2].params.Offset)
+	assert.Equal(t, int64(2048), *client.calls[2].params.Offset)
+	for _, call := range client.calls {
+		require.NotNil(t, call.params.Job)
+		require.NotNil(t, call.params.Step)
+		assert.Equal(t, 1, *call.params.Job)
+		assert.Equal(t, 2, *call.params.Step)
+	}
+
+	out := buf.String()
+	assert.Contains(t, out, "chunk-1")
+	assert.Contains(t, out, "chunk-2")
+	assert.Contains(t, out, "chunk-3")
+	assert.NotContains(t, out, "More output available")
+}
+
+func TestScanLog_StepWithoutJobRejectsStep(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{}
+	cmd, _ := newTestScanLogCmd()
+	cmd.step = 2
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--step requires --job")
+	assert.Empty(t, client.calls)
+}
+
+func TestScanLog_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	resp := continuationPage(2, "next-page")
+	client := &mockScanLogClient{responses: []apitype.InsightsScanLogs{resp}}
+	cmd, buf := newTestScanLogCmd()
+	require.NoError(t, cmd.output.Set("json"))
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	var got apitype.InsightsScanLogs
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, resp, got)
+}
+
+func TestScanLog_OrgOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       insightsAccountScanLogCmd
+		defaultOrg string
+		wantOrg    string
+	}{
+		{
+			name:       "default org used when --org omitted",
+			defaultOrg: "acme",
+			wantOrg:    "acme",
+		},
+		{
+			name:       "--org overrides default",
+			args:       insightsAccountScanLogCmd{org: "other-co"},
+			defaultOrg: "acme",
+			wantOrg:    "other-co",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := &mockScanLogClient{
+				responses: []apitype.InsightsScanLogs{{}},
+			}
+			cmd, _ := newTestScanLogCmd()
+			cmd.org = tt.args.org
+			err := cmd.run(t.Context(), stubScanLogFactory(client, tt.defaultOrg),
+				"prod-aws", "scan-123")
+			require.NoError(t, err)
+			require.Len(t, client.calls, 1)
+			assert.Equal(t, tt.wantOrg, client.calls[0].org)
+			assert.Equal(t, "prod-aws", client.calls[0].account)
+			assert.Equal(t, "scan-123", client.calls[0].scanID)
+		})
+	}
+}
+
+func TestScanLog_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newTestScanLogCmd()
+	err := cmd.output.Set("yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"yaml" not supported`)
+}
+
+func TestScanLog_ClientError(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{err: errors.New("404 not found")}
+	cmd, _ := newTestScanLogCmd()
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "missing-scan")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading insights scan logs")
+	assert.Contains(t, err.Error(), "404 not found")
+}
+
+func TestScanLog_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newTestScanLogCmd()
+	err := cmd.run(t.Context(), failingScanLogFactory(errors.New("not logged in")),
+		"prod-aws", "scan-123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestNewInsightsAccountScanLogCmd_FlagBinding(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{continuationPage(2, "")},
+	}
+	cmd := newInsightsAccountScanLogCmd(stubScanLogFactory(client, "acme"))
+	assert.Equal(t, "log", cmd.Name())
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--org", "other-co",
+		"--count", "5",
+		"--output", "json",
+		"prod-aws", "scan-123",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	require.Len(t, client.calls, 1)
+	assert.Equal(t, "other-co", client.calls[0].org)
+	assert.Equal(t, "prod-aws", client.calls[0].account)
+	assert.Equal(t, "scan-123", client.calls[0].scanID)
+	assert.Equal(t, 5, client.calls[0].params.Count)
+	assert.Empty(t, client.calls[0].params.ContinuationToken)
+
+	var got apitype.InsightsScanLogs
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, continuationPage(2, ""), got)
+}
+
+func TestNewInsightsAccountScanLogCmd_FlagBinding_StepMode(t *testing.T) {
+	t.Parallel()
+
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{{
+			Type: "step", Output: "data\n",
+		}},
+	}
+	cmd := newInsightsAccountScanLogCmd(stubScanLogFactory(client, "acme"))
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	// Zero values must reach the wire, not be conflated with "unset".
+	cmd.SetArgs([]string{
+		"--job", "0",
+		"--step", "0",
+		"prod-aws", "scan-123",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	require.Len(t, client.calls, 1)
+	require.NotNil(t, client.calls[0].params.Job)
+	require.NotNil(t, client.calls[0].params.Step)
+	assert.Equal(t, 0, *client.calls[0].params.Job)
+	assert.Equal(t, 0, *client.calls[0].params.Step)
+}
+
+func TestNewInsightsAccountScanLogCmd_RequiresAccountAndScanID(t *testing.T) {
+	t.Parallel()
+
+	cmd := newInsightsAccountScanLogCmd(stubScanLogFactory(&mockScanLogClient{}, "acme"))
+	cmd.SetArgs([]string{"prod-aws"}) // scan-id missing
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+}
+
+func TestNewInsightsAccountScanLogCmd_NilFactoryUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	// Don't invoke — the default factory would hit the real cloud context.
+	cmd := newInsightsAccountScanLogCmd(nil)
+	require.NotNil(t, cmd)
+	assert.Equal(t, "log", cmd.Name())
+}
+
+func bytesLineCount(s, needle string) int {
+	count := 0
+	for i := 0; i+len(needle) <= len(s); i++ {
+		if s[i:i+len(needle)] == needle {
+			count++
+			i += len(needle) - 1
+		}
+	}
+	return count
+}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
@@ -143,6 +143,36 @@ func TestScanLog_ContinuationEmpty(t *testing.T) {
 	assert.Equal(t, "No log entries.\n", buf.String())
 }
 
+func TestScanLog_ContinuationStripsTrailingNewlines(t *testing.T) {
+	t.Parallel()
+
+	// The server's Line field ends with `\n`; the renderer must not
+	// double-space the output by adding its own newline on top.
+	client := &mockScanLogClient{
+		responses: []apitype.InsightsScanLogs{{
+			Lines: []apitype.InsightsScanLogLine{
+				{
+					Timestamp: time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+					Line:      "starting scan\n",
+				},
+				{
+					Timestamp: time.Date(2026, 5, 1, 14, 30, 1, 0, time.UTC),
+					Line:      "finished scan\n",
+				},
+			},
+		}},
+	}
+	cmd, buf := newTestScanLogCmd()
+	err := cmd.run(t.Context(), stubScanLogFactory(client, "acme"),
+		"prod-aws", "scan-123")
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"2026-05-01T14:30:00Z starting scan\n"+
+			"2026-05-01T14:30:01Z finished scan\n",
+		buf.String())
+}
+
 func TestScanLog_ContinuationLastPage(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/go/common/apitype/insights.go
+++ b/sdk/go/common/apitype/insights.go
@@ -233,3 +233,34 @@ type InsightsAccountScanStatus struct {
 	// JobTimeout is the deadline for jobs in the workflow run.
 	JobTimeout time.Time `json:"jobTimeout"`
 }
+
+// InsightsScanLogsParams are the query parameters for GetScanLogs. The endpoint
+// has two modes; setting Job switches from continuation-token mode to step mode.
+//
+// Job, Step, and Offset are pointers because zero is a legitimate index in the
+// underlying API.
+type InsightsScanLogsParams struct {
+	ContinuationToken string `url:"continuationToken,omitempty"`
+	Count             int    `url:"count,omitempty"`
+	Job               *int   `url:"job,omitempty"`
+	Step              *int   `url:"step,omitempty"`
+	Offset            *int64 `url:"offset,omitempty"`
+}
+
+// InsightsScanLogs is the response from GetScanLogs. Type is the
+// DeploymentLogsBase discriminator; only the fields relevant to the active
+// mode (continuation-token vs step) are populated.
+type InsightsScanLogs struct {
+	Type              string                `json:"__type,omitempty"`
+	Lines             []InsightsScanLogLine `json:"lines,omitempty"`
+	ContinuationToken string                `json:"continuationToken,omitempty"`
+	Output            string                `json:"output,omitempty"`
+	NextOffset        int64                 `json:"nextOffset,omitempty"`
+}
+
+// InsightsScanLogLine mirrors apitype.DeploymentLogLine.
+type InsightsScanLogLine struct {
+	Header    string    `json:"header,omitempty"`
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	Line      string    `json:"line,omitempty"`
+}


### PR DESCRIPTION
```
$ pulumi insights account scan log ... ... | head
[Setup] 
2026-05-13T20:48:55Z Preparing environment
2026-05-13T20:48:57Z Using runner default image with Pulumi version 3.237.0 (...)
2026-05-13T20:48:57Z Starting container
2026-05-13T20:49:04Z Container created (...)
2026-05-13T20:49:05Z Container started (...)
...
```

```
$ pulumi insights account scan log ... ... --output json | head -n 20
{
  "__type": "DeploymentLogs",
  "lines": [
    {
      "header": "Setup",
      "timestamp": "0001-01-01T00:00:00Z"
    },
    {
      "timestamp": "2026-05-13T20:48:55.293497881Z",
      "line": "Preparing environment\n"
    },
    {
      "timestamp": "2026-05-13T20:48:57.294499317Z",
      "line": "Using runner default image with Pulumi version 3.237.0 (...)\n"
    },
    ...
```

(Ellipses my own to hide IDs/URNs)

Closes #22977.
