### PR TITLE
cli/cloud: surface error when `pulumi api --paginate` hits a non-paginated response

### DIFF
--- a/changelog/pending/20260513--cli-cloud--surface-error-when-paginate-is-used-against-a-non-paginated-endpoint.yaml
+++ b/changelog/pending/20260513--cli-cloud--surface-error-when-paginate-is-used-against-a-non-paginated-endpoint.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/cloud
+  description: Surface a clear error when `pulumi api --paginate` is used against an endpoint whose response is not paginatable, instead of silently emitting an empty array

--- a/pkg/cmd/pulumi/cloud/paginate.go
+++ b/pkg/cmd/pulumi/cloud/paginate.go
@@ -393,6 +393,10 @@ func emitPartialFailure(
 	w io.Writer, flags *apiCommand,
 	accumulated []json.RawMessage, itemsField string, apiErr *APIError,
 ) error {
+	// Total failure, return the error without flushing.
+	if len(accumulated) == 0 {
+		return apiErr
+	}
 	flushAccumulated(w, accumulated, itemsField, flags)
 	apiErr.Silent = true
 	return apiErr

--- a/pkg/cmd/pulumi/cloud/paginate_test.go
+++ b/pkg/cmd/pulumi/cloud/paginate_test.go
@@ -341,6 +341,70 @@ func TestRunPaginate_TruncationEmitsPartialPaginationError(t *testing.T) {
 	assert.Equal(t, 3, pagesServed)
 }
 
+func TestRunPaginate_FirstPageShapeErrorEmitsEnvelope(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"organizations":[{"name":"o1"}],"identities":[{"name":"i1"}]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient(srv.URL, "", false, nil)
+	req := paginateRequest{Method: "GET", Path: "/api/user", BaseQuery: url.Values{}, Accept: "application/json"}
+	var buf bytes.Buffer
+	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.Equal(t, cmdutil.ExitCodeError, apiErr.ExitCode)
+	assert.Equal(t, ErrInvalidFlags, apiErr.Envelope.Error.Code)
+	assert.False(t, apiErr.Silent, "first-page failure must not be Silent; user needs the diagnostic on stderr")
+	assert.Empty(t, strings.TrimSpace(buf.String()),
+		"first-page failure must not write a misleading empty envelope to stdout")
+}
+
+func TestRunPaginate_FirstPageHTTPErrorEmitsEnvelope(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient(srv.URL, "", false, nil)
+	req := paginateRequest{Method: "GET", Path: "/list", BaseQuery: url.Values{}, Accept: "application/json"}
+	var buf bytes.Buffer
+	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.False(t, apiErr.Silent, "first-page HTTP failure must not be Silent")
+	assert.Empty(t, strings.TrimSpace(buf.String()), "first-page HTTP failure must not write to stdout")
+}
+
+func TestRunPaginate_LaterPageErrorStaysSilent(t *testing.T) {
+	t.Parallel()
+	var page int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		if page == 1 {
+			fmt.Fprintln(w, `{"items":[{"id":"a"}],"continuationToken":"next"}`)
+			return
+		}
+		http.Error(w, `{"message":"boom"}`, http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	apiClient := client.NewClient(srv.URL, "", false, nil)
+	req := paginateRequest{Method: "GET", Path: "/list", BaseQuery: url.Values{}, Accept: "application/json"}
+	var buf bytes.Buffer
+	err := runPaginate(t.Context(), &buf, apiClient, req, &apiCommand{})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.True(t, apiErr.Silent, "partial failure with accumulated pages must stay Silent")
+	assert.Contains(t, buf.String(), `"items"`, "partial failure must flush accumulated pages to stdout")
+	assert.Contains(t, buf.String(), `"id":"a"`)
+}
+
 // TestHTTPErrorEnvelopeBytes_ExitCodes pins the exit-code contract:
 // 4xx and 5xx both exit 1, only 401/403 exit 3. The error code field still
 // distinguishes 4xx from 5xx for JSON consumers.


### PR DESCRIPTION
## Summary

When `pulumi api --paginate` was used against an endpoint whose response is not a paginated envelope (e.g. `/api/user`, whose response contains multiple top-level arrays), `emitPartialFailure` flushed a misleading `[]` to stdout and silenced the error envelope on stderr — exit code 1 with no diagnostic.

The "partial failure" semantics only apply once at least one page has been accumulated. With an empty accumulator, return the error verbatim so `runWithEnvelope` writes the standard error envelope to stderr.

Fixes #23121.

## Test plan

- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

New tests in `pkg/cmd/pulumi/cloud/paginate_test.go`:
- `TestRunPaginate_FirstPageShapeErrorEmitsEnvelope` — `/api/user`-style multi-array response on page 1 surfaces as a non-Silent APIError with empty stdout.
- `TestRunPaginate_FirstPageHTTPErrorEmitsEnvelope` — HTTP 5xx on page 1 surfaces as a non-Silent APIError.
- `TestRunPaginate_LaterPageErrorStaysSilent` — regression guard: page-2-and-beyond failures still flush accumulated data and stay Silent.

## Validation

- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog

- [x] Changelog entry added.

## Risk

Behavior change is scoped to the `--paginate` failure path with zero accumulated pages, so the only observable difference is that callers now receive a proper error envelope on stderr instead of an empty `[]` on stdout. The genuine partial-failure path (1+ pages accumulated, then a later page fails) is preserved and pinned by a regression test. No public SDK or CLI surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)