### PR TITLE
cli/cloud: add `pulumi org member list`

### DIFF
--- a/changelog/pending/20260514--cli-cloud--add-pulumi-org-member-list.yaml
+++ b/changelog/pending/20260514--cli-cloud--add-pulumi-org-member-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi org member list` to list the members of an organization

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -96,6 +96,7 @@ func init() {
 	addEndpoint("GET", "/api/stacks/{orgName}/{projectName}/{stackName}/updates/{version}", "getStackUpdate")
 	addEndpoint("GET", "/api/stacks/{orgName}/{projectName}/{stackName}/updates/{version}/contents/files", "getUpdateContentsFiles")
 	addEndpoint("GET", "/api/stacks/{orgName}/{projectName}/{stackName}/updates/{version}/contents/file/{path:.*}", "getUpdateContentsFilePath")
+	addEndpoint("GET", "/api/orgs/{orgName}/members", "listOrganizationMembers")
 	addEndpoint("GET", "/api/orgs/{orgName}/templates", "listTemplates")
 	addEndpoint("GET", "/api/orgs/{orgName}/templates/download", "downloadTemplates")
 	addEndpoint("POST", "/api/stacks/{orgName}/{projectName}/{stackName}/batch-decrypt", "batchDecrypt")

--- a/pkg/backend/httpstate/client/client_organization_members_test.go
+++ b/pkg/backend/httpstate/client/client_organization_members_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListOrganizationMembers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns parsed response", func(t *testing.T) {
+		t.Parallel()
+
+		want := apitype.ListOrganizationMembersResponse{
+			Members: []apitype.OrganizationMember{
+				{
+					Role: "admin",
+					User: apitype.UserInfo{
+						Name:        "Alice",
+						GitHubLogin: "alice",
+						AvatarURL:   "https://example.com/a.png",
+					},
+					Created:       "2026-05-01T12:00:00Z",
+					KnownToPulumi: true,
+					VirtualAdmin:  false,
+					Links:         &apitype.MemberLinks{Self: "/api/orgs/acme/members/alice"},
+					FGARole: apitype.FGARole{
+						ID:         "role-admin",
+						Name:       "admin",
+						ModifiedAt: "2026-04-01T00:00:00Z",
+					},
+				},
+				{
+					Role: "member",
+					User: apitype.UserInfo{
+						Name:        "Bob",
+						GitHubLogin: "bob",
+					},
+					Created:       "2026-04-15T08:00:00Z",
+					KnownToPulumi: true,
+					FGARole: apitype.FGARole{
+						ID:         "role-member",
+						Name:       "member",
+						ModifiedAt: "2026-04-01T00:00:00Z",
+					},
+				},
+			},
+			ContinuationToken: "next-page-token",
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		got, err := c.ListOrganizationMembers(t.Context(), "acme", "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("passes continuationToken and mode as query string", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedURI string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"members":[]}`))
+		}))
+		defer server.Close()
+
+		token := "abc"
+		c := newMockClient(server)
+		_, err := c.ListOrganizationMembers(t.Context(), "acme", "backend", &token)
+		require.NoError(t, err)
+		assert.Equal(t,
+			"/api/orgs/acme/members?continuationToken=abc&type=backend",
+			capturedURI,
+		)
+	})
+
+	t.Run("omits zero-valued query params", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedURI string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"members":[]}`))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.ListOrganizationMembers(t.Context(), "acme", "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "/api/orgs/acme/members", capturedURI)
+	})
+
+	t.Run("propagates HTTP errors", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("invalid query parameter"))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.ListOrganizationMembers(t.Context(), "acme", "nope", nil)
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/pulumi/org/org_member.go
+++ b/pkg/cmd/pulumi/org/org_member.go
@@ -15,8 +15,6 @@
 package org
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -40,31 +38,5 @@ func newOrgMemberCmd() *cobra.Command {
 	cmd.AddCommand(newOrgMemberGetCmd())
 	cmd.AddCommand(newOrgMemberEditCmd())
 	cmd.AddCommand(newOrgMemberRemoveCmd())
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/23013]: Not yet implemented.
-func newOrgMemberListCmd() *cobra.Command {
-	var (
-		org  string
-		mode string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List members of an organization",
-		Long:   "[EXPERIMENTAL] List members of an organization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to list members for")
-	cmd.Flags().StringVar(&mode, "mode", "frontend",
-		"Member list mode: frontend or backend")
-
 	return cmd
 }

--- a/pkg/cmd/pulumi/org/org_member_list.go
+++ b/pkg/cmd/pulumi/org/org_member_list.go
@@ -1,0 +1,289 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// orgMemberListClient is the subset of cloud-API operations the list command
+// needs. Defined here so tests can stub a thin interface instead of the full
+// HTTP client surface.
+type orgMemberListClient interface {
+	ListOrganizationMembers(
+		ctx context.Context, orgName, mode string, continuationToken *string,
+	) (apitype.ListOrganizationMembersResponse, error)
+}
+
+// orgMemberListClientFactory resolves a cloud client and the organization name
+// to list members for. orgFlag carries the raw value of `--org` (empty means
+// "use the user's default organization").
+type orgMemberListClientFactory func(
+	ctx context.Context, orgFlag string,
+) (orgMemberListClient, string, error)
+
+// orgMemberListRenderFunc is the per-format renderer signature, parameterised
+// over the outputflag wiring so `--output` selects between the registered
+// renderers at runtime.
+type orgMemberListRenderFunc func(w io.Writer, members []apitype.OrganizationMember) error
+
+// orgMemberListArgs collects the flag values for the list command, in one
+// struct so Run can be driven directly from tests.
+type orgMemberListArgs struct {
+	org          string
+	count        int
+	all          bool
+	renderOutput orgMemberListRenderFunc
+}
+
+func newOrgMemberListCmd() *cobra.Command {
+	return newOrgMemberListCmdWith(nil)
+}
+
+func newOrgMemberListCmdWith(factory orgMemberListClientFactory) *cobra.Command {
+	var args orgMemberListArgs
+	output := outputflag.OutputFlag[orgMemberListRenderFunc]{
+		RenderForTerminal: renderOrgMemberListTable,
+		RenderJSON:        renderOrgMemberListJSON,
+	}
+
+	cmd := &cobra.Command{
+		Hidden: true,
+		Use:    "list",
+		Short:  "List members of an organization",
+		Long: "[EXPERIMENTAL] List members of an organization.\n" +
+			"\n" +
+			"Returns the members of the organization, showing each member's user name,\n" +
+			"role, and join date. Default output is a human-readable table; pass\n" +
+			"--output=json for the full response as a JSON envelope.\n" +
+			"\n" +
+			"Wraps the `ListOrganizationMembers` Pulumi Cloud REST endpoint.",
+		Example: "  # List members of the default organization.\n" +
+			"  pulumi org member list\n\n" +
+			"  # List members of a specific organization.\n" +
+			"  pulumi org member list --org acme\n\n" +
+			"  # List up to 100 members (auto-paginating as needed).\n" +
+			"  pulumi org member list --count 100\n\n" +
+			"  # Fetch every member, paging through all results.\n" +
+			"  pulumi org member list --all\n\n" +
+			"  # Emit JSON for scripting.\n" +
+			"  pulumi org member list --output json",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			f := factory
+			if f == nil {
+				f = defaultOrgMemberListClientFactory
+			}
+			args.renderOutput = output.Get()
+			return runOrgMemberList(cmd.Context(), cmd.OutOrStdout(), f, args)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"The organization to list members for. Defaults to the user's default organization")
+	cmd.Flags().IntVar(&args.count, "count", 0,
+		"The number of members to return; if larger than the server page size, additional pages are fetched automatically. "+
+			"Defaults to the size of the first page")
+	cmd.Flags().BoolVar(&args.all, "all", false,
+		"Fetch every page until the server reports no more results. Mutually exclusive with --count")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	cmd.MarkFlagsMutuallyExclusive("count", "all")
+
+	return cmd
+}
+
+// defaultOrgMemberListClientFactory resolves the current Pulumi Cloud context
+// and returns a client plus the organization name to query. When --org is
+// empty, falls back to the user's default org (from the backend) and finally
+// to the user's own login.
+func defaultOrgMemberListClientFactory(
+	ctx context.Context, orgFlag string,
+) (orgMemberListClient, string, error) {
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return nil, "", err
+	}
+
+	currentBe, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	cloudBe, ok := currentBe.(httpstate.Backend)
+	if !ok {
+		return nil, "", errors.New(
+			"listing organization members requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName := orgFlag
+	if orgName == "" {
+		defaultOrg, err := cloudBe.GetDefaultOrg(ctx)
+		if err != nil {
+			return nil, "", err
+		}
+		orgName = defaultOrg
+	}
+
+	userName, orgs, _, err := cloudBe.CurrentUser()
+	if err != nil {
+		return nil, "", err
+	}
+	if orgName == "" {
+		orgName = userName
+	}
+	if !slices.Contains(orgs, orgName) && orgName != userName {
+		return nil, "", fmt.Errorf("user %s is not a member of organization %s", userName, orgName)
+	}
+
+	return cloudBe.Client(), orgName, nil
+}
+
+// runOrgMemberList is the cobra-decoupled command body so tests can drive it
+// directly without spinning up the flag parser.
+func runOrgMemberList(
+	ctx context.Context, w io.Writer, factory orgMemberListClientFactory, args orgMemberListArgs,
+) error {
+	if args.count < 0 {
+		return fmt.Errorf("--count must be non-negative, got %d", args.count)
+	}
+
+	c, orgName, err := factory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	members, err := fetchOrganizationMembers(ctx, c, orgName, args.count, args.all)
+	if err != nil {
+		return fmt.Errorf("listing organization members: %w", err)
+	}
+
+	return args.renderOutput(w, members)
+}
+
+// fetchOrganizationMembers issues one or more ListOrganizationMembers calls,
+// stopping when the server runs out of pages, when --all is unset and the
+// requested count is reached, or when --all is unset and --count is zero
+// (the caller asked for "just the first page").
+func fetchOrganizationMembers(
+	ctx context.Context,
+	c orgMemberListClient,
+	orgName string,
+	count int,
+	all bool,
+) ([]apitype.OrganizationMember, error) {
+	var members []apitype.OrganizationMember
+	var token *string
+	for {
+		resp, err := c.ListOrganizationMembers(ctx, orgName, "frontend", token)
+		if err != nil {
+			return nil, err
+		}
+		members = append(members, resp.Members...)
+
+		// Without --all, --count==0 means "first page only".
+		if !all && count == 0 {
+			return members, nil
+		}
+		// With --count, stop as soon as we have enough rows. We over-fetch by
+		// at most one server page, then truncate; the API does not accept a
+		// client-side limit.
+		if !all && count > 0 && len(members) >= count {
+			return members[:count], nil
+		}
+		// Server signals end-of-results by omitting (or zeroing) the token.
+		if resp.ContinuationToken == "" {
+			return members, nil
+		}
+		next := resp.ContinuationToken
+		token = &next
+	}
+}
+
+func renderOrgMemberListTable(w io.Writer, members []apitype.OrganizationMember) error {
+	if len(members) == 0 {
+		fmt.Fprintln(w, "No members found for this organization.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"USER", "NAME", "ROLE", "JOINED"})
+
+	for _, m := range members {
+		login := m.User.GitHubLogin
+		if login == "" {
+			login = m.User.Name
+		}
+		role := m.FGARole.Name
+		if role == "" {
+			role = m.Role
+		}
+		t.AppendRow(table.Row{
+			login,
+			m.User.Name,
+			role,
+			m.Created,
+		})
+	}
+	t.Render()
+
+	fmt.Fprintf(w, "\n%d member(s)\n", len(members))
+	return nil
+}
+
+// orgMemberListEnvelope is the JSON shape emitted by
+// `pulumi org member list --output=json`. The wire response from the cloud
+// is one page at a time; this envelope aggregates the pages we actually
+// fetched into a single document for scripts to consume.
+type orgMemberListEnvelope struct {
+	Members []apitype.OrganizationMember `json:"members"`
+	Count   int                          `json:"count"`
+}
+
+func renderOrgMemberListJSON(w io.Writer, members []apitype.OrganizationMember) error {
+	if members == nil {
+		members = []apitype.OrganizationMember{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(orgMemberListEnvelope{
+		Members: members,
+		Count:   len(members),
+	})
+}

--- a/pkg/cmd/pulumi/org/org_member_list_test.go
+++ b/pkg/cmd/pulumi/org/org_member_list_test.go
@@ -1,0 +1,471 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func deref[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}
+
+// capturedMemberCall records the inputs to a single ListOrganizationMembers
+// call.
+type capturedMemberCall struct {
+	org               string
+	mode              string
+	continuationToken *string
+}
+
+// mockOrgMemberListClient stubs orgMemberListClient. Pages are pulled from
+// `responses` in order; further calls beyond the slice return the final
+// response with a nil continuation token.
+type mockOrgMemberListClient struct {
+	responses []apitype.ListOrganizationMembersResponse
+	err       error
+	captured  *[]capturedMemberCall
+	calls     int
+}
+
+func (m *mockOrgMemberListClient) ListOrganizationMembers(
+	_ context.Context, orgName, mode string, continuationToken *string,
+) (apitype.ListOrganizationMembersResponse, error) {
+	if m.captured != nil {
+		*m.captured = append(*m.captured, capturedMemberCall{
+			org:               orgName,
+			mode:              mode,
+			continuationToken: continuationToken,
+		})
+	}
+	if m.err != nil {
+		return apitype.ListOrganizationMembersResponse{}, m.err
+	}
+	idx := m.calls
+	m.calls++
+	if idx >= len(m.responses) {
+		return apitype.ListOrganizationMembersResponse{}, nil
+	}
+	return m.responses[idx], nil
+}
+
+func stubMemberFactory(c orgMemberListClient, orgName string) orgMemberListClientFactory {
+	return func(_ context.Context, _ string) (orgMemberListClient, string, error) {
+		return c, orgName, nil
+	}
+}
+
+func failingMemberFactory(err error) orgMemberListClientFactory {
+	return func(_ context.Context, _ string) (orgMemberListClient, string, error) {
+		return nil, "", err
+	}
+}
+
+// defaultMemberListArgs returns an args struct primed with the default
+// (terminal table) renderer. Tests that want JSON should use
+// jsonMemberListArgs instead.
+func defaultMemberListArgs() orgMemberListArgs {
+	return orgMemberListArgs{renderOutput: renderOrgMemberListTable}
+}
+
+// jsonMemberListArgs is the args equivalent of `--output json`.
+func jsonMemberListArgs(t *testing.T) orgMemberListArgs {
+	t.Helper()
+	a := defaultMemberListArgs()
+	a.renderOutput = renderOrgMemberListJSON
+	return a
+}
+
+func sampleMember(login, name, role string) apitype.OrganizationMember {
+	return apitype.OrganizationMember{
+		Role:          role,
+		User:          apitype.UserInfo{Name: name, GitHubLogin: login},
+		Created:       "2026-05-01T12:00:00Z",
+		KnownToPulumi: true,
+		FGARole:       apitype.FGARole{ID: "role-" + role, Name: role, ModifiedAt: "2026-04-01T00:00:00Z"},
+	}
+}
+
+func sampleMemberResponse() apitype.ListOrganizationMembersResponse {
+	return apitype.ListOrganizationMembersResponse{
+		Members: []apitype.OrganizationMember{
+			sampleMember("alice", "Alice", "admin"),
+			sampleMember("bob", "Bob", "member"),
+		},
+	}
+}
+
+func TestOrgMemberList_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{sampleMemberResponse()}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.NoError(t, err)
+
+	out := buf.String()
+	// Table headers.
+	assert.Contains(t, out, "USER")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "ROLE")
+	assert.Contains(t, out, "JOINED")
+
+	// Rows.
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "Alice")
+	assert.Contains(t, out, "admin")
+	assert.Contains(t, out, "bob")
+	assert.Contains(t, out, "Bob")
+	assert.Contains(t, out, "member")
+	assert.Contains(t, out, "2026-05-01T12:00:00Z")
+
+	assert.Contains(t, out, "2 member(s)")
+}
+
+func TestOrgMemberList_DefaultOutput_Empty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{{}}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.NoError(t, err)
+	assert.Equal(t, "No members found for this organization.\n", buf.String())
+}
+
+func TestOrgMemberList_DefaultOutput_FallsBackToNameWhenGithubLoginMissing(t *testing.T) {
+	t.Parallel()
+
+	resp := apitype.ListOrganizationMembersResponse{
+		Members: []apitype.OrganizationMember{{
+			Role:    "admin",
+			User:    apitype.UserInfo{Name: "Display Name"},
+			Created: "2026-05-01T12:00:00Z",
+			FGARole: apitype.FGARole{Name: "admin"},
+		}},
+	}
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{resp}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Display Name")
+}
+
+func TestOrgMemberList_DefaultOutput_FallsBackToBuiltinRoleWhenFgaRoleEmpty(t *testing.T) {
+	t.Parallel()
+
+	resp := apitype.ListOrganizationMembersResponse{
+		Members: []apitype.OrganizationMember{{
+			Role:    "billingManager",
+			User:    apitype.UserInfo{GitHubLogin: "carol", Name: "Carol"},
+			Created: "2026-05-01T12:00:00Z",
+		}},
+	}
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{resp}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "billingManager")
+}
+
+func TestOrgMemberList_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{sampleMemberResponse()}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), jsonMemberListArgs(t))
+	require.NoError(t, err)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+
+	assert.Equal(t, 2, env.Count)
+	require.Len(t, env.Members, 2)
+	assert.Equal(t, "alice", env.Members[0].User.GitHubLogin)
+	assert.Equal(t, "admin", env.Members[0].FGARole.Name)
+}
+
+func TestOrgMemberList_JSONOutput_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{{}}}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), jsonMemberListArgs(t))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"members":[],"count":0}`, buf.String())
+}
+
+func TestOrgMemberList_FirstPageOnlyByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Server has more pages, but with no --count and no --all the command
+	// should stop after the first page.
+	pages := []apitype.ListOrganizationMembersResponse{
+		{
+			Members:           []apitype.OrganizationMember{sampleMember("alice", "Alice", "admin")},
+			ContinuationToken: "page-2",
+		},
+		{
+			Members: []apitype.OrganizationMember{sampleMember("bob", "Bob", "member")},
+		},
+	}
+
+	var captured []capturedMemberCall
+	c := &mockOrgMemberListClient{responses: pages, captured: &captured}
+	var buf bytes.Buffer
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), jsonMemberListArgs(t))
+	require.NoError(t, err)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, 1, env.Count)
+	require.Len(t, captured, 1)
+	assert.Equal(t, "", deref(captured[0].continuationToken))
+}
+
+func TestOrgMemberList_All_FetchesEveryPage(t *testing.T) {
+	t.Parallel()
+
+	pages := []apitype.ListOrganizationMembersResponse{
+		{
+			Members:           []apitype.OrganizationMember{sampleMember("alice", "Alice", "admin")},
+			ContinuationToken: "page-2",
+		},
+		{
+			Members:           []apitype.OrganizationMember{sampleMember("bob", "Bob", "member")},
+			ContinuationToken: "page-3",
+		},
+		{
+			Members: []apitype.OrganizationMember{sampleMember("carol", "Carol", "admin")},
+		},
+	}
+
+	var captured []capturedMemberCall
+	c := &mockOrgMemberListClient{responses: pages, captured: &captured}
+	var buf bytes.Buffer
+	args := jsonMemberListArgs(t)
+	args.all = true
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), args)
+	require.NoError(t, err)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, 3, env.Count)
+	require.Len(t, captured, 3)
+	assert.Equal(t, "", deref(captured[0].continuationToken))
+	assert.Equal(t, "page-2", deref(captured[1].continuationToken))
+	assert.Equal(t, "page-3", deref(captured[2].continuationToken))
+}
+
+func TestOrgMemberList_Count_TruncatesAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	pages := []apitype.ListOrganizationMembersResponse{
+		{
+			Members: []apitype.OrganizationMember{
+				sampleMember("alice", "Alice", "admin"),
+				sampleMember("bob", "Bob", "member"),
+			},
+			ContinuationToken: "page-2",
+		},
+		{
+			Members: []apitype.OrganizationMember{
+				sampleMember("carol", "Carol", "admin"),
+				sampleMember("dan", "Dan", "member"),
+			},
+			ContinuationToken: "page-3",
+		},
+	}
+
+	var captured []capturedMemberCall
+	c := &mockOrgMemberListClient{responses: pages, captured: &captured}
+	var buf bytes.Buffer
+	args := jsonMemberListArgs(t)
+	args.count = 3
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), args)
+	require.NoError(t, err)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, 3, env.Count)
+	// Two pages fetched: first satisfied 2 of 3, second pushed us to 4 and we
+	// truncated. No third page should have been requested.
+	require.Len(t, captured, 2)
+}
+
+func TestOrgMemberList_Count_StopsAtServerEndEvenIfShort(t *testing.T) {
+	t.Parallel()
+
+	pages := []apitype.ListOrganizationMembersResponse{
+		{
+			Members: []apitype.OrganizationMember{
+				sampleMember("alice", "Alice", "admin"),
+			},
+		},
+	}
+
+	c := &mockOrgMemberListClient{responses: pages}
+	var buf bytes.Buffer
+	args := jsonMemberListArgs(t)
+	args.count = 100
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), args)
+	require.NoError(t, err)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, 1, env.Count)
+}
+
+func TestOrgMemberList_AlwaysQueriesFrontendMembers(t *testing.T) {
+	t.Parallel()
+
+	var captured []capturedMemberCall
+	c := &mockOrgMemberListClient{
+		responses: []apitype.ListOrganizationMembersResponse{{}},
+		captured:  &captured,
+	}
+	var buf bytes.Buffer
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.NoError(t, err)
+	require.Len(t, captured, 1)
+	assert.Equal(t, "frontend", captured[0].mode)
+}
+
+func TestOrgMemberList_NegativeCount(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{{}}}
+	args := defaultMemberListArgs()
+	args.count = -1
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--count must be non-negative")
+}
+
+func TestOrgMemberList_ClientError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	c := &mockOrgMemberListClient{err: errors.New("server boom")}
+	err := runOrgMemberList(t.Context(), &buf, stubMemberFactory(c, "acme"), defaultMemberListArgs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing organization members")
+	assert.Contains(t, err.Error(), "server boom")
+}
+
+func TestOrgMemberList_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	err := runOrgMemberList(t.Context(), &buf, failingMemberFactory(errors.New("not logged in")),
+		defaultMemberListArgs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not logged in")
+}
+
+func TestOrgMemberList_OrgFlagPropagatesToFactory(t *testing.T) {
+	t.Parallel()
+
+	var capturedOrg string
+	factory := func(_ context.Context, orgFlag string) (orgMemberListClient, string, error) {
+		capturedOrg = orgFlag
+		return &mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{{}}}, "acme", nil
+	}
+
+	var buf bytes.Buffer
+	args := defaultMemberListArgs()
+	args.org = "acme"
+	err := runOrgMemberList(t.Context(), &buf, factory, args)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", capturedOrg)
+}
+
+func TestNewOrgMemberListCmd_CobraFlagBinding(t *testing.T) {
+	t.Parallel()
+
+	var captured []capturedMemberCall
+	c := &mockOrgMemberListClient{
+		responses: []apitype.ListOrganizationMembersResponse{sampleMemberResponse()},
+		captured:  &captured,
+	}
+	cmd := newOrgMemberListCmdWith(stubMemberFactory(c, "acme"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{
+		"--org", "acme",
+		"--all",
+		"--output", "json",
+	})
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+
+	require.Len(t, captured, 1)
+	assert.Equal(t, "frontend", captured[0].mode)
+
+	var env orgMemberListEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+	assert.Equal(t, 2, env.Count)
+}
+
+func TestNewOrgMemberListCmd_CountAndAllAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgMemberListCmdWith(stubMemberFactory(
+		&mockOrgMemberListClient{responses: []apitype.ListOrganizationMembersResponse{{}}}, "acme"))
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--count", "5", "--all"})
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+}
+
+func TestNewOrgMemberListCmd_Defaults(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgMemberListCmd()
+	require.NotNil(t, cmd)
+	assert.Equal(t, "list", cmd.Use)
+
+	output := cmd.Flags().Lookup("output")
+	require.NotNil(t, output)
+	assert.Equal(t, "o", output.Shorthand)
+	assert.Equal(t, "default", output.DefValue)
+
+	count := cmd.Flags().Lookup("count")
+	require.NotNil(t, count)
+	assert.Equal(t, "0", count.DefValue)
+
+	all := cmd.Flags().Lookup("all")
+	require.NotNil(t, all)
+	assert.Equal(t, "false", all.DefValue)
+}

