### PR TITLE
[cli/cloud] Fix `pulumi api` help examples to use real operation IDs

### DIFF
--- a/changelog/pending/20260513--cli-cloud--fix-pulumi-api-help-examples-to-use-real-operation-ids.yaml
+++ b/changelog/pending/20260513--cli-cloud--fix-pulumi-api-help-examples-to-use-real-operation-ids.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/cloud
+  description: Fix `pulumi api` help examples that referenced non-existent operation IDs and response fields

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -118,11 +118,11 @@ func NewAPICmd() *cobra.Command {
 		Short: "Call any Pulumi Cloud API endpoint",
 		Long: "[EXPERIMENTAL] Call any Pulumi Cloud API endpoint.\n" +
 			"\n" +
-			"The positional argument may be: a path (with optional {template} variables, e.g.\n" +
-			"`/api/orgs/{orgName}/members`), an operation ID as shown in `list` (e.g.\n" +
-			"`ListOrgMembers`), or a paste-friendly row (`GET /api/...`). Template variables\n" +
-			"are resolved from the current Pulumi project / selected stack, or supplied\n" +
-			"with -F (e.g. `-F orgName=acme`).\n" +
+			"The positional argument may be: a path (with optional {template} variables,\n" +
+			"e.g. `/api/orgs/{orgName}/members`), an operation ID as shown in `list` (e.g.\n" +
+			"`ListOrganizationMembers`), or a paste-friendly row (`GET /api/...`). Template\n" +
+			"variables are resolved from the current Pulumi project / selected stack, or\n" +
+			"supplied with -F (e.g. `-F orgName=acme`).\n" +
 			"\n" +
 			"Fields provided via -F/--field and -f/--raw-field are sent as query parameters\n" +
 			"on GET/HEAD requests and as a JSON request body on POST/PUT/PATCH/DELETE. Method\n" +
@@ -153,7 +153,7 @@ func NewAPICmd() *cobra.Command {
 			"Exit codes: 0 success; 1 caller error; 2 invalid flags; 3 auth; 8 cancelled;\n" +
 			"255 internal.",
 		Example: "  # Verify an op's parameters and schemas with `describe` before calling it.\n" +
-			"  pulumi api describe CreateStackTag\n\n" +
+			"  pulumi api describe AddStackTag\n\n" +
 			"  # Inspect the currently authenticated user.\n" +
 			"  pulumi api /api/user\n\n" +
 			"  # Call by raw path with template variables filled from -F.\n" +
@@ -162,32 +162,34 @@ func NewAPICmd() *cobra.Command {
 			"  pulumi api /api/stacks/{orgName}/{projectName}/{stackName} \\\n" +
 			"    -F orgName=acme -F projectName=web -F stackName=prod\n\n" +
 			"  # Call by operation ID — orgName is taken from the current Pulumi project.\n" +
-			"  pulumi api ListOrgMembers\n\n" +
+			"  pulumi api ListOrganizationMembers\n\n" +
 			"  # Pass path variables explicitly when no project context is available.\n" +
 			"  pulumi api GetStack -F orgName=acme -F projectName=web -F stackName=prod\n\n" +
 			"  # Create a resource via POST; body fields go into a JSON body automatically.\n" +
-			"  pulumi api CreateStackTag -F orgName=acme -F projectName=web \\\n" +
+			"  pulumi api AddStackTag -F orgName=acme -F projectName=web \\\n" +
 			"    -F stackName=prod -F name=env -F value=prod\n\n" +
 			"  # Build a nested body by mixing scalar fields with an inline JSON object.\n" +
 			"  pulumi api CreateStack -F orgName=acme -F projectName=web \\\n" +
 			"    -F stackName=prod -F 'tags={\"env\":\"prod\",\"team\":\"platform\"}'\n\n" +
 			"  # Send an array of items using a JSON literal.\n" +
-			"  pulumi api AddTeamMembers -F orgName=acme -F teamName=eng \\\n" +
-			"    -F 'members=[\"alice\",\"bob\",\"carol\"]'\n\n" +
+			"  pulumi api CreateStack -F orgName=acme -F projectName=web \\\n" +
+			"    -F stackName=prod -F 'teams=[\"platform\",\"sre\"]'\n\n" +
 			"  # Pass the entire request body inline with --body.\n" +
-			"  pulumi api UpdateStack -F orgName=acme -F projectName=web -F stackName=prod \\\n" +
-			"    --body '{\"description\":\"managed by agent\"}'\n\n" +
+			"  pulumi api UpdateStackTags -F orgName=acme -F projectName=web -F stackName=prod \\\n" +
+			"    --body '{\"env\":\"production\",\"team\":\"platform\"}'\n\n" +
 			"  # Read a JSON body from a file, or from stdin with `-`.\n" +
-			"  pulumi api UpdateStackTag --input ./tag.json\n" +
-			"  cat tag.json | pulumi api UpdateStackTag --input -\n\n" +
+			"  pulumi api UpdateStackTag -F orgName=acme -F projectName=web \\\n" +
+			"    -F stackName=prod -F tagName=env --input ./tag.json\n" +
+			"  cat tag.json | pulumi api UpdateStackTag -F orgName=acme -F projectName=web \\\n" +
+			"    -F stackName=prod -F tagName=env --input -\n\n" +
 			"  # Filter the JSON response with jq.\n" +
 			"  pulumi api /api/user --output=json | jq '.githubLogin'\n\n" +
 			"  # Follow pagination cursors and stream the combined result to jq.\n" +
-			"  pulumi api ListStacks --paginate | jq '.stacks[].name'\n\n" +
+			"  pulumi api ListUserStacks --paginate | jq '.stacks[].stackName'\n\n" +
 			"  # Extract just the status line + headers without the body.\n" +
 			"  pulumi api /api/user --include --silent\n\n" +
 			"  # Preview the resolved request without sending it.\n" +
-			"  pulumi api CreateStackTag -F orgName=acme --dry-run",
+			"  pulumi api AddStackTag -F orgName=acme --dry-run",
 	}
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
 		Arguments: []constrictor.Argument{{Name: "path-or-operation-id"}},

--- a/pkg/cmd/pulumi/cloud/describe.go
+++ b/pkg/cmd/pulumi/cloud/describe.go
@@ -45,13 +45,13 @@ func newDescribeCmd(api *apiCommand) *cobra.Command {
 			"Default output is a human-readable schema render. Pass --output=json for the\n" +
 			"stable agent envelope, including the inlined JSON schema.",
 		Example: "  # Describe an operation by its ID.\n" +
-			"  pulumi api describe ListOrgMembers\n\n" +
+			"  pulumi api describe ListOrganizationMembers\n\n" +
 			"  # Describe by path — use --method when the same path maps to multiple ops.\n" +
-			"  pulumi api describe /api/orgs/{orgName}/members --method=POST\n\n" +
+			"  pulumi api describe /api/stacks/{orgName}/{projectName}/{stackName}/tags --method=POST\n\n" +
 			"  # Paste-friendly: copy a METHOD + path row from `list` verbatim.\n" +
 			"  pulumi api describe 'GET /api/user'\n\n" +
 			"  # Extract just the request body schema.\n" +
-			"  pulumi api describe CreateStackTag --output=json | jq '.operation.requestBody.jsonSchema'\n\n" +
+			"  pulumi api describe AddStackTag --output=json | jq '.operation.requestBody.jsonSchema'\n\n" +
 			"  # Pull the parameter list for scripting.\n" +
 			"  pulumi api describe GetStack --output=json | jq '.operation.parameters[] | {name, in, required}'",
 	}


### PR DESCRIPTION
## Summary

Fixes #23120 — every example in the `pulumi api` / `pulumi api describe` help output now resolves against the live Pulumi Cloud OpenAPI spec.

The original issue called out one broken example (`ListStacks --paginate | jq '.stacks[].name'`). A follow-up audit comment on the issue surfaced five more bogus operation IDs in the same help block. This PR fixes all of them in one pass:

| Help example                         | Old (broken)                                              | New (resolves)                                                          |
| ------------------------------------ | --------------------------------------------------------- | ----------------------------------------------------------------------- |
| describe-by-id                       | `pulumi api describe CreateStackTag`                      | `pulumi api describe AddStackTag`                                       |
| describe-by-path with `--method`     | `/api/orgs/{orgName}/members --method=POST` (path is GET-only) | `/api/stacks/{orgName}/{projectName}/{stackName}/tags --method=POST` |
| describe `requestBody.jsonSchema`    | `describe CreateStackTag`                                 | `describe AddStackTag`                                                  |
| call-by-id (context-resolved)        | `ListOrgMembers`                                          | `ListOrganizationMembers`                                               |
| POST body fields                     | `CreateStackTag -F … -F name=env -F value=prod`           | `AddStackTag -F … -F name=env -F value=prod`                            |
| JSON array literal                   | `AddTeamMembers … -F 'members=[…]'` (no equivalent op)    | `CreateStack … -F 'teams=["platform","sre"]'`                           |
| `--body`                             | `UpdateStack … --body '{"description":…}'` (no such op)   | `UpdateStackTags … --body '{"env":"production",…}'`                     |
| `--input` (file + stdin)             | `UpdateStackTag --input ./tag.json` (missing `tagName`)   | adds the required `-F tagName=env` so the call is copy-pasteable        |
| `--paginate` + jq                    | `ListStacks --paginate \| jq '.stacks[].name'`            | `ListUserStacks --paginate \| jq '.stacks[].stackName'`                 |
| `--dry-run`                          | `CreateStackTag -F orgName=acme --dry-run`                | `AddStackTag -F orgName=acme --dry-run`                                 |
| `Long:` docstring on `pulumi api`    | mentions `ListOrgMembers`                                 | mentions `ListOrganizationMembers`                                      |

`ListAccounts`, `GetStack`, `CreateStack`, `UpdateStackTag`, `AddStackTag`, `UpdateStackTags`, `ListUserStacks`, `ListOrganizationMembers`, and `GetCurrentUser` (for the `/api/user` examples) were confirmed against the cached spec at `~/.pulumi/cloud-api-cache/api.pulumi.com/spec.json`. The `.githubLogin` field referenced by the jq example exists on the `User` schema.

The `AddTeamMembers` example had no direct replacement in the spec (the only way to add team members is `UpdateTeam` one at a time), so I rewrote the example as `CreateStack -F 'teams=[…]'` — which still demonstrates passing a JSON array literal via `-F`.

## Test plan

Each fixed example was verified by building the CLI from this branch and running it with `--dry-run` (and `describe` for the describe examples) against the cached spec; every command now resolves to a valid `method + path + body` plan instead of erroring with `pulumi.cloud_api.no_match`. The `describe`-by-path with `--method=POST` example now maps to `AddStackTag`.

- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

Help text isn't covered by a golden test today, so this change is verified by running the binary rather than by a unit test.

## Validation

- [x] `make lint` — clean
- [x] `make format` — clean
- [x] `go test ./cmd/pulumi/cloud/...` — pass
- [ ] `make test_fast` — not run (no behavioural code changed; only the help-text string literals)
- [ ] `make tidy_fix` — not run (no `go.mod` changes)
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog

- [x] Changelog entry added: `changelog/pending/20260513--cli-cloud--fix-pulumi-api-help-examples-to-use-real-operation-ids.yaml`.

## Risk

Help-text only. No runtime behaviour changes; no public API or CLI surface changes. Worst case is a docstring typo, which is what this PR is fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)