### PR TITLE
Fix schedule time round tripping

### DIFF
--- a/pkg/cmd/pulumi/stack/stack_schedule.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule.go
@@ -16,13 +16,34 @@ package stack
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
+
+// parseScheduleTimestamp normalizes a schedule timestamp to the ISO 8601 form the service's request expects. It accepts
+// either that form (what users type into --once) or the SQL-style "2006-01-02 15:04:05.000" format the Cloud API
+// returns in response bodies
+func parseScheduleTimestamp(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.UTC().Format(time.RFC3339), nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04:05.999", s, time.UTC); err == nil {
+		return t.Format(time.RFC3339), nil
+	}
+	return "", fmt.Errorf(
+		"invalid timestamp %q: must be ISO 8601 (e.g. 2026-12-31T23:59:00Z)", s,
+	)
+}
 
 const (
 	scheduleKindRaw   = "raw"

--- a/pkg/cmd/pulumi/stack/stack_schedule_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_edit.go
@@ -189,7 +189,10 @@ func runStackScheduleEdit(
 		req := buildDriftEditRequest(existing, flags)
 		_, err = c.UpdateStackDriftSchedule(ctx, stackID, scheduleID, req)
 	case scheduleKindTTL:
-		req := buildTTLEditRequest(existing, flags)
+		req, buildErr := buildTTLEditRequest(existing, flags)
+		if buildErr != nil {
+			return buildErr
+		}
 		_, err = c.UpdateStackTTLSchedule(ctx, stackID, scheduleID, req)
 	default:
 		return fmt.Errorf("cannot edit schedule of kind %q", kind)
@@ -264,6 +267,13 @@ func buildRawEditRequest(
 		once = flags.once
 		cron = ""
 	}
+	once, err := parseScheduleTimestamp(once)
+	if err != nil {
+		if flags.onceChanged {
+			return apitype.CreateScheduledDeploymentRequest{}, fmt.Errorf("--once %w", err)
+		}
+		return apitype.CreateScheduledDeploymentRequest{}, err
+	}
 
 	existingReq, err := existingDeploymentRequest(existing)
 	if err != nil {
@@ -309,10 +319,17 @@ func buildDriftEditRequest(
 // The TTL update endpoint rewrites the entire definition on every call.
 func buildTTLEditRequest(
 	existing apitype.ScheduledAction, flags stackScheduleEditFlags,
-) apitype.CreateScheduledTTLDeploymentRequest {
+) (apitype.CreateScheduledTTLDeploymentRequest, error) {
 	once := existing.ScheduleOnce
 	if flags.onceChanged {
 		once = flags.once
+	}
+	once, err := parseScheduleTimestamp(once)
+	if err != nil {
+		if flags.onceChanged {
+			return apitype.CreateScheduledTTLDeploymentRequest{}, fmt.Errorf("--once %w", err)
+		}
+		return apitype.CreateScheduledTTLDeploymentRequest{}, err
 	}
 	deleteAfterDestroy := existingDeleteAfterDestroy(existing)
 	if flags.deleteAfterDestroyChanged {
@@ -321,7 +338,7 @@ func buildTTLEditRequest(
 	return apitype.CreateScheduledTTLDeploymentRequest{
 		Timestamp:          once,
 		DeleteAfterDestroy: deleteAfterDestroy,
-	}
+	}, nil
 }
 
 func parseRawOperation(s string) (apitype.PulumiOperation, error) {

--- a/pkg/cmd/pulumi/stack/stack_schedule_edit_test.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_edit_test.go
@@ -327,6 +327,57 @@ func TestStackScheduleEdit_GetError(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestStackScheduleEdit_TTL_NormalizesExistingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	existing := ttlSchedule(t)
+	existing.ScheduleOnce = "2026-12-31 23:59:00.000"
+	c := &mockScheduleEditClient{existing: existing}
+
+	flags := stackScheduleEditFlags{deleteAfterDestroy: false, deleteAfterDestroyChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "ttl-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotTTLReq)
+	assert.Equal(t, "2026-12-31T23:59:00Z", c.gotTTLReq.Timestamp)
+}
+
+func TestStackScheduleEdit_Raw_NormalizesExistingTimestamp(t *testing.T) {
+	t.Parallel()
+
+	existing := apitype.ScheduledAction{
+		ID:           "raw-id",
+		ScheduleOnce: "2026-12-31 23:59:00.000",
+		Kind:         apitype.ScheduledActionKindDeployment,
+		Definition:   defWithOpts(t, apitype.Refresh, nil),
+	}
+	c := &mockScheduleEditClient{existing: existing}
+
+	flags := stackScheduleEditFlags{operation: "update", operationChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "raw-id", flags, renderScheduleGetText,
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, c.gotRawReq)
+	assert.Equal(t, "2026-12-31T23:59:00Z", c.gotRawReq.ScheduleOnce)
+}
+
+func TestStackScheduleEdit_TTL_RejectsInvalidOnce(t *testing.T) {
+	t.Parallel()
+
+	c := &mockScheduleEditClient{existing: ttlSchedule(t)}
+	flags := stackScheduleEditFlags{once: "not-a-timestamp", onceChanged: true}
+	err := runStackScheduleEdit(
+		t.Context(), &bytes.Buffer{}, editClientFactory(c), "", "ttl-id", flags, renderScheduleGetText,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--once invalid timestamp")
+	assert.Nil(t, c.gotTTLReq)
+}
+
 func TestStackScheduleEdit_NoFlags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/stack/stack_schedule_new.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_new.go
@@ -234,14 +234,6 @@ func nonEmptyValidator(what string) func(string) error {
 	}
 }
 
-func timestampValidator(v string) error {
-	if strings.TrimSpace(v) == "" {
-		return errors.New("a timestamp is required")
-	}
-	_, err := parseScheduleTimestamp(v)
-	return err
-}
-
 func defaultStackScheduleNewClientFactory(
 	ctx context.Context, stackFlag string,
 ) (stackScheduleNewClient, client.StackIdentifier, error) {

--- a/pkg/cmd/pulumi/stack/stack_schedule_new.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_new.go
@@ -234,6 +234,14 @@ func nonEmptyValidator(what string) func(string) error {
 	}
 }
 
+func timestampValidator(v string) error {
+	if strings.TrimSpace(v) == "" {
+		return errors.New("a timestamp is required")
+	}
+	_, err := parseScheduleTimestamp(v)
+	return err
+}
+
 func defaultStackScheduleNewClientFactory(
 	ctx context.Context, stackFlag string,
 ) (stackScheduleNewClient, client.StackIdentifier, error) {
@@ -250,6 +258,14 @@ func runStackScheduleNew(
 	kind := strings.ToLower(strings.TrimSpace(args.kind))
 	if err := validateScheduleNewArgs(kind, args); err != nil {
 		return err
+	}
+
+	if args.once != "" {
+		normalized, err := parseScheduleTimestamp(args.once)
+		if err != nil {
+			return fmt.Errorf("--once %w", err)
+		}
+		args.once = normalized
 	}
 
 	c, stackID, err := factory(ctx, args.stack)

--- a/pkg/cmd/pulumi/stack/stack_schedule_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_new_test.go
@@ -265,6 +265,18 @@ func TestStackScheduleNew_ValidationErrors(t *testing.T) {
 			args: stackScheduleNewArgs{kind: "weekly"},
 			want: "invalid --kind",
 		},
+		{
+			name: "ttl invalid once",
+			args: stackScheduleNewArgs{kind: scheduleKindTTL, once: "not-a-timestamp"},
+			want: "--once invalid timestamp",
+		},
+		{
+			name: "raw invalid once",
+			args: stackScheduleNewArgs{
+				kind: scheduleKindRaw, operation: "update", once: "not-a-timestamp",
+			},
+			want: "--once invalid timestamp",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The service expects a time in ISO8601, but returns a different format. Make sure we round trip this properly when editing schedules.

Service issue https://github.com/pulumi/pulumi-service/issues/43334

