### PR TITLE
Refactor function and evaluation logic to an EvalContext type

### DIFF
--- a/sdk/pcl/runtime/builtinFunctions.go
+++ b/sdk/pcl/runtime/builtinFunctions.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/customdecode"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
@@ -42,7 +41,64 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
-func (i *Interpreter) builtinFunctions() map[string]function.Function {
+var invokeOptionsType = cty.ObjectWithOptionalAttrs(map[string]cty.Type{
+	"version":   cty.String,
+	"dependsOn": cty.List(cty.DynamicPseudoType),
+	"provider":  cty.DynamicPseudoType,
+}, []string{
+	"version",
+	"dependsOn",
+	"provider",
+})
+
+func tryExpressions(
+	args []cty.Value,
+	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error),
+) (cty.Value, error) {
+	if len(args) == 0 {
+		return cty.NilVal, errors.New("at least one argument is required")
+	}
+
+	var diags hcl.Diagnostics
+	for _, arg := range args {
+		closure := customdecode.ExpressionClosureFromVal(arg)
+
+		v, moreDiags := closure.Value()
+		diags = append(diags, moreDiags...)
+
+		if moreDiags.HasErrors() {
+			continue
+		}
+
+		if !v.IsWhollyKnown() {
+			return cty.DynamicVal, nil
+		}
+
+		pv, err := ctyToPropertyValue(v)
+		if err != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  err.Error(),
+			})
+			continue
+		}
+		return propertyValueToCty(context.TODO(), getResource, pv)
+	}
+
+	var buf strings.Builder
+	buf.WriteString("no expression succeeded:\n")
+	for _, diag := range diags {
+		if diag.Subject != nil {
+			buf.WriteString(fmt.Sprintf("- %s (at %s)\n  %s\n", diag.Summary, diag.Subject, diag.Detail))
+		} else {
+			buf.WriteString(fmt.Sprintf("- %s\n  %s\n", diag.Summary, diag.Detail))
+		}
+	}
+	buf.WriteString("\nAt least one expression must produce a successful result")
+	return cty.NilVal, errors.New(buf.String())
+}
+
+func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 	literalStringFn := func(value string) function.Function {
 		return function.New(&function.Spec{
 			Params: []function.Parameter{},
@@ -104,14 +160,14 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			Type: customdecode.ExpressionClosureType,
 		},
 		Type: func(args []cty.Value) (cty.Type, error) {
-			v, err := i.tryExpressions(args)
+			v, err := tryExpressions(args, ectx.getResource)
 			if err != nil {
 				return cty.NilType, err
 			}
 			return v.Type(), nil
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			return i.tryExpressions(args)
+			return tryExpressions(args, ectx.getResource)
 		},
 	})
 
@@ -140,7 +196,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				return cty.False, nil
 			}
 			if pv.IsSecret() {
-				return propertyValueToCty(context.TODO(), i.getResource, resource.MakeSecret(resource.NewProperty(true)))
+				return propertyValueToCty(context.TODO(), ectx.getResource, resource.MakeSecret(resource.NewProperty(true)))
 			}
 			return cty.True, nil
 		},
@@ -181,7 +237,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, err
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, outputPV)
+			return propertyValueToCty(context.TODO(), ectx.getResource, outputPV)
 		},
 	})
 
@@ -214,27 +270,14 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				return cty.NilVal, errors.New("invoke token must be a string")
 			}
 			token := args[0].AsString()
-			pkg, mod, member, diags := pcl.DecomposeToken(token, hcl.Range{})
-			if diags.HasErrors() {
-				return cty.NilVal, fmt.Errorf("invalid token format: %s", token)
-			}
-			token = fmt.Sprintf("%s:%s:%s", pkg, mod, member)
 
-			descriptor := i.lookupPackageDescriptor(pkg)
-			pkgref, err := i.loader.LoadPackageReferenceV2(context.TODO(), descriptor)
+			fun, err := ectx.lookupFunction(context.TODO(), token)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("load package for token %s: %w", token, err)
+				return cty.NilVal, fmt.Errorf("lookup function for token %s: %w", token, err)
 			}
-			functions := pkgref.Functions()
-			fun, ok, err := functions.Get(token)
-			if err != nil {
-				return cty.NilVal, fmt.Errorf("get function from package for token %s: %w", token, err)
-			}
-			if ok {
-				// Use the canonical schema token (the alias lookup in Get may have resolved a
-				// normalized form like "pkg:index:name" to the source-form "pkg:index_name:name").
-				token = fun.Token
-			}
+			// Use the canonical schema token (the alias lookup in Get may have resolved a
+			// normalized form like "pkg:index:name" to the source-form "pkg:index_name:name").
+			token = fun.Token
 
 			argsPV, err := ctyToPropertyValue(args[1])
 			if err != nil {
@@ -262,10 +305,6 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			request := &pulumirpc.ResourceInvokeRequest{
 				Tok:  token,
 				Args: obj,
-			}
-			request.PackageRef, err = i.getPackageRefFromToken(token)
-			if err != nil {
-				return cty.NilVal, err
 			}
 
 			if len(args) == 3 && !args[2].IsNull() {
@@ -311,7 +350,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				}
 			}
 
