### PR TITLE
Mark new placeholder commands as experimental

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_cmds.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cmds.go
@@ -36,6 +36,7 @@ func newDeploymentListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List deployments for a stack",
+		Long:   "[EXPERIMENTAL] List deployments for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -61,6 +62,7 @@ func newDeploymentGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Get details for a specific deployment",
+		Long:   "[EXPERIMENTAL] Get details for a specific deployment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -87,7 +89,7 @@ func newDeploymentCancelCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "cancel",
 		Short:  "Cancel an in-progress deployment",
-		Long: "Cancel an in-progress deployment.\n" +
+		Long: "[EXPERIMENTAL] Cancel an in-progress deployment.\n" +
 			"\n" +
 			"Canceling a deployment is a dangerous action and may leave the stack in\n" +
 			"an inconsistent state if canceled during the execution of a Pulumi operation.",
@@ -124,6 +126,7 @@ func newDeploymentLogCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "log",
 		Short:  "Retrieve execution logs for a deployment",
+		Long:   "[EXPERIMENTAL] Retrieve execution logs for a deployment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -155,6 +158,7 @@ func newDeploymentSettingsGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Retrieve the deployment settings for a stack",
+		Long:   "[EXPERIMENTAL] Retrieve the deployment settings for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -179,7 +183,7 @@ func newDeploymentSettingsEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Create or update deployment settings for a stack",
-		Long: "Create or update deployment settings for a stack.\n" +
+		Long: "[EXPERIMENTAL] Create or update deployment settings for a stack.\n" +
 			"\n" +
 			"If no settings exist, they are created. If settings already exist, the\n" +
 			"request body is merged with the current settings.",

--- a/pkg/cmd/pulumi/env/env_new.go
+++ b/pkg/cmd/pulumi/env/env_new.go
@@ -30,7 +30,7 @@ func newEnvNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new Pulumi ESC environment",
-		Long: "Create a new Pulumi ESC environment.\n" +
+		Long: "[EXPERIMENTAL] Create a new Pulumi ESC environment.\n" +
 			"\n" +
 			"The environment starts with an empty YAML definition.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/pulumi/env/env_provider.go
+++ b/pkg/cmd/pulumi/env/env_provider.go
@@ -28,6 +28,7 @@ func newEnvProviderCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "provider",
 		Short:  "Manage environment OIDC providers",
+		Long:   "[EXPERIMENTAL] Manage environment OIDC providers.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -44,6 +45,7 @@ func newEnvProviderNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Register a new OIDC issuer for an organization",
+		Long:   "[EXPERIMENTAL] Register a new OIDC issuer for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -69,6 +71,7 @@ func newEnvProviderNewAWSCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "aws",
 		Short:  "Register an AWS OIDC issuer",
+		Long:   "[EXPERIMENTAL] Register an AWS OIDC issuer.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -98,6 +101,7 @@ func newEnvProviderNewAWSSSOCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "aws-sso",
 		Short:  "Register an AWS SSO OIDC issuer",
+		Long:   "[EXPERIMENTAL] Register an AWS SSO OIDC issuer.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -127,6 +131,7 @@ func newEnvProviderNewAzureCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "azure",
 		Short:  "Register an Azure OIDC issuer",
+		Long:   "[EXPERIMENTAL] Register an Azure OIDC issuer.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -156,6 +161,7 @@ func newEnvProviderNewGCPCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "gcp",
 		Short:  "Register a Google Cloud OIDC issuer",
+		Long:   "[EXPERIMENTAL] Register a Google Cloud OIDC issuer.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/env/env_referrer.go
+++ b/pkg/cmd/pulumi/env/env_referrer.go
@@ -27,6 +27,7 @@ func newEnvReferrerCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "referrer",
 		Short:  "Inspect entities that reference an environment",
