### PR TITLE
cli/neo: warn on HTTP 426 from Pulumi API endpoints

### DIFF
--- a/changelog/pending/20260513--cli-neo--warn-when-the-pulumi-api-returns-http-426-upgrade-required.yaml
+++ b/changelog/pending/20260513--cli-neo--warn-when-the-pulumi-api-returns-http-426-upgrade-required.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: feat
-  scope: cli/neo
-  description: Display a clear "upgrade your CLI" warning when the Pulumi API returns HTTP 426 from a `pulumi neo` endpoint

--- a/changelog/pending/20260513--cli-neo--warn-when-the-pulumi-api-returns-http-426-upgrade-required.yaml
+++ b/changelog/pending/20260513--cli-neo--warn-when-the-pulumi-api-returns-http-426-upgrade-required.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Display a clear "upgrade your CLI" warning when the Pulumi API returns HTTP 426 from a `pulumi neo` endpoint

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1799,8 +1799,12 @@ func (pc *Client) StreamNeoTaskEvents(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
-		return nil, fmt.Errorf("opening Neo event stream: HTTP %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(body)))
+		// Match the shared pulumiAPICall error shape so neo can detect status codes
+		// (e.g. 426) the same way for all three of its endpoints.
+		return nil, &apitype.ErrorResponse{
+			Code:    resp.StatusCode,
+			Message: strings.TrimSpace(string(body)),
+		}
 	}
 
 	stream := make(chan NeoStreamEvent)

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -926,6 +926,24 @@ func TestCreateNeoTask(t *testing.T) {
 		require.Nil(t, resp)
 	})
 
+	t.Run("UpgradeRequiredSurfacesAsErrorResponse", func(t *testing.T) {
+		t.Parallel()
+
+		// HTTP 426 with an empty body should still produce an *apitype.ErrorResponse
+		// with Code 426 so the neo command can recognise the upgrade signal.
+		upgradeServer := newMockServer(http.StatusUpgradeRequired, "")
+		defer upgradeServer.Close()
+
+		client := newMockClient(upgradeServer)
+		resp, err := client.CreateNeoTask(
+			t.Context(), "my-org", "hello", "my-stack", "my-project", CreateNeoTaskOptions{})
+		require.Error(t, err)
+		require.Nil(t, resp)
+		var errResp *apitype.ErrorResponse
+		require.ErrorAs(t, err, &errResp)
+		assert.Equal(t, http.StatusUpgradeRequired, errResp.Code)
+	})
+
 	t.Run("RequestShape", func(t *testing.T) {
 		t.Parallel()
 
@@ -1154,6 +1172,24 @@ func TestStreamNeoTaskEvents(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, stream)
 		assert.Contains(t, err.Error(), "401")
+	})
+
+	t.Run("UpgradeRequiredSurfacesAsErrorResponse", func(t *testing.T) {
+		t.Parallel()
+
+		// StreamNeoTaskEvents bypasses the shared pulumiAPICall path, so verify it
+		// returns the same *apitype.ErrorResponse shape (with Code 426) that the
+		// REST-style endpoints do — neo command relies on this for its upgrade warning.
+		server := newMockServer(http.StatusUpgradeRequired, "")
+		defer server.Close()
+
+		client := newMockClient(server)
+		stream, err := client.StreamNeoTaskEvents(t.Context(), "my-org", "task_1")
+		require.Error(t, err)
+		assert.Nil(t, stream)
+		var errResp *apitype.ErrorResponse
+		require.ErrorAs(t, err, &errResp)
+		assert.Equal(t, http.StatusUpgradeRequired, errResp.Code)
 	})
 
 	t.Run("ContextCancelClosesStream", func(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -203,6 +203,9 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 				ApprovalMode:      client.NeoApprovalModeManual,
 			}, nil)
 		if err != nil {
+			if warnUpgradeRequired(err, nil) {
+				return nil
+			}
 			return err
 		}
 		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
@@ -276,6 +279,11 @@ func runNeo(ctx context.Context, prompt, stackName, orgFlag, cwdFlag string) err
 						)})
 					})
 				if err != nil {
+					if warnUpgradeRequired(err, uiCh) {
+						// The TUI shutdown watcher (gctx cancellation -> p.Quit) will
+						// exit the program after the warning renders.
+						return nil
+					}
 					sendUI(uiCh, UIError{Message: "failed to create Neo task: " + err.Error()})
 					return err
 				}
