### PR TITLE
implement `pulumi org webhook remove`

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-org-webhook-remove.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-org-webhook-remove.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org webhook remove` to delete an organization webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -752,6 +752,12 @@ func (pc *Client) CreateOrgWebhook(
 	return resp, nil
 }
 
+// DeleteOrgWebhook deletes the given webhook from the organization.
+func (pc *Client) DeleteOrgWebhook(ctx context.Context, org, webhookName string) error {
+	return pc.restCall(ctx, "DELETE",
+		"/api/orgs/"+url.PathEscape(org)+"/hooks/"+url.PathEscape(webhookName), nil, nil, nil)
+}
+
 // ListStackWebhooks returns all webhooks configured for the given stack.
 func (pc *Client) ListStackWebhooks(ctx context.Context, stackID StackIdentifier) ([]apitype.Webhook, error) {
 	var resp []apitype.Webhook

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -88,31 +88,7 @@ func newOrgWebhookEditCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/22968]: Not yet implemented.
-func newOrgWebhookRemoveCmd() *cobra.Command {
-	var org string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove",
-		Short:  "Permanently delete an organization webhook",
-		Long:   "[EXPERIMENTAL] Permanently delete an organization webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
-
-	return cmd
-}
+// newOrgWebhookRemoveCmd is defined in org_webhook_remove.go.
 
 // TODO[https://github.com/pulumi/pulumi/issues/22969]: Not yet implemented.
 func newOrgWebhookPingCmd() *cobra.Command {

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -1,0 +1,134 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type orgWebhookRemoveCmd struct {
+	orgName string
+	yes     bool
+
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error)
+}
+
+func newOrgWebhookRemoveCmd() *cobra.Command {
+	orcmd := &orgWebhookRemoveCmd{}
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "[EXPERIMENTAL] Delete an organization webhook",
+		Long: "Delete an organization webhook.\n" +
+			"\n" +
+			"Permanently removes the specified webhook from the organization.\n" +
+			"This cannot be undone. You will be prompted to confirm unless\n" +
+			"--yes is passed.\n" +
+			"\n" +
+			"Returns an error if the webhook does not exist.",
+		Example: "  # Remove a webhook (will prompt for confirmation)\n" +
+			"  pulumi org webhook remove my-webhook\n\n" +
+			"  # Remove without confirmation\n" +
+			"  pulumi org webhook remove my-webhook --yes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return orcmd.run(cmd.Context(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "name"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&orcmd.orgName, "org", "",
+		"The organization that owns the webhook. Defaults to the current org.")
+	cmd.Flags().BoolVarP(&orcmd.yes, "yes", "y", false,
+		"Skip confirmation prompts")
+
+	return cmd
+}
+
+func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error {
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	if !c.yes {
+		prompt := fmt.Sprintf(
+			"This will permanently remove the webhook '%s'!", webhookName)
+		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
+			return result.FprintBailf(os.Stdout, "confirmation declined")
+		}
+	}
+
+	currentBackend := c.currentBackend
+	if currentBackend == nil {
+		currentBackend = cmdBackend.CurrentBackend
+	}
+
+	ws := pkgWorkspace.Instance
+	project, _, err := ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return err
+	}
+
+	be, err := currentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts)
+	if err != nil {
+		return err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return errors.New("this command requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName := c.orgName
+	if orgName == "" {
+		orgName, err = cloudBackend.GetDefaultOrg(ctx)
+		if err != nil {
+			return fmt.Errorf("resolving default org: %w", err)
+		}
+		if orgName == "" {
+			userName, _, _, err := cloudBackend.CurrentUser()
+			if err != nil {
+				return err
+			}
+			orgName = userName
+		}
+	}
+
+	if err := cloudBackend.Client().DeleteOrgWebhook(ctx, orgName, webhookName); err != nil {
+		return fmt.Errorf("removing organization webhook: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Webhook '%s' has been removed.\n", webhookName)
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -37,6 +37,7 @@ import (
 type orgWebhookRemoveCmd struct {
 	orgName string
 	yes     bool
+	w       io.Writer
 
 	currentBackend func(
 		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
@@ -62,6 +63,7 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 			"  # Remove without confirmation\n" +
 			"  pulumi org webhook remove my-webhook --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			orcmd.w = cmd.OutOrStdout()
 			return orcmd.run(cmd.Context(), args[0])
 		},
 	}
@@ -86,7 +88,7 @@ func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error
 		prompt := fmt.Sprintf(
 			"This will permanently remove the webhook '%s'!", webhookName)
 		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
-			return result.FprintBailf(os.Stdout, "confirmation declined")
+			return result.FprintBailf(c.w, "confirmation declined")
 		}
 	}
 
@@ -129,6 +131,6 @@ func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error
 		return fmt.Errorf("removing organization webhook: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Webhook '%s' has been removed.\n", webhookName)
+	fmt.Fprintf(c.w, "Webhook '%s' has been removed.\n", webhookName)
 	return nil
 }


### PR DESCRIPTION
Example output:

```
$ PULUMI_HOME=~/.pulumi4 pulumi org webhook remove test --org tgummerer-org
This will permanently remove the webhook 'test'!
Please confirm that this is what you'd like to do by typing `test`: test
Webhook 'test' has been removed.

$ PULUMI_HOME=~/.pulumi4 pulumi org webhook remove test2 --org tgummerer-org --yes
Webhook 'test2' has been removed.
```

Fixes https://github.com/pulumi/pulumi/issues/22968