### PR TITLE
cli/cloud: implement `pulumi stack get`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-get.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack get` to retrieve detailed information about a stack

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -35,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -47,6 +49,7 @@ type stackArgs struct {
 	startTime              string
 	showStackName          bool
 	fullyQualifyStackNames bool
+	output                 string
 }
 
 func NewStackCmd() *cobra.Command {
@@ -100,6 +103,9 @@ func NewStackCmd() *cobra.Command {
 		&args.showSecrets, "show-secrets", false, "Display stack outputs which are marked as secret in plaintext")
 	cmd.Flags().BoolVar(
 		&args.showStackName, "show-name", false, "Display only the stack name")
+	cmd.Flags().StringVarP(
+		&args.output, "output", "o", "default",
+		"The output format: default (human-readable) or json")
 
 	cmd.AddCommand(newStackExportCmd())
 	cmd.AddCommand(newStackGraphCmd())
@@ -133,6 +139,15 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 		return nil
 	}
 
+	switch args.output {
+	case "", "default":
+		// Fall through to the human-readable rendering below.
+	case "json":
+		return runStackJSON(ctx, s, out, args)
+	default:
+		return fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", args.output)
+	}
+
 	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
 	if err != nil {
 		return err
@@ -150,12 +165,18 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 			fmt.Fprintf(out, "    Owner: %s\n", cs.OrgName())
 
 			if currentOp := cs.CurrentOperation(); currentOp != nil {
-				fmt.Fprintf(out, "    Update in progress:\n")
+				fmt.Fprintf(out, "    %s in progress:\n", capitalizeFirst(string(currentOp.Kind)))
 				args.startTime = humanize.Time(time.Unix(currentOp.Started, 0))
 				fmt.Fprintf(out, "	Started: %v\n", args.startTime)
 				fmt.Fprintf(out, "	Requested By: %s\n", currentOp.Author)
 			}
 		}
+
+		cloudInfo, _, err := fetchCloudStackInfo(ctx, s)
+		if err != nil {
+			return fmt.Errorf("fetching stack: %w", err)
+		}
+		renderCloudStackText(out, cloudInfo)
 	}
 
 	if snap != nil {
@@ -366,4 +387,61 @@ func renderResourceRow(res *resource.State, prefix, infoPrefix string, showURN, 
 	}
 
 	return cmdutil.TableRow{Columns: columns, AdditionalInfo: additionalInfo}
+}
+
+// capitalizeFirst returns s with its first rune uppercased. Empty input
+// yields "Operation" as a sensible fallback for the rare case where an
+// API response omits the operation kind.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return "Operation"
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// renderCloudStackText writes the Pulumi Cloud-only metadata (Version,
+// Active update, Tags) under the current-stack heading. It mirrors the
+// JSON envelope's cloud fields so `pulumi stack` and
+// `pulumi stack --output json` show the same information.
+func renderCloudStackText(out io.Writer, info *apitype.Stack) {
+	if info == nil {
+		return
+	}
+	if info.Version != 0 {
+		fmt.Fprintf(out, "    Version: %d\n", info.Version)
+	}
+	if info.ActiveUpdate != "" {
+		fmt.Fprintf(out, "    Active update: %s\n", info.ActiveUpdate)
+	}
+	if len(info.Tags) > 0 {
+		keys := make([]string, 0, len(info.Tags))
+		for k := range info.Tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		maxKey := 0
+		for _, k := range keys {
+			if len(k) > maxKey {
+				maxKey = len(k)
+			}
+		}
+		fmt.Fprintln(out, "    Tags:")
+		for _, k := range keys {
+			fmt.Fprintf(out, "        %-*s  %s\n", maxKey, k, info.Tags[k])
+		}
+	}
+}
+
+// runStackJSON renders the stack as a JSON envelope. On Pulumi Cloud
+// backends it also fetches the GetStack API for cloud-only metadata
+// (version, tags, activeUpdate, currentOperation, console URL).
+func runStackJSON(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
+	in, err := loadStackJSONInputs(ctx, s, args.showSecrets)
+	if err != nil {
+		return fmt.Errorf("fetching stack: %w", err)
+	}
+	if args.showSecrets {
+		Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack")
+	}
+	return renderStackJSON(out, buildStackJSON(in))
 }

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -15,43 +15,26 @@
 package stack
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"sort"
-	"time"
-
-	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// stackGetClient is the interface the get command needs from the API client.
-type stackGetClient interface {
-	GetStack(ctx context.Context, stackID client.StackIdentifier) (apitype.Stack, error)
-}
-
-// stackGetClientFactory builds a stackGetClient from the environment.
-// It returns the client, the resolved StackIdentifier, and any error.
-type stackGetClientFactory func(
-	ctx context.Context, stackFlag string,
-) (stackGetClient, client.StackIdentifier, error)
-
+// newStackGetCmd registers `pulumi stack get`, a thin convenience alias for
+// `pulumi stack --output=json` that requires the Pulumi Cloud backend.
+//
+// The JSON envelope is identical to `pulumi stack --output=json` and is
+// built by stack_json.go.
 func newStackGetCmd() *cobra.Command {
-	return newStackGetCmdWith(nil)
-}
-
-func newStackGetCmdWith(factory stackGetClientFactory) *cobra.Command {
 	var (
-		stack  string
-		output string
+		stackName   string
+		output      string
+		showSecrets bool
 	)
 
 	cmd := &cobra.Command{
@@ -59,156 +42,36 @@ func newStackGetCmdWith(factory stackGetClientFactory) *cobra.Command {
 		Short: "Retrieve detailed information about a stack",
 		Long: "[EXPERIMENTAL] Retrieve detailed information about a stack.\n" +
 			"\n" +
-			"Displays the organization, project, and stack name, the current version,\n" +
-			"all associated tags, any active update operation (with its kind, author,\n" +
-			"and start time), and the active update UUID. By default the output is\n" +
-			"human-readable; pass --output=json for a stable, machine-readable JSON\n" +
-			"envelope.",
+			"`pulumi stack get` is a convenience alias for `pulumi stack --output=json`\n" +
+			"that requires the Pulumi Cloud backend. It surfaces the organization,\n" +
+			"project, and stack name, the current version, all associated tags, any\n" +
+			"active update operation (with its kind, author, and start time), the\n" +
+			"active update UUID, and (when available) the local resource snapshot.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if factory == nil {
-				factory = defaultStackGetClientFactory
+			ctx := cmd.Context()
+			s, err := RequireStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager,
+				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()})
+			if err != nil {
+				return err
 			}
-			return runStackGet(cmd.Context(), cmd.OutOrStdout(), factory, stack, output)
+			if _, ok := s.(httpstate.Stack); !ok {
+				return errCloudBackendRequired
+			}
+			return runStack(ctx, s, cmd.OutOrStdout(), stackArgs{
+				output:      output,
+				showSecrets: showSecrets,
+			})
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVarP(&output, "output", "o", "default",
+	cmd.Flags().StringVarP(&output, "output", "o", "json",
 		"The output format: default (human-readable) or json")
+	cmd.Flags().BoolVar(&showSecrets, "show-secrets", false,
+		"Display stack outputs which are marked as secret in plaintext")
 
 	return cmd
-}
-
-func defaultStackGetClientFactory(
-	ctx context.Context, stackFlag string,
-) (stackGetClient, client.StackIdentifier, error) {
-	return RequireCloudStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
-}
-
-func runStackGet(
-	ctx context.Context,
-	w io.Writer,
-	factory stackGetClientFactory,
-	stackFlag string,
-	output string,
-) error {
-	renderer, err := stackGetRenderer(output)
-	if err != nil {
-		return err
-	}
-
-	c, stackID, err := factory(ctx, stackFlag)
-	if err != nil {
-		return err
-	}
-
-	stack, err := c.GetStack(ctx, stackID)
-	if err != nil {
-		return fmt.Errorf("getting stack: %w", err)
-	}
-
-	return renderer(w, stack)
-}
-
-type stackGetRenderFunc func(w io.Writer, stack apitype.Stack) error
-
-func stackGetRenderer(output string) (stackGetRenderFunc, error) {
-	switch output {
-	case "", "default":
-		return renderStackGetDefault, nil
-	case "json":
-		return renderStackGetJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
-	}
-}
-
-// stackGetEnvelope is the JSON shape emitted by `pulumi stack get --output=json`.
-type stackGetEnvelope struct {
-	Organization     string                 `json:"organization"`
-	Project          string                 `json:"project"`
-	Stack            string                 `json:"stack"`
-	Version          int                    `json:"version"`
-	ActiveUpdate     string                 `json:"activeUpdate"`
-	CurrentOperation *stackGetOperationJSON `json:"currentOperation,omitempty"`
-	Tags             map[string]string      `json:"tags"`
-}
-
-type stackGetOperationJSON struct {
-	Kind    string `json:"kind"`
-	Author  string `json:"author"`
-	Started string `json:"started"`
-}
-
-func toStackGetEnvelope(s apitype.Stack) stackGetEnvelope {
-	tags := make(map[string]string, len(s.Tags))
-	for k, v := range s.Tags {
-		tags[k] = v
-	}
-	env := stackGetEnvelope{
-		Organization: s.OrgName,
-		Project:      s.ProjectName,
-		Stack:        string(s.StackName),
-		Version:      s.Version,
-		ActiveUpdate: s.ActiveUpdate,
-		Tags:         tags,
-	}
-	if op := s.CurrentOperation; op != nil {
-		env.CurrentOperation = &stackGetOperationJSON{
-			Kind:    string(op.Kind),
-			Author:  op.Author,
-			Started: time.Unix(op.Started, 0).UTC().Format(time.RFC3339),
-		}
-	}
-	return env
-}
-
-func renderStackGetJSON(w io.Writer, stack apitype.Stack) error {
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	return enc.Encode(toStackGetEnvelope(stack))
-}
-
-func renderStackGetDefault(w io.Writer, stack apitype.Stack) error {
-	fmt.Fprintf(w, "Organization:   %s\n", stack.OrgName)
-	fmt.Fprintf(w, "Project:        %s\n", stack.ProjectName)
-	fmt.Fprintf(w, "Stack:          %s\n", stack.StackName)
-	fmt.Fprintf(w, "Version:        %d\n", stack.Version)
-	if stack.ActiveUpdate != "" {
-		fmt.Fprintf(w, "Active update:  %s\n", stack.ActiveUpdate)
-	}
-
-	if op := stack.CurrentOperation; op != nil {
-		started := time.Unix(op.Started, 0)
-		fmt.Fprintln(w, "Update in progress:")
-		fmt.Fprintf(w, "    Kind:    %s\n", op.Kind)
-		fmt.Fprintf(w, "    Author:  %s\n", op.Author)
-		fmt.Fprintf(w, "    Started: %s (%s)\n", humanize.Time(started), started.Format(time.RFC3339))
-	}
-
-	if len(stack.Tags) > 0 {
-		keys := make([]string, 0, len(stack.Tags))
-		for k := range stack.Tags {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		maxKey := 0
-		for _, k := range keys {
-			if len(k) > maxKey {
-				maxKey = len(k)
-			}
-		}
-
-		fmt.Fprintln(w, "Tags:")
-		for _, k := range keys {
-			fmt.Fprintf(w, "    %-*s  %s\n", maxKey, k, stack.Tags[k])
-		}
-	}
-
-	return nil
 }

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -18,18 +18,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// newStackGetCmd registers `pulumi stack get`, a thin convenience alias for
-// `pulumi stack --output=json` that requires the Pulumi Cloud backend.
-//
-// The JSON envelope is identical to `pulumi stack --output=json` and is
-// built by stack_json.go.
+// newStackGetCmd registers `pulumi stack get`, a thin convenience alias
+// for `pulumi stack`. It behaves identically to `pulumi stack` on both
+// the Pulumi Cloud and DIY backends, including the default value of
+// `--output` (human-readable text). Pass `--output=json` for the
+// stable, machine-readable envelope built by stack_json.go.
 func newStackGetCmd() *cobra.Command {
 	var (
 		stackName   string
@@ -42,20 +41,18 @@ func newStackGetCmd() *cobra.Command {
 		Short: "Retrieve detailed information about a stack",
 		Long: "[EXPERIMENTAL] Retrieve detailed information about a stack.\n" +
 			"\n" +
-			"`pulumi stack get` is a convenience alias for `pulumi stack --output=json`\n" +
-			"that requires the Pulumi Cloud backend. It surfaces the organization,\n" +
-			"project, and stack name, the current version, all associated tags, any\n" +
-			"active update operation (with its kind, author, and start time), the\n" +
-			"active update UUID, and (when available) the local resource snapshot.",
+			"`pulumi stack get` is a convenience alias for `pulumi stack --output=json`.\n" +
+			"On the Pulumi Cloud backend it surfaces the organization, project, and\n" +
+			"stack name, the current version, all associated tags, any active update\n" +
+			"operation (with its kind, author, and start time), the active update\n" +
+			"UUID, and (when available) the local resource snapshot. On DIY backends\n" +
+			"the cloud-only fields are omitted; everything else is rendered.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			s, err := RequireStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager,
 				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()})
 			if err != nil {
 				return err
-			}
-			if _, ok := s.(httpstate.Stack); !ok {
-				return errCloudBackendRequired
 			}
 			return runStack(ctx, s, cmd.OutOrStdout(), stackArgs{
 				output:      output,
@@ -68,7 +65,7 @@ func newStackGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVarP(&output, "output", "o", "json",
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
 		"The output format: default (human-readable) or json")
 	cmd.Flags().BoolVar(&showSecrets, "show-secrets", false,
 		"Display stack outputs which are marked as secret in plaintext")

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -1,0 +1,214 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackGetClient is the interface the get command needs from the API client.
+type stackGetClient interface {
+	GetStack(ctx context.Context, stackID client.StackIdentifier) (apitype.Stack, error)
+}
+
+// stackGetClientFactory builds a stackGetClient from the environment.
+// It returns the client, the resolved StackIdentifier, and any error.
+type stackGetClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackGetClient, client.StackIdentifier, error)
+
+func newStackGetCmd() *cobra.Command {
+	return newStackGetCmdWith(nil)
+}
+
+func newStackGetCmdWith(factory stackGetClientFactory) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Retrieve detailed information about a stack",
+		Long: "[EXPERIMENTAL] Retrieve detailed information about a stack.\n" +
+			"\n" +
+			"Displays the organization, project, and stack name, the current version,\n" +
+			"all associated tags, any active update operation (with its kind, author,\n" +
+			"and start time), and the active update UUID. By default the output is\n" +
+			"human-readable; pass --output=json for a stable, machine-readable JSON\n" +
+			"envelope.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackGetClientFactory
+			}
+			return runStackGet(cmd.Context(), cmd.OutOrStdout(), factory, stack, output)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable) or json")
+
+	return cmd
+}
+
+func defaultStackGetClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackGetClient, client.StackIdentifier, error) {
+	return RequireCloudStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackGet(
+	ctx context.Context,
+	w io.Writer,
+	factory stackGetClientFactory,
+	stackFlag string,
+	output string,
+) error {
+	renderer, err := stackGetRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	stack, err := c.GetStack(ctx, stackID)
+	if err != nil {
+		return fmt.Errorf("getting stack: %w", err)
+	}
+
+	return renderer(w, stack)
+}
+
+type stackGetRenderFunc func(w io.Writer, stack apitype.Stack) error
+
+func stackGetRenderer(output string) (stackGetRenderFunc, error) {
+	switch output {
+	case "", "default":
+		return renderStackGetDefault, nil
+	case "json":
+		return renderStackGetJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
+	}
+}
+
+// stackGetEnvelope is the JSON shape emitted by `pulumi stack get --output=json`.
+type stackGetEnvelope struct {
+	Organization     string                 `json:"organization"`
+	Project          string                 `json:"project"`
+	Stack            string                 `json:"stack"`
+	Version          int                    `json:"version"`
+	ActiveUpdate     string                 `json:"activeUpdate"`
+	CurrentOperation *stackGetOperationJSON `json:"currentOperation,omitempty"`
+	Tags             map[string]string      `json:"tags"`
+}
+
+type stackGetOperationJSON struct {
+	Kind    string `json:"kind"`
+	Author  string `json:"author"`
+	Started string `json:"started"`
+}
+
+func toStackGetEnvelope(s apitype.Stack) stackGetEnvelope {
+	tags := make(map[string]string, len(s.Tags))
+	for k, v := range s.Tags {
+		tags[k] = v
+	}
+	env := stackGetEnvelope{
+		Organization: s.OrgName,
+		Project:      s.ProjectName,
+		Stack:        string(s.StackName),
+		Version:      s.Version,
+		ActiveUpdate: s.ActiveUpdate,
+		Tags:         tags,
+	}
+	if op := s.CurrentOperation; op != nil {
+		env.CurrentOperation = &stackGetOperationJSON{
+			Kind:    string(op.Kind),
+			Author:  op.Author,
+			Started: time.Unix(op.Started, 0).UTC().Format(time.RFC3339),
+		}
+	}
+	return env
+}
+
+func renderStackGetJSON(w io.Writer, stack apitype.Stack) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toStackGetEnvelope(stack))
+}
+
+func renderStackGetDefault(w io.Writer, stack apitype.Stack) error {
+	fmt.Fprintf(w, "Organization:   %s\n", stack.OrgName)
+	fmt.Fprintf(w, "Project:        %s\n", stack.ProjectName)
+	fmt.Fprintf(w, "Stack:          %s\n", stack.StackName)
+	fmt.Fprintf(w, "Version:        %d\n", stack.Version)
+	if stack.ActiveUpdate != "" {
+		fmt.Fprintf(w, "Active update:  %s\n", stack.ActiveUpdate)
+	}
+
+	if op := stack.CurrentOperation; op != nil {
+		started := time.Unix(op.Started, 0)
+		fmt.Fprintln(w, "Update in progress:")
+		fmt.Fprintf(w, "    Kind:    %s\n", op.Kind)
+		fmt.Fprintf(w, "    Author:  %s\n", op.Author)
+		fmt.Fprintf(w, "    Started: %s (%s)\n", humanize.Time(started), started.Format(time.RFC3339))
+	}
+
+	if len(stack.Tags) > 0 {
+		keys := make([]string, 0, len(stack.Tags))
+		for k := range stack.Tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		maxKey := 0
+		for _, k := range keys {
+			if len(k) > maxKey {
+				maxKey = len(k)
+			}
+		}
+
+		fmt.Fprintln(w, "Tags:")
+		for _, k := range keys {
+			fmt.Fprintf(w, "    %-*s  %s\n", maxKey, k, stack.Tags[k])
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -221,26 +221,3 @@ func TestBuildStackJSON_WithSnapshot(t *testing.T) {
 	assert.Equal(t, "my-bucket", env.Resources[0].Name)
 	assert.Equal(t, "bucket-id-1", env.Resources[0].ID)
 }
-
-// TestNewStackGetCmd_FlagDefaults guards the cobra surface: --output
-// defaults to json, --stack and --show-secrets are present.
-func TestNewStackGetCmd_FlagDefaults(t *testing.T) {
-	t.Parallel()
-
-	cmd := newStackGetCmd()
-	assert.Equal(t, "get", cmd.Use)
-	require.NotNil(t, cmd.RunE)
-
-	output := cmd.Flags().Lookup("output")
-	require.NotNil(t, output)
-	assert.Equal(t, "o", output.Shorthand)
-	assert.Equal(t, "json", output.DefValue, "stack get must default to --output=json")
-
-	stack := cmd.Flags().Lookup("stack")
-	require.NotNil(t, stack)
-	assert.Equal(t, "s", stack.Shorthand)
-
-	secrets := cmd.Flags().Lookup("show-secrets")
-	require.NotNil(t, secrets)
-	assert.Equal(t, "false", secrets.DefValue)
-}

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -16,39 +16,23 @@ package stack
 
 import (
 	"bytes"
-	"context"
-	"errors"
+	"encoding/json"
 	"testing"
+	"time"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// mockStackGetClient implements stackGetClient for tests.
-type mockStackGetClient struct {
-	stack apitype.Stack
-	err   error
-}
-
-func (m *mockStackGetClient) GetStack(_ context.Context, _ client.StackIdentifier) (apitype.Stack, error) {
-	return m.stack, m.err
-}
-
-func stackGetStubFactory(c stackGetClient) stackGetClientFactory {
-	return func(_ context.Context, _ string) (stackGetClient, client.StackIdentifier, error) {
-		return c, testStackID, nil
-	}
-}
-
-func stackGetFailingFactory(err error) stackGetClientFactory {
-	return func(_ context.Context, _ string) (stackGetClient, client.StackIdentifier, error) {
-		return nil, client.StackIdentifier{}, err
-	}
-}
-
-func sampleStack() apitype.Stack {
+// sampleCloudStack returns a fixture apitype.Stack with every cloud-only
+// field populated; tests use it to assert the JSON envelope's cloud
+// section.
+func sampleCloudStack() apitype.Stack {
 	return apitype.Stack{
 		ID:           "abc123",
 		OrgName:      "my-org",
@@ -59,8 +43,6 @@ func sampleStack() apitype.Stack {
 		Tags: map[apitype.StackTagName]string{
 			"environment":    "production",
 			"pulumi:project": "my-project",
-			"pulumi:runtime": "nodejs",
-			"vcs:owner":      "pulumi",
 		},
 		CurrentOperation: &apitype.OperationStatus{
 			Kind:    apitype.UpdateUpdate,
@@ -70,200 +52,195 @@ func sampleStack() apitype.Stack {
 	}
 }
 
-func TestStackGet_DefaultOutput(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: sampleStack()}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
-	require.NoError(t, err)
-
-	out := buf.String()
-	assert.Contains(t, out, "Organization:   my-org")
-	assert.Contains(t, out, "Project:        my-project")
-	assert.Contains(t, out, "Stack:          dev")
-	assert.Contains(t, out, "Version:        42")
-	assert.Contains(t, out, "Active update:  11111111-2222-3333-4444-555555555555")
-	assert.Contains(t, out, "Update in progress:")
-	assert.Contains(t, out, "Kind:    update")
-	assert.Contains(t, out, "Author:  alice")
-	assert.Contains(t, out, "Tags:")
-	assert.Contains(t, out, "environment")
-	assert.Contains(t, out, "production")
-	assert.Contains(t, out, "pulumi:project")
-	assert.Contains(t, out, "pulumi:runtime")
-	assert.Contains(t, out, "nodejs")
+func sampleIdentityInputs() stackJSONInputs {
+	return stackJSONInputs{
+		StackName:   "dev",
+		Project:     "my-project",
+		BackendName: "pulumi.com",
+	}
 }
 
-func TestStackGet_DefaultOutput_NoOperation(t *testing.T) {
+// TestBuildStackJSON_Cloud asserts that the JSON envelope preserves every
+// field the previous `pulumi stack get` envelope emitted, plus the new
+// snapshot/identity fields.
+func TestBuildStackJSON_Cloud(t *testing.T) {
 	t.Parallel()
 
-	stack := sampleStack()
-	stack.CurrentOperation = nil
+	in := sampleIdentityInputs()
+	cs := sampleCloudStack()
+	in.CloudStack = &cs
+	in.ConsoleURL = "https://app.pulumi.com/my-org/my-project/dev"
 
+	env := buildStackJSON(in)
 	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: stack}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
-	require.NoError(t, err)
-
-	out := buf.String()
-	assert.NotContains(t, out, "Update in progress")
-	assert.NotContains(t, out, "Kind:")
-	assert.NotContains(t, out, "Author:")
-}
-
-func TestStackGet_DefaultOutput_NoActiveUpdate(t *testing.T) {
-	t.Parallel()
-
-	stack := sampleStack()
-	stack.ActiveUpdate = ""
-
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: stack}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
-	require.NoError(t, err)
-
-	assert.NotContains(t, buf.String(), "Active update:")
-}
-
-func TestStackGet_DefaultOutput_NoTags(t *testing.T) {
-	t.Parallel()
-
-	stack := sampleStack()
-	stack.Tags = nil
-
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: stack}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
-	require.NoError(t, err)
-
-	assert.NotContains(t, buf.String(), "Tags:")
-}
-
-func TestStackGet_JSONOutput(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: sampleStack()}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "json")
-	require.NoError(t, err)
+	require.NoError(t, renderStackJSON(&buf, env))
 
 	assert.JSONEq(t, `{
 		"organization": "my-org",
 		"project": "my-project",
 		"stack": "dev",
+		"backend": "pulumi.com",
 		"version": 42,
 		"activeUpdate": "11111111-2222-3333-4444-555555555555",
 		"currentOperation": {
 			"kind": "update",
 			"author": "alice",
-			"started": "2025-05-13T13:20:00Z"
+			"started": "2025-05-13T13:20:00.000Z"
 		},
 		"tags": {
 			"environment":    "production",
-			"pulumi:project": "my-project",
-			"pulumi:runtime": "nodejs",
-			"vcs:owner":      "pulumi"
-		}
+			"pulumi:project": "my-project"
+		},
+		"resources": [],
+		"outputs": {},
+		"consoleUrl": "https://app.pulumi.com/my-org/my-project/dev"
 	}`, buf.String())
 }
 
-func TestStackGet_JSONOutput_NoOperation(t *testing.T) {
+func TestBuildStackJSON_Cloud_NoOperation(t *testing.T) {
 	t.Parallel()
 
-	stack := sampleStack()
-	stack.CurrentOperation = nil
-	stack.Tags = nil
+	in := sampleIdentityInputs()
+	cs := sampleCloudStack()
+	cs.CurrentOperation = nil
+	in.CloudStack = &cs
 
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: stack}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "json")
-	require.NoError(t, err)
-
-	assert.JSONEq(t, `{
-		"organization": "my-org",
-		"project": "my-project",
-		"stack": "dev",
-		"version": 42,
-		"activeUpdate": "11111111-2222-3333-4444-555555555555",
-		"tags": {}
-	}`, buf.String())
+	env := buildStackJSON(in)
+	assert.Nil(t, env.CurrentOperation)
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", env.ActiveUpdate)
 }
 
-func TestStackGet_InvalidOutput(t *testing.T) {
+func TestBuildStackJSON_Cloud_NoTags(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	c := &mockStackGetClient{stack: sampleStack()}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "xml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
-	assert.Contains(t, err.Error(), "xml")
+	in := sampleIdentityInputs()
+	cs := sampleCloudStack()
+	cs.Tags = nil
+	in.CloudStack = &cs
+
+	env := buildStackJSON(in)
+	assert.Equal(t, map[string]string{}, env.Tags, "tags must be present (possibly empty) for JSON consumers")
 }
 
-func TestStackGet_ClientError(t *testing.T) {
+// TestBuildStackJSON_DIY confirms cloud-only fields are absent on DIY
+// backends while the identity fields still render.
+func TestBuildStackJSON_DIY(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	c := &mockStackGetClient{err: errors.New("server error")}
-	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "getting stack")
-	assert.Contains(t, err.Error(), "server error")
-}
-
-func TestStackGet_FactoryError(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	err := runStackGet(t.Context(), &buf, stackGetFailingFactory(errors.New("not logged in")), "", "default")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not logged in")
-}
-
-func TestStackGet_StackFlagPropagation(t *testing.T) {
-	t.Parallel()
-
-	var capturedStack string
-	factory := func(_ context.Context, stackFlag string) (stackGetClient, client.StackIdentifier, error) {
-		capturedStack = stackFlag
-		return &mockStackGetClient{stack: sampleStack()}, testStackID, nil
+	in := stackJSONInputs{
+		StackName:   "dev",
+		Project:     "proj",
+		BackendName: "file:///tmp/state",
 	}
 
+	env := buildStackJSON(in)
 	var buf bytes.Buffer
-	err := runStackGet(t.Context(), &buf, factory, "org/proj/my-stack", "default")
-	require.NoError(t, err)
-	assert.Equal(t, "org/proj/my-stack", capturedStack)
+	require.NoError(t, renderStackJSON(&buf, env))
+
+	assert.JSONEq(t, `{
+		"project": "proj",
+		"stack": "dev",
+		"backend": "file:///tmp/state",
+		"tags": {},
+		"resources": [],
+		"outputs": {}
+	}`, buf.String())
 }
 
-func TestStackGet_CobraFlagBinding(t *testing.T) {
+// TestBuildStackJSON_PreservesLegacyKeys is a regression guard. The shape
+// emitted by the previous `pulumi stack get` JSON envelope is a strict
+// subset of the new unified envelope; anything that consumed it must
+// continue to work.
+func TestBuildStackJSON_PreservesLegacyKeys(t *testing.T) {
 	t.Parallel()
 
-	c := &mockStackGetClient{stack: sampleStack()}
-	cmd := newStackGetCmdWith(stackGetStubFactory(c))
+	in := sampleIdentityInputs()
+	cs := sampleCloudStack()
+	in.CloudStack = &cs
 
 	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--output", "json"})
+	require.NoError(t, renderStackJSON(&buf, buildStackJSON(in)))
 
-	err := cmd.ExecuteContext(t.Context())
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"organization": "my-org"`)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+	legacyKeys := []string{
+		"organization", "project", "stack", "version",
+		"activeUpdate", "currentOperation", "tags",
+	}
+	for _, k := range legacyKeys {
+		assert.Contains(t, got, k, "legacy key %q must remain in the envelope", k)
+	}
+
+	// And legacy values should round-trip unchanged.
+	assert.Equal(t, "my-org", got["organization"])
+	assert.Equal(t, "my-project", got["project"])
+	assert.Equal(t, "dev", got["stack"])
+	assert.Equal(t, float64(42), got["version"])
+	assert.Equal(t, "11111111-2222-3333-4444-555555555555", got["activeUpdate"])
 }
 
