### PR TITLE
batch `pulumi policy group edit` into a single PATCH with full list replacement

### DIFF
--- a/pkg/cmd/pulumi/policy/policy_group_edit.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit.go
@@ -99,8 +99,7 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 			"\n" +
 			"Renames a Policy Group, adds or removes stacks, applies or detaches\n" +
 			"Policy Packs, and adds or removes Insights accounts. At least one\n" +
-			"mutation flag must be provided. Changes are applied in the order\n" +
-			"new-name, adds, removes, and the command stops on the first error.\n" +
+			"mutation flag must be provided.\n" +
 			"\n" +
 			"Default output is a human-readable summary; pass --output=json for the\n" +
 			"full response as JSON.",
@@ -206,18 +205,30 @@ func defaultPolicyGroupEditClientFactory(
 
 // runPolicyGroupEdit is the cobra-decoupled command body so tests can drive it
 // directly without spinning up the flag parser.
+//
+// The command issues a single batched PATCH. For each list field that the
+// user mutated (stacks, policy packs, insights accounts) we GET the current
+// group, apply the requested adds and removes, and send the resulting full
+// list in the PATCH body — the service interprets a list value in a PATCH
+// as a complete replacement of the prior list, so we cannot send isolated
+// "add this one" deltas for those fields without losing the others.
 func runPolicyGroupEdit(
 	ctx context.Context, w io.Writer,
 	factory policyGroupEditClientFactory, name string, args policyGroupEditArgs,
 ) error {
-	patches, err := buildPolicyGroupEditPatches(args)
-	if err != nil {
-		return err
-	}
-	if len(patches) == 0 {
+	if !anyMutationRequested(args) {
 		return errors.New(
 			"no changes specified; pass at least one of --new-name, --add-stack, --remove-stack, " +
 				"--add-policy-pack, --remove-policy-pack, --add-insights-account, --remove-insights-account")
+	}
+
+	addStacks, removeStacks, err := parseStackReferences(args.addStack, args.removeStack)
+	if err != nil {
+		return err
+	}
+	addPacks, removePacks, err := parsePolicyPackRefs(args.addPolicyPack, args.removePolicyPack)
+	if err != nil {
+		return err
 	}
 
 	c, org, err := factory(ctx, args.org)
@@ -225,17 +236,45 @@ func runPolicyGroupEdit(
 		return err
 	}
 
-	current := name
-	for _, p := range patches {
-		if err := c.UpdatePolicyGroup(ctx, org, current, p); err != nil {
-			return err
+	mutatesLists := args.changed["add-stack"] || args.changed["remove-stack"] ||
+		args.changed["add-policy-pack"] || args.changed["remove-policy-pack"] ||
+		args.changed["add-insights-account"] || args.changed["remove-insights-account"]
+
+	patch := apitype.UpdatePolicyGroupRequest{}
+	if args.changed["new-name"] {
+		nn := args.newName
+		patch.NewName = &nn
+	}
+
+	if mutatesLists {
+		// Read the current group so we can compute the post-edit lists.
+		current, err := c.GetPolicyGroup(ctx, org, name)
+		if err != nil {
+			return fmt.Errorf("reading policy group before edit: %w", err)
 		}
-		if p.NewName != nil {
-			current = *p.NewName
+		if args.changed["add-stack"] || args.changed["remove-stack"] {
+			next := mergeStackList(current.Stacks, addStacks, removeStacks)
+			patch.Stacks = &next
+		}
+		if args.changed["add-policy-pack"] || args.changed["remove-policy-pack"] {
+			next := mergePolicyPackList(current.AppliedPolicyPacks, addPacks, removePacks)
+			patch.PolicyPacks = &next
+		}
+		if args.changed["add-insights-account"] || args.changed["remove-insights-account"] {
+			next := mergeStringList(current.Accounts, args.addInsightsAccount, args.removeInsightsAccount)
+			patch.InsightsAccounts = &next
 		}
 	}
 
-	resp, err := c.GetPolicyGroup(ctx, org, current)
+	if err := c.UpdatePolicyGroup(ctx, org, name, patch); err != nil {
+		return err
+	}
+
+	finalName := name
+	if patch.NewName != nil {
+		finalName = *patch.NewName
+	}
+	resp, err := c.GetPolicyGroup(ctx, org, finalName)
 	if err != nil {
 		return fmt.Errorf("reading policy group after edit: %w", err)
 	}
@@ -243,63 +282,109 @@ func runPolicyGroupEdit(
 	return args.outputFormat.Get()(w, resp)
 }
 
-// buildPolicyGroupEditPatches expands the edit args into the ordered sequence
-// of PATCHes to send: rename first, then adds, then removes. Each PATCH
-// carries a single mutation, matching the service's UpdatePolicyGroup
-// contract.
-func buildPolicyGroupEditPatches(args policyGroupEditArgs) ([]apitype.UpdatePolicyGroupRequest, error) {
-	var patches []apitype.UpdatePolicyGroupRequest
+// anyMutationRequested returns true when at least one of the mutation flags
+// was set by the user.
+func anyMutationRequested(args policyGroupEditArgs) bool {
+	for _, name := range mutationFlagNames {
+		if args.changed[name] {
+			return true
+		}
+	}
+	return false
+}
 
-	if args.changed["new-name"] {
-		name := args.newName
-		patches = append(patches, apitype.UpdatePolicyGroupRequest{NewName: &name})
+// parseStackReferences pre-parses every add and remove stack value so the
+// command surfaces parse errors before any network call.
+func parseStackReferences(
+	adds, removes []string,
+) ([]apitype.PulumiStackReference, []apitype.PulumiStackReference, error) {
+	parsedAdds := make([]apitype.PulumiStackReference, 0, len(adds))
+	for _, s := range adds {
+		parsedAdds = append(parsedAdds, parseStackReference(s))
 	}
+	parsedRemoves := make([]apitype.PulumiStackReference, 0, len(removes))
+	for _, s := range removes {
+		parsedRemoves = append(parsedRemoves, parseStackReference(s))
+	}
+	return parsedAdds, parsedRemoves, nil
+}
 
-	if args.changed["add-stack"] {
-		for _, s := range args.addStack {
-			ref := parseStackReference(s)
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{AddStack: &ref})
+// parsePolicyPackRefs pre-parses every add and remove policy-pack value so
+// invalid references surface before any network call.
+func parsePolicyPackRefs(adds, removes []string) ([]apitype.PolicyPackMetadata, []apitype.PolicyPackMetadata, error) {
+	parsedAdds := make([]apitype.PolicyPackMetadata, 0, len(adds))
+	for _, p := range adds {
+		meta, err := parsePolicyPackRef(p)
+		if err != nil {
+			return nil, nil, err
 		}
+		parsedAdds = append(parsedAdds, meta)
 	}
-	if args.changed["add-policy-pack"] {
-		for _, p := range args.addPolicyPack {
-			meta, err := parsePolicyPackRef(p)
-			if err != nil {
-				return nil, err
-			}
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{AddPolicyPack: &meta})
+	parsedRemoves := make([]apitype.PolicyPackMetadata, 0, len(removes))
+	for _, p := range removes {
+		meta, err := parsePolicyPackRef(p)
+		if err != nil {
+			return nil, nil, err
 		}
+		parsedRemoves = append(parsedRemoves, meta)
 	}
-	if args.changed["add-insights-account"] {
-		for _, a := range args.addInsightsAccount {
-			acct := a
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{AddInsightsAccount: &acct})
-		}
-	}
+	return parsedAdds, parsedRemoves, nil
+}
 
-	if args.changed["remove-stack"] {
-		for _, s := range args.removeStack {
-			ref := parseStackReference(s)
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{RemoveStack: &ref})
+// mergeStackList returns the current stacks plus adds, minus any that match a
+// removal. Equality is by RoutingProject + Name.
+func mergeStackList(
+	current []apitype.PulumiStackReference,
+	adds, removes []apitype.PulumiStackReference,
+) []apitype.PulumiStackReference {
+	stackEq := func(a, b apitype.PulumiStackReference) bool {
+		return a.Name == b.Name && a.RoutingProject == b.RoutingProject
+	}
+	out := slices.Clone(current)
+	for _, r := range removes {
+		out = slices.DeleteFunc(out, func(s apitype.PulumiStackReference) bool { return stackEq(s, r) })
+	}
+	for _, a := range adds {
+		if !slices.ContainsFunc(out, func(s apitype.PulumiStackReference) bool { return stackEq(s, a) }) {
+			out = append(out, a)
 		}
 	}
-	if args.changed["remove-policy-pack"] {
-		for _, p := range args.removePolicyPack {
-			meta, err := parsePolicyPackRef(p)
-			if err != nil {
-				return nil, err
-			}
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{RemovePolicyPack: &meta})
-		}
-	}
-	if args.changed["remove-insights-account"] {
-		for _, a := range args.removeInsightsAccount {
-			acct := a
-			patches = append(patches, apitype.UpdatePolicyGroupRequest{RemoveInsightsAccount: &acct})
-		}
-	}
+	return out
+}
 
-	return patches, nil
+// mergePolicyPackList returns the current applied packs plus adds, minus any
+// that match a removal. Equality is by Name and version (Version + VersionTag).
+func mergePolicyPackList(
+	current []apitype.PolicyPackMetadata,
+	adds, removes []apitype.PolicyPackMetadata,
+) []apitype.PolicyPackMetadata {
+	packEq := func(a, b apitype.PolicyPackMetadata) bool {
+		return a.Name == b.Name && a.Version == b.Version && a.VersionTag == b.VersionTag
+	}
+	out := slices.Clone(current)
+	for _, r := range removes {
+		out = slices.DeleteFunc(out, func(p apitype.PolicyPackMetadata) bool { return packEq(p, r) })
+	}
+	for _, a := range adds {
+		if !slices.ContainsFunc(out, func(p apitype.PolicyPackMetadata) bool { return packEq(p, a) }) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// mergeStringList returns current plus adds, minus any in removes.
+func mergeStringList(current, adds, removes []string) []string {
+	out := slices.Clone(current)
+	for _, r := range removes {
+		out = slices.DeleteFunc(out, func(s string) bool { return s == r })
+	}
+	for _, a := range adds {
+		if !slices.Contains(out, a) {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // parseStackReference splits "project/stack" into a PulumiStackReference. A

--- a/pkg/cmd/pulumi/policy/policy_group_edit_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit_test.go
@@ -28,18 +28,20 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// mockPolicyGroupEditClient records the sequence of UpdatePolicyGroup calls,
-// returns getResp / getErr from GetPolicyGroup, and can inject an error on the
-// Nth (1-indexed) UpdatePolicyGroup call via updateErrOn.
+// mockPolicyGroupEditClient records the single batched UpdatePolicyGroup call
+// and returns getResp / getErr from GetPolicyGroup. updateErr forces
+// UpdatePolicyGroup to fail.
 type mockPolicyGroupEditClient struct {
 	updates      []apitype.UpdatePolicyGroupRequest
 	updateGroups []string
-	updateErrOn  int
 	updateErr    error
-	getResp      apitype.GetPolicyGroupResponse
-	getErr       error
-	gotGetOrg    string
-	gotGetGroup  string
+
+	getResp     apitype.GetPolicyGroupResponse
+	getErr      error
+	getErrOn    int // which Get call to fail (1-indexed)
+	getCalls    int
+	gotGetOrg   string
+	gotGetGroup string
 }
 
 func (m *mockPolicyGroupEditClient) UpdatePolicyGroup(
@@ -47,18 +49,19 @@ func (m *mockPolicyGroupEditClient) UpdatePolicyGroup(
 ) error {
 	m.updates = append(m.updates, req)
 	m.updateGroups = append(m.updateGroups, policyGroup)
-	if m.updateErrOn > 0 && len(m.updates) == m.updateErrOn {
-		return m.updateErr
-	}
-	return nil
+	return m.updateErr
 }
 
 func (m *mockPolicyGroupEditClient) GetPolicyGroup(
 	_ context.Context, org, policyGroup string,
 ) (apitype.GetPolicyGroupResponse, error) {
+	m.getCalls++
 	m.gotGetOrg = org
 	m.gotGetGroup = policyGroup
-	if m.getErr != nil {
+	if m.getErrOn > 0 && m.getCalls == m.getErrOn {
+		return apitype.GetPolicyGroupResponse{}, m.getErr
+	}
+	if m.getErrOn == 0 && m.getErr != nil {
 		return apitype.GetPolicyGroupResponse{}, m.getErr
 	}
 	return m.getResp, nil
@@ -98,6 +101,8 @@ func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 		})
 	require.NoError(t, err)
 
+	// Rename-only does not touch any list, so the pre-edit GET is skipped.
+	assert.Equal(t, 1, c.getCalls)
 	assert.Equal(t, []apitype.UpdatePolicyGroupRequest{
 		{NewName: ptrString("production")},
 	}, c.updates)
@@ -117,8 +122,8 @@ Accounts:              0
 func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 	t.Parallel()
 
-	resp := apitype.GetPolicyGroupResponse{
-		Name:         "production",
+	current := apitype.GetPolicyGroupResponse{
+		Name:         "prod-policies",
 		IsOrgDefault: false,
 		EntityType:   apitype.Stacks,
 		Mode:         apitype.PolicyGroupModePreventative,
@@ -130,7 +135,7 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 		},
 		Accounts: []string{"acct-2"},
 	}
-	c := &mockPolicyGroupEditClient{getResp: resp}
+	c := &mockPolicyGroupEditClient{getResp: current}
 
 	args := policyGroupEditArgs{
 		outputFormat:          defaultPolicyGroupGetOutputFormat(),
@@ -153,40 +158,41 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", args)
 	require.NoError(t, err)
 
-	assert.Equal(t, []apitype.UpdatePolicyGroupRequest{
-		{NewName: ptrString("production")},
-		{AddStack: &apitype.PulumiStackReference{Name: "prod", RoutingProject: "web"}},
-		{AddStack: &apitype.PulumiStackReference{Name: "standalone"}},
-		{AddPolicyPack: &apitype.PolicyPackMetadata{Name: "aws-guardrails", Version: 3}},
-		{AddPolicyPack: &apitype.PolicyPackMetadata{Name: "tagging"}},
-		{AddInsightsAccount: ptrString("acct-2")},
-		{RemoveStack: &apitype.PulumiStackReference{Name: "legacy", RoutingProject: "web"}},
-		{RemovePolicyPack: &apitype.PolicyPackMetadata{Name: "old-pack", VersionTag: "stable"}},
-		{RemoveInsightsAccount: ptrString("acct-1")},
-	}, c.updates)
+	// Two GETs: one to seed the merge, one to render after the PATCH.
+	assert.Equal(t, 2, c.getCalls)
 
-	assert.Equal(t, []string{
-		"prod-policies",
-		"production", "production",
-		"production", "production",
-		"production",
-		"production",
-		"production",
-		"production",
-	}, c.updateGroups)
+	// A single batched PATCH with the rename and the full replacement lists.
+	require.Len(t, c.updates, 1)
+	got := c.updates[0]
+	assert.Equal(t, ptrString("production"), got.NewName)
+
+	require.NotNil(t, got.Stacks)
+	assert.Equal(t, []apitype.PulumiStackReference{
+		{Name: "prod", RoutingProject: "web"},
+		{Name: "standalone"},
+	}, *got.Stacks)
+
+	require.NotNil(t, got.PolicyPacks)
+	assert.Equal(t, []apitype.PolicyPackMetadata{
+		{Name: "aws-guardrails", Version: 3},
+		{Name: "tagging"},
+	}, *got.PolicyPacks)
+
+	require.NotNil(t, got.InsightsAccounts)
+	assert.Equal(t, []string{"acct-2"}, *got.InsightsAccounts)
+
+	// Singular Add/Remove fields are not populated when lists are sent.
+	assert.Nil(t, got.AddStack)
+	assert.Nil(t, got.RemoveStack)
+	assert.Nil(t, got.AddPolicyPack)
+	assert.Nil(t, got.RemovePolicyPack)
+	assert.Nil(t, got.AddInsightsAccount)
+	assert.Nil(t, got.RemoveInsightsAccount)
+
+	// PATCH is issued against the original group name; the post-edit GET
+	// uses the new name.
+	assert.Equal(t, []string{"prod-policies"}, c.updateGroups)
 	assert.Equal(t, "production", c.gotGetGroup)
-
-	assert.JSONEq(t, `{
-		"name": "production",
-		"isOrgDefault": false,
-		"entityType": "stacks",
-		"mode": "preventative",
-		"stacks": [{"name": "prod", "routingProject": "web"}],
-		"appliedPolicyPacks": [
-			{"name": "aws-guardrails", "displayName": "", "version": 3, "versionTag": ""}
-		],
-		"accounts": ["acct-2"]
-	}`, buf.String())
 }
 
 func TestPolicyGroupEdit_NoFlagsChanged(t *testing.T) {
@@ -207,35 +213,44 @@ func TestPolicyGroupEdit_NoFlagsChanged(t *testing.T) {
 	assert.Empty(t, c.updates)
 }
 
-func TestPolicyGroupEdit_UpdateErrorStopsSubsequentPatches(t *testing.T) {
+func TestPolicyGroupEdit_UpdateError(t *testing.T) {
 	t.Parallel()
 
-	c := &mockPolicyGroupEditClient{
-		updateErrOn: 2,
-		updateErr:   errors.New("conflict"),
-	}
+	c := &mockPolicyGroupEditClient{updateErr: errors.New("conflict")}
 	var buf bytes.Buffer
 	err := runPolicyGroupEdit(t.Context(), &buf,
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{
 			outputFormat: defaultPolicyGroupGetOutputFormat(),
-			addStack:     []string{"web/prod", "web/staging"},
-			changed:      map[string]bool{"add-stack": true},
+			newName:      "production",
+			changed:      map[string]bool{"new-name": true},
 		})
 	require.Error(t, err)
 	assert.Equal(t, "conflict", err.Error())
+	// The post-edit render is skipped on PATCH failure.
+	assert.Equal(t, 0, c.getCalls)
+}
 
-	// Two PATCHes were attempted; the third never ran and Get was skipped.
-	assert.Equal(t, []apitype.UpdatePolicyGroupRequest{
-		{AddStack: &apitype.PulumiStackReference{Name: "prod", RoutingProject: "web"}},
-		{AddStack: &apitype.PulumiStackReference{Name: "staging", RoutingProject: "web"}},
-	}, c.updates)
-	assert.Empty(t, c.gotGetGroup)
+func TestPolicyGroupEdit_GetBeforeEditError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockPolicyGroupEditClient{getErr: errors.New("boom"), getErrOn: 1}
+	var buf bytes.Buffer
+	err := runPolicyGroupEdit(t.Context(), &buf,
+		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{
+			outputFormat: defaultPolicyGroupGetOutputFormat(),
+			addStack:     []string{"web/prod"},
+			changed:      map[string]bool{"add-stack": true},
+		})
+	require.Error(t, err)
+	assert.Equal(t, "reading policy group before edit: boom", err.Error())
+	// PATCH never fired because we could not compute the new list.
+	assert.Empty(t, c.updates)
 }
 
 func TestPolicyGroupEdit_GetAfterEditError(t *testing.T) {
 	t.Parallel()
 
-	c := &mockPolicyGroupEditClient{getErr: errors.New("boom")}
+	c := &mockPolicyGroupEditClient{getErr: errors.New("boom"), getErrOn: 1}
 	var buf bytes.Buffer
 	err := runPolicyGroupEdit(t.Context(), &buf,
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -257,7 +257,16 @@ type CreatePolicyGroupRequest struct {
 	Name string `json:"name"`
 }
 
-// UpdatePolicyGroupRequest modifies a Policy Group.
+// UpdatePolicyGroupRequest modifies a Policy Group. Callers may set:
+//
+//   - NewName to rename the group.
+//   - A singular AddX/RemoveX field for a single per-PATCH membership change.
+//   - A list field (Stacks, PolicyPacks, InsightsAccounts) to replace the
+//     corresponding list outright; the values sent become the new full list.
+//     Use the pointer-to-slice indirection to distinguish "leave list
+//     unchanged" (nil pointer) from "set list to empty" (non-nil empty slice).
+//
+// Multiple of these may be combined in a single request to batch changes.
 type UpdatePolicyGroupRequest struct {
 	NewName *string `json:"newName,omitempty"`
 
@@ -269,6 +278,15 @@ type UpdatePolicyGroupRequest struct {
 
 	AddInsightsAccount    *string `json:"addInsightsAccount,omitempty"`
 	RemoveInsightsAccount *string `json:"removeInsightsAccount,omitempty"`
+
+	// Stacks, when non-nil, replaces the full list of stacks in the group.
+	Stacks *[]PulumiStackReference `json:"stacks,omitempty"`
+	// PolicyPacks, when non-nil, replaces the full list of Policy Packs
+	// applied to the group.
+	PolicyPacks *[]PolicyPackMetadata `json:"policyPacks,omitempty"`
+	// InsightsAccounts, when non-nil, replaces the full list of Insights
+	// accounts in the group.
+	InsightsAccounts *[]string `json:"insightsAccounts,omitempty"`
 }
 
 // PulumiStackReference contains the StackName and ProjectName of the stack.


### PR DESCRIPTION
Reworks the edit command so that all requested changes are sent in a single batched PATCH instead of one PATCH per add or remove. For each list field the user mutates (stacks, policy packs, insights accounts), the command first reads the current group, applies the requested adds and removes on top, and sends the resulting full list in the PATCH body. This matches the Pulumi Cloud semantics for list-typed PATCH fields (a list value replaces the prior list outright) and avoids clobbering existing members.

Extends `apitype.UpdatePolicyGroupRequest` with optional `Stacks` / `PolicyPacks` / `InsightsAccounts` list-replacement fields (`*[]T`, omitempty); the existing singular Add/Remove fields are kept for backward compatibility with other callers.

Addresses pulumi/pulumi#23183 review feedback.