### PR TITLE
Reusable `--output` flag.

### DIFF
--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -98,7 +99,7 @@ func NewUpCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
-	var output string
+	output := outputflag.OutputFlag[bool]{RenderJSON: true}
 	var policyPackPaths []string
 	var policyPackConfigPaths []string
 	var diffDisplay bool
@@ -588,16 +589,6 @@ func NewUpCmd() *cobra.Command {
 				return err
 			}
 
-			// Validate --output up front. We keep the existing --json flag (which
-			// emits a JSONL stream of engine events) backwards compatible, and
-			// only emit the structured operation summary when --output=json.
-			switch output {
-			case "default", "json":
-				// No-op.
-			default:
-				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
-			}
-
 			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
 			if err != nil {
 				return err
@@ -628,7 +619,7 @@ func NewUpCmd() *cobra.Command {
 				EventLogPath:           eventLogPath,
 				Debug:                  debug,
 				JSONDisplay:            jsonDisplay,
-				SummaryJSON:            output == "json",
+				SummaryJSON:            output.Get(),
 				ShowSecrets:            showSecrets,
 			}
 
@@ -782,11 +773,9 @@ func NewUpCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(
 		&jsonDisplay, "json", "j", false,
 		"Serialize the update diffs, operations, and overall output as JSON")
-	cmd.Flags().StringVar(
-		&output, "output", "default",
-		"Output format. Supported values are: default, json")
+	outputflag.Var(cmd.Flags(), &output)
 	// Hidden until --output is wired up across all operations (destroy, preview, refresh, ...).
-	_ = cmd.Flags().MarkHidden("output")
+	contract.AssertNoErrorf(cmd.Flags().MarkHidden("output"), `Could not mark "output" as hidden`)
 	cmd.MarkFlagsMutuallyExclusive("json", "output")
 	cmd.PersistentFlags().Int32VarP(
 		&parallel, "parallel", "p", defaultParallel(),

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -32,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -66,41 +68,29 @@ func (d *Delimiter) Rune() rune {
 	return rune(*d)
 }
 
-type outputFormat string
+// searchRender renders a search response to cmd.Stdout. The receiver is passed
+// explicitly so we can capture per-format renderers as function values.
+type searchRender func(cmd *searchCmd, results *apitype.ResourceSearchResponse) error
 
-const (
-	outputFormatTable outputFormat = "table"
-	outputFormatJSON  outputFormat = "json"
-	outputFormatYAML  outputFormat = "yaml"
-	outputFormatCSV   outputFormat = "csv"
-)
-
-// String is used both by fmt.Print and by Cobra in help text
-func (o *outputFormat) String() string {
-	return string(*o)
-}
-
-// Set must have pointer receiver so it doesn't change the value of a copy
-func (o *outputFormat) Set(v string) error {
-	switch v {
-	case "csv", "table", "json", "yaml":
-		*o = outputFormat(v)
-		return nil
-	default:
-		return errors.New(`must be one of "csv", "table", "json", or "yaml"`)
+// defaultSearchOutputFormat returns the OutputFlag wired up with every supported
+// format. Callers (cobra constructors and tests) install this on searchCmd so
+// `--output` selects between them.
+func defaultSearchOutputFormat() outputflag.OutputFlag[searchRender] {
+	return outputflag.OutputFlag[searchRender]{
+		RenderForTerminal: (*searchCmd).RenderTable,
+		RenderJSON:        (*searchCmd).RenderJSON,
+		RenderYAML:        (*searchCmd).RenderYAML,
+		RenderCSV: func(cmd *searchCmd, results *apitype.ResourceSearchResponse) error {
+			return cmd.RenderCSV(results.Resources, cmd.csvDelimiter.Rune())
+		},
 	}
-}
-
-// Type is only used in help text
-func (o *outputFormat) Type() string {
-	return "outputFormat"
 }
 
 type searchCmd struct {
 	orgName      string
 	csvDelimiter Delimiter
-	outputFormat
-	openWeb bool
+	outputFormat outputflag.OutputFlag[searchRender]
+	openWeb      bool
 
 	Stdout io.Writer // defaults to os.Stdout
 
@@ -118,10 +108,6 @@ type orgSearchCmd struct {
 
 func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	interactive := cmdutil.Interactive()
-
-	if cmd.outputFormat == "" {
-		cmd.outputFormat = outputFormatTable
-	}
 
 	if cmd.Stdout == nil {
 		cmd.Stdout = os.Stdout
@@ -163,7 +149,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 		cmd.orgName = defaultOrg
 	}
 	if cmd.orgName != "" {
-		if !sliceContains(orgs, cmd.orgName) {
+		if !slices.Contains(orgs, cmd.orgName) {
 			return fmt.Errorf("user %s is not a member of organization %s", userName, cmd.orgName)
 		}
 	} else {
@@ -175,7 +161,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = cmd.Render(&cmd.searchCmd, res)
+	err = cmd.outputFormat.Get()(&cmd.searchCmd, res)
 	if err != nil {
 		return fmt.Errorf("table rendering error: %w", err)
 	}
@@ -190,6 +176,7 @@ func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 
 func newSearchCmd() *cobra.Command {
 	var scmd orgSearchCmd
+	scmd.outputFormat = defaultSearchOutputFormat()
 	cmd := &cobra.Command{
 		Use:   "search",
 		Short: "Search for resources in Pulumi Cloud",
@@ -219,10 +206,7 @@ func newSearchCmd() *cobra.Command {
 			"\t-q \"type:aws:s3/bucketv2:BucketV2\" -q \"modified:>=2023-09-01\"\n"+
 			"See https://www.pulumi.com/docs/pulumi-cloud/insights/search/#query-syntax for syntax reference.",
 	)
-	cmd.PersistentFlags().VarP(
-		&scmd.outputFormat, "output", "o",
-		"Output format. Supported formats are 'table', 'json', 'csv', and 'yaml'.",
-	)
+	outputflag.VarP(cmd.PersistentFlags(), &scmd.outputFormat)
 	cmd.PersistentFlags().Var(
 		&scmd.csvDelimiter, "delimiter",
 		"Delimiter to use when rendering CSV output.",
@@ -233,15 +217,6 @@ func newSearchCmd() *cobra.Command {
 	)
 
 	return cmd
-}
-
-func sliceContains(slice []string, search string) bool {
-	for _, s := range slice {
-		if s == search {
-			return true
-		}
-	}
-	return false
 }
 
 func renderSearchTable(w io.Writer, results *apitype.ResourceSearchResponse) error {
@@ -313,21 +288,6 @@ func renderSearchJSON(w io.Writer, results []apitype.ResourceResult) error {
 	}
 	_, err = w.Write(output)
 	return err
-}
-
-func (o *outputFormat) Render(cmd *searchCmd, result *apitype.ResourceSearchResponse) error {
-	switch *o {
-	case outputFormatJSON:
-		return cmd.RenderJSON(result)
-	case outputFormatTable:
-		return cmd.RenderTable(result)
-	case outputFormatYAML:
-		return cmd.RenderYAML(result)
-	case outputFormatCSV:
-		return cmd.RenderCSV(result.Resources, cmd.csvDelimiter.Rune())
-	default:
-		return fmt.Errorf("unknown output format %q", *o)
-	}
 }
 
 func (cmd *searchCmd) RenderJSON(result *apitype.ResourceSearchResponse) error {

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -19,12 +19,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/pkg/browser"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -42,10 +44,6 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 
 	if cmd.Stdout == nil {
 		cmd.Stdout = os.Stdout
-	}
-
-	if cmd.outputFormat == "" {
-		cmd.outputFormat = outputFormatTable
 	}
 
 	if cmd.currentBackend == nil {
@@ -93,7 +91,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 			userName,
 		)
 	}
-	if !sliceContains(orgs, cmd.orgName) && cmd.orgName != "" {
+	if !slices.Contains(orgs, cmd.orgName) && cmd.orgName != "" {
 		return fmt.Errorf("user %s is not a member of org %s", userName, cmd.orgName)
 	}
 
@@ -101,7 +99,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = cmd.Render(&cmd.searchCmd, res)
+	err = cmd.outputFormat.Get()(&cmd.searchCmd, res)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "rendering error: %s\n", err)
 	}
@@ -116,6 +114,7 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 
 func newSearchAICmd() *cobra.Command {
 	var scmd searchAICmd
+	scmd.outputFormat = defaultSearchOutputFormat()
 	cmd := &cobra.Command{
 		Use:   "ai",
 		Short: "Search for resources in Pulumi Cloud using Pulumi AI",
@@ -136,10 +135,7 @@ func newSearchAICmd() *cobra.Command {
 		&scmd.queryString, "query", "q", "",
 		"Plaintext natural language query",
 	)
-	cmd.PersistentFlags().VarP(
-		&scmd.outputFormat, "output", "o",
-		"Output format. Supported formats are 'table', 'json', 'csv' and 'yaml'.",
-	)
+	outputflag.VarP(cmd.PersistentFlags(), &scmd.outputFormat)
 	cmd.PersistentFlags().Var(
 		&scmd.csvDelimiter, "delimiter",
 		"Delimiter to use when rendering CSV output.",

--- a/pkg/cmd/pulumi/org/org_search_ai_test.go
+++ b/pkg/cmd/pulumi/org/org_search_ai_test.go
@@ -71,7 +71,7 @@ func TestSearchAI_cmd(t *testing.T) {
 			) (backend.Backend, error) {
 				return b, nil
 			},
-			outputFormat: outputFormatTable,
+			outputFormat: defaultSearchOutputFormat(),
 		},
 	}
 

--- a/pkg/cmd/pulumi/org/org_search_test.go
+++ b/pkg/cmd/pulumi/org/org_search_test.go
@@ -46,8 +46,9 @@ func TestSearch_cmd(t *testing.T) {
 	orgName := "org1"
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
-			orgName: orgName,
-			Stdout:  &buff,
+			orgName:      orgName,
+			Stdout:       &buff,
+			outputFormat: defaultSearchOutputFormat(),
 			currentBackend: func(
 				context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {
@@ -101,7 +102,8 @@ func TestSearchNoOrgName_cmd(t *testing.T) {
 	total := int64(132)
 	cmd := orgSearchCmd{
 		searchCmd: searchCmd{
-			Stdout: &buff,
+			Stdout:       &buff,
+			outputFormat: defaultSearchOutputFormat(),
 			currentBackend: func(
 				context.Context, pkgWorkspace.Context, cmdBackend.LoginManager, *workspace.Project, display.Options,
 			) (backend.Backend, error) {

--- a/pkg/util/outputflag/outputflag.go
+++ b/pkg/util/outputflag/outputflag.go
@@ -1,0 +1,137 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputflag
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// Var registers the OutputFlag on flags as --output with no shorthand.
+func Var[R any](flags *pflag.FlagSet, output *OutputFlag[R]) {
+	flags.Var(output, "output", usage(*output))
+}
+
+// VarP registers the OutputFlag on flags as --output with the conventional
+// -o shorthand.
+func VarP[R any](flags *pflag.FlagSet, output *OutputFlag[R]) {
+	flags.VarP(output, "output", "o", usage(*output))
+}
+
+func usage[R any](output OutputFlag[R]) string {
+	return "Output format. Supported values are: " + supportedValues(output, "and")
+}
+
+var _ pflag.Value = (*OutputFlag[struct{}])(nil)
+
+type OutputFlag[R any] struct {
+	RenderForTerminal R // Default behavior
+	RenderJSON        R
+	RenderMarkdown    R
+	RenderCSV         R
+	RenderYAML        R
+
+	// set value
+	value  string
+	render R
+}
+
+func (f OutputFlag[R]) Get() R {
+	if reflect.ValueOf(f.render).IsZero() {
+		return f.RenderForTerminal
+	}
+	return f.render
+}
+
+func (f OutputFlag[R]) String() string {
+	if f.value != "" {
+		return f.value
+	}
+	return "default"
+}
+
+func (f *OutputFlag[R]) Set(s string) error {
+	switch s {
+	case "", "default":
+		f.render = f.RenderForTerminal
+	case "json":
+		if reflect.ValueOf(f.RenderJSON).IsZero() {
+			return f.unsupported(s)
+		}
+		f.render = f.RenderJSON
+	case "markdown", "md":
+		if reflect.ValueOf(f.RenderMarkdown).IsZero() {
+			return f.unsupported(s)
+		}
+		f.render = f.RenderMarkdown
+		s = "markdown" // normalize s
+	case "yaml":
+		if reflect.ValueOf(f.RenderYAML).IsZero() {
+			return f.unsupported(s)
+		}
+		f.render = f.RenderYAML
+	case "csv":
+		if reflect.ValueOf(f.RenderCSV).IsZero() {
+			return f.unsupported(s)
+		}
+		f.render = f.RenderCSV
+	default:
+		return f.unsupported(s)
+	}
+	f.value = s
+	return nil
+}
+
+func (f OutputFlag[R]) Type() string { return "string" }
+
+type unsuportedArgError[R any] struct {
+	f     OutputFlag[R]
+	given string
+}
+
+func (f OutputFlag[R]) unsupported(s string) error {
+	return unsuportedArgError[R]{f, s}
+}
+
+func (err unsuportedArgError[R]) Error() string {
+	return fmt.Sprintf("output %q not supported, valid values are: %s",
+		err.given, supportedValues(err.f, "or"))
+}
+
+func supportedValues[R any](f OutputFlag[R], lastJoin string) string {
+	supported := []string{"default"}
+	if !reflect.ValueOf(f.RenderJSON).IsZero() {
+		supported = append(supported, "json")
+	}
+	if !reflect.ValueOf(f.RenderMarkdown).IsZero() {
+		supported = append(supported, "markdown")
+	}
+	if !reflect.ValueOf(f.RenderYAML).IsZero() {
+		supported = append(supported, "yaml")
+	}
+	if !reflect.ValueOf(f.RenderCSV).IsZero() {
+		supported = append(supported, "csv")
+	}
+
+	if len(supported) == 1 {
+		return supported[0]
+	}
+
+	return strings.Join(supported[:len(supported)-1], ", ") + " " +
+		lastJoin + " " + supported[len(supported)-1]
+}

--- a/pkg/util/outputflag/outputflag_test.go
+++ b/pkg/util/outputflag/outputflag_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package outputflag
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allFormats is a fully-populated OutputFlag used as a fixture across tests.
+// The R type is `string` so each renderer is a self-describing tag.
+func allFormats() OutputFlag[string] {
+	return OutputFlag[string]{
+		RenderForTerminal: "terminal",
+		RenderJSON:        "json",
+		RenderMarkdown:    "markdown",
+		RenderYAML:        "yaml",
+		RenderCSV:         "csv",
+	}
+}
+
+func TestOutputFlag_DefaultUnset(t *testing.T) {
+	t.Parallel()
+
+	f := allFormats()
+	assert.Equal(t, "terminal", f.Get(), "Get() before Set should return RenderForTerminal")
+	assert.Equal(t, "default", f.String(), "String() before Set should report \"default\"")
+}
+
+func TestOutputFlag_SetSelectsRenderer(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"", "terminal"},
+		{"default", "terminal"},
+		{"json", "json"},
+		{"markdown", "markdown"},
+		{"md", "markdown"},
+		{"yaml", "yaml"},
+		{"csv", "csv"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			f := allFormats()
+			require.NoError(t, f.Set(tc.input))
+			assert.Equal(t, tc.want, f.Get())
+		})
+	}
+}
+
+func TestOutputFlag_StringReflectsLastSet(t *testing.T) {
+	t.Parallel()
+
+	f := allFormats()
+	require.NoError(t, f.Set("json"))
+	assert.Equal(t, "json", f.String())
+
+	require.NoError(t, f.Set("md"))
+	assert.Equal(t, "markdown", f.String(), "Set normalizes the md alias to markdown")
+
+	require.NoError(t, f.Set(""))
+	assert.Equal(t, "default", f.String(), "Set(\"\") falls back to the \"default\" String()")
+}
+
+func TestOutputFlag_UnconfiguredFormatRejected(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"json", "json"},
+		{"markdown", "markdown"},
+		{"md alias", "md"},
+		{"yaml", "yaml"},
+		{"csv", "csv"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Empty OutputFlag has only `default` available.
+			var f OutputFlag[string]
+			err := f.Set(tc.input)
+			require.Error(t, err)
+			assert.Equal(t,
+				`output "`+tc.input+`" not supported, valid values are: default`,
+				err.Error())
+		})
+	}
+}
+
+func TestOutputFlag_UnknownFormatRejected(t *testing.T) {
+	t.Parallel()
+
+	f := allFormats()
+	err := f.Set("xml")
+	require.Error(t, err)
+	assert.Equal(t,
+		`output "xml" not supported, valid values are: default, json, markdown, yaml or csv`,
+		err.Error())
+}
+
+func TestOutputFlag_PartialConfigurationListsOnlyAvailable(t *testing.T) {
+	t.Parallel()
+
+	// Only RenderJSON is configured; the error must omit markdown/yaml/csv
+	// but always include "default".
+	f := OutputFlag[string]{RenderJSON: "json"}
+	err := f.Set("yaml")
+	require.Error(t, err)
+	assert.Equal(t,
+		`output "yaml" not supported, valid values are: default or json`,
+		err.Error())
+}
+
+func TestOutputFlag_DefaultAlwaysAcceptedEvenWhenZero(t *testing.T) {
+	t.Parallel()
+
+	// RenderForTerminal left as the zero value of R; "default" must still
+	// be a legal value and Get() must return that zero value.
+	var f OutputFlag[string]
+	require.NoError(t, f.Set("default"))
+	assert.Equal(t, "", f.Get())
+
+	require.NoError(t, f.Set(""))
+	assert.Equal(t, "", f.Get())
+}
+
+func TestOutputFlag_FailedSetLeavesPriorValue(t *testing.T) {
+	t.Parallel()
+
+	f := allFormats()
+	require.NoError(t, f.Set("json"))
+	require.Error(t, f.Set("xml"))
+
+	assert.Equal(t, "json", f.Get(), "rejected Set must not overwrite the prior renderer")
+	assert.Equal(t, "json", f.String(), "rejected Set must not overwrite the prior String()")
+}
+
+func TestOutputFlag_ImplementsPflagValue(t *testing.T) {
+	t.Parallel()
+
+	f := allFormats()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Var(&f, "output", "")
+
+	require.NoError(t, fs.Parse([]string{"--output=json"}))
+	assert.Equal(t, "json", f.Get())
+	assert.Equal(t, "json", f.String())
+
+	// Reset and confirm invalid values surface through pflag too.
+	f = allFormats()
+	fs = pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.SetOutput(discard{}) // silence pflag's default usage dump on error
+	fs.Var(&f, "output", "")
+	err := fs.Parse([]string{"--output=xml"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `output "xml" not supported`)
+}
+
+func TestOutputFlag_FunctionRenderer(t *testing.T) {
+	t.Parallel()
+
+	// Exercise the typical real-world shape: R is a renderer function.
+	type renderer func() string
+	f := OutputFlag[renderer]{
+		RenderForTerminal: func() string { return "terminal" },
+		RenderJSON:        func() string { return "json" },
+	}
+
+	assert.Equal(t, "terminal", f.Get()(), "Get() before Set should return RenderForTerminal")
+
+	require.NoError(t, f.Set("json"))
+	assert.Equal(t, "json", f.Get()())
+
+	require.Error(t, f.Set("yaml"), "yaml must be rejected because RenderYAML is nil")
+}
+
+// discard is an io.Writer that swallows writes, used to silence pflag's
+// usage output on parse errors.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
A cobra based output flag that can be re-used across output formats. 

Another version of https://github.com/pulumi/pulumi/pull/23107.