### PR TITLE
implement `pulumi stack drift list`

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-stack-drift-list.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-stack-drift-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack drift list` to list drift detection runs for a stack

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -714,6 +714,24 @@ func (pc *Client) GetStack(ctx context.Context, stackID StackIdentifier) (apityp
 	return stack, nil
 }
 
+// ListDriftRuns returns a paginated list of drift detection runs for the given stack.
+func (pc *Client) ListDriftRuns(
+	ctx context.Context, stackID StackIdentifier, page, pageSize int,
+) (apitype.ListDriftRunsResponse, error) {
+	queryObj := struct {
+		Page     int `url:"page"`
+		PageSize int `url:"pageSize"`
+	}{
+		Page:     page,
+		PageSize: pageSize,
+	}
+	var resp apitype.ListDriftRunsResponse
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "drift", "runs"), queryObj, nil, &resp); err != nil {
+		return apitype.ListDriftRunsResponse{}, err
+	}
+	return resp, nil
+}
+
 // ListStackWebhooks returns all webhooks configured for the given stack.
 func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier) ([]apitype.Webhook, error) {
 	var resp []apitype.Webhook

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -41,33 +41,7 @@ func newStackDriftCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23051]: Not yet implemented.
-func newStackDriftListCmd() *cobra.Command {
-	var (
-		stack    string
-		page     int
-		pageSize int
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List drift detection runs for a stack",
-		Long:   "[EXPERIMENTAL] List drift detection runs for a stack.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().IntVar(&page, "page", 1, "The page of results to return")
-	cmd.Flags().IntVar(&pageSize, "page-size", 10, "The number of results per page (1-100)")
-
-	return cmd
-}
+// newStackDriftListCmd is defined in stack_drift_list.go.
 
 // TODO[https://github.com/pulumi/pulumi/issues/23052]: Not yet implemented.
 func newStackDriftGetCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/stack/stack_drift_list.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_list.go
@@ -1,0 +1,286 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// driftListClient is the interface the drift list command needs.
+type driftListClient interface {
+	ListDriftRuns(
+		ctx context.Context, stackID client.StackIdentifier,
+		page, pageSize int,
+	) (apitype.ListDriftRunsResponse, error)
+}
+
+type driftListClientFactory func(
+	ctx context.Context, stackFlag string,
+) (driftListClient, client.StackIdentifier, error)
+
+// driftListRender renders a drift list response.
+type driftListRender func(
+	cmd *driftListCmd, runs []apitype.DriftRun, total int,
+) error
+
+// defaultPageSize is the number of items fetched per API call.
+const defaultPageSize = 100
+
+type driftListCmd struct {
+	stack  string
+	count  int
+	all    bool
+	output outputflag.OutputFlag[driftListRender]
+	w      io.Writer
+}
+
+func newStackDriftListCmd() *cobra.Command {
+	return newStackDriftListCmdWith(nil)
+}
+
+func newStackDriftListCmdWith(factory driftListClientFactory) *cobra.Command {
+	dlcmd := &driftListCmd{
+		output: outputflag.OutputFlag[driftListRender]{
+			RenderForTerminal: (*driftListCmd).renderTable,
+			RenderJSON:        (*driftListCmd).renderJSON,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List drift detection runs for a stack",
+		Long: "List drift detection runs for a stack.\n" +
+			"\n" +
+			"Returns drift detection runs for the specified stack. Each run\n" +
+			"includes whether drift was detected, the run status, and details\n" +
+			"about detection and remediation phases.\n" +
+			"\n" +
+			"By default, the first 10 results are shown. Use --count to request\n" +
+			"more, or --all to fetch every run.",
+		Example: "  # List drift runs for the current stack\n" +
+			"  pulumi stack drift list\n\n" +
+			"  # Show the last 50 drift runs\n" +
+			"  pulumi stack drift list --count 50\n\n" +
+			"  # Fetch all drift runs as JSON\n" +
+			"  pulumi stack drift list --all --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultDriftListClientFactory
+			}
+			if dlcmd.all && dlcmd.count > 0 {
+				return errors.New("--all and --count are mutually exclusive")
+			}
+			dlcmd.w = cmd.OutOrStdout()
+			return dlcmd.run(cmd.Context(), factory)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&dlcmd.stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().IntVar(&dlcmd.count, "count", 0,
+		"Number of results to display (fetches multiple pages if needed)")
+	cmd.Flags().BoolVar(&dlcmd.all, "all", false,
+		"Fetch all results (mutually exclusive with --count)")
+	outputflag.VarP(cmd.Flags(), &dlcmd.output)
+
+	return cmd
+}
+
+func defaultDriftListClientFactory(
+	ctx context.Context, stackFlag string,
+) (driftListClient, client.StackIdentifier, error) {
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	s, err := RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
+		stackFlag, LoadOnly, opts)
+	if err != nil {
+		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
+	}
+
+	cloudStack, ok := s.(httpstate.Stack)
+	if !ok {
+		return nil, client.StackIdentifier{},
+			errors.New("drift commands require the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	ref := cloudStack.Ref()
+	project := ""
+	if p, ok := ref.Project(); ok {
+		project = string(p)
+	}
+	stackID := client.StackIdentifier{
+		Owner:   cloudStack.OrgName(),
+		Project: project,
+		Stack:   ref.Name(),
+	}
+
+	be := cloudStack.Backend().(httpstate.Backend)
+	return be.Client(), stackID, nil
+}
+
+func (c *driftListCmd) run(ctx context.Context, factory driftListClientFactory) error {
+	cl, stackID, err := factory(ctx, c.stack)
+	if err != nil {
+		return err
+	}
+
+	// Determine how many results to fetch.
+	want := 10 // default: one page worth
+	if c.count > 0 {
+		want = c.count
+	} else if c.all {
+		want = -1 // sentinel: fetch everything
+	}
+
+	var allRuns []apitype.DriftRun
+	var total int
+	page := 1
+
+	for {
+		pageSize := defaultPageSize
+		if want > 0 && want-len(allRuns) < pageSize {
+			pageSize = want - len(allRuns)
+		}
+
+		resp, err := cl.ListDriftRuns(ctx, stackID, page, pageSize)
+		if err != nil {
+			return fmt.Errorf("listing drift runs: %w", err)
+		}
+		total = resp.Total
+		allRuns = append(allRuns, resp.DriftRuns...)
+
+		// Stop if we've collected enough, or there are no more results.
+		if want > 0 && len(allRuns) >= want {
+			allRuns = allRuns[:want]
+			break
+		}
+		if len(allRuns) >= total || len(resp.DriftRuns) == 0 {
+			break
+		}
+		page++
+	}
+
+	return c.output.Get()(c, allRuns, total)
+}
+
+func (c *driftListCmd) renderJSON(runs []apitype.DriftRun, total int) error {
+	if runs == nil {
+		runs = []apitype.DriftRun{}
+	}
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		DriftRuns []apitype.DriftRun `json:"driftRuns"`
+		Count     int                `json:"count"`
+		Total     int                `json:"total"`
+	}{
+		DriftRuns: runs,
+		Count:     len(runs),
+		Total:     total,
+	})
+}
+
+func (c *driftListCmd) renderTable(runs []apitype.DriftRun, total int) error {
+	if len(runs) == 0 {
+		fmt.Fprintln(c.w, "No drift detection runs found for this stack.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(c.w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{
+		"ID", "CREATED", "STATUS", "DRIFT", "DETECT", "REMEDIATE",
+	})
+
+	for _, run := range runs {
+		drift := "no"
+		if run.DriftDetected {
+			drift = "yes"
+		}
+		detect := formatUpdateStatus(run.DetectUpdate)
+		remediate := formatUpdateStatus(run.RemediateUpdate)
+
+		t.AppendRow(table.Row{
+			run.ID, run.Created, run.Status, drift, detect, remediate,
+		})
+	}
+
+	// Let go-pretty wrap columns to fit the terminal. Fixed-width columns
+	// (CREATED, STATUS, DRIFT) are short enough to never need wrapping.
+	// ID, DETECT, and REMEDIATE get max widths so they wrap if needed.
+	cols := cmdCmd.StdoutWidth()
+	// CREATED(25) + STATUS(11) + DRIFT(5) + borders(~22) = 63 fixed
+	flexible := cols - 63
+	if flexible < 30 {
+		flexible = 30
+	}
+	// Split flexible space: ~40% ID, ~30% DETECT, ~30% REMEDIATE
+	idWidth := flexible * 2 / 5
+	detWidth := flexible * 3 / 10
+	remWidth := flexible - idWidth - detWidth
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "ID", WidthMax: idWidth, WidthMaxEnforcer: text.WrapText},
+		{Name: "DETECT", WidthMax: detWidth, WidthMaxEnforcer: text.WrapText},
+		{Name: "REMEDIATE", WidthMax: remWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+
+	fmt.Fprintf(c.w, "\nShowing %d of %d drift run(s)\n", len(runs), total)
+	return nil
+}
+
+func formatUpdateStatus(u *apitype.DriftRunUpdate) string {
+	if u == nil {
+		return "-"
+	}
+	parts := []string{u.Status}
+	if len(u.ResourceChanges) > 0 {
+		var changes []string
+		for op, count := range u.ResourceChanges {
+			if op != "same" && count > 0 {
+				changes = append(changes, fmt.Sprintf("%d %s", count, op))
+			}
+		}
+		if len(changes) > 0 {
+			parts = append(parts, "("+strings.Join(changes, ", ")+")")
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/pkg/cmd/pulumi/stack/stack_drift_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_list_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDriftListClient struct {
+	// pages maps page number to response.
+	pages   map[int]apitype.ListDriftRunsResponse
+	err     error
+	gotPage []int
+	gotSize []int
+}
+
+func (m *mockDriftListClient) ListDriftRuns(
+	_ context.Context, _ client.StackIdentifier, page, pageSize int,
+) (apitype.ListDriftRunsResponse, error) {
+	m.gotPage = append(m.gotPage, page)
+	m.gotSize = append(m.gotSize, pageSize)
+	if m.err != nil {
+		return apitype.ListDriftRunsResponse{}, m.err
+	}
+	if resp, ok := m.pages[page]; ok {
+		return resp, nil
+	}
+	return apitype.ListDriftRunsResponse{}, nil
+}
+
+var driftTestStackID = client.StackIdentifier{
+	Owner:   "my-org",
+	Project: "my-project",
+	Stack:   tokens.MustParseStackName("dev"),
+}
+
+func stubDriftListFactory(c driftListClient) driftListClientFactory {
+	return func(_ context.Context, _ string) (driftListClient, client.StackIdentifier, error) {
+		return c, driftTestStackID, nil
+	}
+}
+
+func newTestDriftListCmd() (*driftListCmd, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &driftListCmd{
+		output: outputflag.OutputFlag[driftListRender]{
+			RenderForTerminal: (*driftListCmd).renderTable,
+			RenderJSON:        (*driftListCmd).renderJSON,
+		},
+		w: &buf,
+	}, &buf
+}
+
+func singlePageRuns() *mockDriftListClient {
+	return &mockDriftListClient{
+		pages: map[int]apitype.ListDriftRunsResponse{
+			1: {
+				DriftRuns: []apitype.DriftRun{
+					{
+						ID:            "run-1",
+						DriftDetected: true,
+						Created:       "2026-05-13T10:00:00Z",
+						Status:        "succeeded",
+						DetectUpdate: &apitype.DriftRunUpdate{
+							UpdateID:        "u-1",
+							ResourceChanges: map[string]int{"update": 2, "same": 5},
+							Modified:        "2026-05-13T10:01:00Z",
+							Status:          "succeeded",
+						},
+						RemediateUpdate: &apitype.DriftRunUpdate{
+							UpdateID:        "u-2",
+							ResourceChanges: map[string]int{"update": 2},
+							Modified:        "2026-05-13T10:02:00Z",
+							Status:          "succeeded",
+						},
+					},
+					{
+						ID:            "run-2",
+						DriftDetected: false,
+						Created:       "2026-05-12T10:00:00Z",
+						Status:        "succeeded",
+						DetectUpdate: &apitype.DriftRunUpdate{
+							UpdateID: "u-3",
+							Modified: "2026-05-12T10:01:00Z",
+							Status:   "succeeded",
+						},
+					},
+				},
+				ItemsPerPage: 10,
+				Total:        2,
+			},
+		},
+	}
+}
+
+func TestDriftList_TableOutput(t *testing.T) {
+	t.Parallel()
+
+	c := singlePageRuns()
+	dlcmd, buf := newTestDriftListCmd()
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Verify all data is present (exact layout depends on terminal width;
+	// long values like "succeeded (2 update)" may wrap across lines).
+	assert.Contains(t, out, "run-1")
+	assert.Contains(t, out, "2026-05-13T10:00:00Z")
+	assert.Contains(t, out, "succeeded")
+	assert.Contains(t, out, "yes")
+	assert.Contains(t, out, "run-2")
+	assert.Contains(t, out, "no")
+	assert.Contains(t, out, "Showing 2 of 2 drift run(s)")
+}
+
+func TestDriftList_TableOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftListClient{pages: map[int]apitype.ListDriftRunsResponse{
+		1: {Total: 0},
+	}}
+	dlcmd, buf := newTestDriftListCmd()
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.NoError(t, err)
+
+	assert.Equal(t, "No drift detection runs found for this stack.\n", buf.String())
+}
+
+func TestDriftList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := singlePageRuns()
+	dlcmd, buf := newTestDriftListCmd()
+	require.NoError(t, dlcmd.output.Set("json"))
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, `"driftRuns"`)
+	assert.Contains(t, out, `"run-1"`)
+	assert.Contains(t, out, `"total": 2`)
+	assert.Contains(t, out, `"count": 2`)
+}
+
+func TestDriftList_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftListClient{err: errors.New("server error")}
+	dlcmd, _ := newTestDriftListCmd()
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing drift runs")
+}
+
+func TestDriftList_CountFlag(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftListClient{
+		pages: map[int]apitype.ListDriftRunsResponse{
+			1: {
+				DriftRuns: []apitype.DriftRun{
+					{ID: "r-1", Status: "succeeded"},
+					{ID: "r-2", Status: "succeeded"},
+				},
+				ItemsPerPage: 2,
+				Total:        3,
+			},
+			2: {
+				DriftRuns:    []apitype.DriftRun{{ID: "r-3", Status: "succeeded"}},
+				ItemsPerPage: 2,
+				Total:        3,
+			},
+		},
+	}
+	dlcmd, buf := newTestDriftListCmd()
+	dlcmd.count = 2
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{1}, c.gotPage)
+	assert.Contains(t, buf.String(), "r-1")
+	assert.Contains(t, buf.String(), "r-2")
+	assert.NotContains(t, buf.String(), "r-3")
+	assert.Contains(t, buf.String(), "Showing 2 of 3")
+}
+
+func TestDriftList_AllFlag(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftListClient{
+		pages: map[int]apitype.ListDriftRunsResponse{
+			1: {
+				DriftRuns: []apitype.DriftRun{
+					{ID: "r-1", Status: "succeeded"},
+					{ID: "r-2", Status: "succeeded"},
+				},
+				ItemsPerPage: 2,
+				Total:        3,
+			},
+			2: {
+				DriftRuns:    []apitype.DriftRun{{ID: "r-3", Status: "succeeded"}},
+				ItemsPerPage: 2,
+				Total:        3,
+			},
+		},
+	}
+	dlcmd, buf := newTestDriftListCmd()
+	dlcmd.all = true
+	err := dlcmd.run(t.Context(), stubDriftListFactory(c))
+	require.NoError(t, err)
+
+	assert.Equal(t, []int{1, 2}, c.gotPage)
+	assert.Contains(t, buf.String(), "r-1")
+	assert.Contains(t, buf.String(), "r-3")
+	assert.Contains(t, buf.String(), "Showing 3 of 3")
+}
+
+func TestDriftList_AllAndCountMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	c := singlePageRuns()
+	cmd := newStackDriftListCmdWith(stubDriftListFactory(c))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--all", "--count", "5"})
+
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all and --count are mutually exclusive")
+}

--- a/sdk/go/common/apitype/drift.go
+++ b/sdk/go/common/apitype/drift.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// ListDriftRunsResponse is the paginated response for listing drift runs.
+type ListDriftRunsResponse struct {
+	DriftRuns    []DriftRun `json:"driftRuns"`
+	ItemsPerPage int        `json:"itemsPerPage"`
+	Total        int        `json:"total"`
+}
+
+// DriftRun describes a single drift detection run.
+type DriftRun struct {
+	ID                string          `json:"id"`
+	DriftDetected     bool            `json:"driftDetected"`
+	Created           string          `json:"created"`
+	Status            string          `json:"status"`
+	DeploymentID      string          `json:"deploymentId,omitempty"`
+	DeploymentVersion int             `json:"deploymentVersion,omitzero"`
+	DetectUpdate      *DriftRunUpdate `json:"detectUpdate,omitempty"`
+	RemediateUpdate   *DriftRunUpdate `json:"remediateUpdate,omitempty"`
+}
+
+// DriftRunUpdate describes a detect or remediate phase of a drift run.
+type DriftRunUpdate struct {
+	UpdateID        string         `json:"updateId"`
+	ResourceChanges map[string]int `json:"resourceChanges,omitempty"`
+	Modified        string         `json:"modified"`
+	Status          string         `json:"status"`
+}


### PR DESCRIPTION
Output examples:

```
$ pulumi stack drift list -s pulumi/komal-drift-test/dev --count 2
┌──────────────────────────────────────┬─────────────────────────┬───────────┬───────┬───────────────────────┬───────────┐
│ ID                                   │ CREATED                 │ STATUS    │ DRIFT │ DETECT                │ REMEDIATE │
├──────────────────────────────────────┼─────────────────────────┼───────────┼───────┼───────────────────────┼───────────┤
│ e987b772-6353-4545-a30b-a385cbbe9597 │ 2026-05-14 00:00:43.269 │ succeeded │ yes   │ succeeded (19 delete) │ -         │
│ 7db12419-d778-48df-ad82-dbd082442273 │ 2026-05-13 00:00:14.642 │ succeeded │ yes   │ succeeded (19 delete) │ -         │
└──────────────────────────────────────┴─────────────────────────┴───────────┴───────┴───────────────────────┴───────────┘

