### PR TITLE
cli/cloud: add `pulumi insights account new`

### DIFF
--- a/changelog/pending/20260513--cli-cloud--add-pulumi-insights-account-new.yaml
+++ b/changelog/pending/20260513--cli-cloud--add-pulumi-insights-account-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi insights account new` to create a Pulumi Insights account

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3050,6 +3050,28 @@ func (pc *Client) GetInsightsAccount(
 	return resp, nil
 }
 
+// ListESCEnvironments fetches a page of ESC environments visible to the
+// caller in the named organization. Mirrors the endpoint exposed by the ESC
+// CLI (`pulumi esc ls`) so the Pulumi CLI can offer the same picker without
+// pulling in the esc-cli library.
+//
+// The endpoint paginates with an opaque continuation token; nextToken is
+// empty on the last page.
+func (pc *Client) ListESCEnvironments(
+	ctx context.Context, org, continuationToken string,
+) ([]apitype.ESCEnvironment, string, error) {
+	queryObj := struct {
+		ContinuationToken string `url:"continuationToken,omitempty"`
+	}{ContinuationToken: continuationToken}
+
+	path := "/api/esc/environments/" + url.PathEscape(org)
+	var resp apitype.ListESCEnvironmentsResponse
+	if err := pc.restCall(ctx, "GET", path, queryObj, nil, &resp); err != nil {
+		return nil, "", err
+	}
+	return resp.Environments, resp.NextToken, nil
+}
+
 // ListStackDeploymentsOptions are the optional query parameters accepted by
 // ListStackDeployments. Zero values mean "let the server pick the default":
 // Page < 1 → 1, PageSize ≤ 0 → 10 (server-side cap 100), Sort "" → server's

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3014,6 +3014,42 @@ func (pc *Client) ListInsightsAccounts(
 	return resp, nil
 }
 
+// CreateInsightsAccount creates a new Pulumi Insights account.
+//
+// The `accountName` path parameter is double-decoded on the service side, so
+// we double-URL-encode it here — matching the convention already used by
+// GetInsightsResource. The endpoint returns 204 No Content on success; no
+// response body is parsed.
+func (pc *Client) CreateInsightsAccount(
+	ctx context.Context, org, account string, req apitype.CreateInsightsAccountRequest,
+) error {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+	)
+	return pc.restCall(ctx, "POST", path, nil, req, nil)
+}
+
+// GetInsightsAccount fetches the details of a Pulumi Insights account. The
+// `accountName` path parameter is double-decoded on the service side, so we
+// double-URL-encode it here — same convention as CreateInsightsAccount and
+// GetInsightsResource.
+func (pc *Client) GetInsightsAccount(
+	ctx context.Context, org, account string,
+) (apitype.InsightsAccount, error) {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+	)
+	var resp apitype.InsightsAccount
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.InsightsAccount{}, err
+	}
+	return resp, nil
+}
+
 // ListStackDeploymentsOptions are the optional query parameters accepted by
 // ListStackDeployments. Zero values mean "let the server pick the default":
 // Page < 1 → 1, PageSize ≤ 0 → 10 (server-side cap 100), Sort "" → server's

--- a/pkg/backend/httpstate/client/client_insights_test.go
+++ b/pkg/backend/httpstate/client/client_insights_test.go
@@ -548,7 +548,6 @@ func TestListInsightsAccounts(t *testing.T) {
 		require.Error(t, err)
 	})
 }
-
 func TestGetInsightsScanLogs(t *testing.T) {
 	t.Parallel()
 
@@ -726,6 +725,194 @@ func TestGetInsightsScanLogs(t *testing.T) {
 		client := newMockClient(server)
 		_, err := client.GetInsightsScanLogs(t.Context(),
 			"acme", "prod-aws", "missing-scan", apitype.InsightsScanLogsParams{})
+		require.Error(t, err)
+	})
+}
+
+func TestCreateInsightsAccount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sends request and returns nil on 204", func(t *testing.T) {
+		t.Parallel()
+
+		req := apitype.CreateInsightsAccountRequest{
+			Provider:       "aws",
+			Environment:    "infra/prod-aws-creds",
+			ScanSchedule:   "daily",
+			AgentPoolID:    "pool-123",
+			ProviderConfig: json.RawMessage(`{"regions":["us-east-1"]}`),
+		}
+
+		var (
+			capturedMethod string
+			capturedPath   string
+			capturedBody   apitype.CreateInsightsAccountRequest
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.EscapedPath()
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &capturedBody))
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		err := client.CreateInsightsAccount(t.Context(), "acme", "prod-aws", req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, capturedMethod)
+		// orgName is single-encoded ("acme" has no special chars to encode);
+		// accountName is double-encoded — same convention as ReadResource.
+		assert.Equal(t, "/api/preview/insights/acme/accounts/prod-aws", capturedPath)
+		assert.Equal(t, req, capturedBody)
+	})
+
+	t.Run("double-encodes accountName", func(t *testing.T) {
+		t.Parallel()
+
+		// The service double-decodes accountName, so the wire form must be
+		// double-encoded. `/` becomes `%2F` once, then `%252F` — matching
+		// the convention asserted by the GetInsightsResource test above.
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.EscapedPath()
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		err := client.CreateInsightsAccount(t.Context(), "acme", "team/a",
+			apitype.CreateInsightsAccountRequest{Provider: "aws", Environment: "infra/creds"})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/preview/insights/acme/accounts/team%252Fa", capturedPath)
+	})
+
+	t.Run("omits optional fields when unset", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedRaw json.RawMessage
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			capturedRaw = body
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		err := client.CreateInsightsAccount(t.Context(), "acme", "prod-aws",
+			apitype.CreateInsightsAccountRequest{Provider: "aws", Environment: "infra/creds"})
+		require.NoError(t, err)
+
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(capturedRaw, &decoded))
+		// Required fields are always present.
+		assert.Equal(t, "aws", decoded["provider"])
+		assert.Equal(t, "infra/creds", decoded["environment"])
+		// `omitempty` keeps the wire payload tight when optional flags are
+		// unset; the server uses its own defaults for these.
+		assert.NotContains(t, decoded, "scanSchedule")
+		assert.NotContains(t, decoded, "agentPoolID")
+		assert.NotContains(t, decoded, "providerConfig")
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("organization not found"))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		err := client.CreateInsightsAccount(t.Context(), "nonexistent", "prod-aws",
+			apitype.CreateInsightsAccountRequest{Provider: "aws", Environment: "infra/creds"})
+		require.Error(t, err)
+	})
+}
+
+func TestGetInsightsAccount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed account", func(t *testing.T) {
+		t.Parallel()
+
+		finished := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+		want := apitype.InsightsAccount{
+			ID:                   "acc-123",
+			Name:                 "prod-aws",
+			Provider:             "aws",
+			ProviderVersion:      "6.0.0",
+			ProviderEnvRef:       "infra/prod-aws-creds",
+			ScheduledScanEnabled: true,
+			AgentPoolID:          "pool-1",
+			ProviderConfig:       json.RawMessage(`{"regions":["us-east-1"]}`),
+			OwnedBy: apitype.InsightsAccountOwner{
+				Name:        "Jane Doe",
+				GitHubLogin: "jdoe",
+				AvatarURL:   "https://example.com/avatar.png",
+			},
+			ScanStatus: &apitype.InsightsAccountScanStatus{
+				ID:            "scan-1",
+				OrgID:         "org-1",
+				UserID:        "user-1",
+				Status:        "succeeded",
+				ResourceCount: 42,
+				StartedAt:     time.Date(2026, 5, 13, 9, 30, 0, 0, time.UTC),
+				FinishedAt:    &finished,
+				LastUpdatedAt: finished,
+				JobTimeout:    time.Date(2026, 5, 13, 11, 30, 0, 0, time.UTC),
+			},
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		got, err := client.GetInsightsAccount(t.Context(), "acme", "prod-aws")
+		require.NoError(t, err)
+		// ProviderConfig is `json.RawMessage`, so the encoder may re-emit
+		// the bytes with normalized whitespace. Compare it semantically and
+		// the rest of the struct field-by-field.
+		assert.JSONEq(t, string(want.ProviderConfig), string(got.ProviderConfig))
+		want.ProviderConfig, got.ProviderConfig = nil, nil
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("double-encodes accountName", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"x","name":"team/a","provider":"aws"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsAccount(t.Context(), "acme", "team/a")
+		require.NoError(t, err)
+		assert.Equal(t, "/api/preview/insights/acme/accounts/team%252Fa", capturedPath)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.GetInsightsAccount(t.Context(), "acme", "missing")
 		require.Error(t, err)
 	})
 }

--- a/pkg/backend/httpstate/client/client_insights_test.go
+++ b/pkg/backend/httpstate/client/client_insights_test.go
@@ -548,6 +548,7 @@ func TestListInsightsAccounts(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
 func TestGetInsightsScanLogs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/insights/insights_account.go
+++ b/pkg/cmd/pulumi/insights/insights_account.go
@@ -15,8 +15,6 @@
 package insights
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -37,38 +35,6 @@ func newInsightsAccountCmd() *cobra.Command {
 	cmd.AddCommand(newInsightsAccountNewCmd())
 	cmd.AddCommand(newInsightsAccountListCmd(nil))
 	cmd.AddCommand(newInsightsAccountScanCmd(nil))
-
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/22979]: Not yet implemented.
-func newInsightsAccountNewCmd() *cobra.Command {
-	var (
-		org      string
-		provider string
-		parent   string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new Insights account",
-		Long:   "[EXPERIMENTAL] Create a new Insights account.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to create the account in")
-	cmd.Flags().StringVar(&provider, "provider", "", "The cloud provider (e.g. aws, azure, gcp)")
-	cmd.Flags().StringVar(&parent, "parent", "", "The parent account, if any")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_account_new.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new.go
@@ -188,7 +188,7 @@ func resolveAccountNewArgs(
 		if skipPrompts {
 			return args, errors.New("--environment is required")
 		}
-		env, err := promptForESCEnvironment(ctx, c, org, opts)
+		env, err := promptForESCEnvironment(ctx, c, org, newDisplayPrompter(opts))
 		if err != nil {
 			return args, err
 		}
@@ -197,43 +197,84 @@ func resolveAccountNewArgs(
 	return args, nil
 }
 
-// promptForESCEnvironment offers a picker over the org's ESC environments
-// (the same set surfaced by `pulumi esc ls`). The list call is best-effort:
-// if it fails or returns no environments, the prompt degrades to free-text
-// input so an offline-ish or empty-org user can still proceed. The picker
-// always offers an "Enter manually..." choice so users can specify a
-// `@version` suffix or any env the server doesn't yet list.
-func promptForESCEnvironment(
-	ctx context.Context, c insightsAccountNewClient, org string, opts display.Options,
-) (string, error) {
-	free := func() (string, error) {
-		return ui.PromptForValue(
-			false,
-			"ESC environment (project/environment[@version])",
-			"", false,
-			nonEmptyValidator("an ESC environment reference"),
-			opts,
-		)
-	}
+// escEnvManualOption is the label of the picker entry that lets a user
+// bail out of the listed choices and type an environment by hand. Exposed
+// as a constant so the test for [escEnvironmentChoices] can assert on it.
+const escEnvManualOption = "[Enter manually]"
 
+// escEnvironmentChoices builds the picker option list for the org's ESC
+// environments. Returns nil when the listing call errors or comes back
+// empty — the caller treats that signal as "fall back to free-text input."
+// Otherwise it returns the envs formatted as `project/name`, sorted, with
+// [escEnvManualOption] appended as an escape hatch.
+//
+// Pulled out of [promptForESCEnvironment] so the data-shaping logic is
+// unit-testable without driving the survey/stdin interactions.
+func escEnvironmentChoices(
+	ctx context.Context, c insightsAccountNewClient, org string,
+) []string {
 	envs, _, err := c.ListESCEnvironments(ctx, org, "")
 	if err != nil || len(envs) == 0 {
-		// Best-effort: degrade silently to free-text on any error so a
-		// transient listing failure doesn't block account creation.
-		return free()
+		return nil
 	}
-
-	const enterManually = "[Enter manually]"
 	options := make([]string, 0, len(envs)+1)
 	for _, e := range envs {
 		options = append(options, e.Project+"/"+e.Name)
 	}
 	sort.Strings(options)
-	options = append(options, enterManually)
+	options = append(options, escEnvManualOption)
+	return options
+}
 
-	choice := ui.PromptUser("ESC environment", options, options[0], opts.Color)
-	if choice == "" || choice == enterManually {
-		return free()
+// escEnvPrompter is the small interface promptForESCEnvironment uses to
+// reach the UI. Splitting it out lets unit tests substitute stubs in place
+// of the survey-driven [ui.PromptUser]/[ui.PromptForValue] calls, which
+// otherwise block waiting on stdin.
+type escEnvPrompter struct {
+	// pick shows a picker over options and returns the chosen entry, or
+	// "" when the user dismissed the prompt.
+	pick func(options []string) string
+	// enter prompts the user to type an environment reference, with the
+	// usual non-empty validation.
+	enter func() (string, error)
+}
+
+// newDisplayPrompter wires the picker / free-text prompt up to the live UI
+// for production callers. The display options come from the cobra RunE so
+// the prompts inherit the user's global color settings.
+func newDisplayPrompter(opts display.Options) escEnvPrompter {
+	return escEnvPrompter{
+		pick: func(options []string) string {
+			return ui.PromptUser("ESC environment", options, options[0], opts.Color)
+		},
+		enter: func() (string, error) {
+			return ui.PromptForValue(
+				false,
+				"ESC environment (project/environment[@version])",
+				"", false,
+				nonEmptyValidator("an ESC environment reference"),
+				opts,
+			)
+		},
+	}
+}
+
+// promptForESCEnvironment offers a picker over the org's ESC environments
+// (the same set surfaced by `pulumi esc ls`). The list call is best-effort:
+// if it fails or returns no environments, the prompt degrades to free-text
+// input so an offline-ish or empty-org user can still proceed. The picker
+// always offers an "Enter manually" choice so users can specify a
+// `@version` suffix or any env the server doesn't yet list.
+func promptForESCEnvironment(
+	ctx context.Context, c insightsAccountNewClient, org string, p escEnvPrompter,
+) (string, error) {
+	options := escEnvironmentChoices(ctx, c, org)
+	if len(options) == 0 {
+		return p.enter()
+	}
+	choice := p.pick(options)
+	if choice == "" || choice == escEnvManualOption {
+		return p.enter()
 	}
 	return choice, nil
 }

--- a/pkg/cmd/pulumi/insights/insights_account_new.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new.go
@@ -1,0 +1,384 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// insightsAccountNewClient is the subset of cloud-API operations the `new`
+// command needs. Defined inside this package so unit tests can stub it without
+// touching the full HTTP client surface.
+type insightsAccountNewClient interface {
+	CreateInsightsAccount(
+		ctx context.Context, org, account string, req apitype.CreateInsightsAccountRequest,
+	) error
+	GetInsightsAccount(
+		ctx context.Context, org, account string,
+	) (apitype.InsightsAccount, error)
+}
+
+// accountNewClientFactory resolves the cloud client and the effective org for
+// the call. orgOverride wins when non-empty; otherwise the default org from
+// the cloud context is used. A helpful error is returned when the caller is
+// not logged in or no org can be determined.
+type accountNewClientFactory func(
+	ctx context.Context, orgOverride string,
+) (insightsAccountNewClient, string, error)
+
+// accountNewArgs holds the resolved flag values for `pulumi insights account
+// new`. Required values may be filled in interactively when the corresponding
+// flag isn't passed.
+type accountNewArgs struct {
+	org            string
+	provider       string
+	environment    string
+	scanSchedule   string
+	agentPoolID    string
+	providerConfig string
+}
+
+func newInsightsAccountNewCmd() *cobra.Command {
+	return newInsightsAccountNewCmdWith(nil)
+}
+
+// newInsightsAccountNewCmdWith builds the `pulumi insights account new`
+// command. factory produces the cloud client and resolves the effective org;
+// pass nil to use the production factory backed by [cloud.ResolveContext].
+func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Command {
+	args := accountNewArgs{}
+	var yes bool
+	output := outputflag.OutputFlag[insightsAccountRenderFunc]{
+		RenderForTerminal: renderInsightsAccountText,
+		RenderJSON:        renderInsightsAccountJSON,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "Create a new Insights account",
+		Long: "[EXPERIMENTAL] Create a new Pulumi Insights account.\n\n" +
+			"An Insights account represents a cloud provider account (e.g. AWS, Azure,\n" +
+			"GCP, OCI, Kubernetes) configured for resource discovery. The provider\n" +
+			"credentials are sourced from an ESC environment, referenced with\n" +
+			"--environment in the `project/environment[@version]` form.\n\n" +
+			"When run interactively, prompts for required values that aren't provided\n" +
+			"via flags. Pass --yes to fail fast on missing values instead of prompting.\n\n" +
+			"The organization defaults to the current default org and can be overridden\n" +
+			"with --org.",
+		Example: "  # Walk through prompts to create an account\n" +
+			"  pulumi insights account new prod-aws\n\n" +
+			"  # Create an AWS Insights account using credentials from an ESC environment\n" +
+			"  pulumi insights account new prod-aws \\\n" +
+			"      --provider aws --environment infra/prod-aws-creds\n\n" +
+			"  # Override the organization and schedule a daily scan\n" +
+			"  pulumi insights account new prod-aws --org acme \\\n" +
+			"      --provider aws --environment infra/prod-aws-creds \\\n" +
+			"      --scan-schedule daily\n\n" +
+			"  # Pass provider-specific configuration as inline JSON\n" +
+			"  pulumi insights account new prod-aws \\\n" +
+			"      --provider aws --environment infra/prod-aws-creds \\\n" +
+			"      --provider-config '{\"regions\":[\"us-east-1\",\"us-west-2\"]}'",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			if factory == nil {
+				factory = defaultAccountNewClientFactory
+			}
+			skipPrompts := yes || !cmdutil.Interactive()
+			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+			resolved, err := resolveAccountNewArgs(skipPrompts, args, opts)
+			if err != nil {
+				return err
+			}
+			return runInsightsAccountNew(
+				cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], resolved, output.Get(),
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "name"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"Organization that will own the Insights account (defaults to the current default org)")
+	cmd.Flags().StringVar(&args.provider, "provider", "",
+		"Cloud provider for the account. One of: aws, gcp, azure-native, oci, kubernetes")
+	cmd.Flags().StringVar(&args.environment, "environment", "",
+		"ESC environment containing provider credentials, "+
+			"in the form project/environment with an optional @version suffix")
+	cmd.Flags().StringVar(&args.scanSchedule, "scan-schedule", "",
+		"Automated scan schedule. One of: none, 12h, daily")
+	cmd.Flags().StringVar(&args.agentPoolID, "agent-pool-id", "",
+		"ID of the agent pool to run discovery workflows (defaults to the org's default pool)")
+	cmd.Flags().StringVar(&args.providerConfig, "provider-config", "",
+		"Provider-specific configuration as an inline JSON object (e.g. '{\"regions\":[\"us-east-1\"]}')")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
+		"Skip prompts; fail if any required value is missing")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+// resolveAccountNewArgs prompts for any required values not provided via
+// flags. When skipPrompts is true (--yes or non-interactive), missing values
+// return an error instead of prompting.
+func resolveAccountNewArgs(
+	skipPrompts bool, args accountNewArgs, opts display.Options,
+) (accountNewArgs, error) {
+	if strings.TrimSpace(args.provider) == "" {
+		if skipPrompts {
+			return args, errors.New("--provider is required")
+		}
+		// The server validates the enum, so we let unknown values through
+		// rather than hard-coding the list of providers in two places.
+		// Showing the documented options as prompt entries keeps the
+		// happy-path obvious.
+		args.provider = ui.PromptUserSkippable(
+			false, "Cloud provider",
+			[]string{"aws", "gcp", "azure-native", "oci", "kubernetes"},
+			"aws", opts.Color)
+	}
+	if strings.TrimSpace(args.environment) == "" {
+		if skipPrompts {
+			return args, errors.New("--environment is required")
+		}
+		env, err := ui.PromptForValue(
+			false,
+			"ESC environment (project/environment[@version])",
+			"", false,
+			nonEmptyValidator("an ESC environment reference"),
+			opts,
+		)
+		if err != nil {
+			return args, err
+		}
+		args.environment = env
+	}
+	return args, nil
+}
+
+// nonEmptyValidator returns a validator function suitable for
+// [ui.PromptForValue] that rejects empty strings with a helpful message.
+func nonEmptyValidator(what string) func(string) error {
+	return func(v string) error {
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%s is required", what)
+		}
+		return nil
+	}
+}
+
+// runInsightsAccountNew creates the account and then reads it back so the
+// caller can render the structure the new convention asks for. ctx and w are
+// decoupled from cobra so the function is straightforward to drive from
+// tests.
+func runInsightsAccountNew(
+	ctx context.Context,
+	w io.Writer,
+	factory accountNewClientFactory,
+	name string,
+	args accountNewArgs,
+	render insightsAccountRenderFunc,
+) error {
+	// Post-resolve sanity: required values must be set. These would already
+	// have been caught by resolveAccountNewArgs in the cobra path, but Run
+	// can be called directly from tests so we defend ourselves.
+	if strings.TrimSpace(args.provider) == "" {
+		return errors.New("--provider is required")
+	}
+	if strings.TrimSpace(args.environment) == "" {
+		return errors.New("--environment is required")
+	}
+
+	// Validate --provider-config eagerly so a malformed value surfaces
+	// locally rather than as a generic server-side 400. The server contract
+	// is "object optional," so non-object JSON is rejected here.
+	providerConfig, err := parseProviderConfig(args.providerConfig)
+	if err != nil {
+		return err
+	}
+
+	c, org, err := factory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	req := apitype.CreateInsightsAccountRequest{
+		Provider:       args.provider,
+		Environment:    args.environment,
+		ScanSchedule:   args.scanSchedule,
+		AgentPoolID:    args.agentPoolID,
+		ProviderConfig: providerConfig,
+	}
+	if err := c.CreateInsightsAccount(ctx, org, name, req); err != nil {
+		return fmt.Errorf("creating insights account: %w", err)
+	}
+
+	// The CreateAccount endpoint returns 204 No Content. The CLI convention
+	// for `new` commands is "respond with the edited structure," so we read
+	// the account back. If the read fails the account still exists — make
+	// that visible in the error so the user knows the create succeeded.
+	account, err := c.GetInsightsAccount(ctx, org, name)
+	if err != nil {
+		return fmt.Errorf(
+			"insights account %q was created in organization %q, "+
+				"but reading it back failed: %w\n"+
+				"use `pulumi insights account list` to verify",
+			name, org, err)
+	}
+
+	return render(w, account)
+}
+
+// parseProviderConfig validates that --provider-config is a JSON object (or
+// empty). The server's contract is "object optional," so non-object JSON
+// (numbers, strings, arrays) is rejected here rather than relying on the
+// server's error message, which is generic.
+func parseProviderConfig(raw string) (json.RawMessage, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
+		return nil, fmt.Errorf("invalid --provider-config: must be a JSON object: %w", err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+// insightsAccountRenderFunc is the renderer signature shared by `new` and
+// (when it lands) `get`. Both produce a single account in the same shape, so
+// the renderers belong with the first command that needs them.
+type insightsAccountRenderFunc func(w io.Writer, account apitype.InsightsAccount) error
+
+// renderInsightsAccountJSON writes the account as indented JSON. Indentation
+// matches the rest of the cli/cloud commands so jq-style scripting feels
+// consistent.
+func renderInsightsAccountJSON(w io.Writer, account apitype.InsightsAccount) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(account)
+}
+
+// renderInsightsAccountText writes a human-readable key/value view of the
+// account to w. The layout intentionally mirrors `stack schedule get` for
+// visual consistency across the cli/cloud command family.
+func renderInsightsAccountText(w io.Writer, a apitype.InsightsAccount) error {
+	line := func(label, value string) {
+		fmt.Fprintf(w, "%-22s %s\n", label+":", value)
+	}
+	provider := a.Provider
+	if a.ProviderVersion != "" {
+		provider = fmt.Sprintf("%s (v%s)", a.Provider, a.ProviderVersion)
+	}
+	scanSchedule := "off"
+	if a.ScheduledScanEnabled {
+		scanSchedule = "enabled"
+	}
+	agentPool := a.AgentPoolID
+	if agentPool == "" {
+		agentPool = "(default)"
+	}
+	owner := a.OwnedBy.Name
+	if a.OwnedBy.GitHubLogin != "" {
+		owner = fmt.Sprintf("%s (%s)", a.OwnedBy.Name, a.OwnedBy.GitHubLogin)
+	}
+
+	line("ID", a.ID)
+	line("Name", a.Name)
+	line("Owner", owner)
+	line("Provider", provider)
+	if a.ProviderEnvRef != "" {
+		line("Environment", a.ProviderEnvRef)
+	}
+	line("Scheduled scan", scanSchedule)
+	line("Agent pool", agentPool)
+
+	// ProviderConfig is schemaless from the CLI's perspective — its shape
+	// depends on which provider Insights is configured for, so we render
+	// it as indented JSON rather than guessing at known fields. We only
+	// print it when non-empty so an account without any provider-specific
+	// config doesn't show an empty section.
+	if len(a.ProviderConfig) > 0 {
+		// Pretty-print if it's valid JSON; otherwise fall back to the raw
+		// bytes so the user still sees what the service returned.
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, a.ProviderConfig, "", "  "); err == nil {
+			fmt.Fprintf(w, "Provider config:\n%s\n", pretty.String())
+		} else {
+			line("Provider config", string(a.ProviderConfig))
+		}
+	}
+
+	// ScanStatus is absent before the first scan completes; only render it
+	// when the server set one. We surface the most useful fields (status,
+	// finished, resource count) without dumping the entire job tree.
+	if a.ScanStatus != nil {
+		line("Scan status", a.ScanStatus.Status)
+		if a.ScanStatus.FinishedAt != nil && !a.ScanStatus.FinishedAt.IsZero() {
+			line("Last scan finished", a.ScanStatus.FinishedAt.UTC().Format(time.RFC3339))
+		}
+		if a.ScanStatus.ResourceCount > 0 {
+			line("Resources discovered", strconv.FormatInt(a.ScanStatus.ResourceCount, 10))
+		}
+	}
+	return nil
+}
+
+// defaultAccountNewClientFactory is the production wiring for
+// accountNewClientFactory. It parallels defaultClientFactory in
+// insights_resource_get.go and defaultAccountListClientFactory in
+// insights_account_list.go; the duplication is small enough not to justify a
+// shared helper yet, but a fourth command should consolidate.
+func defaultAccountNewClientFactory(
+	ctx context.Context, orgOverride string,
+) (insightsAccountNewClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}