+		Long:   "[EXPERIMENTAL] Inspect entities that reference an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -52,6 +53,7 @@ func newEnvReferrerListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List entities that reference an environment",
+		Long:   "[EXPERIMENTAL] List entities that reference an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/env/env_schedule.go
+++ b/pkg/cmd/pulumi/env/env_schedule.go
@@ -28,6 +28,7 @@ func newEnvScheduleCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "schedule",
 		Short:  "Manage environment scheduled actions",
+		Long:   "[EXPERIMENTAL] Manage environment scheduled actions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -72,6 +73,7 @@ func newEnvScheduleListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List scheduled actions configured for an environment",
+		Long:   "[EXPERIMENTAL] List scheduled actions configured for an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -97,6 +99,7 @@ func newEnvScheduleNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new scheduled action for an environment",
+		Long:   "[EXPERIMENTAL] Create a new scheduled action for an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -120,6 +123,7 @@ func newEnvSchedulePauseCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "pause",
 		Short:  "Pause a scheduled action",
+		Long:   "[EXPERIMENTAL] Pause a scheduled action.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -140,6 +144,7 @@ func newEnvScheduleResumeCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "resume",
 		Short:  "Resume a previously paused scheduled action",
+		Long:   "[EXPERIMENTAL] Resume a previously paused scheduled action.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -160,6 +165,7 @@ func newEnvScheduleRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Permanently delete a scheduled action",
+		Long:   "[EXPERIMENTAL] Permanently delete a scheduled action.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/env/env_webhook.go
+++ b/pkg/cmd/pulumi/env/env_webhook.go
@@ -28,6 +28,7 @@ func newEnvWebhookCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "webhook",
 		Short:  "Manage environment webhooks",
+		Long:   "[EXPERIMENTAL] Manage environment webhooks.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -74,6 +75,7 @@ func newEnvWebhookListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List all webhooks configured for an environment",
+		Long:   "[EXPERIMENTAL] List all webhooks configured for an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -101,6 +103,7 @@ func newEnvWebhookNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new environment webhook",
+		Long:   "[EXPERIMENTAL] Create a new environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -135,6 +138,7 @@ func newEnvWebhookEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update an environment webhook's configuration",
+		Long:   "[EXPERIMENTAL] Update an environment webhook's configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -162,6 +166,7 @@ func newEnvWebhookRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Delete an environment webhook",
+		Long:   "[EXPERIMENTAL] Delete an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -182,6 +187,7 @@ func newEnvWebhookPingCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "ping",
 		Short:  "Send a test ping to an environment webhook",
+		Long:   "[EXPERIMENTAL] Send a test ping to an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -202,6 +208,7 @@ func newEnvWebhookDeliveryCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "delivery",
 		Short:  "Inspect environment webhook deliveries",
+		Long:   "[EXPERIMENTAL] Inspect environment webhook deliveries.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -223,6 +230,7 @@ func newEnvWebhookDeliveryListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List recent deliveries for an environment webhook",
+		Long:   "[EXPERIMENTAL] List recent deliveries for an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/insights/insights_account.go
+++ b/pkg/cmd/pulumi/insights/insights_account.go
@@ -28,6 +28,7 @@ func newInsightsAccountCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "account",
 		Short:  "Manage Pulumi Insights accounts",
+		Long:   "[EXPERIMENTAL] Manage Pulumi Insights accounts.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -54,6 +55,7 @@ func newInsightsAccountNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new Insights account",
+		Long:   "[EXPERIMENTAL] Create a new Insights account.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -81,6 +83,7 @@ func newInsightsAccountListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List Insights accounts available to the authenticated user",
+		Long:   "[EXPERIMENTAL] List Insights accounts available to the authenticated user.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -101,6 +104,7 @@ func newInsightsAccountScanCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "scan",
 		Short:  "Trigger a resource discovery scan for an Insights account",
+		Long:   "[EXPERIMENTAL] Trigger a resource discovery scan for an Insights account.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -134,6 +138,7 @@ func newInsightsAccountScanLogCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "log",
 		Short:  "Retrieve logs for an Insights scan",