-			resp, err := i.monitor.Invoke(context.TODO(), request)
+			resp, err := ectx.invoke(context.TODO(), request)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("invoke engine: %w", err)
 			}
@@ -347,7 +386,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 					Dependencies: dependsOn,
 				})
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resultPV)
+			return propertyValueToCty(context.TODO(), ectx.getResource, resultPV)
 		},
 	})
 
@@ -395,7 +434,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			}
 
 			typeStr := typ.AsString()
-			schemaResource, err := i.lookupResource(context.TODO(), typeStr)
+			schemaResource, err := ectx.lookupResource(context.TODO(), typeStr)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("lookup resource schema for token %s: %w", typeStr, err)
 			}
@@ -448,10 +487,6 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				Tok:  fun.Token,
 				Args: obj,
 			}
-			request.PackageRef, err = i.getPackageRefFromToken(fun.Token)
-			if err != nil {
-				return cty.NilVal, err
-			}
 
 			var dependsOn []resource.URN
 			if len(args) == 4 && !args[3].IsNull() {
@@ -481,7 +516,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				}
 			}
 
-			resp, err := i.monitor.Call(context.TODO(), request)
+			resp, err := ectx.call(context.TODO(), request)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("invoke engine: %w", err)
 			}
@@ -524,7 +559,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 					Dependencies: dependsOn,
 				})
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resultPV)
+			return propertyValueToCty(context.TODO(), ectx.getResource, resultPV)
 		},
 	})
 
@@ -544,11 +579,11 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				return cty.NilVal, errors.New("fileAsset path must be a string")
 			}
 			path := args[0].AsString()
-			a, err := asset.FromPathWithWD(path, i.info.WorkingDir)
+			a, err := asset.FromPathWithWD(path, ectx.workingDirectory)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating file asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -568,11 +603,11 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				return cty.NilVal, errors.New("fileArchive path must be a string")
 			}
 			path := args[0].AsString()
-			a, err := archive.FromPathWithWD(path, i.info.WorkingDir)
+			a, err := archive.FromPathWithWD(path, ectx.workingDirectory)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating file archive: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -597,11 +632,11 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 				assets[k] = v.EncapsulatedValue()
 			}
 
-			a, err := archive.FromAssetsWithWD(assets, i.info.WorkingDir)
+			a, err := archive.FromAssetsWithWD(assets, ectx.workingDirectory)
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating archive from assets: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -625,7 +660,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating string asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -649,7 +684,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating remote asset: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -673,7 +708,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 			if err != nil {
 				return cty.NilVal, fmt.Errorf("creating remote archive: %w", err)
 			}
-			return propertyValueToCty(context.TODO(), i.getResource, resource.NewProperty(a))
+			return propertyValueToCty(context.TODO(), ectx.getResource, resource.NewProperty(a))
 		},
 	})
 
@@ -902,7 +937,7 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 		if filepath.IsAbs(p) {
 			return p
 		}