--- a/pkg/cmd/pulumi/insights/insights_account_new.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -46,6 +47,12 @@ type insightsAccountNewClient interface {
 	GetInsightsAccount(
 		ctx context.Context, org, account string,
 	) (apitype.InsightsAccount, error)
+	// ListESCEnvironments backs the interactive environment picker. Returns
+	// a single page; the picker doesn't paginate — if a user has more envs
+	// than fit on a page, the "Enter manually" option covers them.
+	ListESCEnvironments(
+		ctx context.Context, org, continuationToken string,
+	) ([]apitype.ESCEnvironment, string, error)
 }
 
 // accountNewClientFactory resolves the cloud client and the effective org for
@@ -106,14 +113,21 @@ func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Comman
 			if factory == nil {
 				factory = defaultAccountNewClientFactory
 			}
+			ctx := cmd.Context()
+			// Resolve the cloud client and effective org up front so the
+			// interactive env picker can list the org's ESC environments.
+			c, org, err := factory(ctx, args.org)
+			if err != nil {
+				return err
+			}
 			skipPrompts := yes || !cmdutil.Interactive()
 			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-			resolved, err := resolveAccountNewArgs(skipPrompts, args, opts)
+			resolved, err := resolveAccountNewArgs(ctx, skipPrompts, c, org, args, opts)
 			if err != nil {
 				return err
 			}
 			return runInsightsAccountNew(
-				cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], resolved, output.Get(),
+				ctx, cmd.OutOrStdout(), c, org, posArgs[0], resolved, output.Get(),
 			)
 		},
 	}
