### PR TITLE
Lint enforced standardization on `ptr`

### DIFF
--- a/.golangci/rules.go
+++ b/.golangci/rules.go
@@ -13,3 +13,17 @@ func deferIgnoreClose(m dsl.Matcher) {
 		Report("use defer contract.IgnoreClose($x) directly instead of wrapping in func literal").
 		Suggest("defer contract.IgnoreClose($x)")
 }
+
+// ptrHelperName forbids private pointer-wrapper helpers whose body is just
+// `return &v` from being named anything other than `ptr`. It catches both the
+// monomorphic form (e.g. `intPtr`, `strPtr`, `continuationPtr`) and the generic
+// form (e.g. `func ref[T any](v T) *T { return &v }`). This avoids unnecessary
+// duplication.
+func ptrHelperName(m dsl.Matcher) {
+	m.Match(
+		`func $name($v $T) *$T { return &$v }`,
+		`func $name[$T $_]($v $T) *$T { return &$v }`,
+	).
+		Where(m["name"].Text != "ptr" && m["name"].Text.Matches(`^[a-z]`)).
+		Report(`pointer-wrapping helper "$name" must be named "ptr"; prefer a single generic func ptr[T any](v T) *T { return &v }`)
+}

--- a/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
+++ b/pkg/backend/diy/unauthenticatedregistry/package_registry_test.go
@@ -251,7 +251,7 @@ func TestListPackages(t *testing.T) {
 
 	//nolint:prealloc // capacity unknown ahead of time
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.ListPackages(ctx, ref("castai")) {
+	for pkg, err := range client.ListPackages(ctx, ptr("castai")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}
@@ -310,7 +310,7 @@ func TestListPackagesNoMatches(t *testing.T) {
 
 	//nolint:prealloc // capacity unknown ahead of time
 	results := []apitype.PackageMetadata{}
-	for pkg, err := range client.ListPackages(ctx, ref("404-not-found")) {
+	for pkg, err := range client.ListPackages(ctx, ptr("404-not-found")) {
 		require.NoError(t, err)
 		results = append(results, pkg)
 	}
@@ -318,4 +318,4 @@ func TestListPackagesNoMatches(t *testing.T) {
 	assert.Equal(t, []apitype.PackageMetadata{}, results)
 }
 
-func ref[T any](v T) *T { return &v }
+func ptr[T any](v T) *T { return &v }

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -234,16 +234,8 @@ func (t updateToken) Get(ctx context.Context) (string, error) {
 	return t.source.GetToken(ctx)
 }
 
-func float64Ptr(f float64) *float64 {
-	return &f
-}
-
-func durationPtr(d time.Duration) *time.Duration {
-	return &d
-}
-
-func intPtr(i int) *int {
-	return &i
+func ptr[T any](v T) *T {
+	return &v
 }
 
 // retryPolicy defines the policy for retrying requests by httpClient.Do.
@@ -373,11 +365,11 @@ func (c *defaultHTTPClient) Do(req *http.Request, policy retryPolicy) (*http.Res
 	// maximum delay is reached. Stop after maxRetryCount requests have
 	// been made.
 	opts := httputil.RetryOpts{
-		Delay:    durationPtr(time.Second),
-		Backoff:  float64Ptr(2.0),
-		MaxDelay: durationPtr(30 * time.Second),
+		Delay:    ptr(time.Second),
+		Backoff:  ptr(2.0),
+		MaxDelay: ptr(30 * time.Second),
 
-		MaxRetryCount:         intPtr(4),
+		MaxRetryCount:         ptr(4),
 		HandshakeTimeoutsOnly: !policy.shouldRetry(req),
 	}
 	return httputil.DoWithRetryOpts(req, &tracingClient, opts)

--- a/pkg/backend/httpstate/client/client_org_usage_test.go
+++ b/pkg/backend/httpstate/client/client_org_usage_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-func ref[T any](v T) *T { return &v }
-
 func TestGetOrgUsageSummary(t *testing.T) {
 	t.Parallel()
 
@@ -38,15 +36,15 @@ func TestGetOrgUsageSummary(t *testing.T) {
 			Summary: []apitype.OrgResourceCountSummary{
 				{
 					Year:          2026,
-					Month:         ref(5),
-					Day:           ref(1),
+					Month:         ptr(5),
+					Day:           ptr(1),
 					Resources:     1200,
 					ResourceHours: 28800,
 				},
 				{
 					Year:          2026,
-					Month:         ref(5),
-					Day:           ref(2),
+					Month:         ptr(5),
+					Day:           ptr(2),
 					Resources:     1300,
 					ResourceHours: 31200,
 				},

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -764,8 +764,6 @@ func TestListPackages(t *testing.T) {
 	})
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func TestCallCopilot(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/config/config_env_ls_test.go
+++ b/pkg/cmd/pulumi/config/config_env_ls_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func boolPtr(v bool) *bool {
+func ptr[T any](v T) *T {
 	return &v
 }
 
@@ -48,7 +48,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -104,7 +104,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -139,7 +139,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -175,7 +175,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(false)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: boolPtr(true)}
+		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)

--- a/pkg/cmd/pulumi/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/newcmd/new_test.go
@@ -1050,7 +1050,7 @@ Available Templates:
 	assert.Equal(t, "", stderr.String())
 }
 
-func ref[T any](v T) *T { return &v }
+func ptr[T any](v T) *T { return &v }
 
 //nolint:paralleltest // Sets a global mock backend
 func TestPulumiNewWithRegistryTemplates(t *testing.T) {
@@ -1063,12 +1063,12 @@ func TestPulumiNewWithRegistryTemplates(t *testing.T) {
 			) iter.Seq2[apitype.TemplateMetadata, error] {
 				return func(yield func(apitype.TemplateMetadata, error) bool) {
 					if !yield(apitype.TemplateMetadata{
-						Name: "template-1", Description: ref("Describe 1"), Publisher: "Some org",
+						Name: "template-1", Description: ptr("Describe 1"), Publisher: "Some org",
 					}, nil) {
 						return
 					}
 					if !yield(apitype.TemplateMetadata{
-						Name: "template-2", Description: ref("Describe 2"), RepoSlug: ref("some-org/repo"), Source: "github",
+						Name: "template-2", Description: ptr("Describe 2"), RepoSlug: ptr("some-org/repo"), Source: "github",
 					}, nil) {
 						return
 					}

--- a/pkg/cmd/pulumi/org/org_member_edit_test.go
+++ b/pkg/cmd/pulumi/org/org_member_edit_test.go
@@ -84,8 +84,6 @@ func failingOrgMemberEditFactory(err error) orgMemberEditClientFactory {
 	}
 }
 
-func stringPtr(s string) *string { return &s }
-
 func TestOrgMemberEdit_DefaultOutput_RoleOnly(t *testing.T) {
 	t.Parallel()
 
@@ -111,7 +109,7 @@ func TestOrgMemberEdit_DefaultOutput_RoleOnly(t *testing.T) {
 		{
 			org:       "acme",
 			userLogin: "alice",
-			req:       apitype.UpdateOrganizationMemberRequest{Role: stringPtr("admin")},
+			req:       apitype.UpdateOrganizationMemberRequest{Role: ptr("admin")},
 		},
 	}, c.updateCalls)
 
@@ -152,8 +150,8 @@ func TestOrgMemberEdit_JSONOutput_BothFlags(t *testing.T) {
 			org:       "acme",
 			userLogin: "alice",
 			req: apitype.UpdateOrganizationMemberRequest{
-				Role:      stringPtr("admin"),
-				FgaRoleId: stringPtr("role-abc"),
+				Role:      ptr("admin"),
+				FgaRoleId: ptr("role-abc"),
 			},
 		},
 	}, c.updateCalls)

--- a/pkg/cmd/pulumi/org/org_usage_test.go
+++ b/pkg/cmd/pulumi/org/org_usage_test.go
@@ -59,22 +59,22 @@ func stubUsageFactory(c orgUsageGetClient, resolvedOrg string) orgUsageGetClient
 	}
 }
 
-func ref[T any](v T) *T { return &v }
+func ptr[T any](v T) *T { return &v }
 
 func sampleDailyUsage() apitype.OrgUsageSummaryResponse {
 	return apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{
 			{
 				Year:          2026,
-				Month:         ref(5),
-				Day:           ref(1),
+				Month:         ptr(5),
+				Day:           ptr(1),
 				Resources:     1200,
 				ResourceHours: 28800,
 			},
 			{
 				Year:          2026,
-				Month:         ref(5),
-				Day:           ref(2),
+				Month:         ptr(5),
+				Day:           ptr(2),
 				Resources:     1300,
 				ResourceHours: 31200,
 			},
@@ -166,9 +166,9 @@ func TestOrgUsageGet_HourlyColumns(t *testing.T) {
 	c := &mockUsageGetClient{resp: apitype.OrgUsageSummaryResponse{
 		Summary: []apitype.OrgResourceCountSummary{{
 			Year:          2026,
-			Month:         ref(5),
-			Day:           ref(14),
-			Hour:          ref(13),
+			Month:         ptr(5),
+			Day:           ptr(14),
+			Hour:          ptr(13),
 			Resources:     50,
 			ResourceHours: 50,
 		}},

--- a/pkg/cmd/pulumi/org/org_webhook_list_test.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list_test.go
@@ -38,8 +38,6 @@ func (m *mockOrgWebhookListClient) ListOrgWebhooks(
 	return m.webhooks, m.err
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func sampleOrgWebhooks() []apitype.Webhook {
 	return []apitype.Webhook{
 		{

--- a/pkg/cmd/pulumi/policy/policy_group_edit_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit_test.go
@@ -79,7 +79,7 @@ func failingPolicyGroupEditFactory(err error) policyGroupEditClientFactory {
 	}
 }
 
-func ptrString(s string) *string { return &s }
+func ptr[T any](v T) *T { return &v }
 
 func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 	t.Parallel()
@@ -104,7 +104,7 @@ func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 	// Rename-only does not touch any list, so the pre-edit GET is skipped.
 	assert.Equal(t, 1, c.getCalls)
 	assert.Equal(t, []apitype.UpdatePolicyGroupRequest{
-		{NewName: ptrString("production")},
+		{NewName: ptr("production")},
 	}, c.updates)
 	assert.Equal(t, []string{"prod-policies"}, c.updateGroups)
 	assert.Equal(t, "acme", c.gotGetOrg)
@@ -164,7 +164,7 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 	// A single batched PATCH with the rename and the full replacement lists.
 	require.Len(t, c.updates, 1)
 	got := c.updates[0]
-	assert.Equal(t, ptrString("production"), got.NewName)
+	assert.Equal(t, ptr("production"), got.NewName)
 
 	require.NotNil(t, got.Stacks)
 	assert.Equal(t, []apitype.PulumiStackReference{

--- a/pkg/cmd/pulumi/templates/templates_test.go
+++ b/pkg/cmd/pulumi/templates/templates_test.go
@@ -669,7 +669,7 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 						Name:      "gh-org/repo/name",
 						Source:    "github",
 						Publisher: "pulumi-org",
-						RepoSlug:  ref("gh-org/repo"),
+						RepoSlug:  ptr("gh-org/repo"),
 					}, nil) {
 						return
 					}
@@ -677,7 +677,7 @@ func TestVCSBasedTemplateNames(t *testing.T) {
 						Name:      "gl-org/repo/name",
 						Source:    "gitlab",
 						Publisher: "pulumi-org",
-						RepoSlug:  ref("gl-org/repo"),
+						RepoSlug:  ptr("gl-org/repo"),
 					}, nil) {
 						return
 					}
@@ -730,9 +730,9 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 					if !yield(apitype.TemplateMetadata{
 						Name:        "gh-org/repo/target",
 						Source:      "github",
-						Description: ref("This is from GH"),
+						Description: ptr("This is from GH"),
 						Publisher:   "pulumi-org",
-						RepoSlug:    ref("gh-org/repo"),
+						RepoSlug:    ptr("gh-org/repo"),
 					}, nil) {
 						return
 					}
@@ -740,14 +740,14 @@ func TestVCSBasedTemplateNameFilter(t *testing.T) {
 						Name:      "gl-org/repo/name",
 						Source:    "gitlab",
 						Publisher: "pulumi-org",
-						RepoSlug:  ref("gl-org/repo"),
+						RepoSlug:  ptr("gl-org/repo"),
 					}, nil) {
 						return
 					}
 					if !yield(apitype.TemplateMetadata{
 						Name:        "target",
 						Source:      "private",
-						Description: ref("This is from the registry"),
+						Description: ptr("This is from the registry"),
 						Publisher:   "pulumi-org",
 					}, nil) {
 						return
@@ -796,7 +796,7 @@ func testContext(t *testing.T) context.Context {
 	return ctx
 }
 
-func ref[T any](v T) *T { return &v }
+func ptr[T any](v T) *T { return &v }
 
 //nolint:paralleltest // replaces global backend instance
 func TestRegistryTemplateResolution(t *testing.T) {
@@ -812,7 +812,7 @@ func TestRegistryTemplateResolution(t *testing.T) {
 						Name:        "csharp-documented",
 						Source:      "private",
 						Publisher:   "pulumi_local",
-						Description: ref("A C# template"),
+						Description: ptr("A C# template"),
 					}, nil)
 					yield(apitype.TemplateMetadata{
 						Name:      "csharp-documented",
@@ -823,14 +823,14 @@ func TestRegistryTemplateResolution(t *testing.T) {
 						Name:        "gh-org/repo/target",
 						Source:      "github",
 						Publisher:   "pulumi-org",
-						RepoSlug:    ref("gh-org/repo"),
-						Description: ref("A template from VCS"),
+						RepoSlug:    ptr("gh-org/repo"),
+						Description: ptr("A template from VCS"),
 					}, nil)
 					yield(apitype.TemplateMetadata{
 						Name:        "whatever-template",
 						Source:      "private",
 						Publisher:   "test-org",
-						Description: ref("A template with special chars"),
+						Description: ptr("A template with special chars"),
 					}, nil)
 				}
 			},
@@ -1013,7 +1013,7 @@ func TestVersionedTemplateResolution(t *testing.T) {
 						Name:        name,
 						Source:      source,
 						Publisher:   publisher,
-						Description: ref("A versioned template"),
+						Description: ptr("A versioned template"),
 					}, nil
 				}
 				return apitype.TemplateMetadata{}, backenderr.NotFoundError{}
@@ -1026,7 +1026,7 @@ func TestVersionedTemplateResolution(t *testing.T) {
 						Name:        "my-template",
 						Source:      "private",
 						Publisher:   "my-org",
-						Description: ref("Latest version"),
+						Description: ptr("Latest version"),
 					}, nil)
 				}
 			},

--- a/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/discriminated_union_provider.go
@@ -140,7 +140,7 @@ func (p *DiscriminatedUnionProvider) CheckConfig(
 
 func (p *DiscriminatedUnionProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(p.version()),
+		Version: ptr(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/enum_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/enum_provider.go
@@ -109,7 +109,7 @@ func (p *EnumProvider) CheckConfig(
 
 func (p *EnumProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(p.version()),
+		Version: ptr(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/external_enum_ref_provider.go
@@ -94,7 +94,7 @@ func (p *ExternalEnumRefProvider) CheckConfig(
 
 func (p *ExternalEnumRefProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(p.version()),
+		Version: ptr(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/nested_object_provider.go
@@ -233,7 +233,7 @@ func (p *NestedObjectProvider) Update(
 
 func (p *NestedObjectProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(p.version()),
+		Version: ptr(p.version()),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/output_only_invoke_provider.go
@@ -66,8 +66,6 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 	}
 	resourceRequired := []string{"text"}
 
-	ref := func(b bool) *bool { return &b }
-
 	pkg := schema.PackageSpec{
 		Name:    "output-only-invoke",
 		Version: "24.0.0",
@@ -85,7 +83,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 		},
 		Functions: map[string]schema.FunctionSpec{
 			"output-only-invoke:index:myInvoke": {
-				Plain: ref(false),
+				Plain: ptr(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{
@@ -112,7 +110,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 				},
 			},
 			"output-only-invoke:index:unit": {
-				Plain: ref(false),
+				Plain: ptr(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 				},
@@ -131,7 +129,7 @@ func (p *OutputOnlyInvokeProvider) GetSchema(
 				},
 			},
 			"output-only-invoke:index:secretInvoke": {
-				Plain: ref(false),
+				Plain: ptr(false),
 				Inputs: &schema.ObjectTypeSpec{
 					Type: "object",
 					Properties: map[string]schema.PropertySpec{

--- a/pkg/testing/pulumi-test-language/providers/read_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/read_provider.go
@@ -156,7 +156,7 @@ func (p *ReadProvider) Read(_ context.Context, req plugin.ReadRequest) (plugin.R
 
 func (p *ReadProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(semver.MustParse("39.0.0")),
+		Version: ptr(semver.MustParse("39.0.0")),
 	}, nil
 }
 

--- a/pkg/testing/pulumi-test-language/providers/simple_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/simple_provider.go
@@ -202,7 +202,7 @@ func (p *SimpleProvider) Update(
 
 func (p *SimpleProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
 	return plugin.PluginInfo{
-		Version: ref(p.version()),
+		Version: ptr(p.version()),
 	}, nil
 }
 
@@ -261,4 +261,4 @@ func (p *SimpleProvider) Read(ctx context.Context, req plugin.ReadRequest) (plug
 	}, nil
 }
 
-func ref[T any](v T) *T { return &v }
+func ptr[T any](v T) *T { return &v }

--- a/sdk/go/tools/automation/tests/runtime/commands_test.go
+++ b/sdk/go/tools/automation/tests/runtime/commands_test.go
@@ -43,7 +43,7 @@ import (
 // keeps the public surface stable if we ever change the struct's fields.
 func newAPI() *automation.API { return automation.New(nil) }
 
-func strPtr(s string) *string { return &s }
+func ptr[T any](v T) *T { return &v }
 
 // runStdout invokes fn and returns the rendered CLI command line. It is a
 // thin wrapper that fails the test on error so individual cases stay
@@ -72,7 +72,7 @@ func TestCancel_Empty(t *testing.T) {
 func TestCancel_WithStackName(t *testing.T) {
 	api := newAPI()
 	got := runStdout(t, func() (string, error) {
-		r, err := api.Cancel(t.Context(), strPtr("my-stack"))
+		r, err := api.Cancel(t.Context(), ptr("my-stack"))
 		return r.Stdout, err
 	})
 	want := "pulumi cancel --yes -- my-stack"

--- a/tests/integration/integration_python_acceptance_test.go
+++ b/tests/integration/integration_python_acceptance_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
 )
 
-func boolPointer(b bool) *bool {
-	return &b
+func ptr[T any](v T) *T {
+	return &v
 }
 
 // TestEmptyPython simply tests that we can run an empty Python project.
@@ -92,7 +92,7 @@ func TestDynamicPython(t *testing.T) {
 				}
 			},
 		}},
-		UseSharedVirtualEnv: boolPointer(false),
+		UseSharedVirtualEnv: ptr(false),
 	})
 }
 
@@ -121,7 +121,7 @@ func TestDynamicPythonReadInputs(t *testing.T) {
 				}
 			}
 		},
-		UseSharedVirtualEnv: boolPointer(false),
+		UseSharedVirtualEnv: ptr(false),
 	})
 }
 
@@ -184,7 +184,7 @@ func optsForConstructPython(
 			"secret": "this super secret is encrypted",
 		},
 		Quick:               true,
-		UseSharedVirtualEnv: boolPointer(false),
+		UseSharedVirtualEnv: ptr(false),
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			require.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -537,7 +537,7 @@ func TestDynamicPythonDisableSerializationAsSecret(t *testing.T) {
 				}
 			},
 		}},
-		UseSharedVirtualEnv: boolPointer(false),
+		UseSharedVirtualEnv: ptr(false),
 	})
 }
 


### PR DESCRIPTION
We have 6 plus ways to spell the helper function `T -> *T` (just to express `&`). AI loves adding new ways, I've seen multiple spellings in some form of `func continuationRef(s string) *string { return &s }` functions. 

This PR decides the correct spelling is `ptr`, and adds a lint that enforces the decision.

The second commit applies the lint until the changes pass.