### PR TITLE
feat(cli): shell completion for the `--stack` flag

### DIFF
--- a/changelog/pending/20260514--cli--add-shell-completion-for-the-stack-flag.yaml
+++ b/changelog/pending/20260514--cli--add-shell-completion-for-the-stack-flag.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add shell completion for the `--stack` flag on all commands that operate on an existing stack, listing stacks from the current backend

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -86,6 +87,7 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to get info on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVarP(
 		&transitiveDependencies, "transitive", "t", false, "Include transitive dependencies")
 

--- a/pkg/cmd/pulumi/cancel/cancel.go
+++ b/pkg/cmd/pulumi/cancel/cancel.go
@@ -104,6 +104,7 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/completion/gen.go
+++ b/pkg/cmd/pulumi/completion/gen.go
@@ -15,16 +15,19 @@
 package completion
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
 )
 
-// NewGenCompletionCmd returns a new command that, when run, generates a bash or zsh completion script for the CLI.
+// NewGenCompletionCmd returns a new command that, when run, generates a shell completion script for the CLI.
+//
+// It emits Cobra's modern (V2) completion scripts, which delegate to the
+// `pulumi __complete` hidden subcommand at runtime. This is what makes
+// `RegisterFlagCompletionFunc` registrations such as the one on `--stack` work
+// in interactive shells.
 func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "gen-completion",
@@ -33,11 +36,13 @@ func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":
-				return root.GenBashCompletion(os.Stdout)
+				return root.GenBashCompletionV2(os.Stdout, true)
 			case "zsh":
-				return genZshCompletion(os.Stdout, root)
+				return root.GenZshCompletion(os.Stdout)
 			case "fish":
 				return root.GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(os.Stdout)
 			default:
 				return fmt.Errorf("%q is not a supported shell", args[0])
 			}
@@ -56,158 +61,4 @@ func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 	})
 
 	return cmd
