### PR TITLE
Add `pulumi stack schedule edit` to update an existing scheduled deployment action

### DIFF
--- a/changelog/pending/20260514--cli--add-pulumi-stack-schedule-edit.yaml
+++ b/changelog/pending/20260514--cli--add-pulumi-stack-schedule-edit.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi stack schedule edit` to update an existing scheduled deployment action

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -861,6 +861,51 @@ func (pc *Client) DeleteStackSchedule(
 	return pc.restCall(ctx, "DELETE", path, nil, nil, nil)
 }
 
+// UpdateStackSchedule updates a raw scheduled deployment action. The full request body is expected: callers should read
+// the current schedule and pass back any fields they want to preserve (the service treats omitted bool options as
+// false).
+func (pc *Client) UpdateStackSchedule(
+	ctx context.Context, stackID StackIdentifier, scheduleID string,
+	req apitype.CreateScheduledDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	var resp apitype.ScheduledAction
+	path := getStackPath(stackID, "deployments", "schedules", scheduleID)
+	if err := pc.restCall(ctx, "POST", path, nil, req, &resp); err != nil {
+		return apitype.ScheduledAction{}, err
+	}
+	return resp, nil
+}
+
+// UpdateStackDriftSchedule updates a drift-detection scheduled deployment action. The full request body is expected:
+// callers should read the current schedule and pass back any fields they want to preserve (the service treats omitted
+// bool options as false).
+func (pc *Client) UpdateStackDriftSchedule(
+	ctx context.Context, stackID StackIdentifier, scheduleID string,
+	req apitype.CreateScheduledDriftDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	var resp apitype.ScheduledAction
+	path := getStackPath(stackID, "deployments", "drift", "schedules", scheduleID)
+	if err := pc.restCall(ctx, "POST", path, nil, req, &resp); err != nil {
+		return apitype.ScheduledAction{}, err
+	}
+	return resp, nil
+}
+
+// UpdateStackTTLSchedule updates a TTL scheduled deployment action. The full request body is expected: callers should
+// read the current schedule and pass back any fields they want to preserve (the service treats omitted bool options as
+// false).
+func (pc *Client) UpdateStackTTLSchedule(
+	ctx context.Context, stackID StackIdentifier, scheduleID string,
+	req apitype.CreateScheduledTTLDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	var resp apitype.ScheduledAction
+	path := getStackPath(stackID, "deployments", "ttl", "schedules", scheduleID)
+	if err := pc.restCall(ctx, "POST", path, nil, req, &resp); err != nil {
+		return apitype.ScheduledAction{}, err
+	}
+	return resp, nil
+}
+
 // CreateStackDetails holds additional information returned by the Pulumi Service when a stack is
 // created, beyond the stack itself.
 type CreateStackDetails struct {

--- a/pkg/backend/httpstate/client/client_schedule_test.go
+++ b/pkg/backend/httpstate/client/client_schedule_test.go
@@ -372,3 +372,105 @@ func TestDeleteStackSchedule(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestUpdateStackSchedule(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "my-org",
+		Project: "my-project",
+		Stack:   tokens.MustParseStackName("dev"),
+	}
+	const scheduleID = "bb61b60a"
+
+	t.Run("raw", func(t *testing.T) {
+		t.Parallel()
+
+		req := apitype.CreateScheduledDeploymentRequest{
+			ScheduleCron: "0 */4 * * *",
+			Request: &apitype.CreateDeploymentRequest{
+				Op:              apitype.Refresh,
+				InheritSettings: true,
+			},
+		}
+		var gotPath, gotMethod string
+		var gotBody apitype.CreateScheduledDeploymentRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.ScheduledAction{ID: scheduleID}))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		got, err := c.UpdateStackSchedule(t.Context(), stackID, scheduleID, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/deployments/schedules/"+scheduleID, gotPath)
+		assert.Equal(t, req, gotBody)
+		assert.Equal(t, scheduleID, got.ID)
+	})
+
+	t.Run("drift", func(t *testing.T) {
+		t.Parallel()
+
+		req := apitype.CreateScheduledDriftDeploymentRequest{
+			ScheduleCron:  "0 */4 * * *",
+			AutoRemediate: true,
+		}
+		var gotPath, gotMethod string
+		var gotBody apitype.CreateScheduledDriftDeploymentRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.ScheduledAction{ID: scheduleID}))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.UpdateStackDriftSchedule(t.Context(), stackID, scheduleID, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/deployments/drift/schedules/"+scheduleID, gotPath)
+		assert.Equal(t, req, gotBody)
+	})
+
+	t.Run("ttl", func(t *testing.T) {
+		t.Parallel()
+
+		req := apitype.CreateScheduledTTLDeploymentRequest{
+			Timestamp:          "2026-12-31T23:59:00Z",
+			DeleteAfterDestroy: true,
+		}
+		var gotPath, gotMethod string
+		var gotBody apitype.CreateScheduledTTLDeploymentRequest
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(apitype.ScheduledAction{ID: scheduleID}))
+		}))
+		defer srv.Close()
+
+		c := newMockClient(srv)
+		_, err := c.UpdateStackTTLSchedule(t.Context(), stackID, scheduleID, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/stacks/my-org/my-project/dev/deployments/ttl/schedules/"+scheduleID, gotPath)
+		assert.Equal(t, req, gotBody)
+	})
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -16,7 +16,6 @@ package stack
 
 import (
 	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -141,43 +140,5 @@ func newStackScheduleCmd() *cobra.Command {
 	cmd.AddCommand(newStackScheduleGetCmd())
 	cmd.AddCommand(newStackScheduleEditCmd())
 	cmd.AddCommand(newStackScheduleRemoveCmd())
-	return cmd
-}
-
-// TODO[https://github.com/pulumi/pulumi/issues/23046]: Not yet implemented.
-func newStackScheduleEditCmd() *cobra.Command {
-	var (
-		stack     string
-		cron      string
-		once      string
-		operation string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "Update the configuration of a custom deployment schedule",
-		Long:   "[EXPERIMENTAL] Update the configuration of a custom deployment schedule.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{
-			{Name: "schedule-id"},
-		},
-		Required: 1,
-	})
-
-	cmd.Flags().StringVarP(&stack, "stack", "s", "",
-		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&cron, "cron", "",
-		"A cron expression for recurring executions")
-	cmd.Flags().StringVar(&once, "once", "",
-		"An ISO 8601 timestamp for a one-time execution")
-	cmd.Flags().StringVar(&operation, "operation", "",
-		"The Pulumi operation to perform: update, preview, refresh, or destroy")
-
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_schedule_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_edit.go
@@ -1,0 +1,376 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+type stackScheduleEditClient interface {
+	GetStackSchedule(
+		ctx context.Context, stackID client.StackIdentifier, scheduleID string,
+	) (apitype.ScheduledAction, error)
+	UpdateStackSchedule(
+		ctx context.Context, stackID client.StackIdentifier, scheduleID string,
+		req apitype.CreateScheduledDeploymentRequest,
+	) (apitype.ScheduledAction, error)
+	UpdateStackDriftSchedule(
+		ctx context.Context, stackID client.StackIdentifier, scheduleID string,
+		req apitype.CreateScheduledDriftDeploymentRequest,
+	) (apitype.ScheduledAction, error)
+	UpdateStackTTLSchedule(
+		ctx context.Context, stackID client.StackIdentifier, scheduleID string,
+		req apitype.CreateScheduledTTLDeploymentRequest,
+	) (apitype.ScheduledAction, error)
+}
+
+type stackScheduleEditClientFactory func(
+	ctx context.Context, stackFlag string,
+) (stackScheduleEditClient, client.StackIdentifier, error)
+
+// stackScheduleEditFlags holds the resolved edit flags. The *Changed fields tell us
+// whether the user explicitly passed each flag, since we always send the full request
+// body and would otherwise overwrite existing values with defaults.
+type stackScheduleEditFlags struct {
+	cron               string
+	once               string
+	operation          string
+	autoRemediate      bool
+	deleteAfterDestroy bool
+
+	cronChanged               bool
+	onceChanged               bool
+	operationChanged          bool
+	autoRemediateChanged      bool
+	deleteAfterDestroyChanged bool
+}
+
+func newStackScheduleEditCmd() *cobra.Command {
+	return newStackScheduleEditCmdWith(nil)
+}
+
+func newStackScheduleEditCmdWith(factory stackScheduleEditClientFactory) *cobra.Command {
+	var (
+		stack string
+		flags stackScheduleEditFlags
+	)
+	output := outputflag.OutputFlag[scheduleGetRenderFunc]{
+		RenderForTerminal: renderScheduleGetText,
+		RenderJSON:        renderScheduleGetJSON,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "edit <schedule-id>",
+		Short: "Update the configuration of a scheduled deployment action",
+		Long: "[EXPERIMENTAL] Update the configuration of a scheduled deployment action.\n\n" +
+			"Only the fields you pass are changed; everything else is preserved. " +
+			"Each flag is only valid for a subset of kinds:\n" +
+			"  raw:   --cron, --once, --operation\n" +
+			"  drift: --cron, --auto-remediate\n" +
+			"  ttl:   --once, --delete-after-destroy",
+		Example: "  # Switch a raw schedule to a different cron\n" +
+			"  pulumi stack schedule edit <id> --cron '0 */6 * * *'\n" +
+			"\n" +
+			"  # Enable auto-remediation on a drift schedule\n" +
+			"  pulumi stack schedule edit <id> --auto-remediate\n" +
+			"\n" +
+			"  # Disable delete-after-destroy on a TTL schedule\n" +
+			"  pulumi stack schedule edit <id> --delete-after-destroy=false",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if factory == nil {
+				factory = defaultStackScheduleEditClientFactory
+			}
+			flags.cronChanged = cmd.Flags().Changed("cron")
+			flags.onceChanged = cmd.Flags().Changed("once")
+			flags.operationChanged = cmd.Flags().Changed("operation")
+			flags.autoRemediateChanged = cmd.Flags().Changed("auto-remediate")
+			flags.deleteAfterDestroyChanged = cmd.Flags().Changed("delete-after-destroy")
+			return runStackScheduleEdit(
+				cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], flags, output.Get(),
+			)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "schedule-id"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVarP(&stack, "stack", "s", "",
+		"The name of the stack to operate on. Defaults to the current stack")
+	cmd.Flags().StringVar(&flags.cron, "cron", "",
+		"Cron expression for recurring executions, evaluated in UTC (raw and drift)")
+	cmd.Flags().StringVar(&flags.once, "once", "",
+		"ISO 8601 timestamp for a one-time execution (raw and ttl)")
+	cmd.Flags().StringVar(&flags.operation, "operation", "",
+		"(raw only) Pulumi operation to run. One of: update, preview, refresh, destroy")
+	cmd.Flags().BoolVar(&flags.autoRemediate, "auto-remediate", false,
+		"(drift only) Automatically run a remediation update when drift is detected")
+	cmd.Flags().BoolVar(&flags.deleteAfterDestroy, "delete-after-destroy", false,
+		"(ttl only) Delete the stack from Pulumi Cloud after successfully destroying its resources")
+	outputflag.VarP(cmd.Flags(), &output)
+
+	cmd.MarkFlagsMutuallyExclusive("cron", "once")
+
+	return cmd
+}
+
+func defaultStackScheduleEditClientFactory(
+	ctx context.Context, stackFlag string,
+) (stackScheduleEditClient, client.StackIdentifier, error) {
+	return RequireCloudStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, stackFlag)
+}
+
+func runStackScheduleEdit(
+	ctx context.Context,
+	w io.Writer,
+	factory stackScheduleEditClientFactory,
+	stackFlag string,
+	scheduleID string,
+	flags stackScheduleEditFlags,
+	render scheduleGetRenderFunc,
+) error {
+	if !anyEditFlagChanged(flags) {
+		return errors.New(
+			"at least one of --cron, --once, --operation, --auto-remediate, or --delete-after-destroy " +
+				"must be provided")
+	}
+
+	c, stackID, err := factory(ctx, stackFlag)
+	if err != nil {
+		return err
+	}
+
+	existing, err := c.GetStackSchedule(ctx, stackID, scheduleID)
+	if err != nil {
+		return fmt.Errorf("reading stack schedule: %w", err)
+	}
+
+	kind := scheduleKindLabel(existing)
+	if err := validateScheduleEditFlags(kind, flags); err != nil {
+		return err
+	}
+
+	switch kind {
+	case scheduleKindRaw:
+		req, buildErr := buildRawEditRequest(existing, flags)
+		if buildErr != nil {
+			return buildErr
+		}
+		_, err = c.UpdateStackSchedule(ctx, stackID, scheduleID, req)
+	case scheduleKindDrift:
+		req := buildDriftEditRequest(existing, flags)
+		_, err = c.UpdateStackDriftSchedule(ctx, stackID, scheduleID, req)
+	case scheduleKindTTL:
+		req := buildTTLEditRequest(existing, flags)
+		_, err = c.UpdateStackTTLSchedule(ctx, stackID, scheduleID, req)
+	default:
+		return fmt.Errorf("cannot edit schedule of kind %q", kind)
+	}
+	if err != nil {
+		return fmt.Errorf("updating stack schedule: %w", err)
+	}
+
+	// Refetch instead of using the response body: the raw update endpoint returns the
+	// pre-update snapshot (it reads the schedule before the writes and never refetches).
+	// Drift and TTL refetch server-side, so this extra GET is only strictly required for
+	// raw, but doing it unconditionally keeps the code simple and one extra RTT is cheap.
+	updated, err := c.GetStackSchedule(ctx, stackID, scheduleID)
+	if err != nil {
+		return fmt.Errorf("reading updated stack schedule: %w", err)
+	}
+	return render(w, updated)
+}
+
+func anyEditFlagChanged(flags stackScheduleEditFlags) bool {
+	return flags.cronChanged ||
+		flags.onceChanged ||
+		flags.operationChanged ||
+		flags.autoRemediateChanged ||
+		flags.deleteAfterDestroyChanged
+}
+
+func validateScheduleEditFlags(kind string, flags stackScheduleEditFlags) error {
+	switch kind {
+	case scheduleKindRaw:
+		if flags.autoRemediateChanged {
+			return errors.New("--auto-remediate is only valid for drift schedules")
+		}
+		if flags.deleteAfterDestroyChanged {
+			return errors.New("--delete-after-destroy is only valid for ttl schedules")
+		}
+	case scheduleKindDrift:
+		if flags.onceChanged {
+			return errors.New("--once is not valid for drift schedules; use --cron")
+		}
+		if flags.operationChanged {
+			return errors.New("--operation is not valid for drift schedules")
+		}
+		if flags.deleteAfterDestroyChanged {
+			return errors.New("--delete-after-destroy is only valid for ttl schedules")
+		}
+	case scheduleKindTTL:
+		if flags.cronChanged {
+			return errors.New("--cron is not valid for ttl schedules; use --once")
+		}
+		if flags.operationChanged {
+			return errors.New("--operation is not valid for ttl schedules")
+		}
+		if flags.autoRemediateChanged {
+			return errors.New("--auto-remediate is only valid for drift schedules")
+		}
+	}
+	return nil
+}
+
+// buildRawEditRequest builds the full update body for a raw schedule. We always send the
+// trigger (cron or once) the schedule should end up with, plus a full Request when the
+// user touched anything inside the deployment definition.
+func buildRawEditRequest(
+	existing apitype.ScheduledAction, flags stackScheduleEditFlags,
+) (apitype.CreateScheduledDeploymentRequest, error) {
+	cron, once := existing.ScheduleCron, existing.ScheduleOnce
+	if flags.cronChanged {
+		cron = flags.cron
+		once = ""
+	} else if flags.onceChanged {
+		once = flags.once
+		cron = ""
+	}
+
+	existingReq, err := existingDeploymentRequest(existing)
+	if err != nil {
+		return apitype.CreateScheduledDeploymentRequest{}, err
+	}
+	op := existingReq.Op
+	if flags.operationChanged {
+		parsed, parseErr := parseRawOperation(flags.operation)
+		if parseErr != nil {
+			return apitype.CreateScheduledDeploymentRequest{}, parseErr
+		}
+		op = parsed
+	}
+	existingReq.Op = op
+
+	return apitype.CreateScheduledDeploymentRequest{
+		ScheduleCron: cron,
+		ScheduleOnce: once,
+		Request:      existingReq,
+	}, nil
+}
+
+// buildDriftEditRequest preserves existing values for any field the user didn't change.
+// The drift update endpoint rewrites the entire definition on every call.
+func buildDriftEditRequest(
+	existing apitype.ScheduledAction, flags stackScheduleEditFlags,
+) apitype.CreateScheduledDriftDeploymentRequest {
+	cron := existing.ScheduleCron
+	if flags.cronChanged {
+		cron = flags.cron
+	}
+	autoRemediate := existingAutoRemediate(existing)
+	if flags.autoRemediateChanged {
+		autoRemediate = flags.autoRemediate
+	}
+	return apitype.CreateScheduledDriftDeploymentRequest{
+		ScheduleCron:  cron,
+		AutoRemediate: autoRemediate,
+	}
+}
+
+// buildTTLEditRequest preserves existing values for any field the user didn't change.
+// The TTL update endpoint rewrites the entire definition on every call.
+func buildTTLEditRequest(
+	existing apitype.ScheduledAction, flags stackScheduleEditFlags,
+) apitype.CreateScheduledTTLDeploymentRequest {
+	once := existing.ScheduleOnce
+	if flags.onceChanged {
+		once = flags.once
+	}
+	deleteAfterDestroy := existingDeleteAfterDestroy(existing)
+	if flags.deleteAfterDestroyChanged {
+		deleteAfterDestroy = flags.deleteAfterDestroy
+	}
+	return apitype.CreateScheduledTTLDeploymentRequest{
+		Timestamp:          once,
+		DeleteAfterDestroy: deleteAfterDestroy,
+	}
+}
+
+func parseRawOperation(s string) (apitype.PulumiOperation, error) {
+	switch strings.ToLower(s) {
+	case "update":
+		return apitype.Update, nil
+	case "preview":
+		return apitype.Preview, nil
+	case "refresh":
+		return apitype.Refresh, nil
+	case "destroy":
+		return apitype.Destroy, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid --operation %q: must be one of update, preview, refresh, or destroy", s,
+		)
+	}
+}
+
+func existingDeploymentRequest(s apitype.ScheduledAction) (*apitype.CreateDeploymentRequest, error) {
+	var def apitype.ScheduledDeploymentDefinition
+	if err := json.Unmarshal(s.Definition, &def); err != nil {
+		return nil, fmt.Errorf("parsing existing schedule definition: %w", err)
+	}
+	if def.Request == nil {
+		return nil, errors.New("existing schedule has no deployment request")
+	}
+	req := *def.Request
+	return &req, nil
+}
+
+func existingAutoRemediate(s apitype.ScheduledAction) bool {
+	var def apitype.ScheduledDeploymentDefinition
+	if err := json.Unmarshal(s.Definition, &def); err != nil || def.Request == nil {
+		return false
+	}
+	if def.Request.Operation == nil || def.Request.Operation.Options == nil {
+		return false
+	}
+	return def.Request.Operation.Options.RemediateIfDriftDetected
+}
+
+func existingDeleteAfterDestroy(s apitype.ScheduledAction) bool {
+	var def apitype.ScheduledDeploymentDefinition
+	if err := json.Unmarshal(s.Definition, &def); err != nil || def.Request == nil {
+		return false
+	}
+	if def.Request.Operation == nil || def.Request.Operation.Options == nil {
+		return false
+	}
+	return def.Request.Operation.Options.DeleteAfterDestroy
+}

--- a/pkg/cmd/pulumi/stack/stack_schedule_edit_test.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_edit_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockScheduleEditClient struct {
+	existing apitype.ScheduledAction
+	err      error
+
+	gotRawReq   *apitype.CreateScheduledDeploymentRequest
+	gotDriftReq *apitype.CreateScheduledDriftDeploymentRequest
+	gotTTLReq   *apitype.CreateScheduledTTLDeploymentRequest
+}
+
+func (m *mockScheduleEditClient) GetStackSchedule(
+	_ context.Context, _ client.StackIdentifier, _ string,
+) (apitype.ScheduledAction, error) {
+	return m.existing, m.err
+}
+
+func (m *mockScheduleEditClient) UpdateStackSchedule(
+	_ context.Context, _ client.StackIdentifier, _ string,
+	req apitype.CreateScheduledDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	m.gotRawReq = &req
+	return m.existing, nil
+}
+
+func (m *mockScheduleEditClient) UpdateStackDriftSchedule(
+	_ context.Context, _ client.StackIdentifier, _ string,
+	req apitype.CreateScheduledDriftDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	m.gotDriftReq = &req
+	return m.existing, nil
+}
+
+func (m *mockScheduleEditClient) UpdateStackTTLSchedule(
+	_ context.Context, _ client.StackIdentifier, _ string,
+	req apitype.CreateScheduledTTLDeploymentRequest,
+) (apitype.ScheduledAction, error) {
+	m.gotTTLReq = &req
+	return m.existing, nil
+}
+
+func editClientFactory(c stackScheduleEditClient) stackScheduleEditClientFactory {
+	return func(_ context.Context, _ string) (stackScheduleEditClient, client.StackIdentifier, error) {
+		return c, testScheduleStackID, nil
+	}
+}
+
+func defWithOpts(t *testing.T, op apitype.PulumiOperation, opts *apitype.OperationContextOptions) json.RawMessage {
+	t.Helper()
+	req := &apitype.CreateDeploymentRequest{Op: op, InheritSettings: true}
+	if opts != nil {
+		req.Operation = &apitype.OperationContext{Options: opts}
+	}
+	def := apitype.ScheduledDeploymentDefinition{
+		ProgramID: "5f337707",
+		Request:   req,
+	}
+	b, err := json.Marshal(def)
+	require.NoError(t, err)
+	return b
+}
+
+func rawSchedule(t *testing.T) apitype.ScheduledAction {
+	t.Helper()
+	return apitype.ScheduledAction{
+		ID:           "raw-id",
+		ScheduleCron: "0 */4 * * *",
+		Kind:         apitype.ScheduledActionKindDeployment,
+		Definition:   defWithOpts(t, apitype.Refresh, nil),
+	}
+}
+
+func driftSchedule(t *testing.T) apitype.ScheduledAction {
+	t.Helper()
+	return apitype.ScheduledAction{
+		ID:           "drift-id",
+		ScheduleCron: "0 */4 * * *",
+		Kind:         apitype.ScheduledActionKindDeployment,
+		Definition:   defWithOpts(t, apitype.DetectDrift, &apitype.OperationContextOptions{RemediateIfDriftDetected: true}),
+	}
+}
+
+func ttlSchedule(t *testing.T) apitype.ScheduledAction {
+	t.Helper()
+	return apitype.ScheduledAction{
+		ID:           "ttl-id",
+		ScheduleOnce: "2026-12-31T23:59:00Z",
+		Kind:         apitype.ScheduledActionKindDeployment,
+		Definition:   defWithOpts(t, apitype.Destroy, &apitype.OperationContextOptions{DeleteAfterDestroy: true}),
+	}
+}
+
+func TestStackScheduleEdit_Raw_ChangesCron(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: rawSchedule(t)}
+	flags := stackScheduleEditFlags{cron: "0 */6 * * *", cronChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotRawReq)
+	assert.Equal(t, "0 */6 * * *", c.gotRawReq.ScheduleCron)
+	assert.Empty(t, c.gotRawReq.ScheduleOnce)
+	require.NotNil(t, c.gotRawReq.Request)
+	assert.Equal(t, apitype.Refresh, c.gotRawReq.Request.Op) // preserved
+	assert.Nil(t, c.gotDriftReq)
+	assert.Nil(t, c.gotTTLReq)
+}
+
+func TestStackScheduleEdit_Raw_SwapCronForOnce(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: rawSchedule(t)}
+	flags := stackScheduleEditFlags{once: "2026-12-31T23:59:00Z", onceChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotRawReq)
+	assert.Empty(t, c.gotRawReq.ScheduleCron)
+	assert.Equal(t, "2026-12-31T23:59:00Z", c.gotRawReq.ScheduleOnce)
+}
+
+func TestStackScheduleEdit_Raw_ChangesOperation(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: rawSchedule(t)}
+	flags := stackScheduleEditFlags{operation: "destroy", operationChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotRawReq.Request)
+	assert.Equal(t, apitype.Destroy, c.gotRawReq.Request.Op)
+	// Cron preserved when not changed.
+	assert.Equal(t, "0 */4 * * *", c.gotRawReq.ScheduleCron)
+}
+
+func TestStackScheduleEdit_Raw_InvalidOperation(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: rawSchedule(t)}
+	flags := stackScheduleEditFlags{operation: "detect-drift", operationChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id", flags, renderScheduleGetText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --operation")
+}
+
+func TestStackScheduleEdit_Drift_PreservesAutoRemediate(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: driftSchedule(t)}
+	// User only changes the cron; auto-remediate must be preserved as true.
+	flags := stackScheduleEditFlags{cron: "0 */6 * * *", cronChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "drift-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotDriftReq)
+	assert.Equal(t, "0 */6 * * *", c.gotDriftReq.ScheduleCron)
+	assert.True(t, c.gotDriftReq.AutoRemediate) // preserved
+}
+
+func TestStackScheduleEdit_Drift_DisablesAutoRemediate(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: driftSchedule(t)}
+	// --auto-remediate=false explicitly disables it.
+	flags := stackScheduleEditFlags{autoRemediate: false, autoRemediateChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "drift-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotDriftReq)
+	assert.False(t, c.gotDriftReq.AutoRemediate)
+	assert.Equal(t, "0 */4 * * *", c.gotDriftReq.ScheduleCron) // preserved
+}
+
+func TestStackScheduleEdit_TTL_PreservesDeleteAfterDestroy(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: ttlSchedule(t)}
+	// Changing the timestamp must preserve delete-after-destroy.
+	flags := stackScheduleEditFlags{once: "2027-01-01T00:00:00Z", onceChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "ttl-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotTTLReq)
+	assert.Equal(t, "2027-01-01T00:00:00Z", c.gotTTLReq.Timestamp)
+	assert.True(t, c.gotTTLReq.DeleteAfterDestroy) // preserved
+}
+
+func TestStackScheduleEdit_TTL_DisablesDeleteAfterDestroy(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: ttlSchedule(t)}
+	flags := stackScheduleEditFlags{deleteAfterDestroy: false, deleteAfterDestroyChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "ttl-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotTTLReq)
+	assert.False(t, c.gotTTLReq.DeleteAfterDestroy)
+	assert.Equal(t, "2026-12-31T23:59:00Z", c.gotTTLReq.Timestamp) // preserved
+}
+
+func TestStackScheduleEdit_RejectsWrongKindFlags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		existing apitype.ScheduledAction
+		flags    stackScheduleEditFlags
+		want     string
+	}{
+		{
+			name:     "raw rejects auto-remediate",
+			existing: rawSchedule(t),
+			flags:    stackScheduleEditFlags{autoRemediate: true, autoRemediateChanged: true},
+			want:     "--auto-remediate is only valid for drift",
+		},
+		{
+			name:     "raw rejects delete-after-destroy",
+			existing: rawSchedule(t),
+			flags:    stackScheduleEditFlags{deleteAfterDestroy: true, deleteAfterDestroyChanged: true},
+			want:     "--delete-after-destroy is only valid for ttl",
+		},
+		{
+			name:     "drift rejects once",
+			existing: driftSchedule(t),
+			flags:    stackScheduleEditFlags{once: "2026-12-31T23:59:00Z", onceChanged: true},
+			want:     "--once is not valid for drift",
+		},
+		{
+			name:     "drift rejects operation",
+			existing: driftSchedule(t),
+			flags:    stackScheduleEditFlags{operation: "update", operationChanged: true},
+			want:     "--operation is not valid for drift",
+		},
+		{
+			name:     "drift rejects delete-after-destroy",
+			existing: driftSchedule(t),
+			flags:    stackScheduleEditFlags{deleteAfterDestroy: true, deleteAfterDestroyChanged: true},
+			want:     "--delete-after-destroy is only valid for ttl",
+		},
+		{
+			name:     "ttl rejects cron",
+			existing: ttlSchedule(t),
+			flags:    stackScheduleEditFlags{cron: "0 */4 * * *", cronChanged: true},
+			want:     "--cron is not valid for ttl",
+		},
+		{
+			name:     "ttl rejects operation",
+			existing: ttlSchedule(t),
+			flags:    stackScheduleEditFlags{operation: "update", operationChanged: true},
+			want:     "--operation is not valid for ttl",
+		},
+		{
+			name:     "ttl rejects auto-remediate",
+			existing: ttlSchedule(t),
+			flags:    stackScheduleEditFlags{autoRemediate: true, autoRemediateChanged: true},
+			want:     "--auto-remediate is only valid for drift",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &mockScheduleEditClient{existing: tc.existing}
+			err := runStackScheduleEdit(
+				t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "id", tc.flags, renderScheduleGetText,
+			)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestStackScheduleEdit_GetError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{err: errors.New("not found")}
+	flags := stackScheduleEditFlags{cron: "0 */6 * * *", cronChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "no-such",
+		flags, renderScheduleGetText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading stack schedule")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestStackScheduleEdit_NoFlags(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: rawSchedule(t)}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id",
+		stackScheduleEditFlags{}, renderScheduleGetText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of")
+	// No request should have been issued.
+	assert.Nil(t, c.gotRawReq)
+	assert.Nil(t, c.gotDriftReq)
+	assert.Nil(t, c.gotTTLReq)
+}

--- a/sdk/go/common/apitype/schedules.go
+++ b/sdk/go/common/apitype/schedules.go
@@ -64,8 +64,9 @@ type ScheduledDeploymentDefinition struct {
 	Request *CreateDeploymentRequest `json:"request,omitempty"`
 }
 
-// CreateScheduledDeploymentRequest is the request payload for creating a custom scheduled
-// deployment action. Exactly one of ScheduleCron and ScheduleOnce must be set.
+// CreateScheduledDeploymentRequest is the request payload for creating or updating a
+// custom scheduled deployment action. Exactly one of ScheduleCron and ScheduleOnce must
+// be set.
 type CreateScheduledDeploymentRequest struct {
 	// ScheduleCron is a cron expression defining a recurring schedule for this deployment,
 	// evaluated in UTC. When set, ScheduleOnce must be empty.
@@ -77,21 +78,24 @@ type CreateScheduledDeploymentRequest struct {
 	Request *CreateDeploymentRequest `json:"request,omitempty"`
 }
 
-// CreateScheduledDriftDeploymentRequest is the request payload for creating a scheduled
-// drift detection action.
+// CreateScheduledDriftDeploymentRequest is the request payload for creating or updating a
+// scheduled drift detection action. AutoRemediate is always serialized (no omitempty)
+// because the update endpoint treats an omitted value as false.
 type CreateScheduledDriftDeploymentRequest struct {
 	// ScheduleCron is a cron expression defining when drift detection should run, evaluated in UTC.
 	ScheduleCron string `json:"scheduleCron,omitempty"`
 	// AutoRemediate, when true, automatically runs a remediation update when drift is detected.
-	AutoRemediate bool `json:"autoRemediate,omitempty"`
+	AutoRemediate bool `json:"autoRemediate"`
 }
 
-// CreateScheduledTTLDeploymentRequest is the request payload for creating a scheduled
-// TTL action: a one-time destroy that runs at the given timestamp.
+// CreateScheduledTTLDeploymentRequest is the request payload for creating or updating a
+// scheduled TTL action: a one-time destroy that runs at the given timestamp.
+// DeleteAfterDestroy is always serialized (no omitempty) because the update endpoint
+// treats an omitted value as false.
 type CreateScheduledTTLDeploymentRequest struct {
 	// Timestamp is the ISO 8601 timestamp at which the TTL expires and the stack should be destroyed.
 	Timestamp string `json:"timestamp,omitempty"`
 	// DeleteAfterDestroy, when true, deletes the stack from Pulumi Cloud after successfully
 	// destroying its resources.
-	DeleteAfterDestroy bool `json:"deleteAfterDestroy,omitempty"`
+	DeleteAfterDestroy bool `json:"deleteAfterDestroy"`
 }


### PR DESCRIPTION
```
Update the configuration of a scheduled deployment action.

