### PR TITLE
cli/cloud: rename `pulumi api --paginate` to `pulumi api --all`

### DIFF
--- a/changelog/pending/20260513--cli-cloud--surface-error-when-paginate-is-used-against-a-non-paginated-endpoint.yaml
+++ b/changelog/pending/20260513--cli-cloud--surface-error-when-paginate-is-used-against-a-non-paginated-endpoint.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/cloud
-  description: Surface a clear error when `pulumi api --paginate` is used against an endpoint whose response is not paginatable, instead of silently emitting an empty array
+  description: Surface a clear error when `pulumi api --all` is used against an endpoint whose response is not paginatable, instead of silently emitting an empty array

--- a/changelog/pending/20260515--cli-cloud--rename-pulumi-api-paginate-to-all.yaml
+++ b/changelog/pending/20260515--cli-cloud--rename-pulumi-api-paginate-to-all.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: cli/cloud
-  description: Rename `pulumi api --paginate` to `pulumi api --all`

--- a/changelog/pending/20260515--cli-cloud--rename-pulumi-api-paginate-to-all.yaml
+++ b/changelog/pending/20260515--cli-cloud--rename-pulumi-api-paginate-to-all.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/cloud
+  description: Rename `pulumi api --paginate` to `pulumi api --all`

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -48,15 +48,14 @@ type apiCommand struct {
 	// Persistent flag inherited by subcommands.
 	refreshSpec bool
 
-	// Local api for the dispatcher path. Flag names are a stable contract
-	// matching `gh api`.
+	// Local api for the dispatcher path.
 	method          string
 	fields          []string
 	rawFields       []string
 	headers         []string
 	input           string
 	body            string
-	paginate        bool
+	all             bool
 	include         bool
 	silent          bool
 	verbose         bool
@@ -89,7 +88,7 @@ func bindFlags(cmd *cobra.Command, api *apiCommand) {
 	pf.StringVar(&api.body, "body", "",
 		"Inline request body sent verbatim (default Content-Type: application/json). "+
 			"Mutually exclusive with --input")
-	pf.BoolVar(&api.paginate, "paginate", false,
+	pf.BoolVar(&api.all, "all", false,
 		"Follow pagination cursors and emit the combined result")
 	pf.BoolVarP(&api.include, "include", "i", false,
 		"Include HTTP status line and response headers in output")
@@ -185,7 +184,7 @@ func NewAPICmd() *cobra.Command {
 			"  # Filter the JSON response with jq.\n" +
 			"  pulumi api /api/user --output=json | jq '.githubLogin'\n\n" +
 			"  # Follow pagination cursors and stream the combined result to jq.\n" +
-			"  pulumi api ListUserStacks --paginate | jq '.stacks[].stackName'\n\n" +
+			"  pulumi api ListUserStacks --all | jq '.stacks[].stackName'\n\n" +
 			"  # Extract just the status line + headers without the body.\n" +
 			"  pulumi api /api/user --include --silent\n\n" +
 			"  # Preview the resolved request without sending it.\n" +
@@ -327,7 +326,7 @@ func executeLive(
 			fmt.Sprintf("parsing query string %q: %v", query, err)).WithField("path")
 	}
 
-	if api.paginate {
+	if api.all {
 		return runPaginate(ctx, w, apiClient, paginateRequest{
 			Method:      method,
 			Path:        concretePath,

--- a/pkg/cmd/pulumi/cloud/envelope.go
+++ b/pkg/cmd/pulumi/cloud/envelope.go
@@ -89,7 +89,7 @@ type APIError struct {
 	Envelope ErrorEnvelope
 	// Silent suppresses the automatic ErrorEnvelope emission in
 	// runWithEnvelope. Use when the command has already written its own
-	// structured output (e.g. a partial_failure event during --paginate
+	// structured output (e.g. a partial_failure event during --all
 	// or a cancellation event from the signal handler).
 	Silent bool
 }

--- a/pkg/cmd/pulumi/cloud/paginate.go
+++ b/pkg/cmd/pulumi/cloud/paginate.go
@@ -119,7 +119,7 @@ func runPaginate(
 		if err != nil {
 			return emitPartialFailure(w, flags, accumulated, itemsField,
 				NewAPIError(cmdutil.ExitCodeError, ErrInvalidFlags,
-					fmt.Sprintf("page %d: %v; --paginate requires a JSON shape with an array and "+
+					fmt.Sprintf("page %d: %v; --all requires a JSON shape with an array and "+
 						"optional continuationToken/cursor/nextToken", page, err)))
 		}
 		if itemsField == "" && pageItemsField != "" {
@@ -333,7 +333,7 @@ func cursorFromLink(link string) (cursor, param string) {
 // writeAccumulated writes the combined result to w. When itemsField is
 // non-empty (the server returned an object envelope with a named array), the
 // output is wrapped back into that same shape ({<itemsField>: [...]}) so
-// downstream `| jq` filters work identically whether or not --paginate is set.
+// downstream `| jq` filters work identically whether or not --all is set.
 // When itemsField is empty (server returned a bare array), the output stays
 // a bare array.
 func writeAccumulated(w io.Writer, items []json.RawMessage, itemsField string, flags *apiCommand) error {

--- a/pkg/cmd/pulumi/cloud/paginate_test.go
+++ b/pkg/cmd/pulumi/cloud/paginate_test.go
@@ -264,7 +264,7 @@ func TestMarshalAccumulated_BareArray(t *testing.T) {
 func TestMarshalAccumulated_PreservesEnvelope(t *testing.T) {
 	t.Parallel()
 	// When the server returned an object envelope, we rewrap so downstream
-	// `| jq` filters like '.accounts[]' keep working across --paginate.
+	// `| jq` filters like '.accounts[]' keep working across --all.
 	items := []json.RawMessage{json.RawMessage(`{"id":"a"}`), json.RawMessage(`{"id":"b"}`)}
 	out, err := marshalAccumulated(items, "accounts")
 	require.NoError(t, err)


### PR DESCRIPTION
Renames the `--paginate` flag on `pulumi api` to `--all`.