### PR TITLE
wrap columns better in `pulumi stack webhook list`

### DIFF
--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -276,18 +276,57 @@ func renderWebhookListTable(w io.Writer, webhooks []apitype.Webhook) error {
 		t.AppendRow(row)
 	}
 
-	// Let URL absorb remaining width.
+	// Wrap URL, EVENT GROUPS, and EVENTS to fit the terminal.
+	// Compute actual widths of fixed columns from the data so flex columns
+	// get an accurate share of the remaining space.
 	cols := cmdCmd.StdoutWidth()
-	// 3 chars per column separator + 1 outer border each side = 3*ncols + 1.
 	borderWidth := 3*len(header) + 1
-	fixedColsWidth := 40 // rough room for the non-URL columns
-	urlWidth := cols - borderWidth - fixedColsWidth
-	if urlWidth < 20 {
-		urlWidth = 20
+	idWidth, nameWidth, activeWidth, formatWidth := len("ID"), len("NAME"), len("ACTIVE"), len("FORMAT")
+	for _, r := range rows {
+		if len(r.id) > idWidth {
+			idWidth = len(r.id)
+		}
+		if len(r.name) > nameWidth {
+			nameWidth = len(r.name)
+		}
+		if len(r.active) > activeWidth {
+			activeWidth = len(r.active)
+		}
+		if len(r.format) > formatWidth {
+			formatWidth = len(r.format)
+		}
 	}
-	t.SetColumnConfigs([]table.ColumnConfig{
-		{Name: "URL", WidthMax: urlWidth, WidthMaxEnforcer: text.WrapText},
-	})
+	fixedWidth := borderWidth + idWidth + activeWidth
+	if hasName {
+		fixedWidth += nameWidth
+	}
+	if hasFormat {
+		fixedWidth += formatWidth
+	}
+	flexCols := 1 // URL always present
+	if hasGroups {
+		flexCols++
+	}
+	if hasEvents {
+		flexCols++
+	}
+	remaining := cols - fixedWidth
+	if remaining < 20*flexCols {
+		remaining = 20 * flexCols
+	}
+	flexWidth := remaining / flexCols
+	colConfigs := []table.ColumnConfig{
+		{Name: "URL", WidthMax: flexWidth, WidthMaxEnforcer: text.WrapText},
+	}
+	if hasGroups {
+		colConfigs = append(colConfigs,
+			table.ColumnConfig{Name: "EVENT GROUPS", WidthMax: flexWidth, WidthMaxEnforcer: text.WrapText})
+	}
+	if hasEvents {
+		colConfigs = append(colConfigs,
+			table.ColumnConfig{Name: "EVENTS", WidthMax: flexWidth, WidthMaxEnforcer: text.WrapText})
+	}
+	t.SetColumnConfigs(colConfigs)
 	t.Render()
 
 	fmt.Fprintf(w, "\n%d webhook(s)\n", len(webhooks))

--- a/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
@@ -103,7 +103,7 @@ func TestStackWebhookList_TableOutput(t *testing.T) {
 	// Table should contain data
 	assert.Contains(t, out, "deploy-hook")
 	assert.Contains(t, out, "Deploy Hook")
-	assert.Contains(t, out, "https://example.com/webhook")
+	assert.Contains(t, out, "https://example.com")
 	assert.Contains(t, out, "raw")
 	assert.Contains(t, out, "stacks")
 	assert.Contains(t, out, "stack_update")


### PR DESCRIPTION
We currently don't allow wrapping some columns, specifically events and event groups, that can get quite long.  Instead this is not ideal because then we get the table wrapping around the terminal, which is uglier. Allow event groups and events to be wrapped in addition to the URL.

```
$ pulumi stack webhook list -s pulumi/pulumi-service-review-stacks/tgummerer
┌───────────┬───────────┬────────────────────────┬────────┬────────────────────────┬────────────────────────┬────────┐
│ ID        │ NAME      │ URL                    │ FORMAT │ EVENT GROUPS           │ EVENTS                 │ ACTIVE │
├───────────┼───────────┼────────────────────────┼────────┼────────────────────────┼────────────────────────┼────────┤
│ 96edc9f1  │ whatever  │ https://localhost.loca │ raw    │ deployments, stacks    │ policy_violation_manda │ yes    │
│           │           │ l                      │        │                        │ tory                   │        │
│ my-hook10 │ my-hook10 │ https://example.com    │ raw    │                        │ update_failed, update_ │ yes    │
│           │           │                        │        │                        │ succeeded              │        │
│ my-hook12 │ my-hook12 │ https://example.com    │ raw    │                        │ update_failed, update_ │ yes    │
│           │           │                        │        │                        │ succeeded              │        │
│ my-hook13 │ my-hook13 │ https://example.com    │ raw    │                        │ update_failed, update_ │ yes    │
│           │           │                        │        │                        │ succeeded              │        │
│ my-hook3  │ my-hook3  │ https://xkcd.com       │ raw    │ policies, stacks       │ drift_detection_succee │ yes    │
│           │           │                        │        │                        │ ded, drift_remediation │        │
│           │           │                        │        │                        │ _succeeded             │        │
│ my-hook8  │ my-hook8  │ http://exmaple.com     │ raw    │                        │ update_failed          │ yes    │
│ my-hook   │ my-hook   │ http://localhost.local │ raw    │ policies, stacks       │ deployment_succeeded   │ yes    │
│ my-hook2  │ my-hook2  │ http://localhost.local │ raw    │ deployments, policies, │                        │ yes    │
│           │           │                        │        │ stacks                 │                        │        │
│ my-hook4  │ my-hook4  │ http://xkcd.com        │ raw    │ deployments            │                        │ yes    │
│ my-hook5  │ my-hook5  │ http://example.com     │ raw    │ policies, stacks       │                        │ yes    │
│ my-hook6  │ my-hook6  │ http://bla.com         │ raw    │ deployments, policies, │                        │ yes    │
│           │           │                        │        │ stacks                 │                        │        │
│ my-hook7  │ my-hook7  │ http://bla.com         │ raw    │ deployments, policies, │                        │ no     │
│           │           │                        │        │ stacks                 │                        │        │
│ my-hook9  │ my-hook9  │ https://example.com    │ raw    │                        │ update_failed, update_ │ yes    │
│           │           │                        │        │                        │ succeeded              │        │
└───────────┴───────────┴────────────────────────┴────────┴────────────────────────┴────────────────────────┴────────┘
```