### PR TITLE
Use `--count` and `--all` in `deployment list`

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_list.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list.go
@@ -52,15 +52,17 @@ type deploymentListClientFactory func(
 	ctx context.Context, stackFlag string,
 ) (deploymentListClient, client.StackIdentifier, error)
 
+const defaultPageSize = 100
+
 // deploymentListArgs collects the flag values for the list command, in one
 // struct so Run can be driven directly from tests.
 type deploymentListArgs struct {
-	stack    string
-	page     int64
-	pageSize int64
-	sort     string
-	asc      bool
-	output   string
+	stack  string
+	count  int
+	all    bool
+	sort   string
+	asc    bool
+	output string
 }
 
 // newDeploymentListCmd builds `pulumi deployment list` with the production
@@ -78,23 +80,25 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 		Short: "List deployments for a stack",
 		Long: "[EXPERIMENTAL] List deployments for a stack.\n" +
 			"\n" +
-			"Returns a paginated list of Pulumi Deployments executions for the selected\n" +
-			"stack, showing each deployment's ID, operation, status, version, initiator,\n" +
-			"and the time it was last modified. Default output is a human-readable table;\n" +
-			"pass --output=json for the full response as a JSON envelope.\n" +
+			"Returns deployments for the selected stack, showing each deployment's ID,\n" +
+			"operation, status, version, initiator, and the time it was last modified.\n" +
+			"Default output is a human-readable table; pass --output=json for a JSON\n" +
+			"envelope.\n" +
 			"\n" +
-			"Wraps the `ListStackDeploymentsHandlerV2` Pulumi Cloud REST endpoint.",
-		Example: "  # List deployments for the current stack.\n" +
+			"By default, the first 10 results are shown. Use --count to request more,\n" +
+			"or --all to fetch every deployment.",
+		Example: "  # List the most recent deployments for the current stack.\n" +
 			"  pulumi deployment list\n\n" +
-			"  # List deployments for a different stack.\n" +
-			"  pulumi deployment list --stack acme/web/prod\n\n" +
-			"  # Page through results, 25 at a time.\n" +
-			"  pulumi deployment list --page 2 --page-size 25\n\n" +
+			"  # List the last 50 deployments.\n" +
+			"  pulumi deployment list --count 50\n\n" +
+			"  # Fetch every deployment as JSON.\n" +
+			"  pulumi deployment list --all --output json\n\n" +
 			"  # Sort ascending by a server-supported field.\n" +
