### PR TITLE
Add a custom linter for `go.abhg.dev/requiredfield`

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,12 @@
+# Builds a custom golangci-lint binary that includes the requiredfield
+# linter as a module plugin. The version below must match
+# GOLANGCI_LINT_VERSION in .github/workflows/ci-lint.yml.
+#
+# Build with: golangci-lint custom
+# Result:     bin/custom-gcl
+version: v2.9.0
+name: custom-gcl
+destination: ./bin
+plugins:
+  - module: github.com/pulumi/pulumi/.golangci/plugins/requiredfield
+    path: ./.golangci/plugins/requiredfield

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -17,8 +17,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Must match the `version:` field in .custom-gcl.yml.
   GOLANGCI_LINT_VERSION: v2.9.0
-  REQUIREDFIELD_VERSION: v0.8.0
 
 jobs:
   golangci:
@@ -46,9 +46,6 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --help
-
-      - name: Install requiredfield
-        run: go install go.abhg.dev/requiredfield/cmd/requiredfield@${{ env.REQUIREDFIELD_VERSION }}
 
       - name: Run golangci-lint
         run: make lint_golang

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,12 @@ linters:
     - whitespace
     - copyloopvar
     - gocritic
+    - requiredfield
   settings:
+    custom:
+      requiredfield:
+        type: module
+        description: Checks that required fields are set in struct literals (see go.abhg.dev/requiredfield)
     usetesting:
       os-temp-dir: true
       context-background: true

--- a/.golangci/plugins/requiredfield/go.mod
+++ b/.golangci/plugins/requiredfield/go.mod
@@ -1,0 +1,9 @@
+module github.com/pulumi/pulumi/.golangci/plugins/requiredfield
+
+go 1.23.0
+
+require (
+	github.com/golangci/plugin-module-register v0.1.1
+	go.abhg.dev/requiredfield v0.8.0
+	golang.org/x/tools v0.31.0
+)

--- a/.golangci/plugins/requiredfield/go.sum
+++ b/.golangci/plugins/requiredfield/go.sum
@@ -1,0 +1,10 @@
+github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
+github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
+go.abhg.dev/requiredfield v0.8.0 h1:JNER5vdEKnz9u+F+VarhMylG7k/sKqTvAyU9h/Q8x/Y=
+go.abhg.dev/requiredfield v0.8.0/go.mod h1:gR5JiEwmaFbNdh8/3roAnEiHMVBjuJB70O2rmVHryXo=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=

--- a/.golangci/plugins/requiredfield/plugin.go
+++ b/.golangci/plugins/requiredfield/plugin.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package requiredfield wraps go.abhg.dev/requiredfield as a golangci-lint
+// module plugin. Upstream exposes a standard analysis.Analyzer but does not
+// itself register with the plugin-module-register package, so we adapt it
+// here. See .custom-gcl.yml for how the plugin is wired into the custom
+// golangci-lint binary.
+package requiredfield
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"go.abhg.dev/requiredfield"
+	"golang.org/x/tools/go/analysis"
+)
+
+func init() {
+	register.Plugin("requiredfield", New)
+}
+
+func New(any) (register.LinterPlugin, error) {
+	return &plugin{}, nil
+}
+
+type plugin struct{}
+
+func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{requiredfield.Analyzer}, nil
+}
+
+func (p *plugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}

--- a/Makefile
+++ b/Makefile
@@ -166,21 +166,31 @@ lint_pulumi_json_fix::
 
 lint_fix:: lint_golang_fix lint_pulumi_json_fix
 
+# bin/custom-gcl is a golangci-lint binary with the requiredfield linter
+# baked in as a module plugin. Built from .custom-gcl.yml and the wrapper
+# under .golangci/plugins/requiredfield/.
+CUSTOM_GCL := bin/custom-gcl
+CUSTOM_GCL_DEPS := .custom-gcl.yml \
+		   .golangci/plugins/requiredfield/go.mod \
+		   .golangci/plugins/requiredfield/go.sum \
+		   .golangci/plugins/requiredfield/plugin.go
+
+$(CUSTOM_GCL): $(CUSTOM_GCL_DEPS) .make/ensure/golangci-lint
+	golangci-lint custom
+
 define lint_golang_pkg
 	@echo "[golangci-lint] Linting $(1)..."
-	@(cd $(1) && golangci-lint run $(GOLANGCI_LINT_ARGS) \
+	@(cd $(1) && $(abspath $(CUSTOM_GCL)) run $(GOLANGCI_LINT_ARGS) \
 			--config $(GOLANGCI_LINT_CONFIG) \
 			--max-same-issues 0 \
 			--max-issues-per-linter 0 \
 			--timeout 5m)
-	@echo "[requiredfield] Linting $(1)..."
-	@(cd $(1) && go vet -tags all -vettool=$$(which requiredfield) github.com/pulumi/pulumi/$(1)/...)
 
 endef
 
 .PHONY: lint_golang lint_golang_fix
 lint_golang: GOLANGCI_LINT_CONFIG=$(shell pwd)/.golangci.yml
-lint_golang: .make/ensure/golangci-lint .make/ensure/requiredfield
+lint_golang: $(CUSTOM_GCL)
 	$(foreach pkg,$(LINT_GOLANG_PKGS),$(call lint_golang_pkg,${pkg}))
 
 lint_golang_fix: GOLANGCI_LINT_ARGS=--fix


### PR DESCRIPTION
This allows us to run a full type-checking linter over our binary once, instead of twice for each invocation of `make lint_golang`.


```
𝛌 hyperfine 'make lint_golang' // On this branch
Benchmark 1: make lint_golang
  Time (mean ± σ):     12.333 s ±  1.191 s    [User: 17.652 s, System: 28.811 s]
  Range (min … max):   11.227 s … 15.044 s    10 runs
 
𝛌 hyperfine 'make lint_golang' --warmup 2 // On master
Benchmark 1: make lint_golang
  Time (mean ± σ):     20.135 s ±  0.318 s    [User: 37.838 s, System: 63.905 s]
  Range (min … max):   19.782 s … 20.720 s    10 runs
```