### PR TITLE
Add `pulumi stack schedule list` to list all scheduled actions configured for a stack

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-schedule-list.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-schedule-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack schedule list` to list all scheduled actions configured for a stack

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -691,6 +691,18 @@ func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier
 	return resp, nil
 }
 
+// ListStackSchedules returns all scheduled deployment actions configured for the given stack.
+// The response includes custom deployment schedules, drift detection schedules, and TTL schedules.
+func (pc *Client) ListStackSchedules(
+	ctx context.Context, stackID StackIdentifier,
+) ([]apitype.ScheduledAction, error) {
+	var resp apitype.ListScheduledActionsResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "deployments", "schedules"), nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Schedules, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_schedule_test.go
+++ b/pkg/backend/httpstate/client/client_schedule_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListStackSchedules(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ListScheduledActionsResponse{
+			Schedules: []apitype.ScheduledAction{
+				{
+					ID:            "bb61b60a-a313-46cb-b4ab-9d42dce46de8",
+					OrgID:         "feacc792-460f-4525-a091-e8de1f6ef34c",
+					ScheduleOnce:  "2026-05-13 10:51:00.000",
+					NextExecution: "2026-05-13 10:51:00.000",
+					Paused:        false,
+					Kind:          apitype.ScheduledActionKindDeployment,
+					Definition: json.RawMessage(
+						`{"programID":"5f337707","request":{"operation":"destroy","inheritSettings":true}}`),
+					Created:  "2026-05-13 08:51:42.176",
+					Modified: "2026-05-13 08:51:42.176",
+				},
+				{
+					ID:            "abc-cron",
+					OrgID:         "feacc792-460f-4525-a091-e8de1f6ef34c",
+					ScheduleCron:  "0 */4 * * *",
+					NextExecution: "2026-05-13 12:00:00.000",
+					Paused:        true,
+					Kind:          apitype.ScheduledActionKindDeployment,
+					Definition:    json.RawMessage(`{"request":{"operation":"refresh","inheritSettings":true}}`),
+				},
+			},
+		}
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackSchedules(t.Context(), stackID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/deployments/schedules", gotPath)
+		assert.Equal(t, want.Schedules, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusInternalServerError, `{"message":"internal error"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.ListStackSchedules(t.Context(), stackID)
+		assert.Error(t, err)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"schedules":[]}`))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackSchedules(t.Context(), stackID)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -43,27 +43,6 @@ func newStackScheduleCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23049]: Not yet implemented.
-func newStackScheduleListCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List all scheduled actions configured for a stack",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23048]: Not yet implemented.
 func newStackScheduleNewCmd() *cobra.Command {
 	var (

--- a/pkg/cmd/pulumi/stack/stack_schedule_list.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_list.go
@@ -1,0 +1,183 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackScheduleListClient is the interface the list command needs from the API client.
+type stackScheduleListClient interface {
+	ListStackSchedules(ctx context.Context, stackID client.StackIdentifier) ([]apitype.ScheduledAction, error)
+}
+
+type stackScheduleListClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackScheduleListClient, client.StackIdentifier, error)
+
+func newStackScheduleListCmd() *cobra.Command {
+	return newStackScheduleListCmdWith(nil)
+}
+
+func newStackScheduleListCmdWith(factory stackScheduleListClientFactory) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all scheduled actions configured for a stack",
+		Long:  "[EXPERIMENTAL] List all scheduled actions configured for a stack.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackScheduleListClientFactory
+			}
+			return runStackScheduleList(cmd.Context(), cmd.OutOrStdout(), factory, stack, output)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable table) or json")
+
+	return cmd
+}
+
+func defaultStackScheduleListClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackScheduleListClient, client.StackIdentifier, error) {
+	return RequireCloudStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackScheduleList(
+	ctx context.Context,
+	w io.Writer,
+	factory stackScheduleListClientFactory,
+	stackFlag string,
+	output string,
+) error {
+	renderer, err := ui.Renderer(output, ui.OutputRenderers[scheduleListRenderFunc]{
+		Default: renderScheduleListTable,
+		JSON:    renderScheduleListJSON,
+	})
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	schedules, err := c.ListStackSchedules(ctx, stackID)
+	if err != nil {
+		return fmt.Errorf("listing stack schedules: %w", err)
+	}
+
+	return renderer(w, schedules)
+}
+
+type scheduleListRenderFunc func(w io.Writer, schedules []apitype.ScheduledAction) error
+
+// deploymentOperation extracts the operation name from a scheduled deployment's definition.
+// Returns the empty string for non-deployment kinds or when the definition can't be parsed.
+func deploymentOperation(s apitype.ScheduledAction) string {
+	if s.Kind != apitype.ScheduledActionKindDeployment || len(s.Definition) == 0 {
+		return ""
+	}
+	var def apitype.ScheduledDeploymentDefinition
+	if err := json.Unmarshal(s.Definition, &def); err != nil || def.Request == nil {
+		return ""
+	}
+	return string(def.Request.Op)
+}
+
+func renderScheduleListJSON(w io.Writer, schedules []apitype.ScheduledAction) error {
+	if schedules == nil {
+		schedules = []apitype.ScheduledAction{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(apitype.ListScheduledActionsResponse{Schedules: schedules})
+}
+
+func formatSchedule(s apitype.ScheduledAction) string {
+	switch {
+	case s.ScheduleCron != "":
+		return s.ScheduleCron
+	case s.ScheduleOnce != "":
+		return s.ScheduleOnce
+	default:
+		return ""
+	}
+}
+
+func renderScheduleListTable(w io.Writer, schedules []apitype.ScheduledAction) error {
+	if len(schedules) == 0 {
+		fmt.Fprintln(w, "No scheduled actions configured for this stack.")
+		return nil
+	}
+
+	header := table.Row{"ID", "KIND", "SCHEDULE", "OPERATION", "NEXT EXECUTION", "PAUSED"}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(header)
+
+	for _, s := range schedules {
+		t.AppendRow(table.Row{
+			s.ID,
+			string(s.Kind),
+			formatSchedule(s),
+			deploymentOperation(s),
+			s.NextExecution,
+			strconv.FormatBool(s.Paused),
+		})
+	}
+
+	// Let SCHEDULE absorb remaining width when needed.
+	cols := cmdCmd.StdoutWidth()
+	borderWidth := 3*len(header) + 1
+	fixedColsWidth := 60
+	scheduleWidth := max(cols-borderWidth-fixedColsWidth, 20)
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "SCHEDULE", WidthMax: scheduleWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_list_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockScheduleClient implements stackScheduleListClient for tests.
+type mockScheduleClient struct {
+	schedules []apitype.ScheduledAction
+	err       error
+}
+
+func (m *mockScheduleClient) ListStackSchedules(
+	_ context.Context, _ client.StackIdentifier,
+) ([]apitype.ScheduledAction, error) {
+	return m.schedules, m.err
+}
+
+var testScheduleStackID = client.StackIdentifier{
+	Owner:   "my-org",
+	Project: "my-project",
+	Stack:   tokens.MustParseStackName("dev"),
+}
+
+func clientFactory(c stackScheduleListClient) stackScheduleListClientFactory {
+	return func(_ context.Context, _ string) (stackScheduleListClient, client.StackIdentifier, error) {
+		return c, testScheduleStackID, nil
+	}
+}
+
+func deploymentDefinitionJSON(t *testing.T, op apitype.PulumiOperation) json.RawMessage {
+	t.Helper()
+	def := apitype.ScheduledDeploymentDefinition{
+		ProgramID: "5f337707-1981-48b7-a795-1ba559068db2",
+		Request: &apitype.CreateDeploymentRequest{
+			Op:              op,
+			InheritSettings: true,
+		},
+	}
+	b, err := json.Marshal(def)
+	require.NoError(t, err)
+	return b
+}
+
+func sampleSchedules(t *testing.T) []apitype.ScheduledAction {
+	t.Helper()
+	return []apitype.ScheduledAction{
+		{
+			ID:            "bb61b60a",
+			OrgID:         "feacc792",
+			ScheduleOnce:  "2026-05-13 10:51:00.000",
+			NextExecution: "2026-05-13 10:51:00.000",
+			Paused:        false,
+			Kind:          apitype.ScheduledActionKindDeployment,
+			Definition:    deploymentDefinitionJSON(t, apitype.Destroy),
+			Created:       "2026-05-13 08:51:42.176",
+			Modified:      "2026-05-13 08:51:42.176",
+		},
+		{
+			ID:            "abc-cron",
+			OrgID:         "feacc792",
+			ScheduleCron:  "0 */4 * * *",
+			NextExecution: "2026-05-13 12:00:00.000",
+			Paused:        true,
+			Kind:          apitype.ScheduledActionKindDeployment,
+			Definition:    deploymentDefinitionJSON(t, apitype.Refresh),
+		},
+	}
+}
+
+func TestStackScheduleList_TableOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleClient{schedules: sampleSchedules(t)}
+	err := runStackScheduleList(t.Context(), &buf, clientFactory(c), "", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// Headers
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "KIND")
+	assert.Contains(t, out, "SCHEDULE")
+	assert.Contains(t, out, "OPERATION")
+	assert.Contains(t, out, "NEXT EXECUTION")
+	assert.Contains(t, out, "PAUSED")
+
+	// First schedule
+	assert.Contains(t, out, "bb61b60a")
+	assert.Contains(t, out, "deployment")
+	assert.Contains(t, out, "2026-05-13 10:51:00.000")
+	assert.Contains(t, out, "destroy")
+	assert.Contains(t, out, "false")
+
+	// Second schedule
+	assert.Contains(t, out, "abc-cron")
+	assert.Contains(t, out, "0 */4 * * *")
+	assert.Contains(t, out, "refresh")
+	assert.Contains(t, out, "true")
+}
+
+func TestStackScheduleList_TableOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleClient{schedules: []apitype.ScheduledAction{}}
+	err := runStackScheduleList(t.Context(), &buf, clientFactory(c), "", "default")
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "No scheduled actions configured for this stack.")
+}
+
+func TestStackScheduleList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleClient{schedules: sampleSchedules(t)}
+	err := runStackScheduleList(t.Context(), &buf, clientFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"schedules": [
+			{
+				"id": "bb61b60a",
+				"orgID": "feacc792",
+				"scheduleOnce": "2026-05-13 10:51:00.000",
+				"nextExecution": "2026-05-13 10:51:00.000",
+				"paused": false,
+				"kind": "deployment",
+				"definition": {
+					"programID": "5f337707-1981-48b7-a795-1ba559068db2",
+					"request": {
+						"operation": "destroy",
+						"inheritSettings": true
+					}
+				},
+				"created": "2026-05-13 08:51:42.176",
+				"modified": "2026-05-13 08:51:42.176"
+			},
+			{
+				"id": "abc-cron",
+				"orgID": "feacc792",
+				"scheduleCron": "0 */4 * * *",
+				"nextExecution": "2026-05-13 12:00:00.000",
+				"paused": true,
+				"kind": "deployment",
+				"definition": {
+					"programID": "5f337707-1981-48b7-a795-1ba559068db2",
+					"request": {
+						"operation": "refresh",
+						"inheritSettings": true
+					}
+				}
+			}
+		]
+	}`, buf.String())
+}
+
+func TestStackScheduleList_JSONOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleClient{schedules: []apitype.ScheduledAction{}}
+	err := runStackScheduleList(t.Context(), &buf, clientFactory(c), "", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"schedules": []}`, buf.String())
+}

--- a/sdk/go/common/apitype/schedules.go
+++ b/sdk/go/common/apitype/schedules.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import "encoding/json"
+
+// ScheduledActionKind identifies what kind of action a scheduled action executes.
+type ScheduledActionKind string
+
+const (
+	// ScheduledActionKindDeployment is a scheduled deployment action.
+	ScheduledActionKindDeployment ScheduledActionKind = "deployment"
+	// ScheduledActionKindEnvironmentRotation is a scheduled environment secret rotation action.
+	ScheduledActionKindEnvironmentRotation ScheduledActionKind = "environment_rotation"
+	// ScheduledActionKindScan is a scheduled Insights scan action.
+	ScheduledActionKindScan ScheduledActionKind = "scan"
+	// ScheduledActionKindAgentAutomation is an agent automation.
+	ScheduledActionKindAgentAutomation ScheduledActionKind = "agent_automation"
+)
+
+// ScheduledAction describes the state of a scheduled action returned by the Pulumi Cloud REST API.
+type ScheduledAction struct {
+	// ID is the unique identifier for this scheduled action.
+	ID string `json:"id"`
+	// OrgID is the organization ID that owns this scheduled action.
+	OrgID string `json:"orgID,omitempty"`
+	// ScheduleCron is a cron expression defining the recurring schedule.
+	ScheduleCron string `json:"scheduleCron,omitempty"`
+	// ScheduleOnce is a timestamp for a one-time scheduled execution.
+	ScheduleOnce string `json:"scheduleOnce,omitempty"`
+	// NextExecution is the timestamp of the next scheduled execution.
+	NextExecution string `json:"nextExecution,omitempty"`
+	// Paused indicates whether the scheduled action is currently paused.
+	Paused bool `json:"paused"`
+	// Kind is the kind of action to be executed.
+	Kind ScheduledActionKind `json:"kind"`
+	// Definition is the action definition, which varies based on the action kind.
+	Definition json.RawMessage `json:"definition,omitempty"`
+	// Created is the timestamp when this scheduled action was created.
+	Created string `json:"created,omitempty"`
+	// Modified is the timestamp when this scheduled action was last modified.
+	Modified string `json:"modified,omitempty"`
+	// LastExecuted is the timestamp of the last execution, if any.
+	LastExecuted *string `json:"lastExecuted,omitempty"`
+}
+
+// ListScheduledActionsResponse is the API response when scheduled actions are listed.
+type ListScheduledActionsResponse struct {
+	Schedules []ScheduledAction `json:"schedules"`
+}
+
+// ScheduledDeploymentDefinition is the shape of ScheduledAction.Definition when Kind is
+// ScheduledActionKindDeployment.
+type ScheduledDeploymentDefinition struct {
+	// ProgramID is the Pulumi Cloud-internal identifier for the program (stack) being deployed.
+	ProgramID string `json:"programID,omitempty"`
+	// Request is the deployment request payload that will be executed when the schedule fires.
+	Request *CreateDeploymentRequest `json:"request,omitempty"`
+}


### PR DESCRIPTION
```
% pulumi stack schedule list
┌──────────────────────────────────────┬────────────┬─────────────┬──────────────┬─────────────────────────┬────────┐
│ ID                                   │ KIND       │ SCHEDULE    │ OPERATION    │ NEXT EXECUTION          │ PAUSED │
├──────────────────────────────────────┼────────────┼─────────────┼──────────────┼─────────────────────────┼────────┤
│ bb61b60a-a313-46cb-b4ab-9d42dce46de8 │ deployment │ 12 16 * * * │ detect-drift │ 2026-05-13 16:12:00.000 │ false  │
└──────────────────────────────────────┴────────────┴─────────────┴──────────────┴─────────────────────────┴────────┘

% pulumi stack schedule list --output json
{
  "schedules": [
    {
      "id": "bb61b60a-a313-46cb-b4ab-9d42dce46de8",
      "orgID": "feacc792-460f-4525-a091-e8de1f6ef34c",
      "scheduleCron": "12 16 * * *",
      "nextExecution": "2026-05-13 16:12:00.000",
      "paused": false,
      "kind": "deployment",
      "definition": {
        "programID": "5f337707-1981-48b7-a795-1ba559068db2",
        "request": {
          "inheritSettings": true,
          "operation": "detect-drift",
          "operationContext": {
            "options": {
              "remediateIfDriftDetected": false
            }
          }
        }
      },
      "created": "2026-05-13 08:51:42.176",
      "modified": "2026-05-13 09:47:37.982"
    }
  ]
}
```

Fixes https://github.com/pulumi/pulumi/issues/23049