-			"  pulumi deployment list --sort created --asc\n\n" +
-			"  # Emit JSON for scripting.\n" +
-			"  pulumi deployment list --output json",
+			"  pulumi deployment list --sort created --asc",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if args.all && args.count > 0 {
+				return errors.New("--all and --count are mutually exclusive")
+			}
 			f := factory
 			if f == nil {
 				f = defaultDeploymentListClientFactory
@@ -107,8 +111,10 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 
 	cmd.Flags().StringVarP(&args.stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().Int64Var(&args.page, "page", 1, "The page of results to return (min 1)")
-	cmd.Flags().Int64Var(&args.pageSize, "page-size", 10, "The number of results per page (1-100)")
+	cmd.Flags().IntVar(&args.count, "count", 0,
+		"Number of results to display (fetches multiple pages if needed)")
+	cmd.Flags().BoolVar(&args.all, "all", false,
+		"Fetch all results (mutually exclusive with --count)")
 	cmd.Flags().StringVar(&args.sort, "sort", "", "The field to sort results by")
 	cmd.Flags().BoolVar(&args.asc, "asc", false, "Sort in ascending order (default descending)")
 	cmd.Flags().StringVarP(&args.output, "output", "o", "default",
@@ -172,20 +178,53 @@ func runDeploymentList(
 		return err
 	}
 
-	resp, err := c.ListStackDeployments(ctx, stackID, client.ListStackDeploymentsOptions{
-		Page:     args.page,
-		PageSize: args.pageSize,
-		Sort:     args.sort,
-		Asc:      args.asc,
-	})
-	if err != nil {
-		return fmt.Errorf("listing stack deployments: %w", err)
+	// Determine how many results to fetch.
+	want := 10
+	if args.count > 0 {
+		want = args.count
+	} else if args.all {
+		want = -1 // sentinel: fetch everything
 	}
 
-	return render(w, args, resp)
+	var deployments []apitype.ListDeploymentSnapshot
+	var total int64
+	page := int64(1)
+
+	for {
+		pageSize := int64(defaultPageSize)
+		if want > 0 && want-len(deployments) < int(pageSize) {
+			pageSize = int64(want - len(deployments))
+		}
+
+		resp, err := c.ListStackDeployments(ctx, stackID, client.ListStackDeploymentsOptions{
+			Page:     page,
+			PageSize: pageSize,
+			Sort:     args.sort,
+			Asc:      args.asc,
+		})
+		if err != nil {
+			return fmt.Errorf("listing stack deployments: %w", err)
+		}
+		total = resp.Total
+		deployments = append(deployments, resp.Deployments...)
+
+		// Stop if we've collected enough, or there are no more results.
+		if want > 0 && len(deployments) >= want {
+			deployments = deployments[:want]
+			break
+		}
+		if int64(len(deployments)) >= total || len(resp.Deployments) == 0 {
+			break
+		}
+		page++
+	}
+
+	return render(w, deployments, total)
 }
 
-type deploymentListRenderFunc func(w io.Writer, args deploymentListArgs, resp apitype.ListDeploymentResponseV2) error
+type deploymentListRenderFunc func(
+	w io.Writer, deployments []apitype.ListDeploymentSnapshot, total int64,
+) error
 
 func deploymentListRenderer(format string) (deploymentListRenderFunc, error) {
 	switch format {
@@ -198,13 +237,10 @@ func deploymentListRenderer(format string) (deploymentListRenderFunc, error) {
 	}
 }
 
-// renderDeploymentListTable prints a compact table of deployments plus a
-// pagination footer. Column names are uppercase to match other Cloud-Ready CLI
-// list commands (e.g. `pulumi stack webhook list`, `pulumi api list`).
 func renderDeploymentListTable(
-	w io.Writer, args deploymentListArgs, resp apitype.ListDeploymentResponseV2,
+	w io.Writer, deployments []apitype.ListDeploymentSnapshot, total int64,
 ) error {
-	if len(resp.Deployments) == 0 {
+	if len(deployments) == 0 {
 		fmt.Fprintln(w, "No deployments found for this stack.")
 		return nil
 	}
@@ -214,7 +250,7 @@ func renderDeploymentListTable(
 	t.SetStyle(table.StyleLight)
 	t.AppendHeader(table.Row{"ID", "OPERATION", "VERSION", "STATUS", "INITIATED BY", "MODIFIED"})
 
-	for _, d := range resp.Deployments {
+	for _, d := range deployments {
 		initiatedBy := d.RequestedBy.GitHubLogin
 		if initiatedBy == "" {
 			initiatedBy = d.RequestedBy.Name
@@ -230,31 +266,22 @@ func renderDeploymentListTable(
 	}
 	t.Render()
 
-	fmt.Fprintf(w, "\nShowing %d of %d deployment(s)", len(resp.Deployments), resp.Total)
-	if args.page > 0 {
-		fmt.Fprintf(w, " (page %d)", args.page)
-	}
-	fmt.Fprintln(w)
+	fmt.Fprintf(w, "\nShowing %d of %d deployment(s)\n", len(deployments), total)
 	return nil
 }
 
-// deploymentListEnvelope is the JSON shape emitted by
-// `pulumi deployment list --output=json`. It mirrors the API response but
-// adds the page number the client asked for, which the server doesn't echo
-// back, so scripts can keep paginating without remembering their own state.
+// deploymentListEnvelope is the JSON shape emitted by `pulumi deployment list --output=json`
 type deploymentListEnvelope struct {
-	Deployments  []apitype.ListDeploymentSnapshot `json:"deployments"`
-	Page         int64                            `json:"page"`
-	ItemsPerPage int64                            `json:"itemsPerPage"`
-	Total        int64                            `json:"total"`
+	Deployments []apitype.ListDeploymentSnapshot `json:"deployments"`
+	Count       int                              `json:"count"`
+	Total       int64                            `json:"total"`
 }
 
 func renderDeploymentListJSON(
-	w io.Writer, args deploymentListArgs, resp apitype.ListDeploymentResponseV2,
+	w io.Writer, deployments []apitype.ListDeploymentSnapshot, total int64,
 ) error {
 	// Normalize nil slice to empty so scripts can rely on `.deployments`
 	// always being a JSON array.
-	deployments := resp.Deployments
 	if deployments == nil {
 		deployments = []apitype.ListDeploymentSnapshot{}
 	}
@@ -262,9 +289,8 @@ func renderDeploymentListJSON(
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	return enc.Encode(deploymentListEnvelope{
-		Deployments:  deployments,
-		Page:         args.page,
-		ItemsPerPage: resp.ItemsPerPage,
-		Total:        resp.Total,
+		Deployments: deployments,
+		Count:       len(deployments),
+		Total:       total,
 	})
 }

--- a/pkg/cmd/pulumi/deployment/deployment_list_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list_test.go
@@ -73,12 +73,6 @@ func stubListFactory(c deploymentListClient) deploymentListClientFactory {
 	}
 }
 
-func failingListFactory(err error) deploymentListClientFactory {
-	return func(_ context.Context, _ string) (deploymentListClient, client.StackIdentifier, error) {
-		return nil, client.StackIdentifier{}, err
-	}
-}
-
 func sampleListResponse() apitype.ListDeploymentResponseV2 {
 	return apitype.ListDeploymentResponseV2{
 		ItemsPerPage: 10,

--- a/pkg/cmd/pulumi/deployment/deployment_list_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,23 +35,28 @@ type capturedListCall struct {
 	opts  client.ListStackDeploymentsOptions
 }
 
-// mockDeploymentListClient stubs deploymentListClient. It returns a fixed
-// response (or error) and records the most recent invocation so tests can
-// assert on the flag-to-query propagation.
+// mockDeploymentListClient stubs deploymentListClient. It returns either a
+// fixed response on every call (resp) or page-keyed responses (pages, indexed
+// by 1-based page number); records every call so tests can assert on the
+// pagination loop.
 type mockDeploymentListClient struct {
 	resp     apitype.ListDeploymentResponseV2
+	pages    map[int64]apitype.ListDeploymentResponseV2
 	err      error
-	captured *capturedListCall
+	captured *[]capturedListCall
 }
 
 func (m *mockDeploymentListClient) ListStackDeployments(
 	_ context.Context, stack client.StackIdentifier, opts client.ListStackDeploymentsOptions,
 ) (apitype.ListDeploymentResponseV2, error) {
 	if m.captured != nil {
-		*m.captured = capturedListCall{stack: stack, opts: opts}
+		*m.captured = append(*m.captured, capturedListCall{stack: stack, opts: opts})
 	}
 	if m.err != nil {
 		return apitype.ListDeploymentResponseV2{}, m.err
+	}
+	if m.pages != nil {
+		return m.pages[opts.Page], nil
 	}
 	return m.resp, nil
 }
@@ -118,7 +123,7 @@ func TestDeploymentList_DefaultOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: sampleListResponse()}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{page: 1})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -142,8 +147,8 @@ func TestDeploymentList_DefaultOutput(t *testing.T) {
 	assert.Contains(t, out, "failed")
 	assert.Contains(t, out, "bob")
 
-	// Footer pagination summary.
-	assert.Contains(t, out, "Showing 2 of 2 deployment(s) (page 1)")
+	// Footer summary.
+	assert.Contains(t, out, "Showing 2 of 2 deployment(s)")
 }
 
 func TestDeploymentList_DefaultOutput_Empty(t *testing.T) {
@@ -151,7 +156,7 @@ func TestDeploymentList_DefaultOutput_Empty(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{page: 1})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
 	require.NoError(t, err)
 	assert.Equal(t, "No deployments found for this stack.\n", buf.String())
 }
@@ -176,7 +181,7 @@ func TestDeploymentList_DefaultOutput_FallsBackToNameWhenGithubLoginMissing(t *t
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: resp}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{page: 1})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Display Name")
 }
@@ -187,7 +192,7 @@ func TestDeploymentList_JSONOutput(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: sampleListResponse()}
 	err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-		deploymentListArgs{output: "json", page: 1})
+		deploymentListArgs{output: "json"})
 	require.NoError(t, err)
 
 	// Decode and check structural fields rather than comparing the whole
@@ -196,8 +201,7 @@ func TestDeploymentList_JSONOutput(t *testing.T) {
 	var env deploymentListEnvelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
 
-	assert.Equal(t, int64(1), env.Page)
-	assert.Equal(t, int64(10), env.ItemsPerPage)
+	assert.Equal(t, 2, env.Count)
 	assert.Equal(t, int64(2), env.Total)
 	require.Len(t, env.Deployments, 2)
 	assert.Equal(t, "dep-1", env.Deployments[0].ID)
@@ -211,11 +215,11 @@ func TestDeploymentList_JSONOutput_EmptyArray(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}
 	err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-		deploymentListArgs{output: "json", page: 1})
+		deploymentListArgs{output: "json"})
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
-		`{"deployments":[],"page":1,"itemsPerPage":0,"total":0}`, buf.String())
+		`{"deployments":[],"count":0,"total":0}`, buf.String())
 }
 
 func TestDeploymentList_PropagatesFlagsToClient(t *testing.T) {
@@ -227,19 +231,24 @@ func TestDeploymentList_PropagatesFlagsToClient(t *testing.T) {
 		want client.ListStackDeploymentsOptions
 	}{
 		{
-			name: "defaults flow through",
-			args: deploymentListArgs{page: 1, pageSize: 10},
+			name: "default asks for one page worth",
+			args: deploymentListArgs{},
 			want: client.ListStackDeploymentsOptions{Page: 1, PageSize: 10},
 		},
 		{
-			name: "all options",
-			args: deploymentListArgs{page: 3, pageSize: 25, sort: "modified", asc: true},
-			want: client.ListStackDeploymentsOptions{Page: 3, PageSize: 25, Sort: "modified", Asc: true},
+			name: "--count narrows the first page",
+			args: deploymentListArgs{count: 25},
+			want: client.ListStackDeploymentsOptions{Page: 1, PageSize: 25},
 		},
 		{
-			name: "zero values flow through",
-			args: deploymentListArgs{},
-			want: client.ListStackDeploymentsOptions{},
+			name: "--all uses the default page size",
+			args: deploymentListArgs{all: true},
+			want: client.ListStackDeploymentsOptions{Page: 1, PageSize: defaultPageSize},
+		},
+		{
+			name: "sort flags pass through",
+			args: deploymentListArgs{sort: "modified", asc: true},
+			want: client.ListStackDeploymentsOptions{Page: 1, PageSize: 10, Sort: "modified", Asc: true},
 		},
 	}
 
@@ -247,126 +256,85 @@ func TestDeploymentList_PropagatesFlagsToClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var captured capturedListCall
+			var captured []capturedListCall
 			c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}, captured: &captured}
 			var buf bytes.Buffer
 			err := runDeploymentList(t.Context(), &buf, stubListFactory(c), tt.args)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, captured.opts)
