### PR TITLE
cli/cloud: implement `pulumi org role` (list, new, edit, remove, assign)

### DIFF
--- a/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-assign.yaml
+++ b/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-assign.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org role assign` to assign a custom role to a team

--- a/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-edit.yaml
+++ b/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-edit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org role edit` to update a custom role's name, description, or permission tree

--- a/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-list.yaml
+++ b/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org role list` to list custom roles for an organization

--- a/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-new.yaml
+++ b/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org role new` to create a custom role from a permission descriptor JSON file

--- a/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-remove.yaml
+++ b/changelog/pending/20260514--cli-cloud--implement-pulumi-org-role-remove.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org role remove` to delete a custom role from an organization

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1102,6 +1102,25 @@ func (pc *Client) ListPolicyPacks(ctx context.Context, orgName string, inContTok
 	return resp, nil, nil
 }
 
+// ListOrgRoles lists the custom roles defined in the given organization, optionally
+// filtered by their UX purpose (e.g. "organization", "team", "token"). An empty
+// uxPurpose returns all roles. The Pulumi Cloud REST API is not paginated for
+// this endpoint, so all roles are returned in a single call.
+func (pc *Client) ListOrgRoles(
+	ctx context.Context, orgName, uxPurpose string,
+) ([]apitype.Role, error) {
+	path := fmt.Sprintf("/api/orgs/%s/roles", url.PathEscape(orgName))
+	queryObj := struct {
+		UXPurpose string `url:"uxPurpose,omitempty"`
+	}{UXPurpose: uxPurpose}
+
+	var resp apitype.ListRolesResponse
+	if err := pc.restCall(ctx, "GET", path, queryObj, nil, &resp); err != nil {
+		return nil, fmt.Errorf("listing organization roles: %w", err)
+	}
+	return resp.Roles, nil
+}
+
 // PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it successfully publishes
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1121,6 +1121,18 @@ func (pc *Client) ListOrgRoles(
 	return resp.Roles, nil
 }
 
+// CreateOrgRole creates a new custom role in the given organization.
+func (pc *Client) CreateOrgRole(
+	ctx context.Context, orgName string, req apitype.CreateRoleRequest,
+) (apitype.Role, error) {
+	path := fmt.Sprintf("/api/orgs/%s/roles", url.PathEscape(orgName))
+	var resp apitype.Role
+	if err := pc.restCall(ctx, "POST", path, nil, &req, &resp); err != nil {
+		return apitype.Role{}, fmt.Errorf("creating organization role: %w", err)
+	}
+	return resp, nil
+}
+
 // PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it successfully publishes
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1178,6 +1178,20 @@ func (pc *Client) DeleteOrgRole(
 	return nil
 }
 
+// AssignTeamRole upserts the role assignment for the given team. The Pulumi
+// Cloud REST API currently supports a single role per team, so calling this
+// method replaces any previously assigned custom role.
+func (pc *Client) AssignTeamRole(
+	ctx context.Context, orgName, teamName, roleID string,
+) error {
+	path := fmt.Sprintf("/api/orgs/%s/teams/%s/roles/%s",
+		url.PathEscape(orgName), url.PathEscape(teamName), url.PathEscape(roleID))
+	if err := pc.restCall(ctx, "POST", path, nil, nil, nil); err != nil {
+		return fmt.Errorf("assigning role to team: %w", err)
+	}
+	return nil
+}
+
 // PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it successfully publishes
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1161,6 +1161,23 @@ func (pc *Client) UpdateOrgRole(
 	return resp, nil
 }
 
+// DeleteOrgRole deletes a custom role from an organization. When force is true,
+// the service will delete the role even if it is currently assigned to members
+// or teams (and revoke those assignments).
+func (pc *Client) DeleteOrgRole(
+	ctx context.Context, orgName, roleID string, force bool,
+) error {
+	path := fmt.Sprintf("/api/orgs/%s/roles/%s",
+		url.PathEscape(orgName), url.PathEscape(roleID))
+	queryObj := struct {
+		Force bool `url:"force,omitempty"`
+	}{Force: force}
+	if err := pc.restCall(ctx, "DELETE", path, queryObj, nil, nil); err != nil {
+		return fmt.Errorf("deleting organization role: %w", err)
+	}
+	return nil
+}
+
 // PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it successfully publishes
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1133,6 +1133,34 @@ func (pc *Client) CreateOrgRole(
 	return resp, nil
 }
 
+// GetOrgRole fetches a single custom role by its identifier.
+func (pc *Client) GetOrgRole(
+	ctx context.Context, orgName, roleID string,
+) (apitype.Role, error) {
+	path := fmt.Sprintf("/api/orgs/%s/roles/%s",
+		url.PathEscape(orgName), url.PathEscape(roleID))
+	var resp apitype.Role
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.Role{}, fmt.Errorf("getting organization role: %w", err)
+	}
+	return resp, nil
+}
+
+// UpdateOrgRole updates an existing custom role's name, description, and details.
+// The service requires all three fields; callers that want to leave any of them
+// unchanged should fetch the current role first and merge.
+func (pc *Client) UpdateOrgRole(
+	ctx context.Context, orgName, roleID string, req apitype.UpdateRoleRequest,
+) (apitype.Role, error) {
+	path := fmt.Sprintf("/api/orgs/%s/roles/%s",
+		url.PathEscape(orgName), url.PathEscape(roleID))
+	var resp apitype.Role
+	if err := pc.restCall(ctx, "PATCH", path, nil, &req, &resp); err != nil {
+		return apitype.Role{}, fmt.Errorf("updating organization role: %w", err)
+	}
+	return resp, nil
+}
+
 // PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it successfully publishes
 // the Policy Pack, it returns the version of the pack.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,

--- a/pkg/cmd/pulumi/org/mock_test.go
+++ b/pkg/cmd/pulumi/org/mock_test.go
@@ -32,6 +32,15 @@ type mockOrgRoleClient struct {
 	createResp apitype.Role
 	createErr  error
 	createReq  apitype.CreateRoleRequest
+
+	getResp apitype.Role
+	getErr  error
+	getID   string
+
+	updateResp apitype.Role
+	updateErr  error
+	updateID   string
+	updateReq  apitype.UpdateRoleRequest
 }
 
 func (m *mockOrgRoleClient) ListOrgRoles(_ context.Context, orgName, uxPurpose string) ([]apitype.Role, error) {
@@ -46,6 +55,23 @@ func (m *mockOrgRoleClient) CreateOrgRole(
 	m.capturedOrg = orgName
 	m.createReq = req
 	return m.createResp, m.createErr
+}
+
+func (m *mockOrgRoleClient) GetOrgRole(
+	_ context.Context, orgName, roleID string,
+) (apitype.Role, error) {
+	m.capturedOrg = orgName
+	m.getID = roleID
+	return m.getResp, m.getErr
+}
+
+func (m *mockOrgRoleClient) UpdateOrgRole(
+	_ context.Context, orgName, roleID string, req apitype.UpdateRoleRequest,
+) (apitype.Role, error) {
+	m.capturedOrg = orgName
+	m.updateID = roleID
+	m.updateReq = req
+	return m.updateResp, m.updateErr
 }
 
 func stubRoleFactory(c orgRoleClient, orgName string) orgRoleClientFactory {

--- a/pkg/cmd/pulumi/org/mock_test.go
+++ b/pkg/cmd/pulumi/org/mock_test.go
@@ -28,12 +28,24 @@ type mockOrgRoleClient struct {
 	listErr         error
 	capturedOrg     string
 	capturedPurpose string
+
+	createResp apitype.Role
+	createErr  error
+	createReq  apitype.CreateRoleRequest
 }
 
 func (m *mockOrgRoleClient) ListOrgRoles(_ context.Context, orgName, uxPurpose string) ([]apitype.Role, error) {
 	m.capturedOrg = orgName
 	m.capturedPurpose = uxPurpose
 	return m.roles, m.listErr
+}
+
+func (m *mockOrgRoleClient) CreateOrgRole(
+	_ context.Context, orgName string, req apitype.CreateRoleRequest,
+) (apitype.Role, error) {
+	m.capturedOrg = orgName
+	m.createReq = req
+	return m.createResp, m.createErr
 }
 
 func stubRoleFactory(c orgRoleClient, orgName string) orgRoleClientFactory {

--- a/pkg/cmd/pulumi/org/mock_test.go
+++ b/pkg/cmd/pulumi/org/mock_test.go
@@ -41,6 +41,10 @@ type mockOrgRoleClient struct {
 	updateErr  error
 	updateID   string
 	updateReq  apitype.UpdateRoleRequest
+
+	deleteErr   error
+	deleteID    string
+	deleteForce bool
 }
 
 func (m *mockOrgRoleClient) ListOrgRoles(_ context.Context, orgName, uxPurpose string) ([]apitype.Role, error) {
@@ -72,6 +76,15 @@ func (m *mockOrgRoleClient) UpdateOrgRole(
 	m.updateID = roleID
 	m.updateReq = req
 	return m.updateResp, m.updateErr
+}
+
+func (m *mockOrgRoleClient) DeleteOrgRole(
+	_ context.Context, orgName, roleID string, force bool,
+) error {
+	m.capturedOrg = orgName
+	m.deleteID = roleID
+	m.deleteForce = force
+	return m.deleteErr
 }
 
 func stubRoleFactory(c orgRoleClient, orgName string) orgRoleClientFactory {

--- a/pkg/cmd/pulumi/org/mock_test.go
+++ b/pkg/cmd/pulumi/org/mock_test.go
@@ -45,6 +45,10 @@ type mockOrgRoleClient struct {
 	deleteErr   error
 	deleteID    string
 	deleteForce bool
+
+	assignErr  error
+	assignTeam string
+	assignID   string
 }
 
 func (m *mockOrgRoleClient) ListOrgRoles(_ context.Context, orgName, uxPurpose string) ([]apitype.Role, error) {
@@ -85,6 +89,15 @@ func (m *mockOrgRoleClient) DeleteOrgRole(
 	m.deleteID = roleID
 	m.deleteForce = force
 	return m.deleteErr
+}
+
+func (m *mockOrgRoleClient) AssignTeamRole(
+	_ context.Context, orgName, teamName, roleID string,
+) error {
+	m.capturedOrg = orgName
+	m.assignTeam = teamName
+	m.assignID = roleID
+	return m.assignErr
 }
 
 func stubRoleFactory(c orgRoleClient, orgName string) orgRoleClientFactory {

--- a/pkg/cmd/pulumi/org/mock_test.go
+++ b/pkg/cmd/pulumi/org/mock_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// mockOrgRoleClient is a fake orgRoleClient used by tests across the
+// `pulumi org role ...` commands. Tests may set the returned values directly
+// and read back the captured request fields after invocation.
+type mockOrgRoleClient struct {
+	roles           []apitype.Role
+	listErr         error
+	capturedOrg     string
+	capturedPurpose string
+}
+
+func (m *mockOrgRoleClient) ListOrgRoles(_ context.Context, orgName, uxPurpose string) ([]apitype.Role, error) {
+	m.capturedOrg = orgName
+	m.capturedPurpose = uxPurpose
+	return m.roles, m.listErr
+}
+
+func stubRoleFactory(c orgRoleClient, orgName string) orgRoleClientFactory {
+	return func(_ context.Context, _ string) (orgRoleClient, string, error) {
+		return c, orgName, nil
+	}
+}
+
+func failingRoleFactory(err error) orgRoleClientFactory {
+	return func(_ context.Context, _ string) (orgRoleClient, string, error) {
+		return nil, "", err
+	}
+}

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -52,39 +52,6 @@ func newOrgRoleCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23007]: Not yet implemented.
-func newOrgRoleNewCmd() *cobra.Command {
-	var (
-		org         string
-		description string
-		permissions []string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new custom role for an organization",
-		Long:   "[EXPERIMENTAL] Create a new custom role for an organization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to create the role in")
-	cmd.Flags().StringVar(&description, "description", "", "A description for the role")
-	cmd.Flags().StringArrayVar(&permissions, "permission", nil,
-		"A permission scope for the role (repeatable)")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23006]: Not yet implemented.
 func newOrgRoleEditCmd() *cobra.Command {
 	var (
@@ -190,6 +157,7 @@ type orgRoleClientFactory func(ctx context.Context, orgFlag string) (orgRoleClie
 // exists so tests can substitute a fake.
 type orgRoleClient interface {
 	ListOrgRoles(ctx context.Context, orgName, uxPurpose string) ([]apitype.Role, error)
+	CreateOrgRole(ctx context.Context, orgName string, req apitype.CreateRoleRequest) (apitype.Role, error)
 }
 
 func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleClient, string, error) {

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -52,41 +52,6 @@ func newOrgRoleCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23006]: Not yet implemented.
-func newOrgRoleEditCmd() *cobra.Command {
-	var (
-		org         string
-		newName     string
-		description string
-		permissions []string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "Update a custom role's name, description, or permissions",
-		Long:   "[EXPERIMENTAL] Update a custom role's name, description, or permissions.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "role-id"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
-	cmd.Flags().StringVar(&newName, "new-name", "", "Rename the role")
-	cmd.Flags().StringVar(&description, "description", "", "Update the role's description")
-	cmd.Flags().StringArrayVar(&permissions, "permission", nil,
-		"Set the role's permission scopes (repeatable)")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23005]: Not yet implemented.
 func newOrgRoleRemoveCmd() *cobra.Command {
 	var (
@@ -158,6 +123,10 @@ type orgRoleClientFactory func(ctx context.Context, orgFlag string) (orgRoleClie
 type orgRoleClient interface {
 	ListOrgRoles(ctx context.Context, orgName, uxPurpose string) ([]apitype.Role, error)
 	CreateOrgRole(ctx context.Context, orgName string, req apitype.CreateRoleRequest) (apitype.Role, error)
+	GetOrgRole(ctx context.Context, orgName, roleID string) (apitype.Role, error)
+	UpdateOrgRole(
+		ctx context.Context, orgName, roleID string, req apitype.UpdateRoleRequest,
+	) (apitype.Role, error)
 }
 
 func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleClient, string, error) {

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -52,36 +52,6 @@ func newOrgRoleCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23004]: Not yet implemented.
-func newOrgRoleAssignCmd() *cobra.Command {
-	var (
-		org  string
-		team string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "assign",
-		Short:  "Assign a role to a team",
-		Long:   "[EXPERIMENTAL] Assign a role to a team.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "role-id"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
-	cmd.Flags().StringVar(&team, "team", "", "The team to assign the role to")
-
-	return cmd
-}
-
 // orgRoleClientFactory builds an org-role client and resolves the organization name
 // from the given --org flag (or the user's default org).
 type orgRoleClientFactory func(ctx context.Context, orgFlag string) (orgRoleClient, string, error)
@@ -97,6 +67,7 @@ type orgRoleClient interface {
 		ctx context.Context, orgName, roleID string, req apitype.UpdateRoleRequest,
 	) (apitype.Role, error)
 	DeleteOrgRole(ctx context.Context, orgName, roleID string, force bool) error
+	AssignTeamRole(ctx context.Context, orgName, teamName, roleID string) error
 }
 
 func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleClient, string, error) {

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -15,14 +15,22 @@
 package org
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// TODO[https://github.com/pulumi/pulumi/issues/23003]: Not yet implemented.
 func newOrgRoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -41,32 +49,6 @@ func newOrgRoleCmd() *cobra.Command {
 	cmd.AddCommand(newOrgRoleEditCmd())
 	cmd.AddCommand(newOrgRoleRemoveCmd())
 	cmd.AddCommand(newOrgRoleAssignCmd())
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/23008]: Not yet implemented.
-func newOrgRoleListCmd() *cobra.Command {
-	var (
-		org     string
-		purpose string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List custom roles for an organization",
-		Long:   "[EXPERIMENTAL] List custom roles for an organization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to list roles for")
-	cmd.Flags().StringVar(&purpose, "purpose", "",
-		"The UX purpose to filter by: organization, team, or token")
-
 	return cmd
 }
 
@@ -197,4 +179,49 @@ func newOrgRoleAssignCmd() *cobra.Command {
 	cmd.Flags().StringVar(&team, "team", "", "The team to assign the role to")
 
 	return cmd
+}
+
+// orgRoleClientFactory builds an org-role client and resolves the organization name
+// from the given --org flag (or the user's default org).
+type orgRoleClientFactory func(ctx context.Context, orgFlag string) (orgRoleClient, string, error)
+
+// orgRoleClient is the subset of the cloud client used by org role commands.
+// *client.Client already satisfies this interface directly; the indirection
+// exists so tests can substitute a fake.
+type orgRoleClient interface {
+	ListOrgRoles(ctx context.Context, orgName, uxPurpose string) ([]apitype.Role, error)
+}
+
+func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleClient, string, error) {
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	ws := pkgWorkspace.Instance
+
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, "", err
+	}
+
+	currentBe, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	if err != nil {
+		return nil, "", err
+	}
+	cloudBe, ok := currentBe.(httpstate.Backend)
+	if !ok {
+		return nil, "", errors.New("organization roles require the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName := orgFlag
+	if orgName == "" {
+		defaultOrg, err := cloudBe.GetDefaultOrg(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolving default organization: %w", err)
+		}
+		if defaultOrg == "" {
+			return nil, "", errors.New(
+				"no organization specified and no default organization is set; pass --org or run `pulumi org set-default`")
+		}
+		orgName = defaultOrg
+	}
+
+	return cloudBe.Client(), orgName, nil
 }

--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -52,37 +52,6 @@ func newOrgRoleCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23005]: Not yet implemented.
-func newOrgRoleRemoveCmd() *cobra.Command {
-	var (
-		org   string
-		force bool
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove",
-		Short:  "Delete a custom role from an organization",
-		Long:   "[EXPERIMENTAL] Delete a custom role from an organization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "role-id"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the role")
-	cmd.Flags().BoolVar(&force, "force", false,
-		"Force deletion even if the role is currently assigned")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/23004]: Not yet implemented.
 func newOrgRoleAssignCmd() *cobra.Command {
 	var (
@@ -127,6 +96,7 @@ type orgRoleClient interface {
 	UpdateOrgRole(
 		ctx context.Context, orgName, roleID string, req apitype.UpdateRoleRequest,
 	) (apitype.Role, error)
+	DeleteOrgRole(ctx context.Context, orgName, roleID string, force bool) error
 }
 
 func defaultOrgRoleClientFactory(ctx context.Context, orgFlag string) (orgRoleClient, string, error) {

--- a/pkg/cmd/pulumi/org/org_role_assign.go
+++ b/pkg/cmd/pulumi/org/org_role_assign.go
@@ -1,0 +1,124 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func newOrgRoleAssignCmd() *cobra.Command {
+	return newOrgRoleAssignCmdWith(defaultOrgRoleClientFactory)
+}
+
+// roleAssignRender renders the outcome of an assign operation.
+type roleAssignRender func(w io.Writer, orgName, team, roleID string) error
+
+func defaultRoleAssignOutput() outputflag.OutputFlag[roleAssignRender] {
+	return outputflag.OutputFlag[roleAssignRender]{
+		RenderForTerminal: renderRoleAssignText,
+		RenderJSON:        renderRoleAssignJSON,
+	}
+}
+
+func newOrgRoleAssignCmdWith(factory orgRoleClientFactory) *cobra.Command {
+	contract.Assertf(factory != nil, "factory must not be nil")
+
+	var org string
+	output := defaultRoleAssignOutput()
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "assign <role-id> <team>",
+		Short:  "Assign a role to a team",
+		Long: "[EXPERIMENTAL] Assign a custom role to a team.\n" +
+			"\n" +
+			"Each team can hold a single custom role at a time, so running this command\n" +
+			"replaces the team's previously assigned role.\n" +
+			"\n" +
+			"Both --output default and --output json report the assignment, with JSON\n" +
+			"shaped as an envelope (organization, action, team, roleId) for scripting.",
+		Example: "  pulumi org role assign role-123 platform\n",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOrgRoleAssign(
+				cmd.Context(), cmd.OutOrStdout(), factory, org, args[1], args[0], output.Get())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+			{Name: "team"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "",
+		"The organization that owns the role. Defaults to the current default organization")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+func runOrgRoleAssign(
+	ctx context.Context,
+	w io.Writer,
+	factory orgRoleClientFactory,
+	orgFlag, team, roleID string,
+	render roleAssignRender,
+) error {
+	c, orgName, err := factory(ctx, orgFlag)
+	if err != nil {
+		return err
+	}
+
+	if err := c.AssignTeamRole(ctx, orgName, team, roleID); err != nil {
+		return err
+	}
+
+	return render(w, orgName, team, roleID)
+}
+
+type roleAssignEnvelope struct {
+	Organization string `json:"organization"`
+	Action       string `json:"action"`
+	Team         string `json:"team"`
+	RoleID       string `json:"roleId"`
+}
+
+func renderRoleAssignJSON(w io.Writer, orgName, team, roleID string) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(roleAssignEnvelope{
+		Organization: orgName,
+		Action:       "Assigned",
+		Team:         team,
+		RoleID:       roleID,
+	})
+}
+
+func renderRoleAssignText(w io.Writer, _ /*orgName*/, team, roleID string) error {
+	fmt.Fprintf(w, "Assigned role %q to team %q\n", roleID, team)
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_role_assign_test.go
+++ b/pkg/cmd/pulumi/org/org_role_assign_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrgRoleAssign_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleAssignCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-123", "platform"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "platform", c.assignTeam)
+	assert.Equal(t, "role-123", c.assignID)
+	assert.Equal(t, "my-org", c.capturedOrg)
+	assert.Contains(t, buf.String(), `Assigned role "role-123" to team "platform"`)
+}
+
+func TestOrgRoleAssign_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleAssignCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-123", "platform", "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"organization":"my-org","action":"Assigned","team":"platform","roleId":"role-123"}`,
+		buf.String())
+}
+
+func TestOrgRoleAssign_MissingTeamArg(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleAssignCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-123"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 2 arg(s), received 1")
+}
+
+func TestOrgRoleAssign_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleAssignCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-123", "platform", "--output", "xml"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `output "xml" not supported`)
+}
+
+func TestOrgRoleAssign_AssignError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{assignErr: errors.New("forbidden")}
+	cmd := newOrgRoleAssignCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-123", "platform"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestOrgRoleAssign_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleAssignCmdWith(failingRoleFactory(errors.New("not logged in")))
+	cmd.SetArgs([]string{"role-123", "platform"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgRoleAssign_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleAssignCmd()
+	assert.Equal(t, "assign <role-id> <team>", cmd.Use)
+	require.NotNil(t, cmd.Flags().Lookup("org"))
+	require.NotNil(t, cmd.Flags().Lookup("output"))
+}

--- a/pkg/cmd/pulumi/org/org_role_edit.go
+++ b/pkg/cmd/pulumi/org/org_role_edit.go
@@ -1,0 +1,160 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func newOrgRoleEditCmd() *cobra.Command {
+	return newOrgRoleEditCmdWith(defaultOrgRoleClientFactory)
+}
+
+func newOrgRoleEditCmdWith(factory orgRoleClientFactory) *cobra.Command {
+	contract.Assertf(factory != nil, "factory must not be nil")
+
+	var (
+		org         string
+		newName     string
+		description string
+		detailsFile string
+	)
+	output := defaultRoleSingleOutput()
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "edit <role-id>",
+		Short:  "Update a custom role's name, description, or permissions",
+		Long: "[EXPERIMENTAL] Update a custom role's name, description, or permissions.\n" +
+			"\n" +
+			"Each field follows ternary semantics: a flag that is not passed leaves the\n" +
+			"current value unchanged.\n" +
+			"\n" +
+			"--details-file replaces the role's permission tree. Pass `-` to read from\n" +
+			"stdin. Both --output default and --output json print the updated role.",
+		Example: "  # Rename a role and tweak its description\n" +
+			"  pulumi org role edit role-123 --name auditor --description \"Read-only auditor\"\n\n" +
+			"  # Replace a role's permission tree from a file\n" +
+			"  pulumi org role edit role-123 --details-file ./updated.json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			editArgs := orgRoleEditArgs{RoleID: args[0]}
+			if cmd.Flags().Changed("name") {
+				editArgs.SetName = true
+				editArgs.Name = newName
+			}
+			if cmd.Flags().Changed("description") {
+				editArgs.SetDescription = true
+				editArgs.Description = description
+			}
+			if cmd.Flags().Changed("details-file") {
+				details, err := readRoleDetails(cmd.InOrStdin(), detailsFile)
+				if err != nil {
+					return err
+				}
+				editArgs.SetDetails = true
+				editArgs.Details = details
+			}
+
+			if !editArgs.SetName && !editArgs.SetDescription && !editArgs.SetDetails {
+				return errors.New(
+					"nothing to update: pass at least one of --name, --description, or --details-file")
+			}
+
+			return runOrgRoleEdit(cmd.Context(), cmd.OutOrStdout(), factory, org, editArgs, output.Get())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "",
+		"The organization that owns the role. Defaults to the current default organization")
+	cmd.Flags().StringVar(&newName, "name", "", "Rename the role")
+	cmd.Flags().StringVar(&description, "description", "", "Update the role's description")
+	cmd.Flags().StringVar(&detailsFile, "details-file", "",
+		"Path to a JSON file containing the role's new permission tree (use `-` for stdin)")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+type orgRoleEditArgs struct {
+	RoleID string
+
+	SetName bool
+	Name    string
+
+	SetDescription bool
+	Description    string
+
+	SetDetails bool
+	Details    json.RawMessage
+}
+
+func runOrgRoleEdit(
+	ctx context.Context,
+	w io.Writer,
+	factory orgRoleClientFactory,
+	orgFlag string,
+	args orgRoleEditArgs,
+	render roleSingleRender,
+) error {
+	c, orgName, err := factory(ctx, orgFlag)
+	if err != nil {
+		return err
+	}
+
+	current, err := c.GetOrgRole(ctx, orgName, args.RoleID)
+	if err != nil {
+		return fmt.Errorf("looking up role %q: %w", args.RoleID, err)
+	}
+
+	req := apitype.UpdateRoleRequest{
+		Name:        current.Name,
+		Description: current.Description,
+		Details:     current.Details,
+	}
+	if args.SetName {
+		req.Name = args.Name
+	}
+	if args.SetDescription {
+		req.Description = args.Description
+	}
+	if args.SetDetails {
+		req.Details = args.Details
+	}
+
+	updated, err := c.UpdateOrgRole(ctx, orgName, args.RoleID, req)
+	if err != nil {
+		return fmt.Errorf("updating organization role: %w", err)
+	}
+
+	return render(w, orgName, "Updated", updated)
+}

--- a/pkg/cmd/pulumi/org/org_role_edit_test.go
+++ b/pkg/cmd/pulumi/org/org_role_edit_test.go
@@ -1,0 +1,210 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func currentRole() apitype.Role {
+	return apitype.Role{
+		ID:          "role-1",
+		OrgID:       "my-org",
+		Name:        "Old Name",
+		Description: "Old description",
+		UXPurpose:   "organization",
+		Version:     2,
+		Details:     json.RawMessage(`{"__type":"role","scopes":["old"]}`),
+		Created:     "2026-01-01T00:00:00Z",
+		Modified:    "2026-02-01T00:00:00Z",
+	}
+}
+
+func TestOrgRoleEdit_MergesUnsetFields(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{
+		getResp:    currentRole(),
+		updateResp: currentRole(),
+	}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-1", "--name", "Auditor"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "role-1", c.updateID)
+	assert.Equal(t, apitype.UpdateRoleRequest{
+		Name:        "Auditor",
+		Description: "Old description",
+		Details:     json.RawMessage(`{"__type":"role","scopes":["old"]}`),
+	}, c.updateReq)
+}
+
+func TestOrgRoleEdit_ExplicitEmptyDescriptionClears(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{
+		getResp:    currentRole(),
+		updateResp: currentRole(),
+	}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+
+	cmd.SetArgs([]string{"role-1", "--description", ""})
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, c.updateReq.Description)
+}
+
+func TestOrgRoleEdit_NoChangesError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{getResp: currentRole()}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-1"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to update")
+}
+
+func TestOrgRoleEdit_DetailsFromFile(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{
+		getResp:    currentRole(),
+		updateResp: currentRole(),
+	}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role","scopes":["new"]}`)
+
+	cmd.SetArgs([]string{"role-1", "--details-file", detailsPath})
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, json.RawMessage(`{"__type":"role","scopes":["new"]}`), c.updateReq.Details)
+}
+
+func TestOrgRoleEdit_GetError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{getErr: errors.New("not found")}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-1", "--name", "x"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `looking up role "role-1"`)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestOrgRoleEdit_UpdateError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{
+		getResp:   currentRole(),
+		updateErr: errors.New("server error"),
+	}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"role-1", "--name", "x"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "updating organization role")
+	assert.Contains(t, err.Error(), "server error")
+}
+
+func TestOrgRoleEdit_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	updated := currentRole()
+	updated.Name = "Auditor"
+	updated.Version = 3
+	c := &mockOrgRoleClient{getResp: currentRole(), updateResp: updated}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-1", "--name", "Auditor"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, `Updated role "Auditor"`)
+	assert.Contains(t, out, "version: 3")
+}
+
+func TestOrgRoleEdit_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	updated := currentRole()
+	updated.Name = "Auditor"
+	c := &mockOrgRoleClient{getResp: currentRole(), updateResp: updated}
+	cmd := newOrgRoleEditCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-1", "--name", "Auditor", "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organization": "my-org",
+		"action": "Updated",
+		"role": {
+			"id": "role-1",
+			"name": "Auditor",
+			"description": "Old description",
+			"purpose": "organization",
+			"version": 2,
+			"isOrgDefault": false,
+			"created": "2026-01-01T00:00:00Z",
+			"modified": "2026-02-01T00:00:00Z"
+		}
+	}`, buf.String())
+}
+
+func TestOrgRoleEdit_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleEditCmdWith(failingRoleFactory(errors.New("not logged in")))
+	cmd.SetArgs([]string{"role-1", "--name", "x"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgRoleEdit_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleEditCmd()
+	assert.Equal(t, "edit <role-id>", cmd.Use)
+
+	require.NotNil(t, cmd.Flags().Lookup("name"))
+	require.NotNil(t, cmd.Flags().Lookup("description"))
+	require.NotNil(t, cmd.Flags().Lookup("details-file"))
+	require.NotNil(t, cmd.Flags().Lookup("org"))
+}

--- a/pkg/cmd/pulumi/org/org_role_list.go
+++ b/pkg/cmd/pulumi/org/org_role_list.go
@@ -1,0 +1,198 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// roleListRender renders a list of roles.
+type roleListRender func(w io.Writer, orgName string, roles []apitype.Role) error
+
+func defaultRoleListOutput() outputflag.OutputFlag[roleListRender] {
+	return outputflag.OutputFlag[roleListRender]{
+		RenderForTerminal: renderRoleListTable,
+		RenderJSON:        renderRoleListJSON,
+	}
+}
+
+func newOrgRoleListCmd() *cobra.Command {
+	return newOrgRoleListCmdWith(defaultOrgRoleClientFactory)
+}
+
+func newOrgRoleListCmdWith(factory orgRoleClientFactory) *cobra.Command {
+	contract.Assertf(factory != nil, "factory must not be nil")
+
+	var (
+		org     string
+		purpose string
+	)
+	output := defaultRoleListOutput()
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List custom roles for an organization",
+		Long: "[EXPERIMENTAL] List custom roles for an organization.\n" +
+			"\n" +
+			"Displays the ID, name, description, UX purpose, and version of each role.\n" +
+			"By default the output is a human-readable table; pass --output=json for a\n" +
+			"stable, machine-readable JSON envelope containing the same fields.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOrgRoleList(cmd.Context(), cmd.OutOrStdout(), factory, org, purpose, output.Get())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&org, "org", "",
+		"The organization to list roles for. Defaults to the current default organization")
+	cmd.Flags().StringVar(&purpose, "purpose", "",
+		"Filter by UX purpose: organization, team, or token")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+func runOrgRoleList(
+	ctx context.Context,
+	w io.Writer,
+	factory orgRoleClientFactory,
+	orgFlag, purpose string,
+	render roleListRender,
+) error {
+	c, orgName, err := factory(ctx, orgFlag)
+	if err != nil {
+		return err
+	}
+
+	roles, err := c.ListOrgRoles(ctx, orgName, purpose)
+	if err != nil {
+		return fmt.Errorf("listing organization roles: %w", err)
+	}
+
+	return render(w, orgName, roles)
+}
+
+// roleListEnvelope is the JSON shape emitted by `pulumi org role list --output=json`.
+type roleListEnvelope struct {
+	Organization string     `json:"organization"`
+	Roles        []roleJSON `json:"roles"`
+	Count        int        `json:"count"`
+}
+
+type roleJSON struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	Purpose      string `json:"purpose"`
+	Version      int    `json:"version"`
+	IsOrgDefault bool   `json:"isOrgDefault"`
+	Created      string `json:"created"`
+	Modified     string `json:"modified"`
+}
+
+func toRoleJSON(r apitype.Role) roleJSON {
+	return roleJSON{
+		ID:           r.ID,
+		Name:         r.Name,
+		Description:  r.Description,
+		Purpose:      r.UXPurpose,
+		Version:      r.Version,
+		IsOrgDefault: r.IsOrgDefault,
+		Created:      r.Created,
+		Modified:     r.Modified,
+	}
+}
+
+func renderRoleListJSON(w io.Writer, orgName string, roles []apitype.Role) error {
+	items := make([]roleJSON, 0, len(roles))
+	for _, r := range roles {
+		items = append(items, toRoleJSON(r))
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(roleListEnvelope{
+		Organization: orgName,
+		Roles:        items,
+		Count:        len(items),
+	})
+}
+
+func renderRoleListTable(w io.Writer, orgName string, roles []apitype.Role) error {
+	if len(roles) == 0 {
+		fmt.Fprintf(w, "No custom roles found for organization %q.\n", orgName)
+		return nil
+	}
+
+	hasDescription, hasPurpose, hasDefault := false, false, false
+	for _, r := range roles {
+		hasDescription = hasDescription || r.Description != ""
+		hasPurpose = hasPurpose || r.UXPurpose != ""
+		hasDefault = hasDefault || r.IsOrgDefault
+	}
+
+	header := table.Row{"ID", "NAME"}
+	if hasDescription {
+		header = append(header, "DESCRIPTION")
+	}
+	if hasPurpose {
+		header = append(header, "PURPOSE")
+	}
+	header = append(header, "VERSION")
+	if hasDefault {
+		header = append(header, "DEFAULT")
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(header)
+
+	for _, r := range roles {
+		row := table.Row{r.ID, r.Name}
+		if hasDescription {
+			row = append(row, r.Description)
+		}
+		if hasPurpose {
+			row = append(row, r.UXPurpose)
+		}
+		row = append(row, r.Version)
+		if hasDefault {
+			defaultMark := ""
+			if r.IsOrgDefault {
+				defaultMark = "yes"
+			}
+			row = append(row, defaultMark)
+		}
+		t.AppendRow(row)
+	}
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d role(s)\n", len(roles))
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_role_list_test.go
+++ b/pkg/cmd/pulumi/org/org_role_list_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func sampleRoles() []apitype.Role {
+	return []apitype.Role{
+		{
+			ID:          "role-1",
+			OrgID:       "my-org",
+			Name:        "Stack Reader",
+			Description: "Read-only access to stacks",
+			UXPurpose:   "organization",
+			Version:     1,
+			Created:     "2026-01-01T00:00:00Z",
+			Modified:    "2026-02-01T00:00:00Z",
+		},
+		{
+			ID:           "role-2",
+			OrgID:        "my-org",
+			Name:         "CI Bot",
+			Description:  "Limited token role for CI",
+			UXPurpose:    "token",
+			Version:      3,
+			IsOrgDefault: true,
+			Created:      "2026-01-15T00:00:00Z",
+			Modified:     "2026-03-01T00:00:00Z",
+		},
+	}
+}
+
+func TestOrgRoleList_TableOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: sampleRoles()}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListTable)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "DESCRIPTION")
+	assert.Contains(t, out, "PURPOSE")
+	assert.Contains(t, out, "VERSION")
+	assert.Contains(t, out, "DEFAULT")
+	assert.Contains(t, out, "role-1")
+	assert.Contains(t, out, "Stack Reader")
+	assert.Contains(t, out, "Read-only access to stacks")
+	assert.Contains(t, out, "organization")
+	assert.Contains(t, out, "role-2")
+	assert.Contains(t, out, "CI Bot")
+	assert.Contains(t, out, "yes")
+	assert.Contains(t, out, "2 role(s)")
+}
+
+func TestOrgRoleList_TableOutput_DropsEmptyColumns(t *testing.T) {
+	t.Parallel()
+
+	roles := []apitype.Role{
+		{ID: "role-1", OrgID: "my-org", Name: "Minimal", Version: 1},
+	}
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: roles}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListTable)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "VERSION")
+	assert.NotContains(t, out, "DESCRIPTION")
+	assert.NotContains(t, out, "PURPOSE")
+	assert.NotContains(t, out, "DEFAULT")
+}
+
+func TestOrgRoleList_TableOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: []apitype.Role{}}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListTable)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), `No custom roles found for organization "my-org".`)
+}
+
+func TestOrgRoleList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: sampleRoles()}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListJSON)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organization": "my-org",
+		"roles": [
+			{
+				"id": "role-1",
+				"name": "Stack Reader",
+				"description": "Read-only access to stacks",
+				"purpose": "organization",
+				"version": 1,
+				"isOrgDefault": false,
+				"created": "2026-01-01T00:00:00Z",
+				"modified": "2026-02-01T00:00:00Z"
+			},
+			{
+				"id": "role-2",
+				"name": "CI Bot",
+				"description": "Limited token role for CI",
+				"purpose": "token",
+				"version": 3,
+				"isOrgDefault": true,
+				"created": "2026-01-15T00:00:00Z",
+				"modified": "2026-03-01T00:00:00Z"
+			}
+		],
+		"count": 2
+	}`, buf.String())
+}
+
+func TestOrgRoleList_JSONOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: []apitype.Role{}}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListJSON)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"organization": "my-org", "roles": [], "count": 0}`, buf.String())
+}
+
+func TestOrgRoleList_PurposeFilter_PropagatesToClient(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{roles: []apitype.Role{}}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "team", renderRoleListJSON)
+	require.NoError(t, err)
+	assert.Equal(t, "team", c.capturedPurpose)
+	assert.Equal(t, "my-org", c.capturedOrg)
+}
+
+func TestOrgRoleList_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleListCmdWith(stubRoleFactory(&mockOrgRoleClient{roles: sampleRoles()}, "my-org"))
+	cmd.SetArgs([]string{"--output", "xml"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `output "xml" not supported`)
+}
+
+func TestOrgRoleList_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgRoleClient{listErr: errors.New("server error")}
+	err := runOrgRoleList(t.Context(), &buf, stubRoleFactory(c, "my-org"), "", "", renderRoleListTable)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing organization roles")
+	assert.Contains(t, err.Error(), "server error")
+}
+
+func TestOrgRoleList_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := runOrgRoleList(t.Context(), &buf,
+		failingRoleFactory(errors.New("not logged in")), "", "", renderRoleListTable)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgRoleList_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{roles: sampleRoles()}
+	cmd := newOrgRoleListCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output", "json", "--purpose", "organization"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"count": 2`)
+	assert.Equal(t, "organization", c.capturedPurpose)
+}
+
+func TestOrgRoleList_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleListCmd()
+	assert.Equal(t, "list", cmd.Use)
+	require.NotNil(t, cmd.RunE)
+
+	f := cmd.Flags().Lookup("output")
+	require.NotNil(t, f)
+	assert.Equal(t, "o", f.Shorthand)
+
+	pf := cmd.Flags().Lookup("purpose")
+	require.NotNil(t, pf)
+
+	of := cmd.Flags().Lookup("org")
+	require.NotNil(t, of)
+}

