### PR TITLE
implement `pulumi stack drift status`

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-stack-drift-status.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-stack-drift-status.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack drift status` to show the drift detection status for a stack

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -774,6 +774,17 @@ func (pc *Client) CreateStackWebhook(
 	return resp, nil
 }
 
+// GetDriftStatus returns the current drift detection status for the given stack.
+func (pc *Client) GetDriftStatus(
+	ctx context.Context, stackID StackIdentifier,
+) (apitype.StackDriftStatus, error) {
+	var resp apitype.StackDriftStatus
+	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "drift", "status"), nil, nil, &resp); err != nil {
+		return apitype.StackDriftStatus{}, err
+	}
+	return resp, nil
+}
+
 // DeleteStackWebhook deletes the given webhook from the stack.
 func (pc *Client) DeleteStackWebhook(
 	ctx context.Context, stackID StackIdentifier, webhookName string,

--- a/pkg/cmd/pulumi/stack/stack_drift.go
+++ b/pkg/cmd/pulumi/stack/stack_drift.go
@@ -15,8 +15,6 @@
 package stack
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -37,30 +35,10 @@ func newStackDriftCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newStackDriftListCmd())
-	cmd.AddCommand(newStackDriftGetCmd())
+	cmd.AddCommand(newStackDriftStatusCmd())
 	return cmd
 }
 
 // newStackDriftListCmd is defined in stack_drift_list.go.
 
-// TODO[https://github.com/pulumi/pulumi/issues/23052]: Not yet implemented.
-func newStackDriftGetCmd() *cobra.Command {
-	var stack string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "Retrieve the current drift detection status for a stack",
-		Long:   "[EXPERIMENTAL] Retrieve the current drift detection status for a stack.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-
-	return cmd
-}
+// newStackDriftStatusCmd is defined in stack_drift_status.go.

--- a/pkg/cmd/pulumi/stack/stack_drift_status.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_status.go
@@ -1,0 +1,171 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// driftStatusClient is the interface the drift status command needs.
+type driftStatusClient interface {
+	GetDriftStatus(
+		ctx context.Context, stackID client.StackIdentifier,
+	) (apitype.StackDriftStatus, error)
+}
+
+type driftStatusClientFactory func(
+	ctx context.Context, stackFlag string,
+) (driftStatusClient, client.StackIdentifier, error)
+
+type driftStatusRender func(
+	cmd *driftStatusCmd, status apitype.StackDriftStatus,
+) error
+
+type driftStatusCmd struct {
+	stack  string
+	output outputflag.OutputFlag[driftStatusRender]
+	w      io.Writer
+}
+
+func newStackDriftStatusCmd() *cobra.Command {
+	return newStackDriftStatusCmdWith(nil)
+}
+
+func newStackDriftStatusCmdWith(factory driftStatusClientFactory) *cobra.Command {
+	dscmd := &driftStatusCmd{
+		output: outputflag.OutputFlag[driftStatusRender]{
+			RenderForTerminal: (*driftStatusCmd).renderText,
+			RenderJSON:        (*driftStatusCmd).renderJSON,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "[EXPERIMENTAL] Show the current drift detection status for a stack",
+		Long: "Show the current drift detection status for a stack.\n" +
+			"\n" +
+			"Shows whether drift has been detected, the ID of the latest drift\n" +
+			"detection run, and whether a run is currently in progress.",
+		Example: "  # Show drift status for the current stack\n" +
+			"  pulumi stack drift status\n\n" +
+			"  # Show drift status as JSON\n" +
+			"  pulumi stack drift status --output json\n\n" +
+			"  # Show drift status for a specific stack\n" +
+			"  pulumi stack drift status --stack org/project/dev",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultDriftStatusClientFactory
+			}
+			dscmd.w = cmd.OutOrStdout()
+			return dscmd.run(cmd.Context(), factory)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVarP(&dscmd.stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	outputflag.VarP(cmd.Flags(), &dscmd.output)
+
+	return cmd
+}
+
+func defaultDriftStatusClientFactory(
+	ctx context.Context, stackFlag string,
+) (driftStatusClient, client.StackIdentifier, error) {
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	s, err := RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
+		stackFlag, LoadOnly, opts)
+	if err != nil {
+		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
+	}
+
+	cloudStack, ok := s.(httpstate.Stack)
+	if !ok {
+		return nil, client.StackIdentifier{},
+			errors.New("drift commands require the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	ref := cloudStack.Ref()
+	project := ""
+	if p, ok := ref.Project(); ok {
+		project = string(p)
+	}
+	stackID := client.StackIdentifier{
+		Owner:   cloudStack.OrgName(),
+		Project: project,
+		Stack:   ref.Name(),
+	}
+
+	be := cloudStack.Backend().(httpstate.Backend)
+	return be.Client(), stackID, nil
+}
+
+func (c *driftStatusCmd) run(ctx context.Context, factory driftStatusClientFactory) error {
+	cl, stackID, err := factory(ctx, c.stack)
+	if err != nil {
+		return err
+	}
+
+	status, err := cl.GetDriftStatus(ctx, stackID)
+	if err != nil {
+		return fmt.Errorf("getting drift status: %w", err)
+	}
+
+	return c.output.Get()(c, status)
+}
+
+func (c *driftStatusCmd) renderJSON(status apitype.StackDriftStatus) error {
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(status)
+}
+
+func (c *driftStatusCmd) renderText(status apitype.StackDriftStatus) error {
+	driftDetected := "no"
+	if status.DriftDetected {
+		driftDetected = "yes"
+	}
+	runInProgress := "no"
+	if status.RunInProgress {
+		runInProgress = "yes"
+	}
+
+	fmt.Fprintf(c.w, "Drift detected:    %s\n", driftDetected)
+	if status.LatestDriftRun != "" {
+		fmt.Fprintf(c.w, "Latest drift run:  %s\n", status.LatestDriftRun)
+	}
+	fmt.Fprintf(c.w, "Run in progress:   %s\n", runInProgress)
+	return nil
+}

--- a/pkg/cmd/pulumi/stack/stack_drift_status_test.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_status_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDriftStatusClient struct {
+	status apitype.StackDriftStatus
+	err    error
+}
+
+func (m *mockDriftStatusClient) GetDriftStatus(
+	_ context.Context, _ client.StackIdentifier,
+) (apitype.StackDriftStatus, error) {
+	return m.status, m.err
+}
+
+func stubDriftStatusFactory(c driftStatusClient) driftStatusClientFactory {
+	return func(_ context.Context, _ string) (driftStatusClient, client.StackIdentifier, error) {
+		return c, driftTestStackID, nil
+	}
+}
+
+func newTestDriftStatusCmd() (*driftStatusCmd, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &driftStatusCmd{
+		output: outputflag.OutputFlag[driftStatusRender]{
+			RenderForTerminal: (*driftStatusCmd).renderText,
+			RenderJSON:        (*driftStatusCmd).renderJSON,
+		},
+		w: &buf,
+	}, &buf
+}
+
+func TestDriftStatus_TextOutput_DriftDetected(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftStatusClient{status: apitype.StackDriftStatus{
+		DriftDetected:  true,
+		LatestDriftRun: "run-abc-123",
+		RunInProgress:  false,
+	}}
+	dscmd, buf := newTestDriftStatusCmd()
+	err := dscmd.run(t.Context(), stubDriftStatusFactory(c))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Drift detected:    yes")
+	assert.Contains(t, out, "Latest drift run:  run-abc-123")
+	assert.Contains(t, out, "Run in progress:   no")
+}
+
+func TestDriftStatus_TextOutput_NoDrift(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftStatusClient{status: apitype.StackDriftStatus{
+		DriftDetected:  false,
+		LatestDriftRun: "",
+		RunInProgress:  false,
+	}}
+	dscmd, buf := newTestDriftStatusCmd()
+	err := dscmd.run(t.Context(), stubDriftStatusFactory(c))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Drift detected:    no")
+	assert.NotContains(t, out, "Latest drift run:")
+	assert.Contains(t, out, "Run in progress:   no")
+}
+
+func TestDriftStatus_TextOutput_RunInProgress(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftStatusClient{status: apitype.StackDriftStatus{
+		DriftDetected:  false,
+		LatestDriftRun: "run-xyz",
+		RunInProgress:  true,
+	}}
+	dscmd, buf := newTestDriftStatusCmd()
+	err := dscmd.run(t.Context(), stubDriftStatusFactory(c))
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "Run in progress:   yes")
+}
+
+func TestDriftStatus_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftStatusClient{status: apitype.StackDriftStatus{
+		DriftDetected:  true,
+		LatestDriftRun: "run-abc-123",
+		RunInProgress:  false,
+	}}
+	dscmd, buf := newTestDriftStatusCmd()
+	require.NoError(t, dscmd.output.Set("json"))
+	err := dscmd.run(t.Context(), stubDriftStatusFactory(c))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"driftDetected": true,
+		"latestDriftRun": "run-abc-123",
+		"runInProgress": false
+	}`, buf.String())
+}
+
+func TestDriftStatus_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDriftStatusClient{err: errors.New("server error")}
+	dscmd, _ := newTestDriftStatusCmd()
+	err := dscmd.run(t.Context(), stubDriftStatusFactory(c))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting drift status")
+}

