### PR TITLE
Add `pulumi stack schedule get` to retrieve the configuration of a scheduled action

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-schedule-get.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-schedule-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack schedule get` to retrieve the configuration of a scheduled action

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -703,6 +703,18 @@ func (pc *Client) ListStackSchedules(
 	return resp.Schedules, nil
 }
 
+// GetStackSchedule returns the scheduled deployment action with the given ID.
+func (pc *Client) GetStackSchedule(
+	ctx context.Context, stackID StackIdentifier, scheduleID string,
+) (apitype.ScheduledAction, error) {
+	var resp apitype.ScheduledAction
+	path := getStackPath(stackID, "deployments", "schedules", scheduleID)
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.ScheduledAction{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_schedule_test.go
+++ b/pkg/backend/httpstate/client/client_schedule_test.go
@@ -107,3 +107,58 @@ func TestListStackSchedules(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestGetStackSchedule(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+	const scheduleID = "bb61b60a-a313-46cb-b4ab-9d42dce46de8"
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ScheduledAction{
+			ID:            scheduleID,
+			OrgID:         "feacc792-460f-4525-a091-e8de1f6ef34c",
+			ScheduleCron:  "12 16 * * *",
+			NextExecution: "2026-05-13 16:12:00.000",
+			Paused:        false,
+			Kind:          apitype.ScheduledActionKindDeployment,
+			Definition: json.RawMessage(
+				`{"programID":"5f337707","request":{"operation":"detect-drift","inheritSettings":true}}`),
+			Created:  "2026-05-13 08:51:42.176",
+			Modified: "2026-05-13 09:47:37.982",
+		}
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			err := json.NewEncoder(w).Encode(want)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.GetStackSchedule(t.Context(), stackID, scheduleID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/deployments/schedules/"+scheduleID, gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.GetStackSchedule(t.Context(), stackID, scheduleID)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -75,32 +75,6 @@ func newStackScheduleNewCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23047]: Not yet implemented.
-func newStackScheduleGetCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Retrieve the configuration of a scheduled action",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "schedule-id"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23046]: Not yet implemented.
 func newStackScheduleEditCmd() *cobra.Command {
 	var (

--- a/pkg/cmd/pulumi/stack/stack_schedule_get.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_get.go
@@ -1,0 +1,184 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+type stackScheduleGetClient interface {
+	GetStackSchedule(
+		ctx context.Context, stackID client.StackIdentifier, scheduleID string,
+	) (apitype.ScheduledAction, error)
+}
+
+type stackScheduleGetClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackScheduleGetClient, client.StackIdentifier, error)
+
+func newStackScheduleGetCmd() *cobra.Command {
+	return newStackScheduleGetCmdWith(nil)
+}
+
+func newStackScheduleGetCmdWith(factory stackScheduleGetClientFactory) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get <schedule-id>",
+		Short: "Retrieve the configuration of a scheduled action",
+		Long:  "[EXPERIMENTAL] Retrieve the configuration of a scheduled action.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackScheduleGetClientFactory
+			}
+			return runStackScheduleGet(cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], output)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "schedule-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable text) or json")
+
+	return cmd
+}
+
+func defaultStackScheduleGetClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackScheduleGetClient, client.StackIdentifier, error) {
+	return RequireCloudStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackScheduleGet(
+	ctx context.Context,
+	w io.Writer,
+	factory stackScheduleGetClientFactory,
+	stackFlag, scheduleID, output string,
+) error {
+	renderer, err := ui.Renderer(output, ui.OutputRenderers[scheduleGetRenderFunc]{
+		Default: renderScheduleGetText,
+		JSON:    renderScheduleGetJSON,
+	})
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	schedule, err := c.GetStackSchedule(ctx, stackID, scheduleID)
+	if err != nil {
+		return fmt.Errorf("getting stack schedule: %w", err)
+	}
+
+	return renderer(w, schedule)
+}
+
+type scheduleGetRenderFunc func(w io.Writer, schedule apitype.ScheduledAction) error
+
+func renderScheduleGetJSON(w io.Writer, schedule apitype.ScheduledAction) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(schedule)
+}
+
+func renderScheduleGetText(w io.Writer, s apitype.ScheduledAction) error {
+	line := func(label, value string) {
+		fmt.Fprintf(w, "%-22s %s\n", label+":", value)
+	}
+	optLine := func(label, value string) {
+		if value != "" {
+			line(label, value)
+		}
+	}
+
+	line("ID", s.ID)
+	line("Kind", string(s.Kind))
+	optLine("Cron", s.ScheduleCron)
+	optLine("Once", s.ScheduleOnce)
+	optLine("Next execution", s.NextExecution)
+	if s.LastExecuted != nil && *s.LastExecuted != "" {
+		line("Last executed", *s.LastExecuted)
+	} else {
+		line("Last executed", "(never)")
+	}
+	line("Paused", strconv.FormatBool(s.Paused))
+	optLine("Created", s.Created)
+	optLine("Modified", s.Modified)
+
+	if s.Kind == apitype.ScheduledActionKindDeployment {
+		var def apitype.ScheduledDeploymentDefinition
+		if err := json.Unmarshal(s.Definition, &def); err == nil {
+			renderScheduledDeploymentText(def, line)
+		}
+	}
+	return nil
+}
+
+func renderScheduledDeploymentText(
+	def apitype.ScheduledDeploymentDefinition,
+	line func(label, value string),
+) {
+	req := def.Request
+	if req == nil {
+		return
+	}
+	line("Operation", string(req.Op))
+	line("Inherit settings", strconv.FormatBool(req.InheritSettings))
+
+	var opts apitype.OperationContextOptions
+	if opCtx := req.Operation; opCtx != nil && opCtx.Options != nil {
+		opts = *opCtx.Options
+	}
+	// The schedule-creation flows in the backend pair RemediateIfDriftDetected with
+	// DetectDrift (drift schedules) and DeleteAfterDestroy with Destroy (TTL schedules);
+	// see pulumi-service/cmd/service/api/scheduled_{drift,ttl}_deployments.go. Other
+	// operations don't carry a kind-specific toggle we need to surface.
+	switch req.Op {
+	case apitype.DetectDrift:
+		line("Remediate on drift", strconv.FormatBool(opts.RemediateIfDriftDetected))
+	case apitype.Destroy:
+		line("Delete after destroy", strconv.FormatBool(opts.DeleteAfterDestroy))
+	case apitype.Update, apitype.Preview, apitype.Refresh, apitype.RemediateDrift:
+		// No kind-specific option for these operations.
+	}
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_get_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockScheduleGetClient struct {
+	schedule apitype.ScheduledAction
+	err      error
+}
+
+func (m *mockScheduleGetClient) GetStackSchedule(
+	_ context.Context, _ client.StackIdentifier, _ string,
+) (apitype.ScheduledAction, error) {
+	return m.schedule, m.err
+}
+
+func getClientFactory(c stackScheduleGetClient) stackScheduleGetClientFactory {
+	return func(_ context.Context, _ string) (stackScheduleGetClient, client.StackIdentifier, error) {
+		return c, testScheduleStackID, nil
+	}
+}
+
+func sampleSchedule(t *testing.T) apitype.ScheduledAction {
+	t.Helper()
+	return apitype.ScheduledAction{
+		ID:            "bb61b60a",
+		OrgID:         "feacc792",
+		ScheduleCron:  "12 16 * * *",
+		NextExecution: "2026-05-13 16:12:00.000",
+		Paused:        false,
+		Kind:          apitype.ScheduledActionKindDeployment,
+		Definition:    deploymentDefinitionJSON(t, apitype.DetectDrift),
+		Created:       "2026-05-13 08:51:42.176",
+		Modified:      "2026-05-13 09:47:37.982",
+	}
+}
+
+func TestStackScheduleGet_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleGetClient{schedule: sampleSchedule(t)}
+	err := runStackScheduleGet(t.Context(), &buf, getClientFactory(c), "", "bb61b60a", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID:                    bb61b60a")
+	assert.Contains(t, out, "Kind:                  deployment")
+	assert.Contains(t, out, "Cron:                  12 16 * * *")
+	assert.Contains(t, out, "Next execution:        2026-05-13 16:12:00.000")
+	assert.Contains(t, out, "Last executed:         (never)")
+	assert.Contains(t, out, "Paused:                false")
+	assert.Contains(t, out, "Created:               2026-05-13 08:51:42.176")
+	assert.Contains(t, out, "Modified:              2026-05-13 09:47:37.982")
+	assert.Contains(t, out, "Operation:             detect-drift")
+	assert.Contains(t, out, "Inherit settings:      true")
+	assert.Contains(t, out, "Remediate on drift:    false")
+}
+
+func TestStackScheduleGet_TextOutput_OnceAndPaused(t *testing.T) {
+	t.Parallel()
+
+	lastExecuted := "2026-05-13 11:00:00.000"
+	s := apitype.ScheduledAction{
+		ID:           "abc-once",
+		Kind:         apitype.ScheduledActionKindDeployment,
+		ScheduleOnce: "2026-05-13 10:51:00.000",
+		Paused:       true,
+		Definition:   deploymentDefinitionJSON(t, apitype.Destroy),
+		LastExecuted: &lastExecuted,
+	}
+
+	var buf bytes.Buffer
+	c := &mockScheduleGetClient{schedule: s}
+	err := runStackScheduleGet(t.Context(), &buf, getClientFactory(c), "", "abc-once", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Once:                  2026-05-13 10:51:00.000")
+	assert.Contains(t, out, "Operation:             destroy")
+	assert.Contains(t, out, "Paused:                true")
+	assert.Contains(t, out, "Last executed:         2026-05-13 11:00:00.000")
+	assert.Contains(t, out, "Delete after destroy:  false")
+	assert.NotContains(t, out, "Cron:")
+	assert.NotContains(t, out, "Next execution:")
+}
+
+func TestStackScheduleGet_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockScheduleGetClient{schedule: sampleSchedule(t)}
+	err := runStackScheduleGet(t.Context(), &buf, getClientFactory(c), "", "bb61b60a", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"id": "bb61b60a",
+		"orgID": "feacc792",
+		"scheduleCron": "12 16 * * *",
+		"nextExecution": "2026-05-13 16:12:00.000",
+		"paused": false,
+		"kind": "deployment",
+		"definition": {
+			"programID": "5f337707-1981-48b7-a795-1ba559068db2",
+			"request": {
+				"operation": "detect-drift",
+				"inheritSettings": true
+			}
+		},
+		"created": "2026-05-13 08:51:42.176",
+		"modified": "2026-05-13 09:47:37.982"
+	}`, buf.String())
+}


