### PR TITLE
implement `pulumi stack webhook delivery list`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-delivery-list.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-delivery-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook delivery list` to list recent deliveries for a stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -917,6 +917,18 @@ func (pc *Client) UpdateStackTTLSchedule(
 	return resp, nil
 }
 
+// ListStackWebhookDeliveries returns recent deliveries for the given webhook.
+func (pc *Client) ListStackWebhookDeliveries(
+	ctx context.Context, stackID StackIdentifier, webhookName string,
+) ([]apitype.WebhookDelivery, error) {
+	var resp []apitype.WebhookDelivery
+	path := getStackPath(stackID, "hooks", webhookName, "deliveries")
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -318,3 +318,77 @@ func TestDeleteStackWebhook(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestListStackWebhookDeliveries(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		want := []apitype.WebhookDelivery{
+			{
+				ID:           "d-1",
+				Kind:         "stack_update",
+				Timestamp:    1715558400,
+				Duration:     120,
+				RequestURL:   "https://example.com/webhook",
+				ResponseCode: 200,
+			},
+			{
+				ID:           "d-2",
+				Kind:         "ping",
+				Timestamp:    1715558300,
+				Duration:     42,
+				RequestURL:   "https://example.com/webhook",
+				ResponseCode: 500,
+			},
+		}
+
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(want)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackWebhookDeliveries(t.Context(), stackID, "deploy-hook")
+		require.NoError(t, err)
+
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks/deploy-hook/deliveries", gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListStackWebhookDeliveries(t.Context(), stackID, "hook")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.ListStackWebhookDeliveries(t.Context(), stackID, "no-such")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -109,28 +109,6 @@ func newStackWebhookDeliveryCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23055]: Not yet implemented.
-func newStackWebhookDeliveryListCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List recent deliveries for a stack webhook",
-		Long:   "[EXPERIMENTAL] List recent deliveries for a stack webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23054]: Not yet implemented.
 func newStackWebhookDeliveryGetCmd() *cobra.Command {
 	var stack string

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
-	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -48,6 +48,19 @@ type stackWebhookDeliveryListClientFactory func(
 	ctx context.Context, stackFlag string,
 ) (stackWebhookDeliveryListClient, client.StackIdentifier, error)
 
+type deliveryListRender func(
+	cmd *deliveryListCmd, deliveries []apitype.WebhookDelivery,
+) error
+
+type deliveryListCmd struct {
+	stack string
+	count int
+	w     io.Writer
+
+	output  outputflag.OutputFlag[deliveryListRender]
+	factory stackWebhookDeliveryListClientFactory
+}
+
 func newStackWebhookDeliveryListCmd() *cobra.Command {
 	return newStackWebhookDeliveryListCmdWith(nil)
 }
@@ -55,10 +68,13 @@ func newStackWebhookDeliveryListCmd() *cobra.Command {
 func newStackWebhookDeliveryListCmdWith(
 	factory stackWebhookDeliveryListClientFactory,
 ) *cobra.Command {
-	var (
-		stack  string
-		output string
-	)
+	dlcmd := &deliveryListCmd{
+		output: outputflag.OutputFlag[deliveryListRender]{
+			RenderForTerminal: (*deliveryListCmd).renderTable,
+			RenderJSON:        (*deliveryListCmd).renderJSON,
+		},
+		factory: factory,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -72,25 +88,26 @@ func newStackWebhookDeliveryListCmdWith(
 			"Returns an error if the webhook does not exist.",
 		Example: "  # List deliveries for a webhook\n" +
 			"  pulumi stack webhook delivery list my-webhook\n\n" +
+			"  # List the last 5 deliveries\n" +
+			"  pulumi stack webhook delivery list my-webhook --count 5\n\n" +
 			"  # List deliveries as JSON\n" +
 			"  pulumi stack webhook delivery list my-webhook --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if factory == nil {
-				factory = defaultDeliveryListClientFactory
+			if dlcmd.factory == nil {
+				dlcmd.factory = defaultDeliveryListClientFactory
 			}
-			return runDeliveryList(
-				cmd.Context(), cmd.OutOrStdout(), factory,
-				stack, args[0], output,
-			)
+			dlcmd.w = cmd.OutOrStdout()
+			return dlcmd.run(cmd.Context(), args[0])
 		},
 	}
 
 	constrictor.AttachArguments(cmd, stackWebhookHookArg())
 
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+	cmd.Flags().StringVarP(&dlcmd.stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVarP(&output, "output", "o", "default",
-		"The output format: default (human-readable table) or json")
+	cmd.Flags().IntVar(&dlcmd.count, "count", 0,
+		"Number of deliveries to display (default: all)")
+	outputflag.VarP(cmd.Flags(), &dlcmd.output)
 
 	return cmd
 }
@@ -103,79 +120,54 @@ func defaultDeliveryListClientFactory(
 		cmdBackend.DefaultLoginManager, stackFlag)
 }
 
-func runDeliveryList(
-	ctx context.Context,
-	w io.Writer,
-	factory stackWebhookDeliveryListClientFactory,
-	stackFlag string,
-	webhookName string,
-	output string,
-) error {
-	renderer, err := deliveryListRenderer(output)
-	if err != nil {
-		return err
-	}
-
-	c, stackID, err := factory(ctx, stackFlag)
+func (c *deliveryListCmd) run(ctx context.Context, webhookName string) error {
+	cl, stackID, err := c.factory(ctx, c.stack)
 	if err != nil {
 		return err
 	}
 
 	// Verify the webhook exists first — the deliveries endpoint returns
 	// an empty list for non-existent webhooks instead of 404.
-	if _, err := c.GetStackWebhook(ctx, stackID, webhookName); err != nil {
+	if _, err := cl.GetStackWebhook(ctx, stackID, webhookName); err != nil {
 		return fmt.Errorf("webhook %q not found: %w", webhookName, err)
 	}
 
-	deliveries, err := c.ListStackWebhookDeliveries(ctx, stackID, webhookName)
+	deliveries, err := cl.ListStackWebhookDeliveries(ctx, stackID, webhookName)
 	if err != nil {
 		return fmt.Errorf("listing webhook deliveries: %w", err)
 	}
 
-	return renderer(w, deliveries)
-}
-
-type deliveryListRenderFunc func(w io.Writer, deliveries []apitype.WebhookDelivery) error
-
-func deliveryListRenderer(output string) (deliveryListRenderFunc, error) {
-	switch output {
-	case "", "default", "table":
-		return renderDeliveryListTable, nil
-	case "json":
-		return renderDeliveryListJSON, nil
-	default:
-		return nil, fmt.Errorf(
-			"invalid --output value %q: expected \"default\", \"table\", or \"json\"", output)
+	if c.count > 0 && c.count < len(deliveries) {
+		deliveries = deliveries[:c.count]
 	}
+
+	return c.output.Get()(c, deliveries)
 }
 
-// deliveryListEnvelope is the JSON shape for delivery list output.
-type deliveryListEnvelope struct {
-	Deliveries []apitype.WebhookDelivery `json:"deliveries"`
-	Count      int                       `json:"count"`
-}
-
-func renderDeliveryListJSON(w io.Writer, deliveries []apitype.WebhookDelivery) error {
+func (c *deliveryListCmd) renderJSON(deliveries []apitype.WebhookDelivery) error {
 	if deliveries == nil {
 		deliveries = []apitype.WebhookDelivery{}
 	}
-	enc := json.NewEncoder(w)
+	enc := json.NewEncoder(c.w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	return enc.Encode(deliveryListEnvelope{
+	return enc.Encode(struct {
+		Deliveries []apitype.WebhookDelivery `json:"deliveries"`
+		Count      int                       `json:"count"`
+	}{
 		Deliveries: deliveries,
 		Count:      len(deliveries),
 	})
 }
 
-func renderDeliveryListTable(w io.Writer, deliveries []apitype.WebhookDelivery) error {
+func (c *deliveryListCmd) renderTable(deliveries []apitype.WebhookDelivery) error {
 	if len(deliveries) == 0 {
-		fmt.Fprintln(w, "No deliveries found for this webhook.")
+		fmt.Fprintln(c.w, "No deliveries found for this webhook.")
 		return nil
 	}
 
 	t := table.NewWriter()
-	t.SetOutputMirror(w)
+	t.SetOutputMirror(c.w)
 	t.SetStyle(table.StyleLight)
 	t.AppendHeader(table.Row{"ID", "KIND", "TIMESTAMP", "DURATION", "STATUS"})
 
@@ -185,16 +177,8 @@ func renderDeliveryListTable(w io.Writer, deliveries []apitype.WebhookDelivery) 
 		t.AppendRow(table.Row{d.ID, d.Kind, ts, duration, d.ResponseCode})
 	}
 
-	cols := cmdCmd.StdoutWidth()
-	idWidth := cols - 80 // leave room for other columns
-	if idWidth < 10 {
-		idWidth = 10
-	}
-	t.SetColumnConfigs([]table.ColumnConfig{
-		{Name: "ID", WidthMax: idWidth},
-	})
 	t.Render()
 
-	fmt.Fprintf(w, "\n%d delivery(ies)\n", len(deliveries))
+	fmt.Fprintf(c.w, "\n%d delivery(ies)\n", len(deliveries))
 	return nil
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
@@ -1,0 +1,200 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookDeliveryListClient is the interface the command needs.
+type stackWebhookDeliveryListClient interface {
+	GetStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+	) (apitype.Webhook, error)
+	ListStackWebhookDeliveries(
+		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+	) ([]apitype.WebhookDelivery, error)
+}
+
+type stackWebhookDeliveryListClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookDeliveryListClient, client.StackIdentifier, error)
+
+func newStackWebhookDeliveryListCmd() *cobra.Command {
+	return newStackWebhookDeliveryListCmdWith(nil)
+}
+
+func newStackWebhookDeliveryListCmdWith(
+	factory stackWebhookDeliveryListClientFactory,
+) *cobra.Command {
+	var (
+		stack  string
+		output string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List recent deliveries for a stack webhook",
+		Long: "List recent deliveries for a stack webhook.\n" +
+			"\n" +
+			"Returns the recent delivery history for a specific webhook. Each\n" +
+			"delivery includes the timestamp, event kind, HTTP response code,\n" +
+			"and request duration.\n" +
+			"\n" +
+			"Returns an error if the webhook does not exist.",
+		Example: "  # List deliveries for a webhook\n" +
+			"  pulumi stack webhook delivery list my-webhook\n\n" +
+			"  # List deliveries as JSON\n" +
+			"  pulumi stack webhook delivery list my-webhook --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultDeliveryListClientFactory
+			}
+			return runDeliveryList(
+				cmd.Context(), cmd.OutOrStdout(), factory,
+				stack, args[0], output,
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable table) or json")
+
+	return cmd
+}
+
+func defaultDeliveryListClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookDeliveryListClient, client.StackIdentifier, error) {
+	return RequireCloudStack(
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance,
+		cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runDeliveryList(
+	ctx context.Context,
+	w io.Writer,
+	factory stackWebhookDeliveryListClientFactory,
+	stackFlag string,
+	webhookName string,
+	output string,
+) error {
+	renderer, err := deliveryListRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	// Verify the webhook exists first — the deliveries endpoint returns
+	// an empty list for non-existent webhooks instead of 404.
+	if _, err := c.GetStackWebhook(ctx, stackID, webhookName); err != nil {
+		return fmt.Errorf("webhook %q not found: %w", webhookName, err)
+	}
+
+	deliveries, err := c.ListStackWebhookDeliveries(ctx, stackID, webhookName)
+	if err != nil {
+		return fmt.Errorf("listing webhook deliveries: %w", err)
+	}
+
+	return renderer(w, deliveries)
+}
+
+type deliveryListRenderFunc func(w io.Writer, deliveries []apitype.WebhookDelivery) error
+
+func deliveryListRenderer(output string) (deliveryListRenderFunc, error) {
+	switch output {
+	case "", "default", "table":
+		return renderDeliveryListTable, nil
+	case "json":
+		return renderDeliveryListJSON, nil
+	default:
+		return nil, fmt.Errorf(
+			"invalid --output value %q: expected \"default\", \"table\", or \"json\"", output)
+	}
+}
+
+// deliveryListEnvelope is the JSON shape for delivery list output.
+type deliveryListEnvelope struct {
+	Deliveries []apitype.WebhookDelivery `json:"deliveries"`
+	Count      int                       `json:"count"`
+}
+
+func renderDeliveryListJSON(w io.Writer, deliveries []apitype.WebhookDelivery) error {
+	if deliveries == nil {
+		deliveries = []apitype.WebhookDelivery{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(deliveryListEnvelope{
+		Deliveries: deliveries,
+		Count:      len(deliveries),
+	})
+}
+
+func renderDeliveryListTable(w io.Writer, deliveries []apitype.WebhookDelivery) error {
+	if len(deliveries) == 0 {
+		fmt.Fprintln(w, "No deliveries found for this webhook.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"ID", "KIND", "TIMESTAMP", "DURATION", "STATUS"})
+
+	for _, d := range deliveries {
+		ts := time.Unix(d.Timestamp, 0).UTC().Format(time.RFC3339)
+		duration := strconv.Itoa(d.Duration) + "ms"
+		t.AppendRow(table.Row{d.ID, d.Kind, ts, duration, d.ResponseCode})
+	}
+
+	cols := cmdCmd.StdoutWidth()
+	idWidth := cols - 80 // leave room for other columns
+	if idWidth < 10 {
+		idWidth = 10
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "ID", WidthMax: idWidth},
+	})
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d delivery(ies)\n", len(deliveries))
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,20 @@ func stubDeliveryListFactory(
 	}
 }
 
+func newTestDeliveryListCmd(
+	factory stackWebhookDeliveryListClientFactory,
+) (*deliveryListCmd, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &deliveryListCmd{
+		output: outputflag.OutputFlag[deliveryListRender]{
+			RenderForTerminal: (*deliveryListCmd).renderTable,
+			RenderJSON:        (*deliveryListCmd).renderJSON,
+		},
+		factory: factory,
+		w:       &buf,
+	}, &buf
+}
+
 func sampleDeliveries() []apitype.WebhookDelivery {
 	return []apitype.WebhookDelivery{
 		{
@@ -83,8 +98,8 @@ func TestDeliveryList_TableOutput(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "default")
+	dlcmd, buf := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	err := dlcmd.run(t.Context(), "my-hook")
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -111,8 +126,8 @@ func TestDeliveryList_TableOutput_Empty(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "table")
+	dlcmd, buf := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	err := dlcmd.run(t.Context(), "hook")
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "No deliveries found for this webhook.")
@@ -122,8 +137,9 @@ func TestDeliveryList_JSONOutput(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "json")
+	dlcmd, buf := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	require.NoError(t, dlcmd.output.Set("json"))
+	err := dlcmd.run(t.Context(), "my-hook")
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -161,29 +177,20 @@ func TestDeliveryList_JSONOutput_Empty(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "json")
+	dlcmd, buf := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	require.NoError(t, dlcmd.output.Set("json"))
+	err := dlcmd.run(t.Context(), "hook")
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{"deliveries": [], "count": 0}`, buf.String())
-}
-
-func TestDeliveryList_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "xml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
 }
 
 func TestDeliveryList_WebhookNotFound(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{getErr: errors.New("[404] Not Found")}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "typo-hook", "default")
