### PR TITLE
implement `pulumi stack webhook delivery redeliver`

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-delivery-redeliver.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-delivery-redeliver.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook delivery redeliver` to redeliver a webhook event

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -940,6 +940,18 @@ func (pc *Client) ListStackWebhookDeliveries(
 	return resp, nil
 }
 
+// RedeliverStackWebhookEvent triggers redelivery of a specific event to the given webhook.
+func (pc *Client) RedeliverStackWebhookEvent(
+	ctx context.Context, stackID StackIdentifier, webhookName, eventID string,
+) (apitype.WebhookDelivery, error) {
+	var resp apitype.WebhookDelivery
+	path := getStackPath(stackID, "hooks", webhookName, "deliveries", eventID, "redeliver")
+	if err := pc.restCall(ctx, "POST", path, nil, nil, &resp); err != nil {
+		return apitype.WebhookDelivery{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -392,3 +392,56 @@ func TestListStackWebhookDeliveries(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestRedeliverStackWebhookEvent(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.WebhookDelivery{
+			ID:           "d-new",
+			Kind:         "stack_update",
+			Timestamp:    1715558500,
+			Duration:     55,
+			RequestURL:   "https://example.com/webhook",
+			ResponseCode: 200,
+		}
+
+		var gotPath, gotMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(want)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.RedeliverStackWebhookEvent(t.Context(), stackID, "my-hook", "evt-123")
+		require.NoError(t, err)
+
+		assert.Equal(t, "POST", gotMethod)
+		assert.Equal(t,
+			"/api/stacks/my-org/my-project/dev/hooks/my-hook/deliveries/evt-123/redeliver",
+			gotPath)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.RedeliverStackWebhookEvent(t.Context(), stackID, "hook", "bad-id")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -105,34 +105,6 @@ func newStackWebhookDeliveryCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newStackWebhookDeliveryListCmd())
-	cmd.AddCommand(newStackWebhookDeliveryGetCmd())
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/23054]: Not yet implemented.
-func newStackWebhookDeliveryGetCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Redeliver a specific webhook event",
-		Long:   "[EXPERIMENTAL] Redeliver a specific webhook event.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "webhook"},
-			{Name: "event-id"},
-		},
-		Required: 2,
-	})
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
+	cmd.AddCommand(newStackWebhookDeliveryRedeliverCmd())
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
@@ -32,55 +32,63 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// stackWebhookPingClient is the interface the ping command needs from the API client.
-type stackWebhookPingClient interface {
-	PingStackWebhook(
-		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+// stackWebhookRedeliverClient is the interface the redeliver command needs.
+type stackWebhookRedeliverClient interface {
+	RedeliverStackWebhookEvent(
+		ctx context.Context, stackID client.StackIdentifier,
+		webhookName, eventID string,
 	) (apitype.WebhookDelivery, error)
 }
 
-// stackWebhookPingClientFactory builds a stackWebhookPingClient from the environment.
-type stackWebhookPingClientFactory func(
+type stackWebhookRedeliverClientFactory func(
 	ctx context.Context, stackFlag string,
-) (stackWebhookPingClient, client.StackIdentifier, error)
+) (stackWebhookRedeliverClient, client.StackIdentifier, error)
 
-func newStackWebhookPingCmd() *cobra.Command {
-	return newStackWebhookPingCmdWith(nil)
+func newStackWebhookDeliveryRedeliverCmd() *cobra.Command {
+	return newStackWebhookDeliveryRedeliverCmdWith(nil)
 }
 
-func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Command {
+func newStackWebhookDeliveryRedeliverCmdWith(
+	factory stackWebhookRedeliverClientFactory,
+) *cobra.Command {
 	var (
 		stack  string
 		output string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "ping",
-		Short: "Send a test ping to a stack webhook",
-		Long: "[EXPERIMENTAL] Send a test ping to a stack webhook.\n" +
+		Use:   "redeliver",
+		Short: "[EXPERIMENTAL] Redeliver a specific webhook event",
+		Long: "Redeliver a specific webhook event.\n" +
 			"\n" +
-			"Issues a test ping event to the specified webhook to verify it is\n" +
-			"properly configured and reachable. Unlike normal webhook deliveries,\n" +
-			"this bypasses the message queue and sends the request directly to the\n" +
-			"webhook endpoint.\n" +
+			"Triggers the Pulumi Service to redeliver a specific event to a\n" +
+			"webhook. This is useful for resending an event that the webhook\n" +
+			"endpoint failed to process on the initial delivery attempt.\n" +
 			"\n" +
-			"The response includes the full delivery result: the HTTP request URL,\n" +
-			"response status code, response body, and request duration.\n" +
-			"\n" +
-			"Returns an error if the webhook does not exist.",
-		Example: "  # Ping a webhook to verify it works\n" +
-			"  pulumi stack webhook ping my-webhook\n\n" +
-			"  # Ping a webhook and get the full delivery details as JSON\n" +
-			"  pulumi stack webhook ping my-webhook --output json",
+			"Returns the delivery result with HTTP status and response details.\n" +
+			"Returns an error if the webhook or event does not exist.",
+		Example: "  # Redeliver an event\n" +
+			"  pulumi stack webhook delivery redeliver my-webhook evt-abc123\n\n" +
+			"  # Redeliver and get the full result as JSON\n" +
+			"  pulumi stack webhook delivery redeliver my-webhook evt-abc123 --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
-				factory = defaultStackWebhookPingClientFactory
+				factory = defaultRedeliverClientFactory
 			}
-			return runStackWebhookPing(cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], output)
+			return runRedeliver(
+				cmd.Context(), cmd.OutOrStdout(), factory,
+				stack, args[0], args[1], output,
+			)
 		},
 	}
 
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "webhook"},
+			{Name: "event-id"},
+		},
+		Required: 2,
+	})
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
@@ -90,24 +98,23 @@ func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Co
 	return cmd
 }
 
-// defaultStackWebhookPingClientFactory resolves the current Pulumi Cloud context and
-// returns a client and stack identifier.
-func defaultStackWebhookPingClientFactory(
+func defaultRedeliverClientFactory(
 	ctx context.Context, stackFlag string,
-) (stackWebhookPingClient, client.StackIdentifier, error) {
+) (stackWebhookRedeliverClient, client.StackIdentifier, error) {
 	return RequireCloudStack(
-		ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance,
+		cmdBackend.DefaultLoginManager, stackFlag)
 }
 
-func runStackWebhookPing(
+func runRedeliver(
 	ctx context.Context,
 	w io.Writer,
-	factory stackWebhookPingClientFactory,
+	factory stackWebhookRedeliverClientFactory,
 	stackFlag string,
-	webhookName string,
+	webhookName, eventID string,
 	output string,
 ) error {
-	renderer, err := webhookPingRenderer(output)
+	renderer, err := redeliverRenderer(output)
 	if err != nil {
 		return err
 	}
@@ -117,35 +124,36 @@ func runStackWebhookPing(
 		return err
 	}
 
-	delivery, err := c.PingStackWebhook(ctx, stackID, webhookName)
+	delivery, err := c.RedeliverStackWebhookEvent(ctx, stackID, webhookName, eventID)
 	if err != nil {
-		return fmt.Errorf("pinging stack webhook: %w", err)
+		return fmt.Errorf("redelivering webhook event: %w", err)
 	}
 
 	return renderer(w, delivery)
 }
 
-type webhookPingRenderFunc func(w io.Writer, d apitype.WebhookDelivery) error
+type redeliverRenderFunc func(w io.Writer, d apitype.WebhookDelivery) error
 
-func webhookPingRenderer(output string) (webhookPingRenderFunc, error) {
+func redeliverRenderer(output string) (redeliverRenderFunc, error) {
 	switch output {
 	case "", "default":
-		return renderWebhookPingText, nil
+		return renderRedeliverText, nil
 	case "json":
-		return renderWebhookPingJSON, nil
+		return renderRedeliverJSON, nil
 	default:
-		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
+		return nil, fmt.Errorf(
+			"invalid --output value %q: expected \"default\" or \"json\"", output)
 	}
 }
 
-func renderWebhookPingJSON(w io.Writer, d apitype.WebhookDelivery) error {
+func renderRedeliverJSON(w io.Writer, d apitype.WebhookDelivery) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	return enc.Encode(d)
 }
 
-func renderWebhookPingText(w io.Writer, d apitype.WebhookDelivery) error {
+func renderRedeliverText(w io.Writer, d apitype.WebhookDelivery) error {
 	ts := time.Unix(d.Timestamp, 0).UTC().Format(time.RFC3339)
 
 	fmt.Fprintf(w, "ID:                %s\n", d.ID)

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRedeliverClient struct {
+	delivery   apitype.WebhookDelivery
+	err        error
+	gotWebhook string
+	gotEventID string
+}
+
+func (m *mockRedeliverClient) RedeliverStackWebhookEvent(
+	_ context.Context, _ client.StackIdentifier, webhook, eventID string,
+) (apitype.WebhookDelivery, error) {
+	m.gotWebhook = webhook
+	m.gotEventID = eventID
+	return m.delivery, m.err
+}
+
+func stubRedeliverFactory(
+	c stackWebhookRedeliverClient,
+) stackWebhookRedeliverClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookRedeliverClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func redeliverSample() apitype.WebhookDelivery {
+	return apitype.WebhookDelivery{
+		ID:              "d-new",
+		Kind:            "stack_update",
+		Payload:         `{"action":"update"}`,
+		Timestamp:       1715558500,
+		Duration:        55,
+		RequestURL:      "https://example.com/webhook",
+		RequestHeaders:  "Content-Type: application/json",
+		ResponseCode:    200,
+		ResponseHeaders: "Content-Type: text/plain",
+		ResponseBody:    "ok",
+	}
+}
+
+func TestRedeliver_TextOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockRedeliverClient{delivery: redeliverSample()}
+	var buf bytes.Buffer
+	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "my-hook", "evt-1", "default")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "ID:                d-new")
+	assert.Contains(t, out, "Kind:              stack_update")
+	assert.Contains(t, out, "URL:               https://example.com/webhook")
+	assert.Contains(t, out, "Duration:          55ms")
+	assert.Contains(t, out, "Request headers:\n  Content-Type: application/json\n")
+	assert.Contains(t, out, "Payload:           {\"action\":\"update\"}")
+	assert.Contains(t, out, "Response code:     200")
+	assert.Contains(t, out, "Response body:\n  ok\n")
+}
+
+func TestRedeliver_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockRedeliverClient{delivery: redeliverSample()}
+	var buf bytes.Buffer
+	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "hook", "evt-1", "json")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"id": "d-new",
+		"kind": "stack_update",
+		"payload": "{\"action\":\"update\"}",
+		"timestamp": 1715558500,
+		"duration": 55,
+		"requestUrl": "https://example.com/webhook",
+		"requestHeaders": "Content-Type: application/json",
+		"responseCode": 200,
+		"responseHeaders": "Content-Type: text/plain",
+		"responseBody": "ok"
+	}`, buf.String())
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
@@ -77,7 +77,8 @@ Request headers:
   Content-Type: application/json
 Payload:           {"timestamp":1715558400,"message":"ping"}
 Response code:     200
