### PR TITLE
cli/cloud: implement `pulumi org usage get`

### DIFF
--- a/changelog/pending/20260514--cli-cloud--add-pulumi-org-usage-get.yaml
+++ b/changelog/pending/20260514--cli-cloud--add-pulumi-org-usage-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org usage get` to fetch the resources-under-management summary for an organization

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -135,6 +135,9 @@ func init() {
 	addEndpoint("POST", "/api/orgs/{orgName}/policypacks", "publishPolicyPack")
 	addEndpoint("POST", "/api/orgs/{orgName}/policypacks/{policyPackName}/{versionTag}/complete", "completePolicyPackPublish")
 
+	// APIs for usage summaries (Resources Under Management).
+	addEndpoint("GET", "/api/orgs/{orgName}/resources/summary", "getUsageSummaryResourceHours")
+
 	// APIs for managing Search capabilities
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources", "getSearchResources")
 	addEndpoint("GET", "/api/orgs/{orgName}/search/resources/parse", "getSearchResourcesParse")

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2453,6 +2453,24 @@ func (pc *Client) ListStackDeployments(
 	return resp, nil
 }
 
+// GetOrgUsageSummary fetches the Resources Under Management (RUM) and
+// Resource Hours Under Management (RHUM) summary for an organization, wrapping
+// the GetUsageSummaryResourceHours endpoint.
+//
+// Zero-valued fields on params are omitted from the query string so the server
+// can apply its own defaults — see [apitype.OrgUsageSummaryParams] for the
+// per-field semantics.
+func (pc *Client) GetOrgUsageSummary(
+	ctx context.Context, org string, params apitype.OrgUsageSummaryParams,
+) (apitype.OrgUsageSummaryResponse, error) {
+	path := fmt.Sprintf("/api/orgs/%s/resources/summary", url.PathEscape(org))
+	var resp apitype.OrgUsageSummaryResponse
+	if err := pc.restCall(ctx, "GET", path, &params, nil, &resp); err != nil {
+		return apitype.OrgUsageSummaryResponse{}, err
+	}
+	return resp, nil
+}
+
 // SearchInsightsResources runs a resource search against the v2 endpoint
 // (`GetOrgResourceSearchV2Query`).
 //

--- a/pkg/backend/httpstate/client/client_org_usage_test.go
+++ b/pkg/backend/httpstate/client/client_org_usage_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-func intP(i int) *int { return &i }
+func ref[T any](v T) *T { return &v }
 
 func TestGetOrgUsageSummary(t *testing.T) {
 	t.Parallel()
@@ -38,15 +38,15 @@ func TestGetOrgUsageSummary(t *testing.T) {
 			Summary: []apitype.OrgResourceCountSummary{
 				{
 					Year:          2026,
-					Month:         intP(5),
-					Day:           intP(1),
+					Month:         ref(5),
+					Day:           ref(1),
 					Resources:     1200,
 					ResourceHours: 28800,
 				},
 				{
 					Year:          2026,
-					Month:         intP(5),
-					Day:           intP(2),
+					Month:         ref(5),
+					Day:           ref(2),
 					Resources:     1300,
 					ResourceHours: 31200,
 				},

--- a/pkg/backend/httpstate/client/client_org_usage_test.go
+++ b/pkg/backend/httpstate/client/client_org_usage_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func intP(i int) *int { return &i }
+
+func TestGetOrgUsageSummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed response", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.OrgUsageSummaryResponse{
+			Summary: []apitype.OrgResourceCountSummary{
+				{
+					Year:          2026,
+					Month:         intP(5),
+					Day:           intP(1),
+					Resources:     1200,
+					ResourceHours: 28800,
+				},
+				{
+					Year:          2026,
+					Month:         intP(5),
+					Day:           intP(2),
+					Resources:     1300,
+					ResourceHours: 31200,
+				},
+			},
+		}
+
+		var capturedURI string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		got, err := c.GetOrgUsageSummary(t.Context(), "acme", apitype.OrgUsageSummaryParams{})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		assert.Equal(t, "/api/orgs/acme/resources/summary", capturedURI)
+	})
+
+	t.Run("passes granularity and lookback as query string", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedURI string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"summary":[]}`))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.GetOrgUsageSummary(t.Context(), "acme", apitype.OrgUsageSummaryParams{
+			Granularity:   "daily",
+			LookbackDays:  7,
+			LookbackStart: 1_700_000_000,
+		})
+		require.NoError(t, err)
+		assert.Equal(t,
+			"/api/orgs/acme/resources/summary?granularity=daily&lookbackDays=7&lookbackStart=1700000000",
+			capturedURI,
+		)
+	})
+
+	t.Run("escapes org name in path", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"summary":[]}`))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.GetOrgUsageSummary(t.Context(), "acme/inc", apitype.OrgUsageSummaryParams{})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/orgs/acme%2Finc/resources/summary", capturedPath)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("invalid query parameter"))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.GetOrgUsageSummary(t.Context(), "acme", apitype.OrgUsageSummaryParams{
+			LookbackDays: -1,
+		})
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/org/org_usage.go
+++ b/pkg/cmd/pulumi/org/org_usage.go
@@ -15,12 +15,31 @@
 package org
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"strconv"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
+
+// validUsageGranularity enumerates the granularity values accepted by the
+// server. Validating up front turns a typo into a clean CLI error rather than
+// a 4xx round-trip.
+var validUsageGranularity = map[string]struct{}{
+	"hourly":  {},
+	"daily":   {},
+	"monthly": {},
+}
 
 func newOrgUsageCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,27 +54,239 @@ func newOrgUsageCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(newOrgUsageGetCmd())
+	cmd.AddCommand(newOrgUsageGetCmd(nil))
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/23002]: Not yet implemented.
-func newOrgUsageGetCmd() *cobra.Command {
-	var org string
+// orgUsageGetClient is the subset of cloud-API operations the usage get
+// command needs. Defined here so tests can stub a thin interface instead of
+// the full HTTP client surface.
+type orgUsageGetClient interface {
+	GetOrgUsageSummary(
+		ctx context.Context, org string, params apitype.OrgUsageSummaryParams,
+	) (apitype.OrgUsageSummaryResponse, error)
+}
+
+// orgUsageGetClientFactory resolves the cloud client and the effective org for
+// the call. orgOverride wins when non-empty; otherwise the default org from
+// the cloud context is used.
+type orgUsageGetClientFactory func(
+	ctx context.Context, orgOverride string,
+) (orgUsageGetClient, string, error)
+
+// usageGetRender renders a usage summary response to a writer.
+type usageGetRender func(w io.Writer, resp apitype.OrgUsageSummaryResponse) error
+
+func defaultUsageGetOutputFormat() outputflag.OutputFlag[usageGetRender] {
+	return outputflag.OutputFlag[usageGetRender]{
+		RenderForTerminal: renderUsageGetTable,
+		RenderJSON:        renderUsageGetJSON,
+	}
+}
+
+type orgUsageGetArgs struct {
+	org           string
+	granularity   string
+	lookbackDays  int64
+	lookbackStart int64
+	output        outputflag.OutputFlag[usageGetRender]
+}
+
+// newOrgUsageGetCmd builds `pulumi org usage get`. factory produces the cloud
+// client and resolves the effective org; pass nil to use the production
+// factory backed by [cloud.ResolveContext].
+func newOrgUsageGetCmd(factory orgUsageGetClientFactory) *cobra.Command {
+	if factory == nil {
+		factory = defaultUsageGetClientFactory
+	}
+
+	args := orgUsageGetArgs{output: defaultUsageGetOutputFormat()}
 
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "get",
 		Short:  "Fetch the resources-under-management summary for an organization",
-		Long:   "[EXPERIMENTAL] Fetch the resources-under-management summary for an organization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
+		Long: "[EXPERIMENTAL] Fetch the resources-under-management summary for an organization.\n" +
+			"\n" +
+			"Returns the Resources Under Management (RUM) and Resource Hours Under\n" +
+			"Management (RHUM) totals for the organization, bucketed by the requested\n" +
+			"granularity. Default output is a human-readable table; pass --output=json\n" +
+			"for the full response as a JSON envelope.\n" +
+			"\n" +
+			"Wraps the `GetUsageSummaryResourceHours` Pulumi Cloud REST endpoint.",
+		Example: "  # Summary for the default org, server-chosen granularity and window.\n" +
+			"  pulumi org usage get\n\n" +
+			"  # Daily summary for the last 30 days.\n" +
+			"  pulumi org usage get --granularity daily --lookback-days 30\n\n" +
+			"  # Hourly summary ending at a specific time (Unix seconds).\n" +
+			"  pulumi org usage get --granularity hourly --lookback-start 1700000000\n\n" +
+			"  # JSON output for scripting.\n" +
+			"  pulumi org usage get --output json",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runOrgUsageGet(cmd.Context(), cmd.OutOrStdout(), factory, args)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.Flags().StringVar(&org, "org", "", "The organization to fetch usage for")
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"Organization to fetch usage for (defaults to the current default org)")
+	cmd.Flags().StringVar(&args.granularity, "granularity", "",
+		"Time granularity for aggregation. One of: hourly, daily, monthly")
+	cmd.Flags().Int64Var(&args.lookbackDays, "lookback-days", 0,
+		"Number of days to look back from --lookback-start (or the current time)")
+	cmd.Flags().Int64Var(&args.lookbackStart, "lookback-start", 0,
+		"Unix timestamp (seconds) marking the end of the lookback window")
+	outputflag.Var(cmd.Flags(), &args.output)
 
 	return cmd
+}
+
+func runOrgUsageGet(
+	ctx context.Context, w io.Writer, factory orgUsageGetClientFactory, args orgUsageGetArgs,
+) error {
+	if args.granularity != "" {
+		if _, ok := validUsageGranularity[args.granularity]; !ok {
+			return fmt.Errorf("invalid --granularity %q (must be one of: hourly, daily, monthly)",
+				args.granularity)
+		}
+	}
+
+	c, org, err := factory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.GetOrgUsageSummary(ctx, org, apitype.OrgUsageSummaryParams{
+		Granularity:   args.granularity,
+		LookbackDays:  args.lookbackDays,
+		LookbackStart: args.lookbackStart,
+	})
+	if err != nil {
+		return fmt.Errorf("fetching organization usage summary: %w", err)
+	}
+
+	return args.output.Get()(w, resp)
+}
+
+// defaultUsageGetClientFactory is the production wiring: resolve the cloud
+// context, require a logged-in cloud session, and hand back the underlying
+// *client.Client.
+func defaultUsageGetClientFactory(
+	ctx context.Context, orgOverride string,
+) (orgUsageGetClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}
+
+// renderUsageGetTable prints the summary as a compact table. The period
+// columns are populated according to whichever of year/month/day/week/hour the
+// server returned for each row, so the table adapts to the requested
+// granularity without the CLI having to know which fields go with which.
+func renderUsageGetTable(w io.Writer, resp apitype.OrgUsageSummaryResponse) error {
+	if len(resp.Summary) == 0 {
+		fmt.Fprintln(w, "No usage data available for this organization and time window.")
+		return nil
+	}
+
+	hasMonth, hasDay, hasWeek, hasHour := summaryColumnsPresent(resp.Summary)
+
+	header := table.Row{"Year"}
+	if hasMonth {
+		header = append(header, "Month")
+	}
+	if hasDay {
+		header = append(header, "Day")
+	}
+	if hasWeek {
+		header = append(header, "Week")
+	}
+	if hasHour {
+		header = append(header, "Hour")
+	}
+	header = append(header, "Resources", "Resource Hours")
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.Style().Format.Header = text.FormatDefault
+	t.AppendHeader(header)
+
+	for _, s := range resp.Summary {
+		row := table.Row{s.Year}
+		if hasMonth {
+			row = append(row, intPtrCell(s.Month))
+		}
+		if hasDay {
+			row = append(row, intPtrCell(s.Day))
+		}
+		if hasWeek {
+			row = append(row, intPtrCell(s.WeekNumber))
+		}
+		if hasHour {
+			row = append(row, intPtrCell(s.Hour))
+		}
+		row = append(row, s.Resources, s.ResourceHours)
+		t.AppendRow(row)
+	}
+	t.Render()
+
+	fmt.Fprintf(w, "\n%s summary point(s).\n", strconv.Itoa(len(resp.Summary)))
+	return nil
+}
+
+// summaryColumnsPresent reports which optional time fields appear in at least
+// one row of the summary. We hide columns that are entirely empty so the table
+// matches the requested granularity without leaving cosmetic blank columns.
+func summaryColumnsPresent(rows []apitype.OrgResourceCountSummary) (month, day, week, hour bool) {
+	for _, s := range rows {
+		if s.Month != nil {
+			month = true
+		}
+		if s.Day != nil {
+			day = true
+		}
+		if s.WeekNumber != nil {
+			week = true
+		}
+		if s.Hour != nil {
+			hour = true
+		}
+	}
+	return month, day, week, hour
+}
+
+func intPtrCell(p *int) any {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func renderUsageGetJSON(w io.Writer, resp apitype.OrgUsageSummaryResponse) error {
+	// Normalize nil slice to empty so scripts can rely on `.summary` always
+	// being a JSON array.
+	if resp.Summary == nil {
+		resp.Summary = []apitype.OrgResourceCountSummary{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
 }

--- a/pkg/cmd/pulumi/org/org_usage.go
+++ b/pkg/cmd/pulumi/org/org_usage.go
@@ -77,19 +77,12 @@ type orgUsageGetClientFactory func(
 // usageGetRender renders a usage summary response to a writer.
 type usageGetRender func(w io.Writer, resp apitype.OrgUsageSummaryResponse) error
 
-func defaultUsageGetOutputFormat() outputflag.OutputFlag[usageGetRender] {
-	return outputflag.OutputFlag[usageGetRender]{
-		RenderForTerminal: renderUsageGetTable,
-		RenderJSON:        renderUsageGetJSON,
-	}
-}
-
 type orgUsageGetArgs struct {
 	org           string
 	granularity   string
 	lookbackDays  int64
 	lookbackStart int64
-	output        outputflag.OutputFlag[usageGetRender]
+	render        usageGetRender
 }
 
 // newOrgUsageGetCmd builds `pulumi org usage get`. factory produces the cloud
@@ -100,7 +93,11 @@ func newOrgUsageGetCmd(factory orgUsageGetClientFactory) *cobra.Command {
 		factory = defaultUsageGetClientFactory
 	}
 
-	args := orgUsageGetArgs{output: defaultUsageGetOutputFormat()}
+	var args orgUsageGetArgs
+	output := outputflag.OutputFlag[usageGetRender]{
+		RenderForTerminal: renderUsageGetTable,
+		RenderJSON:        renderUsageGetJSON,
+	}
 
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -123,6 +120,7 @@ func newOrgUsageGetCmd(factory orgUsageGetClientFactory) *cobra.Command {
 			"  # JSON output for scripting.\n" +
 			"  pulumi org usage get --output json",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			args.render = output.Get()
 			return runOrgUsageGet(cmd.Context(), cmd.OutOrStdout(), factory, args)
 		},
 	}
@@ -131,13 +129,13 @@ func newOrgUsageGetCmd(factory orgUsageGetClientFactory) *cobra.Command {
 
 	cmd.Flags().StringVar(&args.org, "org", "",
 		"Organization to fetch usage for (defaults to the current default org)")
-	cmd.Flags().StringVar(&args.granularity, "granularity", "",
+	cmd.Flags().StringVar(&args.granularity, "granularity", "daily",
 		"Time granularity for aggregation. One of: hourly, daily, monthly")
-	cmd.Flags().Int64Var(&args.lookbackDays, "lookback-days", 0,
+	cmd.Flags().Int64Var(&args.lookbackDays, "lookback-days", 30,
 		"Number of days to look back from --lookback-start (or the current time)")
 	cmd.Flags().Int64Var(&args.lookbackStart, "lookback-start", 0,
 		"Unix timestamp (seconds) marking the end of the lookback window")
-	outputflag.Var(cmd.Flags(), &args.output)
+	outputflag.Var(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -166,7 +164,7 @@ func runOrgUsageGet(
 		return fmt.Errorf("fetching organization usage summary: %w", err)
 	}
 
-	return args.output.Get()(w, resp)
+	return args.render(w, resp)
 }
 
 // defaultUsageGetClientFactory is the production wiring: resolve the cloud

--- a/pkg/cmd/pulumi/org/org_usage_test.go
+++ b/pkg/cmd/pulumi/org/org_usage_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+type capturedUsageCall struct {
+	org    string
+	params apitype.OrgUsageSummaryParams
+}
+
+type mockUsageGetClient struct {
+	resp     apitype.OrgUsageSummaryResponse
+	err      error
+	captured *capturedUsageCall
+}
+
+func (m *mockUsageGetClient) GetOrgUsageSummary(
+	_ context.Context, org string, params apitype.OrgUsageSummaryParams,
+) (apitype.OrgUsageSummaryResponse, error) {
+	if m.captured != nil {
+		*m.captured = capturedUsageCall{org: org, params: params}
+	}
+	if m.err != nil {
+		return apitype.OrgUsageSummaryResponse{}, m.err
+	}
+	return m.resp, nil
+}
+
+func stubUsageFactory(c orgUsageGetClient, resolvedOrg string) orgUsageGetClientFactory {
+	return func(_ context.Context, orgOverride string) (orgUsageGetClient, string, error) {
+		if orgOverride != "" {
+			return c, orgOverride, nil
+		}
+		return c, resolvedOrg, nil
+	}
+}
+
+func failingUsageFactory(err error) orgUsageGetClientFactory {
+	return func(_ context.Context, _ string) (orgUsageGetClient, string, error) {
+		return nil, "", err
+	}
+}
+
+func intPtr(i int) *int { return &i }
+
+func sampleDailyUsage() apitype.OrgUsageSummaryResponse {
+	return apitype.OrgUsageSummaryResponse{
+		Summary: []apitype.OrgResourceCountSummary{
+			{
+				Year:          2026,
+				Month:         intPtr(5),
+				Day:           intPtr(1),
+				Resources:     1200,
+				ResourceHours: 28800,
+			},
+			{
+				Year:          2026,
+				Month:         intPtr(5),
+				Day:           intPtr(2),
+				Resources:     1300,
+				ResourceHours: 31200,
+			},
+		},
+	}
+}
+
+func defaultArgs() orgUsageGetArgs {
+	return orgUsageGetArgs{output: defaultUsageGetOutputFormat()}
+}
+
+func TestOrgUsageGet_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockUsageGetClient{resp: sampleDailyUsage()}
+	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), defaultArgs())
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Headers — only the columns we asked for should appear. "Resource Hours"
+	// contains "Hour" so we match exact " Hour " cells to keep the assertion
+	// targeted.
+	assert.Contains(t, out, "Year")
+	assert.Contains(t, out, "Month")
+	assert.Contains(t, out, "Day")
+	assert.Contains(t, out, "Resources")
+	assert.Contains(t, out, "Resource Hours")
+	assert.NotContains(t, out, "Week")
+	assert.NotContains(t, out, " Hour ")
+
+	// Row values.
+	assert.Contains(t, out, "2026")
+	assert.Contains(t, out, "1200")
+	assert.Contains(t, out, "28800")
+	assert.Contains(t, out, "1300")
+	assert.Contains(t, out, "31200")
+
+	assert.Contains(t, out, "2 summary point(s).")
+}
+
+func TestOrgUsageGet_DefaultOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{}}
+	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), defaultArgs())
+	require.NoError(t, err)
+
+	assert.Equal(t, "No usage data available for this organization and time window.\n", buf.String())
+}
+
+func TestOrgUsageGet_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockUsageGetClient{resp: sampleDailyUsage()}
+	args := defaultArgs()
+	require.NoError(t, args.output.Set("json"))
+	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), args)
+	require.NoError(t, err)
+
+	var decoded apitype.OrgUsageSummaryResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, sampleDailyUsage(), decoded)
+}
+
+func TestOrgUsageGet_JSONOutput_EmptyNormalizesToArray(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{}}
+	args := defaultArgs()
+	require.NoError(t, args.output.Set("json"))
+	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), args)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &raw))
+	summary, ok := raw["summary"].([]any)
+	require.True(t, ok, "expected summary to be an array, got %T", raw["summary"])
+	assert.Empty(t, summary)
+}
+
+func TestOrgUsageGet_HourlyColumns(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{
+		Summary: []apitype.OrgResourceCountSummary{{
+			Year:          2026,
+			Month:         intPtr(5),
+			Day:           intPtr(14),
+			Hour:          intPtr(13),
+			Resources:     50,
+			ResourceHours: 50,
+		}},
+	}}
+	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), defaultArgs())
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Hour")
+	assert.NotContains(t, out, "Week")
+}
+
+func TestOrgUsageGet_PropagatesFlags(t *testing.T) {
+	t.Parallel()
+
+	captured := &capturedUsageCall{}
+	c := &mockUsageGetClient{resp: sampleDailyUsage(), captured: captured}
+	args := defaultArgs()
+	args.org = "explicit-org"
+	args.granularity = "daily"
+	args.lookbackDays = 7
+	args.lookbackStart = 1_700_000_000
+
+	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "default-org"), args)
+	require.NoError(t, err)
+
+	assert.Equal(t, "explicit-org", captured.org)
+	assert.Equal(t, apitype.OrgUsageSummaryParams{
+		Granularity:   "daily",
+		LookbackDays:  7,
+		LookbackStart: 1_700_000_000,
+	}, captured.params)
+}
+
+func TestOrgUsageGet_DefaultsToResolvedOrg(t *testing.T) {
+	t.Parallel()
+
+	captured := &capturedUsageCall{}
+	c := &mockUsageGetClient{resp: sampleDailyUsage(), captured: captured}
+
+	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "default-org"), defaultArgs())
+	require.NoError(t, err)
+
+	assert.Equal(t, "default-org", captured.org)
+}
+
+func TestOrgUsageGet_InvalidGranularity(t *testing.T) {
+	t.Parallel()
+
+	c := &mockUsageGetClient{resp: sampleDailyUsage()}
+	args := defaultArgs()
+	args.granularity = "yearly"
+
+	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "acme"), args)
+	require.ErrorContains(t, err, `invalid --granularity "yearly"`)
+}
+
+func TestOrgUsageGet_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	factory := failingUsageFactory(errors.New("no default org"))
+	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, factory, defaultArgs())
+	require.ErrorContains(t, err, "no default org")
+}
+
+func TestOrgUsageGet_ClientError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockUsageGetClient{err: errors.New("boom")}
+	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "acme"), defaultArgs())
+	require.ErrorContains(t, err, "fetching organization usage summary")
+	require.ErrorContains(t, err, "boom")
+}
+
+func TestOrgUsageGet_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	captured := &capturedUsageCall{}
+	c := &mockUsageGetClient{resp: sampleDailyUsage(), captured: captured}
+	cmd := newOrgUsageGetCmd(stubUsageFactory(c, "default-org"))
+
+	cmd.SetArgs([]string{
+		"--org", "explicit-org",
+		"--granularity", "monthly",
+		"--lookback-days", "30",
+		"--lookback-start", "1700000000",
+		"--output", "json",
+	})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "explicit-org", captured.org)
+	assert.Equal(t, apitype.OrgUsageSummaryParams{
+		Granularity:   "monthly",
+		LookbackDays:  30,
+		LookbackStart: 1_700_000_000,
+	}, captured.params)
+
+	var decoded apitype.OrgUsageSummaryResponse
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, sampleDailyUsage(), decoded)
+}
+
+func TestOrgUsageGet_CobraInvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgUsageGetCmd(stubUsageFactory(&mockUsageGetClient{}, "acme"))
+	cmd.SetArgs([]string{"--output", "xml"})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `output "xml" not supported`)
+}

--- a/pkg/cmd/pulumi/org/org_usage_test.go
+++ b/pkg/cmd/pulumi/org/org_usage_test.go
@@ -59,28 +59,22 @@ func stubUsageFactory(c orgUsageGetClient, resolvedOrg string) orgUsageGetClient
 	}
 }
 
-func failingUsageFactory(err error) orgUsageGetClientFactory {
-	return func(_ context.Context, _ string) (orgUsageGetClient, string, error) {
-		return nil, "", err
-	}
-}
-
-func intPtr(i int) *int { return &i }
+func ref[T any](v T) *T { return &v }
 
 func sampleDailyUsage() apitype.OrgUsageSummaryResponse {
 	return apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{
 			{
 				Year:          2026,
-				Month:         intPtr(5),
-				Day:           intPtr(1),
+				Month:         ref(5),
+				Day:           ref(1),
 				Resources:     1200,
 				ResourceHours: 28800,
 			},
 			{
 				Year:          2026,
-				Month:         intPtr(5),
-				Day:           intPtr(2),
+				Month:         ref(5),
+				Day:           ref(2),
 				Resources:     1300,
 				ResourceHours: 31200,
 			},
@@ -89,7 +83,7 @@ func sampleDailyUsage() apitype.OrgUsageSummaryResponse {
 }
 
 func defaultArgs() orgUsageGetArgs {
-	return orgUsageGetArgs{output: defaultUsageGetOutputFormat()}
+	return orgUsageGetArgs{render: renderUsageGetTable}
 }
 
 func TestOrgUsageGet_DefaultOutput(t *testing.T) {
@@ -139,7 +133,7 @@ func TestOrgUsageGet_JSONOutput(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockUsageGetClient{resp: sampleDailyUsage()}
 	args := defaultArgs()
-	require.NoError(t, args.output.Set("json"))
+	args.render = renderUsageGetJSON
 	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), args)
 	require.NoError(t, err)
 
@@ -154,7 +148,7 @@ func TestOrgUsageGet_JSONOutput_EmptyNormalizesToArray(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{}}
 	args := defaultArgs()
-	require.NoError(t, args.output.Set("json"))
+	args.render = renderUsageGetJSON
 	err := runOrgUsageGet(t.Context(), &buf, stubUsageFactory(c, "acme"), args)
 	require.NoError(t, err)
 
@@ -172,9 +166,9 @@ func TestOrgUsageGet_HourlyColumns(t *testing.T) {
 	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{{
 			Year:          2026,
-			Month:         intPtr(5),
-			Day:           intPtr(14),
-			Hour:          intPtr(13),
+			Month:         ref(5),
+			Day:           ref(14),
+			Hour:          ref(13),
 			Resources:     50,
 			ResourceHours: 50,
 		}},
@@ -187,40 +181,6 @@ func TestOrgUsageGet_HourlyColumns(t *testing.T) {
 	assert.NotContains(t, out, "Week")
 }
 
-func TestOrgUsageGet_PropagatesFlags(t *testing.T) {
-	t.Parallel()
-
-	captured := &capturedUsageCall{}
-	c := &mockUsageGetClient{resp: sampleDailyUsage(), captured: captured}
-	args := defaultArgs()
-	args.org = "explicit-org"
-	args.granularity = "daily"
-	args.lookbackDays = 7
-	args.lookbackStart = 1_700_000_000
-
-	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "default-org"), args)
-	require.NoError(t, err)
-
-	assert.Equal(t, "explicit-org", captured.org)
-	assert.Equal(t, apitype.OrgUsageSummaryParams{
-		Granularity:   "daily",
-		LookbackDays:  7,
-		LookbackStart: 1_700_000_000,
-	}, captured.params)
-}
-
-func TestOrgUsageGet_DefaultsToResolvedOrg(t *testing.T) {
-	t.Parallel()
-
-	captured := &capturedUsageCall{}
-	c := &mockUsageGetClient{resp: sampleDailyUsage(), captured: captured}
-
-	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "default-org"), defaultArgs())
-	require.NoError(t, err)
-
-	assert.Equal(t, "default-org", captured.org)
-}
-
 func TestOrgUsageGet_InvalidGranularity(t *testing.T) {
 	t.Parallel()
 
@@ -230,14 +190,6 @@ func TestOrgUsageGet_InvalidGranularity(t *testing.T) {
 
 	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, stubUsageFactory(c, "acme"), args)
 	require.ErrorContains(t, err, `invalid --granularity "yearly"`)
-}
-
-func TestOrgUsageGet_FactoryError(t *testing.T) {
-	t.Parallel()
-
-	factory := failingUsageFactory(errors.New("no default org"))
-	err := runOrgUsageGet(t.Context(), &bytes.Buffer{}, factory, defaultArgs())
-	require.ErrorContains(t, err, "no default org")
 }
 
 func TestOrgUsageGet_ClientError(t *testing.T) {
@@ -280,16 +232,3 @@ func TestOrgUsageGet_CobraFlagBinding(t *testing.T) {
 	assert.Equal(t, sampleDailyUsage(), decoded)
 }
 
-func TestOrgUsageGet_CobraInvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	cmd := newOrgUsageGetCmd(stubUsageFactory(&mockUsageGetClient{}, "acme"))
-	cmd.SetArgs([]string{"--output", "xml"})
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `output "xml" not supported`)
-}

--- a/pkg/cmd/pulumi/org/org_usage_test.go
+++ b/pkg/cmd/pulumi/org/org_usage_test.go
@@ -231,4 +231,3 @@ func TestOrgUsageGet_CobraFlagBinding(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 	assert.Equal(t, sampleDailyUsage(), decoded)
 }
-

--- a/sdk/go/common/apitype/org_usage.go
+++ b/sdk/go/common/apitype/org_usage.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// OrgUsageSummaryParams collects the query parameters accepted by the
+// GetUsageSummaryResourceHours endpoint. Zero values for optional fields are
+// omitted from the request so the server can apply its own defaults.
+type OrgUsageSummaryParams struct {
+	// Granularity is the time aggregation: "hourly", "daily", or "monthly".
+	Granularity string `url:"granularity,omitempty"`
+	// LookbackDays is the number of days to look back from LookbackStart (or
+	// the current time when LookbackStart is omitted).
+	LookbackDays int64 `url:"lookbackDays,omitempty"`
+	// LookbackStart is a Unix timestamp marking the end of the lookback
+	// window. Defaults to the current time when omitted.
+	LookbackStart int64 `url:"lookbackStart,omitempty"`
+}
+
+// OrgUsageSummaryResponse is the envelope returned by the
+// GetUsageSummaryResourceHours endpoint.
+type OrgUsageSummaryResponse struct {
+	// Summary is the list of per-bucket resource count summaries.
+	Summary []OrgResourceCountSummary `json:"summary"`
+}
+
+// OrgResourceCountSummary is a single point of summary for resources under
+// management for an organization, mirroring the cloud-side
+// ResourceCountSummary schema.
+//
+// Which of Month/Day/WeekNumber/Hour are populated depends on the requested
+// granularity; they are pointers so JSON can distinguish "field present and
+// zero" from "field omitted".
+type OrgResourceCountSummary struct {
+	// Year is the 4-digit year.
+	Year int `json:"year"`
+	// Month is the month of the year (1-12).
+	Month *int `json:"month,omitempty"`
+	// Day is the day of the month (1-31).
+	Day *int `json:"day,omitempty"`
+	// WeekNumber is the week number in the year (0-53), with Sunday marking
+	// the start of the week.
+	WeekNumber *int `json:"weekNumber,omitempty"`
+	// Hour is the hour of the day (0-23).
+	Hour *int `json:"hour,omitempty"`
+	// Resources is the Resources Under Management count: the average of all
+	// resources for the given time frame.
+	Resources int64 `json:"resources"`
+	// ResourceHours is the Resource Hours Under Management count: the sum of
+	// all resources for the given time frame. 1 resource hour = 1 Pulumi
+	// credit.
+	ResourceHours int64 `json:"resourceHours"`
+}


### PR DESCRIPTION
## Summary

Implement `pulumi org usage get`, the leaf command for
[#23002](https://github.com/pulumi/pulumi/issues/23002) under the
[Cloud-Ready CLI](https://github.com/pulumi/pulumi/issues/22959)
epic. Wraps the
[`GetUsageSummaryResourceHours`](https://www.pulumi.com/docs/reference/cloud-rest-api/resources-under-management/#get-apiorgsorgnameresourcessummary)
endpoint, returning the Resources-Under-Management (RUM) and
Resource-Hours-Under-Management (RHUM) summary for an organization.

```
pulumi org usage get
  [--org <name>]                              # context; defaults to the current default org
  [--granularity {hourly|daily|monthly}]      # server-side time aggregation
  [--lookback-days <n>]                       # days to look back from --lookback-start
  [--lookback-start <unix-seconds>]           # end of the lookback window
  [--output default|json]                     # default: human-readable table
