### PR TITLE
fix `pulumi policy group new` and unhide the command

### DIFF
--- a/changelog/pending/20260515--cli--add-pulumi-policy-group-new-command-to-allow-creating-new-policy-groups.yaml
+++ b/changelog/pending/20260515--cli--add-pulumi-policy-group-new-command-to-allow-creating-new-policy-groups.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi policy group new` command to allow creating new policy groups

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1285,8 +1285,9 @@ func (pc *Client) ListPolicyGroups(ctx context.Context, orgName string, inContTo
 }
 
 // CreatePolicyGroup creates a new Policy Group in the given organization.
-func (pc *Client) CreatePolicyGroup(ctx context.Context, orgName, name string) error {
-	req := apitype.CreatePolicyGroupRequest{Name: name}
+func (pc *Client) CreatePolicyGroup(
+	ctx context.Context, orgName string, req apitype.CreatePolicyGroupRequest,
+) error {
 	if err := pc.restCall(ctx, "POST", listPolicyGroupsPath(orgName), nil, req, nil); err != nil {
 		return fmt.Errorf("creating policy group: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_group_new.go
+++ b/pkg/cmd/pulumi/policy/policy_group_new.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"errors"
@@ -29,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -37,18 +36,16 @@ import (
 )
 
 // policyGroupNewClient is the narrow subset of cloud-API operations the new
-// command needs. It both creates the Policy Group and reads it back so the
-// command can print the resulting structure (per BEST_PRACTICES §1).
+// command needs.
 type policyGroupNewClient interface {
-	CreatePolicyGroup(ctx context.Context, orgName, name string) error
+	CreatePolicyGroup(ctx context.Context, orgName string, req apitype.CreatePolicyGroupRequest) error
 	GetPolicyGroup(
 		ctx context.Context, orgName, policyGroup string,
 	) (apitype.GetPolicyGroupResponse, error)
 }
 
 // policyGroupNewClientFactory resolves a cloud client and the organization the
-// new Policy Group will be created in. orgFlag carries the raw value of
-// `--org` (empty means "use the default org").
+// new Policy Group will be created in.
 type policyGroupNewClientFactory func(
 	ctx context.Context, orgFlag string,
 ) (policyGroupNewClient, string, error)
@@ -56,8 +53,17 @@ type policyGroupNewClientFactory func(
 // policyGroupNewArgs collects the flag values for the new command.
 type policyGroupNewArgs struct {
 	org          string
+	entityType   string
+	mode         string
+	agentPoolID  string
+	yes          bool
 	outputFormat outputflag.OutputFlag[policyGroupGetRenderFunc]
 }
+
+var (
+	validEntityTypes = []string{"stacks", "accounts"}
+	validModes       = []string{"audit", "preventative"}
+)
 
 // newPolicyGroupNewCmd builds `pulumi policy group new` with the production
 // client factory.
@@ -71,21 +77,26 @@ func newPolicyGroupNewCmdWith(factory policyGroupNewClientFactory) *cobra.Comman
 	args.outputFormat = defaultPolicyGroupGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new <name>",
-		Short:  "[EXPERIMENTAL] Create a new Policy Group",
+		Use:   "new <name>",
+		Short: "[EXPERIMENTAL] Create a new Policy Group",
 		Long: "[EXPERIMENTAL] Create a new Policy Group.\n" +
 			"\n" +
 			"Creates a new Policy Group in the given organization. Policy Groups\n" +
 			"define which Policy Packs are enforced on which stacks or cloud\n" +
 			"accounts, with configurable enforcement levels per pack.\n" +
 			"\n" +
-			"On success the created group is fetched and rendered. Default output is a\n" +
-			"human-readable summary; pass --output=json for the full response as JSON.",
-		Example: "  # Create a Policy Group in the default organization\n" +
+			"When run interactively, prompts for required values that aren't\n" +
+			"provided via flags. Pass --yes to accept defaults without prompting.",
+		Example: "  # Create a Policy Group interactively\n" +
 			"  pulumi policy group new prod-policies\n\n" +
-			"  # Create a Policy Group in a specific organization and emit JSON\n" +
-			"  pulumi policy group new prod-policies --org acme --output json",
+			"  # Create a stack Policy Group non-interactively\n" +
+			"  pulumi policy group new prod-policies --entity-type stacks --yes\n\n" +
+			"  # Create an audit-mode account Policy Group\n" +
+			"  pulumi policy group new compliance \\\n" +
+			"    --entity-type accounts --mode audit --yes\n\n" +
+			"  # Emit JSON\n" +
+			"  pulumi policy group new prod-policies --entity-type stacks \\\n" +
+			"    --yes --output json",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
 			return runPolicyGroupNew(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
@@ -98,15 +109,22 @@ func newPolicyGroupNewCmdWith(factory policyGroupNewClientFactory) *cobra.Comman
 		Required: 1,
 	})
 
-	cmd.Flags().StringVar(&args.org, "org", "", "The organization to create the Policy Group in")
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"The organization to create the Policy Group in")
+	cmd.Flags().StringVar(&args.entityType, "entity-type", "",
+		"The type of entities: stacks or accounts")
+	cmd.Flags().StringVar(&args.mode, "mode", "",
+		"The enforcement mode: audit or preventative")
+	cmd.Flags().StringVar(&args.agentPoolID, "agent-pool-id", "",
+		"Agent pool ID for policy evaluation (optional)")
+	cmd.Flags().BoolVarP(&args.yes, "yes", "y", false,
+		"Skip prompts and proceed with default values")
 	outputflag.VarP(cmd.Flags(), &args.outputFormat)
 
 	return cmd
 }
 
-// defaultPolicyGroupNewClientFactory is the production wiring: resolve the
-// cloud backend, pick the effective organization, and hand back the underlying
-// *client.Client.
+// defaultPolicyGroupNewClientFactory is the production wiring.
 func defaultPolicyGroupNewClientFactory(
 	ctx context.Context, orgFlag string,
 ) (policyGroupNewClient, string, error) {
@@ -147,8 +165,6 @@ func defaultPolicyGroupNewClientFactory(
 	return cloudBackend.Client(), org, nil
 }
 
-// runPolicyGroupNew is the cobra-decoupled command body so tests can drive it
-// directly without spinning up the flag parser.
 func runPolicyGroupNew(
 	ctx context.Context, w io.Writer,
 	factory policyGroupNewClientFactory, name string, args policyGroupNewArgs,
@@ -158,7 +174,48 @@ func runPolicyGroupNew(
 		return err
 	}
 
-	if err := c.CreatePolicyGroup(ctx, org, name); err != nil {
+	skipPrompts := args.yes || !cmdutil.Interactive()
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	// Entity type is required.
+	entityType := args.entityType
+	if entityType == "" {
+		if skipPrompts {
+			return errors.New("--entity-type is required (use --entity-type stacks or --entity-type accounts)")
+		}
+		entityType = ui.PromptUserSkippable(
+			false, "Entity type",
+			validEntityTypes, "stacks",
+			displayOpts.Color)
+	}
+	if !slices.Contains(validEntityTypes, entityType) {
+		return fmt.Errorf("invalid --entity-type %q; must be \"stacks\" or \"accounts\"", entityType)
+	}
+
+	// Mode: prompt if interactive, otherwise use server default.
+	mode := args.mode
+	if mode == "" && !skipPrompts {
+		defaultMode := "preventative"
+		if entityType == "accounts" {
+			defaultMode = "audit"
+		}
+		mode = ui.PromptUserSkippable(
+			false, "Enforcement mode",
+			validModes, defaultMode,
+			displayOpts.Color)
+	}
+	if mode != "" && !slices.Contains(validModes, mode) {
+		return fmt.Errorf("invalid --mode %q; must be \"audit\" or \"preventative\"", mode)
+	}
+
+	req := apitype.CreatePolicyGroupRequest{
+		Name:        name,
+		EntityType:  entityType,
+		Mode:        mode,
+		AgentPoolID: args.agentPoolID,
+	}
+
+	if err := c.CreatePolicyGroup(ctx, org, req); err != nil {
 		return fmt.Errorf("creating policy group: %w", err)
 	}
 

--- a/pkg/cmd/pulumi/policy/policy_group_new.go
+++ b/pkg/cmd/pulumi/policy/policy_group_new.go
@@ -124,7 +124,6 @@ func newPolicyGroupNewCmdWith(factory policyGroupNewClientFactory) *cobra.Comman
 	return cmd
 }
 
-// defaultPolicyGroupNewClientFactory is the production wiring.
 func defaultPolicyGroupNewClientFactory(
 	ctx context.Context, orgFlag string,
 ) (policyGroupNewClient, string, error) {
@@ -183,8 +182,8 @@ func runPolicyGroupNew(
 		if skipPrompts {
 			return errors.New("--entity-type is required (use --entity-type stacks or --entity-type accounts)")
 		}
-		entityType = ui.PromptUserSkippable(
-			false, "Entity type",
+		entityType = ui.PromptUser(
+			"Entity type",
 			validEntityTypes, "stacks",
 			displayOpts.Color)
 	}

--- a/pkg/cmd/pulumi/policy/policy_group_new_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_new_test.go
@@ -43,10 +43,12 @@ type mockPolicyGroupNewClient struct {
 	getCalls    int
 }
 
-func (m *mockPolicyGroupNewClient) CreatePolicyGroup(_ context.Context, org, name string) error {
+func (m *mockPolicyGroupNewClient) CreatePolicyGroup(
+	_ context.Context, org string, req apitype.CreatePolicyGroupRequest,
+) error {
 	m.createCalls++
 	m.createdOrg = org
-	m.createdName = name
+	m.createdName = req.Name
 	return m.createErr
 }
 
@@ -90,7 +92,7 @@ func TestPolicyGroupNew_DefaultOutput(t *testing.T) {
 	c := &mockPolicyGroupNewClient{getResp: newPolicyGroupResponseFixture()}
 	err := runPolicyGroupNew(t.Context(), buf,
 		stubPolicyGroupNewFactory(c, "acme"), "prod-policies",
-		policyGroupNewArgs{outputFormat: defaultPolicyGroupGetOutputFormat()})
+		policyGroupNewArgs{entityType: "stacks", yes: true, outputFormat: defaultPolicyGroupGetOutputFormat()})
 	require.NoError(t, err)
 
 	assert.Equal(t, `Name:                  prod-policies