@@ -424,6 +432,9 @@ func dispatchUserEvents(
 				continue
 			}
 			if err := postEvent(ctx, taskID, ob.event); err != nil {
+				if warnUpgradeRequired(err, uiCh) {
+					continue
+				}
 				sendUI(uiCh, UIWarning{Message: "failed to send event: " + err.Error()})
 			}
 		}

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -63,6 +63,9 @@ type Session struct {
 func (s *Session) Run(ctx context.Context) error {
 	stream, err := s.Client.StreamNeoTaskEvents(ctx, s.OrgName, s.TaskID)
 	if err != nil {
+		if warnUpgradeRequired(err, s.UIEvents) {
+			return nil
+		}
 		return fmt.Errorf("opening event stream: %w", err)
 	}
 
@@ -77,6 +80,9 @@ func (s *Session) Run(ctx context.Context) error {
 				return nil
 			}
 			if evt.Err != nil {
+				if warnUpgradeRequired(evt.Err, s.UIEvents) {
+					return nil
+				}
 				return evt.Err
 			}
 			if err := s.handleEvent(ctx, evt.Data); err != nil {
@@ -156,6 +162,11 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 			Name:       call.Name,
 		}
 		if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, execEvt); err != nil {
+			if warnUpgradeRequired(err, s.UIEvents) {
+				// The agent runtime won't transition this call into "running" without
+				// exec_tool_call, so we can't safely run the batch. Bail out cleanly.
+				return nil
+			}
 			return fmt.Errorf("posting exec_tool_call for %q: %w", call.Name, err)
 		}
 
@@ -170,7 +181,9 @@ func (s *Session) runBatch(ctx context.Context, calls []apitype.AgentBackendEven
 		ToolResults: items,
 	}
 	if err := s.Client.PostNeoTaskUserEvent(ctx, s.OrgName, s.TaskID, result); err != nil {
-		s.logf("error: posting tool_result: %v", err)
+		if !warnUpgradeRequired(err, s.UIEvents) {
+			s.logf("error: posting tool_result: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -620,6 +621,45 @@ func TestSession_RunWrapsStreamOpenError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "opening event stream")
 	assert.Contains(t, err.Error(), "boom")
+}
+
+//nolint:paralleltest // mutates package-global upgradeWarnOnce
+func TestSession_RunHandlesUpgradeRequiredOnStreamOpen(t *testing.T) {
+	resetUpgradeWarnOnceForTest()
+
+	ch := make(chan UIEvent, 4)
+	upgErr := &apitype.ErrorResponse{Code: http.StatusUpgradeRequired}
+
+	s := &Session{
+		Client:   &errStreamer{err: upgErr},
+		OrgName:  "o",
+		TaskID:   "t",
+		UIEvents: ch,
+	}
+	err := s.Run(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, ch, 1)
+	warn, ok := (<-ch).(UIWarning)
+	require.True(t, ok)
+	assert.Contains(t, warn.Message, "Pulumi CLI is out of date")
+}
+
+//nolint:paralleltest // mutates package-global upgradeWarnOnce
+func TestSession_RunHandlesUpgradeRequiredMidStream(t *testing.T) {
+	resetUpgradeWarnOnceForTest()
+
+	ch := make(chan UIEvent, 4)
+	streamer := newFakeStreamer()
+	streamer.stream <- client.NeoStreamEvent{Err: &apitype.ErrorResponse{Code: http.StatusUpgradeRequired}}
+
+	s := &Session{Client: streamer, OrgName: "o", TaskID: "t", UIEvents: ch}
+	err := s.Run(t.Context())
+	require.NoError(t, err)
+
+	require.Len(t, ch, 1)
+	_, ok := (<-ch).(UIWarning)
+	require.True(t, ok)
 }
 
 func TestSession_RunReturnsStreamError(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/upgrade.go
+++ b/pkg/cmd/pulumi/neo/upgrade.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// upgradeRequiredMessage is shown when any of the Neo API endpoints returns HTTP 426.
+const upgradeRequiredMessage = "Your Pulumi CLI is out of date and is incompatible with the Pulumi Cloud API.\n" +
+	"Please upgrade to the latest version: https://www.pulumi.com/docs/install/"
+
+// upgradeWarnOnce ensures we only render the upgrade warning once per process — neo
+// can hit 426 on multiple endpoints (CreateNeoTask, the SSE stream, follow-up
+// tool_result posts) and we want a single, calm signal to the user.
+var upgradeWarnOnce sync.Once
+
+// resetUpgradeWarnOnceForTest is used by unit tests to reset the once between cases.
+func resetUpgradeWarnOnceForTest() {
+	upgradeWarnOnce = sync.Once{}
+}
+
+// isUpgradeRequired reports whether err signals an HTTP 426 from one of the neo
+// API endpoints. The three neo endpoints all return *apitype.ErrorResponse for
+// HTTP errors (CreateNeoTask/PostNeoTaskUserEvent via the shared pulumiAPICall
+// path, StreamNeoTaskEvents via an explicit ErrorResponse return), so a single
+// type check covers them.
+func isUpgradeRequired(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errResp *apitype.ErrorResponse
+	return errors.As(err, &errResp) && errResp.Code == http.StatusUpgradeRequired
+}
+
+// warnUpgradeRequired reports whether err is a 426 from a neo endpoint and, if so,
+// renders the upgrade warning exactly once. uiCh, when non-nil, receives a
+// UIWarning; otherwise the warning is written to stderr. Returns true on a match
+// so callers can substitute nil for the error and exit the command cleanly.
+func warnUpgradeRequired(err error, uiCh chan<- UIEvent) bool {
+	if !isUpgradeRequired(err) {
+		return false
+	}
+	upgradeWarnOnce.Do(func() {
+		if uiCh != nil {
+			sendUI(uiCh, UIWarning{Message: upgradeRequiredMessage})
+			return
+		}
+		fmt.Fprintln(os.Stderr, "warning: "+upgradeRequiredMessage)
+	})
+	return true
+}

--- a/pkg/cmd/pulumi/neo/upgrade_test.go
+++ b/pkg/cmd/pulumi/neo/upgrade_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestIsUpgradeRequired(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DirectErrorResponse", func(t *testing.T) {
+		t.Parallel()
+		err := &apitype.ErrorResponse{Code: http.StatusUpgradeRequired, Message: "upgrade"}
+		assert.True(t, isUpgradeRequired(err))
+	})
+
+	t.Run("WrappedErrorResponse", func(t *testing.T) {
+		t.Parallel()
+		// The neo client wraps with fmt.Errorf("creating Neo task: %w", err), so a
+		// wrapped form must still be detected.
+		inner := &apitype.ErrorResponse{Code: http.StatusUpgradeRequired, Message: "upgrade"}
+		err := fmt.Errorf("creating Neo task: %w", inner)
+		assert.True(t, isUpgradeRequired(err))
+	})
+
+	t.Run("OtherStatusReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		err := &apitype.ErrorResponse{Code: http.StatusBadRequest, Message: "bad"}
+		assert.False(t, isUpgradeRequired(err))
+	})
+
+	t.Run("NonErrorResponseReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isUpgradeRequired(errors.New("network down")))
+	})
+
+	t.Run("NilReturnsFalse", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, isUpgradeRequired(nil))
+	})
+}
+
+//nolint:paralleltest // mutates package-global upgradeWarnOnce
+func TestWarnUpgradeRequired(t *testing.T) {
+	t.Run("EmitsOneUIWarning", func(t *testing.T) {
+		resetUpgradeWarnOnceForTest()
+
+		ch := make(chan UIEvent, 4)
+		err := &apitype.ErrorResponse{Code: http.StatusUpgradeRequired}
+
+		require.True(t, warnUpgradeRequired(err, ch))
+		// A second call must not enqueue another warning — the user gets a single
+		// signal even if multiple endpoints return 426 in the same session.
+		require.True(t, warnUpgradeRequired(err, ch))
+
+		got := drainUIEvents(ch)
+		require.Len(t, got, 1)
+		warn, ok := got[0].(UIWarning)
+		require.True(t, ok)
+		assert.Contains(t, warn.Message, "Pulumi CLI is out of date")
+	})
+
+	t.Run("ReturnsFalseForNon426", func(t *testing.T) {
+		resetUpgradeWarnOnceForTest()
+
+		ch := make(chan UIEvent, 1)
+		assert.False(t, warnUpgradeRequired(errors.New("network"), ch))
+		assert.False(t, warnUpgradeRequired(&apitype.ErrorResponse{Code: 401}, ch))
+		assert.Empty(t, drainUIEvents(ch))
+	})
+}