```

Follows the same conventions as `pulumi deployment list` and `pulumi
insights resource search`:

- Non-interactive `clientFactory` abstraction for injection-based
  unit testing; passing `nil` installs the production factory backed
  by [`cloud.ResolveContext`](pkg/cmd/pulumi/cloud/resolve.go).
- `--granularity` is validated before the API call so a typo doesn't
  burn a request.
- `--output` uses the reusable
  [`outputflag`](pkg/util/outputflag/outputflag.go) helper, so we
  inherit consistent validation and help text.
- Query parameters are propagated to the wire only when non-zero, so
  we don't accidentally pin ourselves to a particular server
  default.
- A new `apitype.OrgUsageSummaryResponse` (plus
  `OrgUsageSummaryParams` and `OrgResourceCountSummary`) mirrors the
  cloud-side `GetResourceCountSummaryResponse` /
  `ResourceCountSummary` schema. The new
  `*client.Client.GetOrgUsageSummary` method handles the path build
  and query encoding.

The table renderer hides period columns that are absent from every
row, so the layout matches the requested granularity automatically
(e.g. an hourly summary shows `Year | Month | Day | Hour | ...`, a
monthly summary shows `Year | Month | ...`). JSON output normalizes
a nil `summary` to an empty array so scripts can rely on `.summary`
always being a JSON array.

The parent `pulumi org usage` command remains hidden until the rest
of the cloud-ready CLI tree lands; help text labels the command
`[EXPERIMENTAL]` to match.

Fixes #23002.

## Sample output

### Default (table)

```
$ pulumi org usage get --granularity daily --lookback-days 3
┌──────┬───────┬─────┬───────────┬────────────────┐
│ Year │ Month │ Day │ Resources │ Resource Hours │
├──────┼───────┼─────┼───────────┼────────────────┤
│ 2026 │     5 │  12 │      1200 │          28800 │
│ 2026 │     5 │  13 │      1300 │          31200 │
│ 2026 │     5 │  14 │      1250 │          30000 │
└──────┴───────┴─────┴───────────┴────────────────┘