Showing 2 of 972 drift run(s)

$ pulumi stack drift list -s pulumi/komal-drift-test/dev --count 2 -o json
{
  "driftRuns": [
    {
      "id": "e987b772-6353-4545-a30b-a385cbbe9597",
      "driftDetected": true,
      "created": "2026-05-14 00:00:43.269",
      "status": "succeeded",
      "deploymentId": "4e962359-1114-4acc-881c-f915c17d29a6",
      "deploymentVersion": 1655,
      "detectUpdate": {
        "updateId": "234e3828-ab15-47ff-8c86-0b54e78b124f",
        "resourceChanges": {
          "delete": 19,
          "same": 2
        },
        "modified": "2026-05-14 00:02:28.863",
        "status": "succeeded"
      }
    },
    {
      "id": "7db12419-d778-48df-ad82-dbd082442273",
      "driftDetected": true,
      "created": "2026-05-13 00:00:14.642",
      "status": "succeeded",
      "deploymentId": "1439fc1f-4c94-4507-87ff-1b741c1bd17a",
      "deploymentVersion": 1654,
      "detectUpdate": {
        "updateId": "875d8c17-c40b-427a-bb45-726ec7aa4b14",
        "resourceChanges": {
          "delete": 19,
          "same": 2
        },
        "modified": "2026-05-13 00:01:35.073",
        "status": "succeeded"
      }
    }
  ],
  "count": 2,
  "total": 972
}
```
