### PR TITLE
cli/neo: tag CLI-created Neo tasks with source:cli

### DIFF
--- a/changelog/pending/20260513--cli-neo--tag-cli-created-neo-tasks-with-source-cli.yaml
+++ b/changelog/pending/20260513--cli-neo--tag-cli-created-neo-tasks-with-source-cli.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/neo
+  description: Tag Neo tasks created from the CLI with a `cli` source so the service can attribute their origin

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -67,6 +67,14 @@ const (
 	NeoApprovalModeAuto NeoApprovalMode = "auto"
 )
 
+// NeoTaskSource identifies the origin that triggered a Neo task.
+type NeoTaskSource string
+
+const (
+	// NeoTaskSourceCLI tags tasks created from the Pulumi CLI.
+	NeoTaskSourceCLI NeoTaskSource = "cli"
+)
+
 // NeoTaskRequest represents a request to create a Neo task. This is a thin client-side
 // shape that the server deserializes into apitype.CreateAgentTaskRequest, so the JSON
 // field names must match the IDL-generated tags exactly.
@@ -86,6 +94,10 @@ type NeoTaskRequest struct {
 	// this by activating PlanModeTracker for the task and gating the exit on an approved
 	// exit_plan_mode call. JSON tag is camelCase to match the service IDL.
 	PlanMode bool `json:"planMode,omitempty"`
+	// Source identifies the origin that triggered the task. The CLI always sends
+	// NeoTaskSourceCLI; the server validates against apitype.AgentTaskSource and defaults
+	// to "api" if omitted.
+	Source NeoTaskSource `json:"source,omitempty"`
 }
 
 // NeoTaskMessage represents the message content for a Neo task.
@@ -1731,6 +1743,7 @@ func (pc *Client) CreateNeoTask(
 		ToolExecutionMode: opts.ToolExecutionMode,
 		ApprovalMode:      opts.ApprovalMode,
 		PlanMode:          opts.PlanMode,
+		Source:            NeoTaskSourceCLI,
 	}
 	// Only attach a stack entity when we actually have one — the backend rejects
 	// entity_diff entries with empty name/project as "unable to access stack".

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -955,6 +955,9 @@ func TestCreateNeoTask(t *testing.T) {
 		assert.Equal(t, http.MethodPost, gotMethod)
 		assert.Equal(t, "/api/preview/agents/my-org/tasks", gotPath)
 		assert.Equal(t, "cli", gotBody["toolExecutionMode"])
+		// source must be "cli" on every task created via the CLI so the server can
+		// attribute the task to its origin (matches apitype.AgentTaskSourceCli).
+		assert.Equal(t, "cli", gotBody["source"], "CLI-originated tasks must send source:cli")
 		// approvalMode is omitempty — must not appear in the body when empty so the
 		// server falls back to its default (auto) mode.
 		assert.NotContains(t, gotBody, "approvalMode", "empty approvalMode must be omitted")


### PR DESCRIPTION
## Summary

- Add a `Source` field to `NeoTaskRequest` and always populate it with the new `NeoTaskSourceCLI` constant (`"cli"`) inside `CreateNeoTask`.
- The Neo backend validates the field and uses it to attribute the task's origin; without an explicit value it defaults to `"api"`, which hides CLI-created tasks behind the generic API source.
- Extends the existing `RequestShape` wire-format test to assert that every CLI-originated task body carries `source: "cli"`.

## Test plan

- [x] `go test ./backend/httpstate/client/... ./cmd/pulumi/neo/...`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)