Only the fields you pass are changed; everything else is preserved. Each flag is only valid for a subset of kinds:
  raw:   --cron, --once, --operation
  drift: --cron, --auto-remediate
  ttl:   --once, --delete-after-destroy

Usage:
  pulumi stack schedule edit <schedule-id> [flags]

Examples:
  # Switch a raw schedule to a different cron
  pulumi stack schedule edit <id> --cron '0 */6 * * *'

  # Enable auto-remediation on a drift schedule
  pulumi stack schedule edit <id> --auto-remediate

  # Disable delete-after-destroy on a TTL schedule
  pulumi stack schedule edit <id> --delete-after-destroy=false

Flags:
      --auto-remediate         (drift only) Automatically run a remediation update when drift is detected
      --cron string            Cron expression for recurring executions, evaluated in UTC (raw and drift)
      --delete-after-destroy   (ttl only) Delete the stack from Pulumi Cloud after successfully destroying its resources
  -h, --help                   help for edit
      --once string            ISO 8601 timestamp for a one-time execution (raw and ttl)
      --operation string       (raw only) Pulumi operation to run. One of: update, preview, refresh, destroy
  -o, --output string          Output format. Supported values are: default and json (default "default")
  -s, --stack string           The name of the stack to operate on. Defaults to the current stack
```

Fixes https://github.com/pulumi/pulumi/issues/23046
