### PR TITLE
Fix duplicated "the" in source comments and helper script

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1118,7 +1118,7 @@ func (display *ProgressDisplay) processTick() {
 }
 
 func (display *ProgressDisplay) getRowForURN(urn resource.URN, metadata *engine.StepEventMetadata) ResourceRow {
-	// Take the write lock here because this can write the the eventUrnToResourceRow map
+	// Take the write lock here because this can write the eventUrnToResourceRow map
 	display.eventMutex.Lock()
 	defer display.eventMutex.Unlock()
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -2429,7 +2429,7 @@ func (s *ViewStep) ResultOp() display.StepOp {
 func (s *ViewStep) Apply() (resource.Status, StepCompleteFunc, error) {
 	// ViewStep is a special step that that represents an operation for a view resource.
 	// It doesn't actually do anything in Apply. It's used to flow the step through the
-	// system for display in the UI and so the the result of the operation is recorded
+	// system for display in the UI and so the result of the operation is recorded
 	// in the state.
 
 	if s.error != "" {

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -179,7 +179,7 @@ func (dg *DependencyGraph) OnlyDependsOn(res *resource.State) []*resource.State 
 	// the list. All resources that depend directly or indirectly on `res` are prepended
 	// onto `dependents`.
 	//
-	// We also walk through the the list of resources before the requested resource, as resources
+	// We also walk through the list of resources before the requested resource, as resources
 	// sorted later could still be dependent on the requested resource.
 	for i := 0; i < cursorIndex; i++ {
 		candidate := dg.resources[i]

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -138,7 +138,7 @@ ALL_PLATFORMS = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
 
 # When updating the minumum and current versions, consider also updating the
-# versions in the the pulumi-docker-containers repo by updating the file
+# versions in the pulumi-docker-containers repo by updating the file
 # https://github.com/pulumi/pulumi-docker-containers/blob/main/.github/scripts/matrix/versions.py
 
 ALL_VERSION_SET = {

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -248,7 +248,7 @@ async function invokeAsync(
         const monitor: any = getMonitor();
 
         const provider = await ProviderResource.register(getProvider(tok, opts));
-        // keep track of the the secretness of the inputs
+        // keep track of the secretness of the inputs
         // if any of the inputs are secret, the invoke response should be marked as secret
         const [plainInputs, inputsContainSecrets] = unwrapSecretValues(serialized);
         const req = await createInvokeRequest(tok, plainInputs, provider, opts, packageRef);


### PR DESCRIPTION
Fixes 5 `the the` duplicated-word typos in source comments / helper scripts:

- `pkg/resource/graph/dependency_graph.go` (line 182)
- `sdk/nodejs/runtime/invoke.ts` (line 251)
- `pkg/resource/deploy/step.go` (line 2432)
- `pkg/backend/display/progress.go` (line 1121)
- `scripts/get-job-matrix.py` (line 141)

All edits are inside comments; no runtime behavior changes. `git diff --check` is clean. Commit is DCO-signed.