-			assert.Equal(t, testStackID, captured.stack)
+			require.NotEmpty(t, captured, "expected at least one client call")
+			assert.Equal(t, tt.want, captured[0].opts)
+			assert.Equal(t, testStackID, captured[0].stack)
 		})
 	}
 }
 
-func TestDeploymentList_StackFlagPropagatesToFactory(t *testing.T) {
+// TestDeploymentList_AutoPaginates verifies the loop stitches multiple pages
+// together to satisfy --count and --all without the caller having to ask.
+func TestDeploymentList_AutoPaginates(t *testing.T) {
 	t.Parallel()
 
-	var capturedStack string
-	factory := func(_ context.Context, stackFlag string) (deploymentListClient, client.StackIdentifier, error) {
-		capturedStack = stackFlag
-		return &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}, testStackID, nil
+	// 250 deployments total, served three pages deep.
+	page := func(start, n int) apitype.ListDeploymentResponseV2 {
+		ds := make([]apitype.ListDeploymentSnapshot, n)
+		for i := range ds {
+			ds[i] = apitype.ListDeploymentSnapshot{ID: fmt.Sprintf("dep-%d", start+i)}
+		}
+		return apitype.ListDeploymentResponseV2{Deployments: ds, Total: 250, ItemsPerPage: 100}
+	}
+	pages := map[int64]apitype.ListDeploymentResponseV2{
+		1: page(1, 100),
+		2: page(101, 100),
+		3: page(201, 50),
 	}
 
-	var buf bytes.Buffer
-	err := runDeploymentList(t.Context(), &buf, factory,
-		deploymentListArgs{stack: "acme/web/staging", page: 1})
-	require.NoError(t, err)
-	assert.Equal(t, "acme/web/staging", capturedStack)
+	t.Run("--all walks every page", func(t *testing.T) {
+		t.Parallel()
+		var captured []capturedListCall
+		c := &mockDeploymentListClient{pages: pages, captured: &captured}
+		var buf bytes.Buffer
+		err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
+			deploymentListArgs{all: true, output: "json"})
+		require.NoError(t, err)
+
+		var env deploymentListEnvelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+		assert.Equal(t, 250, env.Count)
+		require.Len(t, captured, 3)
+		assert.Equal(t, int64(1), captured[0].opts.Page)
+		assert.Equal(t, int64(2), captured[1].opts.Page)
+		assert.Equal(t, int64(3), captured[2].opts.Page)
+	})
+
+	t.Run("--count stops once enough collected", func(t *testing.T) {
+		t.Parallel()
+		var captured []capturedListCall
+		c := &mockDeploymentListClient{pages: pages, captured: &captured}
+		var buf bytes.Buffer
+		err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
+			deploymentListArgs{count: 150, output: "json"})
+		require.NoError(t, err)
+
+		var env deploymentListEnvelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
+		assert.Equal(t, 150, env.Count)
+		require.Len(t, captured, 2)
+		// First call grabs the full default page; the second is sized to the
+		// remainder rather than another full chunk.
+		assert.Equal(t, int64(defaultPageSize), captured[0].opts.PageSize)
+		assert.Equal(t, int64(50), captured[1].opts.PageSize)
+	})
 }
 