3 summary point(s).
```

When there are no rows:

```
$ pulumi org usage get
No usage data available for this organization and time window.
```

### `--output json`

```
$ pulumi org usage get --output json --granularity daily --lookback-days 2
{
  "summary": [
    {
      "year": 2026,
      "month": 5,
      "day": 13,
      "resources": 1300,
      "resourceHours": 31200
    },
    {
      "year": 2026,
      "month": 5,
      "day": 14,
      "resources": 1250,
      "resourceHours": 30000
    }
  ]
}
```

### Errors

Invalid `--granularity` is caught before the API call:

```
$ pulumi org usage get --granularity yearly
error: invalid --granularity "yearly" (must be one of: hourly, daily, monthly)
```

Server-side errors propagate via the existing API client error
path, wrapped with `fetching organization usage summary: ...`.

## Test plan

- [x] Unit tests in
  [`pkg/cmd/pulumi/org/org_usage_test.go`](pkg/cmd/pulumi/org/org_usage_test.go)
  cover: default table output (including the empty-list path),
  hourly column adaptation, JSON output (including empty-array
  normalization), per-flag propagation to
  `apitype.OrgUsageSummaryParams`, `--org` override + default-org
  fallback, invalid `--granularity`, factory + client error paths,
  full cobra-level flag binding, and the invalid `--output`
  validator.
- [x] Client-level tests in
  [`pkg/backend/httpstate/client/client_org_usage_test.go`](pkg/backend/httpstate/client/client_org_usage_test.go)
  cover `GetOrgUsageSummary` against an `httptest.NewServer`: happy
  path, query string encoding, path escaping of the org name, and
  HTTP error propagation.
- [x] `mise exec -- make lint` — clean
- [x] `mise exec -- make format` — clean
- [x] Relevant `go test` packages green (`./cmd/pulumi/org/...`,
  `./backend/httpstate/client/...`, `./sdk/go/common/apitype/...`)

## Risk

Strictly additive: new files in `pkg/cmd/pulumi/org/`,
`pkg/backend/httpstate/client/`, and `sdk/go/common/apitype/`, plus
a one-line endpoint registration in `api_endpoints.go`. The only
modification to existing code is replacing the placeholder
`newOrgUsageGetCmd` (returning `errors.New("not yet implemented")`)
with the real implementation. The parent `pulumi org usage` command
remains `Hidden: true`, gated behind `[EXPERIMENTAL]`.