--- a/pkg/cmd/pulumi/org/org_role_new.go
+++ b/pkg/cmd/pulumi/org/org_role_new.go
@@ -1,0 +1,147 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func newOrgRoleNewCmd() *cobra.Command {
+	return newOrgRoleNewCmdWith(defaultOrgRoleClientFactory)
+}
+
+func newOrgRoleNewCmdWith(factory orgRoleClientFactory) *cobra.Command {
+	contract.Assertf(factory != nil, "factory must not be nil")
+
+	var (
+		org         string
+		description string
+		purpose     string
+	)
+	output := defaultRoleSingleOutput()
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "new <name> <details-file>",
+		Short:  "Create a new custom role for an organization",
+		Long: "[EXPERIMENTAL] Create a new custom role for an organization.\n" +
+			"\n" +
+			"The role's permission tree is read from the JSON file at <details-file>.\n" +
+			"Pass `-` to read the JSON from stdin instead.\n" +
+			"\n" +
+			"Both `--output default` and `--output json` print the same fields for the\n" +
+			"newly created role (id, name, description, purpose, version, etc.).",
+		Example: "  # Create a role from a JSON file\n" +
+			"  pulumi org role new stack-reader ./reader.json \\\n" +
+			"      --description \"Read-only stack access\"\n\n" +
+			"  # Create a role from stdin and get the result as JSON\n" +
+			"  cat reader.json | pulumi org role new stack-reader - --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			details, err := readRoleDetails(cmd.InOrStdin(), args[1])
+			if err != nil {
+				return err
+			}
+			return runOrgRoleNew(cmd.Context(), cmd.OutOrStdout(), factory, org, orgRoleNewArgs{
+				Name:        args[0],
+				Description: description,
+				Purpose:     purpose,
+				Details:     details,
+			}, output.Get())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "name"},
+			{Name: "details-file"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "",
+		"The organization to create the role in. Defaults to the current default organization")
+	cmd.Flags().StringVar(&description, "description", "", "A description for the role")
+	cmd.Flags().StringVar(&purpose, "purpose", "",
+		"The UX purpose for the role: organization, team, or token")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+type orgRoleNewArgs struct {
+	Name        string
+	Description string
+	Purpose     string
+	Details     json.RawMessage
+}
+
+// readRoleDetails reads a JSON document describing the role's permission tree
+// from the given file path (or stdin when the path is "-").
+func readRoleDetails(stdin io.Reader, path string) (json.RawMessage, error) {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading role details from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading role details from %q: %w", path, err)
+		}
+	}
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("role details from %q is not valid JSON", path)
+	}
+	return json.RawMessage(data), nil
+}
+
+func runOrgRoleNew(
+	ctx context.Context,
+	w io.Writer,
+	factory orgRoleClientFactory,
+	orgFlag string,
+	args orgRoleNewArgs,
+	render roleSingleRender,
+) error {
+	c, orgName, err := factory(ctx, orgFlag)
+	if err != nil {
+		return err
+	}
+
+	created, err := c.CreateOrgRole(ctx, orgName, apitype.CreateRoleRequest{
+		Name:        args.Name,
+		Description: args.Description,
+		UXPurpose:   args.Purpose,
+		Details:     args.Details,
+	})
+	if err != nil {
+		return fmt.Errorf("creating organization role: %w", err)
+	}
+
+	return render(w, orgName, "Created", created)
+}

