### PR TITLE
cli/cloud: implement `pulumi env referrer list`

### DIFF
--- a/changelog/pending/20260513--cli-cloud--add-pulumi-env-referrer-list.yaml
+++ b/changelog/pending/20260513--cli-cloud--add-pulumi-env-referrer-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi env referrer list` to list entities that reference a Pulumi ESC environment

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2428,3 +2428,38 @@ func (pc *Client) SearchInsightsResources(
 	}
 	return resp, nil
 }
+
+// --- ESC environment referrers ---
+
+// ListEnvironmentReferrersOptions selects the query parameters accepted by the
+// `ListEnvironmentReferrers` endpoint. The zero value sends no query
+// parameters, leaving server-side defaults in place.
+type ListEnvironmentReferrersOptions struct {
+	// Count is the maximum number of results to return (1-500). Zero leaves
+	// the server-side default in place.
+	Count int `url:"count,omitempty"`
+	// AllRevisions includes references across all revisions of the
+	// environment when true.
+	AllRevisions bool `url:"allRevisions,omitempty"`
+	// LatestStackVersionOnly returns only the latest stack version for each
+	// referring stack when true.
+	LatestStackVersionOnly bool `url:"latestStackVersionOnly,omitempty"`
+	// ContinuationToken pages through results returned by a previous call.
+	ContinuationToken string `url:"continuationToken,omitempty"`
+}
+
+// ListEnvironmentReferrers returns the entities that reference a Pulumi ESC
+// environment.
+func (pc *Client) ListEnvironmentReferrers(
+	ctx context.Context, org, project, env string, opts ListEnvironmentReferrersOptions,
+) (apitype.ListEnvironmentReferrersResponse, error) {
+	path := fmt.Sprintf(
+		"/api/esc/environments/%s/%s/%s/referrers",
+		url.PathEscape(org), url.PathEscape(project), url.PathEscape(env),
+	)
+	var resp apitype.ListEnvironmentReferrersResponse
+	if err := pc.restCall(ctx, "GET", path, opts, nil, &resp); err != nil {
+		return apitype.ListEnvironmentReferrersResponse{}, err
+	}
+	return resp, nil
+}

--- a/pkg/backend/httpstate/client/client_esc_environments_test.go
+++ b/pkg/backend/httpstate/client/client_esc_environments_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestListEnvironmentReferrers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses response and forwards query params", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ListEnvironmentReferrersResponse{
+			Referrers: map[string][]apitype.EnvironmentReferrer{
+				"latest": {
+					{Stack: &apitype.EnvironmentStackReferrer{
+						Project: "p", Stack: "dev", Version: 4,
+					}},
+				},
+			},
+			ContinuationToken: "next-page",
+		}
+
+		var capturedURL string
+		var capturedMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURL = r.URL.String()
+			capturedMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.ListEnvironmentReferrers(t.Context(), "acme", "my-project", "my-env",
+			ListEnvironmentReferrersOptions{
+				Count:                  50,
+				AllRevisions:           true,
+				LatestStackVersionOnly: true,
+				ContinuationToken:      "abc",
+			})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+
+		assert.Equal(t, http.MethodGet, capturedMethod)
+		assert.Contains(t, capturedURL, "/api/esc/environments/acme/my-project/my-env/referrers")
+		assert.Contains(t, capturedURL, "count=50")
+		assert.Contains(t, capturedURL, "allRevisions=true")
+		assert.Contains(t, capturedURL, "latestStackVersionOnly=true")
+		assert.Contains(t, capturedURL, "continuationToken=abc")
+	})
+
+	t.Run("zero-valued options send no query string", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.ListEnvironmentReferrersResponse{}))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.ListEnvironmentReferrers(t.Context(), "acme", "p", "e",
+			ListEnvironmentReferrersOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, capturedQuery)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.ListEnvironmentReferrers(t.Context(), "acme", "p", "missing",
+			ListEnvironmentReferrersOptions{})
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/env/env_referrer.go
+++ b/pkg/cmd/pulumi/env/env_referrer.go
@@ -15,19 +15,26 @@
 package env
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"sort"
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 func newEnvReferrerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "referrer",
-		Short:  "Inspect entities that reference an environment",
-		Long:   "[EXPERIMENTAL] Inspect entities that reference an environment.",
+		Use:   "referrer",
+		Short: "Inspect entities that reference an environment",
+		Long:  "[EXPERIMENTAL] Inspect entities that reference an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -39,42 +46,221 @@ func newEnvReferrerCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23041]: Not yet implemented.
+// envReferrerListClient is the slice of the cloud API the list command needs.
+// Defined locally so unit tests can stub it without touching the full HTTP
+// client surface.
+type envReferrerListClient interface {
+	ListEnvironmentReferrers(
+		ctx context.Context, org, project, env string,
+		opts client.ListEnvironmentReferrersOptions,
+	) (apitype.ListEnvironmentReferrersResponse, error)
+}
+
+// envReferrerListFactory resolves a cloud client and the effective org for the
+// call. orgOverride wins when non-empty; otherwise the default org from the
+// cloud context is used.
+type envReferrerListFactory func(
+	ctx context.Context, orgOverride string,
+) (envReferrerListClient, string, error)
+
+type envReferrerListArgs struct {
+	org                    string
+	count                  int
+	allRevisions           bool
+	latestStackVersionOnly bool
+	continuationToken      string
+	output                 string
+}
+
 func newEnvReferrerListCmd() *cobra.Command {
-	var (
-		org                    string
-		count                  int
-		allRevisions           bool
-		latestStackVersionOnly bool
-		token                  string
-	)
+	return newEnvReferrerListCmdWith(nil)
+}
+
+// newEnvReferrerListCmdWith builds the `pulumi env referrer list` command.
+// factory produces the cloud client and resolves the effective org; pass nil
+// to use the production factory backed by [cloud.ResolveContext].
+func newEnvReferrerListCmdWith(factory envReferrerListFactory) *cobra.Command {
+	var args envReferrerListArgs
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List entities that reference an environment",
-		Long:   "[EXPERIMENTAL] List entities that reference an environment.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+		Use:   "list",
+		Short: "List entities that reference an environment",
+		Long: "[EXPERIMENTAL] List entities that reference an environment.\n" +
+			"\n" +
+			"Returns environments that import the target environment, Pulumi stacks\n" +
+			"whose configuration imports it, and Insights accounts that use it.\n" +
+			"Results are paginated; use --count and --continuation-token to page.\n" +
+			"\n" +
+			"Wraps the `ListEnvironmentReferrers` Pulumi Cloud REST endpoint.",
+		Example: "  # List the referrers of an environment.\n" +
+			"  pulumi env referrer list my-project my-env\n\n" +
+			"  # Page through results.\n" +
+			"  pulumi env referrer list my-project my-env --count 50\n\n" +
+			"  # Emit JSON for scripting.\n" +
+			"  pulumi env referrer list my-project my-env --output json",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			resolveFactory := factory
+			if resolveFactory == nil {
+				resolveFactory = defaultEnvReferrerListFactory
+			}
+			return runEnvReferrerList(cmd.Context(), cmd.OutOrStdout(), resolveFactory,
+				posArgs[0], posArgs[1], args)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "project"},
-			{Name: "name"},
-		},
-		Required: 2,
+		Arguments: []constrictor.Argument{{Name: "project"}, {Name: "name"}},
+		Required:  2,
 	})
 
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-	cmd.Flags().IntVar(&count, "count", 0, "The maximum number of results to return (1-500)")
-	cmd.Flags().BoolVar(&allRevisions, "all-revisions", false,
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"The organization that owns the environment (defaults to the current default org)")
+	cmd.Flags().IntVar(&args.count, "count", 0,
+		"The maximum number of results to return (1-500)")
+	cmd.Flags().BoolVar(&args.allRevisions, "all-revisions", false,
 		"Include references across all revisions")
-	cmd.Flags().BoolVar(&latestStackVersionOnly, "latest-stack-version-only", false,
+	cmd.Flags().BoolVar(&args.latestStackVersionOnly, "latest-stack-version-only", false,
 		"Return only the latest stack version for each referring stack")
-	cmd.Flags().StringVar(&token, "continuation-token", "",
+	cmd.Flags().StringVar(&args.continuationToken, "continuation-token", "",
 		"The continuation token for paginated retrieval")
+	cmd.Flags().StringVarP(&args.output, "output", "o", "default",
+		"Output format. One of: default, json")
 
 	return cmd
+}
+
+// runEnvReferrerList executes the list operation. ctx and out are decoupled
+// from cobra so the function is straightforward to drive from tests.
+func runEnvReferrerList(
+	ctx context.Context, out io.Writer, factory envReferrerListFactory,
+	project, name string, args envReferrerListArgs,
+) error {
+	// Validate --output before talking to the network so a typo doesn't burn
+	// an API call.
+	render, err := envReferrerListRenderer(args.output)
+	if err != nil {
+		return err
+	}
+
+	c, org, err := factory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.ListEnvironmentReferrers(ctx, org, project, name,
+		client.ListEnvironmentReferrersOptions{
+			Count:                  args.count,
+			AllRevisions:           args.allRevisions,
+			LatestStackVersionOnly: args.latestStackVersionOnly,
+			ContinuationToken:      args.continuationToken,
+		})
+	if err != nil {
+		return fmt.Errorf("listing referrers for %s/%s/%s: %w", org, project, name, err)
+	}
+	return render(out, resp)
+}
+
+type envReferrerListRenderFunc func(io.Writer, apitype.ListEnvironmentReferrersResponse) error
+
+// envReferrerListRenderer maps --output to the corresponding render function.
+// Returns a caller-actionable error for unknown values.
+func envReferrerListRenderer(format string) (envReferrerListRenderFunc, error) {
+	switch format {
+	case "", "default":
+		return renderReferrerListText, nil
+	case "json":
+		return renderReferrerListJSON, nil
+	default:
+		return nil, fmt.Errorf(
+			"invalid --output value %q (must be 'default' or 'json')", format)
+	}
+}
+
+// renderReferrerListText writes a human-readable view of the response to w.
+// The API returns referrers grouped by revision tag (e.g. "latest") or
+// revision number; we emit each group under a heading and walk it in deterministic
+// order so the output is stable across runs.
+func renderReferrerListText(w io.Writer, r apitype.ListEnvironmentReferrersResponse) error {
+	total := 0
+	for _, group := range r.Referrers {
+		total += len(group)
+	}
+	if total == 0 {
+		fmt.Fprintln(w, "No referrers found for this environment.")
+		return nil
+	}
+
+	keys := make([]string, 0, len(r.Referrers))
+	for k := range r.Referrers {
+		keys = append(keys, k)
+	}
+	// "latest" first, then numeric/lexicographic order, so the most useful
+	// group is on top and the rest is stable.
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i] == "latest" {
+			return true
+		}
+		if keys[j] == "latest" {
+			return false
+		}
+		return keys[i] < keys[j]
+	})
+
+	for i, key := range keys {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "Revision: %s\n", key)
+		for _, ref := range r.Referrers[key] {
+			switch {
+			case ref.Environment != nil:
+				e := ref.Environment
+				fmt.Fprintf(w, "  environment  %s/%s  rev=%d\n", e.Project, e.Name, e.Revision)
+			case ref.Stack != nil:
+				s := ref.Stack
+				fmt.Fprintf(w, "  stack        %s/%s  ver=%d\n", s.Project, s.Stack, s.Version)
+			case ref.InsightsAccount != nil:
+				fmt.Fprintf(w, "  insights     %s\n", ref.InsightsAccount.AccountName)
+			}
+		}
+	}
+	if r.ContinuationToken != "" {
+		fmt.Fprintf(w, "\nNext page: --continuation-token=%s\n", r.ContinuationToken)
+	}
+	return nil
+}
+
+// renderReferrerListJSON writes the response as indented JSON. Indentation
+// matches the rest of the cli/cloud commands so jq-style scripting feels
+// consistent.
+func renderReferrerListJSON(w io.Writer, r apitype.ListEnvironmentReferrersResponse) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// defaultEnvReferrerListFactory is the production wiring for
+// envReferrerListFactory. It resolves the cloud context via
+// cloud.ResolveContext and surfaces the *client.Client directly —
+// *client.Client already satisfies envReferrerListClient through its
+// ListEnvironmentReferrers method.
+func defaultEnvReferrerListFactory(
+	ctx context.Context, orgOverride string,
+) (envReferrerListClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+	return resolved.Client, org, nil
 }

--- a/pkg/cmd/pulumi/env/env_referrer_test.go
+++ b/pkg/cmd/pulumi/env/env_referrer_test.go
@@ -1,0 +1,206 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+type capturedReferrerCall struct {
+	org, project, env string
+	opts              client.ListEnvironmentReferrersOptions
+}
+
+type mockReferrerClient struct {
+	resp     apitype.ListEnvironmentReferrersResponse
+	err      error
+	captured *capturedReferrerCall
+}
+
+func (m *mockReferrerClient) ListEnvironmentReferrers(
+	_ context.Context, org, project, env string, opts client.ListEnvironmentReferrersOptions,
+) (apitype.ListEnvironmentReferrersResponse, error) {
+	if m.captured != nil {
+		*m.captured = capturedReferrerCall{org: org, project: project, env: env, opts: opts}
+	}
+	return m.resp, m.err
+}
+
+func stubReferrerFactory(c envReferrerListClient, defaultOrg string) envReferrerListFactory {
+	return func(_ context.Context, orgOverride string) (envReferrerListClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return c, org, nil
+	}
+}
+
+func sampleReferrers() apitype.ListEnvironmentReferrersResponse {
+	return apitype.ListEnvironmentReferrersResponse{
+		Referrers: map[string][]apitype.EnvironmentReferrer{
+			"latest": {
+				{Environment: &apitype.EnvironmentImportReferrer{
+					Project: "p2", Name: "shared", Revision: 2,
+				}},
+				{Stack: &apitype.EnvironmentStackReferrer{
+					Project: "p", Stack: "dev", Version: 4,
+				}},
+				{InsightsAccount: &apitype.EnvironmentInsightsAccountReferrer{
+					AccountName: "scanner",
+				}},
+			},
+			"3": {
+				{Stack: &apitype.EnvironmentStackReferrer{
+					Project: "p", Stack: "dev", Version: 2,
+				}},
+			},
+		},
+		ContinuationToken: "token-2",
+	}
+}
+
+func TestEnvReferrerList_DefaultOutput(t *testing.T) {
+	t.Parallel()
+	c := &mockReferrerClient{resp: sampleReferrers()}
+
+	var out bytes.Buffer
+	require.NoError(t, runEnvReferrerList(t.Context(), &out, stubReferrerFactory(c, "acme"),
+		"my-project", "my-env", envReferrerListArgs{}))
+
+	text := out.String()
+	assert.Contains(t, text, "Revision: latest")
+	assert.Contains(t, text, "Revision: 3")
+	assert.Contains(t, text, "environment  p2/shared  rev=2")
+	assert.Contains(t, text, "stack        p/dev  ver=4")
+	assert.Contains(t, text, "insights     scanner")
+	assert.Contains(t, text, "Next page: --continuation-token=token-2")
+	// "latest" should be ordered above "3".
+	assert.Less(t, bytes.Index(out.Bytes(), []byte("Revision: latest")),
+		bytes.Index(out.Bytes(), []byte("Revision: 3")))
+}
+
+func TestEnvReferrerList_JSON(t *testing.T) {
+	t.Parallel()
+	c := &mockReferrerClient{resp: sampleReferrers()}
+
+	var out bytes.Buffer
+	require.NoError(t, runEnvReferrerList(t.Context(), &out, stubReferrerFactory(c, "acme"),
+		"my-project", "my-env", envReferrerListArgs{output: "json"}))
+
+	var got apitype.ListEnvironmentReferrersResponse
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, sampleReferrers(), got)
+}
+
+func TestEnvReferrerList_Empty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		resp apitype.ListEnvironmentReferrersResponse
+	}{
+		{"nil map", apitype.ListEnvironmentReferrersResponse{}},
+		{"empty groups", apitype.ListEnvironmentReferrersResponse{
+			Referrers: map[string][]apitype.EnvironmentReferrer{"latest": {}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &mockReferrerClient{resp: tc.resp}
+			var out bytes.Buffer
+			require.NoError(t, runEnvReferrerList(t.Context(), &out,
+				stubReferrerFactory(c, "acme"), "my-project", "my-env", envReferrerListArgs{}))
+			assert.Contains(t, out.String(), "No referrers found")
+		})
+	}
+}
+
+func TestEnvReferrerList_InvalidOutput(t *testing.T) {
+	t.Parallel()
+	c := &mockReferrerClient{resp: sampleReferrers()}
+
+	var out bytes.Buffer
+	err := runEnvReferrerList(t.Context(), &out, stubReferrerFactory(c, "acme"),
+		"p", "e", envReferrerListArgs{output: "yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
+}
+
+func TestEnvReferrerList_ClientError(t *testing.T) {
+	t.Parallel()
+	c := &mockReferrerClient{err: errors.New("403 forbidden")}
+
+	var out bytes.Buffer
+	err := runEnvReferrerList(t.Context(), &out, stubReferrerFactory(c, "acme"),
+		"p", "e", envReferrerListArgs{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing referrers for acme/p/e")
+}
+
+func TestNewEnvReferrerListCmd_FlagBinding(t *testing.T) {
+	t.Parallel()
+
+	var captured capturedReferrerCall
+	c := &mockReferrerClient{resp: sampleReferrers(), captured: &captured}
+	cmd := newEnvReferrerListCmdWith(stubReferrerFactory(c, "acme"))
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--org", "other-co", "--count", "100", "--all-revisions",
+		"--latest-stack-version-only", "--continuation-token", "tok",
+		"--output", "json", "my-project", "my-env",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	assert.Equal(t, capturedReferrerCall{
+		org: "other-co", project: "my-project", env: "my-env",
+		opts: client.ListEnvironmentReferrersOptions{
+			Count: 100, AllRevisions: true,
+			LatestStackVersionOnly: true, ContinuationToken: "tok",
+		},
+	}, captured)
+}
+
+func TestNewEnvReferrerListCmd_DefaultOrg(t *testing.T) {
+	t.Parallel()
+
+	var captured capturedReferrerCall
+	c := &mockReferrerClient{resp: sampleReferrers(), captured: &captured}
+	cmd := newEnvReferrerListCmdWith(stubReferrerFactory(c, "default-org"))
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"proj", "envname"})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	assert.Equal(t, "default-org", captured.org)
+	assert.Equal(t, "proj", captured.project)
+	assert.Equal(t, "envname", captured.env)
+}

--- a/sdk/go/common/apitype/environment_referrers.go
+++ b/sdk/go/common/apitype/environment_referrers.go
@@ -1,0 +1,70 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// EnvironmentReferrer describes a single referrer of an ESC environment.
+// Exactly one of Environment, Stack, or InsightsAccount is populated.
+type EnvironmentReferrer struct {
+	// Environment is set when the referrer is another ESC environment that
+	// imports the target environment.
+	Environment *EnvironmentImportReferrer `json:"environment,omitempty"`
+	// Stack is set when the referrer is a Pulumi stack whose configuration
+	// imports the target environment.
+	Stack *EnvironmentStackReferrer `json:"stack,omitempty"`
+	// InsightsAccount is set when the referrer is a Pulumi Insights account
+	// that uses the target environment.
+	InsightsAccount *EnvironmentInsightsAccountReferrer `json:"insightsAccount,omitempty"`
+}
+
+// EnvironmentImportReferrer identifies another ESC environment that imports
+// the target environment.
+type EnvironmentImportReferrer struct {
+	// Project is the project name of the referring environment.
+	Project string `json:"project"`
+	// Name is the name of the referring environment.
+	Name string `json:"name"`
+	// Revision is the revision number of the referring environment.
+	Revision int `json:"revision"`
+}
+
+// EnvironmentStackReferrer identifies a stack whose configuration imports the
+// target environment.
+type EnvironmentStackReferrer struct {
+	// Project is the project name of the referring stack.
+	Project string `json:"project"`
+	// Stack is the name of the referring stack.
+	Stack string `json:"stack"`
+	// Version is the version of the stack update that references the target
+	// environment.
+	Version int `json:"version"`
+}
+
+// EnvironmentInsightsAccountReferrer identifies an Insights account that uses
+// the target environment.
+type EnvironmentInsightsAccountReferrer struct {
+	// AccountName is the name of the Insights account that references the
+	// target environment.
+	AccountName string `json:"accountName"`
+}
+
+// ListEnvironmentReferrersResponse is the response shape of
+// `GET /api/esc/environments/{org}/{project}/{env}/referrers`.
+//
+// Referrers is a map keyed by revision tag or revision number (e.g. "latest"
+// or "3") whose value is the slice of referrers that point at that revision.
+type ListEnvironmentReferrersResponse struct {
+	Referrers         map[string][]EnvironmentReferrer `json:"referrers"`
+	ContinuationToken string                           `json:"continuationToken,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Implements `pulumi env referrer list <project> <name>` to list entities (other environments, Insights accounts, stacks) that reference a Pulumi ESC environment.
- Adds `client.ListEnvironmentReferrers` and `apitype.ListEnvironmentReferrersResponse` (and the three referrer record types).
- Default human-readable rendering groups referrers by revision tag (`latest` first); `--output=json` for scripting.

The apitype shapes match the `EnvironmentImportReferrer`, `EnvironmentStackReferrer`, `EnvironmentInsightsAccountReferrer`, and `ListEnvironmentReferrersResponse` schemas in the Pulumi Cloud OpenAPI spec. Notably, `Referrers` is a `map[string][]EnvironmentReferrer` keyed by revision tag/number (e.g. `"latest"` or `"3"`), not a flat slice.

Closes #23041.

## Test plan
- [ ] `cd pkg && mise exec -- go test -count=1 -tags all ./cmd/pulumi/env/... ./backend/httpstate/client/...`
- [ ] `mise exec -- make lint`
- [ ] Manual: `pulumi env referrer list my-project my-env --count 10` against a real environment

Generated with [Claude Code](https://claude.com/claude-code)