### PR TITLE
Drop the dependency on `github.com/moby/moby v28.3.3`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,9 @@ linters:
       - linters:
           - staticcheck
         text: 'other import of'
+      - linters:
+          - goheader
+        path: pkg/cmd/pulumi/logs/timestamp\.go$
     paths:
       - Godeps$
       - builtin$

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	mobytime "github.com/moby/moby/api/types/time"
-
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
@@ -219,11 +217,11 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 }
 
 func parseSince(since string, reference time.Time) (*time.Time, error) {
-	startTimestamp, err := mobytime.GetTimestamp(since, reference)
+	startTimestamp, err := getTimestamp(since, reference)
 	if err != nil {
 		return nil, err
 	}
-	startTimeSec, startTimeNs, err := mobytime.ParseTimestamps(startTimestamp, 0)
+	startTimeSec, startTimeNs, err := parseTimestamps(startTimestamp, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/logs/timestamp.go
+++ b/pkg/cmd/pulumi/logs/timestamp.go
@@ -1,0 +1,135 @@
+// Portions of this file are derived from github.com/moby/moby
+// (api/types/time/timestamp.go), Copyright 2013-2018 Docker, Inc.,
+// licensed under the Apache License, Version 2.0.
+//
+// Modifications Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// getTimestamp and parseTimestamps are vendored from
+// github.com/moby/moby/api/types/time so this package does not pull in the
+// legacy moby/moby module, which collides with the nested moby/moby/client
+// module that testcontainers depends on.
+
+package logs
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	rFC3339Local     = "2006-01-02T15:04:05"
+	rFC3339NanoLocal = "2006-01-02T15:04:05.999999999"
+	dateWithZone     = "2006-01-02Z07:00"
+	dateLocal        = "2006-01-02"
+)
+
+// getTimestamp tries to parse the given string as a Go duration, then as an
+// RFC3339 time, and finally as a Unix timestamp. On success it returns a
+// Unix timestamp as a string; otherwise it returns the input unchanged. For
+// a duration, the returned timestamp is reference minus that duration.
+func getTimestamp(value string, reference time.Time) (string, error) {
+	if d, err := time.ParseDuration(value); value != "0" && err == nil {
+		return strconv.FormatInt(reference.Add(-d).Unix(), 10), nil
+	}
+
+	var format string
+	parseInLocation := !strings.ContainsAny(value, "zZ+") && strings.Count(value, "-") != 3
+
+	if strings.Contains(value, ".") {
+		if parseInLocation {
+			format = rFC3339NanoLocal
+		} else {
+			format = time.RFC3339Nano
+		}
+	} else if strings.Contains(value, "T") {
+		tcolons := strings.Count(value, ":")
+		if !parseInLocation && !strings.ContainsAny(value, "zZ") && tcolons > 0 {
+			tcolons--
+		}
+		if parseInLocation {
+			switch tcolons {
+			case 0:
+				format = "2006-01-02T15"
+			case 1:
+				format = "2006-01-02T15:04"
+			default:
+				format = rFC3339Local
+			}
+		} else {
+			switch tcolons {
+			case 0:
+				format = "2006-01-02T15Z07:00"
+			case 1:
+				format = "2006-01-02T15:04Z07:00"
+			default:
+				format = time.RFC3339
+			}
+		}
+	} else if parseInLocation {
+		format = dateLocal
+	} else {
+		format = dateWithZone
+	}
+
+	var t time.Time
+	var err error
+	if parseInLocation {
+		t, err = time.ParseInLocation(format, value, time.FixedZone(reference.Zone()))
+	} else {
+		t, err = time.Parse(format, value)
+	}
+
+	if err != nil {
+		if strings.Contains(value, "-") {
+			return "", err
+		}
+		if _, _, err := parseTimestamp(value); err != nil {
+			return "", fmt.Errorf("failed to parse value as time or duration: %q", value)
+		}
+		return value, nil
+	}
+
+	return fmt.Sprintf("%d.%09d", t.Unix(), int64(t.Nanosecond())), nil
+}
+
+// parseTimestamps returns seconds and nanoseconds from a timestamp formatted
+// as ("%d.%09d", time.Unix(), int64(time.Nanosecond())). An empty value
+// returns (defaultSeconds, 0, nil).
+func parseTimestamps(value string, defaultSeconds int64) (int64, int64, error) {
+	if value == "" {
+		return defaultSeconds, 0, nil
+	}
+	return parseTimestamp(value)
+}
+
+func parseTimestamp(value string) (int64, int64, error) {
+	s, n, ok := strings.Cut(value, ".")
+	sec, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return sec, 0, err
+	}
+	if !ok {
+		return sec, 0, nil
+	}
+	nsec, err := strconv.ParseInt(n, 10, 64)
+	if err != nil {
+		return sec, nsec, err
+	}
+	nsec = int64(float64(nsec) * math.Pow(float64(10), float64(9-len(n))))
+	return sec, nsec, nil
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/mitchellh/copystructure v1.2.0
-	github.com/moby/moby v28.3.3+incompatible
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
 	github.com/mxschmitt/golang-combinations v1.0.0
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -516,8 +516,6 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/moby/moby v28.3.3+incompatible h1:nzkZIIn9bQP9S553kNmJ+U8PBhdS2ciFWphV2vX/Zp4=
-github.com/moby/moby v28.3.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -4485,7 +4485,6 @@ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6U
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/moby v28.3.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby/api v1.54.1 h1:TqVzuJkOLsgLDDwNLmYqACUuTehOHRGKiPhvH8V3Nn4=
 github.com/moby/moby/api v1.54.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
 github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=


### PR DESCRIPTION
This was causing lint failures when trying to build & lint the whole project with a `go.work`. We only used 2 functions from `github.com/moby/moby v28.3.3`, so I inlined both of them.

Unfortunately, these functions are `internal` in the new version of the Moby SDK.