### PR TITLE
cli/cloud: implement `pulumi env schedule` subcommands

### DIFF
--- a/changelog/pending/20260513--cli-cloud--add-pulumi-env-schedule.yaml
+++ b/changelog/pending/20260513--cli-cloud--add-pulumi-env-schedule.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi env schedule` to manage Pulumi ESC environment scheduled actions

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2428,3 +2428,59 @@ func (pc *Client) SearchInsightsResources(
 	}
 	return resp, nil
 }
+
+// --- ESC environment schedules ---
+
+func envSchedulesPath(org, project, env string, parts ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "/api/esc/environments/%s/%s/%s/schedules",
+		url.PathEscape(org), url.PathEscape(project), url.PathEscape(env))
+	for _, x := range parts {
+		b.WriteByte('/')
+		b.WriteString(url.PathEscape(x))
+	}
+	return b.String()
+}
+
+// ListEnvironmentSchedules returns all scheduled actions for the environment.
+func (pc *Client) ListEnvironmentSchedules(
+	ctx context.Context, org, project, env string,
+) (apitype.ListScheduledActionsResponse, error) {
+	var resp apitype.ListScheduledActionsResponse
+	if err := pc.restCall(ctx, "GET", envSchedulesPath(org, project, env), nil, nil, &resp); err != nil {
+		return apitype.ListScheduledActionsResponse{}, err
+	}
+	return resp, nil
+}
+
+// CreateEnvironmentSchedule creates a scheduled action.
+func (pc *Client) CreateEnvironmentSchedule(
+	ctx context.Context, org, project, env string, req apitype.CreateEnvironmentScheduleRequest,
+) (apitype.ScheduledAction, error) {
+	var resp apitype.ScheduledAction
+	if err := pc.restCall(ctx, "POST", envSchedulesPath(org, project, env), nil, req, &resp); err != nil {
+		return apitype.ScheduledAction{}, err
+	}
+	return resp, nil
+}
+
+// PauseEnvironmentSchedule pauses a scheduled action.
+func (pc *Client) PauseEnvironmentSchedule(
+	ctx context.Context, org, project, env, scheduleID string,
+) error {
+	return pc.restCall(ctx, "POST", envSchedulesPath(org, project, env, scheduleID, "pause"), nil, nil, nil)
+}
+
+// ResumeEnvironmentSchedule resumes a paused scheduled action.
+func (pc *Client) ResumeEnvironmentSchedule(
+	ctx context.Context, org, project, env, scheduleID string,
+) error {
+	return pc.restCall(ctx, "POST", envSchedulesPath(org, project, env, scheduleID, "resume"), nil, nil, nil)
+}
+
+// DeleteEnvironmentSchedule deletes a scheduled action.
+func (pc *Client) DeleteEnvironmentSchedule(
+	ctx context.Context, org, project, env, scheduleID string,
+) error {
+	return pc.restCall(ctx, "DELETE", envSchedulesPath(org, project, env, scheduleID), nil, nil, nil)
+}

--- a/pkg/backend/httpstate/client/client_esc_environments_test.go
+++ b/pkg/backend/httpstate/client/client_esc_environments_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestEnvironmentSchedules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("list", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ListScheduledActionsResponse{
+			Schedules: []apitype.ScheduledAction{
+				{ID: "s1", Kind: "environment_rotation", ScheduleCron: "0 9 * * *"},
+				{ID: "s2", Kind: "environment_rotation", ScheduleOnce: "2030-01-01T00:00:00Z"},
+			},
+		}
+
+		var capturedPath, capturedMethod string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			capturedMethod = r.Method
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer srv.Close()
+
+		got, err := newMockClient(srv).ListEnvironmentSchedules(t.Context(), "acme", "p", "e")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, "/api/esc/environments/acme/p/e/schedules", capturedPath)
+		assert.Equal(t, "GET", capturedMethod)
+	})
+
+	t.Run("list http error", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusInternalServerError, `{"message":"internal error"}`)
+		defer srv.Close()
+
+		_, err := newMockClient(srv).ListEnvironmentSchedules(t.Context(), "acme", "p", "e")
+		assert.Error(t, err)
+	})
+
+	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ScheduledAction{ID: "s1", Kind: "environment_rotation", ScheduleCron: "0 9 * * *"}
+		var capturedBody apitype.CreateEnvironmentScheduleRequest
+		var capturedMethod, capturedPath string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedMethod = r.Method
+			capturedPath = r.URL.Path
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer srv.Close()
+
+		req := apitype.CreateEnvironmentScheduleRequest{
+			ScheduleCron:          "0 9 * * *",
+			SecretRotationRequest: &apitype.CreateEnvironmentSecretRotationScheduleRequest{},
+		}
+		got, err := newMockClient(srv).CreateEnvironmentSchedule(t.Context(), "acme", "p", "e", req)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, "POST", capturedMethod)
+		assert.Equal(t, "/api/esc/environments/acme/p/e/schedules", capturedPath)
+		assert.Equal(t, "0 9 * * *", capturedBody.ScheduleCron)
+		require.NotNil(t, capturedBody.SecretRotationRequest)
+	})
+
+	for _, op := range []struct {
+		name, method, suffix string
+		call                 func(context.Context, *Client) error
+	}{
+		{"pause", "POST", "/pause", func(ctx context.Context, c *Client) error {
+			return c.PauseEnvironmentSchedule(ctx, "acme", "p", "e", "s1")
+		}},
+		{"resume", "POST", "/resume", func(ctx context.Context, c *Client) error {
+			return c.ResumeEnvironmentSchedule(ctx, "acme", "p", "e", "s1")
+		}},
+		{"delete", "DELETE", "", func(ctx context.Context, c *Client) error {
+			return c.DeleteEnvironmentSchedule(ctx, "acme", "p", "e", "s1")
+		}},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			t.Parallel()
+
+			var capturedMethod, capturedPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedMethod = r.Method
+				capturedPath = r.URL.Path
+			}))
+			defer srv.Close()
+
+			require.NoError(t, op.call(t.Context(), newMockClient(srv)))
+			assert.Equal(t, op.method, capturedMethod)
+			assert.Equal(t, "/api/esc/environments/acme/p/e/schedules/s1"+op.suffix, capturedPath)
+		})
+	}
+
+	t.Run("path escaping", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedRawPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedRawPath = r.URL.EscapedPath()
+		}))
+		defer srv.Close()
+
+		require.NoError(t, newMockClient(srv).DeleteEnvironmentSchedule(
+			t.Context(), "acme", "my project", "env/with/slash", "id with space"))
+		assert.Equal(t,
+			"/api/esc/environments/acme/my%20project/env%2Fwith%2Fslash/schedules/id%20with%20space",
+			capturedRawPath)
+	})
+}

--- a/pkg/cmd/pulumi/env/env_schedule.go
+++ b/pkg/cmd/pulumi/env/env_schedule.go
@@ -15,20 +15,41 @@
 package env
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// TODO[https://github.com/pulumi/pulumi/issues/23036]: Not yet implemented.
+// envScheduleClient is the API surface used by `env schedule *`.
+type envScheduleClient interface {
+	ListEnvironmentSchedules(ctx context.Context, org, project, env string) (apitype.ListScheduledActionsResponse, error)
+	CreateEnvironmentSchedule(
+		ctx context.Context, org, project, env string, req apitype.CreateEnvironmentScheduleRequest,
+	) (apitype.ScheduledAction, error)
+	PauseEnvironmentSchedule(ctx context.Context, org, project, env, id string) error
+	ResumeEnvironmentSchedule(ctx context.Context, org, project, env, id string) error
+	DeleteEnvironmentSchedule(ctx context.Context, org, project, env, id string) error
+}
+
+type envScheduleFactory func(ctx context.Context, orgOverride string) (envScheduleClient, string, error)
+
 func newEnvScheduleCmd() *cobra.Command {
+	return newEnvScheduleCmdWith(nil)
+}
+
+func newEnvScheduleCmdWith(factory envScheduleFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "schedule",
-		Short:  "Manage environment scheduled actions",
-		Long:   "[EXPERIMENTAL] Manage environment scheduled actions.",
+		Use:   "schedule",
+		Short: "Manage environment scheduled actions",
+		Long:  "[EXPERIMENTAL] Manage environment scheduled actions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -36,11 +57,11 @@ func newEnvScheduleCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(newEnvScheduleListCmd())
-	cmd.AddCommand(newEnvScheduleNewCmd())
-	cmd.AddCommand(newEnvSchedulePauseCmd())
-	cmd.AddCommand(newEnvScheduleResumeCmd())
-	cmd.AddCommand(newEnvScheduleRemoveCmd())
+	cmd.AddCommand(newEnvScheduleListCmd(factory))
+	cmd.AddCommand(newEnvScheduleNewCmd(factory))
+	cmd.AddCommand(newEnvSchedulePauseCmd(factory))
+	cmd.AddCommand(newEnvScheduleResumeCmd(factory))
+	cmd.AddCommand(newEnvScheduleRemoveCmd(factory))
 	return cmd
 }
 
@@ -65,115 +86,249 @@ func envScheduleEnvWithIDArg() *constrictor.Arguments {
 	}
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23035]: Not yet implemented.
-func newEnvScheduleListCmd() *cobra.Command {
-	var org string
+// --- list ---
 
+func newEnvScheduleListCmd(factory envScheduleFactory) *cobra.Command {
+	var (
+		org    string
+		output string
+	)
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List scheduled actions configured for an environment",
-		Long:   "[EXPERIMENTAL] List scheduled actions configured for an environment.",
+		Use:   "list",
+		Short: "List scheduled actions configured for an environment",
+		Long:  "[EXPERIMENTAL] List scheduled actions configured for an environment.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			render, err := envScheduleListRenderer(output)
+			if err != nil {
+				return err
+			}
+			resolveFactory := factory
+			if resolveFactory == nil {
+				resolveFactory = defaultEnvScheduleFactory
+			}
+			c, resolvedOrg, err := resolveFactory(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			resp, err := c.ListEnvironmentSchedules(cmd.Context(), resolvedOrg, args[0], args[1])
+			if err != nil {
+				return fmt.Errorf("listing schedules for %s/%s/%s: %w", resolvedOrg, args[0], args[1], err)
+			}
+			return render(cmd.OutOrStdout(), resp)
 		},
 	}
-
 	constrictor.AttachArguments(cmd, envScheduleEnvArg())
-
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable) or json")
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23034]: Not yet implemented.
-func newEnvScheduleNewCmd() *cobra.Command {
-	var (
-		org    string
-		cron   string
-		once   string
-		action string
-	)
+// --- new ---
 
+func newEnvScheduleNewCmd(factory envScheduleFactory) *cobra.Command {
+	var (
+		org, cron, once, action string
+		output                  string
+	)
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new scheduled action for an environment",
-		Long:   "[EXPERIMENTAL] Create a new scheduled action for an environment.",
+		Use:   "new",
+		Short: "Create a new scheduled action for an environment",
+		Long: "[EXPERIMENTAL] Create a new scheduled action for an environment.\n" +
+			"\n" +
+			"Exactly one of --cron or --once must be specified. The --action flag\n" +
+			"selects the action kind; only 'rotate-secrets' is supported today.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			if (cron == "") == (once == "") {
+				return errors.New("specify exactly one of --cron or --once")
+			}
+			req := apitype.CreateEnvironmentScheduleRequest{
+				ScheduleCron: cron,
+				ScheduleOnce: once,
+			}
+			switch action {
+			case "", "rotate-secrets":
+				req.SecretRotationRequest = &apitype.CreateEnvironmentSecretRotationScheduleRequest{}
+			default:
+				return fmt.Errorf("unsupported --action %q (only 'rotate-secrets' is supported)", action)
+			}
+			render, err := envScheduleRenderer(output)
+			if err != nil {
+				return err
+			}
+			resolveFactory := factory
+			if resolveFactory == nil {
+				resolveFactory = defaultEnvScheduleFactory
+			}
+			c, resolvedOrg, err := resolveFactory(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			sched, err := c.CreateEnvironmentSchedule(cmd.Context(), resolvedOrg, args[0], args[1], req)
+			if err != nil {
+				return fmt.Errorf("creating schedule for %s/%s/%s: %w", resolvedOrg, args[0], args[1], err)
+			}
+			return render(cmd.OutOrStdout(), sched)
 		},
 	}
-
 	constrictor.AttachArguments(cmd, envScheduleEnvArg())
-
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
 	cmd.Flags().StringVar(&cron, "cron", "", "The cron expression for recurring executions")
 	cmd.Flags().StringVar(&once, "once", "", "The ISO 8601 timestamp for a one-time execution")
-	cmd.Flags().StringVar(&action, "action", "", "The action to perform on each execution")
-
+	cmd.Flags().StringVar(&action, "action", "rotate-secrets", "The action to perform on each execution")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable) or json")
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23033]: Not yet implemented.
-func newEnvSchedulePauseCmd() *cobra.Command {
-	var org string
+// --- pause / resume / remove (share a body) ---
 
+func newEnvSchedulePauseCmd(factory envScheduleFactory) *cobra.Command {
+	return newEnvScheduleSimpleCmd(factory, "pause",
+		"Pause a scheduled action", "Paused schedule",
+		func(c envScheduleClient, ctx context.Context, org, project, env, id string) error {
+			return c.PauseEnvironmentSchedule(ctx, org, project, env, id)
+		})
+}
+
+func newEnvScheduleResumeCmd(factory envScheduleFactory) *cobra.Command {
+	return newEnvScheduleSimpleCmd(factory, "resume",
+		"Resume a previously paused scheduled action", "Resumed schedule",
+		func(c envScheduleClient, ctx context.Context, org, project, env, id string) error {
+			return c.ResumeEnvironmentSchedule(ctx, org, project, env, id)
+		})
+}
+
+func newEnvScheduleRemoveCmd(factory envScheduleFactory) *cobra.Command {
+	return newEnvScheduleSimpleCmd(factory, "remove",
+		"Permanently delete a scheduled action", "Deleted schedule",
+		func(c envScheduleClient, ctx context.Context, org, project, env, id string) error {
+			return c.DeleteEnvironmentSchedule(ctx, org, project, env, id)
+		})
+}
+
+func newEnvScheduleSimpleCmd(
+	factory envScheduleFactory, use, short, successVerb string,
+	op func(envScheduleClient, context.Context, string, string, string, string) error,
+) *cobra.Command {
+	var org string
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "pause",
-		Short:  "Pause a scheduled action",
-		Long:   "[EXPERIMENTAL] Pause a scheduled action.",
+		Use:   use,
+		Short: short,
+		Long:  "[EXPERIMENTAL] " + short + ".",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+			resolveFactory := factory
+			if resolveFactory == nil {
+				resolveFactory = defaultEnvScheduleFactory
+			}
+			c, resolvedOrg, err := resolveFactory(cmd.Context(), org)
+			if err != nil {
+				return err
+			}
+			if err := op(c, cmd.Context(), resolvedOrg, args[0], args[1], args[2]); err != nil {
+				return fmt.Errorf("%s %s: %w", use, args[2], err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s on %s/%s/%s\n",
+				successVerb, args[2], resolvedOrg, args[0], args[1])
+			return nil
 		},
 	}
-
 	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
-
 	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23032]: Not yet implemented.
-func newEnvScheduleResumeCmd() *cobra.Command {
-	var org string
+// --- rendering ---
 
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "resume",
-		Short:  "Resume a previously paused scheduled action",
-		Long:   "[EXPERIMENTAL] Resume a previously paused scheduled action.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
+type (
+	envScheduleListRenderFunc func(io.Writer, apitype.ListScheduledActionsResponse) error
+	envScheduleRenderFunc     func(io.Writer, apitype.ScheduledAction) error
+)
+
+func envScheduleListRenderer(format string) (envScheduleListRenderFunc, error) {
+	switch format {
+	case "", "default":
+		return renderScheduleListText, nil
+	case "json":
+		return func(w io.Writer, r apitype.ListScheduledActionsResponse) error {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			return enc.Encode(r)
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
 	}
-
-	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
-
-	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23031]: Not yet implemented.
-func newEnvScheduleRemoveCmd() *cobra.Command {
-	var org string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove",
-		Short:  "Permanently delete a scheduled action",
-		Long:   "[EXPERIMENTAL] Permanently delete a scheduled action.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
+func envScheduleRenderer(format string) (envScheduleRenderFunc, error) {
+	switch format {
+	case "", "default":
+		return renderScheduleText, nil
+	case "json":
+		return func(w io.Writer, r apitype.ScheduledAction) error {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			return enc.Encode(r)
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
 	}
+}
 
-	constrictor.AttachArguments(cmd, envScheduleEnvWithIDArg())
+func renderScheduleListText(w io.Writer, r apitype.ListScheduledActionsResponse) error {
+	if len(r.Schedules) == 0 {
+		fmt.Fprintln(w, "No schedules configured for this environment.")
+		return nil
+	}
+	for i, s := range r.Schedules {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		if err := renderScheduleText(w, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the environment")
+func renderScheduleText(w io.Writer, s apitype.ScheduledAction) error {
+	fmt.Fprintf(w, "ID:        %s\n", s.ID)
+	fmt.Fprintf(w, "Kind:      %s\n", s.Kind)
+	if s.ScheduleCron != "" {
+		fmt.Fprintf(w, "Cron:      %s\n", s.ScheduleCron)
+	}
+	if s.ScheduleOnce != "" {
+		fmt.Fprintf(w, "Once:      %s\n", s.ScheduleOnce)
+	}
+	fmt.Fprintf(w, "Paused:    %t\n", s.Paused)
+	if s.NextExecution != "" {
+		fmt.Fprintf(w, "Next run:  %s\n", s.NextExecution)
+	}
+	if s.LastExecuted != "" {
+		fmt.Fprintf(w, "Last run:  %s\n", s.LastExecuted)
+	}
+	return nil
+}
 
-	return cmd
+// --- factory ---
+
+func defaultEnvScheduleFactory(
+	ctx context.Context, orgOverride string,
+) (envScheduleClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+	return resolved.Client, org, nil
 }

--- a/pkg/cmd/pulumi/env/env_schedule_test.go
+++ b/pkg/cmd/pulumi/env/env_schedule_test.go
@@ -1,0 +1,355 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// scheduleCall captures one call to the mock client.
+type scheduleCall struct {
+	method  string
+	org     string
+	project string
+	env     string
+	id      string
+	req     apitype.CreateEnvironmentScheduleRequest
+}
+
+// mockScheduleClient is a stub for envScheduleClient that records every call.
+// Per-method `*Result` / `*Err` fields let tests configure the return values.
+type mockScheduleClient struct {
+	listResult   apitype.ListScheduledActionsResponse
+	listErr      error
+	createResult apitype.ScheduledAction
+	createErr    error
+	pauseErr     error
+	resumeErr    error
+	deleteErr    error
+	calls        []scheduleCall
+}
+
+func (m *mockScheduleClient) ListEnvironmentSchedules(
+	_ context.Context, org, project, env string,
+) (apitype.ListScheduledActionsResponse, error) {
+	m.calls = append(m.calls, scheduleCall{method: "list", org: org, project: project, env: env})
+	return m.listResult, m.listErr
+}
+
+func (m *mockScheduleClient) CreateEnvironmentSchedule(
+	_ context.Context, org, project, env string, req apitype.CreateEnvironmentScheduleRequest,
+) (apitype.ScheduledAction, error) {
+	m.calls = append(m.calls, scheduleCall{
+		method: "create", org: org, project: project, env: env, req: req,
+	})
+	return m.createResult, m.createErr
+}
+
+func (m *mockScheduleClient) PauseEnvironmentSchedule(_ context.Context, org, project, env, id string) error {
+	m.calls = append(m.calls, scheduleCall{method: "pause", org: org, project: project, env: env, id: id})
+	return m.pauseErr
+}
+
+func (m *mockScheduleClient) ResumeEnvironmentSchedule(_ context.Context, org, project, env, id string) error {
+	m.calls = append(m.calls, scheduleCall{method: "resume", org: org, project: project, env: env, id: id})
+	return m.resumeErr
+}
+
+func (m *mockScheduleClient) DeleteEnvironmentSchedule(_ context.Context, org, project, env, id string) error {
+	m.calls = append(m.calls, scheduleCall{method: "delete", org: org, project: project, env: env, id: id})
+	return m.deleteErr
+}
+
+// stubScheduleFactory builds an envScheduleFactory that always returns the
+// supplied client and defaultOrg unless overridden by --org.
+func stubScheduleFactory(c envScheduleClient, defaultOrg string) envScheduleFactory {
+	return func(_ context.Context, orgOverride string) (envScheduleClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return c, org, nil
+	}
+}
+
+func failingScheduleFactory(err error) envScheduleFactory {
+	return func(_ context.Context, _ string) (envScheduleClient, string, error) {
+		return nil, "", err
+	}
+}
+
+// runCmd executes the parent `env schedule` cobra command with the supplied
+// args, capturing stdout/stderr.
+func runScheduleCmd(t *testing.T, factory envScheduleFactory, args ...string) (string, error) {
+	t.Helper()
+	cmd := newEnvScheduleCmdWith(factory)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	err := cmd.ExecuteContext(t.Context())
+	return out.String(), err
+}
+
+func TestEnvScheduleList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default output renders all schedules", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{listResult: apitype.ListScheduledActionsResponse{
+			Schedules: []apitype.ScheduledAction{
+				{ID: "s1", Kind: "environment_rotation", ScheduleCron: "0 9 * * *", NextExecution: "2030-01-01T09:00:00Z"},
+				{ID: "s2", Kind: "environment_rotation", ScheduleOnce: "2030-06-01T00:00:00Z", Paused: true},
+			},
+		}}
+		out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"), "list", "proj", "env")
+		require.NoError(t, err)
+		assert.Contains(t, out, "ID:        s1")
+		assert.Contains(t, out, "Cron:      0 9 * * *")
+		assert.Contains(t, out, "Next run:  2030-01-01T09:00:00Z")
+		assert.Contains(t, out, "ID:        s2")
+		assert.Contains(t, out, "Once:      2030-06-01T00:00:00Z")
+		assert.Contains(t, out, "Paused:    true")
+
+		require.Len(t, c.calls, 1)
+		assert.Equal(t, "list", c.calls[0].method)
+		assert.Equal(t, "acme", c.calls[0].org)
+		assert.Equal(t, "proj", c.calls[0].project)
+		assert.Equal(t, "env", c.calls[0].env)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"), "list", "proj", "env")
+		require.NoError(t, err)
+		assert.Contains(t, out, "No schedules configured")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{listResult: apitype.ListScheduledActionsResponse{
+			Schedules: []apitype.ScheduledAction{{ID: "s1", Kind: "environment_rotation"}},
+		}}
+		out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"list", "proj", "env", "--output", "json")
+		require.NoError(t, err)
+		assert.Contains(t, out, `"id": "s1"`)
+		assert.Contains(t, out, `"schedules"`)
+	})
+
+	t.Run("invalid output rejected before call", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"list", "proj", "env", "--output", "yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --output")
+		assert.Empty(t, c.calls, "expected no client call when output validation fails")
+	})
+
+	t.Run("factory error propagates", func(t *testing.T) {
+		t.Parallel()
+		_, err := runScheduleCmd(t, failingScheduleFactory(errors.New("not logged in")),
+			"list", "proj", "env")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not logged in")
+	})
+
+	t.Run("--org override wins", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "default-org"),
+			"list", "proj", "env", "--org", "override-org")
+		require.NoError(t, err)
+		require.Len(t, c.calls, 1)
+		assert.Equal(t, "override-org", c.calls[0].org)
+	})
+
+	t.Run("list http error wraps", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{listErr: errors.New("boom")}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"list", "proj", "env")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "listing schedules")
+		assert.Contains(t, err.Error(), "boom")
+	})
+}
+
+func TestEnvScheduleNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cron schedule with rotate-secrets action", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{createResult: apitype.ScheduledAction{
+			ID: "s1", Kind: "environment_rotation", ScheduleCron: "0 9 * * *",
+		}}
+		out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "0 9 * * *")
+		require.NoError(t, err)
+		assert.Contains(t, out, "ID:        s1")
+
+		require.Len(t, c.calls, 1)
+		got := c.calls[0]
+		assert.Equal(t, "create", got.method)
+		assert.Equal(t, "0 9 * * *", got.req.ScheduleCron)
+		assert.Empty(t, got.req.ScheduleOnce)
+		require.NotNil(t, got.req.SecretRotationRequest)
+	})
+
+	t.Run("once schedule", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{createResult: apitype.ScheduledAction{ID: "s1"}}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--once", "2030-01-01T00:00:00Z")
+		require.NoError(t, err)
+		require.Len(t, c.calls, 1)
+		assert.Equal(t, "2030-01-01T00:00:00Z", c.calls[0].req.ScheduleOnce)
+		assert.Empty(t, c.calls[0].req.ScheduleCron)
+	})
+
+	t.Run("rejects both --cron and --once", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "* * * * *", "--once", "2030-01-01T00:00:00Z")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one of --cron or --once")
+		assert.Empty(t, c.calls)
+	})
+
+	t.Run("rejects neither --cron nor --once", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exactly one of --cron or --once")
+		assert.Empty(t, c.calls)
+	})
+
+	t.Run("rejects unsupported --action", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "* * * * *", "--action", "deploy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported --action")
+		assert.Empty(t, c.calls)
+	})
+
+	t.Run("invalid output rejected", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "* * * * *", "--output", "yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --output")
+		assert.Empty(t, c.calls)
+	})
+
+	t.Run("create error wraps", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{createErr: errors.New("conflict")}
+		_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "* * * * *")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "creating schedule")
+		assert.Contains(t, err.Error(), "conflict")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+		c := &mockScheduleClient{createResult: apitype.ScheduledAction{ID: "s1"}}
+		out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+			"new", "proj", "env", "--cron", "* * * * *", "--output", "json")
+		require.NoError(t, err)
+		assert.Contains(t, out, `"id": "s1"`)
+	})
+}
+
+func TestEnvScheduleSimpleCommands(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		cmd, method, successWord string
+	}{
+		{"pause", "pause", "Paused"},
+		{"resume", "resume", "Resumed"},
+		{"remove", "delete", "Deleted"},
+	} {
+		t.Run(tc.cmd, func(t *testing.T) {
+			t.Parallel()
+			c := &mockScheduleClient{}
+			out, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+				tc.cmd, "proj", "env", "sched-1")
+			require.NoError(t, err)
+			require.Len(t, c.calls, 1)
+			got := c.calls[0]
+			assert.Equal(t, tc.method, got.method)
+			assert.Equal(t, "acme", got.org)
+			assert.Equal(t, "proj", got.project)
+			assert.Equal(t, "env", got.env)
+			assert.Equal(t, "sched-1", got.id)
+			assert.True(t, strings.HasPrefix(out, tc.successWord),
+				"expected output prefix %q, got %q", tc.successWord, out)
+			assert.Contains(t, out, "sched-1")
+			assert.Contains(t, out, "acme/proj/env")
+		})
+
+		t.Run(tc.cmd+" error wraps", func(t *testing.T) {
+			t.Parallel()
+			c := &mockScheduleClient{
+				pauseErr:  errors.New("boom"),
+				resumeErr: errors.New("boom"),
+				deleteErr: errors.New("boom"),
+			}
+			_, err := runScheduleCmd(t, stubScheduleFactory(c, "acme"),
+				tc.cmd, "proj", "env", "sched-1")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.cmd+" sched-1")
+			assert.Contains(t, err.Error(), "boom")
+		})
+	}
+}
+
+func TestEnvScheduleCmd_FactoryDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Constructing the command tree with a nil factory must not panic;
+	// the default factory is only resolved at RunE time.
+	cmd := newEnvScheduleCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "schedule", cmd.Name())
+
+	subs := cmd.Commands()
+	names := make([]string, 0, len(subs))
+	for _, sub := range subs {
+		names = append(names, sub.Name())
+	}
+	assert.ElementsMatch(t, []string{"list", "new", "pause", "resume", "remove"}, names)
+}

--- a/sdk/go/common/apitype/environment_schedules.go
+++ b/sdk/go/common/apitype/environment_schedules.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// ScheduledAction is the response shape for a single Pulumi ESC scheduled
+// action. Fields mirror the `ScheduledAction` OpenAPI schema in
+// `pulumi-service/pkg/apitype/spec/openapi_public.json`.
+//
+// Kind is one of the values enumerated by the server: "deployment",
+// "environment_rotation", "scan", "agent_automation". The Definition field
+// carries action-specific payload — modelled as an open map so we don't have
+// to chase server-side additions.
+type ScheduledAction struct {
+	ID            string         `json:"id"`
+	OrgID         string         `json:"orgID"`
+	Kind          string         `json:"kind"`
+	ScheduleCron  string         `json:"scheduleCron,omitempty"`
+	ScheduleOnce  string         `json:"scheduleOnce,omitempty"`
+	Paused        bool           `json:"paused"`
+	Created       string         `json:"created"`
+	Modified      string         `json:"modified"`
+	LastExecuted  string         `json:"lastExecuted"`
+	NextExecution string         `json:"nextExecution"`
+	Definition    map[string]any `json:"definition,omitempty"`
+}
+
+// ListScheduledActionsResponse is returned by the list endpoint.
+type ListScheduledActionsResponse struct {
+	Schedules []ScheduledAction `json:"schedules"`
+}
+
+// CreateEnvironmentScheduleRequest is the POST body for environment schedules.
+// Set exactly one of ScheduleCron or ScheduleOnce; provide a SecretRotationRequest
+// for the action payload.
+type CreateEnvironmentScheduleRequest struct {
+	ScheduleCron          string                                          `json:"scheduleCron,omitempty"`
+	ScheduleOnce          string                                          `json:"scheduleOnce,omitempty"`
+	SecretRotationRequest *CreateEnvironmentSecretRotationScheduleRequest `json:"secretRotationRequest,omitempty"`
+}
+
+// CreateEnvironmentSecretRotationScheduleRequest describes the secret-rotation
+// action. The OpenAPI schema requires `environmentPath`; an empty string means
+// "rotate every rotated secret in the environment".
+type CreateEnvironmentSecretRotationScheduleRequest struct {
+	// EnvironmentPath optionally narrows rotation to a single rotated secret.
+	// Leave empty to rotate all rotated secrets in the environment.
+	EnvironmentPath string `json:"environmentPath"`
+}


### PR DESCRIPTION
## Summary
- Implements `pulumi env schedule {list,new,pause,resume,remove}` for managing Pulumi ESC scheduled actions.
- Adds five client methods on `pkg/backend/httpstate/client/client.go` plus apitype request/response types in `sdk/go/common/apitype/environment_schedules.go`.
- `--cron` / `--once` are mutually exclusive on `new`; only `--action=rotate-secrets` is supported today (server schema doesn't enumerate other action kinds).
- Surface the previously-hidden `env schedule *` subcommands (parent group already discoverable).

Closes #23036 (and rolls up #23031–#23035).

## Test plan
- [x] `cd pkg && go test -count=1 -tags all ./cmd/pulumi/env/... ./backend/httpstate/client/...`
- [x] `make lint`
- [ ] Manual: create, pause, resume, then remove a schedule against a real environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)