### PR TITLE
fix `pulumi policy group remove` and unhide

### DIFF
--- a/changelog/pending/20260515--cli-policy--add-pulumi-policy-group-remove-command-to-remove-policies.yaml
+++ b/changelog/pending/20260515--cli-policy--add-pulumi-policy-group-remove-command-to-remove-policies.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/policy
+  description: Add `pulumi policy group remove` command to remove policies

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -30,10 +30,12 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // policyGroupRemoveClient is the narrow subset of cloud-API operations the
@@ -52,6 +54,7 @@ type policyGroupRemoveClientFactory func(
 // policyGroupRemoveArgs collects the flag values for the remove command.
 type policyGroupRemoveArgs struct {
 	org          string
+	yes          bool
 	outputFormat outputflag.OutputFlag[policyGroupRemoveRenderFunc]
 }
 
@@ -76,23 +79,22 @@ func newPolicyGroupRemoveCmdWith(factory policyGroupRemoveClientFactory) *cobra.
 	args.outputFormat = defaultPolicyGroupRemoveOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
 		Use:    "remove <name>",
 		Short:  "[EXPERIMENTAL] Delete a Policy Group",
 		Long: "[EXPERIMENTAL] Delete a Policy Group.\n" +
 			"\n" +
-			"Deletes a Policy Group from an organization. A Policy Group defines\n" +
-			"which Policy Packs are enforced on which stacks, with configurable\n" +
-			"enforcement levels per pack. The organization's default Policy Group\n" +
-			"cannot be deleted. Deleting a Policy Group removes all policy\n" +
-			"enforcement associations for the stacks that were assigned to it.\n" +
+			"Deletes a Policy Group from an organization. This cannot be undone.\n" +
+			"You will be prompted to confirm unless --yes is passed.\n" +
 			"\n" +
-			"Default output is a human-readable confirmation; pass --output=json for\n" +
-			"a machine-readable summary.",
-		Example: "  # Remove a Policy Group from the default organization\n" +
+			"The organization's default Policy Group cannot be deleted. Deleting\n" +
+			"a Policy Group removes all policy enforcement associations for the\n" +
+			"stacks that were assigned to it.",
+		Example: "  # Remove a Policy Group (will prompt for confirmation)\n" +
 			"  pulumi policy group remove prod-policies\n\n" +
-			"  # Remove a Policy Group from a specific organization and emit JSON\n" +
-			"  pulumi policy group remove prod-policies --org acme --output json",
+			"  # Remove without confirmation\n" +
+			"  pulumi policy group remove prod-policies --yes\n\n" +
+			"  # Remove from a specific organization\n" +
+			"  pulumi policy group remove prod-policies --org acme --yes",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
 			return runPolicyGroupRemove(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
@@ -106,6 +108,7 @@ func newPolicyGroupRemoveCmdWith(factory policyGroupRemoveClientFactory) *cobra.
 	})
 
 	cmd.Flags().StringVar(&args.org, "org", "", "The organization that owns the Policy Group")
+	cmd.Flags().BoolVarP(&args.yes, "yes", "y", false, "Skip confirmation prompts")
 	outputflag.VarP(cmd.Flags(), &args.outputFormat)
 
 	return cmd
