### PR TITLE
fix `pulumi policy group edit` and unhide it

### DIFF
--- a/changelog/pending/20260515--cli-policy--add-pulumi-policy-group-edit-to-edit-policy-groups.yaml
+++ b/changelog/pending/20260515--cli-policy--add-pulumi-policy-group-edit-to-edit-policy-groups.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Add `pulumi policy group edit` to edit policy groups

--- a/pkg/cmd/pulumi/policy/policy_group_edit.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit.go
@@ -59,13 +59,13 @@ type policyGroupEditClientFactory func(
 
 // policyGroupEditArgs collects the flag values for the edit command. Only the
 // flags listed in changed are applied; this lets the run function distinguish
-// an explicit empty --new-name from "user did not pass --new-name", and lets
+// an explicit empty --name from "user did not pass --name", and lets
 // tests drive the command without spinning up cobra.
 type policyGroupEditArgs struct {
 	org          string
 	outputFormat outputflag.OutputFlag[policyGroupGetRenderFunc]
 
-	newName               string
+	rename                string
 	addStack              []string
 	removeStack           []string
 	addPolicyPack         []string
@@ -74,7 +74,7 @@ type policyGroupEditArgs struct {
 	removeInsightsAccount []string
 
 	// changed records which of the mutation flags were set by the user.
-	// Keys are the flag names: "new-name", "add-stack", "remove-stack",
+	// Keys are the flag names: "name", "add-stack", "remove-stack",
 	// "add-policy-pack", "remove-policy-pack", "add-insights-account",
 	// "remove-insights-account".
 	changed map[string]bool
@@ -92,9 +92,8 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 	args.outputFormat = defaultPolicyGroupGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit <name>",
-		Short:  "[EXPERIMENTAL] Update a Policy Group's configuration",
+		Use:   "edit <name>",
+		Short: "[EXPERIMENTAL] Update a Policy Group's configuration",
 		Long: "[EXPERIMENTAL] Update a Policy Group's configuration.\n" +
 			"\n" +
 			"Renames a Policy Group, adds or removes stacks, applies or detaches\n" +
@@ -104,7 +103,7 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 			"Default output is a human-readable summary; pass --output=json for the\n" +
 			"full response as JSON.",
 		Example: "  # Rename a Policy Group\n" +
-			"  pulumi policy group edit prod-policies --new-name production\n\n" +
+			"  pulumi policy group edit prod-policies --name production\n\n" +
 			"  # Add a stack and a Policy Pack to a group\n" +
 			"  pulumi policy group edit prod-policies " +
 			"--add-stack web/prod --add-policy-pack aws-guardrails@3",
@@ -123,7 +122,7 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 
 	cmd.Flags().StringVar(&args.org, "org", "", "The organization that owns the Policy Group")
 	outputflag.VarP(cmd.Flags(), &args.outputFormat)
-	cmd.Flags().StringVar(&args.newName, "new-name", "", "Rename the Policy Group")
+	cmd.Flags().StringVar(&args.rename, "name", "", "Rename the Policy Group")
 	cmd.Flags().StringArrayVar(&args.addStack, "add-stack", nil,
 		"Add a stack to the Policy Group (repeatable). Format: 'project/stack' or 'stack'")
 	cmd.Flags().StringArrayVar(&args.removeStack, "remove-stack", nil,
@@ -143,7 +142,7 @@ func newPolicyGroupEditCmdWith(factory policyGroupEditClientFactory) *cobra.Comm
 // mutationFlagNames are the flags whose presence triggers a PATCH. --org and
 // --output are excluded because they are context, not mutations.
 var mutationFlagNames = []string{
-	"new-name",
+	"name",
 	"add-stack", "remove-stack",
 	"add-policy-pack", "remove-policy-pack",
 	"add-insights-account", "remove-insights-account",
@@ -218,7 +217,7 @@ func runPolicyGroupEdit(
 ) error {
 	if !anyMutationRequested(args) {
 		return errors.New(
-			"no changes specified; pass at least one of --new-name, --add-stack, --remove-stack, " +
+			"no changes specified; pass at least one of --name, --add-stack, --remove-stack, " +
 				"--add-policy-pack, --remove-policy-pack, --add-insights-account, --remove-insights-account")
 	}
 
@@ -241,8 +240,8 @@ func runPolicyGroupEdit(
 		args.changed["add-insights-account"] || args.changed["remove-insights-account"]
 
 	patch := apitype.UpdatePolicyGroupRequest{}
-	if args.changed["new-name"] {
-		nn := args.newName
+	if args.changed["name"] {
+		nn := args.rename
 		patch.NewName = &nn
 	}
 

--- a/pkg/cmd/pulumi/policy/policy_group_edit_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit_test.go
@@ -96,8 +96,8 @@ func TestPolicyGroupEdit_RenameOnly_DefaultOutput(t *testing.T) {
 	err := runPolicyGroupEdit(t.Context(), &buf,
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{
 			outputFormat: defaultPolicyGroupGetOutputFormat(),
-			newName:      "production",
-			changed:      map[string]bool{"new-name": true},
+			rename:       "production",
+			changed:      map[string]bool{"name": true},
 		})
 	require.NoError(t, err)
 
@@ -139,7 +139,7 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 
 	args := policyGroupEditArgs{
 		outputFormat:          defaultPolicyGroupGetOutputFormat(),
-		newName:               "production",
+		rename:                "production",
 		addStack:              []string{"web/prod", "standalone"},
 		removeStack:           []string{"web/legacy"},
 		addPolicyPack:         []string{"aws-guardrails@3", "tagging"},
@@ -147,7 +147,7 @@ func TestPolicyGroupEdit_AddsAndRemoves_JSONOutput(t *testing.T) {
 		addInsightsAccount:    []string{"acct-2"},
 		removeInsightsAccount: []string{"acct-1"},
 		changed: map[string]bool{
-			"new-name": true, "add-stack": true, "remove-stack": true,
+			"name": true, "add-stack": true, "remove-stack": true,
 			"add-policy-pack": true, "remove-policy-pack": true,
 			"add-insights-account": true, "remove-insights-account": true,
 		},
@@ -207,7 +207,7 @@ func TestPolicyGroupEdit_NoFlagsChanged(t *testing.T) {
 		})
 	require.Error(t, err)
 	assert.Equal(t,
-		"no changes specified; pass at least one of --new-name, --add-stack, --remove-stack, "+
+		"no changes specified; pass at least one of --name, --add-stack, --remove-stack, "+
 			"--add-policy-pack, --remove-policy-pack, --add-insights-account, --remove-insights-account",
 		err.Error())
 	assert.Empty(t, c.updates)
@@ -221,8 +221,8 @@ func TestPolicyGroupEdit_UpdateError(t *testing.T) {
 	err := runPolicyGroupEdit(t.Context(), &buf,
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{
 			outputFormat: defaultPolicyGroupGetOutputFormat(),
-			newName:      "production",
-			changed:      map[string]bool{"new-name": true},
+			rename:       "production",
+			changed:      map[string]bool{"name": true},
 		})
 	require.Error(t, err)
 	assert.Equal(t, "conflict", err.Error())
@@ -255,8 +255,8 @@ func TestPolicyGroupEdit_GetAfterEditError(t *testing.T) {
 	err := runPolicyGroupEdit(t.Context(), &buf,
 		stubPolicyGroupEditFactory(c, "acme"), "prod-policies", policyGroupEditArgs{
 			outputFormat: defaultPolicyGroupGetOutputFormat(),
-			newName:      "production",
-			changed:      map[string]bool{"new-name": true},
+			rename:       "production",
+			changed:      map[string]bool{"name": true},
 		})
 	require.Error(t, err)
 	assert.Equal(t, "reading policy group after edit: boom", err.Error())
@@ -270,8 +270,8 @@ func TestPolicyGroupEdit_FactoryError(t *testing.T) {
 		failingPolicyGroupEditFactory(errors.New("not logged in")),
 		"prod-policies", policyGroupEditArgs{
 			outputFormat: defaultPolicyGroupGetOutputFormat(),
-			newName:      "production",
-			changed:      map[string]bool{"new-name": true},
+			rename:       "production",
+			changed:      map[string]bool{"name": true},
 		})
 	require.Error(t, err)
 	assert.Equal(t, "not logged in", err.Error())

--- a/pkg/cmd/pulumi/policy/policy_group_get_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_get_test.go
@@ -154,7 +154,7 @@ func TestPolicyGroupGet_JSONOutput(t *testing.T) {
 		],
 		"appliedPolicyPacks": [
 			{"name": "aws-guardrails", "displayName": "AWS Guardrails", "version": 3, "versionTag": "1.2.0"},
-			{"name": "tagging", "displayName": "Tagging", "version": 1, "versionTag": ""}
+			{"name": "tagging", "displayName": "Tagging", "version": 1}
 		],
 		"accounts": [],
 		"agentPoolId": "pool-1"

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -284,8 +284,8 @@ type UpdatePolicyGroupRequest struct {
 	AddPolicyPack    *PolicyPackMetadata `json:"addPolicyPack,omitempty"`
 	RemovePolicyPack *PolicyPackMetadata `json:"removePolicyPack,omitempty"`
 
-	AddInsightsAccount    *string `json:"addInsightsAccount,omitempty"`
-	RemoveInsightsAccount *string `json:"removeInsightsAccount,omitempty"`
+	AddInsightsAccount    *InsightsAccountReference `json:"addInsightsAccount,omitempty"`
+	RemoveInsightsAccount *InsightsAccountReference `json:"removeInsightsAccount,omitempty"`
 
 	// Stacks, when non-nil, replaces the full list of stacks in the group.
 	Stacks *[]PulumiStackReference `json:"stacks,omitempty"`
@@ -297,18 +297,24 @@ type UpdatePolicyGroupRequest struct {
 	InsightsAccounts *[]string `json:"insightsAccounts,omitempty"`
 }
 
+// InsightsAccountReference identifies an Insights account for policy group
+// membership. The server requires at least the Name field.
+type InsightsAccountReference struct {
+	Name string `json:"name"`
+}
+
 // PulumiStackReference contains the StackName and ProjectName of the stack.
 type PulumiStackReference struct {
 	Name           string `json:"name"`
-	RoutingProject string `json:"routingProject"`
+	RoutingProject string `json:"routingProject,omitempty"`
 }
 
 // PolicyPackMetadata is the metadata of a Policy Pack.
 type PolicyPackMetadata struct {
 	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	Version     int    `json:"version"`
-	VersionTag  string `json:"versionTag"`
+	DisplayName string `json:"displayName,omitempty"`
+	Version     int    `json:"version,omitempty"`
+	VersionTag  string `json:"versionTag,omitempty"`
 
 	// The configuration that is to be passed to the Policy Pack. This
 	// map ties Policies with their configuration.


### PR DESCRIPTION
Some of the apitypes were incorrect, so fix them up and unhide the command.

Example output:
```
$ PULUMI_HOME=~/.pulumi4 pulumi policy group edit --org pat-staging-org tg-test2 --add-policy-pack cloud-cli-fixture-pack --add-insights-account test-account --remove-stack cloud-cli-fixture/dev
Name:                  tg-test2
Org default:           no
Entity type:           stacks
Mode:                  audit
Applied policy packs:  1
  - cloud-cli-fixture-pack (0.0.2)
Stacks:                0
Accounts:              2
  - test-account/global
  - test-account

$ PULUMI_HOME=~/.pulumi4 pulumi policy group edit --org pat-staging-org tg-test2 --name tg-test3 --output json
{
  "name": "tg-test3",
  "isOrgDefault": false,
  "entityType": "stacks",
  "mode": "audit",
  "stacks": [],
  "appliedPolicyPacks": [
    {
      "name": "cloud-cli-fixture-pack",
      "version": 2,
      "versionTag": "0.0.2"
    }
  ],
  "accounts": [
    "test-account/global",
    "test-account"
  ]
}
```

Fixes https://github.com/pulumi/pulumi/issues/22991