--- a/pkg/cmd/pulumi/org/org_role_new_test.go
+++ b/pkg/cmd/pulumi/org/org_role_new_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func writeRoleDetailsFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "details.json")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+	return p
+}
+
+func sampleCreatedRole() apitype.Role {
+	return apitype.Role{
+		ID:          "role-new",
+		OrgID:       "my-org",
+		Name:        "Stack Reader",
+		Description: "Read-only access",
+		UXPurpose:   "organization",
+		Version:     1,
+		Created:     "2026-05-13T00:00:00Z",
+		Modified:    "2026-05-13T00:00:00Z",
+	}
+}
+
+func TestOrgRoleNew_TextOutput_SendsRequest(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{createResp: sampleCreatedRole()}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role","scopes":["stack:read"]}`)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"Stack Reader", detailsPath,
+		"--description", "Read-only access",
+		"--purpose", "organization",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, apitype.CreateRoleRequest{
+		Name:        "Stack Reader",
+		Description: "Read-only access",
+		UXPurpose:   "organization",
+		Details:     json.RawMessage(`{"__type":"role","scopes":["stack:read"]}`),
+	}, c.createReq)
+	assert.Equal(t, "my-org", c.capturedOrg)
+
+	out := buf.String()
+	assert.Contains(t, out, `Created role "Stack Reader"`)
+	assert.Contains(t, out, "id: role-new")
+	assert.Contains(t, out, "description: Read-only access")
+	assert.Contains(t, out, "purpose: organization")
+	assert.Contains(t, out, "version: 1")
+}
+
+func TestOrgRoleNew_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{createResp: sampleCreatedRole()}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role"}`)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"Stack Reader", detailsPath, "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"organization": "my-org",
+		"action": "Created",
+		"role": {
+			"id": "role-new",
+			"name": "Stack Reader",
+			"description": "Read-only access",
+			"purpose": "organization",
+			"version": 1,
+			"isOrgDefault": false,
+			"created": "2026-05-13T00:00:00Z",
+			"modified": "2026-05-13T00:00:00Z"
+		}
+	}`, buf.String())
+}
+
+func TestOrgRoleNew_ReadDetailsFromStdin(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{createResp: sampleCreatedRole()}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetIn(strings.NewReader(`{"__type":"role","scopes":["a"]}`))
+	cmd.SetArgs([]string{"R", "-"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t,
+		json.RawMessage(`{"__type":"role","scopes":["a"]}`),
+		c.createReq.Details)
+}
+
+func TestOrgRoleNew_MissingDetailsArg(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	cmd.SetArgs([]string{"R"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts 2 arg(s), received 1")
+}
+
+func TestOrgRoleNew_InvalidDetailsJSON(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{not json`)
+	cmd.SetArgs([]string{"R", detailsPath})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestOrgRoleNew_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{createResp: sampleCreatedRole()}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role"}`)
+	cmd.SetArgs([]string{"R", detailsPath, "--output", "xml"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `output "xml" not supported`)
+}
+
+func TestOrgRoleNew_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{createErr: errors.New("server error")}
+	cmd := newOrgRoleNewCmdWith(stubRoleFactory(c, "my-org"))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role"}`)
+	cmd.SetArgs([]string{"R", detailsPath})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating organization role")
+	assert.Contains(t, err.Error(), "server error")
+}
+
+func TestOrgRoleNew_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleNewCmdWith(failingRoleFactory(errors.New("not logged in")))
+	detailsPath := writeRoleDetailsFile(t, `{"__type":"role"}`)
+	cmd.SetArgs([]string{"R", detailsPath})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgRoleNew_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleNewCmd()
+	assert.Equal(t, "new <name> <details-file>", cmd.Use)
+
+	o := cmd.Flags().Lookup("output")
+	require.NotNil(t, o)
+	assert.Equal(t, "o", o.Shorthand)
+}