--- a/pkg/cmd/pulumi/org/org_webhook_list_test.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list_test.go
@@ -38,7 +38,7 @@ func (m *mockOrgWebhookListClient) ListOrgWebhooks(
 	return m.webhooks, m.err
 }
 
-func ptr(s string) *string { return &s }
+func ptr[T any](v T) *T { return &v }
 
 func sampleOrgWebhooks() []apitype.Webhook {
 	return []apitype.Webhook{


### PR DESCRIPTION
## Summary

Adds `pulumi org member list`, a leaf command under the [Cloud-Ready CLI](https://github.com/pulumi/pulumi/issues/22959) epic for `pulumi org member`. Closes #23013.

The command wraps the [`ListOrganizationMembers`](https://www.pulumi.com/docs/reference/cloud-rest-api/organizations/#get-apiorgsorgnamemembers) endpoint:

```
pulumi org member list
  [--org <name>]              # context; defaults to the user's default org
  [--count <n>]               # auto-paginate up to n members
  [--all]                     # auto-paginate every page (mutually exclusive with --count)
  [--output default|json]     # default: human-readable table
```

The wire endpoint exposes a "frontend" / "backend" mode for pagination correctness; the CLI only ever queries the **frontend** (Pulumi Service, seat-counted) member set. The mode is not surfaced as a flag.

### Pagination

The underlying API paginates with opaque continuation tokens, so following the [Cloud-Ready CLI guidance](https://github.com/pulumi/pulumi/issues/22959):

- Default behaviour is to fetch only the first page.
- `--count N` over-fetches just enough pages to satisfy N rows and truncates the result. Stops early if the server runs out of results.
- `--all` walks every page until the server reports no further continuation token.
- `--count` and `--all` are marked mutually exclusive by cobra.

### Implementation notes

This follows the same conventions as [`pulumi deployment list`](https://github.com/pulumi/pulumi/pull/23114) and [`pulumi stack webhook list`](https://github.com/pulumi/pulumi/pull/22994):

- Non-interactive `clientFactory` abstraction for injection-based unit testing; passing `nil` installs the production factory backed by `httpstate.Backend` + `GetDefaultOrg`/`CurrentUser`.
- Default output is a human-readable `go-pretty/v6` table with columns `USER | NAME | ROLE | JOINED`, plus a `N member(s)` footer. `--output json` emits a stable `{members, count}` envelope, wired through the reusable `pkg/util/outputflag` helper.
- The existing `*client.Client.ListOrganizationMembers` (added in #23183) is reused; we only register the endpoint with the trace muxer.
- `ROLE` is rendered from `fgaRole.name` when present, falling back to the deprecated built-in `role` field.
- `USER` is rendered from `user.githubLogin` when present, falling back to `user.name`.

The placeholder `newOrgMemberListCmd` is replaced with the real implementation. The parent `pulumi org member` command stays hidden until the rest of the new subcommand tree lands (help text labels the tree `[EXPERIMENTAL]` to match).

## Sample output

### Default (table)

```
$ pulumi org member list --org acme
┌───────┬───────┬────────┬──────────────────────┐
│ USER  │ NAME  │ ROLE   │ JOINED               │
├───────┼───────┼────────┼──────────────────────┤
│ alice │ Alice │ admin  │ 2026-05-01T12:00:00Z │
│ bob   │ Bob   │ member │ 2026-04-15T08:00:00Z │
└───────┴───────┴────────┴──────────────────────┘

2 member(s)
```

When there are no members:

```
$ pulumi org member list --org acme
No members found for this organization.
```

### `--output json`

```
$ pulumi org member list --org acme --output json
{
  "members": [
    {
      "role": "admin",
      "user": {
        "name": "Alice",
        "githubLogin": "alice",
        "avatarUrl": "https://example.com/a.png"
      },
      "created": "2026-05-01T12:00:00Z",
      "knownToPulumi": true,
      "virtualAdmin": false,
      "links": { "self": "/api/orgs/acme/members/alice" },
      "fgaRole": {
        "id": "role-admin",
        "name": "admin",
        "modifiedAt": "2026-04-01T00:00:00Z"
      }
    }
  ],
  "count": 1
}
```

### Errors

`--count` and `--all` are mutually exclusive:

```
$ pulumi org member list --count 5 --all
error: if any flags in the group [count all] are set none of the others can be; [all count] were all set
```

## Test plan

- [x] Added appropriate unit tests
- [ ] Added a test in `pkg/engine/lifecycletest` — n/a
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` — n/a
- [ ] Added a golden test in `pkg/backend/display` — n/a

`pkg/cmd/pulumi/org/org_member_list_test.go` covers:

- Default (table) output, including the empty-list path, the fallback from `githubLogin` to `name`, and the fallback from `fgaRole.name` to built-in `role`
- JSON output, including the empty-array normalization
- Pagination: first-page-only default, `--all` walks every page, `--count` truncates across pages, `--count` stops at server end when results are short
- The command always passes `"frontend"` as the wire-level mode (no `--mode` flag is exposed)
- `--org` propagation to the factory
- Negative `--count`, client errors, and factory errors
- Full cobra-level flag binding, the mutually-exclusive `--count`/`--all` pair, and the `nil`-factory default

`pkg/backend/httpstate/client/client_organization_members_test.go` covers `ListOrganizationMembers` against a `httptest.NewServer`:

- Round-trip of a populated response
- Query string emission for `continuationToken` and `type`
- Zero values omit the corresponding query params entirely
- HTTP error propagation

## Validation

- [x] `make lint` — clean
- [x] Relevant tests pass (`./cmd/pulumi/org/...`, `./backend/httpstate/client/...`, `./sdk/go/common/apitype/...`)
- [x] `make format` — clean
- [ ] `make check_proto` — n/a, no proto changes

## Changelog

- [x] Changelog entry added: ``cli/cloud: Add `pulumi org member list` to list the members of an organization``

## Risk

Strictly additive: new files in `pkg/cmd/pulumi/org/`, `pkg/backend/httpstate/client/`, plus a one-line endpoint registration in `api_endpoints.go`. The only deletion is the placeholder `newOrgMemberListCmd` returning `errors.New("not yet implemented")`, replaced by the real implementation.

The parent `pulumi org member` command remains hidden (`Hidden: true`) until the rest of the new subcommand tree lands.