### PR TITLE
Refactor property evaluation

### DIFF
--- a/pkg/pcl/runtime/builtinFunctions.go
+++ b/pkg/pcl/runtime/builtinFunctions.go
@@ -284,12 +284,12 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 				return cty.NilVal, fmt.Errorf("invalid invoke arguments: %w", err)
 			}
 			argsPV, dependsOn := unwrapOutputs(argsPV)
-			if fun != nil && fun.Inputs != nil && argsPV.IsObject() {
-				convertedArgs, err := convertInvokeInputObject(argsPV.ObjectValue(), fun.Inputs)
+			if fun.Inputs != nil {
+				args, err := applySchemaInputs(argsPV.ObjectValue(), fun.Inputs.Properties)
 				if err != nil {
 					return cty.NilVal, fmt.Errorf("convert invoke arguments: %w", err)
 				}
-				argsPV = resource.NewProperty(convertedArgs)
+				argsPV = resource.NewProperty(args)
 			}
 
 			marshalOpts := plugin.MarshalOptions{
@@ -456,6 +456,12 @@ func (ectx *EvalContext) builtinFunctions() map[string]function.Function {
 			}
 			argsPV, _ = unwrapOutputs(argsPV)
 			argsPM := argsPV.ObjectValue()
+			if fun.Inputs != nil {
+				argsPM, err = applySchemaInputs(argsPM, fun.Inputs.Properties)
+				if err != nil {
+					return cty.NilVal, fmt.Errorf("convert call arguments: %w", err)
+				}
+			}
 
 			urnVal, ok := self["urn"]
 			if !ok || urnVal.IsNull() || !urnVal.IsKnown() || urnVal.Type() != cty.String {

--- a/pkg/pcl/runtime/convert.go
+++ b/pkg/pcl/runtime/convert.go
@@ -319,37 +319,74 @@ func ctyToPropertyValue(value cty.Value) (resource.PropertyValue, error) {
 	return pv, nil
 }
 
-func convertInvokeInputObject(args resource.PropertyMap, inputType *schema.ObjectType) (resource.PropertyMap, error) {
-	schemaProperties := make(map[string]schema.Type, len(inputType.Properties))
-	for _, prop := range inputType.Properties {
-		schemaProperties[prop.Name] = prop.Type
-	}
+// applySchemaInputs returns a new PropertyMap derived from inputs by, for each schema
+// property: coercing the input value to the property's type, filling in the schema default
+// when no input is provided, and wrapping the value in a secret marker when the property
+// is declared secret. Inputs whose key does not match any schema property pass through
+// unchanged.
+//
+// Recursion through nested objects also applies defaults and conversions, but suppresses
+// secret-marking when an ancestor is already a secret — the outer wrap covers the inner
+// values, so adding redundant inner marks would be wasted (and trips up callers that walk
+// the snapshot, like the language conformance suite). User-supplied inner secrets are
+// preserved untouched.
+func applySchemaInputs(
+	inputs resource.PropertyMap, properties []*schema.Property,
+) (resource.PropertyMap, error) {
+	return applySchemaInputsInner(inputs, properties, false)
+}
 
-	converted := make(resource.PropertyMap, len(args))
-	for key, value := range args {
-		targetType, ok := schemaProperties[string(key)]
-		if !ok {
-			converted[key] = value
+func applySchemaInputsInner(
+	inputs resource.PropertyMap, properties []*schema.Property, insideSecret bool,
+) (resource.PropertyMap, error) {
+	converted := make(resource.PropertyMap, len(inputs))
+	seen := make(map[resource.PropertyKey]struct{}, len(properties))
+
+	for _, prop := range properties {
+		key := resource.PropertyKey(prop.Name)
+		seen[key] = struct{}{}
+
+		// Anything nested below a secret-marked property is itself "inside a secret".
+		nestedInsideSecret := insideSecret || prop.Secret
+
+		var val resource.PropertyValue
+		if input, hasInput := inputs[key]; hasInput {
+			v, err := applySchemaInputConversion(input, prop.Type, nestedInsideSecret)
+			if err != nil {
+				return nil, fmt.Errorf("property %q: %w", key, err)
+			}
+			val = v
+		} else if prop.DefaultValue != nil {
+			val = resource.NewPropertyValue(prop.DefaultValue.Value)
+		} else {
 			continue
 		}
 
-		convertedValue, err := convertPropertyValueForSchemaType(value, targetType)
-		if err != nil {
-			return nil, fmt.Errorf("property %q: %w", key, err)
+		// Only add a fresh secret marker at the outermost level — once inside a secret,
+		// schema-driven marks would just duplicate the outer wrap.
+		if !insideSecret && prop.Secret && !val.IsSecret() {
+			val = resource.MakeSecret(val)
 		}
-		converted[key] = convertedValue
+		converted[key] = val
+	}
+
+	for key, value := range inputs {
+		if _, ok := seen[key]; !ok {
+			converted[key] = value
+		}
 	}
 
 	return converted, nil
 }
 
-func convertPropertyValueForSchemaType(
-	value resource.PropertyValue, targetType schema.Type,
+func applySchemaInputConversion(
+	value resource.PropertyValue, targetType schema.Type, insideSecret bool,
 ) (resource.PropertyValue, error) {
 	targetType = codegen.UnwrapType(targetType)
 
 	if value.IsSecret() {
-		converted, err := convertPropertyValueForSchemaType(value.SecretValue().Element, targetType)
+		// Anything inside the secret wrap is by definition "inside a secret".
+		converted, err := applySchemaInputConversion(value.SecretValue().Element, targetType, true)
 		if err != nil {
 			return resource.PropertyValue{}, err
 		}
@@ -366,7 +403,7 @@ func convertPropertyValueForSchemaType(
 		}
 
 		if copied.Known {
-			converted, err := convertPropertyValueForSchemaType(copied.Element, targetType)
+			converted, err := applySchemaInputConversion(copied.Element, targetType, insideSecret || out.Secret)
 			if err != nil {
 				return resource.PropertyValue{}, err
 			}
@@ -387,7 +424,7 @@ func convertPropertyValueForSchemaType(
 		arr := value.ArrayValue()
 		converted := make([]resource.PropertyValue, len(arr))
 		for i, elem := range arr {
-			v, err := convertPropertyValueForSchemaType(elem, t.ElementType)
+			v, err := applySchemaInputConversion(elem, t.ElementType, insideSecret)
 			if err != nil {
 				return resource.PropertyValue{}, fmt.Errorf("array index %d: %w", i, err)
 			}
@@ -401,7 +438,7 @@ func convertPropertyValueForSchemaType(
 		obj := value.ObjectValue()
 		converted := make(resource.PropertyMap, len(obj))
 		for key, elem := range obj {
-			v, err := convertPropertyValueForSchemaType(elem, t.ElementType)
+			v, err := applySchemaInputConversion(elem, t.ElementType, insideSecret)
 			if err != nil {
 				return resource.PropertyValue{}, fmt.Errorf("map key %q: %w", key, err)
 			}
@@ -412,7 +449,10 @@ func convertPropertyValueForSchemaType(
 		if !value.IsObject() {
 			return value, nil
 		}
-		converted, err := convertInvokeInputObject(value.ObjectValue(), t)
+		// Recurse with the full helper so nested objects also fill in schema defaults and
+		// mark schema-secret properties. Pass insideSecret through so the inner pass knows
+		// to suppress redundant marks when the outer is already a secret.
+		converted, err := applySchemaInputsInner(value.ObjectValue(), t.Properties, insideSecret)
 		if err != nil {
 			return resource.PropertyValue{}, err
 		}
@@ -423,7 +463,7 @@ func convertPropertyValueForSchemaType(
 		var first *resource.PropertyValue
 		var errs []error
 		for _, elementType := range t.ElementTypes {
-			converted, err := convertPropertyValueForSchemaType(value, elementType)
+			converted, err := applySchemaInputConversion(value, elementType, insideSecret)
 			if err != nil {
 				errs = append(errs, err)
 			} else {

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -1120,13 +1120,6 @@ func (i *Interpreter) registerResourceWith(
 		token = schemaResource.Token
 	}
 
-	inputPropertyTypes := map[string]schema.Type{}
-	if schemaResource != nil {
-		for _, property := range schemaResource.InputProperties {
-			inputPropertyTypes[property.Name] = property.Type
-		}
-	}
-
 	inputs := resource.PropertyMap{}
 	for _, attr := range res.Inputs {
 		targetType := attr.Value.Type()
@@ -1148,28 +1141,15 @@ func (i *Interpreter) registerResourceWith(
 		if diags.HasErrors() {
 			return cty.NilVal, diags
 		}
-		propertyValue := collapseResourceReferences(val)
-		if inputPropertyType, ok := inputPropertyTypes[attr.Name]; ok {
-			converted, err := convertPropertyValueForSchemaType(propertyValue, inputPropertyType)
-			if err != nil {
-				return cty.NilVal, err
-			}
-			propertyValue = converted
-		}
-		inputs[resource.PropertyKey(attr.Name)] = propertyValue
+		inputs[resource.PropertyKey(attr.Name)] = collapseResourceReferences(val)
 	}
 
 	if schemaResource != nil {
-		applySchemaInputDefaults(inputs, schemaResource)
-		for _, input := range schemaResource.InputProperties {
-			if input.Secret {
-				key := resource.PropertyKey(input.Name)
-				attr, ok := inputs[key]
-				if ok && !attr.IsSecret() {
-					inputs[key] = resource.MakeSecret(attr)
-				}
-			}
+		converted, err := applySchemaInputs(inputs, schemaResource.InputProperties)
+		if err != nil {
+			return cty.NilVal, err
 		}
+		inputs = converted
 	}
 
 	marshalOpts := plugin.MarshalOptions{
@@ -1837,19 +1817,6 @@ func (i *Interpreter) registerResourceWith(
 	})
 
 	return propertyValueToCty(ctx, i.getResource, result)
-}
-
-func applySchemaInputDefaults(inputs resource.PropertyMap, schemaResource *schema.Resource) {
-	for _, input := range schemaResource.InputProperties {
-		if input.DefaultValue == nil {
-			continue
-		}
-		key := resource.PropertyKey(input.Name)
-		if _, exists := inputs[key]; exists {
-			continue
-		}
-		inputs[key] = resource.NewPropertyValue(input.DefaultValue.Value)
-	}
 }
 
 func (i *Interpreter) registerComponent(ctx context.Context, component *pcl.Component) hcl.Diagnostics {

--- a/pkg/pcl/runtime/interpreter_test.go
+++ b/pkg/pcl/runtime/interpreter_test.go
@@ -147,23 +147,21 @@ resource "dependent_on_output" "test:index:Resource" {
 	}
 }
 
-func TestApplySchemaInputDefaults(t *testing.T) {
+func TestApplySchemaInputs_Defaults(t *testing.T) {
 	t.Parallel()
 
-	schemaResource := &schema.Resource{
-		InputProperties: []*schema.Property{
-			{
-				Name:         "boolean",
-				DefaultValue: &schema.DefaultValue{Value: false},
-			},
-			{
-				Name:         "numberArray",
-				DefaultValue: &schema.DefaultValue{Value: []any{0.0}},
-			},
-			{
-				Name:         "booleanMap",
-				DefaultValue: &schema.DefaultValue{Value: map[string]any{"default": false}},
-			},
+	properties := []*schema.Property{
+		{
+			Name:         "boolean",
+			DefaultValue: &schema.DefaultValue{Value: false},
+		},
+		{
+			Name:         "numberArray",
+			DefaultValue: &schema.DefaultValue{Value: []any{0.0}},
+		},
+		{
+			Name:         "booleanMap",
+			DefaultValue: &schema.DefaultValue{Value: map[string]any{"default": false}},
 		},
 	}
 
@@ -171,13 +169,243 @@ func TestApplySchemaInputDefaults(t *testing.T) {
 		"boolean": resource.NewProperty(true),
 	}
 
-	applySchemaInputDefaults(inputs, schemaResource)
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
 
-	assert.Equal(t, resource.NewProperty(true), inputs["boolean"])
+	assert.Equal(t, resource.NewProperty(true), converted["boolean"])
 	assert.Equal(t, resource.NewProperty([]resource.PropertyValue{
 		resource.NewProperty(0.0),
-	}), inputs["numberArray"])
+	}), converted["numberArray"])
 	assert.Equal(t, resource.NewProperty(resource.PropertyMap{
 		"default": resource.NewProperty(false),
-	}), inputs["booleanMap"])
+	}), converted["booleanMap"])
+}
+
+func TestApplySchemaInputs_Conversions(t *testing.T) {
+	t.Parallel()
+
+	nested := &schema.ObjectType{
+		Properties: []*schema.Property{
+			{Name: "count", Type: schema.IntType},
+		},
+	}
+
+	properties := []*schema.Property{
+		{Name: "boolean", Type: schema.BoolType},
+		{Name: "number", Type: schema.NumberType},
+		{Name: "integer", Type: schema.IntType},
+		{Name: "string", Type: schema.StringType},
+		{Name: "numbers", Type: &schema.ArrayType{ElementType: schema.NumberType}},
+		{Name: "flags", Type: &schema.MapType{ElementType: schema.BoolType}},
+		{Name: "nested", Type: nested},
+	}
+
+	inputs := resource.PropertyMap{
+		// String "44" coerces to number 44 when the schema says number.
+		"number":  resource.NewProperty("44"),
+		"integer": resource.NewProperty("7"),
+		// String "true" coerces to bool.
+		"boolean": resource.NewProperty("true"),
+		// Number coerces to its decimal string.
+		"string": resource.NewProperty(3.5),
+		// Array elements coerce per the element type.
+		"numbers": resource.NewProperty([]resource.PropertyValue{
+			resource.NewProperty("1"),
+			resource.NewProperty("2.5"),
+		}),
+		// Map values coerce per the element type.
+		"flags": resource.NewProperty(resource.PropertyMap{
+			"a": resource.NewProperty("true"),
+			"b": resource.NewProperty("false"),
+		}),
+		// Nested object fields coerce too.
+		"nested": resource.NewProperty(resource.PropertyMap{
+			"count": resource.NewProperty("99"),
+		}),
+		// Properties not in the schema pass through unchanged.
+		"extra": resource.NewProperty("untouched"),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.NewProperty(true), converted["boolean"])
+	assert.Equal(t, resource.NewProperty(44.0), converted["number"])
+	assert.Equal(t, resource.NewProperty(7.0), converted["integer"])
+	assert.Equal(t, resource.NewProperty("3.5"), converted["string"])
+	assert.Equal(t, resource.NewProperty([]resource.PropertyValue{
+		resource.NewProperty(1.0),
+		resource.NewProperty(2.5),
+	}), converted["numbers"])
+	assert.Equal(t, resource.NewProperty(resource.PropertyMap{
+		"a": resource.NewProperty(true),
+		"b": resource.NewProperty(false),
+	}), converted["flags"])
+	assert.Equal(t, resource.NewProperty(resource.PropertyMap{
+		"count": resource.NewProperty(99.0),
+	}), converted["nested"])
+	assert.Equal(t, resource.NewProperty("untouched"), converted["extra"])
+
+	// applySchemaInputs is non-destructive: the original map is unchanged.
+	assert.Equal(t, resource.NewProperty("44"), inputs["number"])
+}
+
+func TestApplySchemaInputs_PreservesSecrets(t *testing.T) {
+	t.Parallel()
+
+	properties := []*schema.Property{
+		{Name: "count", Type: schema.IntType},
+	}
+
+	inputs := resource.PropertyMap{
+		"count": resource.MakeSecret(resource.NewProperty("42")),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty(42.0)), converted["count"])
+}
+
+func TestApplySchemaInputs_Secrets(t *testing.T) {
+	t.Parallel()
+
+	properties := []*schema.Property{
+		{Name: "token", Type: schema.StringType, Secret: true},
+		{Name: "name", Type: schema.StringType},
+		{Name: "preMarked", Type: schema.StringType, Secret: true},
+		{Name: "missing", Type: schema.StringType, Secret: true},
+	}
+
+	inputs := resource.PropertyMap{
+		"token":     resource.NewProperty("s3cret"),
+		"name":      resource.NewProperty("hello"),
+		"preMarked": resource.MakeSecret(resource.NewProperty("already")),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty("s3cret")), converted["token"])
+	// Non-secret property is left alone.
+	assert.Equal(t, resource.NewProperty("hello"), converted["name"])
+	// Already-secret property isn't double-wrapped.
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty("already")), converted["preMarked"])
+	// Missing properties without defaults are not synthesized, even if marked secret.
+	_, has := converted["missing"]
+	assert.False(t, has)
+}
+
+func TestApplySchemaInputs_RecursesIntoNestedObjects(t *testing.T) {
+	t.Parallel()
+
+	// Nested type with both a default and a secret property.
+	data := &schema.ObjectType{
+		Properties: []*schema.Property{
+			{Name: "public", Type: schema.StringType},
+			{Name: "private", Type: schema.StringType, Secret: true},
+			{
+				Name:         "region",
+				Type:         schema.StringType,
+				DefaultValue: &schema.DefaultValue{Value: "us-west-2"},
+			},
+		},
+	}
+
+	properties := []*schema.Property{
+		// Outer property is itself secret — nested marking still happens, even though the
+		// outer wrap arguably already covers everything.
+		{Name: "outerSecret", Type: data, Secret: true},
+		// Outer property is not secret — nested secrets must be marked.
+		{Name: "outer", Type: data},
+	}
+
+	inputs := resource.PropertyMap{
+		"outerSecret": resource.NewProperty(resource.PropertyMap{
+			"public":  resource.NewProperty("o"),
+			"private": resource.NewProperty("p"),
+		}),
+		"outer": resource.NewProperty(resource.PropertyMap{
+			"public":  resource.NewProperty("o"),
+			"private": resource.NewProperty("p"),
+		}),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+
+	// outer (not secret-wrapped at top level): nested private is marked, region default fills in.
+	assert.Equal(t, resource.NewProperty(resource.PropertyMap{
+		"public":  resource.NewProperty("o"),
+		"private": resource.MakeSecret(resource.NewProperty("p")),
+		"region":  resource.NewProperty("us-west-2"),
+	}), converted["outer"])
+
+	// outerSecret: the whole thing is wrapped, defaults still fill in inside, but the
+	// schema-driven secret mark on "private" is suppressed because the outer wrap already
+	// covers everything.
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+		"public":  resource.NewProperty("o"),
+		"private": resource.NewProperty("p"),
+		"region":  resource.NewProperty("us-west-2"),
+	})), converted["outerSecret"])
+}
+
+func TestApplySchemaInputs_PreservesUserSecretInsideSecretParent(t *testing.T) {
+	t.Parallel()
+
+	data := &schema.ObjectType{
+		Properties: []*schema.Property{
+			{Name: "private", Type: schema.StringType, Secret: true},
+			{Name: "public", Type: schema.StringType},
+		},
+	}
+	properties := []*schema.Property{
+		{Name: "outer", Type: data, Secret: true},
+	}
+
+	// User explicitly marked the inner "private" as secret. The outer wrap shouldn't strip it.
+	inputs := resource.PropertyMap{
+		"outer": resource.NewProperty(resource.PropertyMap{
+			"private": resource.MakeSecret(resource.NewProperty("user-marked")),
+			"public":  resource.NewProperty("p"),
+		}),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty(resource.PropertyMap{
+		"private": resource.MakeSecret(resource.NewProperty("user-marked")),
+		"public":  resource.NewProperty("p"),
+	})), converted["outer"])
+}
+
+func TestApplySchemaInputs(t *testing.T) {
+	t.Parallel()
+
+	properties := []*schema.Property{
+		{Name: "count", Type: schema.IntType},
+		{Name: "token", Type: schema.StringType, Secret: true},
+		{Name: "region", Type: schema.StringType, DefaultValue: &schema.DefaultValue{Value: "us-west-2"}},
+		{
+			Name:         "secretWithDefault",
+			Type:         schema.StringType,
+			Secret:       true,
+			DefaultValue: &schema.DefaultValue{Value: "fallback"},
+		},
+	}
+
+	inputs := resource.PropertyMap{
+		"count": resource.NewProperty("12"),
+		"token": resource.NewProperty("plain"),
+	}
+
+	converted, err := applySchemaInputs(inputs, properties)
+	require.NoError(t, err)
+
+	assert.Equal(t, resource.NewProperty(12.0), converted["count"])
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty("plain")), converted["token"])
+	assert.Equal(t, resource.NewProperty("us-west-2"), converted["region"])
+	// Defaults that fill in for secret properties get wrapped too.
+	assert.Equal(t, resource.MakeSecret(resource.NewProperty("fallback")), converted["secretWithDefault"])
 }


### PR DESCRIPTION
This refactors invokes, calls, and resources to all go through the same `applySchemaInputs` logic to set defaults, conversions, and secrets. We can then use this same logic in `do` when evaluating a function/resource body.