### PR TITLE
[cli/import] Strip InputType after union reduction in structural typing

### DIFF
--- a/changelog/pending/20260511--cli-import--skip-codegen-for-local-component-imports.yaml
+++ b/changelog/pending/20260511--cli-import--skip-codegen-for-local-component-imports.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Skip code generation for local component imports so `pulumi import` no longer crashes with "expected '::' in provider reference ''" after a successful import

--- a/changelog/pending/20260511--cli-import--skip-codegen-for-local-component-imports.yaml
+++ b/changelog/pending/20260511--cli-import--skip-codegen-for-local-component-imports.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: cli/import
-  description: Skip code generation for local component imports so `pulumi import` no longer crashes with "expected '::' in provider reference ''" after a successful import

--- a/changelog/pending/20260513--cli-import--keep-union-typed-map-values-with-input-wrapped-elements.yaml
+++ b/changelog/pending/20260513--cli-import--keep-union-typed-map-values-with-input-wrapped-elements.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Stop dropping map values whose element type is a union of Input-wrapped types during HCL2 import

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -608,6 +608,12 @@ func valueStructurallyTypedAs(value property.Value, schemaType schema.Type) bool
 			break
 		}
 	}
+	// An enum value is represented as a value of the enum's underlying primitive
+	// type at the wire level (e.g. a string for a string-typed enum). Substitute
+	// the underlying type so the primitive-value branches below match.
+	if enum, ok := schemaType.(*schema.EnumType); ok {
+		schemaType = enum.ElementType
+	}
 	if union, ok := schemaType.(*schema.UnionType); ok {
 		schemaType = reduceUnionType(union, value)
 	}
@@ -622,13 +628,23 @@ func valueStructurallyTypedAs(value property.Value, schemaType schema.Type) bool
 		}
 	}
 
-	if schemaType == schema.AnyType {
+	// AnyType, JSONType, and AnyResourceType all share the "pulumi:pulumi:Any"
+	// token but are distinct singletons. Each one accepts any value at the
+	// structural level, so short-circuit them together.
+	if schemaType == schema.AnyType || schemaType == schema.JSONType || schemaType == schema.AnyResourceType {
 		return true
 	}
 
 	switch {
 	case value.IsMap():
 		switch arg := schemaType.(type) {
+		case *schema.MapType:
+			for _, vv := range value.AsMap().All {
+				if !valueStructurallyTypedAs(vv, arg.ElementType) {
+					return false
+				}
+			}
+			return true
 		case *schema.ObjectType:
 			schemaProperties := make(map[string]schema.Type)
 			for _, schemaProperty := range arg.Properties {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -611,6 +611,16 @@ func valueStructurallyTypedAs(value property.Value, schemaType schema.Type) bool
 	if union, ok := schemaType.(*schema.UnionType); ok {
 		schemaType = reduceUnionType(union, value)
 	}
+	// reduceUnionType returns a member of the union as-is, which is often an
+	// *schema.InputType wrapping the real type. Strip those wrappers again so
+	// the type switch below can match on the underlying type.
+	for {
+		if input, ok := schemaType.(*schema.InputType); ok {
+			schemaType = input.ElementType
+		} else {
+			break
+		}
+	}
 
 	if schemaType == schema.AnyType {
 		return true

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1113,6 +1113,59 @@ func TestStructuralTypeChecks(t *testing.T) {
 		assert.True(t, valueStructurallyTypedAs(complexFittingValue, complexUnionOfObjects))
 	})
 
+	t.Run("Enum", func(t *testing.T) {
+		t.Parallel()
+
+		// An enum is represented on the wire as a value of its underlying
+		// primitive type. valueStructurallyTypedAs must look through the enum
+		// to its ElementType so a primitive value can be accepted.
+		stringEnum := &schema.EnumType{
+			Token:       "a:index:S",
+			ElementType: schema.StringType,
+			Elements:    []*schema.Enum{{Value: "x"}, {Value: "y"}},
+		}
+		boolEnum := &schema.EnumType{
+			Token:       "a:index:B",
+			ElementType: schema.BoolType,
+			Elements:    []*schema.Enum{{Value: true}, {Value: false}},
+		}
+
+		assert.True(t, valueStructurallyTypedAs(property.New("x"), stringEnum))
+		assert.True(t, valueStructurallyTypedAs(property.New(false), boolEnum))
+		// A bool against a string-typed enum is still rejected.
+		assert.False(t, valueStructurallyTypedAs(property.New(true), stringEnum))
+		// Enum wrapped in InputType is unwrapped too.
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(false),
+			&schema.InputType{ElementType: boolEnum}))
+	})
+
+	t.Run("MissingTypeCases", func(t *testing.T) {
+		t.Parallel()
+
+		// schema.JSONType and schema.AnyResourceType share the
+		// "pulumi:pulumi:Any" token with schema.AnyType but are distinct
+		// singletons. All three accept any value structurally.
+		assert.True(t, valueStructurallyTypedAs(property.New(""), schema.JSONType))
+		assert.True(t, valueStructurallyTypedAs(property.New(false), schema.JSONType))
+		assert.True(t, valueStructurallyTypedAs(property.New(""), schema.AnyResourceType))
+		assert.True(t, valueStructurallyTypedAs(property.New(false), schema.AnyResourceType))
+
+		// A property.Map value against *schema.MapType must accept entries
+		// whose values match the element type (the previous implementation
+		// only handled ObjectType and UnionType for IsMap values).
+		stringMap := &schema.MapType{ElementType: schema.StringType}
+		assert.True(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"k": property.New("v")}),
+			stringMap))
+		// Empty maps trivially match.
+		assert.True(t, valueStructurallyTypedAs(makeObject(nil), stringMap))
+		// Mismatched element type is still rejected.
+		assert.False(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"k": property.New(42.0)}),
+			stringMap))
+	})
+
 	t.Run("UnionOfInputWrappedObjects", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1112,6 +1112,35 @@ func TestStructuralTypeChecks(t *testing.T) {
 
 		assert.True(t, valueStructurallyTypedAs(complexFittingValue, complexUnionOfObjects))
 	})