+		Long:   "[EXPERIMENTAL] Retrieve logs for an Insights scan.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/insights/insights_resource.go
+++ b/pkg/cmd/pulumi/insights/insights_resource.go
@@ -56,6 +56,7 @@ func newInsightsResourceSearchCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "search",
 		Short:  "Search for resources within an organization",
+		Long:   "[EXPERIMENTAL] Search for resources within an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/org/org_audit_log.go
+++ b/pkg/cmd/pulumi/org/org_audit_log.go
@@ -27,6 +27,7 @@ func newOrgAuditLogCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "audit-log",
 		Short:  "Inspect organization audit logs",
+		Long:   "[EXPERIMENTAL] Inspect organization audit logs.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -53,6 +54,7 @@ func newOrgAuditLogListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List audit log events for an organization",
+		Long:   "[EXPERIMENTAL] List audit log events for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -86,6 +88,7 @@ func newOrgAuditLogExportCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "export",
 		Short:  "Export audit log events for an organization",
+		Long:   "[EXPERIMENTAL] Export audit log events for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/org/org_member.go
+++ b/pkg/cmd/pulumi/org/org_member.go
@@ -28,6 +28,7 @@ func newOrgMemberCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "member",
 		Short:  "Manage organization members",
+		Long:   "[EXPERIMENTAL] Manage organization members.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -53,6 +54,7 @@ func newOrgMemberListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List members of an organization",
+		Long:   "[EXPERIMENTAL] List members of an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -75,6 +77,7 @@ func newOrgMemberGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Get a member of an organization",
+		Long:   "[EXPERIMENTAL] Get a member of an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -104,6 +107,7 @@ func newOrgMemberEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Modify a member's role within an organization",
+		Long:   "[EXPERIMENTAL] Modify a member's role within an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -133,6 +137,7 @@ func newOrgMemberRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Remove a member from an organization",
+		Long:   "[EXPERIMENTAL] Remove a member from an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -28,6 +28,7 @@ func newOrgRoleCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "role",
 		Short:  "Manage organization custom roles",
+		Long:   "[EXPERIMENTAL] Manage organization custom roles.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -54,6 +55,7 @@ func newOrgRoleListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List custom roles for an organization",
+		Long:   "[EXPERIMENTAL] List custom roles for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -80,6 +82,7 @@ func newOrgRoleNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new custom role for an organization",
+		Long:   "[EXPERIMENTAL] Create a new custom role for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -113,6 +116,7 @@ func newOrgRoleEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update a custom role's name, description, or permissions",
+		Long:   "[EXPERIMENTAL] Update a custom role's name, description, or permissions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -145,6 +149,7 @@ func newOrgRoleRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Delete a custom role from an organization",
+		Long:   "[EXPERIMENTAL] Delete a custom role from an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -175,6 +180,7 @@ func newOrgRoleAssignCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "assign",
 		Short:  "Assign a role to a team",
+		Long:   "[EXPERIMENTAL] Assign a role to a team.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/org/org_usage.go
+++ b/pkg/cmd/pulumi/org/org_usage.go
@@ -27,6 +27,7 @@ func newOrgUsageCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "usage",
 		Short:  "Inspect organization resource usage",
+		Long:   "[EXPERIMENTAL] Inspect organization resource usage.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -46,6 +47,7 @@ func newOrgUsageGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Fetch the resources-under-management summary for an organization",
+		Long:   "[EXPERIMENTAL] Fetch the resources-under-management summary for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -28,6 +28,7 @@ func newOrgWebhookCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "webhook",
 		Short:  "Manage organization-level webhooks",