-func TestDeploymentList_InvalidOutput(t *testing.T) {
+func TestDeploymentList_AllAndCountMutuallyExclusive(t *testing.T) {
 	t.Parallel()
 
-	var buf bytes.Buffer
-	c := &mockDeploymentListClient{resp: sampleListResponse()}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-		deploymentListArgs{output: "yaml"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
-}
-
-func TestDeploymentList_ClientError(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockDeploymentListClient{err: errors.New("server boom")}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{page: 1})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "listing stack deployments")
-	assert.Contains(t, err.Error(), "server boom")
-}
-
-func TestDeploymentList_FactoryError(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	err := runDeploymentList(t.Context(), &buf, failingListFactory(errors.New("not logged in")),
-		deploymentListArgs{page: 1})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not logged in")
-}
-
-func TestNewDeploymentListCmd_CobraFlagBinding(t *testing.T) {
-	t.Parallel()
-
-	var captured capturedListCall
-	c := &mockDeploymentListClient{resp: sampleListResponse(), captured: &captured}
+	c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}
 	cmd := newDeploymentListCmdWith(stubListFactory(c))
-
+	cmd.SetArgs([]string{"--all", "--count", "10"})
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{
-		"--stack", "acme/web/staging",
-		"--page", "2",
-		"--page-size", "50",
-		"--sort", "modified",
-		"--asc",
-		"--output", "json",
-	})
-	require.NoError(t, cmd.ExecuteContext(t.Context()))
-
-	// --stack reaches the factory, the rest reach the client as options.
-	assert.Equal(t, client.ListStackDeploymentsOptions{
-		Page:     2,
-		PageSize: 50,
-		Sort:     "modified",
-		Asc:      true,
-	}, captured.opts)
-
-	var env deploymentListEnvelope
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
-	assert.Equal(t, int64(2), env.Page)
-}
-
-func TestNewDeploymentListCmd_Defaults(t *testing.T) {
-	t.Parallel()
-
-	// Passing nil installs the production factory; assert the command is
-	// well-formed without invoking it (the prod factory would touch the
-	// real filesystem / cloud config).
-	cmd := newDeploymentListCmd()
-	require.NotNil(t, cmd)
-	assert.Equal(t, "list", cmd.Use)
-
-	f := cmd.Flags().Lookup("output")
-	require.NotNil(t, f)
-	assert.Equal(t, "o", f.Shorthand)
-	assert.Equal(t, "default", f.DefValue)
-
-	sf := cmd.Flags().Lookup("stack")
-	require.NotNil(t, sf)
-	assert.Equal(t, "s", sf.Shorthand)
-
-	page := cmd.Flags().Lookup("page")
-	require.NotNil(t, page)
-	assert.Equal(t, "1", page.DefValue)
-
-	pageSize := cmd.Flags().Lookup("page-size")
-	require.NotNil(t, pageSize)
-	assert.Equal(t, "10", pageSize.DefValue)
-
-	asc := cmd.Flags().Lookup("asc")
-	require.NotNil(t, asc)
-	assert.Equal(t, "false", asc.DefValue)
+	err := cmd.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all and --count are mutually exclusive")
 }