-func TestStackGet_DefaultCmd(t *testing.T) {
+// TestBuildStackJSON_WithSnapshot verifies that local snapshot data
+// (manifest, resources) flows into the envelope when a snapshot is
+// supplied.
+func TestBuildStackJSON_WithSnapshot(t *testing.T) {
+	t.Parallel()
+
+	v123 := semver.MustParse("1.2.3")
+
+	urn := resource.NewURN("dev", "proj", "", "aws:s3/bucket:Bucket", "my-bucket")
+	snap := &deploy.Snapshot{
+		Manifest: deploy.Manifest{
+			Time:    time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+			Version: "v3.140.0",
+			Plugins: []workspace.PluginInfo{
+				{Name: "aws", Kind: "resource", Version: &v123},
+			},
+		},
+		Resources: []*resource.State{
+			{URN: urn, Type: "aws:s3/bucket:Bucket", ID: "bucket-id-1"},
+		},
+	}
+
+	in := sampleIdentityInputs()
+	in.Snapshot = snap
+
+	env := buildStackJSON(in)
+
+	require.NotNil(t, env.Manifest)
+	assert.Equal(t, "v3.140.0", env.Manifest.PulumiVersion)
+	assert.Equal(t, "2026-05-13T12:00:00.000Z", env.Manifest.Time,
+		"manifest time must use cmd.FormatTime (RFC 5424 ms, UTC)")
+	require.Len(t, env.Manifest.Plugins, 1)
+	assert.Equal(t, "aws", env.Manifest.Plugins[0].Name)
+	assert.Equal(t, "1.2.3", env.Manifest.Plugins[0].Version)
+
+	require.Len(t, env.Resources, 1)
+	assert.Equal(t, string(urn), env.Resources[0].URN)
+	assert.Equal(t, "aws:s3/bucket:Bucket", env.Resources[0].Type)
+	assert.Equal(t, "my-bucket", env.Resources[0].Name)
+	assert.Equal(t, "bucket-id-1", env.Resources[0].ID)
+}
+
+// TestNewStackGetCmd_FlagDefaults guards the cobra surface: --output
+// defaults to json, --stack and --show-secrets are present.
+func TestNewStackGetCmd_FlagDefaults(t *testing.T) {
 	t.Parallel()
 
 	cmd := newStackGetCmd()
 	assert.Equal(t, "get", cmd.Use)
 	require.NotNil(t, cmd.RunE)
 
-	f := cmd.Flags().Lookup("output")
-	require.NotNil(t, f)
-	assert.Equal(t, "o", f.Shorthand)
-	assert.Equal(t, "default", f.DefValue)
+	output := cmd.Flags().Lookup("output")
+	require.NotNil(t, output)
+	assert.Equal(t, "o", output.Shorthand)
+	assert.Equal(t, "json", output.DefValue, "stack get must default to --output=json")
 
-	sf := cmd.Flags().Lookup("stack")
-	require.NotNil(t, sf)
-	assert.Equal(t, "s", sf.Shorthand)
+	stack := cmd.Flags().Lookup("stack")
+	require.NotNil(t, stack)
+	assert.Equal(t, "s", stack.Shorthand)
+
+	secrets := cmd.Flags().Lookup("show-secrets")
+	require.NotNil(t, secrets)
+	assert.Equal(t, "false", secrets.DefValue)
 }

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -16,14 +16,18 @@ package stack
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -220,4 +224,168 @@ func TestBuildStackJSON_WithSnapshot(t *testing.T) {
 	assert.Equal(t, "aws:s3/bucket:Bucket", env.Resources[0].Type)
 	assert.Equal(t, "my-bucket", env.Resources[0].Name)
 	assert.Equal(t, "bucket-id-1", env.Resources[0].ID)
+}
+
+func TestCapitalizeFirst(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"update", "Update"},
+		{"refresh", "Refresh"},
+		{"destroy", "Destroy"},
+		{"X", "X"},
+		{"", "Operation"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, capitalizeFirst(c.in), "input %q", c.in)
+	}
+}
+
+// TestRenderCloudStackText exercises the cloud-metadata text renderer used
+// inside `pulumi stack`'s text path on cloud backends.
+func TestRenderCloudStackText(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cs := sampleCloudStack()
+	renderCloudStackText(&buf, &cs)
+
+	out := buf.String()
+	assert.Contains(t, out, "Version: 42")
+	assert.Contains(t, out, "Active update: 11111111-2222-3333-4444-555555555555")
+	assert.Contains(t, out, "Tags:")
+	assert.Contains(t, out, "environment")
+	assert.Contains(t, out, "production")
+	assert.Contains(t, out, "pulumi:project")
+}
+
+func TestRenderCloudStackText_NilInfo(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	renderCloudStackText(&buf, nil)
+	assert.Empty(t, buf.String())
+}
+
+func TestRenderCloudStackText_EmptyInfo(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	renderCloudStackText(&buf, &apitype.Stack{}) // zero-value: no version, no update, no tags
+	assert.Empty(t, buf.String(),
+		"zero-value cloud info must produce no output (each field is conditional)")
+}
+
+func TestRenderCloudStackText_OnlyTags(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	renderCloudStackText(&buf, &apitype.Stack{
+		Tags: map[apitype.StackTagName]string{
+			"b": "two",
+			"a": "one",
+		},
+	})
+
+	out := buf.String()
+	assert.NotContains(t, out, "Version:")
+	assert.NotContains(t, out, "Active update:")
+	assert.Contains(t, out, "Tags:")
+	// Tags must be sorted by key.
+	aIdx := stringIndex(out, "a  ")
+	bIdx := stringIndex(out, "b  ")
+	require.NotEqual(t, -1, aIdx)
+	require.NotEqual(t, -1, bIdx)
+	assert.Less(t, aIdx, bIdx, "tags must render in sorted key order")
+}
+
+func stringIndex(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// newMockStack builds a backend.Stack stub whose Snapshot/Ref/Backend
+// hooks return the values supplied. It deliberately does NOT implement
+// httpstate.Stack, so the cloud-info path stays unexercised.
+func newMockStack(snap *deploy.Snapshot, snapErr error) backend.Stack {
+	mockBe := &backend.MockBackend{
+		NameF: func() string { return "mock://test" },
+	}
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:    tokens.MustParseStackName("dev"),
+				ProjectV: "proj",
+				StringV:  "dev",
+			}
+		},
+		BackendF: func() backend.Backend { return mockBe },
+		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+			return snap, snapErr
+		},
+	}
+}
+
+// TestLoadStackJSONInputs_NonCloud_NilSnapshot exercises the non-cloud
+// path through loadStackJSONInputs end-to-end (no GetStack call).
+func TestLoadStackJSONInputs_NonCloud_NilSnapshot(t *testing.T) {
+	t.Parallel()
+
+	in, err := loadStackJSONInputs(t.Context(), newMockStack(nil, nil), false)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", in.StackName)
+	assert.Equal(t, "proj", in.Project)
+	assert.Equal(t, "mock://test", in.BackendName)
+	assert.Nil(t, in.CloudStack, "non-cloud backends must not populate CloudStack")
+	assert.Empty(t, in.ConsoleURL)
+	assert.Nil(t, in.Snapshot, "nil snapshot must propagate (it is a legitimate 'no updates yet' state)")
+}
+
+// TestLoadStackJSONInputs_PropagatesSnapshotError checks that snapshot
+// load failures are surfaced rather than swallowed.
+func TestLoadStackJSONInputs_PropagatesSnapshotError(t *testing.T) {
+	t.Parallel()
+
+	want := assert.AnError
+	_, err := loadStackJSONInputs(t.Context(), newMockStack(nil, want), false)
+	require.ErrorIs(t, err, want)
+}
+
+// TestFetchCloudStackInfo_NonCloud confirms the helper returns
+// (nil, "", nil) when the stack isn't on the Pulumi Cloud backend, so
+// callers can skip the cloud block without an error path.
+func TestFetchCloudStackInfo_NonCloud(t *testing.T) {
+	t.Parallel()
+
+	info, url, err := fetchCloudStackInfo(t.Context(), newMockStack(nil, nil))
+	require.NoError(t, err)
+	assert.Nil(t, info)
+	assert.Empty(t, url)
+}
+
+// TestRunStackJSON_NonCloud_NilSnapshot end-to-end-tests runStackJSON
+// against a non-cloud backend with no snapshot; the JSON must contain
+// the identity fields and the empty resource/output/tag scaffolding.
+func TestRunStackJSON_NonCloud_NilSnapshot(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := runStackJSON(t.Context(), newMockStack(nil, nil), &buf, stackArgs{output: "json"})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"project": "proj",
+		"stack": "dev",
+		"backend": "mock://test",
+		"tags": {},
+		"resources": [],
+		"outputs": {}
+	}`, buf.String())
 }

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStackGetClient implements stackGetClient for tests.
+type mockStackGetClient struct {
+	stack apitype.Stack
+	err   error
+}
+
+func (m *mockStackGetClient) GetStack(_ context.Context, _ client.StackIdentifier) (apitype.Stack, error) {
+	return m.stack, m.err
+}
+
+func stackGetStubFactory(c stackGetClient) stackGetClientFactory {
+	return func(_ context.Context, _ string) (stackGetClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func stackGetFailingFactory(err error) stackGetClientFactory {
+	return func(_ context.Context, _ string) (stackGetClient, client.StackIdentifier, error) {
+		return nil, client.StackIdentifier{}, err
+	}
+}
+
+func sampleStack() apitype.Stack {
+	return apitype.Stack{
+		ID:           "abc123",
+		OrgName:      "my-org",
+		ProjectName:  "my-project",
+		StackName:    "dev",
+		ActiveUpdate: "11111111-2222-3333-4444-555555555555",
+		Version:      42,
+		Tags: map[apitype.StackTagName]string{
+			"environment":    "production",
+			"pulumi:project": "my-project",
+			"pulumi:runtime": "nodejs",
+			"vcs:owner":      "pulumi",
+		},
+		CurrentOperation: &apitype.OperationStatus{
+			Kind:    apitype.UpdateUpdate,
+			Author:  "alice",
+			Started: 1747142400, // 2025-05-13T13:20:00Z
+		},
+	}
+}
+
+func TestStackGet_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: sampleStack()}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Organization:   my-org")
+	assert.Contains(t, out, "Project:        my-project")
+	assert.Contains(t, out, "Stack:          dev")
+	assert.Contains(t, out, "Version:        42")
+	assert.Contains(t, out, "Active update:  11111111-2222-3333-4444-555555555555")
+	assert.Contains(t, out, "Update in progress:")
+	assert.Contains(t, out, "Kind:    update")
+	assert.Contains(t, out, "Author:  alice")
+	assert.Contains(t, out, "Tags:")
+	assert.Contains(t, out, "environment")
+	assert.Contains(t, out, "production")
+	assert.Contains(t, out, "pulumi:project")
+	assert.Contains(t, out, "pulumi:runtime")
+	assert.Contains(t, out, "nodejs")
+}
+
+func TestStackGet_DefaultOutput_NoOperation(t *testing.T) {
+	t.Parallel()
+
+	stack := sampleStack()
+	stack.CurrentOperation = nil
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: stack}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "Update in progress")
+	assert.NotContains(t, out, "Kind:")
+	assert.NotContains(t, out, "Author:")
+}
+
+func TestStackGet_DefaultOutput_NoActiveUpdate(t *testing.T) {
+	t.Parallel()
+
+	stack := sampleStack()
+	stack.ActiveUpdate = ""
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: stack}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "Active update:")
+}
+
+func TestStackGet_DefaultOutput_NoTags(t *testing.T) {
+	t.Parallel()
+
+	stack := sampleStack()
+	stack.Tags = nil
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: stack}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "Tags:")
+}
+
+func TestStackGet_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: sampleStack()}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organization": "my-org",
+		"project": "my-project",
+		"stack": "dev",
+		"version": 42,
+		"activeUpdate": "11111111-2222-3333-4444-555555555555",
+		"currentOperation": {
+			"kind": "update",
+			"author": "alice",
+			"started": "2025-05-13T13:20:00Z"
+		},
+		"tags": {
+			"environment":    "production",
+			"pulumi:project": "my-project",
+			"pulumi:runtime": "nodejs",
+			"vcs:owner":      "pulumi"
+		}
+	}`, buf.String())
+}
+
+func TestStackGet_JSONOutput_NoOperation(t *testing.T) {
+	t.Parallel()
+
+	stack := sampleStack()
+	stack.CurrentOperation = nil
+	stack.Tags = nil
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: stack}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organization": "my-org",
+		"project": "my-project",
+		"stack": "dev",
+		"version": 42,
+		"activeUpdate": "11111111-2222-3333-4444-555555555555",
+		"tags": {}
+	}`, buf.String())
+}
+
+func TestStackGet_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{stack: sampleStack()}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestStackGet_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockStackGetClient{err: errors.New("server error")}
+	err := runStackGet(t.Context(), &buf, stackGetStubFactory(c), "", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting stack")
+	assert.Contains(t, err.Error(), "server error")
+}
+
+func TestStackGet_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := runStackGet(t.Context(), &buf, stackGetFailingFactory(errors.New("not logged in")), "", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestStackGet_StackFlagPropagation(t *testing.T) {
+	t.Parallel()
+
+	var capturedStack string
+	factory := func(_ context.Context, stackFlag string) (stackGetClient, client.StackIdentifier, error) {
+		capturedStack = stackFlag
+		return &mockStackGetClient{stack: sampleStack()}, testStackID, nil
+	}
+
+	var buf bytes.Buffer
+	err := runStackGet(t.Context(), &buf, factory, "org/proj/my-stack", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "org/proj/my-stack", capturedStack)
+}
+
+func TestStackGet_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	c := &mockStackGetClient{stack: sampleStack()}
+	cmd := newStackGetCmdWith(stackGetStubFactory(c))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"organization": "my-org"`)
+}
+
+func TestStackGet_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStackGetCmd()
+	assert.Equal(t, "get", cmd.Use)
+	require.NotNil(t, cmd.RunE)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "o", f.Shorthand)
+	assert.Equal(t, "default", f.DefValue)
+
+	sf := cmd.Flags().Lookup("stack")
+	require.NotNil(t, sf)
+	assert.Equal(t, "s", sf.Shorthand)
+}

