### PR TITLE
cli/cloud: implement `pulumi env webhook` subcommands

### DIFF
--- a/changelog/pending/20260513--cli-cloud--add-pulumi-env-webhook.yaml
+++ b/changelog/pending/20260513--cli-cloud--add-pulumi-env-webhook.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi env webhook` to manage Pulumi ESC environment webhooks

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2428,3 +2428,94 @@ func (pc *Client) SearchInsightsResources(
 	}
 	return resp, nil
 }
+
+// --- ESC environment webhooks ---
+
+// envHooksPath returns the path to the env webhook collection or a sub-resource
+// underneath it. ESC routes do not double-encode path segments.
+func envHooksPath(org, project, env string, parts ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "/api/esc/environments/%s/%s/%s/hooks",
+		url.PathEscape(org), url.PathEscape(project), url.PathEscape(env))
+	for _, x := range parts {
+		b.WriteByte('/')
+		b.WriteString(url.PathEscape(x))
+	}
+	return b.String()
+}
+
+// ListEnvironmentWebhooks lists all webhooks configured for an environment.
+func (pc *Client) ListEnvironmentWebhooks(
+	ctx context.Context, org, project, env string,
+) ([]apitype.EnvironmentWebhook, error) {
+	var resp []apitype.EnvironmentWebhook
+	if err := pc.restCall(ctx, "GET", envHooksPath(org, project, env), nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// GetEnvironmentWebhook fetches a single environment webhook by name.
+func (pc *Client) GetEnvironmentWebhook(
+	ctx context.Context, org, project, env, name string,
+) (apitype.EnvironmentWebhook, error) {
+	var resp apitype.EnvironmentWebhook
+	if err := pc.restCall(ctx, "GET", envHooksPath(org, project, env, name), nil, nil, &resp); err != nil {
+		return apitype.EnvironmentWebhook{}, err
+	}
+	return resp, nil
+}
+
+// CreateEnvironmentWebhook creates a new environment webhook.
+func (pc *Client) CreateEnvironmentWebhook(
+	ctx context.Context, org, project, env string, req apitype.CreateEnvironmentWebhookRequest,
+) (apitype.EnvironmentWebhook, error) {
+	var resp apitype.EnvironmentWebhook
+	if err := pc.restCall(ctx, "POST", envHooksPath(org, project, env), nil, req, &resp); err != nil {
+		return apitype.EnvironmentWebhook{}, err
+	}
+	return resp, nil
+}
+
+// UpdateEnvironmentWebhook PATCHes an environment webhook. Fields left nil on
+// the request are not modified.
+func (pc *Client) UpdateEnvironmentWebhook(
+	ctx context.Context, org, project, env, name string, req apitype.UpdateEnvironmentWebhookRequest,
+) (apitype.EnvironmentWebhook, error) {
+	var resp apitype.EnvironmentWebhook
+	if err := pc.restCall(ctx, "PATCH", envHooksPath(org, project, env, name), nil, req, &resp); err != nil {
+		return apitype.EnvironmentWebhook{}, err
+	}
+	return resp, nil
+}
+
+// DeleteEnvironmentWebhook deletes an environment webhook by name.
+func (pc *Client) DeleteEnvironmentWebhook(
+	ctx context.Context, org, project, env, name string,
+) error {
+	return pc.restCall(ctx, "DELETE", envHooksPath(org, project, env, name), nil, nil, nil)
+}
+
+// PingEnvironmentWebhook sends a test delivery to an environment webhook and
+// returns the resulting delivery record.
+func (pc *Client) PingEnvironmentWebhook(
+	ctx context.Context, org, project, env, name string,
+) (apitype.EnvironmentWebhookDelivery, error) {
+	var resp apitype.EnvironmentWebhookDelivery
+	if err := pc.restCall(ctx, "POST", envHooksPath(org, project, env, name, "ping"), nil, nil, &resp); err != nil {
+		return apitype.EnvironmentWebhookDelivery{}, err
+	}
+	return resp, nil
+}
+
+// ListEnvironmentWebhookDeliveries returns recent deliveries for an
+// environment webhook.
+func (pc *Client) ListEnvironmentWebhookDeliveries(
+	ctx context.Context, org, project, env, name string,
+) ([]apitype.EnvironmentWebhookDelivery, error) {
+	var resp []apitype.EnvironmentWebhookDelivery
+	if err := pc.restCall(ctx, "GET", envHooksPath(org, project, env, name, "deliveries"), nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/pkg/backend/httpstate/client/client_esc_environments_test.go
+++ b/pkg/backend/httpstate/client/client_esc_environments_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// envWebhookCapture records the method, path, and decoded body of the single
+// request a test routes through the mock server. Tests assert against this
+// shape so a regression in path encoding or request shape fails loudly.
+type envWebhookCapture struct {
+	method string
+	path   string
+	body   []byte
+}
+
+// newEnvHooksServer spins up an httptest.Server that records each request and
+// responds with the supplied JSON-encoded payload. Use status to override the
+// 200/204 default for sad-path tests.
+func newEnvHooksServer(
+	t *testing.T, captured *envWebhookCapture, status int, payload any,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		*captured = envWebhookCapture{
+			method: r.Method,
+			path:   r.URL.EscapedPath(),
+			body:   body,
+		}
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if payload != nil {
+			require.NoError(t, json.NewEncoder(w).Encode(payload))
+		}
+	}))
+}
+
+func TestEnvironmentWebhooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ListEnvironmentWebhooks", func(t *testing.T) {
+		t.Parallel()
+		want := []apitype.EnvironmentWebhook{
+			{Name: "a", DisplayName: "A", PayloadURL: "https://a", Active: true},
+		}
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, want)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).ListEnvironmentWebhooks(t.Context(), "acme", "proj", "env")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, http.MethodGet, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks", captured.path)
+	})
+
+	t.Run("GetEnvironmentWebhook", func(t *testing.T) {
+		t.Parallel()
+		want := apitype.EnvironmentWebhook{Name: "h", DisplayName: "H", PayloadURL: "https://h", Active: true}
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, want)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).GetEnvironmentWebhook(t.Context(), "acme", "proj", "env", "h")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, http.MethodGet, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks/h", captured.path)
+	})
+
+	t.Run("CreateEnvironmentWebhook", func(t *testing.T) {
+		t.Parallel()
+		req := apitype.CreateEnvironmentWebhookRequest{
+			Name:        "h",
+			DisplayName: "H",
+			PayloadURL:  "https://h",
+			Active:      true,
+			Format:      "raw",
+			Filters:     []string{"a"},
+		}
+		resp := apitype.EnvironmentWebhook{Name: "h", DisplayName: "H", PayloadURL: "https://h", Active: true}
+
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusCreated, resp)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).CreateEnvironmentWebhook(t.Context(), "acme", "proj", "env", req)
+		require.NoError(t, err)
+		assert.Equal(t, resp, got)
+		assert.Equal(t, http.MethodPost, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks", captured.path)
+
+		var decoded apitype.CreateEnvironmentWebhookRequest
+		require.NoError(t, json.Unmarshal(captured.body, &decoded))
+		assert.Equal(t, req, decoded)
+	})
+
+	t.Run("UpdateEnvironmentWebhook only sends set fields", func(t *testing.T) {
+		t.Parallel()
+
+		active := false
+		req := apitype.UpdateEnvironmentWebhookRequest{Active: &active}
+		resp := apitype.EnvironmentWebhook{Name: "h", Active: false}
+
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, resp)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).UpdateEnvironmentWebhook(t.Context(), "acme", "proj", "env", "h", req)
+		require.NoError(t, err)
+		assert.Equal(t, resp, got)
+		assert.Equal(t, http.MethodPatch, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks/h", captured.path)
+
+		// Ensure that only `active` made it into the JSON body — none of the
+		// other ternary fields should serialize.
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(captured.body, &decoded))
+		assert.Equal(t, map[string]any{"active": false}, decoded)
+	})
+
+	t.Run("DeleteEnvironmentWebhook", func(t *testing.T) {
+		t.Parallel()
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusNoContent, nil)
+		defer srv.Close()
+
+		require.NoError(t, newMockClient(srv).DeleteEnvironmentWebhook(t.Context(), "acme", "proj", "env", "h"))
+		assert.Equal(t, http.MethodDelete, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks/h", captured.path)
+	})
+
+	t.Run("PingEnvironmentWebhook", func(t *testing.T) {
+		t.Parallel()
+		want := apitype.EnvironmentWebhookDelivery{
+			ID: "d1", Kind: "ping", Timestamp: 1, Duration: 42,
+			Payload: "{}", RequestURL: "https://h", RequestHeaders: "{}",
+			ResponseCode: 200, ResponseHeaders: "{}", ResponseBody: "{}",
+		}
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, want)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).PingEnvironmentWebhook(t.Context(), "acme", "proj", "env", "h")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, http.MethodPost, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks/h/ping", captured.path)
+	})
+
+	t.Run("ListEnvironmentWebhookDeliveries", func(t *testing.T) {
+		t.Parallel()
+		want := []apitype.EnvironmentWebhookDelivery{
+			{ID: "d1", Kind: "ping", ResponseCode: 200, Duration: 5},
+			{ID: "d2", Kind: "stack.updated", ResponseCode: 500, Duration: 10},
+		}
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, want)
+		defer srv.Close()
+
+		got, err := newMockClient(srv).ListEnvironmentWebhookDeliveries(t.Context(), "acme", "proj", "env", "h")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, http.MethodGet, captured.method)
+		assert.Equal(t, "/api/esc/environments/acme/proj/env/hooks/h/deliveries", captured.path)
+	})
+
+	t.Run("path segments are URL-escaped", func(t *testing.T) {
+		t.Parallel()
+		var captured envWebhookCapture
+		srv := newEnvHooksServer(t, &captured, http.StatusOK, []apitype.EnvironmentWebhook{})
+		defer srv.Close()
+
+		_, err := newMockClient(srv).ListEnvironmentWebhooks(t.Context(), "acme/team", "my proj", "env+1")
+		require.NoError(t, err)
+		assert.Equal(t,
+			"/api/esc/environments/acme%2Fteam/my%20proj/env+1/hooks",
+			captured.path,
+		)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+		}))
+		defer srv.Close()
+
+		_, err := newMockClient(srv).GetEnvironmentWebhook(t.Context(), "acme", "proj", "env", "missing")
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/env/env_webhook.go
+++ b/pkg/cmd/pulumi/env/env_webhook.go
@@ -15,20 +15,88 @@
 package env
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"strings"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// TODO[https://github.com/pulumi/pulumi/issues/23030]: Not yet implemented.
+// envWebhookClient is the subset of cloud-API operations the env webhook
+// commands need. Defined inside this package so unit tests can stub it without
+// touching the full HTTP client surface.
+type envWebhookClient interface {
+	ListEnvironmentWebhooks(
+		ctx context.Context, org, project, env string,
+	) ([]apitype.EnvironmentWebhook, error)
+	GetEnvironmentWebhook(
+		ctx context.Context, org, project, env, name string,
+	) (apitype.EnvironmentWebhook, error)
+	CreateEnvironmentWebhook(
+		ctx context.Context, org, project, env string, req apitype.CreateEnvironmentWebhookRequest,
+	) (apitype.EnvironmentWebhook, error)
+	UpdateEnvironmentWebhook(
+		ctx context.Context, org, project, env, name string, req apitype.UpdateEnvironmentWebhookRequest,
+	) (apitype.EnvironmentWebhook, error)
+	DeleteEnvironmentWebhook(
+		ctx context.Context, org, project, env, name string,
+	) error
+	PingEnvironmentWebhook(
+		ctx context.Context, org, project, env, name string,
+	) (apitype.EnvironmentWebhookDelivery, error)
+	ListEnvironmentWebhookDeliveries(
+		ctx context.Context, org, project, env, name string,
+	) ([]apitype.EnvironmentWebhookDelivery, error)
+}
+
+// envWebhookFactory resolves a cloud client and the effective org for the
+// command. orgOverride wins when non-empty; otherwise the default org from the
+// cloud context is used.
+type envWebhookFactory func(ctx context.Context, orgOverride string) (envWebhookClient, string, error)
+
+// defaultEnvWebhookFactory is the production wiring for envWebhookFactory. It
+// resolves the cloud context via cloud.ResolveContext and surfaces the
+// *client.Client directly — *client.Client already satisfies envWebhookClient.
+func defaultEnvWebhookFactory(
+	ctx context.Context, orgOverride string,
+) (envWebhookClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+	return resolved.Client, org, nil
+}
+
 func newEnvWebhookCmd() *cobra.Command {
+	return newEnvWebhookCmdWith(nil)
+}
+
+func newEnvWebhookCmdWith(factory envWebhookFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "webhook",
-		Short:  "Manage environment webhooks",
-		Long:   "[EXPERIMENTAL] Manage environment webhooks.",
+		Use:   "webhook",
+		Short: "Manage environment webhooks",
+		Long:  "[EXPERIMENTAL] Manage Pulumi ESC environment webhooks.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -36,12 +104,12 @@ func newEnvWebhookCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(newEnvWebhookListCmd())
-	cmd.AddCommand(newEnvWebhookNewCmd())
-	cmd.AddCommand(newEnvWebhookEditCmd())
-	cmd.AddCommand(newEnvWebhookRemoveCmd())
-	cmd.AddCommand(newEnvWebhookPingCmd())
-	cmd.AddCommand(newEnvWebhookDeliveryCmd())
+	cmd.AddCommand(newEnvWebhookListCmd(factory))
+	cmd.AddCommand(newEnvWebhookNewCmd(factory))
+	cmd.AddCommand(newEnvWebhookEditCmd(factory))
+	cmd.AddCommand(newEnvWebhookRemoveCmd(factory))
+	cmd.AddCommand(newEnvWebhookPingCmd(factory))
+	cmd.AddCommand(newEnvWebhookDeliveryCmd(factory))
 
 	return cmd
 }
@@ -67,108 +135,307 @@ func envWebhookEnvWithHookArg() *constrictor.Arguments {
 	}
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23029]: Not yet implemented.
-func newEnvWebhookListCmd() *cobra.Command {
-	var org string
+// --- list --------------------------------------------------------------------
+
+func newEnvWebhookListCmd(factory envWebhookFactory) *cobra.Command {
+	var (
+		org    string
+		output string
+	)
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List all webhooks configured for an environment",
-		Long:   "[EXPERIMENTAL] List all webhooks configured for an environment.",
+		Use:   "list",
+		Short: "List all webhooks configured for an environment",
+		Long:  "[EXPERIMENTAL] List all webhooks configured for an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			render, err := envWebhookListRenderer(output)
+			if err != nil {
+				return err
+			}
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			hooks, err := c.ListEnvironmentWebhooks(cmd.Context(), resolvedOrg, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("listing environment webhooks: %w", err)
+			}
+			return render(cmd.OutOrStdout(), hooks)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, envWebhookEnvArg())
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"Output format. One of: default, json")
 
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23028]: Not yet implemented.
-func newEnvWebhookNewCmd() *cobra.Command {
+// --- new ---------------------------------------------------------------------
+
+func newEnvWebhookNewCmd(factory envWebhookFactory) *cobra.Command {
 	var (
-		org     string
-		url     string
-		format  string
-		filters []string
-		active  bool
-		secret  string
+		org         string
+		payloadURL  string
+		displayName string
+		format      string
+		filters     []string
+		active      bool
+		secret      string
+		output      string
 	)
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new environment webhook",
-		Long:   "[EXPERIMENTAL] Create a new environment webhook.",
+		Use:   "new",
+		Short: "Create a new environment webhook",
+		Long:  "[EXPERIMENTAL] Create a new environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			renderOne, err := envWebhookRenderer(output)
+			if err != nil {
+				return err
+			}
+
+			project, envName, hookName := args[0], args[1], args[2]
+			displayed := displayName
+			if displayed == "" {
+				displayed = hookName
+			}
+
+			req := apitype.CreateEnvironmentWebhookRequest{
+				Name:        hookName,
+				DisplayName: displayed,
+				PayloadURL:  payloadURL,
+				Active:      active,
+				Format:      format,
+				Filters:     filters,
+				Secret:      secret,
+			}
+
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			hook, err := c.CreateEnvironmentWebhook(cmd.Context(), resolvedOrg, project, envName, req)
+			if err != nil {
+				return fmt.Errorf("creating environment webhook: %w", err)
+			}
+			return renderOne(cmd.OutOrStdout(), hook)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&payloadURL, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&displayName, "display-name", "",
+		"The human-readable display name for the webhook (defaults to the webhook name)")
 	cmd.Flags().StringVar(&format, "format", "raw",
 		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
 	cmd.Flags().StringArrayVar(&filters, "filter", nil,
 		"An event type to subscribe to (repeatable)")
 	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
 	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"Output format. One of: default, json")
+	_ = cmd.MarkFlagRequired("url")
 
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23027]: Not yet implemented.
-func newEnvWebhookEditCmd() *cobra.Command {
+// --- edit --------------------------------------------------------------------
+
+func newEnvWebhookEditCmd(factory envWebhookFactory) *cobra.Command {
 	var (
-		org     string
-		url     string
-		format  string
-		filters []string
-		active  bool
-		secret  string
+		org         string
+		payloadURL  string
+		displayName string
+		format      string
+		filters     []string
+		addFilters  []string
+		rmFilters   []string
+		active      bool
+		secret      string
+		output      string
 	)
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "Update an environment webhook's configuration",
-		Long:   "[EXPERIMENTAL] Update an environment webhook's configuration.",
+		Use:   "edit",
+		Short: "Update an environment webhook's configuration",
+		Long: "[EXPERIMENTAL] Update an environment webhook's configuration.\n" +
+			"\n" +
+			"Only flags explicitly provided on the command line are sent in the PATCH.\n" +
+			"Use --filter to replace the filter list outright, or --add-filter /\n" +
+			"--remove-filter to merge against the current webhook configuration.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			renderOne, err := envWebhookRenderer(output)
+			if err != nil {
+				return err
+			}
+
+			project, envName, hookName := args[0], args[1], args[2]
+
+			if cmd.Flags().Changed("filter") &&
+				(cmd.Flags().Changed("add-filter") || cmd.Flags().Changed("remove-filter")) {
+				return errors.New(
+					"--filter cannot be combined with --add-filter or --remove-filter")
+			}
+
+			req := buildEnvWebhookPatch(cmd, payloadURL, displayName, format, secret, active, filters)
+
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+
+			if cmd.Flags().Changed("add-filter") || cmd.Flags().Changed("remove-filter") {
+				current, gerr := c.GetEnvironmentWebhook(cmd.Context(), resolvedOrg, project, envName, hookName)
+				if gerr != nil {
+					return fmt.Errorf("reading current webhook: %w", gerr)
+				}
+				merged := mergeFilters(current.Filters, addFilters, rmFilters)
+				req.Filters = &merged
+			}
+
+			hook, err := c.UpdateEnvironmentWebhook(cmd.Context(), resolvedOrg, project, envName, hookName, req)
+			if err != nil {
+				return fmt.Errorf("updating environment webhook: %w", err)
+			}
+			return renderOne(cmd.OutOrStdout(), hook)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&payloadURL, "url", "", "The webhook payload URL")
+	cmd.Flags().StringVar(&displayName, "display-name", "",
+		"The human-readable display name for the webhook")
 	cmd.Flags().StringVar(&format, "format", "",
 		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
 	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		"An event type to subscribe to (repeatable)")
+		"Replace the filter list with these event types (repeatable)")
+	cmd.Flags().StringArrayVar(&addFilters, "add-filter", nil,
+		"Add an event type to the existing filter list (repeatable)")
+	cmd.Flags().StringArrayVar(&rmFilters, "remove-filter", nil,
+		"Remove an event type from the existing filter list (repeatable)")
 	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
 	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"Output format. One of: default, json")
 
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23026]: Not yet implemented.
-func newEnvWebhookRemoveCmd() *cobra.Command {
+// buildEnvWebhookPatch constructs the PATCH body from the parsed flags. Only
+// flags explicitly set on the command line are included — this implements the
+// parent epic's "ternary flags" rule, where the absence of a flag means "leave
+// unchanged" rather than "send the default".
+func buildEnvWebhookPatch(
+	cmd *cobra.Command,
+	payloadURL, displayName, format, secret string,
+	active bool,
+	filters []string,
+) apitype.UpdateEnvironmentWebhookRequest {
+	var req apitype.UpdateEnvironmentWebhookRequest
+	if cmd.Flags().Changed("url") {
+		u := payloadURL
+		req.PayloadURL = &u
+	}
+	if cmd.Flags().Changed("display-name") {
+		d := displayName
+		req.DisplayName = &d
+	}
+	if cmd.Flags().Changed("format") {
+		fv := format
+		req.Format = &fv
+	}
+	if cmd.Flags().Changed("active") {
+		a := active
+		req.Active = &a
+	}
+	if cmd.Flags().Changed("secret") {
+		s := secret
+		req.Secret = &s
+	}
+	if cmd.Flags().Changed("filter") {
+		f := append([]string{}, filters...)
+		req.Filters = &f
+	}
+	return req
+}
+
+// mergeFilters returns a new list with adds appended (deduped, preserving order)
+// and any entries in removes filtered out. The original ordering of existing
+// is preserved; new entries from adds are appended in the order given.
+func mergeFilters(existing, adds, removes []string) []string {
+	rm := make(map[string]struct{}, len(removes))
+	for _, r := range removes {
+		rm[r] = struct{}{}
+	}
+	out := make([]string, 0, len(existing)+len(adds))
+	seen := make(map[string]struct{}, len(existing)+len(adds))
+	for _, e := range existing {
+		if _, drop := rm[e]; drop {
+			continue
+		}
+		if _, dup := seen[e]; dup {
+			continue
+		}
+		seen[e] = struct{}{}
+		out = append(out, e)
+	}
+	for _, a := range adds {
+		if _, drop := rm[a]; drop {
+			continue
+		}
+		if _, dup := seen[a]; dup {
+			continue
+		}
+		seen[a] = struct{}{}
+		out = append(out, a)
+	}
+	return out
+}
+
+// --- remove ------------------------------------------------------------------
+
+func newEnvWebhookRemoveCmd(factory envWebhookFactory) *cobra.Command {
 	var org string
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove",
-		Short:  "Delete an environment webhook",
-		Long:   "[EXPERIMENTAL] Delete an environment webhook.",
+		Use:   "remove",
+		Short: "Delete an environment webhook",
+		Long:  "[EXPERIMENTAL] Delete an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			project, envName, hookName := args[0], args[1], args[2]
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			if err := c.DeleteEnvironmentWebhook(cmd.Context(), resolvedOrg, project, envName, hookName); err != nil {
+				return fmt.Errorf("deleting environment webhook: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed webhook %q from environment %s/%s\n",
+				hookName, project, envName)
+			return nil
 		},
 	}
 
@@ -179,66 +446,293 @@ func newEnvWebhookRemoveCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23025]: Not yet implemented.
-func newEnvWebhookPingCmd() *cobra.Command {
-	var org string
+// --- ping --------------------------------------------------------------------
+
+func newEnvWebhookPingCmd(factory envWebhookFactory) *cobra.Command {
+	var (
+		org    string
+		output string
+	)
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "ping",
-		Short:  "Send a test ping to an environment webhook",
-		Long:   "[EXPERIMENTAL] Send a test ping to an environment webhook.",
+		Use:   "ping",
+		Short: "Send a test ping to an environment webhook",
+		Long:  "[EXPERIMENTAL] Send a test ping to an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			render, err := envWebhookDeliveryRenderer(output)
+			if err != nil {
+				return err
+			}
+			project, envName, hookName := args[0], args[1], args[2]
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			delivery, err := c.PingEnvironmentWebhook(cmd.Context(), resolvedOrg, project, envName, hookName)
+			if err != nil {
+				return fmt.Errorf("pinging environment webhook: %w", err)
+			}
+			return render(cmd.OutOrStdout(), delivery)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"Output format. One of: default, json")
 
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23024]: Not yet implemented.
-func newEnvWebhookDeliveryCmd() *cobra.Command {
-	var org string
+// --- delivery / delivery list ------------------------------------------------
 
+func newEnvWebhookDeliveryCmd(factory envWebhookFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "delivery",
-		Short:  "Inspect environment webhook deliveries",
-		Long:   "[EXPERIMENTAL] Inspect environment webhook deliveries.",
+		Use:   "delivery",
+		Short: "Inspect environment webhook deliveries",
+		Long:  "[EXPERIMENTAL] Inspect environment webhook deliveries.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-
-	cmd.AddCommand(newEnvWebhookDeliveryListCmd())
+	cmd.AddCommand(newEnvWebhookDeliveryListCmd(factory))
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23023]: Not yet implemented.
-func newEnvWebhookDeliveryListCmd() *cobra.Command {
-	var org string
+func newEnvWebhookDeliveryListCmd(factory envWebhookFactory) *cobra.Command {
+	var (
+		org    string
+		output string
+	)
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List recent deliveries for an environment webhook",
-		Long:   "[EXPERIMENTAL] List recent deliveries for an environment webhook.",
+		Use:   "list",
+		Short: "List recent deliveries for an environment webhook",
+		Long:  "[EXPERIMENTAL] List recent deliveries for an environment webhook.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			f := factory
+			if f == nil {
+				f = defaultEnvWebhookFactory
+			}
+			render, err := envWebhookDeliveryListRenderer(output)
+			if err != nil {
+				return err
+			}
+			project, envName, hookName := args[0], args[1], args[2]
+			c, resolvedOrg, err := f(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			deliveries, err := c.ListEnvironmentWebhookDeliveries(cmd.Context(), resolvedOrg, project, envName, hookName)
+			if err != nil {
+				return fmt.Errorf("listing environment webhook deliveries: %w", err)
+			}
+			return render(cmd.OutOrStdout(), deliveries)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, envWebhookEnvWithHookArg())
 
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"Output format. One of: default, json")
 
 	return cmd
+}
+
+// --- rendering ---------------------------------------------------------------
+
+func envWebhookRenderer(format string) (func(io.Writer, apitype.EnvironmentWebhook) error, error) {
+	switch format {
+	case "", "default":
+		return renderEnvWebhookText, nil
+	case "json":
+		return renderEnvWebhookJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+func renderEnvWebhookText(w io.Writer, h apitype.EnvironmentWebhook) error {
+	fmt.Fprintf(w, "Name:         %s\n", h.Name)
+	if h.DisplayName != "" && h.DisplayName != h.Name {
+		fmt.Fprintf(w, "Display name: %s\n", h.DisplayName)
+	}
+	fmt.Fprintf(w, "URL:          %s\n", h.PayloadURL)
+	if h.Format != "" {
+		fmt.Fprintf(w, "Format:       %s\n", h.Format)
+	}
+	fmt.Fprintf(w, "Active:       %s\n", yesNo(h.Active))
+	if len(h.Filters) > 0 {
+		fmt.Fprintf(w, "Filters:      %s\n", strings.Join(h.Filters, ", "))
+	}
+	if len(h.Groups) > 0 {
+		fmt.Fprintf(w, "Groups:       %s\n", strings.Join(h.Groups, ", "))
+	}
+	if h.HasSecret {
+		fmt.Fprintln(w, "Secret:       (set)")
+	}
+	return nil
+}
+
+func renderEnvWebhookJSON(w io.Writer, h apitype.EnvironmentWebhook) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(h)
+}
+
+func envWebhookListRenderer(format string) (func(io.Writer, []apitype.EnvironmentWebhook) error, error) {
+	switch format {
+	case "", "default", "table":
+		return renderEnvWebhookListTable, nil
+	case "json":
+		return renderEnvWebhookListJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+func renderEnvWebhookListJSON(w io.Writer, hooks []apitype.EnvironmentWebhook) error {
+	if hooks == nil {
+		hooks = []apitype.EnvironmentWebhook{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		Webhooks []apitype.EnvironmentWebhook `json:"webhooks"`
+		Count    int                          `json:"count"`
+	}{
+		Webhooks: hooks,
+		Count:    len(hooks),
+	})
+}
+
+func renderEnvWebhookListTable(w io.Writer, hooks []apitype.EnvironmentWebhook) error {
+	if len(hooks) == 0 {
+		fmt.Fprintln(w, "No webhooks configured for this environment.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"NAME", "DISPLAY NAME", "URL", "FORMAT", "FILTERS", "ACTIVE"})
+
+	for _, h := range hooks {
+		filters := ""
+		if len(h.Filters) > 0 {
+			filters = strings.Join(h.Filters, ", ")
+		}
+		t.AppendRow(table.Row{
+			h.Name,
+			h.DisplayName,
+			h.PayloadURL,
+			h.Format,
+			filters,
+			yesNo(h.Active),
+		})
+	}
+
+	cols := cmdCmd.StdoutWidth()
+	borderWidth := 3*6 + 1
+	fixedColsWidth := 50
+	urlWidth := cols - borderWidth - fixedColsWidth
+	if urlWidth < 20 {
+		urlWidth = 20
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "URL", WidthMax: urlWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d webhook(s)\n", len(hooks))
+	return nil
+}
+
+func envWebhookDeliveryRenderer(format string) (func(io.Writer, apitype.EnvironmentWebhookDelivery) error, error) {
+	switch format {
+	case "", "default":
+		return renderEnvWebhookDeliveryText, nil
+	case "json":
+		return renderEnvWebhookDeliveryJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+func renderEnvWebhookDeliveryText(w io.Writer, d apitype.EnvironmentWebhookDelivery) error {
+	fmt.Fprintf(w, "ID:            %s\n", d.ID)
+	fmt.Fprintf(w, "Kind:          %s\n", d.Kind)
+	fmt.Fprintf(w, "Response code: %d\n", d.ResponseCode)
+	fmt.Fprintf(w, "Duration:      %dms\n", d.Duration)
+	return nil
+}
+
+func renderEnvWebhookDeliveryJSON(w io.Writer, d apitype.EnvironmentWebhookDelivery) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(d)
+}
+
+func envWebhookDeliveryListRenderer(
+	format string,
+) (func(io.Writer, []apitype.EnvironmentWebhookDelivery) error, error) {
+	switch format {
+	case "", "default", "table":
+		return renderEnvWebhookDeliveryListTable, nil
+	case "json":
+		return renderEnvWebhookDeliveryListJSON, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+func renderEnvWebhookDeliveryListJSON(w io.Writer, deliveries []apitype.EnvironmentWebhookDelivery) error {
+	if deliveries == nil {
+		deliveries = []apitype.EnvironmentWebhookDelivery{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		Deliveries []apitype.EnvironmentWebhookDelivery `json:"deliveries"`
+		Count      int                                  `json:"count"`
+	}{
+		Deliveries: deliveries,
+		Count:      len(deliveries),
+	})
+}
+
+func renderEnvWebhookDeliveryListTable(w io.Writer, deliveries []apitype.EnvironmentWebhookDelivery) error {
+	if len(deliveries) == 0 {
+		fmt.Fprintln(w, "No deliveries recorded for this webhook.")
+		return nil
+	}
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"ID", "KIND", "TIMESTAMP", "RESPONSE", "DURATION (MS)"})
+	for _, d := range deliveries {
+		t.AppendRow(table.Row{d.ID, d.Kind, d.Timestamp, d.ResponseCode, d.Duration})
+	}
+	t.Render()
+	fmt.Fprintf(w, "\n%d delivery(ies)\n", len(deliveries))
+	return nil
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
 }

--- a/pkg/cmd/pulumi/env/env_webhook_test.go
+++ b/pkg/cmd/pulumi/env/env_webhook_test.go
@@ -1,0 +1,671 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// mockEnvWebhookClient records every call the cobra command makes so tests can
+// assert flag propagation, and returns either canned fixture data or a canned
+// error. A single struct backs every test (one field per recorded call) so a
+// single mock instance can be passed to commands that chain GET-then-PATCH.
+type mockEnvWebhookClient struct {
+	// list
+	listHooks []apitype.EnvironmentWebhook
+	listErr   error
+	listCall  *struct{ org, project, env string }
+
+	// get
+	getHook apitype.EnvironmentWebhook
+	getErr  error
+	getCall *struct{ org, project, env, name string }
+
+	// create
+	createResp apitype.EnvironmentWebhook
+	createErr  error
+	createCall *struct {
+		org, project, env string
+		req               apitype.CreateEnvironmentWebhookRequest
+	}
+
+	// update
+	updateResp apitype.EnvironmentWebhook
+	updateErr  error
+	updateCall *struct {
+		org, project, env, name string
+		req                     apitype.UpdateEnvironmentWebhookRequest
+	}
+
+	// delete
+	deleteErr  error
+	deleteCall *struct{ org, project, env, name string }
+
+	// ping
+	pingResp apitype.EnvironmentWebhookDelivery
+	pingErr  error
+	pingCall *struct{ org, project, env, name string }
+
+	// deliveries
+	deliveries     []apitype.EnvironmentWebhookDelivery
+	deliveriesErr  error
+	deliveriesCall *struct{ org, project, env, name string }
+}
+
+func (m *mockEnvWebhookClient) ListEnvironmentWebhooks(
+	_ context.Context, org, project, env string,
+) ([]apitype.EnvironmentWebhook, error) {
+	if m.listCall != nil {
+		*m.listCall = struct{ org, project, env string }{org, project, env}
+	}
+	return m.listHooks, m.listErr
+}
+
+func (m *mockEnvWebhookClient) GetEnvironmentWebhook(
+	_ context.Context, org, project, env, name string,
+) (apitype.EnvironmentWebhook, error) {
+	if m.getCall != nil {
+		*m.getCall = struct{ org, project, env, name string }{org, project, env, name}
+	}
+	return m.getHook, m.getErr
+}
+
+func (m *mockEnvWebhookClient) CreateEnvironmentWebhook(
+	_ context.Context, org, project, env string, req apitype.CreateEnvironmentWebhookRequest,
+) (apitype.EnvironmentWebhook, error) {
+	if m.createCall != nil {
+		*m.createCall = struct {
+			org, project, env string
+			req               apitype.CreateEnvironmentWebhookRequest
+		}{org, project, env, req}
+	}
+	return m.createResp, m.createErr
+}
+
+func (m *mockEnvWebhookClient) UpdateEnvironmentWebhook(
+	_ context.Context, org, project, env, name string, req apitype.UpdateEnvironmentWebhookRequest,
+) (apitype.EnvironmentWebhook, error) {
+	if m.updateCall != nil {
+		*m.updateCall = struct {
+			org, project, env, name string
+			req                     apitype.UpdateEnvironmentWebhookRequest
+		}{org, project, env, name, req}
+	}
+	return m.updateResp, m.updateErr
+}
+
+func (m *mockEnvWebhookClient) DeleteEnvironmentWebhook(
+	_ context.Context, org, project, env, name string,
+) error {
+	if m.deleteCall != nil {
+		*m.deleteCall = struct{ org, project, env, name string }{org, project, env, name}
+	}
+	return m.deleteErr
+}
+
+func (m *mockEnvWebhookClient) PingEnvironmentWebhook(
+	_ context.Context, org, project, env, name string,
+) (apitype.EnvironmentWebhookDelivery, error) {
+	if m.pingCall != nil {
+		*m.pingCall = struct{ org, project, env, name string }{org, project, env, name}
+	}
+	return m.pingResp, m.pingErr
+}
+
+func (m *mockEnvWebhookClient) ListEnvironmentWebhookDeliveries(
+	_ context.Context, org, project, env, name string,
+) ([]apitype.EnvironmentWebhookDelivery, error) {
+	if m.deliveriesCall != nil {
+		*m.deliveriesCall = struct{ org, project, env, name string }{org, project, env, name}
+	}
+	return m.deliveries, m.deliveriesErr
+}
+
+// stubEnvWebhookFactory returns a factory that always yields the supplied
+// client and (overridable) org.
+func stubEnvWebhookFactory(c envWebhookClient, defaultOrg string) envWebhookFactory {
+	return func(_ context.Context, override string) (envWebhookClient, string, error) {
+		org := override
+		if org == "" {
+			org = defaultOrg
+		}
+		return c, org, nil
+	}
+}
+
+// failingEnvWebhookFactory returns a factory that always errors.
+func failingEnvWebhookFactory(err error) envWebhookFactory {
+	return func(_ context.Context, _ string) (envWebhookClient, string, error) {
+		return nil, "", err
+	}
+}
+
+// --- list --------------------------------------------------------------------
+
+func TestEnvWebhookList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text output with multiple webhooks", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			listHooks: []apitype.EnvironmentWebhook{
+				{Name: "a", DisplayName: "Alpha", PayloadURL: "https://a.example", Active: true},
+				{Name: "b", DisplayName: "Beta", PayloadURL: "https://b.example", Active: false},
+			},
+			listCall: &struct{ org, project, env string }{},
+		}
+
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"list", "myproj", "myenv"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		assert.Equal(t, "acme", mock.listCall.org)
+		assert.Equal(t, "myproj", mock.listCall.project)
+		assert.Equal(t, "myenv", mock.listCall.env)
+		assert.Contains(t, out.String(), "a")
+		assert.Contains(t, out.String(), "Alpha")
+		assert.Contains(t, out.String(), "2 webhook(s)")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			listHooks: []apitype.EnvironmentWebhook{
+				{Name: "a", DisplayName: "Alpha", PayloadURL: "https://a.example", Active: true},
+			},
+		}
+
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"list", "myproj", "myenv", "--output", "json"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		var got struct {
+			Webhooks []apitype.EnvironmentWebhook `json:"webhooks"`
+			Count    int                          `json:"count"`
+		}
+		require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+		assert.Equal(t, 1, got.Count)
+		assert.Equal(t, "a", got.Webhooks[0].Name)
+	})
+
+	t.Run("empty list prints a friendly line", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"list", "p", "e"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Contains(t, out.String(), "No webhooks configured")
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"list", "p", "e"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- new ---------------------------------------------------------------------
+
+func TestEnvWebhookNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forwards all flags to the create request", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			createResp: apitype.EnvironmentWebhook{
+				Name: "hook1", DisplayName: "Hook One", PayloadURL: "https://x", Active: true,
+			},
+			createCall: &struct {
+				org, project, env string
+				req               apitype.CreateEnvironmentWebhookRequest
+			}{},
+		}
+
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{
+			"new", "p", "e", "hook1",
+			"--url", "https://x",
+			"--display-name", "Hook One",
+			"--format", "slack",
+			"--filter", "added",
+			"--filter", "removed",
+			"--active=false",
+			"--secret", "shh",
+		})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		assert.Equal(t, "acme", mock.createCall.org)
+		assert.Equal(t, "p", mock.createCall.project)
+		assert.Equal(t, "e", mock.createCall.env)
+		assert.Equal(t, apitype.CreateEnvironmentWebhookRequest{
+			Name:        "hook1",
+			DisplayName: "Hook One",
+			PayloadURL:  "https://x",
+			Active:      false,
+			Format:      "slack",
+			Filters:     []string{"added", "removed"},
+			Secret:      "shh",
+		}, mock.createCall.req)
+	})
+
+	t.Run("defaults display name to webhook name", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			createCall: &struct {
+				org, project, env string
+				req               apitype.CreateEnvironmentWebhookRequest
+			}{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"new", "p", "e", "hook1", "--url", "https://x"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Equal(t, "hook1", mock.createCall.req.DisplayName)
+		assert.Equal(t, "raw", mock.createCall.req.Format)
+		assert.True(t, mock.createCall.req.Active)
+	})
+
+	t.Run("--url is required", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"new", "p", "e", "hook1"})
+		err := cmd.ExecuteContext(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "url")
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"new", "p", "e", "h", "--url", "https://x"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- edit --------------------------------------------------------------------
+
+func TestEnvWebhookEdit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("only --active=false sends just that field", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			updateCall: &struct {
+				org, project, env, name string
+				req                     apitype.UpdateEnvironmentWebhookRequest
+			}{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"edit", "p", "e", "h", "--active=false"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		got := mock.updateCall.req
+		require.NotNil(t, got.Active)
+		assert.False(t, *got.Active)
+		assert.Nil(t, got.PayloadURL)
+		assert.Nil(t, got.DisplayName)
+		assert.Nil(t, got.Format)
+		assert.Nil(t, got.Filters)
+		assert.Nil(t, got.Secret)
+	})
+
+	t.Run("no flags sends an empty PATCH body but still hits server", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			updateCall: &struct {
+				org, project, env, name string
+				req                     apitype.UpdateEnvironmentWebhookRequest
+			}{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"edit", "p", "e", "h"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Equal(t, "h", mock.updateCall.name)
+		assert.Equal(t, apitype.UpdateEnvironmentWebhookRequest{}, mock.updateCall.req)
+	})
+
+	t.Run("--add-filter triggers GET-then-PATCH and merges filters", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			getHook: apitype.EnvironmentWebhook{
+				Name: "h", Filters: []string{"existing-1", "existing-2"},
+			},
+			getCall: &struct{ org, project, env, name string }{},
+			updateCall: &struct {
+				org, project, env, name string
+				req                     apitype.UpdateEnvironmentWebhookRequest
+			}{},
+		}
+
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{
+			"edit", "p", "e", "h",
+			"--add-filter", "added-1",
+			"--remove-filter", "existing-2",
+		})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Equal(t, "h", mock.getCall.name)
+		require.NotNil(t, mock.updateCall.req.Filters)
+		assert.Equal(t, []string{"existing-1", "added-1"}, *mock.updateCall.req.Filters)
+	})
+
+	t.Run("--filter replaces the list outright with no GET", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			updateCall: &struct {
+				org, project, env, name string
+				req                     apitype.UpdateEnvironmentWebhookRequest
+			}{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"edit", "p", "e", "h", "--filter", "only-one"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		// GET should not be invoked: getCall is nil so we can't assert; just
+		// check Filters was set to the literal flag value.
+		require.NotNil(t, mock.updateCall.req.Filters)
+		assert.Equal(t, []string{"only-one"}, *mock.updateCall.req.Filters)
+	})
+
+	t.Run("--filter together with --add-filter is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"edit", "p", "e", "h", "--filter", "x", "--add-filter", "y"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "cannot be combined")
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"edit", "p", "e", "h"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- remove ------------------------------------------------------------------
+
+func TestEnvWebhookRemove(t *testing.T) {
+	t.Parallel()
+
+	t.Run("delete and confirmation line", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			deleteCall: &struct{ org, project, env, name string }{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"remove", "p", "e", "h"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Equal(t, "h", mock.deleteCall.name)
+		assert.Contains(t, out.String(), "Removed webhook")
+		assert.Contains(t, out.String(), "h")
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"remove", "p", "e", "h"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- ping --------------------------------------------------------------------
+
+func TestEnvWebhookPing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text rendering", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			pingResp: apitype.EnvironmentWebhookDelivery{
+				ID: "did-1", Kind: "ping", ResponseCode: 200, Duration: 42,
+			},
+			pingCall: &struct{ org, project, env, name string }{},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"ping", "p", "e", "h"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Equal(t, "h", mock.pingCall.name)
+		s := out.String()
+		assert.Contains(t, s, "did-1")
+		assert.Contains(t, s, "ping")
+		assert.Contains(t, s, "200")
+		assert.Contains(t, s, "42")
+	})
+
+	t.Run("json round-trips through apitype", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			pingResp: apitype.EnvironmentWebhookDelivery{
+				ID: "did-1", Kind: "ping", Timestamp: 123, Duration: 42,
+				Payload: "{}", RequestURL: "https://x", RequestHeaders: "{}",
+				ResponseCode: 200, ResponseHeaders: "{}", ResponseBody: "{}",
+			},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"ping", "p", "e", "h", "--output", "json"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		var got apitype.EnvironmentWebhookDelivery
+		require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+		assert.Equal(t, mock.pingResp, got)
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"ping", "p", "e", "h"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- delivery list -----------------------------------------------------------
+
+func TestEnvWebhookDeliveryList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders rows", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			deliveries: []apitype.EnvironmentWebhookDelivery{
+				{ID: "d1", Kind: "ping", Timestamp: 1, ResponseCode: 200, Duration: 10},
+				{ID: "d2", Kind: "stack.updated", Timestamp: 2, ResponseCode: 500, Duration: 20},
+			},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"delivery", "list", "p", "e", "h"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		s := out.String()
+		assert.Contains(t, s, "d1")
+		assert.Contains(t, s, "d2")
+		assert.Contains(t, s, "2 delivery(ies)")
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"delivery", "list", "p", "e", "h"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+		assert.Contains(t, out.String(), "No deliveries")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockEnvWebhookClient{
+			deliveries: []apitype.EnvironmentWebhookDelivery{
+				{ID: "d1", Kind: "ping", ResponseCode: 200},
+			},
+		}
+		cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"delivery", "list", "p", "e", "h", "--output", "json"})
+		require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+		var env struct {
+			Deliveries []apitype.EnvironmentWebhookDelivery `json:"deliveries"`
+			Count      int                                  `json:"count"`
+		}
+		require.NoError(t, json.Unmarshal(out.Bytes(), &env))
+		assert.Equal(t, 1, env.Count)
+		assert.Equal(t, "d1", env.Deliveries[0].ID)
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := newEnvWebhookCmdWith(failingEnvWebhookFactory(errors.New("nope")))
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&out)
+		cmd.SetArgs([]string{"delivery", "list", "p", "e", "h"})
+		require.ErrorContains(t, cmd.ExecuteContext(t.Context()), "nope")
+	})
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func TestMergeFilters(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                          string
+		existing, adds, removes, want []string
+	}{
+		{"no-op", []string{"a", "b"}, nil, nil, []string{"a", "b"}},
+		{"add new", []string{"a"}, []string{"b"}, nil, []string{"a", "b"}},
+		{"add dup", []string{"a"}, []string{"a"}, nil, []string{"a"}},
+		{"remove existing", []string{"a", "b"}, nil, []string{"a"}, []string{"b"}},
+		{"add and remove", []string{"a", "b"}, []string{"c"}, []string{"b"}, []string{"a", "c"}},
+		{"remove wins over add", []string{}, []string{"a"}, []string{"a"}, []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, mergeFilters(tc.existing, tc.adds, tc.removes))
+		})
+	}
+}
+
+func TestEnvWebhookInvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockEnvWebhookClient{}
+	cmd := newEnvWebhookCmdWith(stubEnvWebhookFactory(mock, "acme"))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"list", "p", "e", "--output", "yaml"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "invalid --output")
+}

--- a/sdk/go/common/apitype/environment_webhooks.go
+++ b/sdk/go/common/apitype/environment_webhooks.go
@@ -1,0 +1,75 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// EnvironmentWebhook is the response shape for a Pulumi ESC environment
+// webhook. It mirrors the OpenAPI `WebhookResponse` schema for the env
+// endpoints — distinct from the stack-shaped `Webhook` defined in webhooks.go.
+type EnvironmentWebhook struct {
+	OrganizationName string   `json:"organizationName"`
+	ProjectName      string   `json:"projectName,omitempty"`
+	EnvName          string   `json:"envName,omitempty"`
+	Name             string   `json:"name"`
+	DisplayName      string   `json:"displayName"`
+	PayloadURL       string   `json:"payloadUrl"`
+	Active           bool     `json:"active"`
+	Format           string   `json:"format,omitempty"`
+	Filters          []string `json:"filters,omitempty"`
+	Groups           []string `json:"groups,omitempty"`
+	HasSecret        bool     `json:"hasSecret,omitempty"`
+	SecretCiphertext string   `json:"secretCiphertext,omitempty"`
+}
+
+// CreateEnvironmentWebhookRequest is the body for the create endpoint.
+// Required: Name, DisplayName, PayloadURL, Active.
+type CreateEnvironmentWebhookRequest struct {
+	OrganizationName string   `json:"organizationName,omitempty"`
+	ProjectName      string   `json:"projectName,omitempty"`
+	EnvName          string   `json:"envName,omitempty"`
+	Name             string   `json:"name"`
+	DisplayName      string   `json:"displayName"`
+	PayloadURL       string   `json:"payloadUrl"`
+	Active           bool     `json:"active"`
+	Format           string   `json:"format,omitempty"`
+	Filters          []string `json:"filters,omitempty"`
+	Secret           string   `json:"secret,omitempty"`
+}
+
+// UpdateEnvironmentWebhookRequest is the PATCH body for edit. All fields are
+// pointers so callers can express "leave unchanged" by passing nil. Lists
+// replace the entire stored list; for partial edits do a GET first and merge.
+type UpdateEnvironmentWebhookRequest struct {
+	DisplayName *string   `json:"displayName,omitempty"`
+	PayloadURL  *string   `json:"payloadUrl,omitempty"`
+	Active      *bool     `json:"active,omitempty"`
+	Format      *string   `json:"format,omitempty"`
+	Filters     *[]string `json:"filters,omitempty"`
+	Secret      *string   `json:"secret,omitempty"`
+}
+
+// EnvironmentWebhookDelivery describes one delivery attempt for an environment
+// webhook. Mirrors the OpenAPI `WebhookDelivery` schema.
+type EnvironmentWebhookDelivery struct {
+	ID              string `json:"id"`
+	Kind            string `json:"kind"`
+	Timestamp       int64  `json:"timestamp"`
+	Duration        int64  `json:"duration"`
+	Payload         string `json:"payload"`
+	RequestURL      string `json:"requestUrl"`
+	RequestHeaders  string `json:"requestHeaders"`
+	ResponseCode    int64  `json:"responseCode"`
+	ResponseHeaders string `json:"responseHeaders"`
+	ResponseBody    string `json:"responseBody"`
+}


### PR DESCRIPTION
## Summary
- Implements `pulumi env webhook {list,new,edit,remove,ping,delivery list}` for managing Pulumi ESC environment webhooks.
- Adds seven client methods on `pkg/backend/httpstate/client/client.go` plus environment-specific webhook apitypes (distinct from the stack-shaped `apitype.Webhook`).
- `edit` honours the parent epic's ternary-flag rules and supports `--add-filter` / `--remove-filter` via GET-then-PATCH.

Closes #23030 (and rolls up #23023–#23029).

## Test plan
- [x] `cd pkg && mise exec -- go test -count=1 -tags all ./cmd/pulumi/env/... ./backend/httpstate/client/...`
- [x] `mise exec -- make lint`
- [ ] Manual: create a webhook against a real environment, ping it, list deliveries, edit it (toggle active, swap a filter), remove it

🤖 Generated with [Claude Code](https://claude.com/claude-code)