@@ -145,9 +159,17 @@ func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Comman
 
 // resolveAccountNewArgs prompts for any required values not provided via
 // flags. When skipPrompts is true (--yes or non-interactive), missing values
-// return an error instead of prompting.
+// return an error instead of prompting. The ESC environment prompt asks the
+// service for the org's environments and presents them as a picker; if the
+// list call fails or comes back empty we silently fall back to free-text
+// input so the picker never blocks the user.
 func resolveAccountNewArgs(
-	skipPrompts bool, args accountNewArgs, opts display.Options,
+	ctx context.Context,
+	skipPrompts bool,
+	c insightsAccountNewClient,
+	org string,
+	args accountNewArgs,
+	opts display.Options,
 ) (accountNewArgs, error) {
 	if strings.TrimSpace(args.provider) == "" {
 		if skipPrompts {
@@ -166,19 +188,54 @@ func resolveAccountNewArgs(
 		if skipPrompts {
 			return args, errors.New("--environment is required")
 		}
-		env, err := ui.PromptForValue(
-			false,
-			"ESC environment (project/environment[@version])",
-			"", false,
-			nonEmptyValidator("an ESC environment reference"),
-			opts,
-		)
+		env, err := promptForESCEnvironment(ctx, c, org, opts)
 		if err != nil {
 			return args, err
 		}
 		args.environment = env
 	}
 	return args, nil
+}
+
+// promptForESCEnvironment offers a picker over the org's ESC environments
+// (the same set surfaced by `pulumi esc ls`). The list call is best-effort:
+// if it fails or returns no environments, the prompt degrades to free-text
+// input so an offline-ish or empty-org user can still proceed. The picker
+// always offers an "Enter manually..." choice so users can specify a
+// `@version` suffix or any env the server doesn't yet list.
+func promptForESCEnvironment(
+	ctx context.Context, c insightsAccountNewClient, org string, opts display.Options,
+) (string, error) {
+	free := func() (string, error) {
+		return ui.PromptForValue(
+			false,
+			"ESC environment (project/environment[@version])",
+			"", false,
+			nonEmptyValidator("an ESC environment reference"),
+			opts,
+		)
+	}
+
+	envs, _, err := c.ListESCEnvironments(ctx, org, "")
+	if err != nil || len(envs) == 0 {
+		// Best-effort: degrade silently to free-text on any error so a
+		// transient listing failure doesn't block account creation.
+		return free()
+	}
+
+	const enterManually = "[Enter manually]"
+	options := make([]string, 0, len(envs)+1)
+	for _, e := range envs {
+		options = append(options, e.Project+"/"+e.Name)
+	}
+	sort.Strings(options)
+	options = append(options, enterManually)
+
+	choice := ui.PromptUser("ESC environment", options, options[0], opts.Color)
+	if choice == "" || choice == enterManually {
+		return free()
+	}
+	return choice, nil
 }
 
 // nonEmptyValidator returns a validator function suitable for
@@ -195,12 +252,13 @@ func nonEmptyValidator(what string) func(string) error {
 // runInsightsAccountNew creates the account and then reads it back so the
 // caller can render the structure the new convention asks for. ctx and w are
 // decoupled from cobra so the function is straightforward to drive from
-// tests.
+// tests; c and org are pre-resolved by the caller (the cobra RunE) so the
+// env picker in resolveAccountNewArgs can share them.
 func runInsightsAccountNew(
 	ctx context.Context,
 	w io.Writer,
-	factory accountNewClientFactory,
-	name string,
+	c insightsAccountNewClient,
+	org, name string,
 	args accountNewArgs,
 	render insightsAccountRenderFunc,
 ) error {
@@ -218,11 +276,6 @@ func runInsightsAccountNew(
 	// locally rather than as a generic server-side 400. The server contract
 	// is "object optional," so non-object JSON is rejected here.
 	providerConfig, err := parseProviderConfig(args.providerConfig)
-	if err != nil {
-		return err
-	}
-
-	c, org, err := factory(ctx, args.org)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/insights/insights_account_new.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new.go
@@ -87,14 +87,8 @@ func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Comman
 		Use:   "new",
 		Short: "Create a new Insights account",
 		Long: "[EXPERIMENTAL] Create a new Pulumi Insights account.\n\n" +
-			"An Insights account represents a cloud provider account (e.g. AWS, Azure,\n" +
-			"GCP, OCI, Kubernetes) configured for resource discovery. The provider\n" +
-			"credentials are sourced from an ESC environment, referenced with\n" +
-			"--environment in the `project/environment[@version]` form.\n\n" +
-			"When run interactively, prompts for required values that aren't provided\n" +
-			"via flags. Pass --yes to fail fast on missing values instead of prompting.\n\n" +
-			"The organization defaults to the current default org and can be overridden\n" +
-			"with --org.",
+			"An Insights account represents a cloud provider account (e.g. AWS,\n" +
+			"Azure, GCP, OCI, Kubernetes) configured for resource discovery.",
 		Example: "  # Walk through prompts to create an account\n" +
 			"  pulumi insights account new prod-aws\n\n" +
 			"  # Create an AWS Insights account using credentials from an ESC environment\n" +
@@ -144,7 +138,7 @@ func newInsightsAccountNewCmdWith(factory accountNewClientFactory) *cobra.Comman
 		"Provider-specific configuration as an inline JSON object (e.g. '{\"regions\":[\"us-east-1\"]}')")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
 		"Skip prompts; fail if any required value is missing")
-	outputflag.VarP(cmd.Flags(), &output)
+	outputflag.Var(cmd.Flags(), &output)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_account_new_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new_test.go
@@ -504,3 +504,167 @@ func TestNewInsightsAccountNewCmd_NilFactoryUsesDefault(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, "new", cmd.Name())
 }
+
+func TestESCEnvironmentChoices(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when listing errors", func(t *testing.T) {
+		t.Parallel()
+		// The picker treats any listing error as "fall back to free-text,"
+		// so the helper must return nil so the caller can detect that.
+		client := &mockInsightsAccountNewClient{listEnvsErr: errors.New("boom")}
+		assert.Nil(t, escEnvironmentChoices(t.Context(), client, "acme"))
+	})
+
+	t.Run("returns nil when listing is empty", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{listEnvs: nil}
+		assert.Nil(t, escEnvironmentChoices(t.Context(), client, "acme"))
+	})
+
+	t.Run("formats, sorts, and appends the manual option", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{listEnvs: []apitype.ESCEnvironment{
+			// Intentionally unsorted to confirm we sort.
+			{Project: "platform", Name: "prod"},
+			{Project: "infra", Name: "dev"},
+			{Project: "infra", Name: "prod-aws-creds"},
+		}}
+		got := escEnvironmentChoices(t.Context(), client, "acme")
+		assert.Equal(t, []string{
+			"infra/dev",
+			"infra/prod-aws-creds",
+			"platform/prod",
+			escEnvManualOption,
+		}, got)
+	})
+
+	t.Run("passes the org through to the listing call", func(t *testing.T) {
+		t.Parallel()
+		var got string
+		client := &mockInsightsAccountNewClient{
+			listEnvs:     []apitype.ESCEnvironment{{Project: "p", Name: "e"}},
+			listEnvsCall: &got,
+		}
+		_ = escEnvironmentChoices(t.Context(), client, "the-org")
+		assert.Equal(t, "the-org", got)
+	})
+}
+
+func TestPromptForESCEnvironment(t *testing.T) {
+	t.Parallel()
+
+	// scriptedPrompter records the picker's option list (for assertions
+	// against `escEnvironmentChoices`) and replays a canned answer for
+	// each hook so we can drive every branch from a unit test.
+	scriptedPrompter := func(pickResult, enterResult string, enterErr error) (escEnvPrompter, *[]string, *int, *int) {
+		var (
+			pickedOptions []string
+			pickCalls     int
+			enterCalls    int
+		)
+		p := escEnvPrompter{
+			pick: func(options []string) string {
+				pickedOptions = options
+				pickCalls++
+				return pickResult
+			},
+			enter: func() (string, error) {
+				enterCalls++
+				return enterResult, enterErr
+			},
+		}
+		return p, &pickedOptions, &pickCalls, &enterCalls
+	}
+
+	t.Run("empty list falls back to free-text", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{} // listEnvs nil
+		p, _, pickCalls, enterCalls := scriptedPrompter("", "infra/dev", nil)
+		got, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.NoError(t, err)
+		assert.Equal(t, "infra/dev", got)
+		assert.Zero(t, *pickCalls)
+		assert.Equal(t, 1, *enterCalls)
+	})
+
+	t.Run("listing error falls back to free-text", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{listEnvsErr: errors.New("boom")}
+		p, _, pickCalls, enterCalls := scriptedPrompter("", "infra/dev", nil)
+		got, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.NoError(t, err)
+		assert.Equal(t, "infra/dev", got)
+		assert.Zero(t, *pickCalls)
+		assert.Equal(t, 1, *enterCalls)
+	})
+
+	t.Run("picker returns the user's selection", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{listEnvs: []apitype.ESCEnvironment{
+			{Project: "infra", Name: "dev"},
+			{Project: "infra", Name: "prod"},
+		}}
+		p, options, pickCalls, enterCalls := scriptedPrompter("infra/prod", "", nil)
+		got, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.NoError(t, err)
+		assert.Equal(t, "infra/prod", got)
+		assert.Equal(t, 1, *pickCalls)
+		assert.Zero(t, *enterCalls)
+		// The picker is fed the sorted formatted list plus the manual option.
+		assert.Equal(t, []string{"infra/dev", "infra/prod", escEnvManualOption}, *options)
+	})
+
+	t.Run("manual choice falls back to free-text", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{listEnvs: []apitype.ESCEnvironment{
+			{Project: "infra", Name: "dev"},
+		}}
+		p, _, pickCalls, enterCalls := scriptedPrompter(
+			escEnvManualOption, "infra/dev@2", nil,
+		)
+		got, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.NoError(t, err)
+		assert.Equal(t, "infra/dev@2", got)
+		assert.Equal(t, 1, *pickCalls)
+		assert.Equal(t, 1, *enterCalls)
+	})
+
+	t.Run("dismissed picker (empty choice) falls back to free-text", func(t *testing.T) {
+		t.Parallel()
+		// survey returns "" when the user hits Ctrl-C or the parent
+		// process closes stdin; the picker treats it as "user wants
+		// out, ask for free-text input instead" rather than aborting.
+		client := &mockInsightsAccountNewClient{listEnvs: []apitype.ESCEnvironment{
+			{Project: "infra", Name: "dev"},
+		}}
+		p, _, _, enterCalls := scriptedPrompter("", "infra/dev", nil)
+		got, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.NoError(t, err)
+		assert.Equal(t, "infra/dev", got)
+		assert.Equal(t, 1, *enterCalls)
+	})
+
+	t.Run("free-text error propagates", func(t *testing.T) {
+		t.Parallel()
+		client := &mockInsightsAccountNewClient{} // empty → free-text path
+		p, _, _, _ := scriptedPrompter("", "", errors.New("stdin closed"))
+		_, err := promptForESCEnvironment(t.Context(), client, "acme", p)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stdin closed")
+	})
+}
+
+func TestNonEmptyValidator(t *testing.T) {
+	t.Parallel()
+
+	validator := nonEmptyValidator("a thing")
+	require.NoError(t, validator("anything"))
+	// Whitespace-only counts as empty so the prompt re-asks instead of
+	// accepting an unusable value.
+	for _, empty := range []string{"", " ", "\t\n"} {
+		err := validator(empty)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "a thing is required")
+	}
+}

