### PR TITLE
fix arguments for `pulumi stack webhook new`

### DIFF
--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -79,8 +79,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 		Long: "Create a new stack webhook.\n" +
 			"\n" +
 			"Creates a webhook that delivers events for the specified stack to a\n" +
-			"given URL. The webhook name must be unique within the stack and can\n" +
-			"contain letters, numbers, hyphens, underscores, and dots (1-32 chars).\n" +
+			"given URL.\n" +
 			"\n" +
 			"When run interactively, prompts for required values that aren't\n" +
 			"provided via flags. Pass --yes to accept defaults without prompting.\n" +
@@ -89,16 +88,16 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 			"\n" +
 			"Returns 409 if a webhook with the same name already exists.",
 		Example: "  # Create a webhook interactively\n" +
-			"  pulumi stack webhook new --name my-hook\n\n" +
+			"  pulumi stack webhook new\n\n" +
 			"  # Create a webhook non-interactively\n" +
-			"  pulumi stack webhook new --name my-hook --url https://example.com/hook --yes\n\n" +
+			"  pulumi stack webhook new --name \"My Hook\" --url https://example.com/hook --yes\n\n" +
 			"  # Create a Slack webhook with specific event filters\n" +
 			"  pulumi stack webhook new --name slack-alerts \\\n" +
 			"    --url https://hooks.slack.com/services/T00/B00/xxx \\\n" +
 			"    --format slack \\\n" +
-			"    --filter update_succeeded --filter update_failed --yes\n\n" +
+			"    --event update_succeeded --event update_failed --yes\n\n" +
 			"  # Create a webhook and get the result as JSON\n" +
-			"  pulumi stack webhook new --name my-hook --url https://example.com --yes --output json",
+			"  pulumi stack webhook new --name \"My Hook\" --url https://example.com --yes --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultStackWebhookNewClientFactory
@@ -128,7 +127,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.Flags().StringVar(&name, "name", "",
-		"The webhook name (1-32 chars: letters, numbers, hyphens, underscores, dots)")
+		"The webhook name (required)")
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.Flags().StringVar(&url, "url", "",
@@ -324,7 +323,6 @@ func runStackWebhookNew(
 		OrganizationName: stackID.Owner,
 		ProjectName:      &project,
 		StackName:        &stack,
-		Name:             args.Name,
 		DisplayName:      args.Name,
 		PayloadURL:       args.URL,
 		Active:           args.Active,

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -71,7 +71,7 @@ func TestStackWebhookNew_TextOutput(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:   "my-hook",
+		Name:   "My Hook",
 		URL:    "https://example.com/webhook",
 		Format: "raw",
 		Active: true,
@@ -99,7 +99,7 @@ func TestStackWebhookNew_JSONOutput(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:   "my-hook",
+		Name:   "My Hook",
 		URL:    "https://example.com/webhook",
 		Format: "raw",
 		Active: true,
@@ -118,7 +118,7 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 
 	c := &mockWebhookNewClient{created: createdWebhook()}
 	args := stackWebhookNewArgs{
-		Name:    "my-hook",
+		Name:    "My Hook",
 		URL:     "https://example.com/webhook",
 		Format:  "slack",
 		Filters: []string{"update_succeeded", "update_failed"},
@@ -131,8 +131,8 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
 	require.NoError(t, err)
 
-	assert.Equal(t, "my-hook", c.gotReq.Name)
-	assert.Equal(t, "my-hook", c.gotReq.DisplayName)
+	assert.Equal(t, "", c.gotReq.Name)
+	assert.Equal(t, "My Hook", c.gotReq.DisplayName)
 	assert.Equal(t, "https://example.com/webhook", c.gotReq.PayloadURL)
 	require.NotNil(t, c.gotReq.Format)
 	assert.Equal(t, "slack", *c.gotReq.Format)
@@ -208,12 +208,12 @@ func TestStackWebhookNew_StackFlagPropagation(t *testing.T) {
 func TestStackWebhookNew_ResolveArgs_Yes(t *testing.T) {
 	t.Parallel()
 
-	// With skipPrompts=true and --url set, should use defaults without prompting.
-	args, err := resolveNewArgs(true, "my-hook", "https://example.com", "raw",
+	// With skipPrompts=true and --name/--url set, should use values without prompting.
+	args, err := resolveNewArgs(true, "My Hook", "https://example.com", "raw",
 		nil, nil, display.Options{})
 	require.NoError(t, err)
 
-	assert.Equal(t, "my-hook", args.Name)
+	assert.Equal(t, "My Hook", args.Name)
 	assert.Equal(t, "https://example.com", args.URL)
 	assert.Equal(t, "raw", args.Format)
 	assert.Empty(t, args.Filters)
@@ -235,7 +235,7 @@ func TestStackWebhookNew_ResolveArgs_YesNoURL(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true but no URL, should error because URL is required.
-	_, err := resolveNewArgs(true, "my-hook", "", "raw",
+	_, err := resolveNewArgs(true, "My Hook", "", "raw",
 		nil, nil, display.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payload URL is required")


### PR DESCRIPTION
I realized this after the code was already in the merge queue, but we should be consistent here.  `pulumi stack webhook list` and `pulumi stack webhook get` already use ID, and name for this (as does the cloud interface), so rename the arguments for this as well.
