### PR TITLE
implement `pulumi org webhook new`

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-org-webhook-new.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-org-webhook-new.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org webhook new` to create a new organization webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -741,6 +741,17 @@ func (pc *Client) ListOrgWebhooks(ctx context.Context, org string) ([]apitype.We
 	return resp, nil
 }
 
+// CreateOrgWebhook creates a new webhook for the given organization.
+func (pc *Client) CreateOrgWebhook(
+	ctx context.Context, org string, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	if err := pc.restCall(ctx, "POST", "/api/orgs/"+url.PathEscape(org)+"/hooks", nil, &req, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
 // ListStackWebhooks returns all webhooks configured for the given stack.
 func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier) ([]apitype.Webhook, error) {
 	var resp []apitype.Webhook

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -46,48 +46,6 @@ func newOrgWebhookCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/22966]: Not yet implemented.
-func newOrgWebhookNewCmd() *cobra.Command {
-	var (
-		org         string
-		url         string
-		format      string
-		filters     []string
-		active      bool
-		secret      string
-		displayName string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new",
-		Short:  "Create a new organization webhook",
-		Long:   "[EXPERIMENTAL] Create a new organization webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to create the webhook in")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
-	cmd.Flags().StringVar(&format, "format", "raw",
-		"The webhook format: raw, slack, ms_teams, or pulumi_deployments")
-	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		"An event type to subscribe to (repeatable)")
-	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
-	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
-	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
-
-	return cmd
-}
-
 // TODO[https://github.com/pulumi/pulumi/issues/22967]: Not yet implemented.
 func newOrgWebhookEditCmd() *cobra.Command {
 	var (

--- a/pkg/cmd/pulumi/org/org_webhook_new.go
+++ b/pkg/cmd/pulumi/org/org_webhook_new.go
@@ -1,0 +1,395 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type orgWebhookNewRender func(cmd *orgWebhookNewCmd, wh apitype.Webhook) error
+
+// Valid event groups for org webhooks (superset of stack groups).
+var orgWebhookGroups = []string{
+	"stacks", "deployments", "policies",
+	"environments", "change_requests",
+}
+
+// orgGroupFilters maps each event group to its contained filters for org webhooks.
+var orgGroupFilters = map[string][]string{
+	"stacks": {
+		"stack_created", "stack_deleted",
+		"update_succeeded", "update_failed",
+		"preview_succeeded", "preview_failed",
+		"destroy_succeeded", "destroy_failed",
+		"refresh_succeeded", "refresh_failed",
+		"import_succeeded", "import_failed",
+	},
+	"deployments": {
+		"deployment_queued", "deployment_started",
+		"deployment_succeeded", "deployment_failed",
+		"drift_detected",
+		"drift_detection_succeeded", "drift_detection_failed",
+		"drift_remediation_succeeded", "drift_remediation_failed",
+		"deployment_file_ingestion_failed",
+	},
+	"policies": {
+		"policy_violation_mandatory", "policy_violation_advisory",
+	},
+	"environments": {
+		"environment_created", "environment_deleted",
+		"environment_revision_created", "environment_revision_retracted",
+		"environment_revision_tag_created", "environment_revision_tag_deleted",
+		"environment_revision_tag_updated",
+		"environment_tag_created", "environment_tag_deleted",
+		"environment_tag_updated",
+		"imported_environment_changed",
+	},
+	"change_requests": {
+		"change_request_created", "change_request_updated",
+		"change_request_approved", "change_request_unapproved",
+		"change_request_closed", "change_request_applied",
+		"change_request_submitted",
+	},
+}
+
+type orgWebhookNewCmd struct {
+	orgName string
+	output  outputflag.OutputFlag[orgWebhookNewRender]
+	w       io.Writer
+
+	// Flags.
+	name   string
+	url    string
+	format string
+	events []string
+	groups []string
+	active bool
+	secret string
+	yes    bool
+
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error)
+}
+
+func newOrgWebhookNewCmd() *cobra.Command {
+	return newOrgWebhookNewCmdWith(nil)
+}
+
+func newOrgWebhookNewCmdWith(
+	overrideBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error),
+) *cobra.Command {
+	oncmd := &orgWebhookNewCmd{
+		output: outputflag.OutputFlag[orgWebhookNewRender]{
+			RenderForTerminal: (*orgWebhookNewCmd).renderText,
+			RenderJSON:        (*orgWebhookNewCmd).renderJSON,
+		},
+		currentBackend: overrideBackend,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "[EXPERIMENTAL] Create a new organization webhook",
+		Long: "Create a new organization webhook.\n" +
+			"\n" +
+			"Creates a webhook that delivers events for the specified organization\n" +
+			"to a given URL. Organization webhooks can fire on stack lifecycle,\n" +
+			"deployment, drift detection, environment, and policy violation events.\n" +
+			"\n" +
+			"When run interactively, prompts for required values that aren't\n" +
+			"provided via flags. Pass --yes to accept defaults without prompting.",
+		Example: "  # Create a webhook interactively\n" +
+			"  pulumi org webhook new --name my-hook\n\n" +
+			"  # Create non-interactively\n" +
+			"  pulumi org webhook new --name my-hook --url https://example.com/hook --yes\n\n" +
+			"  # Create with specific event groups\n" +
+			"  pulumi org webhook new --name my-hook \\\n" +
+			"    --url https://example.com --group stacks --group deployments --yes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			oncmd.w = cmd.OutOrStdout()
+			return oncmd.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&oncmd.name, "name", "",
+		"The webhook name (1-32 chars, alphanumeric/hyphens/underscores/dots)")
+	cmd.Flags().StringVar(&oncmd.orgName, "org", "",
+		"The organization to create the webhook in. Defaults to the current org.")
+	cmd.Flags().StringVar(&oncmd.url, "url", "",
+		"The webhook payload URL, including protocol (e.g. https://example.com/hook)")
+	cmd.Flags().StringVar(&oncmd.format, "hook-format", "raw",
+		"The webhook format: raw, slack, or ms_teams")
+	cmd.Flags().StringArrayVar(&oncmd.events, "event", nil,
+		"An event type to subscribe to (repeatable)")
+	cmd.Flags().StringArrayVar(&oncmd.groups, "group", nil,
+		"An event group to subscribe to (repeatable)")
+	cmd.Flags().BoolVar(&oncmd.active, "active", true,
+		"Whether the webhook is active")
+	cmd.Flags().StringVar(&oncmd.secret, "secret", "",
+		"The HMAC key for signature verification")
+	cmd.Flags().BoolVarP(&oncmd.yes, "yes", "y", false,
+		"Skip prompts and proceed with default values")
+	outputflag.VarP(cmd.Flags(), &oncmd.output)
+
+	return cmd
+}
+
+func (c *orgWebhookNewCmd) run(ctx context.Context) error {
+	currentBackend := c.currentBackend
+	if currentBackend == nil {
+		currentBackend = cmdBackend.CurrentBackend
+	}
+
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return err
+	}
+
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	be, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	if err != nil {
+		return err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return errors.New("this command requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName := c.orgName
+	if orgName == "" {
+		orgName, err = cloudBackend.GetDefaultOrg(ctx)
+		if err != nil {
+			return fmt.Errorf("resolving default org: %w", err)
+		}
+		if orgName == "" {
+			userName, _, _, err := cloudBackend.CurrentUser()
+			if err != nil {
+				return err
+			}
+			orgName = userName
+		}
+	}
+
+	// Resolve interactive values.
+	skipPrompts := c.yes || !cmdutil.Interactive()
+
+	name := c.name
+	if name == "" {
+		nameErrMsg := "a webhook name is required (use --name)"
+		if !skipPrompts {
+			nameErrMsg = "a webhook name is required"
+		}
+		name, err = ui.PromptForValue(
+			skipPrompts, "Webhook name", "", false,
+			func(v string) error {
+				if v == "" {
+					return errors.New(nameErrMsg) //nolint:goerr113 // intentional
+				}
+				return nil
+			}, displayOpts)
+		if err != nil {
+			return err
+		}
+	}
+
+	webhookURL := c.url
+	if webhookURL == "" {
+		if !skipPrompts {
+			fmt.Fprintln(c.w,
+				"Enter the URL that will receive webhook payloads "+
+					"(e.g. https://example.com/webhook).")
+		}
+		urlErrMsg := "a payload URL is required (use --url)"
+		if !skipPrompts {
+			urlErrMsg = "a payload URL is required"
+		}
+		webhookURL, err = ui.PromptForValue(
+			skipPrompts, "Webhook payload URL", "", false,
+			func(v string) error {
+				if v == "" {
+					return errors.New(urlErrMsg) //nolint:goerr113 // intentional
+				}
+				return nil
+			}, displayOpts)
+		if err != nil {
+			return err
+		}
+	}
+
+	format := c.format
+	if !skipPrompts {
+		formats := []string{"raw", "slack", "ms_teams"}
+		format = ui.PromptUserSkippable(
+			false, "Webhook format", formats, format, displayOpts.Color)
+	}
+
+	groups := c.groups
+	if len(groups) == 0 && !skipPrompts {
+		groups = ui.PromptUserMultiSkippable(
+			false, "Event groups to subscribe to",
+			orgWebhookGroups, orgWebhookGroups,
+			displayOpts.Color)
+	}
+
+	events := c.events
+	if len(events) == 0 && !skipPrompts {
+		remaining := orgFiltersNotCoveredByGroups(groups)
+		if len(remaining) > 0 {
+			events = ui.PromptUserMultiSkippable(
+				false, "Additional events to subscribe to",
+				remaining, nil, displayOpts.Color)
+		}
+	}
+
+	if err := validateOrgGroupsAndEvents(groups, events); err != nil {
+		return err
+	}
+
+	formatPtr := &format
+	if format == "" {
+		formatPtr = nil
+	}
+
+	req := apitype.Webhook{
+		OrganizationName: orgName,
+		DisplayName:      name,
+		PayloadURL:       webhookURL,
+		Active:           c.active,
+		Format:           formatPtr,
+		Groups:           groups,
+		Filters:          events,
+	}
+	if c.secret != "" {
+		req.Secret = c.secret
+	}
+
+	created, err := cloudBackend.Client().CreateOrgWebhook(ctx, orgName, req)
+	if err != nil {
+		return fmt.Errorf("creating organization webhook: %w", err)
+	}
+
+	return c.output.Get()(c, created)
+}
+
+func (c *orgWebhookNewCmd) renderText(wh apitype.Webhook) error {
+	fmt.Fprintf(c.w, "Created webhook %q\n", wh.Name)
+	return nil
+}
+
+func (c *orgWebhookNewCmd) renderJSON(wh apitype.Webhook) error {
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toOrgWebhookJSON(wh))
+}
+
+// orgFiltersNotCoveredByGroups returns event filters not covered by selected groups.
+func orgFiltersNotCoveredByGroups(selectedGroups []string) []string {
+	covered := make(map[string]bool)
+	for _, g := range selectedGroups {
+		for _, f := range orgGroupFilters[g] {
+			covered[f] = true
+		}
+	}
+	var remaining []string
+	for _, group := range orgWebhookGroups {
+		for _, f := range orgGroupFilters[group] {
+			if !covered[f] {
+				remaining = append(remaining, f)
+			}
+		}
+	}
+	return remaining
+}
+
+var validOrgGroupSet = func() map[string]bool {
+	m := make(map[string]bool, len(orgWebhookGroups))
+	for _, g := range orgWebhookGroups {
+		m[g] = true
+	}
+	return m
+}()
+
+var validOrgEventSet = func() map[string]bool {
+	m := make(map[string]bool)
+	for _, events := range orgGroupFilters {
+		for _, e := range events {
+			m[e] = true
+		}
+	}
+	return m
+}()
+
+func validateOrgGroupsAndEvents(groups, events []string) error {
+	for _, g := range groups {
+		if !validOrgGroupSet[g] {
+			return fmt.Errorf("invalid group %q; valid groups: %s",
+				g, joinOrgQuoted(orgWebhookGroups))
+		}
+	}
+	for _, e := range events {
+		if !validOrgEventSet[e] {
+			return fmt.Errorf("invalid event %q", e)
+		}
+	}
+	covered := make(map[string]string)
+	for _, g := range groups {
+		for _, e := range orgGroupFilters[g] {
+			covered[e] = g
+		}
+	}
+	for _, e := range events {
+		if g, ok := covered[e]; ok {
+			return fmt.Errorf(
+				"event %q is already included by group %q; "+
+					"remove the event or the group", e, g)
+		}
+	}
+	return nil
+}
+
+func joinOrgQuoted(ss []string) string {
+	quoted := make([]string, len(ss))
+	for i, s := range ss {
+		quoted[i] = fmt.Sprintf("%q", s)
+	}
+	return strings.Join(quoted, ", ")
+}

--- a/pkg/cmd/pulumi/org/org_webhook_new_test.go
+++ b/pkg/cmd/pulumi/org/org_webhook_new_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOrgGroupsAndEvents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		err := validateOrgGroupsAndEvents(
+			[]string{"stacks", "environments"},
+			[]string{"deployment_queued"},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid group", func(t *testing.T) {
+		t.Parallel()
+		err := validateOrgGroupsAndEvents([]string{"bogus"}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid group "bogus"`)
+	})
+
+	t.Run("invalid event", func(t *testing.T) {
+		t.Parallel()
+		err := validateOrgGroupsAndEvents(nil, []string{"not_real"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid event "not_real"`)
+	})
+
+	t.Run("event covered by group", func(t *testing.T) {
+		t.Parallel()
+		err := validateOrgGroupsAndEvents(
+			[]string{"stacks"}, []string{"update_succeeded"},
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `already included by group "stacks"`)
+	})
+
+	t.Run("org-specific groups valid", func(t *testing.T) {
+		t.Parallel()
+		err := validateOrgGroupsAndEvents(
+			[]string{"environments", "change_requests"}, nil,
+		)
+		require.NoError(t, err)
+	})
+}
+
+func TestOrgFiltersNotCoveredByGroups(t *testing.T) {
+	t.Parallel()
+
+	// All groups → no remaining.
+	assert.Empty(t, orgFiltersNotCoveredByGroups(orgWebhookGroups))
+
+	// Only stacks → other groups' filters remain.
+	remaining := orgFiltersNotCoveredByGroups([]string{"stacks"})
+	assert.Contains(t, remaining, "deployment_queued")
+	assert.Contains(t, remaining, "environment_created")
+	assert.NotContains(t, remaining, "update_succeeded")
+}

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -46,14 +46,13 @@ type stackWebhookNewClientFactory func(
 
 // stackWebhookNewArgs holds the resolved arguments for creating a webhook.
 type stackWebhookNewArgs struct {
-	Name        string
-	DisplayName string
-	URL         string
-	Format      string
-	Filters     []string
-	Groups      []string
-	Active      bool
-	Secret      string
+	Name    string
+	URL     string
+	Format  string
+	Filters []string
+	Groups  []string
+	Active  bool
+	Secret  string
 }
 
 func newStackWebhookNewCmd() *cobra.Command {
@@ -62,17 +61,16 @@ func newStackWebhookNewCmd() *cobra.Command {
 
 func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Command {
 	var (
-		stack       string
-		name        string
-		url         string
-		format      string
-		filters     []string
-		groups      []string
-		active      bool
-		secret      string
-		displayName string
-		yes         bool
-		output      string
+		stack   string
+		name    string
+		url     string
+		format  string
+		filters []string
+		groups  []string
+		active  bool
+		secret  string
+		yes     bool
+		output  string
 	)
 
 	cmd := &cobra.Command{
@@ -111,7 +109,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 			webhookArgs, err := resolveNewArgs(
-				skipPrompts, name, displayName, url, format,
+				skipPrompts, name, url, format,
 				filters, groups, opts,
 			)
 			if err != nil {
@@ -145,8 +143,6 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 		"Whether the webhook is active")
 	cmd.Flags().StringVar(&secret, "secret", "",
 		"The HMAC key for signature verification")
-	cmd.Flags().StringVar(&displayName, "display-name", "",
-		"The webhook display name (defaults to the webhook name)")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
 		"Skip prompts and proceed with default values")
 	cmd.Flags().StringVarP(&output, "output", "o", "default",
@@ -215,7 +211,7 @@ func filtersNotCoveredByGroups(selectedGroups []string) []string {
 // resolveNewArgs prompts for any required values not provided via flags.
 func resolveNewArgs(
 	skipPrompts bool,
-	name, displayName, url, format string,
+	name, url, format string,
 	filters, groups []string,
 	opts display.Options,
 ) (stackWebhookNewArgs, error) {
@@ -238,11 +234,6 @@ func resolveNewArgs(
 		if err != nil {
 			return stackWebhookNewArgs{}, err
 		}
-	}
-
-	// Display name defaults to the webhook name.
-	if displayName == "" {
-		displayName = name
 	}
 
 	// URL is required.
@@ -296,12 +287,11 @@ func resolveNewArgs(
 	}
 
 	return stackWebhookNewArgs{
-		Name:        name,
-		DisplayName: displayName,
-		URL:         url,
-		Format:      format,
-		Filters:     filters,
-		Groups:      groups,
+		Name:    name,
+		URL:     url,
+		Format:  format,
+		Filters: filters,
+		Groups:  groups,
 	}, nil
 }
 
@@ -335,7 +325,7 @@ func runStackWebhookNew(
 		ProjectName:      &project,
 		StackName:        &stack,
 		Name:             args.Name,
-		DisplayName:      args.DisplayName,
+		DisplayName:      args.Name,
 		PayloadURL:       args.URL,
 		Active:           args.Active,
 		Format:           formatPtr,

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -71,12 +71,11 @@ func TestStackWebhookNew_TextOutput(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:        "my-hook",
-		DisplayName: "My Hook",
-		URL:         "https://example.com/webhook",
-		Format:      "raw",
-		Active:      true,
-		Secret:      "s3cret",
+		Name:   "my-hook",
+		URL:    "https://example.com/webhook",
+		Format: "raw",
+		Active: true,
+		Secret: "s3cret",
 	}
 
 	var buf bytes.Buffer
@@ -100,11 +99,10 @@ func TestStackWebhookNew_JSONOutput(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:        "my-hook",
-		DisplayName: "My Hook",
-		URL:         "https://example.com/webhook",
-		Format:      "raw",
-		Active:      true,
+		Name:   "my-hook",
+		URL:    "https://example.com/webhook",
+		Format: "raw",
+		Active: true,
 	}
 
 	var buf bytes.Buffer
@@ -120,14 +118,13 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:        "my-hook",
-		DisplayName: "My Hook",
-		URL:         "https://example.com/webhook",
-		Format:      "slack",
-		Filters:     []string{"update_succeeded", "update_failed"},
-		Groups:      []string{"stacks"},
-		Active:      true,
-		Secret:      "s3cret",
+		Name:    "my-hook",
+		URL:     "https://example.com/webhook",
+		Format:  "slack",
+		Filters: []string{"update_succeeded", "update_failed"},
+		Groups:  []string{"stacks"},
+		Active:  true,
+		Secret:  "s3cret",
 	}
 
 	var buf bytes.Buffer
@@ -135,7 +132,7 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-hook", c.gotReq.Name)
-	assert.Equal(t, "My Hook", c.gotReq.DisplayName)
+	assert.Equal(t, "my-hook", c.gotReq.DisplayName)
 	assert.Equal(t, "https://example.com/webhook", c.gotReq.PayloadURL)
 	require.NotNil(t, c.gotReq.Format)
 	assert.Equal(t, "slack", *c.gotReq.Format)
@@ -212,12 +209,11 @@ func TestStackWebhookNew_ResolveArgs_Yes(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true and --url set, should use defaults without prompting.
-	args, err := resolveNewArgs(true, "my-hook", "", "https://example.com", "raw",
+	args, err := resolveNewArgs(true, "my-hook", "https://example.com", "raw",
 		nil, nil, display.Options{})
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-hook", args.Name)
-	assert.Equal(t, "my-hook", args.DisplayName) // defaults to name
 	assert.Equal(t, "https://example.com", args.URL)
 	assert.Equal(t, "raw", args.Format)
 	assert.Empty(t, args.Filters)
@@ -228,7 +224,7 @@ func TestStackWebhookNew_ResolveArgs_YesNoName(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true but no name, should error because name is required.
-	_, err := resolveNewArgs(true, "", "", "https://example.com", "raw",
+	_, err := resolveNewArgs(true, "", "https://example.com", "raw",
 		nil, nil, display.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "webhook name is required")
@@ -239,21 +235,11 @@ func TestStackWebhookNew_ResolveArgs_YesNoURL(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true but no URL, should error because URL is required.
-	_, err := resolveNewArgs(true, "my-hook", "", "", "raw",
+	_, err := resolveNewArgs(true, "my-hook", "", "raw",
 		nil, nil, display.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payload URL is required")
 	assert.Contains(t, err.Error(), "--url")
-}
-
-func TestStackWebhookNew_ResolveArgs_ExplicitDisplayName(t *testing.T) {
-	t.Parallel()
-
-	// Explicit display name should be kept as-is.
-	args, err := resolveNewArgs(true, "my-hook", "Custom Name", "https://example.com", "raw",
-		nil, nil, display.Options{})
-	require.NoError(t, err)
-	assert.Equal(t, "Custom Name", args.DisplayName)
 }
 
 func TestFiltersNotCoveredByGroups(t *testing.T) {


### PR DESCRIPTION
Very similar to `pulumi stack webhook new`, example output:

```
$ PULUMI_HOME=~/.pulumi4 pulumi org webhook new --org tgummerer-org --output json
Webhook name: test2
Enter the URL that will receive webhook payloads (e.g. https://example.com/webhook).
Webhook payload URL: https://example.com/webhook
Webhook format raw
Event groups to subscribe to (use enter to accept the current selection) stacks, change_requests
Additional events to subscribe to (use enter to accept the current selection) deployment_queued
{
  "id": "test2",
  "name": "test2",
  "url": "https://example.com/webhook",
  "format": "raw",
  "active": true,
  "eventGroups": [
    "change_requests",
    "stacks"
  ],
  "events": [
    "deployment_queued"
  ]
}
```

Fixes https://github.com/pulumi/pulumi/issues/22966