-}
-
-const (
-	// Inspired by https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/completion.go
-	zshHead = `#compdef pulumi
-__pulumi_bash_source() {
-	alias shopt=':'
-	alias _expand=_bash_expand
-	alias _complete=_bash_comp
-	emulate -L sh
-	setopt kshglob noshglob braceexpand
- 	source "$@"
-}
- __pulumi_type() {
-	# -t is not supported by zsh
-	if [ "$1" == "-t" ]; then
-		shift
- 		# fake Bash 4 to disable "complete -o nospace". Instead
-		# "compopt +-o nospace" is used in the code to toggle trailing
-		# spaces. We don't support that, but leave trailing spaces on
-		# all the time
-		if [ "$1" = "__pulumi_compopt" ]; then
-			echo builtin
-			return 0
-		fi
-	fi
-	type "$@"
-}
- __pulumi_compgen() {
-	local completions w
-	completions=( $(compgen "$@") ) || return $?
- 	# filter by given word as prefix
-	while [[ "$1" = -* && "$1" != -- ]]; do
-		shift
-		shift
-	done
-	if [[ "$1" == -- ]]; then
-		shift
-	fi
-	for w in "${completions[@]}"; do
-		if [[ "${w}" = "$1"* ]]; then
-			echo "${w}"
-		fi
-	done
-}
- __pulumi_compopt() {
-	true # don't do anything. Not supported by bashcompinit in zsh
-}
- __pulumi_ltrim_colon_completions()
-{
-	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
-		# Remove colon-word prefix from COMPREPLY items
-		local colon_word=${1%${1##*:}}
-		local i=${#COMPREPLY[*]}
-		while [[ $((--i)) -ge 0 ]]; do
-			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
-		done
-	fi
-}
- __pulumi_get_comp_words_by_ref() {
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
-	words=("${COMP_WORDS[@]}")
-	cword=("${COMP_CWORD[@]}")
-}
- __pulumi_filedir() {
-	local RET OLD_IFS w qw
- 	__debug "_filedir $@ cur=$cur"
-	if [[ "$1" = \~* ]]; then
-		# somehow does not work. Maybe, zsh does not call this at all
-		eval echo "$1"
-		return 0
-	fi
- 	OLD_IFS="$IFS"
-	IFS=$'\n'
-	if [ "$1" = "-d" ]; then
-		shift
-		RET=( $(compgen -d) )
-	else
-		RET=( $(compgen -f) )
-	fi
-	IFS="$OLD_IFS"
- 	IFS="," __debug "RET=${RET[@]} len=${#RET[@]}"
- 	for w in ${RET[@]}; do
-		if [[ ! "${w}" = "${cur}"* ]]; then
-			continue
-		fi
-		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
-			qw="$(__pulumi_quote "${w}")"
-			if [ -d "${w}" ]; then
-				COMPREPLY+=("${qw}/")
-			else
-				COMPREPLY+=("${qw}")
-			fi
-		fi
-	done
-}
- __pulumi_quote() {
-    if [[ $1 == \'* || $1 == \"* ]]; then
-        # Leave out first character
-        printf %q "${1:1}"
-    else
-    	printf %q "$1"
-    fi
-}
- autoload -U +X bashcompinit && bashcompinit
- # use word boundary patterns for BSD or GNU sed
-LWORD='[[:<:]]'
-RWORD='[[:>:]]'
-if sed --help 2>&1 | grep -q GNU; then
-	LWORD='\<'
-	RWORD='\>'
-fi
- __pulumi_convert_bash_to_zsh() {
-	sed \
-	-e 's/declare -F/whence -w/' \
-	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
-	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
-	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
-	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
-	-e "s/${LWORD}_filedir${RWORD}/__pulumi_filedir/g" \
-	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__pulumi_get_comp_words_by_ref/g" \
-	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__pulumi_ltrim_colon_completions/g" \
-	-e "s/${LWORD}compgen${RWORD}/__pulumi_compgen/g" \
-	-e "s/${LWORD}compopt${RWORD}/__pulumi_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
-	-e "s/\\\$(type${RWORD}/\$(__pulumi_type/g" \
-	<<'BASH_COMPLETION_EOF'
-`
-
-	zshTail = `
-BASH_COMPLETION_EOF
-}
-__pulumi_bash_source <(__pulumi_convert_bash_to_zsh)
-_complete pulumi 2>/dev/null
-`
-)
-
-func genZshCompletion(out io.Writer, root *cobra.Command) error {
-	buf := new(bytes.Buffer)
-	if err := root.GenBashCompletion(buf); err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintf(out, "%s", zshHead); err != nil { //nolint
-		return err
-	}
-
-	if _, err := fmt.Fprint(out, buf.String()); err != nil {
-		return err
-	}
-
-	_, err := fmt.Fprint(out, zshTail)
-	return err
 }

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -138,6 +138,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -108,6 +109,7 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to view")
+	cmdStack.RegisterCompleteStack(cmd)
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/deployment/deployment_cmds.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cmds.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 )
 
 // TODO[https://github.com/pulumi/pulumi/issues/22987]: Not yet implemented.
@@ -45,6 +46,7 @@ func newDeploymentGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -75,6 +77,7 @@ func newDeploymentCancelCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -109,6 +112,7 @@ func newDeploymentLogCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().IntVar(&job, "job", -1, "The job index to fetch step-level logs for")
 	cmd.Flags().IntVar(&step, "step", -1, "The step index within the job (requires --job)")
 	cmd.Flags().IntVar(&offset, "offset", 0, "The byte offset within the step's logs")
@@ -136,6 +140,7 @@ func newDeploymentSettingsGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -164,6 +169,7 @@ func newDeploymentSettingsEditCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().StringVarP(&file, "file", "f", "",
 		"Read settings patch from file; `-` reads stdin")
 

