### PR TITLE
`l2-const-values` conformance test + PCL Fix

### DIFF
--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -299,6 +299,11 @@ func (t *ObjectType) conversionFrom(src Type, unifying bool, seen map[Type]struc
 			for k, dst := range t.Properties {
 				src, ok := src.Properties[k]
 				if !ok {
+					if IsConstType(dst) {
+						// Const values are implied — omitting them from a source object literal
+						// is allowed because the SDK is expected to fill the const value in.
+						continue
+					}
 					src = NoneType
 				}
 				if ck, why := dst.conversionFrom(src, unifying, seen); ck < conversionKind {

--- a/pkg/pcl/runtime/convert.go
+++ b/pkg/pcl/runtime/convert.go
@@ -356,6 +356,8 @@ func applySchemaInputsInner(
 				return nil, fmt.Errorf("property %q: %w", key, err)
 			}
 			val = v
+		} else if prop.ConstValue != nil {
+			val = resource.NewPropertyValue(prop.ConstValue)
 		} else if prop.DefaultValue != nil {
 			val = resource.NewPropertyValue(prop.DefaultValue.Value)
 		} else {

--- a/pkg/testing/pulumi-test-language/providers/const_values_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/const_values_provider.go
@@ -1,0 +1,283 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// ConstValuesProvider exercises properties that carry a `const` value in the
+// schema. Const properties are present at every nesting level the schema
+// supports: directly on a resource/function input, inside an object property,
+// inside the items of an array property, and inside the values of a map
+// property.
+type ConstValuesProvider struct {
+	plugin.UnimplementedProvider
+}
+
+var _ plugin.Provider = (*ConstValuesProvider)(nil)
+
+const (
+	directConstValue = "direct-const"
+	nestedConstValue = "nested-const"
+)
+
+func (p *ConstValuesProvider) Pkg() tokens.Package {
+	return "const-values"
+}
+
+func (ConstValuesProvider) version() semver.Version {
+	return semver.Version{Major: 40}
+}
+
+func (p *ConstValuesProvider) Close() error {
+	return nil
+}
+
+func (p *ConstValuesProvider) Configure(
+	context.Context, plugin.ConfigureRequest,
+) (plugin.ConfigureResponse, error) {
+	return plugin.ConfigureResponse{}, nil
+}
+
+func (p *ConstValuesProvider) GetPluginInfo(context.Context) (plugin.PluginInfo, error) {
+	return plugin.PluginInfo{Version: ref(p.version())}, nil
+}
+
+func (p *ConstValuesProvider) SignalCancellation(context.Context) error {
+	return nil
+}
+
+func (p *ConstValuesProvider) GetMapping(
+	context.Context, plugin.GetMappingRequest,
+) (plugin.GetMappingResponse, error) {
+	return plugin.GetMappingResponse{}, nil
+}
+
+func (p *ConstValuesProvider) GetMappings(
+	context.Context, plugin.GetMappingsRequest,
+) (plugin.GetMappingsResponse, error) {
+	return plugin.GetMappingsResponse{}, nil
+}
+
+func (p *ConstValuesProvider) DiffConfig(
+	context.Context, plugin.DiffConfigRequest,
+) (plugin.DiffConfigResponse, error) {
+	return plugin.DiffResult{}, nil
+}
+
+func (p *ConstValuesProvider) Diff(
+	context.Context, plugin.DiffRequest,
+) (plugin.DiffResponse, error) {
+	return plugin.DiffResult{}, nil
+}
+
+func (p *ConstValuesProvider) Delete(
+	context.Context, plugin.DeleteRequest,
+) (plugin.DeleteResponse, error) {
+	return plugin.DeleteResponse{}, nil
+}
+
+func (p *ConstValuesProvider) GetSchema(
+	context.Context, plugin.GetSchemaRequest,
+) (plugin.GetSchemaResponse, error) {
+	nested := schema.ObjectTypeSpec{
+		Type: "object",
+		Properties: map[string]schema.PropertySpec{
+			"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			"constInNested": {
+				TypeSpec: schema.TypeSpec{Type: "string"},
+				Const:    nestedConstValue,
+			},
+		},
+		Required: []string{"value", "constInNested"},
+	}
+
+	nestedRef := schema.TypeSpec{Type: "ref", Ref: "#/types/const-values:index:Nested"}
+
+	properties := map[string]schema.PropertySpec{
+		"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+		"directConst": {
+			TypeSpec: schema.TypeSpec{Type: "string"},
+			Const:    directConstValue,
+		},
+		"nested": {TypeSpec: nestedRef},
+		"arrayItems": {
+			TypeSpec: schema.TypeSpec{Type: "array", Items: &nestedRef},
+		},
+		"mapItems": {
+			TypeSpec: schema.TypeSpec{Type: "object", AdditionalProperties: &nestedRef},
+		},
+	}
+	required := []string{"name", "directConst", "nested", "arrayItems", "mapItems"}
+
+	pkg := schema.PackageSpec{
+		Name:    string(p.Pkg()),
+		Version: p.version().String(),
+		Types: map[string]schema.ComplexTypeSpec{
+			"const-values:index:Nested": {ObjectTypeSpec: nested},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"const-values:index:Resource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type:       "object",
+					Properties: properties,
+					Required:   required,
+				},
+				InputProperties: properties,
+				RequiredInputs:  required,
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"const-values:index:applyConst": {
+				Inputs: &schema.ObjectTypeSpec{
+					Type:       "object",
+					Properties: properties,
+					Required:   required,
+				},
+				ReturnType: &schema.ReturnTypeSpec{
+					ObjectTypeSpec: &schema.ObjectTypeSpec{
+						Type:       "object",
+						Properties: properties,
+						Required:   required,
+					},
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(pkg)
+	return plugin.GetSchemaResponse{Schema: jsonBytes}, err
+}
+
+func (p *ConstValuesProvider) CheckConfig(
+	_ context.Context, req plugin.CheckConfigRequest,
+) (plugin.CheckConfigResponse, error) {
+	return plugin.CheckConfigResponse{Properties: req.News}, nil
+}
+
+func validateInputs(props resource.PropertyMap) []plugin.CheckFailure {
+	directConst, ok := props["directConst"]
+	if !ok {
+		return makeCheckFailure("directConst", "missing required property")
+	}
+	if !directConst.IsString() || directConst.StringValue() != directConstValue {
+		return makeCheckFailure("directConst", fmt.Sprintf("expected %q, got %#v", directConstValue, directConst))
+	}
+
+	validateNested := func(key resource.PropertyKey, obj resource.PropertyValue) []plugin.CheckFailure {
+		if !obj.IsObject() {
+			return makeCheckFailure(key, "expected an object")
+		}
+		m := obj.ObjectValue()
+		c, ok := m["constInNested"]
+		if !ok {
+			return makeCheckFailure(key, "missing constInNested")
+		}
+		if !c.IsString() || c.StringValue() != nestedConstValue {
+			return makeCheckFailure(key, fmt.Sprintf("expected constInNested %q, got %#v", nestedConstValue, c))
+		}
+		return nil
+	}
+
+	nested, ok := props["nested"]
+	if !ok {
+		return makeCheckFailure("nested", "missing required property")
+	}
+	if failures := validateNested("nested", nested); failures != nil {
+		return failures
+	}
+
+	arrayItems, ok := props["arrayItems"]
+	if !ok {
+		return makeCheckFailure("arrayItems", "missing required property")
+	}
+	if !arrayItems.IsArray() {
+		return makeCheckFailure("arrayItems", "expected an array")
+	}
+	for i, item := range arrayItems.ArrayValue() {
+		if failures := validateNested(resource.PropertyKey(fmt.Sprintf("arrayItems[%d]", i)), item); failures != nil {
+			return failures
+		}
+	}
+
+	mapItems, ok := props["mapItems"]
+	if !ok {
+		return makeCheckFailure("mapItems", "missing required property")
+	}
+	if !mapItems.IsObject() {
+		return makeCheckFailure("mapItems", "expected a map")
+	}
+	for k, v := range mapItems.ObjectValue() {
+		if failures := validateNested("mapItems."+k, v); failures != nil {
+			return failures
+		}
+	}
+
+	return nil
+}
+
+func (p *ConstValuesProvider) Check(
+	_ context.Context, req plugin.CheckRequest,
+) (plugin.CheckResponse, error) {
+	if req.URN.Type() != "const-values:index:Resource" {
+		return plugin.CheckResponse{
+			Failures: makeCheckFailure("", fmt.Sprintf("invalid URN type: %s", req.URN.Type())),
+		}, nil
+	}
+	if failures := validateInputs(req.News); failures != nil {
+		return plugin.CheckResponse{Failures: failures}, nil
+	}
+	return plugin.CheckResponse{Properties: req.News}, nil
+}
+
+func (p *ConstValuesProvider) Create(
+	_ context.Context, req plugin.CreateRequest,
+) (plugin.CreateResponse, error) {
+	if req.URN.Type() != "const-values:index:Resource" {
+		return plugin.CreateResponse{Status: resource.StatusUnknown},
+			fmt.Errorf("invalid URN type: %s", req.URN.Type())
+	}
+	id := resource.ID("id")
+	if req.Preview {
+		id = ""
+	}
+	return plugin.CreateResponse{
+		ID:         id,
+		Properties: req.Properties,
+		Status:     resource.StatusOK,
+	}, nil
+}
+
+func (p *ConstValuesProvider) Invoke(
+	_ context.Context, req plugin.InvokeRequest,
+) (plugin.InvokeResponse, error) {
+	if req.Tok != "const-values:index:applyConst" {
+		return plugin.InvokeResponse{}, fmt.Errorf("unknown function %v", req.Tok)
+	}
+	if failures := validateInputs(req.Args); failures != nil {
+		return plugin.InvokeResponse{Failures: failures}, nil
+	}
+	return plugin.InvokeResponse{Properties: req.Args}, nil
+}

--- a/pkg/testing/pulumi-test-language/tests/l2_const_values.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_const_values.go
@@ -1,0 +1,65 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	nested := func(value string) resource.PropertyValue {
+		return resource.NewProperty(resource.PropertyMap{
+			"value":         resource.NewProperty(value),
+			"constInNested": resource.NewProperty("nested-const"),
+		})
+	}
+
+	expectedInputs := resource.PropertyMap{
+		"name":        resource.NewProperty("example"),
+		"directConst": resource.NewProperty("direct-const"),
+		"nested":      nested("inner"),
+		"arrayItems": resource.NewProperty([]resource.PropertyValue{
+			nested("first"),
+			nested("second"),
+		}),
+		"mapItems": resource.NewProperty(resource.PropertyMap{
+			"one": nested("one-value"),
+			"two": nested("two-value"),
+		}),
+	}
+
+	LanguageTests["l2-const-values"] = LanguageTest{
+		Providers: []func() plugin.Provider{
+			func() plugin.Provider { return &providers.ConstValuesProvider{} },
+		},
+		Runs: []TestRun{{
+			Assert: func(l *L, res AssertArgs) {
+				RequireStackResource(l, res.Err, res.Changes)
+				require.Len(l, res.Snap.Resources, 3, "expected 3 resources in snapshot")
+
+				RequireSingleResource(l, res.Snap.Resources, "pulumi:providers:const-values")
+				instance := RequireSingleNamedResource(l, res.Snap.Resources, "instance")
+				require.Equal(l, expectedInputs, instance.Inputs, "resource inputs")
+				require.Equal(l, expectedInputs, instance.Outputs, "resource outputs")
+
+				stack := RequireSingleResource(l, res.Snap.Resources, "pulumi:pulumi:Stack")
+				AssertPropertyMapMember(l, stack.Outputs, "invokeResult", resource.NewProperty(expectedInputs))
+			},
+		}},
+	}
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-const-values/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-const-values/main.pp
@@ -1,0 +1,31 @@
+resource "instance" "const-values:index:Resource" {
+  name = "example"
+  nested = {
+    value = "inner"
+  }
+  arrayItems = [
+    { value = "first" },
+    { value = "second" },
+  ]
+  mapItems = {
+    one = { value = "one-value" }
+    two = { value = "two-value" }
+  }
+}
+
+output "invokeResult" {
+  value = invoke("const-values:index:applyConst", {
+    name = "example"
+    nested = {
+      value = "inner"
+    }
+    arrayItems = [
+      { value = "first" },
+      { value = "second" },
+    ]
+    mapItems = {
+      one = { value = "one-value" }
+      two = { value = "two-value" }
+    }
+  })
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -110,6 +110,7 @@ var expectedFailures = map[string]string{
 	"l2-resource-config-primitives": "cannot convert secretBool (variable of struct type pulumi.BoolOutput) to type pulumi.Bool, etc", //nolint:lll
 	"l2-resource-config-objects":    "cannot convert plainBooleanMap (variable of type string) to type pulumi.BoolMap",
 	"l2-discriminated-union":        "pulumi#21829: does not compile",
+	"l2-const-values":               "PCL binder rejects omitted const fields in nested object literals",
 
 	// pulumi/pulumi#18345
 	"l2-map-keys":                         "NonPlainData.InnerData renders as interface{}{} instead of &plain.InnerDataArgs{}",                                           //nolint:lll

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -101,6 +101,7 @@ var expectedFailures = map[string]string{
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
 	"l3-range-ref":                       "Property 'k1' does not exist on type 'Target[]'",
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
+	"l2-const-values":                    "PCL binder rejects omitted const fields in nested object literals",
 }
 
 // testLanguage runs the language conformance tests for the given runtime ("nodejs" or "bun").

--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -98,7 +98,6 @@ var expectedFailures = map[string]string{
 	"l3-component-nested": "nested component outputs are not propagated correctly",
 	"l2-resource-read":    "need to update pkg",
 	"l1-builtin-min-max":  "cannot pin the current commit",
-	"l2-const-values":     "PCL binder rejects omitted const fields in nested object literals",
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -98,6 +98,7 @@ var expectedFailures = map[string]string{
 	"l3-component-nested": "nested component outputs are not propagated correctly",
 	"l2-resource-read":    "need to update pkg",
 	"l1-builtin-min-max":  "cannot pin the current commit",
+	"l2-const-values":     "PCL binder rejects omitted const fields in nested object literals",
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-const-values
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/const-values.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/const-values.pp
@@ -1,0 +1,4 @@
+package "const-values" {
+  baseProviderName    = "const-values"
+  baseProviderVersion = "40.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-const-values/main.pp
@@ -1,0 +1,31 @@
+resource "instance" "const-values:index:Resource" {
+  name = "example"
+  nested = {
+    value = "inner"
+  }
+  arrayItems = [
+    { value = "first" },
+    { value = "second" },
+  ]
+  mapItems = {
+    one = { value = "one-value" }
+    two = { value = "two-value" }
+  }
+}
+
+output "invokeResult" {
+  value = invoke("const-values:index:applyConst", {
+    name = "example"
+    nested = {
+      value = "inner"
+    }
+    arrayItems = [
+      { value = "first" },
+      { value = "second" },
+    ]
+    mapItems = {
+      one = { value = "one-value" }
+      two = { value = "two-value" }
+    }
+  })
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-const-values
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/const-values.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/const-values.pp
@@ -1,0 +1,4 @@
+package "const-values" {
+  baseProviderName    = "const-values"
+  baseProviderVersion = "40.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-const-values/main.pp
@@ -1,0 +1,31 @@
+resource "instance" "const-values:index:Resource" {
+  name = "example"
+  nested = {
+    value = "inner"
+  }
+  arrayItems = [
+    { value = "first" },
+    { value = "second" },
+  ]
+  mapItems = {
+    one = { value = "one-value" }
+    two = { value = "two-value" }
+  }
+}
+
+output "invokeResult" {
+  value = invoke("const-values:index:applyConst", {
+    name = "example"
+    nested = {
+      value = "inner"
+    }
+    arrayItems = [
+      { value = "first" },
+      { value = "second" },
+    ]
+    mapItems = {
+      one = { value = "one-value" }
+      two = { value = "two-value" }
+    }
+  })
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-const-values
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/const-values.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/const-values.pp
@@ -1,0 +1,4 @@
+package "const-values" {
+  baseProviderName    = "const-values"
+  baseProviderVersion = "40.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-const-values/main.pp
@@ -1,0 +1,31 @@
+resource "instance" "const-values:index:Resource" {
+  name = "example"
+  nested = {
+    value = "inner"
+  }
+  arrayItems = [
+    { value = "first" },
+    { value = "second" },
+  ]
+  mapItems = {
+    one = { value = "one-value" }
+    two = { value = "two-value" }
+  }
+}
+
+output "invokeResult" {
+  value = invoke("const-values:index:applyConst", {
+    name = "example"
+    nested = {
+      value = "inner"
+    }
+    arrayItems = [
+      { value = "first" },
+      { value = "second" },
+    ]
+    mapItems = {
+      one = { value = "one-value" }
+      two = { value = "two-value" }
+    }
+  })
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/const-values-40.0.0/const-values-40.0.0.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/sdks/const-values-40.0.0/const-values-40.0.0.pp
@@ -1,0 +1,4 @@
+package "const-values" {
+  baseProviderName    = "const-values"
+  baseProviderVersion = "40.0.0"
+}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -107,6 +107,7 @@ var expectedFailures = map[string]string{
 	"l3-range-ref":                       `Item "None" of "Target | None" has no attribute "name"  [union-attr]`,
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll
 	"l3-component-nested":                "syntax error",
+	"l2-const-values":                    "PCL binder rejects omitted const fields in nested object literals",
 }
 
 type languageTestConfig struct {


### PR DESCRIPTION
Adds a `l2-const-values` conformance test, then gets the test working for PCL.