### PR TITLE
Refactor propertyValueToCty to not need a whole monitor

### DIFF
--- a/sdk/pcl/runtime/builtinFunctions.go
+++ b/sdk/pcl/runtime/builtinFunctions.go
@@ -140,7 +140,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				return cty.False, nil
 			}
 			if pv.IsSecret() {
-				return propertyValueToCty(context.TODO(), i.monitor, resource.MakeSecret(resource.NewProperty(true)))
+				return propertyValueToCty(context.TODO(), i.getResource, resource.MakeSecret(resource.NewProperty(true)))
 			}
 			return cty.True, nil
 		},
@@ -181,7 +181,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, err
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, outputPV)
+			return propertyValueToCty(context.TODO(), i.getResource, outputPV)
 		},
 	})
 
@@ -347,7 +347,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 					Dependencies: dependsOn,
 				})
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resultPV)
+			return propertyValueToCty(context.TODO(), i.getResource, resultPV)
 		},
 	})
 
@@ -524,7 +524,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 					Dependencies: dependsOn,
 				})
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resultPV)
+			return propertyValueToCty(context.TODO(), i.getResource, resultPV)
 		},
 	})
 
@@ -548,7 +548,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating file asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -572,7 +572,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating file archive: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -601,7 +601,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating archive from assets: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -625,7 +625,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating string asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -649,7 +649,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating remote asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -673,7 +673,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating remote archive: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.monitor, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
 		},
 	})
 

