### PR TITLE
Revert "don't run merges on MacOS"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
     secrets: inherit
 
   test-collect-reports:
-    needs: [unit-test, integration-test]
+    needs: [unit-test, integration-test, acceptance-test-macos]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -44,6 +44,7 @@ jobs:
       enable-coverage: true
       fail-fast: true
       test-retries: 2
+      acceptance-test-platforms: 'macos-latest'
       fuzz-test-optional: true
     secrets: inherit
 


### PR DESCRIPTION
Reverts pulumi/pulumi#23080.

Turns out this didn't actually do what I thought it does and we've been running MacOS tests all along. Doesn't seem to be a big problem, so let's just revert this PR.

Fixes https://github.com/pulumi/pulumi/issues/23081