@@ -114,7 +116,7 @@ func TestPolicyGroupNew_JSONOutput(t *testing.T) {
 
 	buf := &bytes.Buffer{}
 	c := &mockPolicyGroupNewClient{getResp: newPolicyGroupResponseFixture()}
-	args := policyGroupNewArgs{outputFormat: defaultPolicyGroupGetOutputFormat()}
+	args := policyGroupNewArgs{entityType: "stacks", yes: true, outputFormat: defaultPolicyGroupGetOutputFormat()}
 	require.NoError(t, args.outputFormat.Set("json"))
 	err := runPolicyGroupNew(t.Context(), buf,
 		stubPolicyGroupNewFactory(c, "acme"), "prod-policies", args)
@@ -138,7 +140,7 @@ func TestPolicyGroupNew_CreateError(t *testing.T) {
 	c := &mockPolicyGroupNewClient{createErr: errors.New("already exists")}
 	err := runPolicyGroupNew(t.Context(), buf,
 		stubPolicyGroupNewFactory(c, "acme"), "prod-policies",
-		policyGroupNewArgs{outputFormat: defaultPolicyGroupGetOutputFormat()})
+		policyGroupNewArgs{entityType: "stacks", yes: true, outputFormat: defaultPolicyGroupGetOutputFormat()})
 	require.Error(t, err)
 	assert.Equal(t, "creating policy group: already exists", err.Error())
 	assert.Equal(t, 1, c.createCalls)
@@ -152,7 +154,7 @@ func TestPolicyGroupNew_GetAfterCreateError(t *testing.T) {
 	c := &mockPolicyGroupNewClient{getErr: errors.New("not found")}
 	err := runPolicyGroupNew(t.Context(), buf,
 		stubPolicyGroupNewFactory(c, "acme"), "prod-policies",
-		policyGroupNewArgs{outputFormat: defaultPolicyGroupGetOutputFormat()})
+		policyGroupNewArgs{entityType: "stacks", yes: true, outputFormat: defaultPolicyGroupGetOutputFormat()})
 	require.Error(t, err)
 	assert.Equal(t, "reading policy group after create: not found", err.Error())
 	assert.Equal(t, 1, c.createCalls)
@@ -165,7 +167,10 @@ func TestPolicyGroupNew_FactoryError(t *testing.T) {
 	buf := &bytes.Buffer{}
 	err := runPolicyGroupNew(t.Context(), buf,
 		failingPolicyGroupNewFactory(errors.New("not logged in")),
-		"prod-policies", policyGroupNewArgs{outputFormat: defaultPolicyGroupGetOutputFormat()})
+		"prod-policies", policyGroupNewArgs{
+			entityType: "stacks", yes: true,
+			outputFormat: defaultPolicyGroupGetOutputFormat(),
+		})
 	require.Error(t, err)
 	assert.Equal(t, "not logged in", err.Error())
 }

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -255,6 +255,14 @@ type GetStackPolicyPacksResponse struct {
 type CreatePolicyGroupRequest struct {
 	// Name is the name of the new Policy Group.
 	Name string `json:"name"`
+	// EntityType is the type of entities this policy group applies to:
+	// "stacks" or "accounts".
+	EntityType string `json:"entityType"`
+	// Mode is the enforcement mode: "audit" or "preventative".
+	// If empty, defaults to "audit" for accounts and "preventative" for stacks.
+	Mode string `json:"mode,omitempty"`
+	// AgentPoolID is the optional agent pool to use for policy evaluation.
+	AgentPoolID string `json:"agentPoolId,omitempty"`
 }
 
 // UpdatePolicyGroupRequest modifies a Policy Group.


### PR DESCRIPTION
Example outputs:

```
$ PULUMI_HOME=~/.pulumi4 pulumi policy group new --org pat-staging-org tg-test
Entity type stacks
Enforcement mode preventative
Name:                  tg-test
Org default:           no
Entity type:           stacks
Mode:                  preventative
Applied policy packs:  0
Stacks:                0
Accounts:              0

$ PULUMI_HOME=~/.pulumi4 pulumi policy group new --org pat-staging-org tg-test2 --output json --entity-type stacks --mode audit
{
  "name": "tg-test2",
  "isOrgDefault": false,
  "entityType": "stacks",
  "mode": "audit",
  "stacks": [],
  "appliedPolicyPacks": [],
  "accounts": []
}
```

Fixes https://github.com/pulumi/pulumi/issues/22993