--- a/pkg/cmd/pulumi/org/org_role_remove.go
+++ b/pkg/cmd/pulumi/org/org_role_remove.go
@@ -1,0 +1,173 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func newOrgRoleRemoveCmd() *cobra.Command {
+	return newOrgRoleRemoveCmdWith(defaultOrgRoleClientFactory, defaultConfirmFunc)
+}
+
+// confirmFunc abstracts the interactive confirmation prompt so tests can stub
+// it out without standing up a TTY. It is expected to also reject non-interactive
+// sessions by returning (false, an error explaining --yes is required).
+type confirmFunc func(prompt, name string) (bool, error)
+
+// defaultConfirmFunc uses cmdutil.Interactive + ui.ConfirmPrompt and returns an
+// error when the session is non-interactive (so callers must pass --yes).
+func defaultConfirmFunc(prompt, name string) (bool, error) {
+	if !cmdutil.Interactive() {
+		return false, errors.New(
+			"--yes is required when not running in a terminal (non-interactive)")
+	}
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	return ui.ConfirmPrompt(prompt, name, opts), nil
+}
+
+// roleRemoveRender renders the outcome of a remove operation.
+type roleRemoveRender func(w io.Writer, orgName, roleID string, force bool) error
+
+func defaultRoleRemoveOutput() outputflag.OutputFlag[roleRemoveRender] {
+	return outputflag.OutputFlag[roleRemoveRender]{
+		RenderForTerminal: renderRoleRemoveText,
+		RenderJSON:        renderRoleRemoveJSON,
+	}
+}
+
+func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory, confirm confirmFunc) *cobra.Command {
+	contract.Assertf(factory != nil, "factory must not be nil")
+	contract.Assertf(confirm != nil, "confirm must not be nil")
+
+	var (
+		org   string
+		force bool
+		yes   bool
+	)
+	output := defaultRoleRemoveOutput()
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "remove <role-id>",
+		Short:  "Delete a custom role from an organization",
+		Long: "[EXPERIMENTAL] Delete a custom role from an organization.\n" +
+			"\n" +
+			"Removing a role revokes any permissions it had granted to members and\n" +
+			"teams. If the role is currently assigned, the service rejects the delete\n" +
+			"unless --force is passed.\n" +
+			"\n" +
+			"By default the command asks for confirmation; pass --yes to skip the\n" +
+			"prompt. Both --output default and --output json report the deletion\n" +
+			"outcome, with the JSON form including the organization and role id for\n" +
+			"scripting.",
+		Example: "  # Delete a role interactively\n" +
+			"  pulumi org role remove role-123\n\n" +
+			"  # Delete a role non-interactively, even if it is assigned\n" +
+			"  pulumi org role remove role-123 --force --yes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOrgRoleRemove(
+				cmd.Context(), cmd.OutOrStdout(), factory, confirm,
+				org, args[0], force, yes, output.Get())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "role-id"},
+		},
+		Required: 1,
+	})
+
+	cmd.Flags().StringVar(&org, "org", "",
+		"The organization that owns the role. Defaults to the current default organization")
+	cmd.Flags().BoolVar(&force, "force", false,
+		"Force deletion even if the role is currently assigned to members or teams")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
+		"Skip the confirmation prompt and proceed with deletion")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	return cmd
+}
+
+func runOrgRoleRemove(
+	ctx context.Context,
+	w io.Writer,
+	factory orgRoleClientFactory,
+	confirm confirmFunc,
+	orgFlag, roleID string,
+	force, yes bool,
+	render roleRemoveRender,
+) error {
+	c, orgName, err := factory(ctx, orgFlag)
+	if err != nil {
+		return err
+	}
+
+	if !yes {
+		prompt := fmt.Sprintf(
+			"This will permanently delete role %q from organization %q.", roleID, orgName)
+		ok, err := confirm(prompt, roleID)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.New("confirmation declined")
+		}
+	}
+
+	if err := c.DeleteOrgRole(ctx, orgName, roleID, force); err != nil {
+		return err
+	}
+
+	return render(w, orgName, roleID, force)
+}
+
+type roleRemoveEnvelope struct {
+	Organization string `json:"organization"`
+	Action       string `json:"action"`
+	RoleID       string `json:"roleId"`
+	Forced       bool   `json:"forced"`
+}
+
+func renderRoleRemoveJSON(w io.Writer, orgName, roleID string, force bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(roleRemoveEnvelope{
+		Organization: orgName,
+		Action:       "Removed",
+		RoleID:       roleID,
+		Forced:       force,
+	})
+}
+
+func renderRoleRemoveText(w io.Writer, _ /*orgName*/, roleID string, _ /*force*/ bool) error {
+	fmt.Fprintf(w, "Removed role %q\n", roleID)
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_role_remove_test.go
+++ b/pkg/cmd/pulumi/org/org_role_remove_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func acceptAllConfirm(_ string, _ string) (bool, error) { return true, nil }
+func denyAllConfirm(_ string, _ string) (bool, error)   { return false, nil }
+func nonInteractiveConfirm(_ string, _ string) (bool, error) {
+	return false, errors.New("--yes is required when not running in a terminal (non-interactive)")
+}
+
+func TestOrgRoleRemove_Yes_NoConfirm(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-1", "--yes"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "role-1", c.deleteID)
+	assert.False(t, c.deleteForce)
+	assert.Contains(t, buf.String(), `Removed role "role-1"`)
+}
+
+func TestOrgRoleRemove_ForceFlagPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd.SetArgs([]string{"role-1", "--yes", "--force"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.True(t, c.deleteForce)
+}
+
+func TestOrgRoleRemove_ConfirmAccepted(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), acceptAllConfirm)
+	cmd.SetArgs([]string{"role-1"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "role-1", c.deleteID)
+}
+
+func TestOrgRoleRemove_ConfirmDeclined(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd.SetArgs([]string{"role-1"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation declined")
+	assert.Empty(t, c.deleteID)
+}
+
+func TestOrgRoleRemove_NonInteractiveWithoutYes(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), nonInteractiveConfirm)
+	cmd.SetArgs([]string{"role-1"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--yes is required")
+}
+
+func TestOrgRoleRemove_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"role-1", "--yes", "--force", "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"organization":"my-org","action":"Removed","roleId":"role-1","forced":true}`,
+		buf.String())
+}
+
+func TestOrgRoleRemove_InvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd.SetArgs([]string{"role-1", "--yes", "--output", "xml"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `output "xml" not supported`)
+}
+
+func TestOrgRoleRemove_DeleteError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockOrgRoleClient{deleteErr: errors.New("conflict")}
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd.SetArgs([]string{"role-1", "--yes"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflict")
+}
+
+func TestOrgRoleRemove_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleRemoveCmdWith(failingRoleFactory(errors.New("not logged in")), denyAllConfirm)
+	cmd.SetArgs([]string{"role-1", "--yes"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgRoleRemove_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgRoleRemoveCmd()
+	assert.Equal(t, "remove <role-id>", cmd.Use)
+	require.NotNil(t, cmd.Flags().Lookup("force"))
+	yes := cmd.Flags().Lookup("yes")
+	require.NotNil(t, yes)
+	assert.Equal(t, "y", yes.Shorthand)
+}

--- a/pkg/cmd/pulumi/org/org_role_render.go
+++ b/pkg/cmd/pulumi/org/org_role_render.go
@@ -1,0 +1,71 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// roleSingleRender formats a single role for the user. The action describes
+// the verb the command performed (e.g. "Created", "Updated") and is shown in
+// the default human-readable output.
+type roleSingleRender func(w io.Writer, orgName, action string, role apitype.Role) error
+
+func defaultRoleSingleOutput() outputflag.OutputFlag[roleSingleRender] {
+	return outputflag.OutputFlag[roleSingleRender]{
+		RenderForTerminal: renderRoleSingleText,
+		RenderJSON:        renderRoleSingleJSON,
+	}
+}
+
+// roleSingleEnvelope is the JSON shape emitted by single-role mutating commands
+// (`new`, `edit`) when --output=json is set.
+type roleSingleEnvelope struct {
+	Organization string   `json:"organization"`
+	Action       string   `json:"action"`
+	Role         roleJSON `json:"role"`
+}
+
+func renderRoleSingleJSON(w io.Writer, orgName, action string, role apitype.Role) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(roleSingleEnvelope{
+		Organization: orgName,
+		Action:       action,
+		Role:         toRoleJSON(role),
+	})
+}
+
+func renderRoleSingleText(w io.Writer, _ /*orgName*/, action string, role apitype.Role) error {
+	label := role.Name
+	if label == "" {
+		label = role.ID
+	}
+	fmt.Fprintf(w, "%s role %q (id: %s)\n", action, label, role.ID)
+	if role.Description != "" {
+		fmt.Fprintf(w, "  description: %s\n", role.Description)
+	}
+	if role.UXPurpose != "" {
+		fmt.Fprintf(w, "  purpose: %s\n", role.UXPurpose)
+	}
+	fmt.Fprintf(w, "  version: %d\n", role.Version)
+	return nil
+}

--- a/sdk/go/common/apitype/roles.go
+++ b/sdk/go/common/apitype/roles.go
@@ -1,0 +1,56 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import "encoding/json"
+
+// Role represents a custom role in an organization, as returned by the Pulumi
+// Cloud REST API. It mirrors the service's PermissionDescriptorRecord schema.
+type Role struct {
+	ID                string          `json:"id"`
+	OrgID             string          `json:"orgId"`
+	Name              string          `json:"name,omitempty"`
+	Description       string          `json:"description,omitempty"`
+	ResourceType      string          `json:"resourceType,omitempty"`
+	UXPurpose         string          `json:"uxPurpose,omitempty"`
+	DefaultIdentifier string          `json:"defaultIdentifier,omitempty"`
+	Details           json.RawMessage `json:"details,omitempty"`
+	Version           int             `json:"version"`
+	IsOrgDefault      bool            `json:"isOrgDefault"`
+	Created           string          `json:"created"`
+	Modified          string          `json:"modified"`
+}
+
+// ListRolesResponse is the response body for GET /api/orgs/{orgName}/roles.
+type ListRolesResponse struct {
+	Roles []Role `json:"roles"`
+}
+
+// CreateRoleRequest is the request body for POST /api/orgs/{orgName}/roles.
+// It mirrors the service's PermissionDescriptorBase schema.
+type CreateRoleRequest struct {
+	Name         string          `json:"name,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	ResourceType string          `json:"resourceType,omitempty"`
+	UXPurpose    string          `json:"uxPurpose,omitempty"`
+	Details      json.RawMessage `json:"details,omitempty"`
+}
+
+// UpdateRoleRequest is the request body for PATCH /api/orgs/{orgName}/roles/{roleID}.
+type UpdateRoleRequest struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Details     json.RawMessage `json:"details"`
+}


### PR DESCRIPTION
## Summary
Implements the `pulumi org role` command family for managing custom organization
roles via the Pulumi Cloud REST API. Each subcommand lands as its own commit
with its own changelog entry and tests, and each commit is independently
buildable, testable, and shippable.

| Command                              | API endpoint                                                       | Issue   |
|--------------------------------------|--------------------------------------------------------------------|---------|
| `pulumi org role list`               | `GET /api/orgs/{org}/roles` (`ListRolesByOrgIDAndUXPurpose`)       | #23008  |
| `pulumi org role new <name> <file>`  | `POST /api/orgs/{org}/roles` (`CreateRole`)                        | #23007  |
| `pulumi org role edit <id>`          | `PATCH /api/orgs/{org}/roles/{id}` (`UpdateRole`)                  | #23006  |
| `pulumi org role remove <id>`        | `DELETE /api/orgs/{org}/roles/{id}` (`DeleteRole`)                 | #23005  |
| `pulumi org role assign <id> <team>` | `POST /api/orgs/{org}/teams/{team}/roles/{id}` (`UpdateTeamRoles`) | #23004  |

The whole family stays `Hidden: true` and labelled `[EXPERIMENTAL]` until the
suite is ready to ship per the existing rollout convention.

### Conformance to #22959

- **Required inputs are positional arguments**: `<role-id>`, `<team>` (on
  `assign`), and `<details-file>` (on `new`) are positional, not flags. Only
  context inputs like `--org` remain flags.
- **`edit` fields are ternary via `cmd.Flags().Changed(...)`**: omitting a flag
  leaves the field unchanged; `--description ""` clears it explicitly. The
  command does `GET` then `PATCH` to satisfy the service's "all fields required
  on PATCH" contract.
- **Response from `new` and `edit` is the edited structure** rendered through a
  shared single-role renderer.
- **Default `--output` is human-readable, not JSON** — the reusable
  [`pkg/util/outputflag`](pkg/util/outputflag) (introduced in #23112) drives
  output selection across all five subcommands.
- **Service-side validation only**: the CLI does not enumerate accepted
  `--purpose` values or inspect the `details` discriminator; it only verifies
  the details file parses as JSON before forwarding it.

### Design notes

- The list endpoint is not paginated on the service side, so the client returns
  the full list in a single round-trip; the pagination flag conventions from
  #22959 do not apply here.
- `--details-file` accepts `-` for stdin, so callers can pipe the
  `PermissionDescriptor` tree from another tool.
- Confirmation in `remove` is dependency-injected so the prompt path is
  exercised in unit tests without a TTY; the default refuses to run in
  non-interactive sessions unless `--yes` is passed.

Closes #23004
Closes #23005
Closes #23006
Closes #23007
Closes #23008
Refs #23003
Refs #22959

## Test plan
- [x] `go build ./...` from `pkg/`
- [x] `go test -count=1 ./pkg/cmd/pulumi/org/... ./pkg/backend/httpstate/client/...`
- [x] Each commit builds and tests green in isolation
- [ ] `mise exec -- make lint` (running)
- [ ] End-to-end against a live Pulumi Cloud org for each subcommand