--- a/sdk/go/common/apitype/drift.go
+++ b/sdk/go/common/apitype/drift.go
@@ -40,3 +40,10 @@ type DriftRunUpdate struct {
 	Modified        string         `json:"modified"`
 	Status          string         `json:"status"`
 }
+
+// StackDriftStatus is the response from the drift status endpoint.
+type StackDriftStatus struct {
+	DriftDetected  bool   `json:"driftDetected"`
+	LatestDriftRun string `json:"latestDriftRun"`
+	RunInProgress  bool   `json:"runInProgress"`
+}


### PR DESCRIPTION
Note that the original issue claims it should be `pulumi stack drift get`, but that's not really what the endpoint provides.  There's no endpoint afaict that allows getting a single drift run, `pulumi stack drift list` is gonna be the best option for that for now.

Example output:
```
$ pulumi stack drift status -s pulumi/komal-drift-test/dev
Drift detected:    yes
Latest drift run:  e987b772-6353-4545-a30b-a385cbbe9597
Run in progress:   no

$ pulumi stack drift status -s pulumi/komal-drift-test/dev  -o json
{
  "driftDetected": true,
  "latestDriftRun": "e987b772-6353-4545-a30b-a385cbbe9597",
  "runInProgress": false
}
```

Fixes https://github.com/pulumi/pulumi/issues/23052