### PR DESCRIPTION
Use the `--count`/`--all` flags instead of pagination

```
% pulumi deployment list -s julienp-test/random-python/dev --count 3
┌──────────────────────────────────────┬──────────────┬─────────┬───────────┬──────────────────────────────────────────────────────┬─────────────────────────┐
│ ID                                   │ OPERATION    │ VERSION │ STATUS    │ INITIATED BY                                         │ MODIFIED                │
├──────────────────────────────────────┼──────────────┼─────────┼───────────┼──────────────────────────────────────────────────────┼─────────────────────────┤
│ 80e7322f-9f49-4ba4-9f7b-791763dd5014 │ detect-drift │       7 │ succeeded │ julienp                                              │ 2026-05-15 13:25:14.594 │
│ da3eede9-5c97-47f8-ba9e-929aa9e4ba63 │ detect-drift │       6 │ succeeded │ service-account:1d352c71-cf89-40dc-bd7f-bca3f82c82b0 │ 2026-05-15 06:00:42.656 │
│ 09b6b30a-6e18-4bc4-90c3-435eef8ee6fc │ detect-drift │       5 │ succeeded │ service-account:1d352c71-cf89-40dc-bd7f-bca3f82c82b0 │ 2026-05-15 03:01:46.533 │
└──────────────────────────────────────┴──────────────┴─────────┴───────────┴──────────────────────────────────────────────────────┴─────────────────────────┘

Showing 3 of 7 deployment(s)
```