--- a/pkg/cmd/pulumi/insights/insights_account_new_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new_test.go
@@ -1,0 +1,505 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedAccountCall records the arguments a single CreateInsightsAccount
+// call received, so tests can assert that flags propagate correctly to the
+// cloud client.
+type capturedAccountCall struct {
+	org     string
+	account string
+	req     apitype.CreateInsightsAccountRequest
+}
+
+// mockInsightsAccountNewClient stubs insightsAccountNewClient. Each instance
+// records the most recent Create invocation and replays a fixed GetAccount
+// response (or an error on either method) so tests can drive each branch.
+type mockInsightsAccountNewClient struct {
+	getAccount apitype.InsightsAccount
+	createErr  error
+	getErr     error
+	captured   *capturedAccountCall
+}
+
+func (m *mockInsightsAccountNewClient) CreateInsightsAccount(
+	_ context.Context, org, account string, req apitype.CreateInsightsAccountRequest,
+) error {
+	if m.captured != nil {
+		*m.captured = capturedAccountCall{org: org, account: account, req: req}
+	}
+	return m.createErr
+}
+
+func (m *mockInsightsAccountNewClient) GetInsightsAccount(
+	_ context.Context, _, _ string,
+) (apitype.InsightsAccount, error) {
+	if m.getErr != nil {
+		return apitype.InsightsAccount{}, m.getErr
+	}
+	return m.getAccount, nil
+}
+
+// stubAccountNewFactory returns an accountNewClientFactory that always yields
+// client and effectiveOrg. If orgOverride is non-empty, the override wins —
+// matching production behaviour so per-call --org assertions still work in
+// the cobra-level test.
+func stubAccountNewFactory(client insightsAccountNewClient, defaultOrg string) accountNewClientFactory {
+	return func(_ context.Context, orgOverride string) (insightsAccountNewClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return client, org, nil
+	}
+}
+
+// failingAccountNewFactory returns a factory that always errors. Useful to
+// cover the not-logged-in / missing-org branches.
+func failingAccountNewFactory(err error) accountNewClientFactory {
+	return func(_ context.Context, _ string) (insightsAccountNewClient, string, error) {
+		return nil, "", err
+	}
+}
+
+// sampleNewAccount is a representative successful read-back. Tests that don't
+// care about the renderer reuse it to keep test setup compact.
+func sampleNewAccount() apitype.InsightsAccount {
+	finished := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	return apitype.InsightsAccount{
+		ID:                   "acc-123",
+		Name:                 "prod-aws",
+		Provider:             "aws",
+		ProviderVersion:      "6.0.0",
+		ProviderEnvRef:       "infra/prod-aws-creds",
+		ScheduledScanEnabled: true,
+		AgentPoolID:          "pool-1",
+		ProviderConfig:       json.RawMessage(`{"regions":["us-east-1"]}`),
+		OwnedBy: apitype.InsightsAccountOwner{
+			Name:        "Jane Doe",
+			GitHubLogin: "jdoe",
+			AvatarURL:   "https://example.com/avatar.png",
+		},
+		ScanStatus: &apitype.InsightsAccountScanStatus{
+			ID:            "scan-1",
+			OrgID:         "org-1",
+			UserID:        "user-1",
+			Status:        "succeeded",
+			ResourceCount: 42,
+			FinishedAt:    &finished,
+		},
+	}
+}
+
+func TestRunInsightsAccountNew_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
+	var out bytes.Buffer
+	err := runInsightsAccountNew(
+		t.Context(), &out, stubAccountNewFactory(client, "acme"), "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/prod-aws-creds"},
+		renderInsightsAccountText,
+	)
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "ID:")
+	assert.Contains(t, output, "acc-123")
+	assert.Contains(t, output, "Owner:")
+	assert.Contains(t, output, "Jane Doe (jdoe)")
+	assert.Contains(t, output, "Provider:")
+	assert.Contains(t, output, "aws (v6.0.0)")
+	assert.Contains(t, output, "Environment:")
+	assert.Contains(t, output, "infra/prod-aws-creds")
+	assert.Contains(t, output, "Scheduled scan:")
+	assert.Contains(t, output, "Scan status:")
+	assert.Contains(t, output, "succeeded")
+	assert.Contains(t, output, "Resources discovered:")
+	assert.Contains(t, output, "42")
+}
+
+func TestRunInsightsAccountNew_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
+	var out bytes.Buffer
+	err := runInsightsAccountNew(
+		t.Context(), &out, stubAccountNewFactory(client, "acme"), "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/prod-aws-creds"},
+		renderInsightsAccountJSON,
+	)
+	require.NoError(t, err)
+
+	var got apitype.InsightsAccount
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	// ProviderConfig is `json.RawMessage`, so the encoder may re-emit the
+	// bytes with normalized whitespace. Compare it semantically and the
+	// rest of the struct field-by-field.
+	want := sampleNewAccount()
+	assert.JSONEq(t, string(want.ProviderConfig), string(got.ProviderConfig))
+	want.ProviderConfig, got.ProviderConfig = nil, nil
+	assert.Equal(t, want, got)
+}
+
+func TestRunInsightsAccountNew_RequestPropagation(t *testing.T) {
+	t.Parallel()
+
+	var captured capturedAccountCall
+	client := &mockInsightsAccountNewClient{
+		getAccount: sampleNewAccount(),
+		captured:   &captured,
+	}
+	err := runInsightsAccountNew(
+		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		accountNewArgs{
+			provider:       "gcp",
+			environment:    "infra/gcp-creds@2",
+			scanSchedule:   "12h",
+			agentPoolID:    "pool-xyz",
+			providerConfig: `{"project":"my-proj"}`,
+		},
+		renderInsightsAccountText,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, capturedAccountCall{
+		org:     "acme",
+		account: "prod-aws",
+		req: apitype.CreateInsightsAccountRequest{
+			Provider:       "gcp",
+			Environment:    "infra/gcp-creds@2",
+			ScanSchedule:   "12h",
+			AgentPoolID:    "pool-xyz",
+			ProviderConfig: json.RawMessage(`{"project":"my-proj"}`),
+		},
+	}, captured)
+}
+
+func TestRunInsightsAccountNew_OrgOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       accountNewArgs
+		defaultOrg string
+		wantOrg    string
+	}{
+		{
+			name:       "default org used when --org omitted",
+			args:       accountNewArgs{provider: "aws", environment: "infra/creds"},
+			defaultOrg: "acme",
+			wantOrg:    "acme",
+		},
+		{
+			name: "--org overrides default",
+			args: accountNewArgs{
+				org: "other-co", provider: "aws", environment: "infra/creds",
+			},
+			defaultOrg: "acme",
+			wantOrg:    "other-co",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured capturedAccountCall
+			client := &mockInsightsAccountNewClient{
+				getAccount: sampleNewAccount(),
+				captured:   &captured,
+			}
+			err := runInsightsAccountNew(
+				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, tt.defaultOrg),
+				"prod-aws", tt.args, renderInsightsAccountText,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOrg, captured.org)
+			assert.Equal(t, "prod-aws", captured.account)
+		})
+	}
+}
+
+func TestRunInsightsAccountNew_MissingRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args accountNewArgs
+		want string
+	}{
+		{
+			name: "missing provider",
+			args: accountNewArgs{environment: "infra/creds"},
+			want: "--provider is required",
+		},
+		{
+			name: "missing environment",
+			args: accountNewArgs{provider: "aws"},
+			want: "--environment is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
+			err := runInsightsAccountNew(
+				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"),
+				"prod-aws", tt.args, renderInsightsAccountText,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestRunInsightsAccountNew_InvalidProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "garbage", raw: "not json"},
+		// JSON scalars and arrays are not objects — the server contract is
+		// "object optional," so we reject early with a clear message.
+		{name: "scalar", raw: `"a string"`},
+		{name: "array", raw: `["a","b"]`},
+		{name: "number", raw: `42`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
+			err := runInsightsAccountNew(
+				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"),
+				"prod-aws",
+				accountNewArgs{provider: "aws", environment: "infra/creds", providerConfig: tt.raw},
+				renderInsightsAccountText,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid --provider-config")
+		})
+	}
+}
+
+func TestRunInsightsAccountNew_CreateError(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountNewClient{createErr: errors.New("404 environment not found")}
+	err := runInsightsAccountNew(
+		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/missing"},
+		renderInsightsAccountText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating insights account")
+	assert.Contains(t, err.Error(), "404 environment not found")
+}
+
+func TestRunInsightsAccountNew_ReadBackError(t *testing.T) {
+	t.Parallel()
+
+	// Create succeeds but the follow-up GET fails. The error message must
+	// make clear that the account was created so the user knows to use
+	// `list` to verify.
+	client := &mockInsightsAccountNewClient{getErr: errors.New("503 service unavailable")}
+	err := runInsightsAccountNew(
+		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/creds"},
+		renderInsightsAccountText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `account "prod-aws" was created`)
+	assert.Contains(t, err.Error(), `organization "acme"`)
+	assert.Contains(t, err.Error(), "503 service unavailable")
+	assert.Contains(t, err.Error(), "pulumi insights account list")
+}
+
+func TestRunInsightsAccountNew_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	err := runInsightsAccountNew(
+		t.Context(), &bytes.Buffer{},
+		failingAccountNewFactory(errors.New("not logged in")), "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/creds"},
+		renderInsightsAccountText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestRenderInsightsAccountText_OmitsAbsentFields(t *testing.T) {
+	t.Parallel()
+
+	account := apitype.InsightsAccount{
+		ID:       "acc-123",
+		Name:     "prod-aws",
+		Provider: "aws",
+		// No ProviderVersion, ProviderEnvRef, ProviderConfig, ScanStatus.
+		OwnedBy: apitype.InsightsAccountOwner{Name: "Jane Doe"},
+	}
+	var out bytes.Buffer
+	require.NoError(t, renderInsightsAccountText(&out, account))
+
+	output := out.String()
+	// Required fields are always present.
+	assert.Contains(t, output, "Provider:")
+	assert.Contains(t, output, "aws")
+	// Optional sections are suppressed; matching the bare label avoids
+	// accidentally tripping on `Provider:` (the required field) when
+	// looking for `Provider config:`.
+	assert.NotContains(t, output, "Environment:")
+	assert.NotContains(t, output, "Provider config:")
+	assert.NotContains(t, output, "Scan status:")
+	// Provider without a version doesn't get the "(v...)" suffix.
+	assert.NotContains(t, output, "(v")
+	// Agent pool falls back to "(default)" when unset rather than blank.
+	assert.Contains(t, output, "(default)")
+}
+
+func TestResolveAccountNewArgs_SkipPromptsRequiresFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args accountNewArgs
+		want string
+	}{
+		{
+			name: "missing provider",
+			args: accountNewArgs{environment: "infra/creds"},
+			want: "--provider is required",
+		},
+		{
+			name: "missing environment",
+			args: accountNewArgs{provider: "aws"},
+			want: "--environment is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveAccountNewArgs(true, tt.args, display.Options{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestResolveAccountNewArgs_PassesThroughCompleteArgs(t *testing.T) {
+	t.Parallel()
+
+	// When both required flags are already set, resolve is a no-op
+	// regardless of skipPrompts. This covers the happy path the cobra
+	// RunE follows when the user passed everything on the command line.
+	args := accountNewArgs{provider: "aws", environment: "infra/creds"}
+	got, err := resolveAccountNewArgs(true, args, display.Options{})
+	require.NoError(t, err)
+	assert.Equal(t, args, got)
+}
+
+func TestNewInsightsAccountNewCmd_FlagBinding(t *testing.T) {
+	t.Parallel()
+
+	var captured capturedAccountCall
+	client := &mockInsightsAccountNewClient{
+		getAccount: sampleNewAccount(),
+		captured:   &captured,
+	}
+	cmd := newInsightsAccountNewCmdWith(stubAccountNewFactory(client, "acme"))
+	assert.Equal(t, "new", cmd.Name())
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--org", "other-co",
+		"--provider", "aws",
+		"--environment", "infra/prod-aws-creds@3",
+		"--scan-schedule", "daily",
+		"--agent-pool-id", "pool-1",
+		"--provider-config", `{"regions":["us-east-1"]}`,
+		"--output", "json",
+		// --yes ensures the test passes even when the harness happens to
+		// have an interactive stdin (otherwise resolveAccountNewArgs would
+		// try to prompt for confirmation of values already on the command
+		// line, which would block).
+		"--yes",
+		"prod-aws",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	assert.Equal(t, capturedAccountCall{
+		org:     "other-co",
+		account: "prod-aws",
+		req: apitype.CreateInsightsAccountRequest{
+			Provider:       "aws",
+			Environment:    "infra/prod-aws-creds@3",
+			ScanSchedule:   "daily",
+			AgentPoolID:    "pool-1",
+			ProviderConfig: json.RawMessage(`{"regions":["us-east-1"]}`),
+		},
+	}, captured)
+
+	// Output is JSON, so the buffer parses cleanly back to InsightsAccount.
+	var got apitype.InsightsAccount
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, "prod-aws", got.Name)
+}
+
+func TestNewInsightsAccountNewCmd_YesSkipsPrompts(t *testing.T) {
+	t.Parallel()
+
+	// With --yes and a required flag missing, the command fails fast with
+	// the matching "required" error rather than blocking on a prompt.
+	cmd := newInsightsAccountNewCmdWith(
+		stubAccountNewFactory(&mockInsightsAccountNewClient{}, "acme"),
+	)
+	cmd.SetArgs([]string{"--yes", "--provider", "aws", "prod-aws"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--environment is required")
+}
+
+func TestNewInsightsAccountNewCmd_NilFactoryUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	// Passing nil installs the production factory; we only check the
+	// command is well-formed without invoking it, since the default
+	// factory would hit the real cloud context.
+	cmd := newInsightsAccountNewCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "new", cmd.Name())
+}

