### PR TITLE
implement `pulumi stack webhook new`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-new.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook new` to create a new stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -745,6 +745,17 @@ func (pc *Client) PingStackWebhook(
 	return resp, nil
 }
 
+// CreateStackWebhook creates a new webhook for the given stack.
+func (pc *Client) CreateStackWebhook(
+	ctx context.Context, stackID StackIdentifier, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	if err := pc.restCall(ctx, "POST", getStackPath(stackID, "hooks"), nil, &req, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -229,7 +229,7 @@ func TestCreateStackWebhook(t *testing.T) {
 			PayloadURL:       "https://example.com/webhook",
 			Active:           true,
 			Format:           &format,
-			HasSecret:        true,
+			HasSecret:        false,
 		}
 
 		var gotPath, gotMethod string
@@ -260,8 +260,7 @@ func TestCreateStackWebhook(t *testing.T) {
 
 		assert.Equal(t, "POST", gotMethod)
 		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks", gotPath)
-		assert.Equal(t, "new-hook", gotBody.Name)
-		assert.Equal(t, "https://example.com/webhook", gotBody.PayloadURL)
+		assert.Equal(t, req, gotBody)
 		assert.Equal(t, want, got)
 	})
 

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -62,7 +62,7 @@ func TestListStackWebhooks(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotPath = r.URL.Path
 			w.Header().Set("Content-Type", "application/json")
-			err := json.NewEncoder(w).Encode(want)
+			err := json.NewEncoder(w).Encode(want) //nolint:gosec // test data
 			require.NoError(t, err)
 		}))
 		defer srv.Close()
@@ -206,5 +206,76 @@ func TestPingStackWebhook(t *testing.T) {
 		c := newMockClient(srv)
 		_, err := c.PingStackWebhook(t.Context(), stackID, "no-such-hook")
 		assert.Error(t, err)
+	})
+}
+
+func TestCreateStackWebhook(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		format := "raw"
+		want := apitype.Webhook{
+			OrganizationName: "my-org",
+			Name:             "new-hook",
+			DisplayName:      "New Hook",
+			PayloadURL:       "https://example.com/webhook",
+			Active:           true,
+			Format:           &format,
+			HasSecret:        true,
+		}
+
+		var gotPath, gotMethod string
+		var gotBody apitype.Webhook
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			err := json.NewDecoder(r.Body).Decode(&gotBody)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			err = json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		req := apitype.Webhook{
+			OrganizationName: "my-org",
+			Name:             "new-hook",
+			DisplayName:      "New Hook",
+			PayloadURL:       "https://example.com/webhook",
+			Active:           true,
+			Format:           &format,
+		}
+
+		c := newMockClient(srv)
+		got, err := c.CreateStackWebhook(t.Context(), stackID, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "POST", gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks", gotPath)
+		assert.Equal(t, "new-hook", gotBody.Name)
+		assert.Equal(t, "https://example.com/webhook", gotBody.PayloadURL)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusConflict, `{"message":"webhook already exists"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.CreateStackWebhook(t.Context(), stackID, apitype.Webhook{
+			Name:       "existing",
+			PayloadURL: "https://example.com",
+		})
+		assert.ErrorContains(t, err, "webhook already exists")
 	})
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -55,44 +55,6 @@ func stackWebhookHookArg() *constrictor.Arguments {
 	}
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23060]: Not yet implemented.
-func newStackWebhookNewCmd() *cobra.Command {
-	var (
-		stack       string
-		url         string
-		format      string
-		filters     []string
-		active      bool
-		secret      string
-		displayName string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new stack webhook",
-		Long:   "[EXPERIMENTAL] Create a new stack webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
-	cmd.Flags().StringVar(&format, "format", "raw",
-		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
-	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		"An event type to subscribe to (repeatable)")
-	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
-	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
-	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23059]: Not yet implemented.
 func newStackWebhookEditCmd() *cobra.Command {
 	var (

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -63,6 +63,7 @@ func newStackWebhookNewCmd() *cobra.Command {
 func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Command {
 	var (
 		stack       string
+		name        string
 		url         string
 		format      string
 		filters     []string
@@ -90,16 +91,16 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 			"\n" +
 			"Returns 409 if a webhook with the same name already exists.",
 		Example: "  # Create a webhook interactively\n" +
-			"  pulumi stack webhook new my-hook\n\n" +
+			"  pulumi stack webhook new --name my-hook\n\n" +
 			"  # Create a webhook non-interactively\n" +
-			"  pulumi stack webhook new my-hook --url https://example.com/hook --yes\n\n" +
+			"  pulumi stack webhook new --name my-hook --url https://example.com/hook --yes\n\n" +
 			"  # Create a Slack webhook with specific event filters\n" +
-			"  pulumi stack webhook new slack-alerts \\\n" +
+			"  pulumi stack webhook new --name slack-alerts \\\n" +
 			"    --url https://hooks.slack.com/services/T00/B00/xxx \\\n" +
 			"    --format slack \\\n" +
 			"    --filter update_succeeded --filter update_failed --yes\n\n" +
 			"  # Create a webhook and get the result as JSON\n" +
-			"  pulumi stack webhook new my-hook --url https://example.com --yes --output json",
+			"  pulumi stack webhook new --name my-hook --url https://example.com --yes --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultStackWebhookNewClientFactory
@@ -110,7 +111,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 			webhookArgs, err := resolveNewArgs(
-				skipPrompts, args[0], displayName, url, format,
+				skipPrompts, name, displayName, url, format,
 				filters, groups, opts,
 			)
 			if err != nil {
@@ -126,8 +127,10 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 		},
 	}
 
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
+	cmd.Flags().StringVar(&name, "name", "",
+		"The webhook name (1-32 chars: letters, numbers, hyphens, underscores, dots)")
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.Flags().StringVar(&url, "url", "",
@@ -217,6 +220,25 @@ func resolveNewArgs(
 	opts display.Options,
 ) (stackWebhookNewArgs, error) {
 	var err error
+
+	// Name is required.
+	if name == "" {
+		nameErrMsg := "a webhook name is required (use --name)"
+		if !skipPrompts {
+			nameErrMsg = "a webhook name is required"
+		}
+		name, err = ui.PromptForValue(
+			skipPrompts, "Webhook name", "", false,
+			func(v string) error {
+				if v == "" {
+					return errors.New(nameErrMsg) //nolint:goerr113 // dynamic but intentional
+				}
+				return nil
+			}, opts)
+		if err != nil {
+			return stackWebhookNewArgs{}, err
+		}
+	}
 
 	// Display name defaults to the webhook name.
 	if displayName == "" {
@@ -337,7 +359,7 @@ type webhookNewRenderFunc func(w io.Writer, wh apitype.Webhook) error
 func webhookNewRenderer(output string) (webhookNewRenderFunc, error) {
 	switch output {
 	case "", "default":
-		return renderWebhookNewText, nil
+		return renderWebhookGetText, nil
 	case "json":
 		return renderWebhookGetJSON, nil
 	default:
@@ -345,9 +367,4 @@ func webhookNewRenderer(output string) (webhookNewRenderFunc, error) {
 			"invalid --output value %q: expected \"default\" or \"json\"",
 			output)
 	}
-}
-
-func renderWebhookNewText(w io.Writer, wh apitype.Webhook) error {
-	fmt.Fprintf(w, "Created webhook %q\n", wh.Name)
-	return nil
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -1,0 +1,353 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookNewClient is the interface the new command needs from the API client.
+type stackWebhookNewClient interface {
+	CreateStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier, req apitype.Webhook,
+	) (apitype.Webhook, error)
+}
+
+// stackWebhookNewClientFactory builds a stackWebhookNewClient from the environment.
+type stackWebhookNewClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookNewClient, client.StackIdentifier, error)
+
+// stackWebhookNewArgs holds the resolved arguments for creating a webhook.
+type stackWebhookNewArgs struct {
+	Name        string
+	DisplayName string
+	URL         string
+	Format      string
+	Filters     []string
+	Groups      []string
+	Active      bool
+	Secret      string
+}
+
+func newStackWebhookNewCmd() *cobra.Command {
+	return newStackWebhookNewCmdWith(nil)
+}
+
+func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Command {
+	var (
+		stack       string
+		url         string
+		format      string
+		filters     []string
+		groups      []string
+		active      bool
+		secret      string
+		displayName string
+		yes         bool
+		output      string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "[EXPERIMENTAL] Create a new stack webhook",
+		Long: "Create a new stack webhook.\n" +
+			"\n" +
+			"Creates a webhook that delivers events for the specified stack to a\n" +
+			"given URL. The webhook name must be unique within the stack and can\n" +
+			"contain letters, numbers, hyphens, underscores, and dots (1-32 chars).\n" +
+			"\n" +
+			"When run interactively, prompts for required values that aren't\n" +
+			"provided via flags. Pass --yes to accept defaults without prompting.\n" +
+			"\n" +
+			"Supported formats: raw (default), slack, ms_teams, pulumi_deployments.\n" +
+			"\n" +
+			"Returns 409 if a webhook with the same name already exists.",
+		Example: "  # Create a webhook interactively\n" +
+			"  pulumi stack webhook new my-hook\n\n" +
+			"  # Create a webhook non-interactively\n" +
+			"  pulumi stack webhook new my-hook --url https://example.com/hook --yes\n\n" +
+			"  # Create a Slack webhook with specific event filters\n" +
+			"  pulumi stack webhook new slack-alerts \\\n" +
+			"    --url https://hooks.slack.com/services/T00/B00/xxx \\\n" +
+			"    --format slack \\\n" +
+			"    --filter update_succeeded --filter update_failed --yes\n\n" +
+			"  # Create a webhook and get the result as JSON\n" +
+			"  pulumi stack webhook new my-hook --url https://example.com --yes --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackWebhookNewClientFactory
+			}
+
+			// Skip prompts when --yes is set or when running non-interactively.
+			skipPrompts := yes || !cmdutil.Interactive()
+			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+			webhookArgs, err := resolveNewArgs(
+				skipPrompts, args[0], displayName, url, format,
+				filters, groups, opts,
+			)
+			if err != nil {
+				return err
+			}
+			webhookArgs.Active = active
+			webhookArgs.Secret = secret
+
+			return runStackWebhookNew(
+				cmd.Context(), cmd.OutOrStdout(), factory,
+				stack, webhookArgs, output,
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&url, "url", "",
+		"The webhook payload URL, including protocol (e.g. https://example.com/hook)")
+	cmd.Flags().StringVar(&format, "hook-format", "raw",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&filters, "event", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().StringArrayVar(&groups, "group", nil,
+		"An event group to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true,
+		"Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "",
+		"The HMAC key for signature verification")
+	cmd.Flags().StringVar(&displayName, "display-name", "",
+		"The webhook display name (defaults to the webhook name)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
+		"Skip prompts and proceed with default values")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable text) or json")
+
+	return cmd
+}
+
+// defaultStackWebhookNewClientFactory resolves the current Pulumi Cloud context.
+func defaultStackWebhookNewClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookNewClient, client.StackIdentifier, error) {
+	return RequireCloudStack(
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+// Valid webhook formats.
+var webhookFormats = []string{"raw", "slack", "ms_teams", "pulumi_deployments"}
+
+// Valid event groups for stack webhooks.
+var stackWebhookGroups = []string{"stacks", "deployments", "policies"}
+
+// groupFilters maps each event group to its contained event filters.
+var groupFilters = map[string][]string{
+	"stacks": {
+		"update_succeeded", "update_failed",
+		"preview_succeeded", "preview_failed",
+		"destroy_succeeded", "destroy_failed",
+		"refresh_succeeded", "refresh_failed",
+		"import_succeeded", "import_failed",
+	},
+	"deployments": {
+		"deployment_queued", "deployment_started",
+		"deployment_succeeded", "deployment_failed",
+		"drift_detected",
+		"drift_detection_succeeded", "drift_detection_failed",
+		"drift_remediation_succeeded", "drift_remediation_failed",
+		"deployment_file_ingestion_failed",
+	},
+	"policies": {
+		"policy_violation_mandatory", "policy_violation_advisory",
+	},
+}
+
+// filtersNotCoveredByGroups returns event filters that are not already
+// covered by the selected groups.
+func filtersNotCoveredByGroups(selectedGroups []string) []string {
+	covered := make(map[string]bool)
+	for _, g := range selectedGroups {
+		for _, f := range groupFilters[g] {
+			covered[f] = true
+		}
+	}
+	// Collect all known filters that aren't covered.
+	var remaining []string
+	for _, group := range stackWebhookGroups {
+		for _, f := range groupFilters[group] {
+			if !covered[f] {
+				remaining = append(remaining, f)
+			}
+		}
+	}
+	return remaining
+}
+
+// resolveNewArgs prompts for any required values not provided via flags.
+func resolveNewArgs(
+	skipPrompts bool,
+	name, displayName, url, format string,
+	filters, groups []string,
+	opts display.Options,
+) (stackWebhookNewArgs, error) {
+	var err error
+
+	// Display name defaults to the webhook name.
+	if displayName == "" {
+		displayName = name
+	}
+
+	// URL is required.
+	if url == "" {
+		if !skipPrompts {
+			fmt.Println("Enter the URL that will receive webhook payloads " +
+				"(e.g. https://example.com/webhook).")
+		}
+		urlErrMsg := "a payload URL is required (use --url)"
+		if !skipPrompts {
+			urlErrMsg = "a payload URL is required"
+		}
+		url, err = ui.PromptForValue(
+			skipPrompts, "Webhook payload URL", "", false,
+			func(v string) error {
+				if v == "" {
+					return errors.New(urlErrMsg) //nolint:goerr113 // dynamic but intentional
+				}
+				return nil
+			}, opts)
+		if err != nil {
+			return stackWebhookNewArgs{}, err
+		}
+	}
+
+	// Format: prompt with a picker when interactive.
+	if !skipPrompts {
+		format = ui.PromptUserSkippable(
+			false, "Webhook format", webhookFormats, format,
+			opts.Color)
+	}
+
+	// Event groups: prompt with a multi-select when interactive.
+	if len(groups) == 0 && !skipPrompts {
+		groups = ui.PromptUserMultiSkippable(
+			false, "Event groups to subscribe to",
+			stackWebhookGroups, stackWebhookGroups,
+			opts.Color)
+	}
+
+	// Event filters: only show events not already covered by selected groups.
+	if len(filters) == 0 && !skipPrompts {
+		remaining := filtersNotCoveredByGroups(groups)
+		if len(remaining) > 0 {
+			filters = ui.PromptUserMultiSkippable(
+				false,
+				"Additional events to subscribe to",
+				remaining, nil,
+				opts.Color)
+		}
+	}
+
+	return stackWebhookNewArgs{
+		Name:        name,
+		DisplayName: displayName,
+		URL:         url,
+		Format:      format,
+		Filters:     filters,
+		Groups:      groups,
+	}, nil
+}
+
+func runStackWebhookNew(
+	ctx context.Context,
+	w io.Writer,
+	factory stackWebhookNewClientFactory,
+	stackFlag string,
+	args stackWebhookNewArgs,
+	output string,
+) error {
+	renderer, err := webhookNewRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	formatPtr := &args.Format
+	if args.Format == "" {
+		formatPtr = nil
+	}
+
+	project := stackID.Project
+	stack := stackID.Stack.String()
+	req := apitype.Webhook{
+		OrganizationName: stackID.Owner,
+		ProjectName:      &project,
+		StackName:        &stack,
+		Name:             args.Name,
+		DisplayName:      args.DisplayName,
+		PayloadURL:       args.URL,
+		Active:           args.Active,
+		Format:           formatPtr,
+		Filters:          args.Filters,
+		Groups:           args.Groups,
+	}
+	if args.Secret != "" {
+		req.Secret = args.Secret
+	}
+
+	created, err := c.CreateStackWebhook(ctx, stackID, req)
+	if err != nil {
+		return fmt.Errorf("creating stack webhook: %w", err)
+	}
+
+	return renderer(w, created)
+}
+
+type webhookNewRenderFunc func(w io.Writer, wh apitype.Webhook) error
+
+func webhookNewRenderer(output string) (webhookNewRenderFunc, error) {
+	switch output {
+	case "", "default":
+		return renderWebhookNewText, nil
+	case "json":
+		return renderWebhookGetJSON, nil
+	default:
+		return nil, fmt.Errorf(
+			"invalid --output value %q: expected \"default\" or \"json\"",
+			output)
+	}
+}
+
+func renderWebhookNewText(w io.Writer, wh apitype.Webhook) error {
+	fmt.Fprintf(w, "Created webhook %q\n", wh.Name)
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -83,7 +83,16 @@ func TestStackWebhookNew_TextOutput(t *testing.T) {
 	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
 	require.NoError(t, err)
 
-	assert.Equal(t, "Created webhook \"my-hook\"\n", buf.String())
+	expected := "ID:                my-hook\n" +
+		"Name:              My Hook\n" +
+		"Organization:      my-org\n" +
+		"Project:           my-project\n" +
+		"Stack:             dev\n" +
+		"URL:               https://example.com/webhook\n" +
+		"Format:            raw\n" +
+		"Active:            yes\n" +
+		"Has secret:        yes\n"
+	assert.Equal(t, expected, buf.String())
 }
 
 func TestStackWebhookNew_JSONOutput(t *testing.T) {
@@ -213,6 +222,17 @@ func TestStackWebhookNew_ResolveArgs_Yes(t *testing.T) {
 	assert.Equal(t, "raw", args.Format)
 	assert.Empty(t, args.Filters)
 	assert.Empty(t, args.Groups)
+}
+
+func TestStackWebhookNew_ResolveArgs_YesNoName(t *testing.T) {
+	t.Parallel()
+
+	// With skipPrompts=true but no name, should error because name is required.
+	_, err := resolveNewArgs(true, "", "", "https://example.com", "raw",
+		nil, nil, display.Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "webhook name is required")
+	assert.Contains(t, err.Error(), "--name")
 }
 
 func TestStackWebhookNew_ResolveArgs_YesNoURL(t *testing.T) {

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWebhookNewClient struct {
+	created apitype.Webhook
+	err     error
+	gotReq  apitype.Webhook
+}
+
+func (m *mockWebhookNewClient) CreateStackWebhook(
+	_ context.Context, _ client.StackIdentifier, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	m.gotReq = req
+	return m.created, m.err
+}
+
+func stubNewFactory(c stackWebhookNewClient) stackWebhookNewClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookNewClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func failingNewFactory(err error) stackWebhookNewClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookNewClient, client.StackIdentifier, error) {
+		return nil, client.StackIdentifier{}, err
+	}
+}
+
+func createdWebhook() apitype.Webhook {
+	return apitype.Webhook{
+		OrganizationName: "my-org",
+		ProjectName:      ptr("my-project"),
+		StackName:        ptr("dev"),
+		Name:             "my-hook",
+		DisplayName:      "My Hook",
+		PayloadURL:       "https://example.com/webhook",
+		Active:           true,
+		Format:           ptr("raw"),
+		HasSecret:        true,
+	}
+}
+
+func TestStackWebhookNew_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookNewClient{created: createdWebhook()}
+	args := stackWebhookNewArgs{
+		Name:        "my-hook",
+		DisplayName: "My Hook",
+		URL:         "https://example.com/webhook",
+		Format:      "raw",
+		Active:      true,
+		Secret:      "s3cret",
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Created webhook \"my-hook\"\n", buf.String())
+}
+
+func TestStackWebhookNew_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookNewClient{created: createdWebhook()}
+	args := stackWebhookNewArgs{
+		Name:        "my-hook",
+		DisplayName: "My Hook",
+		URL:         "https://example.com/webhook",
+		Format:      "raw",
+		Active:      true,
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "json")
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), `"id": "my-hook"`)
+	assert.Contains(t, buf.String(), `"organizationName": "my-org"`)
+}
+
+func TestStackWebhookNew_RequestFields(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookNewClient{created: createdWebhook()}
+	args := stackWebhookNewArgs{
+		Name:        "my-hook",
+		DisplayName: "My Hook",
+		URL:         "https://example.com/webhook",
+		Format:      "slack",
+		Filters:     []string{"update_succeeded", "update_failed"},
+		Groups:      []string{"stacks"},
+		Active:      true,
+		Secret:      "s3cret",
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-hook", c.gotReq.Name)
+	assert.Equal(t, "My Hook", c.gotReq.DisplayName)
+	assert.Equal(t, "https://example.com/webhook", c.gotReq.PayloadURL)
+	require.NotNil(t, c.gotReq.Format)
+	assert.Equal(t, "slack", *c.gotReq.Format)
+	assert.Equal(t, []string{"update_succeeded", "update_failed"}, c.gotReq.Filters)
+	assert.Equal(t, []string{"stacks"}, c.gotReq.Groups)
+	assert.True(t, c.gotReq.Active)
+	assert.Equal(t, "s3cret", c.gotReq.Secret)
+}
+
+func TestStackWebhookNew_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookNewClient{created: createdWebhook()}
+	args := stackWebhookNewArgs{
+		Name: "hook", URL: "https://example.com", Format: "raw", Active: true,
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+}
+
+func TestStackWebhookNew_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookNewClient{err: errors.New("409 conflict")}
+	args := stackWebhookNewArgs{
+		Name: "hook", URL: "https://example.com", Format: "raw", Active: true,
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating stack webhook")
+	assert.Contains(t, err.Error(), "409 conflict")
+}
+
+func TestStackWebhookNew_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	args := stackWebhookNewArgs{
+		Name: "hook", URL: "https://example.com", Format: "raw", Active: true,
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(
+		t.Context(), &buf, failingNewFactory(errors.New("not logged in")),
+		"", args, "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestStackWebhookNew_StackFlagPropagation(t *testing.T) {
+	t.Parallel()
+
+	var capturedStack string
+	factory := func(_ context.Context, stackFlag string) (stackWebhookNewClient, client.StackIdentifier, error) {
+		capturedStack = stackFlag
+		return &mockWebhookNewClient{created: createdWebhook()}, testStackID, nil
+	}
+
+	args := stackWebhookNewArgs{
+		Name: "hook", URL: "https://example.com", Format: "raw", Active: true,
+	}
+
+	var buf bytes.Buffer
+	err := runStackWebhookNew(t.Context(), &buf, factory, "org/proj/my-stack", args, "default")
+	require.NoError(t, err)
+	assert.Equal(t, "org/proj/my-stack", capturedStack)
+}
+
+func TestStackWebhookNew_ResolveArgs_Yes(t *testing.T) {
+	t.Parallel()
+
+	// With skipPrompts=true and --url set, should use defaults without prompting.
+	args, err := resolveNewArgs(true, "my-hook", "", "https://example.com", "raw",
+		nil, nil, display.Options{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-hook", args.Name)
+	assert.Equal(t, "my-hook", args.DisplayName) // defaults to name
+	assert.Equal(t, "https://example.com", args.URL)
+	assert.Equal(t, "raw", args.Format)
+	assert.Empty(t, args.Filters)
+	assert.Empty(t, args.Groups)
+}
+
+func TestStackWebhookNew_ResolveArgs_YesNoURL(t *testing.T) {
+	t.Parallel()
+
+	// With skipPrompts=true but no URL, should error because URL is required.
+	_, err := resolveNewArgs(true, "my-hook", "", "", "raw",
+		nil, nil, display.Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payload URL is required")
+	assert.Contains(t, err.Error(), "--url")
+}
+
+func TestStackWebhookNew_ResolveArgs_ExplicitDisplayName(t *testing.T) {
+	t.Parallel()
+
+	// Explicit display name should be kept as-is.
+	args, err := resolveNewArgs(true, "my-hook", "Custom Name", "https://example.com", "raw",
+		nil, nil, display.Options{})
+	require.NoError(t, err)
+	assert.Equal(t, "Custom Name", args.DisplayName)
+}
+
+func TestFiltersNotCoveredByGroups(t *testing.T) {
+	t.Parallel()
+
+	// All groups selected → no remaining filters.
+	assert.Empty(t, filtersNotCoveredByGroups([]string{"stacks", "deployments", "policies"}))
+
+	// Only stacks → deployments + policies filters remain.
+	remaining := filtersNotCoveredByGroups([]string{"stacks"})
+	assert.Contains(t, remaining, "deployment_queued")
+	assert.Contains(t, remaining, "policy_violation_mandatory")
+	assert.NotContains(t, remaining, "update_succeeded")
+
+	// No groups → all filters remain.
+	all := filtersNotCoveredByGroups(nil)
+	assert.Contains(t, all, "update_succeeded")
+	assert.Contains(t, all, "deployment_queued")
+	assert.Contains(t, all, "policy_violation_mandatory")
+}

--- a/sdk/go/common/apitype/webhooks.go
+++ b/sdk/go/common/apitype/webhooks.go
@@ -27,6 +27,7 @@ type Webhook struct {
 	Format           *string  `json:"format,omitempty"`
 	Filters          []string `json:"filters,omitempty"`
 	Groups           []string `json:"groups,omitempty"`
+	Secret           string   `json:"secret,omitempty"`
 	HasSecret        bool     `json:"hasSecret"`
 	SecretCiphertext string   `json:"secretCiphertext"`
 }


### PR DESCRIPTION
Implement this command using a similar interface to `pulumi new`. Flags can be passed to set values, and whatever is not set by flags will be prompted.  If `--yes` is passed, we default as many things as possible, which is everything apart from the url.  If `--url` is not passed in this case, we error out.

Example outputs:
```
$ pulumi stack webhook new my-hook10 -s pulumi/pulumi-service-review-stacks/tgummerer --url https://example.com --event update_failed --event update_succeeded --yes
Created webhook "my-hook10"
```

```
$ pulumi stack webhook new my-hook8 -s pulumi/pulumi-service-review-stacks/tgummerer
Enter the URL that will receive webhook payloads (e.g. https://example.com/webhook).
Webhook payload URL: http://exmaple.com
Webhook format raw
Event groups to subscribe to (use enter to accept the current selection)
Additional events to subscribe to (use enter to accept the current selection) update_failed
Created webhook "my-hook8"
```

Fixes https://github.com/pulumi/pulumi/issues/23060

Built on top of https://github.com/pulumi/pulumi/pull/23089