### PR TITLE
unhide the `pulumi policy group get` command

### DIFF
--- a/changelog/pending/20260515--cli-policy--add-the-pulumi-policy-group-get-command.yaml
+++ b/changelog/pending/20260515--cli-policy--add-the-pulumi-policy-group-get-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Add the `pulumi policy group get` command

--- a/pkg/cmd/pulumi/policy/policy_group_get.go
+++ b/pkg/cmd/pulumi/policy/policy_group_get.go
@@ -82,9 +82,8 @@ func newPolicyGroupGetCmdWith(factory policyGroupGetClientFactory) *cobra.Comman
 	args.outputFormat = defaultPolicyGroupGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get <name>",
-		Short:  "[EXPERIMENTAL] Get the details of a Policy Group",
+		Use:   "get <name>",
+		Short: "[EXPERIMENTAL] Get the details of a Policy Group",
 		Long: "[EXPERIMENTAL] Get the details of a Policy Group.\n" +
 			"\n" +
 			"Retrieves detailed information about a single Policy Group in an\n" +


### PR DESCRIPTION
The original clanker actually got this one right for a change.  So just unhide it and add the changelog.

Example output:
```
$ PULUMI_HOME=~/.pulumi4 pulumi policy group get --org pat-staging-org tg-test2 
Name:                  tg-test2
Org default:           no
Entity type:           stacks
Mode:                  audit
Applied policy packs:  0
Stacks:                0
Accounts:              0

$ PULUMI_HOME=~/.pulumi4 pulumi policy group get --org pat-staging-org tg-test2 --output json
{
  "name": "tg-test2",
  "isOrgDefault": false,
  "entityType": "stacks",
  "mode": "audit",
  "stacks": [],
  "appliedPolicyPacks": [],
  "accounts": []
}
```

Fixes https://github.com/pulumi/pulumi/issues/22992