--- a/pkg/cmd/pulumi/stack/stack_json.go
+++ b/pkg/cmd/pulumi/stack/stack_json.go
@@ -1,0 +1,253 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// errCloudBackendRequired is returned by cloud-only commands when invoked
+// against a DIY backend.
+var errCloudBackendRequired = errors.New(
+	"this command requires the Pulumi Cloud backend; run `pulumi login`")
+
+// stackJSONEnvelope is the stable, machine-readable shape emitted by
+// `pulumi stack --output json` (and its alias, `pulumi stack get`). New
+// fields may be added; existing field names and types should not change.
+//
+// Time values are formatted with cmd.FormatTime (RFC 5424 with millisecond
+// precision, UTC) to match the convention already established by
+// `pulumi stack history --json` and `pulumi stack ls --json`.
+type stackJSONEnvelope struct {
+	Organization     string              `json:"organization,omitempty"`
+	Project          string              `json:"project,omitempty"`
+	Stack            string              `json:"stack"`
+	Backend          string              `json:"backend"`
+	Version          *int                `json:"version,omitempty"`
+	ActiveUpdate     string              `json:"activeUpdate,omitempty"`
+	CurrentOperation *stackOperationJSON `json:"currentOperation,omitempty"`
+	Tags             map[string]string   `json:"tags"`
+	Manifest         *stackManifestJSON  `json:"manifest,omitempty"`
+	Resources        []stackResourceJSON `json:"resources"`
+	Outputs          map[string]any      `json:"outputs"`
+	ConsoleURL       string              `json:"consoleUrl,omitempty"`
+}
+
+type stackOperationJSON struct {
+	Kind    string `json:"kind"`
+	Author  string `json:"author"`
+	Started string `json:"started"`
+}
+
+type stackManifestJSON struct {
+	Time          string            `json:"time,omitempty"`
+	PulumiVersion string            `json:"pulumiVersion,omitempty"`
+	Plugins       []stackPluginJSON `json:"plugins,omitempty"`
+}
+
+type stackPluginJSON struct {
+	Name    string `json:"name"`
+	Kind    string `json:"kind"`
+	Version string `json:"version,omitempty"`
+}
+
+type stackResourceJSON struct {
+	URN    string `json:"urn"`
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	ID     string `json:"id,omitempty"`
+	Parent string `json:"parent,omitempty"`
+}
+
+// stackJSONInputs bundles the resolved inputs for buildStackJSON. Splitting
+// it out keeps the builder pure: it has no I/O and no dependency on the
+// backend interface, so tests can populate the struct directly.
+type stackJSONInputs struct {
+	// StackName is the short stack name (no org/project prefix). This is what
+	// the `stack` field of the JSON envelope is set to.
+	StackName string
+	// Project is the project name. May be overridden by the cloud-side value.
+	Project string
+	// BackendName names the backend the stack lives on (e.g. "pulumi.com").
+	BackendName string
+
+	// CloudStack carries cloud-only metadata from GetStack. nil on DIY
+	// backends or when the lookup wasn't performed.
+	CloudStack *apitype.Stack
+	// ConsoleURL is the Pulumi Cloud console link for this stack. Empty on
+	// DIY backends.
+	ConsoleURL string
+
+	// Snapshot is the locally-loaded deployment snapshot. nil if it could
+	// not be loaded (e.g. no local project).
+	Snapshot *deploy.Snapshot
+	// ShowSecrets controls whether stack output secrets are unmasked.
+	ShowSecrets bool
+}
+
+// buildStackJSON assembles a stackJSONEnvelope from the resolved inputs.
+// Pure — no I/O.
+func buildStackJSON(in stackJSONInputs) *stackJSONEnvelope {
+	env := &stackJSONEnvelope{
+		Project:   in.Project,
+		Stack:     in.StackName,
+		Backend:   in.BackendName,
+		Tags:      map[string]string{},
+		Resources: []stackResourceJSON{},
+		Outputs:   map[string]any{},
+	}
+
+	if cs := in.CloudStack; cs != nil {
+		env.Organization = cs.OrgName
+		if cs.ProjectName != "" {
+			env.Project = cs.ProjectName
+		}
+		v := cs.Version
+		env.Version = &v
+		env.ActiveUpdate = cs.ActiveUpdate
+		for k, v := range cs.Tags {
+			env.Tags[k] = v
+		}
+		if op := cs.CurrentOperation; op != nil {
+			env.CurrentOperation = &stackOperationJSON{
+				Kind:    string(op.Kind),
+				Author:  op.Author,
+				Started: cmdCmd.FormatTime(time.Unix(op.Started, 0).UTC()),
+			}
+		}
+	}
+	env.ConsoleURL = in.ConsoleURL
+
+	if snap := in.Snapshot; snap != nil {
+		manifestTime := ""
+		if !snap.Manifest.Time.IsZero() {
+			manifestTime = cmdCmd.FormatTime(snap.Manifest.Time.UTC())
+		}
+		env.Manifest = &stackManifestJSON{
+			Time:          manifestTime,
+			PulumiVersion: snap.Manifest.Version,
+		}
+		for _, p := range snap.Manifest.Plugins {
+			version := ""
+			if p.Version != nil {
+				version = p.Version.String()
+			}
+			env.Manifest.Plugins = append(env.Manifest.Plugins, stackPluginJSON{
+				Name:    p.Name,
+				Kind:    string(p.Kind),
+				Version: version,
+			})
+		}
+
+		env.Resources = make([]stackResourceJSON, 0, len(snap.Resources))
+		for _, r := range snap.Resources {
+			env.Resources = append(env.Resources, snapshotResourceJSON(r))
+		}
+
+		if outs, err := getStackOutputs(snap, in.ShowSecrets); err == nil {
+			env.Outputs = outs
+		}
+	}
+
+	return env
+}
+
+func snapshotResourceJSON(r *resource.State) stackResourceJSON {
+	return stackResourceJSON{
+		URN:    string(r.URN),
+		Type:   string(r.Type),
+		Name:   r.URN.Name(),
+		ID:     string(r.ID),
+		Parent: string(r.Parent),
+	}
+}
+
+// loadStackJSONInputs assembles the inputs buildStackJSON needs from a
+// resolved backend.Stack: it best-effort loads the local snapshot and, on
+// Pulumi Cloud backends, fetches the GetStack metadata.
+func loadStackJSONInputs(
+	ctx context.Context, s backend.Stack, showSecrets bool,
+) (stackJSONInputs, error) {
+	ref := s.Ref()
+	project := ""
+	if p, ok := ref.Project(); ok {
+		project = string(p)
+	}
+
+	in := stackJSONInputs{
+		StackName:   ref.Name().String(),
+		Project:     project,
+		BackendName: s.Backend().Name(),
+		ShowSecrets: showSecrets,
+	}
+
+	cloudInfo, consoleURL, err := fetchCloudStackInfo(ctx, s)
+	if err != nil {
+		return stackJSONInputs{}, err
+	}
+	in.CloudStack = cloudInfo
+	in.ConsoleURL = consoleURL
+
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	if err != nil {
+		return stackJSONInputs{}, err
+	}
+	// snap may legitimately be nil (no updates yet); buildStackJSON handles
+	// that and just omits the manifest/resources/outputs sections.
+	in.Snapshot = snap
+
+	return in, nil
+}
+
+// fetchCloudStackInfo fetches the cloud-only stack metadata (version, tags,
+// activeUpdate, currentOperation) and console URL for s. Returns
+// (nil, "", nil) when s isn't on the Pulumi Cloud backend.
+func fetchCloudStackInfo(
+	ctx context.Context, s backend.Stack,
+) (*apitype.Stack, string, error) {
+	cloudStack, ok := s.(httpstate.Stack)
+	if !ok {
+		return nil, "", nil
+	}
+	be := cloudStack.Backend().(httpstate.Backend)
+	info, err := be.Client().GetStack(ctx, cloudStack.StackIdentifier())
+	if err != nil {
+		return nil, "", err
+	}
+	consoleURL := ""
+	if u, urlErr := be.StackConsoleURL(s.Ref()); urlErr == nil {
+		consoleURL = u
+	}
+	return &info, consoleURL, nil
+}
+
+func renderStackJSON(w io.Writer, env *stackJSONEnvelope) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
+}

