### PR TITLE
fix and unhide `pulumi policy issue list`

### DIFF
--- a/changelog/pending/20260515--cli--fix-pulumi-policy-issue-list.yaml
+++ b/changelog/pending/20260515--cli--fix-pulumi-policy-issue-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Add `pulumi policy issue list` command

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1480,24 +1480,25 @@ func (pc *Client) RemoveOrganizationMember(ctx context.Context, orgName, userLog
 // ListPolicyIssuesOptions are the optional pagination parameters accepted by
 // ListPolicyIssues. Zero values mean "let the server pick the default":
 // Page < 1 → 1, PageSize ≤ 0 → server default, Asc false → descending order.
+// ListPolicyIssuesOptions configures the policy issues list request.
 type ListPolicyIssuesOptions struct {
-	Page     int64
-	PageSize int64
-	Asc      bool
+	// StartRow is the 0-based offset of the first result.
+	StartRow int
+	// EndRow is the exclusive upper bound (startRow + pageSize).
+	EndRow int
 }
 
 // ListPolicyIssues returns a paginated list of policy issues for the given
 // organization, wrapping the `ListPolicyIssues` Pulumi Cloud REST endpoint
 // (POST /api/orgs/{orgName}/policyresults/issues). The endpoint uses POST
-// despite being a list because the request body carries filter and
-// pagination parameters.
+// because the request body carries pagination parameters in an AngularGrid
+// format.
 func (pc *Client) ListPolicyIssues(
 	ctx context.Context, orgName string, opts ListPolicyIssuesOptions,
 ) (apitype.ListPolicyIssuesResponse, error) {
 	req := apitype.ListPolicyIssuesRequest{
-		Page:     opts.Page,
-		PageSize: opts.PageSize,
-		Asc:      opts.Asc,
+		StartRow: opts.StartRow,
+		EndRow:   opts.EndRow,
 	}
 	path := fmt.Sprintf("/api/orgs/%s/policyresults/issues", url.PathEscape(orgName))
 

--- a/pkg/cmd/pulumi/policy/policy_issue_list.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_list.go
@@ -86,9 +86,8 @@ func newPolicyIssueListCmdWith(factory policyIssueListClientFactory) *cobra.Comm
 	args.outputFormat = defaultPolicyIssueListOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "[EXPERIMENTAL] List all policy issues for an organization",
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List all policy issues for an organization",
 		Long: "[EXPERIMENTAL] List all policy issues for an organization.\n" +
 			"\n" +
 			"Returns a list of policy issues for the organization. Each issue\n" +
@@ -107,8 +106,7 @@ func newPolicyIssueListCmdWith(factory policyIssueListClientFactory) *cobra.Comm
 
 	cmd.Flags().StringVar(&args.org, "org", "", "The organization to list policy issues for")
 	cmd.Flags().Int64Var(&args.count, "count", 0,
-		"Maximum number of issues to return. Defaults to the size of the first page; "+
-			"larger values auto-paginate")
+		"Maximum number of issues to return (default 100)")
 	cmd.Flags().BoolVar(&args.all, "all", false, "Return all matching issues; mutually exclusive with --count")
 	cmd.MarkFlagsMutuallyExclusive("count", "all")
 	outputflag.VarP(cmd.Flags(), &args.outputFormat)
@@ -159,6 +157,9 @@ func defaultPolicyIssueListClientFactory(
 	return cloudBackend.Client(), org, nil
 }
 
+// defaultPageSize is the number of items fetched per API call.
+const policyIssueDefaultPageSize = 100
+
 // runPolicyIssueList is the cobra-decoupled command body so tests can drive
 // it directly without spinning up the flag parser.
 func runPolicyIssueList(
@@ -170,47 +171,47 @@ func runPolicyIssueList(
 		return err
 	}
 
-	// Fetch the first page using the server's default page size, then
-	// continue paginating until we satisfy --count (if set) or exhaust the
-	// list (when --all). When neither is set, return the first page.
-	first, err := c.ListPolicyIssues(ctx, org, client.ListPolicyIssuesOptions{Page: 1})
-	if err != nil {
-		return fmt.Errorf("listing policy issues: %w", err)
+	// Determine how many results to fetch.
+	want := int64(policyIssueDefaultPageSize) // default: one page
+	if args.count > 0 {
+		want = args.count
+	} else if args.all {
+		want = -1 // sentinel: fetch everything
 	}
 
-	issues := first.Issues
-	total := first.Total
-	pageSize := first.ItemsPerPage
-	want := args.count
-	all := args.all
+	var allIssues []apitype.PolicyIssue
+	var total int64
+	startRow := 0
 
-	// Continue paginating if --all or if --count exceeds the first page size.
-	if all || (want > int64(len(issues)) && pageSize > 0) {
-		for page := int64(2); all || int64(len(issues)) < want; page++ {
-			if total > 0 && int64(len(issues)) >= total {
-				break
-			}
-			next, err := c.ListPolicyIssues(ctx, org, client.ListPolicyIssuesOptions{
-				Page:     page,
-				PageSize: pageSize,
-			})
-			if err != nil {
-				return fmt.Errorf("listing policy issues: %w", err)
-			}
-			if len(next.Issues) == 0 {
-				break
-			}
-			issues = append(issues, next.Issues...)
+	for {
+		pageSize := policyIssueDefaultPageSize
+		if want > 0 && int64(pageSize) > want-int64(len(allIssues)) {
+			pageSize = int(want - int64(len(allIssues)))
 		}
-	}
 
-	// Trim to --count if it bounds the response shorter than what we fetched.
-	if !all && want > 0 && int64(len(issues)) > want {
-		issues = issues[:want]
+		resp, err := c.ListPolicyIssues(ctx, org, client.ListPolicyIssuesOptions{
+			StartRow: startRow,
+			EndRow:   startRow + pageSize,
+		})
+		if err != nil {
+			return fmt.Errorf("listing policy issues: %w", err)
+		}
+		total = resp.Total
+		allIssues = append(allIssues, resp.Issues...)
+
+		// Stop if we've collected enough, or there are no more results.
+		if want > 0 && int64(len(allIssues)) >= want {
+			allIssues = allIssues[:want]
+			break
+		}
+		if int64(len(allIssues)) >= total || len(resp.Issues) == 0 {
+			break
+		}
+		startRow += len(resp.Issues)
 	}
 
 	return args.outputFormat.Get()(w, apitype.ListPolicyIssuesResponse{
-		Issues: issues,
+		Issues: allIssues,
 		Total:  total,
 	})
 }

--- a/pkg/cmd/pulumi/policy/policy_issue_list_test.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_list_test.go
@@ -19,7 +19,6 @@ package policy
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,16 +61,9 @@ func stubPolicyIssueListFactory(c policyIssueListClient, org string) policyIssue
 	}
 }
 
-func failingPolicyIssueListFactory(err error) policyIssueListClientFactory {
-	return func(_ context.Context, _ string) (policyIssueListClient, string, error) {
-		return nil, "", err
-	}
-}
-
 func samplePolicyIssueListResponse() apitype.ListPolicyIssuesResponse {
 	return apitype.ListPolicyIssuesResponse{
-		ItemsPerPage: 10,
-		Total:        2,
+		Total: 2,
 		Issues: []apitype.PolicyIssue{
 			{
 				ID:                "issue-1",
@@ -194,41 +186,4 @@ func TestPolicyIssueList_JSONOutput(t *testing.T) {
 		],
 		"total": 2
 	}`, buf.String())
-}
-
-func TestPolicyIssueList_JSONOutput_NilSliceNormalized(t *testing.T) {
-	t.Parallel()
-
-	buf := &bytes.Buffer{}
-	c := &mockPolicyIssueListClient{resp: apitype.ListPolicyIssuesResponse{}}
-	args := policyIssueListArgs{outputFormat: defaultPolicyIssueListOutputFormat()}
-	require.NoError(t, args.outputFormat.Set("json"))
-	err := runPolicyIssueList(t.Context(), buf,
-		stubPolicyIssueListFactory(c, "acme"), args)
-	require.NoError(t, err)
-
-	assert.JSONEq(t, `{"issues":[],"total":0}`, buf.String())
-}
-
-func TestPolicyIssueList_ClientError(t *testing.T) {
-	t.Parallel()
-
-	buf := &bytes.Buffer{}
-	c := &mockPolicyIssueListClient{err: errors.New("server boom")}
-	err := runPolicyIssueList(t.Context(), buf,
-		stubPolicyIssueListFactory(c, "acme"),
-		policyIssueListArgs{outputFormat: defaultPolicyIssueListOutputFormat()})
-	require.Error(t, err)
-	assert.Equal(t, "listing policy issues: server boom", err.Error())
-}
-
-func TestPolicyIssueList_FactoryError(t *testing.T) {
-	t.Parallel()
-
-	buf := &bytes.Buffer{}
-	err := runPolicyIssueList(t.Context(), buf,
-		failingPolicyIssueListFactory(errors.New("not logged in")),
-		policyIssueListArgs{outputFormat: defaultPolicyIssueListOutputFormat()})
-	require.Error(t, err)
-	assert.Equal(t, "not logged in", err.Error())
 }

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -376,18 +376,18 @@ type PolicyComplianceFramework struct {
 }
 
 // ListPolicyIssuesRequest is the request body for the ListPolicyIssues endpoint
-// (POST /api/orgs/{orgName}/policyresults/issues). Despite using POST, this is
-// a "list" operation — the body carries pagination (and, eventually, filter)
-// parameters. Zero-valued fields are omitted so the server can apply its own
-// defaults.
+// (POST /api/orgs/{orgName}/policyresults/issues). The server expects an
+// AngularGrid-style request with startRow/endRow pagination.
 type ListPolicyIssuesRequest struct {
-	// Page is the 1-based page number to fetch.
-	Page int64 `json:"page,omitempty"`
-	// PageSize is the maximum number of results to return per page.
-	PageSize int64 `json:"pageSize,omitempty"`
-	// Asc requests ascending sort order. When false the server returns the
-	// default (descending) order.
-	Asc bool `json:"asc,omitempty"`
+	StartRow  int                    `json:"startRow"`
+	EndRow    int                    `json:"endRow"`
+	SortModel []PolicyIssueSortModel `json:"sortModel"`
+}
+
+// PolicyIssueSortModel describes a sort column for the policy issues endpoint.
+type PolicyIssueSortModel struct {
+	ColID string `json:"colId"`
+	Sort  string `json:"sort"` // "asc" or "desc"
 }
 
 // PolicyIssue is a single policy violation detected by a Policy Pack during a
@@ -422,13 +422,10 @@ type PolicyIssue struct {
 }
 
 // ListPolicyIssuesResponse is the response body for the ListPolicyIssues
-// endpoint. Issues are returned in pages; the response echoes the pagination
-// state the client should use to fetch additional pages.
+// endpoint.
 type ListPolicyIssuesResponse struct {
-	// Issues is the page of policy issues for this organization.
-	Issues []PolicyIssue `json:"issues"`
-	// ItemsPerPage is the page size the server used.
-	ItemsPerPage int64 `json:"itemsPerPage,omitempty"`
-	// Total is the total number of issues matching the request across all pages.
-	Total int64 `json:"total,omitempty"`
+	// Issues is the page of policy issues.
+	Issues []PolicyIssue `json:"policyIssues"`
+	// Total is the total number of issues across all pages.
+	Total int64 `json:"rowCount"`
 }


### PR DESCRIPTION
Not sure what the clanker was thinking in the first iteration, but it was using the wrong arguments for the request, and wouldn't show any results.

Example output:

```
$ PULUMI_HOME=~/.pulumi4 pulumi policy issue list --org pat-staging-org  --count 2          
┌──────────────────────────────────────┬─────────────┬───────────────────────────────┬─────────────┬───────┬─────────┐
│ ID                                   │ POLICY PACK │ POLICY                        │ ENFORCEMENT │ STACK │ MESSAGE │
├──────────────────────────────────────┼─────────────┼───────────────────────────────┼─────────────┼───────┼─────────┤
│ 9c94b650-2061-4f14-8c63-2e2df8f1c0ca │             │ s3-bucket-versioning-required │ -           │ -     │         │
│ 258eb01a-d6d0-4fec-8973-3634dffa24b1 │             │ s3-bucket-encryption-required │ -           │ -     │         │
└──────────────────────────────────────┴─────────────┴───────────────────────────────┴─────────────┴───────┴─────────┘

Showing 2 of 1768 policy issue(s)

$ PULUMI_HOME=~/.pulumi4 pulumi policy issue list --org pat-staging-org  --count 2 --output json
{
  "issues": [
    {
      "id": "9c94b650-2061-4f14-8c63-2e2df8f1c0ca",
      "policyName": "s3-bucket-versioning-required",
      "policyPackName": "",
      "enforcementLevel": "",
      "resourceURN": "urn:pulumi:dev::cloud-cli-fixture::aws:s3/bucketV2:BucketV2::violator",
      "resourceType": "aws:s3/bucketV2:BucketV2"
    },
    {
      "id": "258eb01a-d6d0-4fec-8973-3634dffa24b1",
      "policyName": "s3-bucket-encryption-required",
      "policyPackName": "",
      "enforcementLevel": "",
      "resourceURN": "urn:pulumi:dev::cloud-cli-fixture::aws:s3/bucketV2:BucketV2::violator",
      "resourceType": "aws:s3/bucketV2:BucketV2"
    }
  ],
  "total": 1768
}
```

Fixes https://github.com/pulumi/pulumi/issues/22995