+
+	t.Run("UnionOfInputWrappedObjects", func(t *testing.T) {
+		t.Parallel()
+
+		// Schema-bound unions wrap their members in *schema.InputType, e.g.
+		// Map<Union<Input<Obj>, Input<Archive>>>. valueStructurallyTypedAs
+		// strips *schema.InputType from its argument *before* the union is
+		// reduced, but reduceUnionType returns the chosen element as-is —
+		// typically Input<Obj>. The type switch below must still see the
+		// underlying type, so the function must strip the wrapper again
+		// after the reduction.
+		objectType := makeObjectType(
+			makeProperty("foo", schema.StringType),
+		)
+		union := makeUnionType(
+			&schema.InputType{ElementType: objectType},
+			&schema.InputType{ElementType: schema.ArchiveType},
+		)
+
+		// A map that fits Obj is accepted even though Obj is wrapped in
+		// *schema.InputType inside the union.
+		assert.True(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"foo": property.New("x")}),
+			union))
+		// A map that does not fit Obj (unknown property) is still rejected.
+		assert.False(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"unknown": property.New("x")}),
+			union))
+	})
 }
 
 func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {


### PR DESCRIPTION
## Summary

`valueStructurallyTypedAs` (`pkg/importer/hcl2.go`) strips `*schema.InputType` from its `schemaType` argument **before** calling `reduceUnionType`, but `reduceUnionType` returns whichever union element fits as-is. Schema-bound unions almost always have `*schema.InputType`-wrapped members (e.g. `Input<Obj0>`), so the post-union type switch never matches and the function returns `false` even when the value structurally matches the underlying type.

The visible symptom is that `GenerateHCL2Definition` logs `"dropped non-conforming value from object type"` and silently drops the entry: an input like `{"k": {}}` against `Map<Union<Input<Obj0>, Input<Archive>>>` round-trips to `{}` when `Obj0` has no required properties.

This is the root cause of the `TestRapidGenerateHCL2Definition` failure on https://github.com/pulumi/pulumi/actions/runs/25798683952/job/75783074303?pr=23112 (the rapid shrinker minimised it to a value with `b = {"":{}}` whose element type was `Input<Union<Input<a-:index:Obj0•Input>, Input<pulumi:pulumi:Archive>>>`).

Fix: reapply the `*schema.InputType`-strip loop after the union reduction so the switch sees the unwrapped element type.

## Test plan

- [x] `go test -count=1 -tags all -timeout 5m ./importer -run TestRapidGenerateHCL2Definition -rapid.seed=10040562407060112324` — the exact seed from the linked CI run, now passes.
- [x] `go test -count=1 -tags all ./importer` — the existing `valueStructurallyTypedAs` unit tests still pass; the fix is strictly additive (it never flips `true` to `false`).
- [ ] Note: this test still flakes from at least one other unrelated importer bug (`valueStructurallyTypedAs` doesn't handle `*schema.EnumType` in its primitive-value cases). That is out of scope here and will be addressed separately.

Fixes https://github.com/pulumi/pulumi/issues/23105