### PR TITLE
Correct `valueStructurallyTypedAs` for unions of enums

### DIFF
--- a/changelog/pending/20260515--engine--fix-importer-dropping-bool-or-string-values-in-unions-of-input-wrapped-enums.yaml
+++ b/changelog/pending/20260515--engine--fix-importer-dropping-bool-or-string-values-in-unions-of-input-wrapped-enums.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Fix `pulumi import` dropping map entries whose value matched the enum member of a `Union<Input<Enum<T>>, ...>` element type

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -606,6 +606,11 @@ removeNonStructuralTypes:
 		switch t := schemaType.(type) {
 		case *schema.InputType:
 			schemaType = t.ElementType
+		case *schema.OptionalType:
+			if value.IsNull() {
+				return true
+			}
+			schemaType = t.ElementType
 		case *schema.EnumType:
 			schemaType = t.ElementType
 		case *schema.UnionType:

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -601,30 +601,17 @@ func generatePropertyValue(
 
 // valueStructurallyTypedAs returns true if the given value is structurally typed as the given schema type.
 func valueStructurallyTypedAs(value property.Value, schemaType schema.Type) bool {
+removeNonStructuralTypes:
 	for {
-		if input, ok := schemaType.(*schema.InputType); ok {
-			schemaType = input.ElementType
-		} else {
-			break
-		}
-	}
-	// An enum value is represented as a value of the enum's underlying primitive
-	// type at the wire level (e.g. a string for a string-typed enum). Substitute
-	// the underlying type so the primitive-value branches below match.
-	if enum, ok := schemaType.(*schema.EnumType); ok {
-		schemaType = enum.ElementType
-	}
-	if union, ok := schemaType.(*schema.UnionType); ok {
-		schemaType = reduceUnionType(union, value)
-	}
-	// reduceUnionType returns a member of the union as-is, which is often an
-	// *schema.InputType wrapping the real type. Strip those wrappers again so
-	// the type switch below can match on the underlying type.
-	for {
-		if input, ok := schemaType.(*schema.InputType); ok {
-			schemaType = input.ElementType
-		} else {
-			break
+		switch t := schemaType.(type) {
+		case *schema.InputType:
+			schemaType = t.ElementType
+		case *schema.EnumType:
+			schemaType = t.ElementType
+		case *schema.UnionType:
+			schemaType = reduceUnionType(t, value)
+		default:
+			break removeNonStructuralTypes
 		}
 	}
 

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1194,6 +1194,42 @@ func TestStructuralTypeChecks(t *testing.T) {
 			makeObject(map[string]property.Value{"unknown": property.New("x")}),
 			union))
 	})
+
+	t.Run("UnionOfInputWrappedEnums", func(t *testing.T) {
+		t.Parallel()
+
+		// Schema-bound unions wrap enum members in *schema.InputType too, e.g.
+		// Union<Input<Enum<bool>>, Input<bool>>. reduceUnionType returns the
+		// chosen member as-is (Input<Enum<bool>>), so valueStructurallyTypedAs
+		// must strip *both* the input wrapper *and* the enum wrapper after the
+		// reduction — otherwise the IsBool case never sees BoolType and the
+		// value is wrongly rejected.
+		boolEnum := &schema.EnumType{
+			Token:       "a:index:B",
+			ElementType: schema.BoolType,
+			Elements:    []*schema.Enum{{Value: true}, {Value: false}},
+		}
+		stringEnum := &schema.EnumType{
+			Token:       "a:index:S",
+			ElementType: schema.StringType,
+			Elements:    []*schema.Enum{{Value: "x"}, {Value: "y"}},
+		}
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(false),
+			makeUnionType(&schema.InputType{ElementType: boolEnum})))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(true),
+			makeUnionType(&schema.InputType{ElementType: boolEnum}, schema.NumberType)))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New("x"),
+			makeUnionType(&schema.InputType{ElementType: stringEnum})))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(1.5),
+			makeUnionType(
+				&schema.InputType{ElementType: boolEnum},
+				&schema.InputType{ElementType: schema.NumberType},
+			)))
+	})
 }
 
 func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -1195,6 +1195,44 @@ func TestStructuralTypeChecks(t *testing.T) {
 			union))
 	})
 
+	t.Run("OptionalWrappers", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(false),
+			&schema.OptionalType{ElementType: schema.BoolType}))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(""),
+			&schema.OptionalType{ElementType: &schema.InputType{ElementType: schema.AnyType}}))
+		// Optional<Object> with a present, conforming value.
+		assert.True(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"foo": property.New("x")}),
+			&schema.OptionalType{ElementType: makeObjectType(
+				makeProperty("foo", schema.StringType),
+			)}))
+		// Optional<Object> with a present, non-conforming value still rejected.
+		assert.False(t, valueStructurallyTypedAs(
+			makeObject(map[string]property.Value{"foo": property.New(42.0)}),
+			&schema.OptionalType{ElementType: makeObjectType(
+				makeProperty("foo", schema.StringType),
+			)}))
+	})
+
+	t.Run("OptionalAcceptsNull", func(t *testing.T) {
+		t.Parallel()
+
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(property.Null),
+			&schema.OptionalType{ElementType: schema.StringType}))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(property.Null),
+			&schema.OptionalType{ElementType: &schema.InputType{ElementType: schema.BoolType}}))
+		// A required (non-Optional) T must still reject null.
+		assert.False(t, valueStructurallyTypedAs(
+			property.New(property.Null),
+			schema.StringType))
+	})
+
 	t.Run("UnionOfInputWrappedEnums", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi/issues/23105