+		Long:   "[EXPERIMENTAL] Manage organization-level webhooks.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -53,6 +54,7 @@ func newOrgWebhookListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List all webhooks configured at the organization level",
+		Long:   "[EXPERIMENTAL] List all webhooks configured at the organization level.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -81,6 +83,7 @@ func newOrgWebhookNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new organization webhook",
+		Long:   "[EXPERIMENTAL] Create a new organization webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -122,6 +125,7 @@ func newOrgWebhookEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update an organization webhook's configuration",
+		Long:   "[EXPERIMENTAL] Update an organization webhook's configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -155,6 +159,7 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Permanently delete an organization webhook",
+		Long:   "[EXPERIMENTAL] Permanently delete an organization webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -180,6 +185,7 @@ func newOrgWebhookPingCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "ping",
 		Short:  "Send a test ping to an organization webhook",
+		Long:   "[EXPERIMENTAL] Send a test ping to an organization webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -202,6 +208,7 @@ func newOrgWebhookDeliveryCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "delivery",
 		Short:  "Inspect organization webhook deliveries",
+		Long:   "[EXPERIMENTAL] Inspect organization webhook deliveries.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -221,6 +228,7 @@ func newOrgWebhookDeliveryListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List recent deliveries for an organization webhook",
+		Long:   "[EXPERIMENTAL] List recent deliveries for an organization webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/policy/policy_compliance.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance.go
@@ -27,6 +27,7 @@ func newPolicyComplianceCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "compliance",
 		Short:  "Inspect policy compliance results",
+		Long:   "[EXPERIMENTAL] Inspect policy compliance results.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -49,6 +50,7 @@ func newPolicyComplianceListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List compliance results grouped by entity",
+		Long:   "[EXPERIMENTAL] List compliance results grouped by entity.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/policy/policy_group_cmds.go
+++ b/pkg/cmd/pulumi/policy/policy_group_cmds.go
@@ -30,6 +30,7 @@ func newPolicyGroupNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new Policy Group",
+		Long:   "[EXPERIMENTAL] Create a new Policy Group.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -55,6 +56,7 @@ func newPolicyGroupGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Get the details of a Policy Group",
+		Long:   "[EXPERIMENTAL] Get the details of a Policy Group.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -89,6 +91,7 @@ func newPolicyGroupEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update a Policy Group's configuration",
+		Long:   "[EXPERIMENTAL] Update a Policy Group's configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -125,6 +128,7 @@ func newPolicyGroupRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Delete a Policy Group",
+		Long:   "[EXPERIMENTAL] Delete a Policy Group.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/policy/policy_issue.go
+++ b/pkg/cmd/pulumi/policy/policy_issue.go
@@ -27,6 +27,7 @@ func newPolicyIssueCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "issue",
 		Short:  "Inspect policy issues",
+		Long:   "[EXPERIMENTAL] Inspect policy issues.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -51,6 +52,7 @@ func newPolicyIssueListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List all policy issues for an organization",
+		Long:   "[EXPERIMENTAL] List all policy issues for an organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -73,6 +75,7 @@ func newPolicyIssueGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Get the details of a specific policy issue",
+		Long:   "[EXPERIMENTAL] Get the details of a specific policy issue.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -28,6 +28,7 @@ func newStackDriftCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "drift",
 		Short:  "Inspect stack drift detection results",
+		Long:   "[EXPERIMENTAL] Inspect stack drift detection results.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -52,6 +53,7 @@ func newStackDriftListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List drift detection runs for a stack",
+		Long:   "[EXPERIMENTAL] List drift detection runs for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -75,6 +77,7 @@ func newStackDriftGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Retrieve the current drift detection status for a stack",
+		Long:   "[EXPERIMENTAL] Retrieve the current drift detection status for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -36,6 +36,7 @@ func newStackHistoryEventsCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "events",
 		Short:  "Retrieve engine events for an update",
+		Long:   "[EXPERIMENTAL] Retrieve engine events for an update.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -36,7 +36,7 @@ func newStackNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new stack",
-		Long: "Create a new stack.\n" +
+		Long: "[EXPERIMENTAL] Create a new stack.\n" +
 			"\n" +
 			"A stack is an isolated, independently configurable instance of a Pulumi\n" +
 			"program, typically representing a deployment environment.",
