### PR TITLE
[cli/package] Use --output=markdown in package-add docs hint

### DIFF
--- a/changelog/pending/20260513--cli-package--use-output-flag-in-package-add-docs-hint.yaml
+++ b/changelog/pending/20260513--cli-package--use-output-flag-in-package-add-docs-hint.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/package
+  description: Use `--output=markdown` (not the renamed-away `--format=markdown`) in the `pulumi api` pointers printed by `pulumi package add` and `pulumi package gen-sdk`

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -254,7 +254,7 @@ func printRegistryDocsHint(
 	}
 	fmt.Fprintln(w, "Documentation:")
 	for _, h := range hints {
-		fmt.Fprintf(w, "  pulumi api --format=markdown '%s%s'%s\n", base, h.suffix, h.comment)
+		fmt.Fprintf(w, "  pulumi api --output=markdown '%s%s'%s\n", base, h.suffix, h.comment)
 	}
 }
 
@@ -293,7 +293,8 @@ func loadEnclosingTarget(ctx context.Context, wd string) (addTarget, error) {
 			// Cloud registry is linked to a backend, but we don't have one
 			// available in a plugin. Use the default backend.
 			reg: cmdCmd.NewDefaultRegistry(
-				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
+				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global(),
+			),
 		}, nil
 	default:
 		panic(fmt.Sprintf("workspace.LoadBaseProjectFrom promises that it will return "+

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -243,7 +243,7 @@ func TestPrintRegistryDocsHint(t *testing.T) {
 
 	expectedBase := "/api/registry/packages/pulumi/pulumi/random/versions/4.19.1"
 	cmdLine := func(suffix, comment string) string {
-		return "  pulumi api --format=markdown '" + expectedBase + suffix + "'" + comment + "\n"
+		return "  pulumi api --output=markdown '" + expectedBase + suffix + "'" + comment + "\n"
 	}
 	expectedOutput := "Documentation:\n" +
 		cmdLine("/readme", "                    # package readme") +


### PR DESCRIPTION
The `--format` flag on `pulumi api` was renamed to `--output` in
https://github.com/pulumi/pulumi/pull/23072. The post-install docs hint
printed by `pulumi package add` and `pulumi package gen-sdk` was missed
in that rename, so it still emits `pulumi api --format=markdown`. Against
the renamed command the hint fails with `unknown flag: --format`.

Update the format string in `printRegistryDocsHint` and the matching
expected output in `TestPrintRegistryDocsHint`.

## Test plan

- `cd pkg && go test -run TestPrintRegistryDocsHint ./cmd/pulumi/packagecmd/...`
  passes; the `agent_on,_happy_path` subtest asserts the full expected hint output.
