### PR TITLE
add `pulumi stack webhook edit` command

### DIFF
--- a/changelog/pending/20260513--cli--add-pulumi-stack-webhook-edit.yaml
+++ b/changelog/pending/20260513--cli--add-pulumi-stack-webhook-edit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack webhook edit` to update an existing stack webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -811,6 +811,17 @@ func (pc *Client) GetDriftStatus(
 	return resp, nil
 }
 
+// UpdateStackWebhook updates an existing webhook for the given stack.
+func (pc *Client) UpdateStackWebhook(
+	ctx context.Context, stackID StackIdentifier, webhookName string, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	if err := pc.restCall(ctx, "PATCH", getStackPath(stackID, "hooks", webhookName), nil, &req, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
 // DeleteStackWebhook deletes the given webhook from the stack.
 func (pc *Client) DeleteStackWebhook(
 	ctx context.Context, stackID StackIdentifier, webhookName string,

--- a/pkg/backend/httpstate/client/client_webhook_test.go
+++ b/pkg/backend/httpstate/client/client_webhook_test.go
@@ -442,6 +442,63 @@ func TestRedeliverStackWebhookEvent(t *testing.T) {
 
 		c := newMockClient(srv)
 		_, err := c.RedeliverStackWebhookEvent(t.Context(), stackID, "hook", "bad-id")
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "not found")
+	})
+}
+
+func TestUpdateStackWebhook(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		format := "slack"
+		want := apitype.Webhook{
+			OrganizationName: "my-org",
+			Name:             "my-hook",
+			DisplayName:      "Updated Hook",
+			PayloadURL:       "https://new.example.com",
+			Active:           false,
+			Format:           &format,
+		}
+
+		var gotPath, gotMethod string
+		var gotBody apitype.Webhook
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			err := json.NewDecoder(r.Body).Decode(&gotBody)
+			require.NoError(t, err)
+			w.Header().Set("Content-Type", "application/json")
+			err = json.NewEncoder(w).Encode(want) //nolint:gosec // test data
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.UpdateStackWebhook(t.Context(), stackID, "my-hook", want)
+		require.NoError(t, err)
+
+		assert.Equal(t, "PATCH", gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/hooks/my-hook", gotPath)
+		assert.Equal(t, "Updated Hook", gotBody.DisplayName)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
+
+		srv := newMockServer(http.StatusNotFound, `{"message":"not found"}`)
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.UpdateStackWebhook(t.Context(), stackID, "nope", apitype.Webhook{})
+		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -15,8 +15,6 @@
 package stack
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -53,44 +51,6 @@ func stackWebhookHookArg() *constrictor.Arguments {
 		},
 		Required: 1,
 	}
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/23059]: Not yet implemented.
-func newStackWebhookEditCmd() *cobra.Command {
-	var (
-		stack       string
-		url         string
-		format      string
-		filters     []string
-		active      bool
-		secret      string
-		displayName string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "Update a stack webhook's configuration",
-		Long:   "[EXPERIMENTAL] Update a stack webhook's configuration.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, stackWebhookHookArg())
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
-	cmd.Flags().StringVar(&format, "format", "",
-		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
-	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		"An event type to subscribe to (repeatable)")
-	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
-	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
-	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
-
-	return cmd
 }
 
 func newStackWebhookDeliveryCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit.go
@@ -1,0 +1,276 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// stackWebhookEditClient is the interface the edit command needs.
+type stackWebhookEditClient interface {
+	GetStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier, webhookName string,
+	) (apitype.Webhook, error)
+	UpdateStackWebhook(
+		ctx context.Context, stackID client.StackIdentifier,
+		webhookName string, req apitype.Webhook,
+	) (apitype.Webhook, error)
+}
+
+type stackWebhookEditClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackWebhookEditClient, client.StackIdentifier, error)
+
+func newStackWebhookEditCmd() *cobra.Command {
+	return newStackWebhookEditCmdWith(nil)
+}
+
+func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Command {
+	var (
+		stack        string
+		url          string
+		format       string
+		addEvents    []string
+		removeEvents []string
+		addGroups    []string
+		removeGroups []string
+		active       bool
+		secret       string
+		displayName  string
+		output       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "[EXPERIMENTAL] Update a stack webhook's configuration",
+		Long: "Update a stack webhook's configuration.\n" +
+			"\n" +
+			"Modifies an existing webhook. Only the flags you pass are changed;\n" +
+			"all other fields are preserved. For example, passing --active=false\n" +
+			"disables the webhook without altering its URL or filters.\n" +
+			"\n" +
+			"To clear the webhook secret, pass --secret \"\".\n" +
+			"\n" +
+			"Returns an error if the webhook does not exist.",
+		Example: "  # Disable a webhook\n" +
+			"  pulumi stack webhook edit my-hook --active=false\n\n" +
+			"  # Change the payload URL\n" +
+			"  pulumi stack webhook edit my-hook --url https://new-url.example.com\n\n" +
+			"  # Add event filters\n" +
+			"  pulumi stack webhook edit my-hook " +
+			"--add-event update_succeeded --add-event update_failed\n\n" +
+			"  # Remove an event and add another\n" +
+			"  pulumi stack webhook edit my-hook " +
+			"--remove-event update_failed --add-event destroy_failed\n\n" +
+			"  # Clear the secret\n" +
+			"  pulumi stack webhook edit my-hook --secret \"\"",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultEditClientFactory
+			}
+			return runEdit(
+				cmd.Context(), cmd.OutOrStdout(), cmd, factory,
+				stack, args[0], editFlags{
+					url:          url,
+					format:       format,
+					addEvents:    addEvents,
+					removeEvents: removeEvents,
+					addGroups:    addGroups,
+					removeGroups: removeGroups,
+					active:       active,
+					secret:       secret,
+					displayName:  displayName,
+				}, output,
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, stackWebhookHookArg())
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&url, "url", "",
+		"The webhook payload URL")
+	cmd.Flags().StringVar(&format, "hook-format", "",
+		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
+	cmd.Flags().StringArrayVar(&addEvents, "add-event", nil,
+		"An event type to add (repeatable)")
+	cmd.Flags().StringArrayVar(&removeEvents, "remove-event", nil,
+		"An event type to remove (repeatable)")
+	cmd.Flags().StringArrayVar(&addGroups, "add-group", nil,
+		"An event group to add (repeatable)")
+	cmd.Flags().StringArrayVar(&removeGroups, "remove-group", nil,
+		"An event group to remove (repeatable)")
+	cmd.Flags().BoolVar(&active, "active", true,
+		"Whether the webhook is active")
+	cmd.Flags().StringVar(&secret, "secret", "",
+		"The HMAC key for signature verification (empty string removes the secret)")
+	cmd.Flags().StringVar(&displayName, "display-name", "",
+		"The webhook display name")
+	cmd.Flags().StringVarP(&output, "output", "o", "default",
+		"The output format: default (human-readable text) or json")
+
+	return cmd
+}
+
+type editFlags struct {
+	url          string
+	format       string
+	addEvents    []string
+	removeEvents []string
+	addGroups    []string
+	removeGroups []string
+	active       bool
+	secret       string
+	displayName  string
+}
+
+func defaultEditClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackWebhookEditClient, client.StackIdentifier, error) {
+	return RequireCloudStack(
+		ctx, cmdutil.Diag(), pkgWorkspace.Instance,
+		cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runEdit(
+	ctx context.Context,
+	w io.Writer,
+	cmd *cobra.Command,
+	factory stackWebhookEditClientFactory,
+	stackFlag string,
+	webhookName string,
+	flags editFlags,
+	output string,
+) error {
+	renderer, err := webhookGetRenderer(output)
+	if err != nil {
+		return err
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the existing webhook so we only change what was explicitly set.
+	existing, err := c.GetStackWebhook(ctx, stackID, webhookName)
+	if err != nil {
+		return fmt.Errorf("reading webhook %q: %w", webhookName, err)
+	}
+
+	req, err := applyEditFlags(cmd, existing, flags)
+	if err != nil {
+		return err
+	}
+
+	updated, err := c.UpdateStackWebhook(ctx, stackID, webhookName, req)
+	if err != nil {
+		return fmt.Errorf("updating webhook %q: %w", webhookName, err)
+	}
+
+	return renderer(w, updated)
+}
+
+// removeSecretSentinel is the value the Pulumi Service recognises as
+// "clear the secret" in a PATCH request.
+const removeSecretSentinel = "__remove-secret"
+
+// applyEditFlags merges explicitly-set flags into the existing webhook
+// and validates the result.
+func applyEditFlags(
+	cmd *cobra.Command, wh apitype.Webhook, f editFlags,
+) (apitype.Webhook, error) {
+	if cmd.Flags().Changed("display-name") {
+		wh.DisplayName = f.displayName
+	}
+	if cmd.Flags().Changed("url") {
+		wh.PayloadURL = f.url
+	}
+	if cmd.Flags().Changed("hook-format") {
+		wh.Format = &f.format
+	}
+	if cmd.Flags().Changed("remove-event") {
+		wh.Filters = removeFromSlice(wh.Filters, f.removeEvents)
+	}
+	if cmd.Flags().Changed("add-event") {
+		wh.Filters = addToSlice(wh.Filters, f.addEvents)
+	}
+	if cmd.Flags().Changed("remove-group") {
+		wh.Groups = removeFromSlice(wh.Groups, f.removeGroups)
+	}
+	if cmd.Flags().Changed("add-group") {
+		wh.Groups = addToSlice(wh.Groups, f.addGroups)
+	}
+	if cmd.Flags().Changed("active") {
+		wh.Active = f.active
+	}
+	if cmd.Flags().Changed("secret") {
+		if f.secret == "" {
+			wh.Secret = removeSecretSentinel
+		} else {
+			wh.Secret = f.secret
+		}
+	}
+
+	if err := validateGroupsAndEvents(wh.Groups, wh.Filters); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return wh, nil
+}
+
+// removeFromSlice returns a new slice with elements in remove excluded.
+func removeFromSlice(existing, remove []string) []string {
+	toRemove := make(map[string]bool, len(remove))
+	for _, r := range remove {
+		toRemove[r] = true
+	}
+	var result []string
+	for _, v := range existing {
+		if !toRemove[v] {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// addToSlice returns a new slice with elements in add appended,
+// skipping any that are already present.
+func addToSlice(existing, add []string) []string {
+	seen := make(map[string]bool, len(existing))
+	for _, v := range existing {
+		seen[v] = true
+	}
+	result := make([]string, len(existing))
+	copy(result, existing)
+	for _, v := range add {
+		if !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockEditClient struct {
+	existing  apitype.Webhook
+	getErr    error
+	updated   apitype.Webhook
+	updateErr error
+	gotReq    apitype.Webhook
+	gotName   string
+}
+
+func (m *mockEditClient) GetStackWebhook(
+	_ context.Context, _ client.StackIdentifier, name string,
+) (apitype.Webhook, error) {
+	return m.existing, m.getErr
+}
+
+func (m *mockEditClient) UpdateStackWebhook(
+	_ context.Context, _ client.StackIdentifier, name string, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	m.gotName = name
+	m.gotReq = req
+	return m.updated, m.updateErr
+}
+
+func stubEditFactory(c stackWebhookEditClient) stackWebhookEditClientFactory {
+	return func(_ context.Context, _ string) (stackWebhookEditClient, client.StackIdentifier, error) {
+		return c, testStackID, nil
+	}
+}
+
+func existingWebhook() apitype.Webhook {
+	return apitype.Webhook{
+		OrganizationName: "my-org",
+		ProjectName:      ptr("my-project"),
+		StackName:        ptr("dev"),
+		Name:             "my-hook",
+		DisplayName:      "My Hook",
+		PayloadURL:       "https://example.com/webhook",
+		Active:           true,
+		Format:           ptr("raw"),
+		Groups:           []string{"stacks"},
+		Filters:          []string{"deployment_queued"},
+		HasSecret:        true,
+	}
+}
+
+func TestEdit_ChangeURL(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+	c.updated.PayloadURL = "https://new-url.example.com"
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--url", "https://new-url.example.com"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	// Only URL should have changed in the request.
+	assert.Equal(t, "https://new-url.example.com", c.gotReq.PayloadURL)
+	// Everything else preserved.
+	assert.Equal(t, "My Hook", c.gotReq.DisplayName)
+	assert.True(t, c.gotReq.Active)
+	assert.Equal(t, []string{"stacks"}, c.gotReq.Groups)
+	assert.Equal(t, []string{"deployment_queued"}, c.gotReq.Filters)
+}
+
+func TestEdit_ChangeActive(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+	c.updated.Active = false
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--active=false"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.False(t, c.gotReq.Active)
+	// URL preserved.
+	assert.Equal(t, "https://example.com/webhook", c.gotReq.PayloadURL)
+}
+
+func TestEdit_AddEvents(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--add-event", "deployment_started",
+		"--add-event", "deployment_failed",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	// Original event preserved, new ones added.
+	assert.Equal(t, []string{"deployment_queued", "deployment_started", "deployment_failed"}, c.gotReq.Filters)
+	// Groups unchanged.
+	assert.Equal(t, []string{"stacks"}, c.gotReq.Groups)
+}
+
+func TestEdit_RemoveEvents(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	existing.Filters = []string{"deployment_queued", "deployment_started", "deployment_failed"}
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--remove-event", "deployment_started",
+		"--remove-event", "deployment_failed",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"deployment_queued"}, c.gotReq.Filters)
+}
+
+func TestEdit_AddAndRemoveEvents(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	existing.Filters = []string{"deployment_queued", "deployment_started"}
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--remove-event", "deployment_started",
+		"--add-event", "deployment_failed",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	// deployment_started removed, deployment_failed added.
+	assert.Equal(t, []string{"deployment_queued", "deployment_failed"}, c.gotReq.Filters)
+}
+
+func TestEdit_AddGroups(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	existing.Groups = []string{"stacks"}
+	existing.Filters = nil
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--add-group", "deployments",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"stacks", "deployments"}, c.gotReq.Groups)
+}
+
+func TestEdit_RemoveGroups(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	existing.Groups = []string{"stacks", "deployments"}
+	existing.Filters = nil
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--remove-group", "deployments",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"stacks"}, c.gotReq.Groups)
+}
+
+func TestEdit_AddDuplicateEventIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--add-event", "deployment_queued", // already present
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"deployment_queued"}, c.gotReq.Filters)
+}
+
+func TestEdit_RemoveNonexistentEventIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--remove-event", "deployment_started", // not present
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	// Original filter unchanged.
+	assert.Equal(t, []string{"deployment_queued"}, c.gotReq.Filters)
+}
+
+func TestEdit_ClearSecret(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--secret", ""})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, removeSecretSentinel, c.gotReq.Secret)
+}
+
+func TestEdit_SetSecret(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--secret", "new-secret"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "new-secret", c.gotReq.Secret)
+}
+
+func TestEdit_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"my-hook", "--active=false", "--output", "json"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"id": "my-hook"`)
+}
+
+func TestEdit_WebhookNotFound(t *testing.T) {
+	t.Parallel()
+
+	c := &mockEditClient{getErr: errors.New("[404] Not Found")}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"bad-hook", "--active=false"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `reading webhook "bad-hook"`)
+}
+
+func TestEdit_UpdateError(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{
+		existing:  existing,
+		updateErr: errors.New("server error"),
+	}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"my-hook", "--url", "https://x.com"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `updating webhook "my-hook"`)
+}
+
+func TestEdit_InvalidGroup(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"my-hook", "--add-group", "bogus"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid group "bogus"`)
+}
+
+func TestEdit_InvalidEvent(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"my-hook", "--add-event", "not_a_real_event"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid event "not_a_real_event"`)
+}
+
+func TestEdit_EventCoveredByGroup(t *testing.T) {
+	t.Parallel()
+
+	existing := existingWebhook()
+	existing.Groups = nil
+	existing.Filters = nil
+	c := &mockEditClient{existing: existing, updated: existing}
+
+	cmd := newStackWebhookEditCmdWith(stubEditFactory(c))
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	// update_succeeded is already in the "stacks" group
+	cmd.SetArgs([]string{
+		"my-hook",
+		"--add-group", "stacks",
+		"--add-event", "update_succeeded",
+	})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `event "update_succeeded" is already included by group "stacks"`)
+}
+
+func TestEdit_DefaultCmd(t *testing.T) {
+	t.Parallel()
+
+	cmd := newStackWebhookEditCmd()
+	assert.Contains(t, cmd.Use, "edit")
+	require.NotNil(t, cmd.RunE)
+
+	for _, name := range []string{
+		"url", "hook-format",
+		"add-event", "remove-event",
+		"add-group", "remove-group",
+		"active", "secret",
+		"display-name", "output",
+	} {
+		f := cmd.Flags().Lookup(name)
+		require.NotNil(t, f, "expected flag %q", name)
+	}
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -186,6 +187,66 @@ var groupFilters = map[string][]string{
 	},
 }
 