--- a/sdk/pcl/runtime/convert.go
+++ b/sdk/pcl/runtime/convert.go
@@ -29,12 +29,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type (
@@ -491,7 +487,7 @@ func convertPropertyValueForSchemaType(
 
 func propertyValueToCty(
 	ctx context.Context,
-	monitor pulumirpc.ResourceMonitorClient,
+	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error),
 	value resource.PropertyValue,
 ) (cty.Value, error) {
 	switch {
@@ -502,7 +498,7 @@ func propertyValueToCty(
 		a := value.ArchiveValue()
 		return cty.CapsuleVal(archiveType, a), nil
 	case value.IsSecret():
-		ctyVal, err := propertyValueToCty(ctx, monitor, value.SecretValue().Element)
+		ctyVal, err := propertyValueToCty(ctx, getResource, value.SecretValue().Element)
 		if err != nil {
 			return cty.NilVal, err
 		}
@@ -514,7 +510,7 @@ func propertyValueToCty(
 			ctyVal = cty.UnknownVal(cty.DynamicPseudoType)
 		} else {
 			var err error
-			ctyVal, err = propertyValueToCty(ctx, monitor, output.Element)
+			ctyVal, err = propertyValueToCty(ctx, getResource, output.Element)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -540,7 +536,7 @@ func propertyValueToCty(
 		array := value.ArrayValue()
 		vals := make([]cty.Value, len(array))
 		for i, elem := range array {
-			ctyElem, err := propertyValueToCty(ctx, monitor, elem)
+			ctyElem, err := propertyValueToCty(ctx, getResource, elem)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -560,7 +556,7 @@ func propertyValueToCty(
 		obj := value.ObjectValue()
 		vals := map[string]cty.Value{}
 		for k, v := range obj {
-			ctyVal, err := propertyValueToCty(ctx, monitor, v)
+			ctyVal, err := propertyValueToCty(ctx, getResource, v)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -571,37 +567,12 @@ func propertyValueToCty(
 		// We need to expand the resource into a resource object
 		ref := value.ResourceReferenceValue()
 
-		args, err := structpb.NewStruct(map[string]any{
-			"urn": string(ref.URN),
-		})
-		contract.AssertNoErrorf(err, "failed to create structpb for resource reference")
-
-		resp, err := monitor.Invoke(ctx, &pulumirpc.ResourceInvokeRequest{
-			Tok:             "pulumi:pulumi:getResource",
-			Args:            args,
-			AcceptResources: true,
-		})
+		outputs, err := getResource(ctx, ref)
 		if err != nil {
-			return cty.NilVal, fmt.Errorf("invoke getResource for %s: %w", ref.URN, err)
+			return cty.NilVal, fmt.Errorf("get resource for %s: %w", ref.URN, err)
 		}
 
-		marshalOpts := plugin.MarshalOptions{
-			KeepUnknowns:  true,
-			KeepSecrets:   true,
-			KeepResources: true,
-		}
-		outputs, err := plugin.UnmarshalProperties(resp.Return, marshalOpts)
-		if err != nil {
-			return cty.NilVal, fmt.Errorf("unmarshal stack outputs: %w", err)
-		}
-		outputs = outputs["state"].ObjectValue()
-
-		outputs["id"] = ref.ID
-		outputs["urn"] = resource.NewProperty(string(ref.URN))
-		outputs["__name"] = resource.NewProperty(ref.URN.Name())
-		outputs["__type"] = resource.NewProperty(string(ref.URN.Type()))
-
-		return propertyValueToCty(ctx, monitor, resource.NewProperty(outputs))
+		return propertyValueToCty(ctx, getResource, resource.NewProperty(outputs))
 	}
 
 	return cty.NilVal, errors.New("unsupported property value")

--- a/sdk/pcl/runtime/interpreter.go
+++ b/sdk/pcl/runtime/interpreter.go
@@ -257,7 +257,7 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 			if err != nil {
 				return cty.EmptyObjectVal, err
 			}
-			val, err := propertyValueToCty(ctx, i.monitor, resource.NewProperty(props))
+			val, err := propertyValueToCty(ctx, i.getResource, resource.NewProperty(props))
 			if err != nil {
 				return cty.EmptyObjectVal, err
 			}
@@ -344,6 +344,40 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 	// Store the hook's registered name as a string so it can be referenced in hooks options.
 	i.setRawVariable(ctx, h.Name(), cty.StringVal(hookName))
 	return nil
+}
+
+func (i *Interpreter) getResource(ctx context.Context, ref resource.ResourceReference) (resource.PropertyMap, error) {
+	args, err := structpb.NewStruct(map[string]any{
+		"urn": string(ref.URN),
+	})
+	contract.AssertNoErrorf(err, "failed to create structpb for resource reference")
+
+	resp, err := i.monitor.Invoke(ctx, &pulumirpc.ResourceInvokeRequest{
+		Tok:             "pulumi:pulumi:getResource",
+		Args:            args,
+		AcceptResources: true,
+	})
+	if err != nil {
+		return resource.PropertyMap{}, fmt.Errorf("invoke getResource for %s: %w", ref.URN, err)
+	}
+
+	marshalOpts := plugin.MarshalOptions{
+		KeepUnknowns:  true,
+		KeepSecrets:   true,
+		KeepResources: true,
+	}
+	outputs, err := plugin.UnmarshalProperties(resp.Return, marshalOpts)
+	if err != nil {
+		return resource.PropertyMap{}, fmt.Errorf("unmarshal stack outputs: %w", err)
+	}
+	outputs = outputs["state"].ObjectValue()
+
+	outputs["id"] = ref.ID
+	outputs["urn"] = resource.NewProperty(string(ref.URN))
+	outputs["__name"] = resource.NewProperty(ref.URN.Name())
+	outputs["__type"] = resource.NewProperty(string(ref.URN.Type()))
+
+	return outputs, nil
 }
 
 // effectiveName returns the name to use when registering a resource or component with the given
@@ -1024,7 +1058,7 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 			evalCtx *hcl.EvalContext
 		}, 0, len(values))
 		for idx, v := range values {
-			val, err := propertyValueToCty(ctx, i.monitor, v)
+			val, err := propertyValueToCty(ctx, i.getResource, v)
 			if err != nil {
 				return err
 			}
@@ -1048,7 +1082,7 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 		sort.Strings(keys)
 		resultMap := make(map[string]cty.Value, len(keys))
 		for _, key := range keys {
-			val, err := propertyValueToCty(ctx, i.monitor, values[resource.PropertyKey(key)])
+			val, err := propertyValueToCty(ctx, i.getResource, values[resource.PropertyKey(key)])
 			if err != nil {
 				return err
 			}
@@ -1798,7 +1832,7 @@ func (i *Interpreter) registerResourceWith(
 		Known:        true,
 	})
 
-	return propertyValueToCty(ctx, i.monitor, result)
+	return propertyValueToCty(ctx, i.getResource, result)
 }
 
 func applySchemaInputDefaults(inputs resource.PropertyMap, schemaResource *schema.Resource) {
@@ -2007,7 +2041,7 @@ func (i *Interpreter) registerStackOutputs(ctx context.Context, outputs resource
 }
 
 func (i *Interpreter) setVariable(ctx context.Context, name string, value resource.PropertyValue) error {
-	ctyValue, err := propertyValueToCty(ctx, i.monitor, value)
+	ctyValue, err := propertyValueToCty(ctx, i.getResource, value)
 	if err != nil {
 		return err
 	}
@@ -2064,7 +2098,7 @@ func (i *Interpreter) tryExpressions(args []cty.Value) (cty.Value, error) {
 			})
 			continue
 		}
-		return propertyValueToCty(context.TODO(), i.monitor, pv)
+		return propertyValueToCty(context.TODO(), i.getResource, pv)
 	}
 
 	var buf strings.Builder


### PR DESCRIPTION
pre-work for `do` support, we need parts of the pcl runtime for `do` but when running in stateless mode we won't have a monitor. This is part of helping with that, we can call into this function with just a stub error method for getResource when running in stateless mode.