--- a/pkg/cmd/pulumi/insights/insights_account_new_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_new_test.go
@@ -40,11 +40,16 @@ type capturedAccountCall struct {
 // mockInsightsAccountNewClient stubs insightsAccountNewClient. Each instance
 // records the most recent Create invocation and replays a fixed GetAccount
 // response (or an error on either method) so tests can drive each branch.
+// listEnvs / listEnvsErr drive the optional environment-picker path used by
+// resolveAccountNewArgs.
 type mockInsightsAccountNewClient struct {
-	getAccount apitype.InsightsAccount
-	createErr  error
-	getErr     error
-	captured   *capturedAccountCall
+	getAccount   apitype.InsightsAccount
+	createErr    error
+	getErr       error
+	listEnvs     []apitype.ESCEnvironment
+	listEnvsErr  error
+	captured     *capturedAccountCall
+	listEnvsCall *string // optional: captures the org passed to ListESCEnvironments
 }
 
 func (m *mockInsightsAccountNewClient) CreateInsightsAccount(
@@ -63,6 +68,18 @@ func (m *mockInsightsAccountNewClient) GetInsightsAccount(
 		return apitype.InsightsAccount{}, m.getErr
 	}
 	return m.getAccount, nil
+}
+
+func (m *mockInsightsAccountNewClient) ListESCEnvironments(
+	_ context.Context, org, _ string,
+) ([]apitype.ESCEnvironment, string, error) {
+	if m.listEnvsCall != nil {
+		*m.listEnvsCall = org
+	}
+	if m.listEnvsErr != nil {
+		return nil, "", m.listEnvsErr
+	}
+	return m.listEnvs, "", nil
 }
 
 // stubAccountNewFactory returns an accountNewClientFactory that always yields
@@ -122,7 +139,7 @@ func TestRunInsightsAccountNew_DefaultOutput(t *testing.T) {
 	client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
 	var out bytes.Buffer
 	err := runInsightsAccountNew(
-		t.Context(), &out, stubAccountNewFactory(client, "acme"), "prod-aws",
+		t.Context(), &out, client, "acme", "prod-aws",
 		accountNewArgs{provider: "aws", environment: "infra/prod-aws-creds"},
 		renderInsightsAccountText,
 	)
@@ -150,7 +167,7 @@ func TestRunInsightsAccountNew_JSONOutput(t *testing.T) {
 	client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
 	var out bytes.Buffer
 	err := runInsightsAccountNew(
-		t.Context(), &out, stubAccountNewFactory(client, "acme"), "prod-aws",
+		t.Context(), &out, client, "acme", "prod-aws",
 		accountNewArgs{provider: "aws", environment: "infra/prod-aws-creds"},
 		renderInsightsAccountJSON,
 	)
@@ -176,7 +193,7 @@ func TestRunInsightsAccountNew_RequestPropagation(t *testing.T) {
 		captured:   &captured,
 	}
 	err := runInsightsAccountNew(
-		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		t.Context(), &bytes.Buffer{}, client, "acme", "prod-aws",
 		accountNewArgs{
 			provider:       "gcp",
 			environment:    "infra/gcp-creds@2",
@@ -201,48 +218,27 @@ func TestRunInsightsAccountNew_RequestPropagation(t *testing.T) {
 	}, captured)
 }
 
-func TestRunInsightsAccountNew_OrgOverride(t *testing.T) {
+func TestRunInsightsAccountNew_PassesOrgAndNameToClient(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		args       accountNewArgs
-		defaultOrg string
-		wantOrg    string
-	}{
-		{
-			name:       "default org used when --org omitted",
-			args:       accountNewArgs{provider: "aws", environment: "infra/creds"},
-			defaultOrg: "acme",
-			wantOrg:    "acme",
-		},
-		{
-			name: "--org overrides default",
-			args: accountNewArgs{
-				org: "other-co", provider: "aws", environment: "infra/creds",
-			},
-			defaultOrg: "acme",
-			wantOrg:    "other-co",
-		},
+	// runInsightsAccountNew is called by the cobra RunE with an already-
+	// resolved org (the factory in RunE applies any --org override). This
+	// test just verifies that whatever org/name the caller hands in lands
+	// on the CreateInsightsAccount call. Cobra-level coverage of the
+	// --org override lives in TestNewInsightsAccountNewCmd_FlagBinding.
+	var captured capturedAccountCall
+	client := &mockInsightsAccountNewClient{
+		getAccount: sampleNewAccount(),
+		captured:   &captured,
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			var captured capturedAccountCall
-			client := &mockInsightsAccountNewClient{
-				getAccount: sampleNewAccount(),
-				captured:   &captured,
-			}
-			err := runInsightsAccountNew(
-				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, tt.defaultOrg),
-				"prod-aws", tt.args, renderInsightsAccountText,
-			)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantOrg, captured.org)
-			assert.Equal(t, "prod-aws", captured.account)
-		})
-	}
+	err := runInsightsAccountNew(
+		t.Context(), &bytes.Buffer{}, client, "other-co", "prod-aws",
+		accountNewArgs{provider: "aws", environment: "infra/creds"},
+		renderInsightsAccountText,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "other-co", captured.org)
+	assert.Equal(t, "prod-aws", captured.account)
 }
 
 func TestRunInsightsAccountNew_MissingRequired(t *testing.T) {
@@ -270,8 +266,8 @@ func TestRunInsightsAccountNew_MissingRequired(t *testing.T) {
 			t.Parallel()
 			client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
 			err := runInsightsAccountNew(
-				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"),
-				"prod-aws", tt.args, renderInsightsAccountText,
+				t.Context(), &bytes.Buffer{}, client, "acme", "prod-aws",
+				tt.args, renderInsightsAccountText,
 			)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.want)
@@ -299,8 +295,7 @@ func TestRunInsightsAccountNew_InvalidProviderConfig(t *testing.T) {
 			t.Parallel()
 			client := &mockInsightsAccountNewClient{getAccount: sampleNewAccount()}
 			err := runInsightsAccountNew(
-				t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"),
-				"prod-aws",
+				t.Context(), &bytes.Buffer{}, client, "acme", "prod-aws",
 				accountNewArgs{provider: "aws", environment: "infra/creds", providerConfig: tt.raw},
 				renderInsightsAccountText,
 			)
@@ -315,7 +310,7 @@ func TestRunInsightsAccountNew_CreateError(t *testing.T) {
 
 	client := &mockInsightsAccountNewClient{createErr: errors.New("404 environment not found")}
 	err := runInsightsAccountNew(
-		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		t.Context(), &bytes.Buffer{}, client, "acme", "prod-aws",
 		accountNewArgs{provider: "aws", environment: "infra/missing"},
 		renderInsightsAccountText,
 	)
@@ -332,7 +327,7 @@ func TestRunInsightsAccountNew_ReadBackError(t *testing.T) {
 	// `list` to verify.
 	client := &mockInsightsAccountNewClient{getErr: errors.New("503 service unavailable")}
 	err := runInsightsAccountNew(
-		t.Context(), &bytes.Buffer{}, stubAccountNewFactory(client, "acme"), "prod-aws",
+		t.Context(), &bytes.Buffer{}, client, "acme", "prod-aws",
 		accountNewArgs{provider: "aws", environment: "infra/creds"},
 		renderInsightsAccountText,
 	)
@@ -343,15 +338,17 @@ func TestRunInsightsAccountNew_ReadBackError(t *testing.T) {
 	assert.Contains(t, err.Error(), "pulumi insights account list")
 }
 
-func TestRunInsightsAccountNew_FactoryError(t *testing.T) {
+func TestNewInsightsAccountNewCmd_FactoryError(t *testing.T) {
 	t.Parallel()
 
-	err := runInsightsAccountNew(
-		t.Context(), &bytes.Buffer{},
-		failingAccountNewFactory(errors.New("not logged in")), "prod-aws",
-		accountNewArgs{provider: "aws", environment: "infra/creds"},
-		renderInsightsAccountText,
-	)
+	// With the cobra RunE responsible for calling the factory, factory
+	// failures surface through cobra rather than runInsightsAccountNew.
+	cmd := newInsightsAccountNewCmdWith(failingAccountNewFactory(errors.New("not logged in")))
+	cmd.SetArgs([]string{"--yes", "--provider", "aws", "--environment", "infra/creds", "prod-aws"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	err := cmd.ExecuteContext(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
@@ -408,7 +405,11 @@ func TestResolveAccountNewArgs_SkipPromptsRequiresFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := resolveAccountNewArgs(true, tt.args, display.Options{})
+			// skipPrompts=true short-circuits before the client is touched,
+			// so a nil client is fine here.
+			_, err := resolveAccountNewArgs(
+				t.Context(), true, nil, "acme", tt.args, display.Options{},
+			)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.want)
 		})
@@ -422,7 +423,7 @@ func TestResolveAccountNewArgs_PassesThroughCompleteArgs(t *testing.T) {
 	// regardless of skipPrompts. This covers the happy path the cobra
 	// RunE follows when the user passed everything on the command line.
 	args := accountNewArgs{provider: "aws", environment: "infra/creds"}
-	got, err := resolveAccountNewArgs(true, args, display.Options{})
+	got, err := resolveAccountNewArgs(t.Context(), true, nil, "acme", args, display.Options{})
 	require.NoError(t, err)
 	assert.Equal(t, args, got)
 }

--- a/sdk/go/common/apitype/esc.go
+++ b/sdk/go/common/apitype/esc.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// ESCEnvironment is a single Pulumi ESC environment as returned by the ESC
+// `ListEnvironments` endpoint (`GET /api/esc/environments/{orgName}`). The
+// shape mirrors the OrgEnvironment schema used by the `pulumi esc ls` CLI.
+type ESCEnvironment struct {
+	// Organization is the org that owns the environment.
+	Organization string `json:"organization,omitempty"`
+	// Project is the ESC project the environment lives under.
+	Project string `json:"project,omitempty"`
+	// Name is the human-readable name of the environment within the project.
+	Name string `json:"name,omitempty"`
+}
+
+// ListESCEnvironmentsResponse is the envelope returned by the ESC
+// ListEnvironments endpoint. NextToken is empty on the last page.
+type ListESCEnvironmentsResponse struct {
+	Environments []ESCEnvironment `json:"environments,omitempty"`
+	NextToken    string           `json:"nextToken,omitempty"`
+}

--- a/sdk/go/common/apitype/insights.go
+++ b/sdk/go/common/apitype/insights.go
@@ -19,6 +19,32 @@ import (
 	"time"
 )
 
+// CreateInsightsAccountRequest is the body sent to the Pulumi Insights
+// CreateAccount endpoint. The shape mirrors the OpenAPI schema of the same
+// name in the Pulumi Cloud REST API.
+//
+// Both required fields (Provider, Environment) are server-validated; the CLI
+// surfaces the validation error rather than re-checking the enum locally.
+type CreateInsightsAccountRequest struct {
+	// Provider is the cloud provider the account discovers resources from.
+	// Server-side enum: aws, gcp, azure-native, oci, kubernetes.
+	Provider string `json:"provider"`
+	// Environment is the ESC environment reference holding provider
+	// credentials, in the form `project/environment` with an optional
+	// `@version` suffix.
+	Environment string `json:"environment"`
+	// ScanSchedule controls automated discovery scans. Server-side enum:
+	// none, 12h, daily. Empty means "use the server default."
+	ScanSchedule string `json:"scanSchedule,omitempty"`
+	// AgentPoolID selects an agent pool for discovery workflows. Empty
+	// means the org's default pool.
+	AgentPoolID string `json:"agentPoolID,omitempty"`
+	// ProviderConfig is provider-specific configuration (e.g. the list of
+	// regions to scan). The shape is provider-dependent; the CLI passes it
+	// through verbatim as JSON.
+	ProviderConfig json.RawMessage `json:"providerConfig,omitempty"`
+}
+
 // InsightsResourceWithVersion is a single discovered resource as returned by the
 // Pulumi Insights ReadResource endpoint. The shape mirrors the OpenAPI schema of
 // the same name in the Pulumi Cloud REST API.


### PR DESCRIPTION
```
bin/pulumi insights account new test-account --org pat-staging-org --provider aws --environment cloud-cli-fixture/env
ID:                    f162f900-6f93-4dd5-84c1-495fd669f3ad
Name:                  test-account
Owner:                  (v-tharding-pulumi-com)
Provider:              aws
Environment:           cloud-cli-fixture/env
Scheduled scan:        off
Agent pool:            (default)
Provider config:
{
  "regions": []
}
Scan status:
```

```json
{
  "id": "c4f9818f-c48b-438e-9566-16de768be246",
  "name": "test-account-2",
  "provider": "aws",
  "providerEnvRef": "cloud-cli-fixture/env",
  "scheduledScanEnabled": false,
  "providerConfig": {
    "regions": []
  },
  "ownedBy": {
    "name": "",
    "githubLogin": "v-tharding-pulumi-com",
    "avatarUrl": "https://api.pulumi-staging.io/static/avatars/V-88C2B6.png"
  },
  "scanStatus": {
    "id": "",
    "orgId": "",
    "userId": "",
    "status": "",
    "startedAt": "0001-01-01T00:00:00Z",
    "finishedAt": null,
    "lastUpdatedAt": "0001-01-01T00:00:00Z",
    "jobTimeout": "0001-01-01T00:00:00Z"
  }
}
```

Closes #22979.