--- a/pkg/cmd/pulumi/stack/stack_json.go
+++ b/pkg/cmd/pulumi/stack/stack_json.go
@@ -17,7 +17,6 @@ package stack
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"time"
 
@@ -29,11 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
-
-// errCloudBackendRequired is returned by cloud-only commands when invoked
-// against a DIY backend.
-var errCloudBackendRequired = errors.New(
-	"this command requires the Pulumi Cloud backend; run `pulumi login`")
 
 // stackJSONEnvelope is the stable, machine-readable shape emitted by
 // `pulumi stack --output json` (and its alias, `pulumi stack get`). New

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -65,25 +65,3 @@ func newStackNewCmd() *cobra.Command {
 
 	return cmd
 }
-
-// TODO[https://github.com/pulumi/pulumi/issues/23065]: Not yet implemented.
-func newStackGetCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Retrieve detailed information about a stack",
-		Long:   "[EXPERIMENTAL] Retrieve detailed information about a stack.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}


### PR DESCRIPTION
## Summary

- Implement `pulumi stack get`, wrapping the [GetStack](https://www.pulumi.com/docs/reference/cloud-rest-api/stacks/#get-apistacksorgnameprojectnamestackname) endpoint.
- Adds `--output json` to `pulumi stack` and makes `pulumi stack get` a thin alias (same flags, same defaults, same renderer).
- Default text output of `pulumi stack` now also surfaces the cloud-side `Version`, `Active update`, and `Tags` (previously only `Owner`, current operation, and console URL were rendered).
- The "Update in progress" line now names the operation kind ("Refresh in progress:", etc.).

Fixes #23065.

### JSON envelope

Strict superset of the previous `pulumi stack get` JSON shape (`organization`, `project`, `stack`, `version`, `activeUpdate`, `currentOperation`, `tags`) plus the snapshot data the text view also shows (`backend`, `manifest`, `resources`, `outputs`, `consoleUrl`). Time fields use `cmd.FormatTime` (RFC 5424 ms, UTC), matching `pulumi stack history --json` and `pulumi stack ls --json`.

### Output examples (cloud-backed)

Default:
```
$ pulumi stack
Current stack is dev:
    Owner: pulumi
    Refresh in progress:
        Started: 5 minutes ago
        Requested By: alice
    Version: 42
    Active update: 11111111-2222-3333-4444-555555555555
    Tags:
        env             test
        pulumi:project  my-project
    Last updated: 5 minutes ago (...)
    Pulumi version used: v3.140.0
Current stack resources (0):
    No resources currently in this stack
More information at: https://app.pulumi.com/.../dev
```

JSON:
```
$ pulumi stack get
{
  "organization": "pulumi",
  "project": "my-project",
  "stack": "dev",
  "backend": "pulumi.com",
  "version": 42,
  "activeUpdate": "...",
  "currentOperation": {"kind": "refresh", "author": "alice", "started": "2025-05-13T13:20:00.000Z"},
  "tags": {...},
  "manifest": {"time": "...", "pulumiVersion": "v3.140.0", "plugins": [...]},
  "resources": [...],
  "outputs": {...},
  "consoleUrl": "..."
}
```

## Test plan

- [x] Unit tests for the pure JSON builder cover cloud envelope, DIY envelope, missing optional fields, legacy-key preservation, and snapshot-derived fields.
- [x] Manually smoke-tested DIY and Pulumi Cloud backends (both `pulumi stack` and `pulumi stack get`, both `--output default` and `--output json`).