@@ -74,6 +74,7 @@ func newStackGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Retrieve detailed information about a stack",
+		Long:   "[EXPERIMENTAL] Retrieve detailed information about a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -28,6 +28,7 @@ func newStackScheduleCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "schedule",
 		Short:  "Manage scheduled deployment actions for a stack",
+		Long:   "[EXPERIMENTAL] Manage scheduled deployment actions for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -51,6 +52,7 @@ func newStackScheduleListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List all scheduled actions configured for a stack",
+		Long:   "[EXPERIMENTAL] List all scheduled actions configured for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -77,6 +79,7 @@ func newStackScheduleNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a custom deployment schedule for a stack",
+		Long:   "[EXPERIMENTAL] Create a custom deployment schedule for a stack.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -104,6 +107,7 @@ func newStackScheduleGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Retrieve the configuration of a scheduled action",
+		Long:   "[EXPERIMENTAL] Retrieve the configuration of a scheduled action.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -135,6 +139,7 @@ func newStackScheduleEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update the configuration of a custom deployment schedule",
+		Long:   "[EXPERIMENTAL] Update the configuration of a custom deployment schedule.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -167,6 +172,7 @@ func newStackScheduleRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Permanently delete a scheduled deployment action",
+		Long:   "[EXPERIMENTAL] Permanently delete a scheduled deployment action.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -28,6 +28,7 @@ func newStackWebhookCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "webhook",
 		Short:  "Manage stack webhooks",
+		Long:   "[EXPERIMENTAL] Manage stack webhooks.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -64,6 +65,7 @@ func newStackWebhookGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Get the details of a stack webhook",
+		Long:   "[EXPERIMENTAL] Get the details of a stack webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -93,6 +95,7 @@ func newStackWebhookNewCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "new",
 		Short:  "Create a new stack webhook",
+		Long:   "[EXPERIMENTAL] Create a new stack webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -130,6 +133,7 @@ func newStackWebhookEditCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "edit",
 		Short:  "Update a stack webhook's configuration",
+		Long:   "[EXPERIMENTAL] Update a stack webhook's configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -159,6 +163,7 @@ func newStackWebhookRemoveCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "remove",
 		Short:  "Delete a stack webhook",
+		Long:   "[EXPERIMENTAL] Delete a stack webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -180,6 +185,7 @@ func newStackWebhookPingCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "ping",
 		Short:  "Send a test ping to a stack webhook",
+		Long:   "[EXPERIMENTAL] Send a test ping to a stack webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -199,6 +205,7 @@ func newStackWebhookDeliveryCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "delivery",
 		Short:  "Inspect stack webhook deliveries",
+		Long:   "[EXPERIMENTAL] Inspect stack webhook deliveries.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -219,6 +226,7 @@ func newStackWebhookDeliveryListCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "list",
 		Short:  "List recent deliveries for a stack webhook",
+		Long:   "[EXPERIMENTAL] List recent deliveries for a stack webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},
@@ -240,6 +248,7 @@ func newStackWebhookDeliveryGetCmd() *cobra.Command {
 		Hidden: true,
 		Use:    "get",
 		Short:  "Redeliver a specific webhook event",
+		Long:   "[EXPERIMENTAL] Redeliver a specific webhook event.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("not yet implemented")
 		},

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -62,7 +62,7 @@ func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all webhooks configured for a stack",
-		Long: "List all webhooks configured for a stack.\n" +
+		Long: "[EXPERIMENTAL] List all webhooks configured for a stack.\n" +
 			"\n" +
 			"Displays the ID, name, payload URL, format, event groups, events, and active\n" +
 			"status of each webhook. By default the output is a human-readable table;\n" +


### PR DESCRIPTION
The new commands show an `[EXPERIMENTAL]` marker in their long description. Commands do **not** require `PULUMI_EXPERIMENTAL` to run.

Ref https://github.com/pulumi/pulumi/issues/22959