+// validGroupSet is the set of valid group names for fast lookup.
+var validGroupSet = func() map[string]bool {
+	m := make(map[string]bool, len(stackWebhookGroups))
+	for _, g := range stackWebhookGroups {
+		m[g] = true
+	}
+	return m
+}()
+
+// validEventSet is the set of all valid event names for fast lookup.
+var validEventSet = func() map[string]bool {
+	m := make(map[string]bool)
+	for _, events := range groupFilters {
+		for _, e := range events {
+			m[e] = true
+		}
+	}
+	return m
+}()
+
+// validateGroupsAndEvents checks that all group and event names are valid,
+// and that no event is already covered by a selected group.
+func validateGroupsAndEvents(groups, events []string) error {
+	for _, g := range groups {
+		if !validGroupSet[g] {
+			return fmt.Errorf("invalid group %q; valid groups: %s",
+				g, joinQuoted(stackWebhookGroups))
+		}
+	}
+	for _, e := range events {
+		if !validEventSet[e] {
+			return fmt.Errorf("invalid event %q", e)
+		}
+	}
+
+	// Build the set of events already covered by the selected groups.
+	covered := make(map[string]string) // event -> group
+	for _, g := range groups {
+		for _, e := range groupFilters[g] {
+			covered[e] = g
+		}
+	}
+	for _, e := range events {
+		if g, ok := covered[e]; ok {
+			return fmt.Errorf(
+				"event %q is already included by group %q; "+
+					"remove the event or the group", e, g)
+		}
+	}
+	return nil
+}
+
+func joinQuoted(ss []string) string {
+	quoted := make([]string, len(ss))
+	for i, s := range ss {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(quoted, ", ")
+}
+
 // filtersNotCoveredByGroups returns event filters that are not already
 // covered by the selected groups.
 func filtersNotCoveredByGroups(selectedGroups []string) []string {
@@ -283,6 +344,10 @@ func resolveNewArgs(
 				remaining, nil,
 				opts.Color)
 		}
+	}
+
+	if err := validateGroupsAndEvents(groups, filters); err != nil {
+		return stackWebhookNewArgs{}, err
 	}
 
 	return stackWebhookNewArgs{


### PR DESCRIPTION
Example outputs:
```
$ pulumi stack webhook edit  -s pulumi/pulumi-service-review-stacks/tgummerer my-hook4 --event update_failed
ID:                my-hook4
Name:              my-hook4
Organization:      pulumi
Project:           pulumi-service-review-stacks
Stack:             tgummerer
URL:               http://xkcd.com
Format:            raw
Event groups:      deployments
Events:            update_failed
Active:            yes
Has secret:        no
```

```
$ pulumi stack webhook edit  -s pulumi/pulumi-service-review-stacks/tgummerer my-hook4 --group deployments -o json --clear-events
{
  "organizationName": "pulumi",
  "projectName": "pulumi-service-review-stacks",
  "stackName": "tgummerer",
  "envName": "",
  "id": "my-hook4",
  "name": "my-hook4",
  "url": "http://xkcd.com",
  "format": "raw",
  "active": true,
  "eventGroups": [
    "deployments"
  ],
  "events": [],
  "hasSecret": false,
  "secretCiphertext": ""
}
```

Fixes https://github.com/pulumi/pulumi/issues/23059