### PR DESCRIPTION
## Summary
- When any of the three `pulumi neo` API endpoints returns HTTP 426 (Upgrade Required), display a single clear "upgrade your CLI" warning and exit cleanly instead of bubbling up an opaque API error.
- Scoped strictly to neo: the shared `pulumiAPICall` layer and `backenderr` are untouched, so no other command's behaviour changes.
- Detection lives in a tiny `warnUpgradeRequired` helper in the neo package, gated by `sync.Once` so 426s on multiple endpoints in one session collapse to a single warning. `StreamNeoTaskEvents` (which bypasses `pulumiAPICall`) gets a one-line tweak to return `*apitype.ErrorResponse` for HTTP errors, so neo can detect status codes uniformly across all three endpoints — matching the existing `is404` pattern at `client.go:1662`.

## Test plan
- [x] `go test ./pkg/cmd/pulumi/neo/... ./pkg/backend/httpstate/client/...` — new unit tests cover `isUpgradeRequired`, `warnUpgradeRequired` (including the once-only emission), `Session.Run` on a 426 at stream open, `Session.Run` on a 426 mid-stream, plus 426 mock-server cases for `CreateNeoTask` and `StreamNeoTaskEvents`
- [x] `mise exec -- make lint`
- [x] `mise exec -- make test_fast` — only pre-existing unrelated local failures (timing-flaky `TestTokenSourceWithClient`, AWS-KMS tests that need credentials, `TestConfigEnvAddCmd` hanging on an interactive TTY prompt)
- [ ] Manual end-to-end: stand up an httptest server returning 426 on `/api/preview/agents/...`, point `PULUMI_API` at it, run `pulumi neo "hello"` in both interactive and non-interactive modes, confirm a single upgrade warning and clean exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)