+	dlcmd, _ := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	err := dlcmd.run(t.Context(), "typo-hook")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `webhook "typo-hook" not found`)
 }
@@ -192,8 +199,8 @@ func TestDeliveryList_ClientError(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{err: errors.New("not found")}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "default")
+	dlcmd, _ := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	err := dlcmd.run(t.Context(), "hook")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing webhook deliveries")
 }
@@ -202,39 +209,8 @@ func TestDeliveryList_WebhookNamePropagation(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
-	var buf bytes.Buffer
-	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "default")
+	dlcmd, _ := newTestDeliveryListCmd(stubDeliveryListFactory(c))
+	err := dlcmd.run(t.Context(), "my-hook")
 	require.NoError(t, err)
 	assert.Equal(t, "my-hook", c.gotName)
-}
-
-func TestDeliveryList_CobraFlagBinding(t *testing.T) {
-	t.Parallel()
-
-	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
-	cmd := newStackWebhookDeliveryListCmdWith(stubDeliveryListFactory(c))
-
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"my-hook", "--output", "json"})
-
-	err := cmd.ExecuteContext(t.Context())
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"count": 2`)
-}
-
-func TestDeliveryList_DefaultCmd(t *testing.T) {
-	t.Parallel()
-
-	cmd := newStackWebhookDeliveryListCmd()
-	assert.Contains(t, cmd.Use, "list")
-	require.NotNil(t, cmd.RunE)
-
-	f := cmd.Flags().Lookup("output")
-	require.NotNil(t, f)
-	assert.Equal(t, "o", f.Shorthand)
-
-	sf := cmd.Flags().Lookup("stack")
-	require.NotNil(t, sf)
-	assert.Equal(t, "s", sf.Shorthand)
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDeliveryListClient struct {
+	deliveries []apitype.WebhookDelivery
+	err        error
+	getErr     error
+	gotName    string
+}
+
+func (m *mockDeliveryListClient) GetStackWebhook(
+	_ context.Context, _ client.StackIdentifier, _ string,
+) (apitype.Webhook, error) {
+	if m.getErr != nil {
+		return apitype.Webhook{}, m.getErr
+	}
+	return apitype.Webhook{}, nil
+}
+
+func (m *mockDeliveryListClient) ListStackWebhookDeliveries(
+	_ context.Context, _ client.StackIdentifier, name string,
+) ([]apitype.WebhookDelivery, error) {
+	m.gotName = name
+	return m.deliveries, m.err
+}
+
+func stubDeliveryListFactory(
+	c stackWebhookDeliveryListClient,
+) stackWebhookDeliveryListClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookDeliveryListClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func sampleDeliveries() []apitype.WebhookDelivery {
+	return []apitype.WebhookDelivery{
+		{
+			ID:           "d-1",
+			Kind:         "stack_update",
+			Timestamp:    1715558400,
+			Duration:     120,
+			RequestURL:   "https://example.com/webhook",
+			ResponseCode: 200,
+		},
+		{
+			ID:           "d-2",
+			Kind:         "ping",
+			Timestamp:    1715558300,
+			Duration:     42,
+			RequestURL:   "https://example.com/webhook",
+			ResponseCode: 500,
+			ResponseBody: "error",
+		},
+	}
+}
+
+func TestDeliveryList_TableOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "KIND")
+	assert.Contains(t, out, "TIMESTAMP")
+	assert.Contains(t, out, "DURATION")
+	assert.Contains(t, out, "STATUS")
+
+	assert.Contains(t, out, "d-1")
+	assert.Contains(t, out, "stack_update")
+	assert.Contains(t, out, "2024-05-13T00:00:00Z")
+	assert.Contains(t, out, "120ms")
+	assert.Contains(t, out, "200")
+
+	assert.Contains(t, out, "d-2")
+	assert.Contains(t, out, "ping")
+	assert.Contains(t, out, "500")
+
+	assert.Contains(t, out, "2 delivery(ies)")
+}
+
+func TestDeliveryList_TableOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "table")
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "No deliveries found for this webhook.")
+}
+
+func TestDeliveryList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"deliveries": [
+			{
+				"id": "d-1",
+				"kind": "stack_update",
+				"payload": "",
+				"timestamp": 1715558400,
+				"duration": 120,
+				"requestUrl": "https://example.com/webhook",
+				"requestHeaders": "",
+				"responseCode": 200,
+				"responseHeaders": "",
+				"responseBody": ""
+			},
+			{
+				"id": "d-2",
+				"kind": "ping",
+				"payload": "",
+				"timestamp": 1715558300,
+				"duration": 42,
+				"requestUrl": "https://example.com/webhook",
+				"requestHeaders": "",
+				"responseCode": 500,
+				"responseHeaders": "",
+				"responseBody": "error"
+			}
+		],
+		"count": 2
+	}`, buf.String())
+}
+
+func TestDeliveryList_JSONOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"deliveries": [], "count": 0}`, buf.String())
+}
+
+func TestDeliveryList_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --output value")
+}
+
+func TestDeliveryList_WebhookNotFound(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{getErr: errors.New("[404] Not Found")}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "typo-hook", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `webhook "typo-hook" not found`)
+}
+
+func TestDeliveryList_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{err: errors.New("not found")}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "hook", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing webhook deliveries")
+}
+
+func TestDeliveryList_WebhookNamePropagation(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: []apitype.WebhookDelivery{}}
+	var buf bytes.Buffer
+	err := runDeliveryList(t.Context(), &buf, stubDeliveryListFactory(c), "", "my-hook", "default")
+	require.NoError(t, err)
+	assert.Equal(t, "my-hook", c.gotName)
+}
+
+func TestDeliveryList_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeliveryListClient{deliveries: sampleDeliveries()}
+	cmd := newStackWebhookDeliveryListCmdWith(stubDeliveryListFactory(c))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"count": 2`)
+}
+
+func TestDeliveryList_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStackWebhookDeliveryListCmd()
+	assert.Contains(t, cmd.Use, "list")
+	require.NotNil(t, cmd.RunE)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "o", f.Shorthand)
+
+	sf := cmd.Flags().Lookup("stack")
+	require.NotNil(t, sf)
+	assert.Equal(t, "s", sf.Shorthand)
+}


