### PR TITLE
`LiteralArchiveGenerator` stops generating invalid values

### DIFF
--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	rarchive "github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	rasset "github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -38,6 +40,18 @@ import (
 const (
 	go19Version = "go1.9"
 )
+
+func TestBadArchiveOfAssets(t *testing.T) {
+	t.Parallel()
+	skipWindows(t) // Windows doesn't error here
+
+	textAsset, err := asset.FromText("A")
+	require.NoError(t, err)
+	inner, err := archive.FromAssets(map[string]any{"..": textAsset})
+	require.NoError(t, err)
+	_, err = archive.FromAssets(map[string]any{"/": inner})
+	require.Error(t, err, "can't path above /")
+}
 
 // TODO[pulumi/pulumi#8647]
 func skipWindows(t *testing.T) {

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -16,6 +16,10 @@
 package testing
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
@@ -226,22 +230,53 @@ func AssetPropertyGenerator() *rapid.Generator[resource.PropertyValue] {
 
 // LiteralArchiveGenerator generates *archive.Archive values with literal archive contents.
 func LiteralArchiveGenerator(maxDepth int) *rapid.Generator[*archive.Archive] {
-	return rapid.Custom(func(t *rapid.T) *archive.Archive {
-		var contentsGenerator *rapid.Generator[map[string]any]
-		if maxDepth > 0 {
-			contentsGenerator = rapid.MapOfN(
-				rapid.StringMatching(`^(/[^[:cntrl:]/]+)*/?[^[:cntrl:]/]+$`),
-				rapid.OneOf(AssetGenerator().AsAny(), ArchiveGenerator(maxDepth-1).AsAny()),
-				0,  // min length
-				16, // max length
-			)
-		} else {
-			contentsGenerator = rapid.Just(map[string]any{})
-		}
-		archive, err := archive.FromAssets(contentsGenerator.Draw(t, "literal archive contents"))
-		require.NoError(t, err)
-		return archive
-	})
+	keyGenerator := rapid.StringMatching(`^(/[^[:cntrl:]/]+)*/?[^[:cntrl:]/]+$`)
+
+	var gen func(maxDepth int, currentPath string) *rapid.Generator[*archive.Archive]
+	gen = func(maxDepth int, currentPath string) *rapid.Generator[*archive.Archive] {
+		return rapid.Custom(func(t *rapid.T) *archive.Archive {
+			maxCount := 0
+			if maxDepth > 0 {
+				maxCount = 16
+			}
+			count := rapid.IntRange(0, maxCount).Draw(t, "literal archive entry count")
+			contents := map[string]any{}
+			for i := range count {
+				key := keyGenerator.
+					Filter(func(k string) bool {
+						return validNestedArchivePath(currentPath, k) && contents[k] == nil
+					}).
+					Draw(t, fmt.Sprintf("literal archive key %d", i))
+				entryPath := filepath.Join(currentPath, key)
+				if rapid.Bool().Draw(t, fmt.Sprintf("literal archive entry %d is asset", i)) {
+					contents[key] = AssetGenerator().Draw(t, fmt.Sprintf("literal archive asset %d", i))
+				} else {
+					contents[key] = gen(maxDepth-1, entryPath).
+						Draw(t, fmt.Sprintf("literal archive sub-archive %d", i))
+				}
+			}
+			a, err := archive.FromAssets(contents)
+			require.NoError(t, err)
+			return a
+		})
+	}
+	return gen(maxDepth, "")
+}
+
+// validNestedArchivePath reports whether key, when joined with currentPath, produces a path that
+// archive/tar can safely write: non-empty, not the filesystem root, and a strict descendant of
+// currentPath (so keys containing ".." can't escape their mount point).
+func validNestedArchivePath(currentPath, key string) bool {
+	joined := filepath.Clean(filepath.Join(currentPath, key))
+	switch joined {
+	case "", ".", "/", "..":
+		return false
+	}
+	if currentPath == "" {
+		return true
+	}
+	parent := filepath.Clean(currentPath)
+	return strings.HasPrefix(joined, parent+string(filepath.Separator))
 }
 
 // ArchiveGenerator generates *archive.Archive values.

--- a/sdk/go/common/resource/testing/rapid_test.go
+++ b/sdk/go/common/resource/testing/rapid_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	resourcetesting "github.com/pulumi/pulumi/sdk/v3/go/common/resource/testing"
+)
+
+func TestLiteralArchiveGeneratorProducesValidArchives(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		resourcetesting.LiteralArchiveGenerator(3).Draw(t, "archive")
+	})
+}


### PR DESCRIPTION
A bridge [CI
run](https://github.com/pulumi/pulumi-terraform-bridge/actions/runs/25910736549/job/76155187969) failed due to the rapid generator `LiteralArchiveGenerator` generating an invalid value. Turns out, we didn't guard against path escapes, so the invalid value (shown in `TestBadArchiveOfAssets`) was generated.

This PR makes the generator careful to not generate invalid values there.