### PR TITLE
add `org webhook edit/ping/delivery list`

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-org-webhook-delivery-list.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-org-webhook-delivery-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org webhook delivery list` to list recent deliveries for an organization webhook

--- a/changelog/pending/20260514--cli--add-pulumi-org-webhook-edit.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-org-webhook-edit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org webhook edit` to update an organization webhook

--- a/changelog/pending/20260514--cli--add-pulumi-org-webhook-ping.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-org-webhook-ping.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org webhook ping` to send a test ping to an organization webhook

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -752,10 +752,56 @@ func (pc *Client) CreateOrgWebhook(
 	return resp, nil
 }
 
+// GetOrgWebhook returns a single webhook by name for the given organization.
+func (pc *Client) GetOrgWebhook(ctx context.Context, org, webhookName string) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	path := "/api/orgs/" + url.PathEscape(org) + "/hooks/" + url.PathEscape(webhookName)
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
+// UpdateOrgWebhook updates an existing webhook for the given organization.
+func (pc *Client) UpdateOrgWebhook(
+	ctx context.Context, org, webhookName string, req apitype.Webhook,
+) (apitype.Webhook, error) {
+	var resp apitype.Webhook
+	path := "/api/orgs/" + url.PathEscape(org) + "/hooks/" + url.PathEscape(webhookName)
+	if err := pc.restCall(ctx, "PATCH", path, nil, &req, &resp); err != nil {
+		return apitype.Webhook{}, err
+	}
+	return resp, nil
+}
+
 // DeleteOrgWebhook deletes the given webhook from the organization.
 func (pc *Client) DeleteOrgWebhook(ctx context.Context, org, webhookName string) error {
 	return pc.restCall(ctx, "DELETE",
 		"/api/orgs/"+url.PathEscape(org)+"/hooks/"+url.PathEscape(webhookName), nil, nil, nil)
+}
+
+// PingOrgWebhook sends a test ping to the given organization webhook.
+func (pc *Client) PingOrgWebhook(
+	ctx context.Context, org, webhookName string,
+) (apitype.WebhookDelivery, error) {
+	var resp apitype.WebhookDelivery
+	path := "/api/orgs/" + url.PathEscape(org) + "/hooks/" + url.PathEscape(webhookName) + "/ping"
+	if err := pc.restCall(ctx, "POST", path, nil, nil, &resp); err != nil {
+		return apitype.WebhookDelivery{}, err
+	}
+	return resp, nil
+}
+
+// ListOrgWebhookDeliveries returns recent deliveries for the given org webhook.
+func (pc *Client) ListOrgWebhookDeliveries(
+	ctx context.Context, org, webhookName string,
+) ([]apitype.WebhookDelivery, error) {
+	var resp []apitype.WebhookDelivery
+	path := "/api/orgs/" + url.PathEscape(org) + "/hooks/" + url.PathEscape(webhookName) + "/deliveries"
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // ListStackWebhooks returns all webhooks configured for the given stack.

--- a/pkg/cmd/pulumi/org/org_webhook.go
+++ b/pkg/cmd/pulumi/org/org_webhook.go
@@ -15,8 +15,6 @@
 package org
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -46,82 +44,10 @@ func newOrgWebhookCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/22967]: Not yet implemented.
-func newOrgWebhookEditCmd() *cobra.Command {
-	var (
-		org         string
-		url         string
-		format      string
-		filters     []string
-		active      bool
-		secret      string
-		displayName string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "Update an organization webhook's configuration",
-		Long:   "[EXPERIMENTAL] Update an organization webhook's configuration.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
-	cmd.Flags().StringVar(&url, "url", "", "The webhook payload URL")
-	cmd.Flags().StringVar(&format, "format", "",
-		"The webhook format: raw, slack, or ms_teams")
-	cmd.Flags().StringArrayVar(&filters, "filter", nil,
-		"An event type to subscribe to (repeatable)")
-	cmd.Flags().BoolVar(&active, "active", true, "Whether the webhook is active")
-	cmd.Flags().StringVar(&secret, "secret", "", "The HMAC key for signature verification")
-	cmd.Flags().StringVar(&displayName, "display-name", "", "The webhook display name")
-
-	return cmd
-}
-
-// newOrgWebhookRemoveCmd is defined in org_webhook_remove.go.
-
-// TODO[https://github.com/pulumi/pulumi/issues/22969]: Not yet implemented.
-func newOrgWebhookPingCmd() *cobra.Command {
-	var org string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "ping",
-		Short:  "Send a test ping to an organization webhook",
-		Long:   "[EXPERIMENTAL] Send a test ping to an organization webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "name"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
-
-	return cmd
-}
-
 func newOrgWebhookDeliveryCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "delivery",
-		Short:  "Inspect organization webhook deliveries",
-		Long:   "[EXPERIMENTAL] Inspect organization webhook deliveries.",
+		Use:   "delivery",
+		Short: "[EXPERIMENTAL] Inspect organization webhook deliveries",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -130,31 +56,5 @@ func newOrgWebhookDeliveryCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	cmd.AddCommand(newOrgWebhookDeliveryListCmd())
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/22997]: Not yet implemented.
-func newOrgWebhookDeliveryListCmd() *cobra.Command {
-	var org string
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List recent deliveries for an organization webhook",
-		Long:   "[EXPERIMENTAL] List recent deliveries for an organization webhook.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "webhook"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization that owns the webhook")
-
 	return cmd
 }

--- a/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
@@ -1,0 +1,173 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type orgWebhookDeliveryListRender func(
+	cmd *orgWebhookDeliveryListCmd, deliveries []apitype.WebhookDelivery,
+) error
+
+type orgWebhookDeliveryListCmd struct {
+	orgName string
+	output  outputflag.OutputFlag[orgWebhookDeliveryListRender]
+	w       io.Writer
+
+	ws             pkgWorkspace.Context
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error)
+}
+
+func newOrgWebhookDeliveryListCmd() *cobra.Command {
+	dlcmd := &orgWebhookDeliveryListCmd{
+		output: outputflag.OutputFlag[orgWebhookDeliveryListRender]{
+			RenderForTerminal: (*orgWebhookDeliveryListCmd).renderTable,
+			RenderJSON:        (*orgWebhookDeliveryListCmd).renderJSON,
+		},
+		ws:             pkgWorkspace.Instance,
+		currentBackend: cmdBackend.CurrentBackend,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List recent deliveries for an organization webhook",
+		Long: "List recent deliveries for an organization webhook.\n" +
+			"\n" +
+			"Returns the recent delivery history for a specific webhook. Each\n" +
+			"delivery includes the timestamp, event kind, HTTP response code,\n" +
+			"and request duration.",
+		Example: "  # List deliveries for a webhook\n" +
+			"  pulumi org webhook delivery list my-webhook\n\n" +
+			"  # List deliveries as JSON\n" +
+			"  pulumi org webhook delivery list my-webhook --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dlcmd.w = cmd.OutOrStdout()
+			return dlcmd.run(cmd.Context(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "webhook"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&dlcmd.orgName, "org", "",
+		"The organization that owns the webhook. Defaults to the current org.")
+	outputflag.VarP(cmd.Flags(), &dlcmd.output)
+
+	return cmd
+}
+
+func (c *orgWebhookDeliveryListCmd) run(ctx context.Context, webhookName string) error {
+	project, _, err := c.ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return err
+	}
+
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	be, err := c.currentBackend(ctx, c.ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	if err != nil {
+		return err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return errors.New("this command requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName, err := resolveOrgName(ctx, c.orgName, cloudBackend)
+	if err != nil {
+		return err
+	}
+
+	cl := cloudBackend.Client()
+
+	// Verify the webhook exists — the deliveries endpoint returns empty
+	// for non-existent webhooks instead of 404.
+	if _, err := cl.GetOrgWebhook(ctx, orgName, webhookName); err != nil {
+		return fmt.Errorf("webhook %q not found: %w", webhookName, err)
+	}
+
+	deliveries, err := cl.ListOrgWebhookDeliveries(ctx, orgName, webhookName)
+	if err != nil {
+		return fmt.Errorf("listing webhook deliveries: %w", err)
+	}
+
+	return c.output.Get()(c, deliveries)
+}
+
+func (c *orgWebhookDeliveryListCmd) renderJSON(deliveries []apitype.WebhookDelivery) error {
+	if deliveries == nil {
+		deliveries = []apitype.WebhookDelivery{}
+	}
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		Deliveries []apitype.WebhookDelivery `json:"deliveries"`
+		Count      int                       `json:"count"`
+	}{
+		Deliveries: deliveries,
+		Count:      len(deliveries),
+	})
+}
+
+func (c *orgWebhookDeliveryListCmd) renderTable(deliveries []apitype.WebhookDelivery) error {
+	if len(deliveries) == 0 {
+		fmt.Fprintln(c.w, "No deliveries found for this webhook.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(c.w)
+	t.SetStyle(table.StyleLight)
+	t.AppendHeader(table.Row{"ID", "KIND", "TIMESTAMP", "DURATION", "STATUS"})
+
+	for _, d := range deliveries {
+		ts := time.Unix(d.Timestamp, 0).UTC().Format(time.RFC3339)
+		duration := strconv.Itoa(d.Duration) + "ms"
+		t.AppendRow(table.Row{d.ID, d.Kind, ts, duration, d.ResponseCode})
+	}
+
+	t.SetAllowedRowLength(cmdCmd.StdoutWidth())
+	t.Render()
+
+	fmt.Fprintf(c.w, "\n%d delivery(ies)\n", len(deliveries))
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_webhook_edit.go
+++ b/pkg/cmd/pulumi/org/org_webhook_edit.go
@@ -1,0 +1,248 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type orgWebhookEditRender func(cmd *orgWebhookEditCmd, wh apitype.Webhook) error
+
+const orgRemoveSecretSentinel = "__remove-secret"
+
+type orgWebhookEditCmd struct {
+	orgName string
+	output  outputflag.OutputFlag[orgWebhookEditRender]
+	w       io.Writer
+
+	// Flags.
+	url          string
+	format       string
+	addEvents    []string
+	removeEvents []string
+	addGroups    []string
+	removeGroups []string
+	active       bool
+	secret       string
+	displayName  string
+
+	ws             pkgWorkspace.Context
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error)
+}
+
+func newOrgWebhookEditCmd() *cobra.Command {
+	oecmd := &orgWebhookEditCmd{
+		output: outputflag.OutputFlag[orgWebhookEditRender]{
+			RenderForTerminal: (*orgWebhookEditCmd).renderText,
+			RenderJSON:        (*orgWebhookEditCmd).renderJSON,
+		},
+		ws:             pkgWorkspace.Instance,
+		currentBackend: cmdBackend.CurrentBackend,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "[EXPERIMENTAL] Update an organization webhook's configuration",
+		Long: "Update an organization webhook's configuration.\n" +
+			"\n" +
+			"Modifies an existing webhook. Only the flags you pass are changed;\n" +
+			"all other fields are preserved.\n" +
+			"\n" +
+			"Use --add-event/--remove-event and --add-group/--remove-group to\n" +
+			"modify event subscriptions incrementally. To clear the secret,\n" +
+			"pass --secret \"\".",
+		Example: "  # Disable a webhook\n" +
+			"  pulumi org webhook edit my-hook --active=false\n\n" +
+			"  # Change the payload URL\n" +
+			"  pulumi org webhook edit my-hook --url https://new-url.example.com\n\n" +
+			"  # Add an event and remove another\n" +
+			"  pulumi org webhook edit my-hook \\\n" +
+			"    --add-event deployment_failed --remove-event deployment_started\n\n" +
+			"  # Add a group\n" +
+			"  pulumi org webhook edit my-hook --add-group environments",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			oecmd.w = cmd.OutOrStdout()
+			return oecmd.run(cmd.Context(), cmd, args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "name"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&oecmd.orgName, "org", "",
+		"The organization that owns the webhook. Defaults to the current org.")
+	cmd.Flags().StringVar(&oecmd.url, "url", "",
+		"The webhook payload URL")
+	cmd.Flags().StringVar(&oecmd.format, "hook-format", "",
+		"The webhook format: raw, slack, or ms_teams")
+	cmd.Flags().StringArrayVar(&oecmd.addEvents, "add-event", nil,
+		"An event type to add (repeatable)")
+	cmd.Flags().StringArrayVar(&oecmd.removeEvents, "remove-event", nil,
+		"An event type to remove (repeatable)")
+	cmd.Flags().StringArrayVar(&oecmd.addGroups, "add-group", nil,
+		"An event group to add (repeatable)")
+	cmd.Flags().StringArrayVar(&oecmd.removeGroups, "remove-group", nil,
+		"An event group to remove (repeatable)")
+	cmd.Flags().BoolVar(&oecmd.active, "active", true,
+		"Whether the webhook is active")
+	cmd.Flags().StringVar(&oecmd.secret, "secret", "",
+		"The HMAC key for signature verification (empty string removes the secret)")
+	cmd.Flags().StringVar(&oecmd.displayName, "display-name", "",
+		"The webhook display name")
+	outputflag.VarP(cmd.Flags(), &oecmd.output)
+
+	return cmd
+}
+
+func (c *orgWebhookEditCmd) run(ctx context.Context, cobraCmd *cobra.Command, webhookName string) error {
+	project, _, err := c.ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return err
+	}
+
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	be, err := c.currentBackend(ctx, c.ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	if err != nil {
+		return err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return errors.New("this command requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName, err := resolveOrgName(ctx, c.orgName, cloudBackend)
+	if err != nil {
+		return err
+	}
+
+	cl := cloudBackend.Client()
+
+	existing, err := cl.GetOrgWebhook(ctx, orgName, webhookName)
+	if err != nil {
+		return fmt.Errorf("reading webhook %q: %w", webhookName, err)
+	}
+
+	// Apply only explicitly-set flags.
+	if cobraCmd.Flags().Changed("display-name") {
+		existing.DisplayName = c.displayName
+	}
+	if cobraCmd.Flags().Changed("url") {
+		existing.PayloadURL = c.url
+	}
+	if cobraCmd.Flags().Changed("hook-format") {
+		existing.Format = &c.format
+	}
+	if cobraCmd.Flags().Changed("active") {
+		existing.Active = c.active
+	}
+	if cobraCmd.Flags().Changed("secret") {
+		if c.secret == "" {
+			existing.Secret = orgRemoveSecretSentinel
+		} else {
+			existing.Secret = c.secret
+		}
+	}
+
+	// Remove first, then add (order matters for idempotency).
+	if cobraCmd.Flags().Changed("remove-event") {
+		existing.Filters = removeFromSlice(existing.Filters, c.removeEvents)
+	}
+	if cobraCmd.Flags().Changed("add-event") {
+		existing.Filters = addToSlice(existing.Filters, c.addEvents)
+	}
+	if cobraCmd.Flags().Changed("remove-group") {
+		existing.Groups = removeFromSlice(existing.Groups, c.removeGroups)
+	}
+	if cobraCmd.Flags().Changed("add-group") {
+		existing.Groups = addToSlice(existing.Groups, c.addGroups)
+	}
+
+	if err := validateOrgGroupsAndEvents(existing.Groups, existing.Filters); err != nil {
+		return err
+	}
+
+	updated, err := cl.UpdateOrgWebhook(ctx, orgName, webhookName, existing)
+	if err != nil {
+		return fmt.Errorf("updating webhook %q: %w", webhookName, err)
+	}
+
+	return c.output.Get()(c, updated)
+}
+
+// removeFromSlice returns existing with all elements in remove filtered out.
+func removeFromSlice(existing, remove []string) []string {
+	toRemove := make(map[string]bool, len(remove))
+	for _, r := range remove {
+		toRemove[r] = true
+	}
+	var result []string
+	for _, v := range existing {
+		if !toRemove[v] {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
+// addToSlice returns existing with add appended, deduplicating.
+func addToSlice(existing, add []string) []string {
+	seen := make(map[string]bool, len(existing))
+	for _, v := range existing {
+		seen[v] = true
+	}
+	result := make([]string, len(existing))
+	copy(result, existing)
+	for _, v := range add {
+		if !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+func (c *orgWebhookEditCmd) renderText(wh apitype.Webhook) error {
+	fmt.Fprintf(c.w, "Updated webhook %q\n", wh.Name)
+	return nil
+}
+
+func (c *orgWebhookEditCmd) renderJSON(wh apitype.Webhook) error {
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toOrgWebhookJSON(wh))
+}

--- a/pkg/cmd/pulumi/org/org_webhook_edit_test.go
+++ b/pkg/cmd/pulumi/org/org_webhook_edit_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveFromSlice(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]string{"b"},
+		removeFromSlice([]string{"a", "b", "c"}, []string{"a", "c"}))
+
+	// Removing nonexistent is a no-op.
+	assert.Equal(t,
+		[]string{"a"},
+		removeFromSlice([]string{"a"}, []string{"z"}))
+
+	// Empty remove.
+	assert.Equal(t,
+		[]string{"a"},
+		removeFromSlice([]string{"a"}, nil))
+}
+
+func TestAddToSlice(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]string{"a", "b"},
+		addToSlice([]string{"a"}, []string{"b"}))
+
+	// Duplicate is idempotent.
+	assert.Equal(t,
+		[]string{"a"},
+		addToSlice([]string{"a"}, []string{"a"}))
+
+	// Add to empty.
+	assert.Equal(t,
+		[]string{"x"},
+		addToSlice(nil, []string{"x"}))
+}
+
+func TestOrgWebhookEditCmd_Flags(t *testing.T) {
+	t.Parallel()
+
+	cmd := newOrgWebhookEditCmd()
+	assert.Contains(t, cmd.Use, "edit")
+	require.NotNil(t, cmd.RunE)
+
+	for _, name := range []string{
+		"org", "url", "hook-format",
+		"add-event", "remove-event",
+		"add-group", "remove-group",
+		"active", "secret", "display-name", "output",
+	} {
+		f := cmd.Flags().Lookup(name)
+		require.NotNil(t, f, "expected flag %q", name)
+	}
+}

--- a/pkg/cmd/pulumi/org/org_webhook_ping.go
+++ b/pkg/cmd/pulumi/org/org_webhook_ping.go
@@ -1,0 +1,159 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type orgWebhookPingRender func(cmd *orgWebhookPingCmd, d apitype.WebhookDelivery) error
+
+type orgWebhookPingCmd struct {
+	orgName string
+	output  outputflag.OutputFlag[orgWebhookPingRender]
+	w       io.Writer
+
+	ws             pkgWorkspace.Context
+	currentBackend func(
+		context.Context, pkgWorkspace.Context, cmdBackend.LoginManager,
+		*workspace.Project, display.Options,
+	) (backend.Backend, error)
+}
+
+func newOrgWebhookPingCmd() *cobra.Command {
+	opcmd := &orgWebhookPingCmd{
+		output: outputflag.OutputFlag[orgWebhookPingRender]{
+			RenderForTerminal: (*orgWebhookPingCmd).renderText,
+			RenderJSON:        (*orgWebhookPingCmd).renderJSON,
+		},
+		ws:             pkgWorkspace.Instance,
+		currentBackend: cmdBackend.CurrentBackend,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "[EXPERIMENTAL] Send a test ping to an organization webhook",
+		Long: "Send a test ping to an organization webhook.\n" +
+			"\n" +
+			"Issues a test ping event to the specified webhook to verify it is\n" +
+			"properly configured and reachable. Returns the delivery result\n" +
+			"including the HTTP response code and duration.",
+		Example: "  # Ping a webhook\n" +
+			"  pulumi org webhook ping my-webhook\n\n" +
+			"  # Ping and get full delivery details as JSON\n" +
+			"  pulumi org webhook ping my-webhook --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opcmd.w = cmd.OutOrStdout()
+			return opcmd.run(cmd.Context(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "name"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&opcmd.orgName, "org", "",
+		"The organization that owns the webhook. Defaults to the current org.")
+	outputflag.VarP(cmd.Flags(), &opcmd.output)
+
+	return cmd
+}
+
+func (c *orgWebhookPingCmd) run(ctx context.Context, webhookName string) error {
+	project, _, err := c.ws.ReadProject()
+	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
+		return err
+	}
+
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	be, err := c.currentBackend(ctx, c.ws, cmdBackend.DefaultLoginManager, project, displayOpts)
+	if err != nil {
+		return err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return errors.New("this command requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	orgName, err := resolveOrgName(ctx, c.orgName, cloudBackend)
+	if err != nil {
+		return err
+	}
+
+	delivery, err := cloudBackend.Client().PingOrgWebhook(ctx, orgName, webhookName)
+	if err != nil {
+		return fmt.Errorf("pinging organization webhook: %w", err)
+	}
+
+	return c.output.Get()(c, delivery)
+}
+
+func (c *orgWebhookPingCmd) renderJSON(d apitype.WebhookDelivery) error {
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(d)
+}
+
+func (c *orgWebhookPingCmd) renderText(d apitype.WebhookDelivery) error {
+	ts := time.Unix(d.Timestamp, 0).UTC().Format(time.RFC3339)
+
+	fmt.Fprintf(c.w, "ID:                %s\n", d.ID)
+	fmt.Fprintf(c.w, "Kind:              %s\n", d.Kind)
+	fmt.Fprintf(c.w, "URL:               %s\n", d.RequestURL)
+	fmt.Fprintf(c.w, "Timestamp:         %s\n", ts)
+	fmt.Fprintf(c.w, "Duration:          %dms\n", d.Duration)
+	if d.RequestHeaders != "" {
+		fmt.Fprintln(c.w, "Request headers:")
+		for _, line := range strings.Split(d.RequestHeaders, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				fmt.Fprintf(c.w, "  %s\n", line)
+			}
+		}
+	}
+	if d.Payload != "" {
+		fmt.Fprintf(c.w, "Payload:           %s\n", d.Payload)
+	}
+	fmt.Fprintf(c.w, "Response code:     %d\n", d.ResponseCode)
+	if d.ResponseBody != "" {
+		fmt.Fprintln(c.w, "Response body:")
+		for _, line := range strings.Split(d.ResponseBody, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				fmt.Fprintf(c.w, "  %s\n", line)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/org/org_webhook_resolve.go
+++ b/pkg/cmd/pulumi/org/org_webhook_resolve.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+)
+
+// resolveOrgName returns the org name to use, falling back to the default
+// org or current user if orgFlag is empty.
+func resolveOrgName(ctx context.Context, orgFlag string, be httpstate.Backend) (string, error) {
+	if orgFlag != "" {
+		return orgFlag, nil
+	}
+	orgName, err := be.GetDefaultOrg(ctx)
+	if err != nil {
+		return "", fmt.Errorf("resolving default org: %w", err)
+	}
+	if orgName != "" {
+		return orgName, nil
+	}
+	userName, _, _, err := be.CurrentUser()
+	if err != nil {
+		return "", err
+	}
+	return userName, nil
+}


### PR DESCRIPTION
Example output:

Ping:
```
$ PULUMI_HOME=~/.pulumi4 pulumi org webhook ping --org tgummerer-org test
ID:                413284dd-45b3-4564-8378-611cc5bebf84
Kind:              ping
URL:               http://example.com/w
Timestamp:         2026-05-14T17:05:00Z
Duration:          15ms
Request headers:
  Accept: */*
  Content-Type: application/json
  Pulumi-Webhook-Id: 413284dd-45b3-4564-8378-611cc5bebf84
  Pulumi-Webhook-Kind: ping
Payload:           {"timestamp":1778778300,"message":"🍹 Just a friendly ping from Pulumi 🍹"}
Response code:     405
Response body:
  <!doctype html><html lang="en"><head><title>Example Domain</title><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn more</a></div></body></html>

$ PULUMI_HOME=~/.pulumi4 pulumi org webhook ping --org tgummerer-org test --output json
{
  "id": "b6413063-8766-42f5-83a1-0298f4af63ec",
  "kind": "ping",
  "payload": "{\"timestamp\":1778778340,\"message\":\"🍹 Just a friendly ping from Pulumi 🍹\"}",
  "timestamp": 1778778340,
  "duration": 18,
  "requestUrl": "http://example.com/w",
  "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: b6413063-8766-42f5-83a1-0298f4af63ec\r\nPulumi-Webhook-Kind: ping\r\n",
  "responseCode": 405,
  "responseHeaders": "Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\nCf-Ray: 9fbb7d317cb61571-PDX\r\nConnection: keep-alive\r\nContent-Type: text/html\r\nDate: Thu, 14 May 2026 17:05:40 GMT\r\nExpires: Thu, 01 Jan 1970 00:00:01 GMT\r\nReferrer-Policy: same-origin\r\nServer: cloudflare\r\nX-Frame-Options: SAMEORIGIN\r\n",
  "responseBody": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href=\"https://iana.org/domains/example\">Learn more</a></div></body></html>"
}
```

edit:

```
$ PULUMI_HOME=~/.pulumi4 pulumi org webhook edit --org tgummerer-org test --output json --remove-group stacks
{
  "id": "test",
  "name": "test",
  "url": "http://example.com/w",
  "format": "raw",
  "active": true,
  "eventGroups": [
    "change_requests",
    "deployments",
    "environments",
    "policies"
  ],
  "events": []
}

$ PULUMI_HOME=~/.pulumi4 pulumi org webhook edit --org tgummerer-org test --output json --remove-group policies
{
  "id": "test",
  "name": "test",
  "url": "http://example.com/w",
  "format": "raw",
  "active": true,
  "eventGroups": [
    "change_requests",
    "deployments",
    "environments"
  ],
  "events": []
}
```

Delivery list:

```
$ PULUMI_HOME=~/.pulumi4 pulumi org webhook delivery list --org tgummerer-org test --output json
{
  "deliveries": [
    {
      "id": "b6413063-8766-42f5-83a1-0298f4af63ec",
      "kind": "ping",
      "payload": "{\"timestamp\":1778778340,\"message\":\"🍹 Just a friendly ping from Pulumi 🍹\"}",
      "timestamp": 1778778340,
      "duration": 18,
      "requestUrl": "http://example.com/w",
      "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: b6413063-8766-42f5-83a1-0298f4af63ec\r\nPulumi-Webhook-Kind: ping\r\n",
      "responseCode": 405,
      "responseHeaders": "Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\nCf-Ray: 9fbb7d317cb61571-PDX\r\nConnection: keep-alive\r\nContent-Type: text/html\r\nDate: Thu, 14 May 2026 17:05:40 GMT\r\nExpires: Thu, 01 Jan 1970 00:00:01 GMT\r\nReferrer-Policy: same-origin\r\nServer: cloudflare\r\nX-Frame-Options: SAMEORIGIN\r\n",
      "responseBody": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href=\"https://iana.org/domains/example\">Learn more</a></div></body></html>"
    },
    {
      "id": "413284dd-45b3-4564-8378-611cc5bebf84",
      "kind": "ping",
      "payload": "{\"timestamp\":1778778300,\"message\":\"🍹 Just a friendly ping from Pulumi 🍹\"}",
      "timestamp": 1778778300,
      "duration": 15,
      "requestUrl": "http://example.com/w",
      "requestHeaders": "Accept: */*\r\nContent-Type: application/json\r\nPulumi-Webhook-Id: 413284dd-45b3-4564-8378-611cc5bebf84\r\nPulumi-Webhook-Kind: ping\r\n",
      "responseCode": 405,
      "responseHeaders": "Cache-Control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0\r\nCf-Ray: 9fbb7c3b8c84f7ed-PDX\r\nConnection: keep-alive\r\nContent-Type: text/html\r\nDate: Thu, 14 May 2026 17:05:00 GMT\r\nExpires: Thu, 01 Jan 1970 00:00:01 GMT\r\nReferrer-Policy: same-origin\r\nServer: cloudflare\r\nX-Frame-Options: SAMEORIGIN\r\n",
      "responseBody": "<!doctype html><html lang=\"en\"><head><title>Example Domain</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.<p><a href=\"https://iana.org/domains/example\">Learn more</a></div></body></html>"
    }
  ],
  "count": 2
}

$ PULUMI_HOME=~/.pulumi4 pulumi org webhook delivery list --org tgummerer-org test
┌──────────────────────────────────────┬──────┬──────────────────────┬──────────┬────────┐
│ ID                                   │ KIND │ TIMESTAMP            │ DURATION │ STATUS │
├──────────────────────────────────────┼──────┼──────────────────────┼──────────┼────────┤
│ b6413063-8766-42f5-83a1-0298f4af63ec │ ping │ 2026-05-14T17:05:40Z │ 18ms     │    405 │
│ 413284dd-45b3-4564-8378-611cc5bebf84 │ ping │ 2026-05-14T17:05:00Z │ 15ms     │    405 │
└──────────────────────────────────────┴──────┴──────────────────────┴──────────┴────────┘
```


Fixes: https://github.com/pulumi/pulumi/issues/22997
Fixes: https://github.com/pulumi/pulumi/issues/22967
Fixes: https://github.com/pulumi/pulumi/issues/22969