### PR DESCRIPTION
Sample output:

```
$ pulumi stack webhook delivery list my-hook6 -s pulumi/pulumi-service-review-stacks/tgummerer
┌─────────────────┬───────────────┬──────────────────────┬──────────┬────────┐
│ ID              │ KIND          │ TIMESTAMP            │ DURATION │ STATUS │
├─────────────────┼───────────────┼──────────────────────┼──────────┼────────┤
│ 8d001000-7ef4-4 │ stack_update  │ 2026-05-13T13:45:58Z │ 121ms    │    405 │
│ 086-b12a-3ec6d3 │               │                      │          │        │
│ ea1de9          │               │                      │          │        │
│ 7a636726-2e8f-4 │ stack_preview │ 2026-05-13T13:45:18Z │ 156ms    │    405 │
│ 5cf-9a3d-1ea161 │               │                      │          │        │
│ 4bbd85          │               │                      │          │        │
│ 172ad9a5-2d8e-4 │ stack_preview │ 2026-05-13T13:34:12Z │ 180ms    │    405 │
│ 587-afb0-3db9f0 │               │                      │          │        │
│ 0a87d4          │               │                      │          │        │
└─────────────────┴───────────────┴──────────────────────┴──────────┴────────┘

3 delivery(ies)

$ pulumi stack webhook delivery list my-hook6 -s pulumi/pulumi-service-review-stacks/tgummerer  -o json
{
  "deliveries": [
    {
      "id": "8d001000-7ef4-4086-b12a-3ec6d3ea1de9",
      "kind": "stack_update",
      "payload": "{\"user\":{\"name\":\"Thomas Gummerer\",\"githubLogin\":\"v-thomas-pulumi-corp\",\"avatarUrl\":\"https://avatars.githubusercontent.com/u/191004?v=4\"},\"organization\":{\"name\":\"Pulumi\",\"githubLogin\":\"pulumi\",\"avatarUrl\":\"https://avatars0.githubusercontent.com/u/21992475?v=4\"},\"projectName\":\"pulumi-service-review-stacks\",\"stackName\":\"tgummerer\",\"updateUrl\":\"https://app.pulumi.com/pulumi/pulumi-service-review-stacks/tgummerer/updates/4\",\"kind\":\"update\",\"result\":\"failed\",\"resourceChanges\":{\"create\":3,\"same\":28},\"isPreview\":false}",
      "timestamp": 1778679958,
      "duration": 121,
      "requestUrl": "http://bla.com",
      "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: 8d001000-7ef4-4086-b12a-3ec6d3ea1de9\r\nPulumi-Webhook-Kind: stack_update\r\n",
      "responseCode": 405,
      "responseHeaders": "Connection: keep-alive\r\nContent-Length: 150\r\nContent-Type: text/html\r\nDate: Wed, 13 May 2026 13:45:58 GMT\r\nServer: nginx\r\n",
      "responseBody": "<html>\r\n<head><title>405 Not Allowed</title></head>\r\n<body>\r\n<center><h1>405 Not Allowed</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
    },
    [...]
    "count": 3
}
```

Fixes https://github.com/pulumi/pulumi/issues/23055