### PR TITLE
cli/cloud: implement `pulumi stack history events`

### DIFF
--- a/changelog/pending/20260513--cli-cloud--implement-pulumi-stack-history-events.yaml
+++ b/changelog/pending/20260513--cli-cloud--implement-pulumi-stack-history-events.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Implement `pulumi stack history events` to retrieve engine events for a Pulumi Cloud update

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2568,7 +2568,9 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 	var continuationToken *string
 	var lastEvent engine.Event
 	for {
-		resp, err := b.client.GetUpdateEngineEvents(ctx, update, continuationToken)
+		resp, err := b.client.GetUpdateEngineEvents(ctx, update, client.GetUpdateEngineEventsOptions{
+			ContinuationToken: continuationToken,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1496,13 +1496,42 @@ func (pc *Client) CompleteUpdate(ctx context.Context, update UpdateIdentifier, s
 		updateAccessToken(token), httpCallOptions{RetryPolicy: retryAllMethods})
 }
 
+// GetUpdateEngineEventsOptions configures filtering and pagination for
+// GetUpdateEngineEvents.
+type GetUpdateEngineEventsOptions struct {
+	// ContinuationToken, if non-nil, fetches the next page of events.
+	ContinuationToken *string
+	// EventTypes, if non-empty, restricts results to the listed engine event
+	// type codes.
+	EventTypes []string
+	// URN, if non-empty, restricts results to events for the given resource URN.
+	URN string
+	// IncludeNonActivated, when true, includes events that have not yet been
+	// marked as activated.
+	IncludeNonActivated bool
+}
+
 // GetUpdateEngineEvents returns the engine events for an update.
 func (pc *Client) GetUpdateEngineEvents(ctx context.Context, update UpdateIdentifier,
-	continuationToken *string,
+	opts GetUpdateEngineEventsOptions,
 ) (apitype.GetUpdateEventsResponse, error) {
 	path := getUpdatePath(update, "events")
-	if continuationToken != nil {
-		path += "?continuationToken=" + *continuationToken
+
+	query := url.Values{}
+	if opts.ContinuationToken != nil {
+		query.Set("continuationToken", *opts.ContinuationToken)
+	}
+	for _, t := range opts.EventTypes {
+		query.Add("type", t)
+	}
+	if opts.URN != "" {
+		query.Set("urn", opts.URN)
+	}
+	if opts.IncludeNonActivated {
+		query.Set("include_non_activated", "true")
+	}
+	if encoded := query.Encode(); encoded != "" {
+		path += "?" + encoded
 	}
 
 	var resp apitype.GetUpdateEventsResponse

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -115,22 +115,22 @@ This command displays data about previous updates for a stack.`,
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.PersistentFlags().StringVarP(
+	cmd.Flags().StringVarP(
 		&stack, "stack", "s", "",
 		"Choose a stack other than the currently selected one")
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show secret values when listing config instead of displaying blinded values")
-	cmd.PersistentFlags().BoolVarP(
+	cmd.Flags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
-	cmd.PersistentFlags().BoolVar(
+	cmd.Flags().BoolVar(
 		&showFullDates, "full-dates", false, "Show full dates, instead of relative dates")
-	cmd.PersistentFlags().IntVar(
+	cmd.Flags().IntVar(
 		&pageSize, "page-size", 10, "Used with 'page' to control number of results returned")
-	cmd.PersistentFlags().IntVar(
+	cmd.Flags().IntVar(
 		&page, "page", 1, "Used with 'page-size' to paginate results")
 
-	cmd.AddCommand(newStackHistoryEventsCmd())
+	cmd.AddCommand(newStackHistoryEventsCmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -15,30 +15,98 @@
 package stack
 
 import (
-	"errors"
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+	"strings"
+	"time"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// TODO[https://github.com/pulumi/pulumi/issues/23064]: Not yet implemented.
-func newStackHistoryEventsCmd() *cobra.Command {
+// stackHistoryEventsClient is the interface iterateEngineEvents needs from the
+// API client. Defined locally so tests can drive the iterator with a fake
+// without pulling in the full *client.Client surface.
+type stackHistoryEventsClient interface {
+	GetUpdateEngineEvents(
+		ctx context.Context,
+		update client.UpdateIdentifier,
+		opts client.GetUpdateEngineEventsOptions,
+	) (apitype.GetUpdateEventsResponse, error)
+}
+
+type historyEventsRender func(
+	w io.Writer, events iter.Seq2[apitype.EngineEvent, error],
+) error
+
+type stackHistoryEventsArgs struct {
+	updateID            string
+	eventTypes          []string
+	resourceURN         string
+	includeNonActivated bool
+	count               int
+	all                 bool
+	render              historyEventsRender
+}
+
+func newStackHistoryEventsCmd(
+	ws pkgWorkspace.Context,
+	lm cmdBackend.LoginManager,
+) *cobra.Command {
 	var (
-		stack               string
-		eventTypes          []string
-		resourceURN         string
-		includeNonActivated bool
-		token               string
+		stack string
+		args  = stackHistoryEventsArgs{}
 	)
 
+	outputFormat := outputflag.OutputFlag[historyEventsRender]{
+		RenderForTerminal: renderHistoryEventsTable,
+		RenderJSON:        renderHistoryEventsJSON,
+	}
+
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "events",
-		Short:  "Retrieve engine events for an update",
-		Long:   "[EXPERIMENTAL] Retrieve engine events for an update.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+		Use:   "events",
+		Short: "Retrieve engine events for an update",
+		Long: "[EXPERIMENTAL] Retrieve engine events for a specific update of a stack.\n" +
+			"\n" +
+			"Engine events represent individual resource operations and diagnostic\n" +
+			"messages produced during an update. By default a single page of\n" +
+			"events is returned.\n" +
+			"\n" +
+			"This command requires the Pulumi Cloud backend.",
+		Example: "  # Show the first page of events in a human-readable table.\n" +
+			"  pulumi stack history events <update-id>\n\n" +
+			"  # Return at least 500 events.\n" +
+			"  pulumi stack history events <update-id> --count 500\n\n" +
+			"  # Return every event for the update.\n" +
+			"  pulumi stack history events <update-id> --all\n\n" +
+			"  # Emit the raw event stream as JSON for scripting.\n" +
+			"  pulumi stack history events <update-id> --all --output json\n\n" +
+			"  # Filter to a specific resource URN.\n" +
+			"  pulumi stack history events <update-id> \\\n" +
+			"      --urn urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
+		RunE: func(cmd *cobra.Command, positional []string) error {
+			args.updateID = positional[0]
+			args.render = outputFormat.Get()
+			sink := diag.DefaultSink(cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{
+				Color: cmdutil.GetGlobalColorization(),
+			})
+			return runStackHistoryEvents(cmd.Context(), cmd.OutOrStdout(), sink, ws, lm, stack, args)
 		},
 	}
 
@@ -51,13 +119,274 @@ func newStackHistoryEventsCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringArrayVar(&eventTypes, "event-type", nil,
-		"Filter by engine event type code (repeatable)")
-	cmd.Flags().StringVar(&resourceURN, "urn", "", "Filter by resource URN")
-	cmd.Flags().BoolVar(&includeNonActivated, "include-non-activated", false,
+	cmd.Flags().StringArrayVar(&args.eventTypes, "event-type", nil,
+		"Filter by Pulumi Cloud engine event type code; numeric, repeatable")
+	cmd.Flags().StringVar(&args.resourceURN, "urn", "", "Filter by resource URN")
+	cmd.Flags().BoolVar(&args.includeNonActivated, "include-non-activated", false,
 		"Include events not yet marked as activated")
-	cmd.Flags().StringVar(&token, "continuation-token", "",
-		"The continuation token for paginated retrieval")
+	cmd.Flags().IntVar(&args.count, "count", 0,
+		"Return at least this many events, fetching additional pages as needed")
+	cmd.Flags().BoolVar(&args.all, "all", false,
+		"Return every event for the update")
+	cmd.MarkFlagsMutuallyExclusive("count", "all")
+	outputflag.VarP(cmd.Flags(), &outputFormat)
 
 	return cmd
+}
+
+func runStackHistoryEvents(
+	ctx context.Context,
+	w io.Writer,
+	sink diag.Sink,
+	ws pkgWorkspace.Context,
+	lm cmdBackend.LoginManager,
+	stackFlag string,
+	args stackHistoryEventsArgs,
+) error {
+	c, stackID, err := RequireCloudStack(ctx, sink, ws, lm, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	update := client.UpdateIdentifier{
+		StackIdentifier: stackID,
+		UpdateKind:      apitype.UpdateUpdate,
+		UpdateID:        args.updateID,
+	}
+
+	opts := client.GetUpdateEngineEventsOptions{
+		EventTypes:          args.eventTypes,
+		URN:                 args.resourceURN,
+		IncludeNonActivated: args.includeNonActivated,
+	}
+
+	events := iterateEngineEvents(ctx, c, update, opts, args.all, args.count)
+	return args.render(w, events)
+}
+
+// iterateEngineEvents returns an iterator over engine events. The pagination
+// behavior depends on (all, count):
+//   - all=true: follow continuation tokens until the cloud reports no more.
+//   - count>0: keep fetching pages until at least count events have been yielded
+//     or the cloud reports no more.
+//   - otherwise: fetch exactly one page.
+func iterateEngineEvents(
+	ctx context.Context,
+	c stackHistoryEventsClient,
+	update client.UpdateIdentifier,
+	opts client.GetUpdateEngineEventsOptions,
+	all bool,
+	count int,
+) iter.Seq2[apitype.EngineEvent, error] {
+	return func(yield func(apitype.EngineEvent, error) bool) {
+		page := opts
+		yielded := 0
+		for {
+			resp, err := c.GetUpdateEngineEvents(ctx, update, page)
+			if err != nil {
+				yield(apitype.EngineEvent{}, fmt.Errorf("getting update engine events: %w", err))
+				return
+			}
+			for _, ev := range resp.Events {
+				if !yield(ev, nil) {
+					return
+				}
+				yielded++
+			}
+			done := resp.ContinuationToken == nil ||
+				(!all && count <= 0) ||
+				(count > 0 && yielded >= count)
+			if done {
+				return
+			}
+			page.ContinuationToken = resp.ContinuationToken
+		}
+	}
+}
+
+// historyEventJSON wraps apitype.EngineEvent for JSON output, hiding the
+// embedded Sequence field. The cloud's GET .../events endpoint does not
+// populate sequence (the docs are explicit: "Events are returned sorted by
+// their internal sequence number (not exposed to the API)"), so emitting it
+// would surface a misleading constant 0.
+//
+// The outer Sequence field shadows the embedded one (shallower fields win
+// during Go's JSON conflict resolution) and `omitempty` plus its zero value
+// makes the encoder drop the key entirely. `json:"-"` would not work here
+// because it removes the outer field from consideration, leaving the
+// embedded field as the only candidate.
+type historyEventJSON struct {
+	apitype.EngineEvent
+	Sequence int `json:"sequence,omitempty"`
+}
+
+// renderHistoryEventsJSON streams events as an indented JSON array so
+// consumers see output as it arrives rather than having to wait for the
+// last page.
+func renderHistoryEventsJSON(
+	w io.Writer, events iter.Seq2[apitype.EngineEvent, error],
+) error {
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	if _, err := bw.WriteString("[\n"); err != nil {
+		return err
+	}
+	first := true
+	for ev, err := range events {
+		if err != nil {
+			return err
+		}
+		if !first {
+			if _, err := bw.WriteString(",\n"); err != nil {
+				return err
+			}
+		}
+		first = false
+		b, err := json.MarshalIndent(historyEventJSON{EngineEvent: ev}, "  ", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := bw.WriteString("  "); err != nil {
+			return err
+		}
+		if _, err := bw.Write(b); err != nil {
+			return err
+		}
+		// Flush after each event so streamed consumers see incremental output.
+		if err := bw.Flush(); err != nil {
+			return err
+		}
+	}
+	if !first {
+		if _, err := bw.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+	if _, err := bw.WriteString("]\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+const historyEventsFixedColsWidth = 50
+
+// renderHistoryEventsTable buffers all events before rendering because the
+// box-style table needs to know its full contents to draw consistent
+// borders. Use --output json (with --all or --count) to stream very large
+// updates.
+func renderHistoryEventsTable(
+	w io.Writer, events iter.Seq2[apitype.EngineEvent, error],
+) error {
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	// The cloud GET endpoint does not expose the internal sequence number, so
+	// we omit the column entirely rather than rendering a constant 0.
+	t.AppendHeader(table.Row{"TIMESTAMP", "TYPE", "DETAILS"})
+
+	count := 0
+	for ev, err := range events {
+		if err != nil {
+			return err
+		}
+		ts := ""
+		if ev.Timestamp > 0 {
+			ts = time.Unix(int64(ev.Timestamp), 0).UTC().Format(time.RFC3339)
+		}
+		kind, details := describeEngineEvent(ev)
+		t.AppendRow(table.Row{ts, kind, details})
+		count++
+	}
+
+	if count == 0 {
+		fmt.Fprintln(w, "No events found for this update.")
+		return nil
+	}
+
+	cols := cmdCmd.StdoutWidth()
+	// Borders and separators take ~3 chars per column plus 1 outer border each side.
+	borderWidth := 3*3 + 1
+	detailsWidth := cols - borderWidth - historyEventsFixedColsWidth
+	if detailsWidth < 20 {
+		detailsWidth = 20
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "DETAILS", WidthMax: detailsWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d event(s)\n", count)
+	return nil
+}
+
+// describeEngineEvent returns a short (kind, details) summary for an engine event.
+// It is intentionally lossy; callers wanting full fidelity should use --output=json.
+//
+// Diagnostic messages contain Pulumi color directives (e.g. "<{%reset%}>") which
+// would otherwise render as literal text in the table. We strip them via the
+// Never colorization mode.
+func describeEngineEvent(ev apitype.EngineEvent) (string, string) {
+	switch {
+	case ev.CancelEvent != nil:
+		return "cancel", ""
+	case ev.StdoutEvent != nil:
+		return "stdout", strings.TrimRight(plain(ev.StdoutEvent.Message), "\n")
+	case ev.DiagnosticEvent != nil:
+		d := ev.DiagnosticEvent
+		details := strings.TrimRight(plain(d.Message), "\n")
+		if d.URN != "" {
+			details = d.URN + ": " + details
+		}
+		if d.Severity != "" {
+			return "diagnostic/" + d.Severity, details
+		}
+		return "diagnostic", details
+	case ev.PreludeEvent != nil:
+		return "prelude", ""
+	case ev.SummaryEvent != nil:
+		s := ev.SummaryEvent
+		result := string(s.Result)
+		if result == "" {
+			// Older updates may not include Result on the summary event.
+			result = "unknown"
+		}
+		return "summary", fmt.Sprintf("result=%s duration=%ds", result, s.DurationSeconds)
+	case ev.ResourcePreEvent != nil:
+		m := ev.ResourcePreEvent.Metadata
+		return "resource-pre", fmt.Sprintf("%s %s", m.Op, m.URN)
+	case ev.ResOutputsEvent != nil:
+		m := ev.ResOutputsEvent.Metadata
+		return "resource-outputs", fmt.Sprintf("%s %s", m.Op, m.URN)
+	case ev.ResOpFailedEvent != nil:
+		m := ev.ResOpFailedEvent.Metadata
+		return "resource-op-failed", fmt.Sprintf("%s %s", m.Op, m.URN)
+	case ev.PolicyEvent != nil:
+		p := ev.PolicyEvent
+		return "policy", fmt.Sprintf("%s/%s: %s", p.PolicyPackName, p.PolicyName, plain(p.Message))
+	case ev.PolicyRemediationEvent != nil:
+		p := ev.PolicyRemediationEvent
+		return "policy-remediation", fmt.Sprintf("%s/%s on %s", p.PolicyPackName, p.PolicyName, p.ResourceURN)
+	case ev.PolicyLoadEvent != nil:
+		return "policy-load", ""
+	case ev.PolicyAnalyzeSummaryEvent != nil:
+		return "policy-analyze-summary", ev.PolicyAnalyzeSummaryEvent.PolicyPackName
+	case ev.PolicyRemediateSummaryEvent != nil:
+		return "policy-remediate-summary", ev.PolicyRemediateSummaryEvent.PolicyPackName
+	case ev.PolicyAnalyzeStackSummaryEvent != nil:
+		return "policy-analyze-stack-summary", ev.PolicyAnalyzeStackSummaryEvent.PolicyPackName
+	case ev.StartDebuggingEvent != nil:
+		return "start-debugging", ""
+	case ev.ProgressEvent != nil:
+		p := ev.ProgressEvent
+		return "progress", fmt.Sprintf("%s %s (%d/%d)", p.Type, plain(p.Message), p.Completed, p.Total)
+	case ev.ErrorEvent != nil:
+		return "error", plain(ev.ErrorEvent.Error)
+	default:
+		return "unknown", ""
+	}
+}
+
+func plain(s string) string {
+	return colors.Never.Colorize(s)
 }

--- a/pkg/cmd/pulumi/stack/stack_history_events_test.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// mockHistoryEventsClient returns a fixed sequence of responses, advancing
+// through them on each call. This lets tests simulate paginated responses
+// from the cloud.
+type mockHistoryEventsClient struct {
+	pages []apitype.GetUpdateEventsResponse
+	err   error
+
+	gotOpts []client.GetUpdateEngineEventsOptions
+}
+
+func (m *mockHistoryEventsClient) GetUpdateEngineEvents(
+	_ context.Context, _ client.UpdateIdentifier, opts client.GetUpdateEngineEventsOptions,
+) (apitype.GetUpdateEventsResponse, error) {
+	m.gotOpts = append(m.gotOpts, opts)
+	if m.err != nil {
+		return apitype.GetUpdateEventsResponse{}, m.err
+	}
+	if len(m.gotOpts) > len(m.pages) {
+		return apitype.GetUpdateEventsResponse{}, nil
+	}
+	return m.pages[len(m.gotOpts)-1], nil
+}
+
+func (m *mockHistoryEventsClient) calls() int { return len(m.gotOpts) }
+
+func singlePage(events []apitype.EngineEvent) *mockHistoryEventsClient {
+	return &mockHistoryEventsClient{pages: []apitype.GetUpdateEventsResponse{{Events: events}}}
+}
+
+func sampleEvents() []apitype.EngineEvent {
+	return []apitype.EngineEvent{
+		{
+			Sequence:     1,
+			Timestamp:    1700000000,
+			PreludeEvent: &apitype.PreludeEvent{Config: map[string]string{}},
+		},
+		{
+			Sequence:  2,
+			Timestamp: 1700000001,
+			DiagnosticEvent: &apitype.DiagnosticEvent{
+				URN:      "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
+				Message:  "boom",
+				Severity: "error",
+			},
+		},
+		{
+			Sequence:  3,
+			Timestamp: 1700000002,
+			SummaryEvent: &apitype.SummaryEvent{
+				DurationSeconds: 5,
+				Result:          apitype.OperationResultSucceeded,
+			},
+		},
+		{
+			Sequence:    4,
+			Timestamp:   1700000003,
+			CancelEvent: &apitype.CancelEvent{},
+		},
+	}
+}
+
+// collectEvents drains an iter.Seq2 into slices for easier assertion.
+func collectEvents(seq iter.Seq2[apitype.EngineEvent, error]) ([]apitype.EngineEvent, []error) {
+	var events []apitype.EngineEvent
+	var errs []error
+	for ev, err := range seq {
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events, errs
+}
+
+func TestIterateEngineEvents_DefaultStopsAfterOnePage(t *testing.T) {
+	t.Parallel()
+
+	tok := "tok-1"
+	c := &mockHistoryEventsClient{
+		pages: []apitype.GetUpdateEventsResponse{
+			{Events: sampleEvents()[:2], ContinuationToken: &tok},
+			{Events: sampleEvents()[2:]},
+		},
+	}
+
+	events, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, client.GetUpdateEngineEventsOptions{},
+		false /*all*/, 0 /*count*/))
+	require.Empty(t, errs)
+	assert.Equal(t, 1, c.calls())
+	assert.Equal(t, sampleEvents()[:2], events)
+}
+
+func TestIterateEngineEvents_AllFollowsContinuationTokens(t *testing.T) {
+	t.Parallel()
+
+	tok1, tok2 := "tok-1", "tok-2"
+	c := &mockHistoryEventsClient{
+		pages: []apitype.GetUpdateEventsResponse{
+			{Events: sampleEvents()[:2], ContinuationToken: &tok1},
+			{Events: sampleEvents()[2:3], ContinuationToken: &tok2},
+			{Events: sampleEvents()[3:]},
+		},
+	}
+
+	events, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, client.GetUpdateEngineEventsOptions{},
+		true /*all*/, 0 /*count*/))
+	require.Empty(t, errs)
+
+	assert.Equal(t, 3, c.calls())
+	require.Len(t, c.gotOpts, 3)
+	assert.Nil(t, c.gotOpts[0].ContinuationToken)
+	require.NotNil(t, c.gotOpts[1].ContinuationToken)
+	assert.Equal(t, "tok-1", *c.gotOpts[1].ContinuationToken)
+	require.NotNil(t, c.gotOpts[2].ContinuationToken)
+	assert.Equal(t, "tok-2", *c.gotOpts[2].ContinuationToken)
+
+	assert.Equal(t, sampleEvents(), events)
+}
+
+func TestIterateEngineEvents_CountFetchesEnoughPages(t *testing.T) {
+	t.Parallel()
+
+	// Each page yields a single event; --count 3 must trigger three calls.
+	tok1, tok2, tok3 := "tok-1", "tok-2", "tok-3"
+	c := &mockHistoryEventsClient{
+		pages: []apitype.GetUpdateEventsResponse{
+			{Events: sampleEvents()[:1], ContinuationToken: &tok1},
+			{Events: sampleEvents()[1:2], ContinuationToken: &tok2},
+			{Events: sampleEvents()[2:3], ContinuationToken: &tok3},
+			{Events: sampleEvents()[3:]},
+		},
+	}
+
+	events, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, client.GetUpdateEngineEventsOptions{},
+		false /*all*/, 3 /*count*/))
+	require.Empty(t, errs)
+	assert.Equal(t, 3, c.calls())
+	assert.Equal(t, sampleEvents()[:3], events)
+}
+
+func TestIterateEngineEvents_CountStopsEarlyOnNilToken(t *testing.T) {
+	t.Parallel()
+
+	c := singlePage(sampleEvents()[:2])
+
+	events, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, client.GetUpdateEngineEventsOptions{},
+		false /*all*/, 10 /*count*/))
+	require.Empty(t, errs)
+	assert.Equal(t, 1, c.calls())
+	assert.Equal(t, sampleEvents()[:2], events)
+}
+
+func TestIterateEngineEvents_PropagatesFilterOptions(t *testing.T) {
+	t.Parallel()
+
+	c := singlePage(sampleEvents())
+
+	opts := client.GetUpdateEngineEventsOptions{
+		EventTypes:          []string{"3", "5"},
+		URN:                 "urn:pulumi:dev::p::pkg:m:Type::name",
+		IncludeNonActivated: true,
+	}
+	_, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, opts, false, 0))
+	require.Empty(t, errs)
+	require.Equal(t, 1, c.calls())
+
+	assert.Equal(t, []string{"3", "5"}, c.gotOpts[0].EventTypes)
+	assert.Equal(t, "urn:pulumi:dev::p::pkg:m:Type::name", c.gotOpts[0].URN)
+	assert.True(t, c.gotOpts[0].IncludeNonActivated)
+	assert.Nil(t, c.gotOpts[0].ContinuationToken)
+}
+
+func TestIterateEngineEvents_PropagatesClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockHistoryEventsClient{err: errors.New("server error")}
+	_, errs := collectEvents(iterateEngineEvents(
+		t.Context(), c, client.UpdateIdentifier{}, client.GetUpdateEngineEventsOptions{},
+		false, 0))
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "getting update engine events")
+	assert.Contains(t, errs[0].Error(), "server error")
+}
+
+// eventsFromSlice builds an iter.Seq2 yielding the given events with no
+// errors so renderer tests don't need a mock client.
+func eventsFromSlice(events []apitype.EngineEvent) iter.Seq2[apitype.EngineEvent, error] {
+	return func(yield func(apitype.EngineEvent, error) bool) {
+		for _, ev := range events {
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestRenderHistoryEventsTable(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := renderHistoryEventsTable(&buf, eventsFromSlice(sampleEvents()))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.NotContains(t, out, "SEQUENCE", "GET endpoint does not expose sequence")
+	assert.Contains(t, out, "TIMESTAMP")
+	assert.Contains(t, out, "TYPE")
+	assert.Contains(t, out, "DETAILS")
+	assert.Contains(t, out, "prelude")
+	assert.Contains(t, out, "diagnostic/error")
+	// Details column may wrap on narrow terminals; assert on the URN prefix
+	// rather than the full diagnostic message.
+	assert.Contains(t, out, "urn:pulumi:dev")
+	assert.Contains(t, out, "summary")
+	assert.Contains(t, out, "cancel")
+	assert.Contains(t, out, "4 event(s)")
+}
+
+func TestRenderHistoryEventsTable_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := renderHistoryEventsTable(&buf, eventsFromSlice(nil))
+	require.NoError(t, err)
+	assert.Equal(t, "No events found for this update.\n", buf.String())
+}
+
+func TestRenderHistoryEventsJSON(t *testing.T) {
+	t.Parallel()
+
+	events := []apitype.EngineEvent{
+		{
+			Sequence:  1,
+			Timestamp: 1700000000,
+			DiagnosticEvent: &apitype.DiagnosticEvent{
+				URN:      "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
+				Message:  "boom",
+				Severity: "error",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := renderHistoryEventsJSON(&buf, eventsFromSlice(events))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `[
+		{
+			"timestamp": 1700000000,
+			"diagnosticEvent": {
+				"urn": "urn:pulumi:dev::proj::aws:s3/bucket:Bucket::my-bucket",
+				"message": "boom",
+				"color": "",
+				"severity": "error"
+			}
+		}
+	]`, buf.String())
+}
+
+func TestRenderHistoryEventsJSON_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := renderHistoryEventsJSON(&buf, eventsFromSlice(nil))
+	require.NoError(t, err)
+	assert.JSONEq(t, `[]`, buf.String())
+}
+
+func TestRenderHistoryEventsJSON_PropagatesIteratorError(t *testing.T) {
+	t.Parallel()
+
+	seq := iter.Seq2[apitype.EngineEvent, error](func(yield func(apitype.EngineEvent, error) bool) {
+		yield(apitype.EngineEvent{}, assert.AnError)
+	})
+
+	var buf bytes.Buffer
+	err := renderHistoryEventsJSON(&buf, seq)
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestDescribeEngineEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		event       apitype.EngineEvent
+		wantKind    string
+		wantDetails string
+	}{
+		{
+			name:     "cancel",
+			event:    apitype.EngineEvent{CancelEvent: &apitype.CancelEvent{}},
+			wantKind: "cancel",
+		},
+		{
+			name:        "stdout",
+			event:       apitype.EngineEvent{StdoutEvent: &apitype.StdoutEngineEvent{Message: "hello"}},
+			wantKind:    "stdout",
+			wantDetails: "hello",
+		},
+		{
+			name: "diagnostic with urn",
+			event: apitype.EngineEvent{DiagnosticEvent: &apitype.DiagnosticEvent{
+				URN: "urn:x", Message: "bad", Severity: "warning",
+			}},
+			wantKind:    "diagnostic/warning",
+			wantDetails: "urn:x: bad",
+		},
+		{
+			name: "diagnostic without severity or urn",
+			event: apitype.EngineEvent{DiagnosticEvent: &apitype.DiagnosticEvent{
+				Message: "bad",
+			}},
+			wantKind:    "diagnostic",
+			wantDetails: "bad",
+		},
+		{
+			name: "error",
+			event: apitype.EngineEvent{ErrorEvent: &apitype.ErrorEvent{
+				Error: "engine exploded",
+			}},
+			wantKind:    "error",
+			wantDetails: "engine exploded",
+		},
+		{
+			name:     "unknown",
+			event:    apitype.EngineEvent{},
+			wantKind: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			kind, details := describeEngineEvent(tc.event)
+			assert.Equal(t, tc.wantKind, kind)
+			assert.Equal(t, tc.wantDetails, details)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Wires up the previously-stubbed `pulumi stack history events <update-id>` to the cloud backend's `GET /api/stacks/{org}/{proj}/{stack}/update/{updateID}/events` endpoint.

Follows the pagination model laid out in #22959 and the [CLI Option Guidelines](https://www.notion.so/CLI-Option-Guidelines-357fdbdf1cce8043af51c13f8246b5ce):

- **Pagination** (per #22959):
  - Default: return the first page of events.
  - `--count <N>`: fetch enough pages internally to return at least N events.
  - `--all`: return every event for the update (mutually exclusive with `--count`).
- **Filters**: `--event-type <code>` (repeatable, numeric Pulumi Cloud engine-event type codes), `--urn`, `--include-non-activated`.
- **Output**: `--output {default,json}` via the reusable `pkg/util/outputflag.OutputFlag` helper from #23112. Table output is wrapped to the terminal width with color directives stripped; JSON output streams a top-level array, flushing after each event so very long updates emit incrementally.

Also demotes the `--json`, `--full-dates`, `--page-size`, and `--page` flags on the parent `pulumi stack history` from `PersistentFlags` to `Flags` so they no longer silently inherit onto the new `events` subcommand. This does not change `pulumi stack history`'s own behavior.

Refactors `client.GetUpdateEngineEvents` to take a `GetUpdateEngineEventsOptions` struct so the new filter query parameters (`type`, `urn`, `include_non_activated`) can be passed alongside the existing continuation token.

Closes #23064.

## Test plan

- [x] `make lint`
- [x] `go test ./cmd/pulumi/stack/...`
- [x] `pulumi stack history events --help` renders the documented flags
- [x] Manually exercised against several real cloud stacks (table + JSON, URN filter, numeric type filter, `--count`, `--all`, 404 path)
- [ ] CI on this PR is green