-		return filepath.Join(i.info.WorkingDir, p)
+		return filepath.Join(ectx.workingDirectory, p)
 	}
 
 	readFileFn := function.New(&function.Spec{
@@ -977,11 +1012,11 @@ func (i *Interpreter) builtinFunctions() map[string]function.Function {
 	})
 
 	return map[string]function.Function{
-		"cwd":                literalStringFn(i.info.WorkingDir),
-		"rootDirectory":      literalStringFn(i.info.RootDirectory),
-		"project":            literalStringFn(i.info.Project),
-		"stack":              literalStringFn(i.info.Stack),
-		"organization":       literalStringFn(i.info.Organization),
+		"cwd":                literalStringFn(ectx.workingDirectory),
+		"rootDirectory":      literalStringFn(ectx.rootDirectory),
+		"project":            literalStringFn(ectx.project),
+		"stack":              literalStringFn(ectx.stack),
+		"organization":       literalStringFn(ectx.organization),
 		"secret":             secretFn,
 		"unsecret":           unsecretFn,
 		"try":                tryFn,

--- a/sdk/pcl/runtime/evalContext.go
+++ b/sdk/pcl/runtime/evalContext.go
@@ -1,0 +1,129 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type EvalContext struct {
+	workingDirectory string
+	rootDirectory    string
+	organization     string
+	project          string
+	stack            string
+
+	lookupResource func(context.Context, string) (*schema.Resource, error)
+	lookupFunction func(context.Context, string) (*schema.Function, error)
+
+	invoke      func(context.Context, *pulumirpc.ResourceInvokeRequest) (*pulumirpc.InvokeResponse, error)
+	call        func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error)
+	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error)
+
+	// we write variables to the eval context in parallel during execution, so we need to synchronize access to it
+	evalLock    sync.Mutex
+	evalContext *hcl.EvalContext
+}
+
+func NewEvalContext(
+	workingDirectory, rootDirectory, organization, project, stack string,
+	lookupResource func(context.Context, string) (*schema.Resource, error),
+	lookupFunction func(context.Context, string) (*schema.Function, error),
+	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error),
+	invoke func(context.Context, *pulumirpc.ResourceInvokeRequest) (*pulumirpc.InvokeResponse, error),
+	call func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error),
+) *EvalContext {
+	ctx := &EvalContext{
+		workingDirectory: workingDirectory,
+		rootDirectory:    rootDirectory,
+		organization:     organization,
+		project:          project,
+		stack:            stack,
+		lookupResource:   lookupResource,
+		lookupFunction:   lookupFunction,
+		getResource:      getResource,
+		invoke:           invoke,
+		call:             call,
+	}
+
+	ctx.evalContext = &hcl.EvalContext{
+		Functions: ctx.builtinFunctions(),
+	}
+
+	return ctx
+}
+
+func (ectx *EvalContext) NewChild() *EvalContext {
+	ectx.evalLock.Lock()
+	defer ectx.evalLock.Unlock()
+	child := ectx.evalContext.NewChild()
+	return &EvalContext{
+		workingDirectory: ectx.workingDirectory,
+		rootDirectory:    ectx.rootDirectory,
+		organization:     ectx.organization,
+		project:          ectx.project,
+		stack:            ectx.stack,
+		lookupResource:   ectx.lookupResource,
+		lookupFunction:   ectx.lookupFunction,
+		getResource:      ectx.getResource,
+		invoke:           ectx.invoke,
+		call:             ectx.call,
+		evalContext:      child,
+	}
+}
+
+func (ectx *EvalContext) SetVariable(name string, value cty.Value) {
+	ectx.evalLock.Lock()
+	defer ectx.evalLock.Unlock()
+	if ectx.evalContext.Variables == nil {
+		ectx.evalContext.Variables = make(map[string]cty.Value)
+	}
+	ectx.evalContext.Variables[name] = value
+}
+
+// Evaluate evaluates an expression in the context of the interpreter's evalContext and returns a PropertyValue. If the
+// expression evaluates to a poisoned value, the culprit resource's name will be returned in the second return value. If
+// there are any errors during evaluation, they will be returned in the diagnostics.
+func (ectx *EvalContext) Evaluate(expr model.Expression) (resource.PropertyValue, *string, hcl.Diagnostics) {
+	ectx.evalLock.Lock()
+	defer ectx.evalLock.Unlock()
+	value, diags := expr.Evaluate(ectx.evalContext)
+
+	if diags.HasErrors() {
+		return resource.PropertyValue{}, nil, diags
+	}
+	pv, err := ctyToPropertyValue(value)
+	if err != nil {
+		var poison *poisonError
+		if errors.As(err, &poison) {
+			return resource.PropertyValue{}, &poison.name, nil
+		}
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  err.Error(),
+		})
+		return resource.PropertyValue{}, nil, diags
+	}
+	return pv, nil, diags
+}

--- a/sdk/pcl/runtime/evalContext.go
+++ b/sdk/pcl/runtime/evalContext.go
@@ -41,7 +41,7 @@ type EvalContext struct {
 	call        func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error)
 	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error)
 
-	// we write variables to the eval context in parallel during execution, so we need to synchronize access to it
+	// we write variables to the hcl.EvalContext in parallel during execution, so we need to synchronize access to it
 	evalLock    sync.Mutex
 	evalContext *hcl.EvalContext
 }

