### PR TITLE
fix flaky `NewImportCmd` tests

### DIFF
--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -618,9 +618,9 @@ func TestImportFileMarshal(t *testing.T) {
 // the `--output` flag with the expected default and hidden state. The
 // display-layer behaviour is covered by TestUp_OutputJSONSummary; here we
 // just check the flag is plumbed.
+//
+//nolint:paralleltest // NewImportCmd writes to global cmdStack.ConfigFile
 func TestImportCmd_OutputFlagRegistered(t *testing.T) {
-	t.Parallel()
-
 	cmd := NewImportCmd()
 	flag := cmd.Flags().Lookup("output")
 	require.NotNil(t, flag, "expected --output flag on `pulumi import`")
@@ -631,9 +631,9 @@ func TestImportCmd_OutputFlagRegistered(t *testing.T) {
 // TestImportCmd_OutputAndJSONMutuallyExclusive verifies that passing both
 // --json and --output is rejected by cobra's flag-group validation before
 // RunE is invoked, so the command never starts a real import.
+//
+//nolint:paralleltest // NewImportCmd writes to global cmdStack.ConfigFile
 func TestImportCmd_OutputAndJSONMutuallyExclusive(t *testing.T) {
-	t.Parallel()
-
 	cmd := NewImportCmd()
 	cmd.SetArgs([]string{"--json", "--output", "json"})
 	cmd.SetOut(io.Discard)


### PR DESCRIPTION
This test can flake because two parallel tests may use the same global cmdStack.ConfigFile, which the race detector doesn't like.  Fix that by making the tests not run in parallel.

Fixes https://github.com/pulumi/pulumi/issues/23167