### PR DESCRIPTION
    % pulumi stack schedule get bb61b60a-a313-46cb-b4ab-9d42dce46de8
    ID:                    bb61b60a-a313-46cb-b4ab-9d42dce46de8
    Kind:                  deployment
    Cron:                  12 16 * * *
    Next execution:        2026-05-13 16:12:00.000
    Last executed:         (never)
    Paused:                false
    Created:               2026-05-13 08:51:42.176
    Modified:              2026-05-13 09:47:37.982
    Program ID:            5f337707-1981-48b7-a795-1ba559068db2
    Operation:             detect-drift
    Inherit settings:      true
    Remediate on drift:    false

    % pulumi stack schedule get bb61b60a-a313-46cb-b4ab-9d42dce46de8 --output json
    {
      "id": "bb61b60a-a313-46cb-b4ab-9d42dce46de8",
      "orgID": "feacc792-460f-4525-a091-e8de1f6ef34c",
      "scheduleCron": "12 16 * * *",
      "nextExecution": "2026-05-13 16:12:00.000",
      "paused": false,
      "kind": "deployment",
      "definition": {
        "programID": "5f337707-1981-48b7-a795-1ba559068db2",
        "request": {
          "inheritSettings": true,
          "operation": "detect-drift",
          "operationContext": {
            "options": {
              "remediateIfDriftDetected": false
            }
          }
        }
      },
      "created": "2026-05-13 08:51:42.176",
      "modified": "2026-05-13 09:47:37.982"
    }


Fixes https://github.com/pulumi/pulumi/issues/23047