--- a/sdk/pcl/runtime/interpreter.go
+++ b/sdk/pcl/runtime/interpreter.go
@@ -21,12 +21,10 @@ import (
 	"os/exec"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/ext/customdecode"
 	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -46,16 +44,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
-
-var invokeOptionsType = cty.ObjectWithOptionalAttrs(map[string]cty.Type{
-	"version":   cty.String,
-	"dependsOn": cty.List(cty.DynamicPseudoType),
-	"provider":  cty.DynamicPseudoType,
-}, []string{
-	"version",
-	"dependsOn",
-	"provider",
-})
 
 type RunInfo struct {
 	Project        string
@@ -84,9 +72,7 @@ type Interpreter struct {
 	engine  pulumirpc.EngineClient
 	loader  schema.ReferenceLoader
 
-	// we write variables to the eval context in parallel during execution, so we need to synchronize access to it
-	evalLock    sync.Mutex
-	evalContext *hcl.EvalContext
+	evalContext *EvalContext
 	stackURN    string
 
 	// namePrefix is prepended to resource and component names when this interpreter is executing
@@ -198,7 +184,7 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 
 	onDryRun := false
 	if h.OnDryRun != nil {
-		odrVal, _, diags := i.evalExpression(h.OnDryRun)
+		odrVal, _, diags := i.evalContext.Evaluate(h.OnDryRun)
 		if diags.HasErrors() {
 			return diags
 		}
@@ -211,7 +197,7 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 
 	ignoreErrors := false
 	if h.IgnoreErrors != nil {
-		ieVal, _, diags := i.evalExpression(h.IgnoreErrors)
+		ieVal, _, diags := i.evalContext.Evaluate(h.IgnoreErrors)
 		if diags.HasErrors() {
 			return diags
 		}
@@ -242,9 +228,7 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 		}
 
 		// Build a child eval context with `args` populated from the hook request.
-		i.evalLock.Lock()
 		evalCtx := i.evalContext.NewChild()
-		i.evalLock.Unlock()
 
 		unmarshal := func(s *structpb.Struct) (cty.Value, error) {
 			if s == nil {
@@ -285,12 +269,10 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 			}
 		}
 
-		evalCtx.Variables = map[string]cty.Value{
-			"args": cty.ObjectVal(args),
-		}
+		evalCtx.SetVariable("args", cty.ObjectVal(args))
 
 		// Evaluate the command expression with the args context.
-		cmdVal, _, evalDiags := i.evalExpressionWith(cmdExpr, evalCtx)
+		cmdVal, _, evalDiags := evalCtx.Evaluate(cmdExpr)
 		if evalDiags.HasErrors() {
 			return &pulumirpc.ResourceHookResponse{
 				Error: fmt.Sprintf("hook %s: evaluating command: %v", hookName, evalDiags),
@@ -342,8 +324,32 @@ func (i *Interpreter) registerHookNode(ctx context.Context, h *pcl.Hook) error {
 	}
 
 	// Store the hook's registered name as a string so it can be referenced in hooks options.
-	i.setRawVariable(ctx, h.Name(), cty.StringVal(hookName))
+	i.evalContext.SetVariable(h.Name(), cty.StringVal(hookName))
 	return nil
+}
+
+func (i *Interpreter) invoke(
+	ctx context.Context, req *pulumirpc.ResourceInvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	ref, err := i.getPackageRefFromToken(req.Tok)
+	if err != nil {
+		return nil, err
+	}
+	req.PackageRef = ref
+	resp, err := i.monitor.Invoke(ctx, req)
+	return resp, err
+}
+
+func (i *Interpreter) call(
+	ctx context.Context, req *pulumirpc.ResourceCallRequest,
+) (*pulumirpc.CallResponse, error) {
+	ref, err := i.getPackageRefFromToken(req.Tok)
+	if err != nil {
+		return nil, err
+	}
+	req.PackageRef = ref
+	resp, err := i.monitor.Call(ctx, req)
+	return resp, err
 }
 
 func (i *Interpreter) getResource(ctx context.Context, ref resource.ResourceReference) (resource.PropertyMap, error) {
@@ -424,10 +430,18 @@ func (i *Interpreter) Run(ctx context.Context) error {
 		i.engine = pulumirpc.NewEngineClient(engineConn)
 	}
 
-	i.evalContext = &hcl.EvalContext{
-		Variables: map[string]cty.Value{},
-		Functions: i.builtinFunctions(),
-	}
+	i.evalContext = NewEvalContext(
+		i.info.WorkingDir,
+		i.info.RootDirectory,
+		i.info.Organization,
+		i.info.Project,
+		i.info.Stack,
+		i.lookupResource,
+		i.lookupFunction,
+		i.getResource,
+		i.invoke,
+		i.call,
+	)
 
 	if diags := i.bindConfigVariables(ctx); diags.HasErrors() {
 		return diags
@@ -509,9 +523,9 @@ func (i *Interpreter) executeProgramNodes(ctx context.Context) (resource.Propert
 				return fmt.Errorf("failed to register hook %s: %w", node.Name(), err)
 			}
 		case *pcl.LocalVariable:
-			value, poison, diags := i.evalExpression(node.Definition.Value)
+			value, poison, diags := i.evalContext.Evaluate(node.Definition.Value)
 			if poison != nil {
-				i.setRawVariable(ctx, node.Name(), makePoisonValue(*poison))
+				i.evalContext.SetVariable(node.Name(), makePoisonValue(*poison))
 				return nil
 			}
 			if diags.HasErrors() {
@@ -529,7 +543,7 @@ func (i *Interpreter) executeProgramNodes(ctx context.Context) (resource.Propert
 				return fmt.Errorf("failed to register component %s: %w", node.Name(), err)
 			}
 		case *pcl.OutputVariable:
-			value, poison, diags := i.evalExpression(node.Value)
+			value, poison, diags := i.evalContext.Evaluate(node.Value)
 			if poison != nil {
 				return nil
 			}
@@ -578,6 +592,28 @@ func (i *Interpreter) lookupResource(ctx context.Context, token string) (*schema
 		return nil, fmt.Errorf("get resource from package for token %s", token)
 	}
 	return schemaResource, nil
+}
+
+func (i *Interpreter) lookupFunction(ctx context.Context, token string) (*schema.Function, error) {
+	pkg, mod, typ, diags := pcl.DecomposeToken(token, hcl.Range{})
+	contract.Assertf(!diags.HasErrors(), "invalid token format for function token %s", token)
+
+	token = fmt.Sprintf("%s:%s:%s", pkg, mod, typ)
+
+	descriptor := i.lookupPackageDescriptor(pkg)
+	pkgref, err := i.loader.LoadPackageReferenceV2(ctx, descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("load package for token %s: %w", token, err)
+	}
+	functions := pkgref.Functions()
+	schemaFunction, ok, err := functions.Get(token)
+	if err != nil {
+		return nil, fmt.Errorf("get function from package for token %s: %w", token, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("get function from package for token %s", token)
+	}
+	return schemaFunction, nil
 }
 
 func (i *Interpreter) lookupPackageDescriptor(pkgName string) *schema.PackageDescriptor {
@@ -657,36 +693,6 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 	return nil
 }
 
-func (i *Interpreter) evalExpression(expr model.Expression) (resource.PropertyValue, *string, hcl.Diagnostics) {
-	return i.evalExpressionWith(expr, i.evalContext)
-}
-
-// evalExpressionWith evaluates an expression using the given eval context (which may be a child of
-// i.evalContext with additional variables, e.g. range.key/range.value for ranged resources).
-func (i *Interpreter) evalExpressionWith(
-	expr model.Expression, evalCtx *hcl.EvalContext,
-) (resource.PropertyValue, *string, hcl.Diagnostics) {
-	i.evalLock.Lock()
-	value, diags := expr.Evaluate(evalCtx)
-	i.evalLock.Unlock()
-	if diags.HasErrors() {
-		return resource.PropertyValue{}, nil, diags
-	}
-	pv, err := ctyToPropertyValue(value)
-	if err != nil {
-		var poison *poisonError
-		if errors.As(err, &poison) {
-			return resource.PropertyValue{}, &poison.name, nil
-		}
-		diags = append(diags, &hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  err.Error(),
-		})
-		return resource.PropertyValue{}, nil, diags
-	}
-	return pv, nil, diags
-}
-
 func (i *Interpreter) bindConfigVariables(ctx context.Context) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 	secretKeys := map[string]struct{}{}
@@ -698,7 +704,7 @@ func (i *Interpreter) bindConfigVariables(ctx context.Context) hcl.Diagnostics {
 		raw, has := i.info.Config[key]
 		if !has {
 			if cfg.DefaultValue != nil {
-				value, poison, diags := i.evalExpression(cfg.DefaultValue)
+				value, poison, diags := i.evalContext.Evaluate(cfg.DefaultValue)
 				contract.Assertf(poison == nil, "config variables can't be poisoned")
 				diagnostics = append(diagnostics, diags...)
 				if _, isSecret := secretKeys[key]; isSecret || cfg.Secret {
@@ -754,7 +760,7 @@ func (i *Interpreter) enforceRequiredVersion(ctx context.Context) error {
 		return nil
 	}
 
-	value, poison, diags := i.evalExpression(required)
+	value, poison, diags := i.evalContext.Evaluate(required)
 	if poison != nil {
 		return fmt.Errorf("could not evaluate requiredVersion because of failure from %s", *poison)
 	}
@@ -965,13 +971,13 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 		if err != nil {
 			return err
 		}
-		i.setRawVariable(ctx, lexicalBaseName, result)
+		i.evalContext.SetVariable(lexicalBaseName, result)
 		return nil
 	}
 
-	rangeValue, poison, diags := i.evalExpression(res.Options.Range)
+	rangeValue, poison, diags := i.evalContext.Evaluate(res.Options.Range)
 	if poison != nil {
-		i.setRawVariable(ctx, lexicalBaseName, makePoisonValue(*poison))
+		i.evalContext.SetVariable(lexicalBaseName, makePoisonValue(*poison))
 	}
 	if diags.HasErrors() {
 		return diags
@@ -991,25 +997,23 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 		if err != nil {
 			return err
 		}
-		i.setRawVariable(ctx, lexicalBaseName, result)
+		i.evalContext.SetVariable(lexicalBaseName, result)
 		return nil
 	}
 
-	makeRangeCtx := func(key cty.Value, value cty.Value) *hcl.EvalContext {
+	makeRangeCtx := func(key cty.Value, value cty.Value) *EvalContext {
 		rangeCtx := i.evalContext.NewChild()
 		rangeVars := map[string]cty.Value{"value": value}
 		if key != cty.NilVal {
 			rangeVars["key"] = key
 		}
-		rangeCtx.Variables = map[string]cty.Value{
-			"range": cty.ObjectVal(rangeVars),
-		}
+		rangeCtx.SetVariable("range", cty.ObjectVal(rangeVars))
 		return rangeCtx
 	}
 
 	registerMany := func(items []struct {
 		suffix  string
-		evalCtx *hcl.EvalContext
+		evalCtx *EvalContext
 	},
 	) error {
 		results := make([]cty.Value, 0, len(items))
@@ -1022,10 +1026,10 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 			results = append(results, result)
 		}
 		if len(results) == 0 {
-			i.setRawVariable(ctx, lexicalBaseName, cty.ListValEmpty(cty.DynamicPseudoType))
+			i.evalContext.SetVariable(lexicalBaseName, cty.ListValEmpty(cty.DynamicPseudoType))
 			return nil
 		}
-		i.setRawVariable(ctx, lexicalBaseName, cty.ListVal(results))
+		i.evalContext.SetVariable(lexicalBaseName, cty.ListVal(results))
 		return nil
 	}
 
@@ -1036,13 +1040,13 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 		}
 		items := make([]struct {
 			suffix  string
-			evalCtx *hcl.EvalContext
+			evalCtx *EvalContext
 		}, 0, count)
 		for idx := 0; idx < count; idx++ {
 			idxVal := cty.NumberIntVal(int64(idx))
 			items = append(items, struct {
 				suffix  string
-				evalCtx *hcl.EvalContext
+				evalCtx *EvalContext
 			}{
 				suffix:  strconv.Itoa(idx),
 				evalCtx: makeRangeCtx(cty.NilVal, idxVal),
@@ -1055,7 +1059,7 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 		values := rangeValue.ArrayValue()
 		items := make([]struct {
 			suffix  string
-			evalCtx *hcl.EvalContext
+			evalCtx *EvalContext
 		}, 0, len(values))
 		for idx, v := range values {
 			val, err := propertyValueToCty(ctx, i.getResource, v)
@@ -1064,7 +1068,7 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 			}
 			items = append(items, struct {
 				suffix  string
-				evalCtx *hcl.EvalContext
+				evalCtx *EvalContext
 			}{
 				suffix:  strconv.Itoa(idx),
 				evalCtx: makeRangeCtx(cty.NumberIntVal(int64(idx)), val),
@@ -1094,9 +1098,9 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 			resultMap[key] = result
 		}
 		if len(resultMap) == 0 {
-			i.setRawVariable(ctx, lexicalBaseName, cty.EmptyObjectVal)
+			i.evalContext.SetVariable(lexicalBaseName, cty.EmptyObjectVal)
 		} else {
-			i.setRawVariable(ctx, lexicalBaseName, cty.ObjectVal(resultMap))
+			i.evalContext.SetVariable(lexicalBaseName, cty.ObjectVal(resultMap))
 		}
 		return nil
 	}
@@ -1105,7 +1109,7 @@ func (i *Interpreter) registerResource(ctx context.Context, res *pcl.Resource) e
 }
 
 func (i *Interpreter) registerResourceWith(
-	ctx context.Context, res *pcl.Resource, evalCtx *hcl.EvalContext, logicalName string,
+	ctx context.Context, res *pcl.Resource, evalCtx *EvalContext, logicalName string,
 ) (cty.Value, error) {
 	token, _ := res.GetToken()
 	schemaResource, err := i.lookupResource(ctx, token)
@@ -1137,7 +1141,7 @@ func (i *Interpreter) registerResourceWith(
 			return cty.NilVal, diags
 		}
 
-		val, poison, diags := i.evalExpressionWith(expr, evalCtx)
+		val, poison, diags := evalCtx.Evaluate(expr)
 		if poison != nil {
 			return makePoisonValue(*poison), nil
 		}
@@ -1217,7 +1221,7 @@ func (i *Interpreter) registerResourceWith(
 
 	if res.Options != nil {
 		if res.Options.AdditionalSecretOutputs != nil {
-			additionalSecretOutputs, poison, diags := i.evalExpressionWith(res.Options.AdditionalSecretOutputs, evalCtx)
+			additionalSecretOutputs, poison, diags := evalCtx.Evaluate(res.Options.AdditionalSecretOutputs)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1242,7 +1246,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Aliases != nil {
-			aliases, poison, diags := i.evalExpressionWith(res.Options.Aliases, evalCtx)
+			aliases, poison, diags := evalCtx.Evaluate(res.Options.Aliases)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1320,7 +1324,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.DependsOn != nil {
-			dependsOn, poison, diags := i.evalExpressionWith(res.Options.DependsOn, evalCtx)
+			dependsOn, poison, diags := evalCtx.Evaluate(res.Options.DependsOn)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1346,7 +1350,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.EnvVarMappings != nil {
-			envVars, poison, diags := i.evalExpressionWith(res.Options.EnvVarMappings, evalCtx)
+			envVars, poison, diags := evalCtx.Evaluate(res.Options.EnvVarMappings)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1370,7 +1374,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.ImportID != nil {
-			importID, poison, diags := i.evalExpressionWith(res.Options.ImportID, evalCtx)
+			importID, poison, diags := evalCtx.Evaluate(res.Options.ImportID)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1385,7 +1389,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.IgnoreChanges != nil {
-			ignoreChanges, poison, diags := i.evalExpressionWith(res.Options.IgnoreChanges, evalCtx)
+			ignoreChanges, poison, diags := evalCtx.Evaluate(res.Options.IgnoreChanges)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1410,7 +1414,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Protect != nil {
-			protect, poison, diags := i.evalExpressionWith(res.Options.Protect, evalCtx)
+			protect, poison, diags := evalCtx.Evaluate(res.Options.Protect)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1429,7 +1433,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.ReplaceWith != nil {
-			replaceWith, poison, diags := i.evalExpressionWith(res.Options.ReplaceWith, evalCtx)
+			replaceWith, poison, diags := evalCtx.Evaluate(res.Options.ReplaceWith)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1455,7 +1459,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.ReplaceOnChanges != nil {
-			replaceOnChanges, poison, diags := i.evalExpressionWith(res.Options.ReplaceOnChanges, evalCtx)
+			replaceOnChanges, poison, diags := evalCtx.Evaluate(res.Options.ReplaceOnChanges)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1480,7 +1484,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.ReplacementTrigger != nil {
-			replacement, poison, diags := i.evalExpressionWith(res.Options.ReplacementTrigger, evalCtx)
+			replacement, poison, diags := evalCtx.Evaluate(res.Options.ReplacementTrigger)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1494,7 +1498,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.RetainOnDelete != nil {
-			retain, poison, diags := i.evalExpressionWith(res.Options.RetainOnDelete, evalCtx)
+			retain, poison, diags := evalCtx.Evaluate(res.Options.RetainOnDelete)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1513,7 +1517,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Version != nil {
-			version, poison, diags := i.evalExpressionWith(res.Options.Version, evalCtx)
+			version, poison, diags := evalCtx.Evaluate(res.Options.Version)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1528,7 +1532,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.CustomTimeouts != nil {
-			timeouts, poison, diags := i.evalExpressionWith(res.Options.CustomTimeouts, evalCtx)
+			timeouts, poison, diags := evalCtx.Evaluate(res.Options.CustomTimeouts)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1557,7 +1561,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.DeleteBeforeReplace != nil {
-			dbr, poison, diags := i.evalExpressionWith(res.Options.DeleteBeforeReplace, evalCtx)
+			dbr, poison, diags := evalCtx.Evaluate(res.Options.DeleteBeforeReplace)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1574,7 +1578,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.DeletedWith != nil {
-			deletedWith, poison, diags := i.evalExpressionWith(res.Options.DeletedWith, evalCtx)
+			deletedWith, poison, diags := evalCtx.Evaluate(res.Options.DeletedWith)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1590,7 +1594,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.PluginDownloadURL != nil {
-			downloadURL, poison, diags := i.evalExpressionWith(res.Options.PluginDownloadURL, evalCtx)
+			downloadURL, poison, diags := evalCtx.Evaluate(res.Options.PluginDownloadURL)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1605,7 +1609,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Parent != nil {
-			parent, poison, diags := i.evalExpressionWith(res.Options.Parent, evalCtx)
+			parent, poison, diags := evalCtx.Evaluate(res.Options.Parent)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1621,7 +1625,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Provider != nil {
-			provider, poison, diags := i.evalExpressionWith(res.Options.Provider, evalCtx)
+			provider, poison, diags := evalCtx.Evaluate(res.Options.Provider)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1643,7 +1647,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.Providers != nil {
-			providers, poison, diags := i.evalExpressionWith(res.Options.Providers, evalCtx)
+			providers, poison, diags := evalCtx.Evaluate(res.Options.Providers)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1694,7 +1698,7 @@ func (i *Interpreter) registerResourceWith(
 			}
 		}
 		if res.Options.HideDiffs != nil {
-			hideDiffs, poison, diags := i.evalExpressionWith(res.Options.HideDiffs, evalCtx)
+			hideDiffs, poison, diags := evalCtx.Evaluate(res.Options.HideDiffs)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1721,7 +1725,7 @@ func (i *Interpreter) registerResourceWith(
 
 		// Process hooks - register command hooks and build the hooks binding
 		if res.Options.Hooks != nil {
-			hooksVal, poison, diags := i.evalExpressionWith(res.Options.Hooks, evalCtx)
+			hooksVal, poison, diags := evalCtx.Evaluate(res.Options.Hooks)
 			if poison != nil {
 				return makePoisonValue(*poison), nil
 			}
@@ -1863,9 +1867,9 @@ func (i *Interpreter) registerComponent(ctx context.Context, component *pcl.Comp
 			return diags
 		}
 
-		val, poison, diags := i.evalExpression(expr)
+		val, poison, diags := i.evalContext.Evaluate(expr)
 		if poison != nil {
-			i.setRawVariable(ctx, component.Name(), makePoisonValue(*poison))
+			i.evalContext.SetVariable(component.Name(), makePoisonValue(*poison))
 			return nil
 		}
 		if diags.HasErrors() {
@@ -1900,9 +1904,9 @@ func (i *Interpreter) registerComponent(ctx context.Context, component *pcl.Comp
 		Parent:          i.stackURN,
 	}
 	if component.Options != nil && component.Options.Parent != nil {
-		parent, poison, diags := i.evalExpression(component.Options.Parent)
+		parent, poison, diags := i.evalContext.Evaluate(component.Options.Parent)
 		if poison != nil {
-			i.setRawVariable(ctx, component.Name(), makePoisonValue(*poison))
+			i.evalContext.SetVariable(component.Name(), makePoisonValue(*poison))
 			return nil
 		}
 		if diags.HasErrors() {
@@ -1937,9 +1941,18 @@ func (i *Interpreter) registerComponent(ctx context.Context, component *pcl.Comp
 		}}
 	}
 
-	componentEval := &hcl.EvalContext{}
-	componentEval.Functions = i.evalContext.Functions
-	componentEval.Variables = map[string]cty.Value{}
+	componentEval := NewEvalContext(
+		i.info.WorkingDir,
+		i.info.RootDirectory,
+		i.info.Organization,
+		i.info.Project,
+		i.info.Stack,
+		i.lookupResource,
+		i.lookupFunction,
+		i.getResource,
+		i.invoke,
+		i.call,
+	)
 	componentInterpreter := &Interpreter{
 		program:     component.Program,
 		info:        i.info,
@@ -2045,14 +2058,8 @@ func (i *Interpreter) setVariable(ctx context.Context, name string, value resour
 	if err != nil {
 		return err
 	}
-	i.setRawVariable(ctx, name, ctyValue)
+	i.evalContext.SetVariable(name, ctyValue)
 	return nil
-}
-
-func (i *Interpreter) setRawVariable(ctx context.Context, name string, value cty.Value) {
-	i.evalLock.Lock()
-	i.evalContext.Variables[name] = value
-	i.evalLock.Unlock()
 }
 
 func parseConfigPropertyValue(raw string, typ model.Type) (resource.PropertyValue, hcl.Diagnostics) {
@@ -2068,50 +2075,6 @@ func parseConfigPropertyValue(raw string, typ model.Type) (resource.PropertyValu
 		})
 	}
 	return pv, diags
-}
-
-func (i *Interpreter) tryExpressions(args []cty.Value) (cty.Value, error) {
-	if len(args) == 0 {
-		return cty.NilVal, errors.New("at least one argument is required")
-	}
-
-	var diags hcl.Diagnostics
-	for _, arg := range args {
-		closure := customdecode.ExpressionClosureFromVal(arg)
-
-		v, moreDiags := closure.Value()
-		diags = append(diags, moreDiags...)
-
-		if moreDiags.HasErrors() {
-			continue
-		}
-
-		if !v.IsWhollyKnown() {
-			return cty.DynamicVal, nil
-		}
-
-		pv, err := ctyToPropertyValue(v)
-		if err != nil {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  err.Error(),
-			})
-			continue
-		}
-		return propertyValueToCty(context.TODO(), i.getResource, pv)
-	}
-
-	var buf strings.Builder
-	buf.WriteString("no expression succeeded:\n")
-	for _, diag := range diags {
-		if diag.Subject != nil {
-			buf.WriteString(fmt.Sprintf("- %s (at %s)\n  %s\n", diag.Summary, diag.Subject, diag.Detail))
-		} else {
-			buf.WriteString(fmt.Sprintf("- %s\n  %s\n", diag.Summary, diag.Detail))
-		}
-	}
-	buf.WriteString("\nAt least one expression must produce a successful result")
-	return cty.NilVal, errors.New(buf.String())
 }
 
 func getStackOutput(stackRef resource.PropertyValue, outputName string) (resource.PropertyValue, error) {


### PR DESCRIPTION
More work to support `do`. This refactors the builtin functions and expression evaluation logic to an `EvalContext` struct. All the required inputs and support methods needed for builtin functions to run are passed in via constructor parameters. In `do` most of these will be error stubs.