--- a/pkg/cmd/pulumi/deployment/deployment_list.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list.go
@@ -107,6 +107,7 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 
 	cmd.Flags().StringVarP(&args.stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().Int64Var(&args.page, "page", 1, "The page of results to return (min 1)")
 	cmd.Flags().Int64Var(&args.pageSize, "page-size", 10, "The number of results per page (1-100)")
 	cmd.Flags().StringVar(&args.sort, "sort", "", "The field to sort results by")

--- a/pkg/cmd/pulumi/deployment/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment/deployment_run.go
@@ -117,6 +117,7 @@ func newDeploymentRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -219,6 +219,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	cmd.PersistentFlags().BoolVarP(
 		&force, "force", "f", false,
@@ -369,6 +370,7 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -73,6 +74,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -128,6 +130,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -179,6 +182,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -278,6 +282,7 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -199,6 +199,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 	logsCmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(logsCmd)
 	logsCmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/neo/tools"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	displaytypes "github.com/pulumi/pulumi/pkg/v3/display"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -147,6 +148,7 @@ func NewNeoCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
 		"The name of the stack to attach to the Neo task")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().StringVar(&orgFlag, "org", "",
 		"The organization that owns the Neo task (defaults to the user's default org)")
 	cmd.Flags().StringVar(&cwdFlag, "cwd", "",

--- a/pkg/cmd/pulumi/newcmd/new.go
+++ b/pkg/cmd/pulumi/newcmd/new.go
@@ -628,6 +628,7 @@ func NewNewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&args.stack, "stack", "s", "",
 		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVarP(
 		&args.yes, "yes", "y", false,
 		"Skip prompts and proceed with default values")

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -391,6 +391,7 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -1106,6 +1106,7 @@ func NewImportCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -629,6 +629,7 @@ func NewPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -363,6 +363,7 @@ func NewRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -534,11 +534,18 @@ func NewUpCmd() *cobra.Command {
 		}
 	}
 
+	completionOptions := cobra.CompletionOptions{}
+	completionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveFilterDirs)
 	cmd := &cobra.Command{
-		Use:        "up",
-		Aliases:    []string{"update"},
-		SuggestFor: []string{"apply", "deploy", "push"},
-		Short:      "Create or update the resources in a stack",
+		Use:               "up",
+		Aliases:           []string{"update"},
+		SuggestFor:        []string{"apply", "deploy", "push"},
+		Short:             "Create or update the resources in a stack",
+		Args:              cobra.MaximumNArgs(1),
+		CompletionOptions: completionOptions,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
 		Long: "Create or update the resources in a stack.\n" +
 			"\n" +
 			"This command creates or updates resources in a stack. The new desired goal state for the target stack\n" +
@@ -723,6 +730,7 @@ func NewUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -197,6 +197,7 @@ func NewWatchCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVar(
 		&cmdStack.ConfigFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -152,6 +152,7 @@ func newPolicyAnalyzeCmd(
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to analyze. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(&diffDisplay, "diff", false,
 		"Display policy diagnostics as a rich diff instead of grouped progress output")
 	cmd.Flags().BoolVarP(&jsonDisplay, "json", "j", false,

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -58,6 +58,7 @@ func newPolicyInstallCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/completion.go
+++ b/pkg/cmd/pulumi/stack/completion.go
@@ -1,0 +1,95 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// CompleteStackName is a cobra flag-completion function that lists stack names
+// from the current backend, filtered to the current project when one is
+// available. It is intended for use with RegisterFlagCompletionFunc on the
+// `--stack` flag.
+//
+// Failures (unreadable project, unreachable backend, list errors) are surfaced
+// to the user via cobra ActiveHelp lines so the completion menu shows why no
+// candidates are offered, rather than silently dropping back to file
+// completion. ActiveHelp is the only channel actually displayed by the
+// generated shell completion scripts — stderr from this function is discarded.
+func CompleteStackName(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return cobra.AppendActiveHelp(nil, fmt.Sprintf("cannot read project: %v", err)), cobra.ShellCompDirectiveNoFileComp
+	}
+
+	b, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts)
+	if err != nil {
+		return cobra.AppendActiveHelp(nil, fmt.Sprintf("cannot reach backend: %v", err)), cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var filter backend.ListStacksFilter
+	if project != nil {
+		projName := string(project.Name)
+		filter.Project = &projName
+	}
+
+	var names []string
+	var inContToken backend.ContinuationToken
+	for {
+		summaries, outContToken, err := b.ListStacks(ctx, filter, inContToken)
+		if err != nil {
+			return cobra.AppendActiveHelp(nil, fmt.Sprintf("cannot list stacks: %v", err)), cobra.ShellCompDirectiveNoFileComp
+		}
+		for _, s := range summaries {
+			names = append(names, s.Name().String())
+		}
+		if outContToken == nil {
+			break
+		}
+		inContToken = outContToken
+	}
+
+	if len(names) == 0 {
+		return cobra.AppendActiveHelp(nil, "no stacks found for this project"), cobra.ShellCompDirectiveNoFileComp
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// RegisterCompleteStack registers CompleteStackName as the completion function
+// for the `--stack` flag on the given command. Callers should prefer this
+// helper over calling RegisterFlagCompletionFunc directly so behavior stays
+// consistent across the CLI.
+func RegisterCompleteStack(cmd *cobra.Command) {
+	_ = cmd.RegisterFlagCompletionFunc("stack", CompleteStackName)
+}

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -92,6 +92,7 @@ func NewStackCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVarP(
 		&args.showIDs, "show-ids", "i", false, "Display each resource's provider-assigned unique ID")
 	cmd.Flags().BoolVarP(

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -83,6 +83,7 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&scspcmd.stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -63,6 +63,7 @@ func newStackDriftListCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().IntVar(&page, "page", 1, "The page of results to return")
 	cmd.Flags().IntVar(&pageSize, "page-size", 10, "The number of results per page (1-100)")
 
@@ -87,6 +88,7 @@ func newStackDriftGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -140,6 +140,7 @@ func newStackExportCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().StringVarP(
 		&file, "file", "", "", "A filename to write stack output to")
 	cmd.PersistentFlags().StringVarP(

--- a/pkg/cmd/pulumi/stack/stack_graph.go
+++ b/pkg/cmd/pulumi/stack/stack_graph.go
@@ -124,6 +124,7 @@ func newStackGraphCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(
 		&cmdOpts.stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVar(&cmdOpts.ignoreParentEdges, "ignore-parent-edges", false,
 		"Ignores edges introduced by parent/child resource relationships")
 	cmd.PersistentFlags().BoolVar(&cmdOpts.ignoreDependencyEdges, "ignore-dependency-edges", false,

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -118,6 +118,7 @@ This command displays data about previous updates for a stack.`,
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"Choose a stack other than the currently selected one")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show secret values when listing config instead of displaying blinded values")

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -51,6 +51,7 @@ func newStackHistoryEventsCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringArrayVar(&eventTypes, "event-type", nil,
 		"Filter by engine event type code (repeatable)")
 	cmd.Flags().StringVar(&resourceURN, "urn", "", "Filter by resource URN")

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -137,6 +137,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVarP(
 		&force, "force", "f", false,
 		"Force the import to occur, even if apparent errors are discovered beforehand (not recommended)")

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -70,6 +70,7 @@ func newStackOutputCmd() *cobra.Command {
 		&socmd.shellOut, "shell", false, "Emit output as a shell script")
 	cmd.PersistentFlags().StringVarP(
 		&socmd.stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVar(
 		&socmd.showSecrets, "show-secrets", false, "Display outputs which are marked as secret in plaintext")
 

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -116,5 +116,6 @@ func newStackRenameCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -143,6 +143,7 @@ func newStackRmCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVar(
 		&preserveConfig, "preserve-config", false,
 		"Do not delete the corresponding Pulumi.<stack-name>.yaml configuration file for the stack")

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -62,6 +62,7 @@ func newStackScheduleListCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -89,6 +90,7 @@ func newStackScheduleNewCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVar(&cron, "cron", "",
 		"A cron expression for recurring executions (e.g. '0 */4 * * *')")
 	cmd.Flags().StringVar(&once, "once", "",
@@ -122,6 +124,7 @@ func newStackScheduleGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -154,6 +157,7 @@ func newStackScheduleEditCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVar(&cron, "cron", "",
 		"A cron expression for recurring executions")
 	cmd.Flags().StringVar(&once, "once", "",
@@ -187,6 +191,7 @@ func newStackScheduleRemoveCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -133,6 +133,7 @@ func newStackSelectCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to select")
+	RegisterCompleteStack(cmd)
 	cmd.PersistentFlags().BoolVarP(
 		&create, "create", "c", false,
 		"If selected stack does not exist, create it")

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -49,6 +49,7 @@ func newStackTagCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	cmd.AddCommand(newStackTagGetCmd(&stack))
 	cmd.AddCommand(newStackTagLsCmd(&stack))

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -81,6 +81,7 @@ func newStackWebhookNewCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
 	cmd.Flags().StringVar(&format, "format", "raw",
 		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
@@ -119,6 +120,7 @@ func newStackWebhookEditCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
 	cmd.Flags().StringVar(&format, "format", "",
 		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
@@ -149,6 +151,7 @@ func newStackWebhookRemoveCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -171,6 +174,7 @@ func newStackWebhookPingCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -212,6 +216,7 @@ func newStackWebhookDeliveryListCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }
@@ -240,6 +245,7 @@ func newStackWebhookDeliveryGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_get.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get.go
@@ -76,6 +76,7 @@ func newStackWebhookGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVarP(&output, "output", "o", "default",
 		"The output format: default (human-readable text) or json")
 

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -75,6 +75,7 @@ func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Co
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	RegisterCompleteStack(cmd)
 	cmd.Flags().StringVarP(&output, "output", "o", "default",
 		"The output format: default (human-readable table) or json")
 

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -155,6 +156,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(&force, "force", false, "Force deletion of protected resources")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 	cmd.Flags().BoolVar(&all, "all", false, "Delete all resources in the stack")

--- a/pkg/cmd/pulumi/state/state_protect.go
+++ b/pkg/cmd/pulumi/state/state_protect.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -104,6 +105,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(&protectAll, "all", false, "Protect all resources in the checkpoint")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 

--- a/pkg/cmd/pulumi/state/state_rename.go
+++ b/pkg/cmd/pulumi/state/state_rename.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -257,6 +258,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 	return cmd

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -108,6 +108,7 @@ not write any changes.
 
 	cmd.Flags().StringVarP(&stateRepair.Args.Stack,
 		"stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVarP(&stateRepair.Args.Yes,
 		"yes", "y", false, "Automatically approve and perform the repair")
 

--- a/pkg/cmd/pulumi/state/state_taint.go
+++ b/pkg/cmd/pulumi/state/state_taint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -93,6 +94,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 
 	return cmd

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -97,6 +98,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(&unprotectAll, "all", false, "Unprotect all resources in the checkpoint")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 

--- a/pkg/cmd/pulumi/state/state_untaint.go
+++ b/pkg/cmd/pulumi/state/state_untaint.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -98,6 +99,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
+	cmdStack.RegisterCompleteStack(cmd)
 	cmd.Flags().BoolVar(&untaintAll, "all", false, "Untaint all resources in the checkpoint")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 


### PR DESCRIPTION
Add a `cmdStack.CompleteStackName` Cobra completion function that lists stacks from the current backend (filtered to the current project) and register it on the `--stack` flag of every command that operates on an existing stack: `up`, `preview`, `refresh`, `destroy`, `import`, `watch`, `cancel`, `logs`, `config`, `about`, `console`, `console`, `new`, the `state`, `stack`, `deployment`, and `policy` sub-trees, and others. Stack-creating flows (`stack init`, `stack new`) intentionally skip completion so users are not steered toward reusing existing names.

Failures (unreachable backend, expired credentials, list errors) surface to the user as `cobra.AppendActiveHelp` lines in the completion menu so the cause is visible, rather than dropping into silent file fallback. `ShellCompDirectiveNoFileComp` is returned on every path so no file fallback ever kicks in.

`pulumi gen-completion` is migrated from Cobra's legacy V1 templates (`GenBashCompletion` plus a hand-rolled zsh wrapper) to the V2 API (`GenBashCompletionV2`, `GenZshCompletion`, `GenFishCompletion`, `GenPowerShellCompletionWithDesc`). The V1 templates do not honor `RegisterFlagCompletionFunc`, so this migration is what actually makes flag completions reach installed shell scripts. Users will need to regenerate their installed completion script after upgrading.

Constraint: V1 completion templates ignore RegisterFlagCompletionFunc
Constraint: zsh's V2 completion script discards `__complete` stderr, so error reporting must go through ActiveHelp, not stderr
Constraint: Completion must list existing stacks only — never suggest existing names for stack-creating flows
Rejected: Wire stack completion through the V1 BashCompCustom annotation | does not scale, requires hand-written bash per flag
Rejected: Use ShellCompDirectiveError on failure | shell silently swallows errors and falls back to files
Confidence: high
Scope-risk: moderate
Directive: When adding new commands that take an existing `--stack` value, call cmdStack.RegisterCompleteStack(cmd) right after the flag is registered
Directive: Stay on the V2 completion API for any new RegisterFlagCompletionFunc work — do not reintroduce custom bash/zsh scaffolding
Not-tested: PowerShell and fish output beyond compile-time wiring
Not-tested: Live shell completion in commands beyond `pulumi up` (verified at compile + cobra layer for all)

## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->

## Test plan
<!-- How did you test this change? -->
- [ ] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