-Response body:     ok
+Response body:
+  ok
 `, buf.String())
 }
 


### PR DESCRIPTION
Example output:

```
$ pulumi stack webhook delivery redeliver my-hook6 8d001000-7ef4-4086-b12a-3ec6d3ea1de9 -s pulumi/pulumi-service-review-stacks/tgummerer
ID:                8d001000-7ef4-4086-b12a-3ec6d3ea1de9
Kind:              stack_update
URL:               http://bla.com
Timestamp:         2026-05-13T15:12:59Z
Duration:          181ms
Request headers:
  Accept: */*
  Content-Type: application/json
  Pulumi-Webhook-Id: 8d001000-7ef4-4086-b12a-3ec6d3ea1de9
  Pulumi-Webhook-Kind: stack_update
Payload:           {"user":{"name":"Thomas Gummerer","githubLogin":"v-thomas-pulumi-corp","avatarUrl":"https://avatars.githubusercontent.com/u/191004?v=4"},"organization":{"name":"Pulumi","githubLogin":"pulumi","avatarUrl":"https://avatars0.githubusercontent.com/u/21992475?v=4"},"projectName":"pulumi-service-review-stacks","stackName":"tgummerer","updateUrl":"https://app.pulumi.com/pulumi/pulumi-service-review-stacks/tgummerer/updates/4","kind":"update","result":"failed","resourceChanges":{"create":3,"same":28},"isPreview":false}
Response code:     405
Response body:
  <html>
  <head><title>405 Not Allowed</title></head>
  <body>
  <center><h1>405 Not Allowed</h1></center>
  <hr><center>nginx</center>
  </body>
  </html>
```

```
$ pulumi stack webhook delivery redeliver my-hook6 8d001000-7ef4-4086-b12a-3ec6d3ea1de9 -s pulumi/pulumi-service-review-stacks/tgummerer -o json
{
  "id": "8d001000-7ef4-4086-b12a-3ec6d3ea1de9",
  "kind": "stack_update",
  "payload": "{\"user\":{\"name\":\"Thomas Gummerer\",\"githubLogin\":\"v-thomas-pulumi-corp\",\"avatarUrl\":\"https://avatars.githubusercontent.com/u/191004?v=4\"},\"organization\":{\"name\":\"Pulumi\",\"githubLogin\":\"pulumi\",\"avatarUrl\":\"https://avatars0.githubusercontent.com/u/21992475?v=4\"},\"projectName\":\"pulumi-service-review-stacks\",\"stackName\":\"tgummerer\",\"updateUrl\":\"https://app.pulumi.com/pulumi/pulumi-service-review-stacks/tgummerer/updates/4\",\"kind\":\"update\",\"result\":\"failed\",\"resourceChanges\":{\"create\":3,\"same\":28},\"isPreview\":false}",
  "timestamp": 1778683786,
  "duration": 192,
  "requestUrl": "http://bla.com",
  "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: 8d001000-7ef4-4086-b12a-3ec6d3ea1de9\r\nPulumi-Webhook-Kind: stack_update\r\n",
  "responseCode": 405,
  "responseHeaders": "Connection: keep-alive\r\nContent-Length: 150\r\nContent-Type: text/html\r\nDate: Wed, 13 May 2026 14:49:46 GMT\r\nServer: nginx\r\n",
  "responseBody": "<html>\r\n<head><title>405 Not Allowed</title></head>\r\n<body>\r\n<center><h1>405 Not Allowed</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
}
```

Fixes https://github.com/pulumi/pulumi/issues/23054