@@ -160,6 +163,14 @@ func runPolicyGroupRemove(
 	ctx context.Context, w io.Writer,
 	factory policyGroupRemoveClientFactory, name string, args policyGroupRemoveArgs,
 ) error {
+	if !args.yes {
+		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+		prompt := fmt.Sprintf("This will permanently remove the policy group '%s'!", name)
+		if !ui.ConfirmPrompt(prompt, name, opts) {
+			return result.FprintBailf(w, "confirmation declined")
+		}
+	}
+
 	c, org, err := factory(ctx, args.org)
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -79,8 +79,8 @@ func newPolicyGroupRemoveCmdWith(factory policyGroupRemoveClientFactory) *cobra.
 	args.outputFormat = defaultPolicyGroupRemoveOutputFormat()
 
 	cmd := &cobra.Command{
-		Use:    "remove <name>",
-		Short:  "[EXPERIMENTAL] Delete a Policy Group",
+		Use:   "remove <name>",
+		Short: "[EXPERIMENTAL] Delete a Policy Group",
 		Long: "[EXPERIMENTAL] Delete a Policy Group.\n" +
 			"\n" +
 			"Deletes a Policy Group from an organization. This cannot be undone.\n" +

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -163,6 +164,10 @@ func runPolicyGroupRemove(
 	ctx context.Context, w io.Writer,
 	factory policyGroupRemoveClientFactory, name string, args policyGroupRemoveArgs,
 ) error {
+	if !cmdutil.Interactive() && !args.yes {
+		return backenderr.NonInteractiveRequiresYesError{}
+	}
+
 	if !args.yes {
 		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 		prompt := fmt.Sprintf("This will permanently remove the policy group '%s'!", name)

--- a/pkg/cmd/pulumi/policy/policy_group_remove_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove_test.go
@@ -59,7 +59,7 @@ func TestPolicyGroupRemove_DefaultOutput(t *testing.T) {
 	c := &mockPolicyGroupRemoveClient{}
 	err := runPolicyGroupRemove(t.Context(), &buf,
 		stubPolicyGroupRemoveFactory(c, "acme"), "prod-policies",
-		policyGroupRemoveArgs{outputFormat: defaultPolicyGroupRemoveOutputFormat()})
+		policyGroupRemoveArgs{yes: true, outputFormat: defaultPolicyGroupRemoveOutputFormat()})
 	require.NoError(t, err)
 
 	assert.Equal(t, "Removed policy group prod-policies from organization acme.\n", buf.String())
@@ -72,7 +72,7 @@ func TestPolicyGroupRemove_JSONOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockPolicyGroupRemoveClient{}
-	args := policyGroupRemoveArgs{outputFormat: defaultPolicyGroupRemoveOutputFormat()}
+	args := policyGroupRemoveArgs{yes: true, outputFormat: defaultPolicyGroupRemoveOutputFormat()}
 	require.NoError(t, args.outputFormat.Set("json"))
 	err := runPolicyGroupRemove(t.Context(), &buf,
 		stubPolicyGroupRemoveFactory(c, "acme"), "prod-policies", args)
@@ -91,7 +91,7 @@ func TestPolicyGroupRemove_ClientError(t *testing.T) {
 	c := &mockPolicyGroupRemoveClient{err: errors.New("cannot delete default group")}
 	err := runPolicyGroupRemove(t.Context(), &buf,
 		stubPolicyGroupRemoveFactory(c, "acme"), "default-policy-group",
-		policyGroupRemoveArgs{outputFormat: defaultPolicyGroupRemoveOutputFormat()})
+		policyGroupRemoveArgs{yes: true, outputFormat: defaultPolicyGroupRemoveOutputFormat()})
 	require.Error(t, err)
 	assert.Equal(t, "removing policy group: cannot delete default group", err.Error())
 	assert.Equal(t, "", buf.String())
@@ -103,7 +103,7 @@ func TestPolicyGroupRemove_FactoryError(t *testing.T) {
 	var buf bytes.Buffer
 	err := runPolicyGroupRemove(t.Context(), &buf,
 		failingPolicyGroupRemoveFactory(errors.New("not logged in")),
-		"prod-policies", policyGroupRemoveArgs{outputFormat: defaultPolicyGroupRemoveOutputFormat()})
+		"prod-policies", policyGroupRemoveArgs{yes: true, outputFormat: defaultPolicyGroupRemoveOutputFormat()})
 	require.Error(t, err)
 	assert.Equal(t, "not logged in", err.Error())
 }


### PR DESCRIPTION
Add the same validation as for the other remove commands and unhide it.

Example output:
```
$ PULUMI_HOME=~/.pulumi4 pulumi policy group remove --org pat-staging-org tg-test2
This will permanently remove the policy group 'tg-test2'!
Please confirm that this is what you'd like to do by typing `tg-test2`: tg-test2
Removed policy group tg-test2 from organization pat-staging-org.
```

Fixes https://github.com/pulumi/pulumi/issues/22990