### PR TITLE
add `pulumi stack webhook remove`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-remove.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-remove.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook remove` to delete a stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -756,6 +756,13 @@ func (pc *Client) CreateStackWebhook(
 	return resp, nil
 }
 
+// DeleteStackWebhook deletes the given webhook from the stack.
+func (pc *Client) DeleteStackWebhook(
+	ctx context.Context, stackID StackIdentifier, webhookName string,
+) error {
+	return pc.restCall(ctx, "DELETE", getStackPath(stackID, "hooks", webhookName), nil, nil, nil)
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -278,3 +278,43 @@ func TestCreateStackWebhook(t *testing.T) {
 		assert.ErrorContains(t, err, "webhook already exists")
 	})
 }
+
+func TestDeleteStackWebhook(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var gotPath, gotMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		err := c.DeleteStackWebhook(t.Context(), stackID, "deploy-hook")
+		require.NoError(t, err)
+
+		assert.Equal(t, "DELETE", gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks/deploy-hook", gotPath)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		err := c.DeleteStackWebhook(t.Context(), stackID, "no-such-hook")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -93,28 +93,6 @@ func newStackWebhookEditCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23058]: Not yet implemented.
-func newStackWebhookRemoveCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove",
-		Short:  "Delete a stack webhook",
-		Long:   "[EXPERIMENTAL] Delete a stack webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23056]: Not yet implemented.
 func newStackWebhookDeliveryCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -1,0 +1,128 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+)
+
+// stackWebhookRemoveClient is the interface the remove command needs.
+type stackWebhookRemoveClient interface {
+	DeleteStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+	) error
+}
+
+// stackWebhookRemoveClientFactory builds a stackWebhookRemoveClient.
+type stackWebhookRemoveClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookRemoveClient, client.StackIdentifier, error)
+
+func newStackWebhookRemoveCmd() *cobra.Command {
+	return newStackWebhookRemoveCmdWith(nil)
+}
+
+func newStackWebhookRemoveCmdWith(factory stackWebhookRemoveClientFactory) *cobra.Command {
+	var (
+		stack string
+		yes   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "[EXPERIMENTAL] Delete a stack webhook",
+		Long: "Delete a stack webhook.\n" +
+			"\n" +
+			"Permanently removes the specified webhook from the stack. This cannot\n" +
+			"be undone. You will be prompted to confirm unless --yes is passed.\n" +
+			"\n" +
+			"Returns an error if the webhook does not exist.",
+		Example: "  # Remove a webhook (will prompt for confirmation)\n" +
+			"  pulumi stack webhook remove my-webhook\n\n" +
+			"  # Remove without confirmation\n" +
+			"  pulumi stack webhook remove my-webhook --yes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackWebhookRemoveClientFactory
+			}
+			return runStackWebhookRemove(
+				cmd.Context(), cmd.OutOrStdout(), factory,
+				stack, args[0], yes,
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
+		"Skip confirmation prompts")
+
+	return cmd
+}
+
+func defaultStackWebhookRemoveClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookRemoveClient, client.StackIdentifier, error) {
+	return RequireCloudStack(
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackWebhookRemove(
+	ctx context.Context,
+	w io.Writer,
+	factory stackWebhookRemoveClientFactory,
+	stackFlag string,
+	webhookName string,
+	yes bool,
+) error {
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	if !yes {
+		prompt := fmt.Sprintf(
+			"This will permanently remove the webhook '%s'!",
+			webhookName)
+		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
+			return result.FprintBailf(os.Stdout, "confirmation declined")
+		}
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	if err := c.DeleteStackWebhook(ctx, stackID, webhookName); err != nil {
+		return fmt.Errorf("removing stack webhook: %w", err)
+	}
+
+	fmt.Fprintf(w, "Webhook '%s' has been removed.\n", webhookName)
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockWebhookRemoveClient struct {
+	err     error
+	gotName string
+}
+
+func (m *mockWebhookRemoveClient) DeleteStackWebhook(
+	_ context.Context, _ client.StackIdentifier, name string,
+) error {
+	m.gotName = name
+	return m.err
+}
+
+func stubRemoveFactory(c stackWebhookRemoveClient) stackWebhookRemoveClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookRemoveClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func TestStackWebhookRemove_Success(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookRemoveClient{}
+	var buf bytes.Buffer
+	err := runStackWebhookRemove(
+		t.Context(), &buf, stubRemoveFactory(c),
+		"", "my-hook", true, // yes=true to skip confirmation
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-hook", c.gotName)
+	assert.Contains(t, buf.String(), "Webhook 'my-hook' has been removed.")
+}
+
+func TestStackWebhookRemove_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockWebhookRemoveClient{err: errors.New("not found")}
+	var buf bytes.Buffer
+	err := runStackWebhookRemove(
+		t.Context(), &buf, stubRemoveFactory(c),
+		"", "no-such", true,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "removing stack webhook")
+	assert.Contains(t, err.Error(), "not found")
+}


### PR DESCRIPTION
This removes a webhook for a specific stack (defaults to the current stack).

It has the same confirmation prompt as `pulumi stack remove`, asking the user to re-type the name of the hook, unless `--yes` is passed.

```
$ pulumi stack webhook remove my-hook -s pulumi/pulumi-service-review-stacks/tgummerer
This will permanently remove the webhook 'my-hook'!
Please confirm that this is what you'd like to do by typing `my-hook`: my-hook
Webhook 'my-hook' has been removed.

$ pulumi stack webhook remove my-hook -s pulumi/pulumi-service-review-stacks/tgummerer --yes
Webhook 'my-hook' has been removed.
```

Fixes https://github.com/pulumi/pulumi/issues/23058

Built on top of https://github.com/pulumi/pulumi/pull/23101