### PR TITLE
add `pulumi policy compliance list`

### DIFF
--- a/changelog/pending/20260515--cli--add-pulumi-policy-compliance-list.yaml
+++ b/changelog/pending/20260515--cli--add-pulumi-policy-compliance-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi policy compliance list` to list compliance results grouped by entity

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1520,6 +1520,20 @@ func (pc *Client) ListPolicyIssues(
 	return resp, nil
 }
 
+// GetPolicyComplianceResults returns compliance results for policy issues
+// grouped by entity.
+func (pc *Client) GetPolicyComplianceResults(
+	ctx context.Context, orgName string, req apitype.GetPolicyComplianceResultsRequest,
+) (apitype.GetPolicyComplianceResultsResponse, error) {
+	path := fmt.Sprintf("/api/orgs/%s/policyresults/compliance", url.PathEscape(orgName))
+	var resp apitype.GetPolicyComplianceResultsResponse
+	if err := pc.restCall(ctx, http.MethodPost, path, nil, req, &resp); err != nil {
+		return apitype.GetPolicyComplianceResultsResponse{},
+			fmt.Errorf("getting policy compliance results: %w", err)
+	}
+	return resp, nil
+}
+
 // GetPolicyIssue returns the details of a single policy issue in the given
 // organization, wrapping the `GetPolicyIssue` Pulumi Cloud REST endpoint
 // (GET /api/orgs/{orgName}/policyresults/issues/{issueId}).

--- a/pkg/cmd/pulumi/policy/policy_compliance.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance.go
@@ -34,5 +34,3 @@ func newPolicyComplianceCmd() *cobra.Command {
 	cmd.AddCommand(newPolicyComplianceListCmd())
 	return cmd
 }
-
-// newPolicyComplianceListCmd is defined in policy_compliance_list.go.

--- a/pkg/cmd/pulumi/policy/policy_compliance.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance.go
@@ -15,8 +15,6 @@
 package policy
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -24,10 +22,8 @@ import (
 
 func newPolicyComplianceCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "compliance",
-		Short:  "Inspect policy compliance results",
-		Long:   "[EXPERIMENTAL] Inspect policy compliance results.",
+		Use:   "compliance",
+		Short: "[EXPERIMENTAL] Inspect policy compliance results",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -39,28 +35,4 @@ func newPolicyComplianceCmd() *cobra.Command {
 	return cmd
 }
 
-// TODO[https://github.com/pulumi/pulumi/issues/22994]: Not yet implemented.
-func newPolicyComplianceListCmd() *cobra.Command {
-	var (
-		org     string
-		groupBy string
-	)
-
-	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "List compliance results grouped by entity",
-		Long:   "[EXPERIMENTAL] List compliance results grouped by entity.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not yet implemented")
-		},
-	}
-
-	constrictor.AttachArguments(cmd, constrictor.NoArgs)
-
-	cmd.Flags().StringVar(&org, "org", "", "The organization to fetch compliance results for")
-	cmd.Flags().StringVar(&groupBy, "group-by", "stack",
-		"How to group results: stack, account, or severity")
-
-	return cmd
-}
+// newPolicyComplianceListCmd is defined in policy_compliance_list.go.

--- a/pkg/cmd/pulumi/policy/policy_compliance_list.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance_list.go
@@ -1,0 +1,294 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+type complianceListClient interface {
+	GetPolicyComplianceResults(
+		ctx context.Context, orgName string, req apitype.GetPolicyComplianceResultsRequest,
+	) (apitype.GetPolicyComplianceResultsResponse, error)
+}
+
+type complianceListClientFactory func(
+	ctx context.Context, orgFlag string,
+) (complianceListClient, string, error)
+
+type complianceListRender func(
+	cmd *complianceListCmd,
+	columns []string, rows []apitype.PolicyComplianceResult,
+) error
+
+var validGroupByValues = []string{"stack", "account", "severity"}
+
+type complianceListCmd struct {
+	org     string
+	groupBy string
+	count   int
+	output  outputflag.OutputFlag[complianceListRender]
+	w       io.Writer
+}
+
+func newPolicyComplianceListCmd() *cobra.Command {
+	return newPolicyComplianceListCmdWith(defaultComplianceListClientFactory)
+}
+
+func newPolicyComplianceListCmdWith(factory complianceListClientFactory) *cobra.Command {
+	contract.Assertf(factory != nil, "complianceListClientFactory must not be nil")
+
+	clcmd := &complianceListCmd{
+		output: outputflag.OutputFlag[complianceListRender]{
+			RenderForTerminal: (*complianceListCmd).renderTable,
+			RenderJSON:        (*complianceListCmd).renderJSON,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List compliance results grouped by entity",
+		Long: "List compliance results grouped by entity.\n" +
+			"\n" +
+			"Returns compliance results for policy issues grouped by stack,\n" +
+			"cloud account, or severity. Each row shows a compliance score\n" +
+			"(0-100%) per policy group/pack column.\n" +
+			"\n" +
+			"Score values: 0-100 = compliance %, N/A = not applicable,\n" +
+			"ERR = configuration error.",
+		Example: "  # List compliance by stack (default)\n" +
+			"  pulumi policy compliance list\n\n" +
+			"  # List compliance by severity\n" +
+			"  pulumi policy compliance list --group-by severity\n\n" +
+			"  # List compliance by account as JSON\n" +
+			"  pulumi policy compliance list --group-by account --output json",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clcmd.w = cmd.OutOrStdout()
+			return clcmd.run(cmd.Context(), factory)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&clcmd.org, "org", "",
+		"The organization to fetch compliance results for")
+	cmd.Flags().StringVar(&clcmd.groupBy, "group-by", "stack",
+		"How to group results: stack, account, or severity")
+	cmd.Flags().IntVar(&clcmd.count, "count", 0,
+		"Maximum number of rows to display (default: all)")
+	outputflag.VarP(cmd.Flags(), &clcmd.output)
+
+	return cmd
+}
+
+func defaultComplianceListClientFactory(
+	ctx context.Context, orgFlag string,
+) (complianceListClient, string, error) {
+	ws := pkgWorkspace.Instance
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	be, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, nil, opts)
+	if err != nil {
+		return nil, "", err
+	}
+	cloudBackend, ok := be.(httpstate.Backend)
+	if !ok {
+		return nil, "", errors.New(
+			"listing compliance results requires the Pulumi Cloud backend; run `pulumi login`")
+	}
+
+	userName, orgs, _, err := cloudBackend.CurrentUser()
+	if err != nil {
+		return nil, "", err
+	}
+
+	org := orgFlag
+	if org == "" {
+		defaultOrg, err := cloudBackend.GetDefaultOrg(ctx)
+		if err != nil {
+			return nil, "", err
+		}
+		org = defaultOrg
+	}
+	if org == "" {
+		org = userName
+	}
+	if !slices.Contains(orgs, org) && org != userName {
+		return nil, "", fmt.Errorf("user %s is not a member of organization %s", userName, org)
+	}
+
+	return cloudBackend.Client(), org, nil
+}
+
+func (c *complianceListCmd) run(ctx context.Context, factory complianceListClientFactory) error {
+	if !slices.Contains(validGroupByValues, c.groupBy) {
+		return fmt.Errorf(
+			"invalid --group-by %q; must be \"stack\", \"account\", or \"severity\"",
+			c.groupBy)
+	}
+
+	cl, org, err := factory(ctx, c.org)
+	if err != nil {
+		return err
+	}
+
+	// Fetch all pages.
+	var allRows []apitype.PolicyComplianceResult
+	var columns []string
+	var continuationToken *string
+
+	for {
+		pageSize := 1000
+		if c.count > 0 && c.count-len(allRows) < pageSize {
+			pageSize = c.count - len(allRows)
+		}
+		size := pageSize
+
+		resp, err := cl.GetPolicyComplianceResults(ctx, org,
+			apitype.GetPolicyComplianceResultsRequest{
+				Entity:            c.groupBy,
+				ContinuationToken: continuationToken,
+				Size:              &size,
+			})
+		if err != nil {
+			return fmt.Errorf("listing compliance results: %w", err)
+		}
+
+		columns = resp.Columns
+		allRows = append(allRows, resp.Rows...)
+
+		if c.count > 0 && len(allRows) >= c.count {
+			allRows = allRows[:c.count]
+			break
+		}
+		if resp.ContinuationToken == nil || *resp.ContinuationToken == "" {
+			break
+		}
+		continuationToken = resp.ContinuationToken
+	}
+
+	return c.output.Get()(c, columns, allRows)
+}
+
+func scoreString(score int) string {
+	switch score {
+	case -1:
+		return "N/A"
+	case -2:
+		return "ERR"
+	default:
+		return strconv.Itoa(score) + "%"
+	}
+}
+
+func (c *complianceListCmd) renderTable(
+	columns []string, rows []apitype.PolicyComplianceResult,
+) error {
+	if len(rows) == 0 {
+		fmt.Fprintln(c.w, "No compliance results found.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(c.w)
+	t.SetStyle(table.StyleLight)
+
+	header := table.Row{"ENTITY"}
+	for _, col := range columns {
+		header = append(header, col)
+	}
+	t.AppendHeader(header)
+
+	for _, row := range rows {
+		r := table.Row{row.EntityName}
+		for _, score := range row.Scores {
+			r = append(r, scoreString(score))
+		}
+		t.AppendRow(r)
+	}
+
+	// Score columns are short (e.g. "100%", "N/A"). Let the ENTITY column
+	// and any long column headers wrap to fit the terminal.
+	cols := cmdCmd.StdoutWidth()
+	// Each score column needs ~6 chars + borders. Reserve the rest for ENTITY.
+	scoreCols := len(columns)
+	borders := 3*(scoreCols+1) + 1
+	scoreWidth := 6 * scoreCols
+	entityWidth := cols - borders - scoreWidth
+	if entityWidth < 15 {
+		entityWidth = 15
+	}
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Name: "ENTITY", WidthMax: entityWidth, WidthMaxEnforcer: text.WrapText},
+	})
+	t.Render()
+
+	fmt.Fprintf(c.w, "\n%d result(s)\n", len(rows))
+	return nil
+}
+
+type complianceJSONRow struct {
+	Entity string         `json:"entity"`
+	Scores map[string]int `json:"scores"`
+}
+
+func (c *complianceListCmd) renderJSON(
+	columns []string, rows []apitype.PolicyComplianceResult,
+) error {
+	jsonRows := make([]complianceJSONRow, 0, len(rows))
+	for _, row := range rows {
+		scores := make(map[string]int, len(columns))
+		for i, col := range columns {
+			if i < len(row.Scores) {
+				scores[col] = row.Scores[i]
+			}
+		}
+		jsonRows = append(jsonRows, complianceJSONRow{
+			Entity: row.EntityName,
+			Scores: scores,
+		})
+	}
+	enc := json.NewEncoder(c.w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		Results []complianceJSONRow `json:"results"`
+		Count   int                 `json:"count"`
+	}{
+		Results: jsonRows,
+		Count:   len(jsonRows),
+	})
+}

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -432,3 +432,34 @@ type ListPolicyIssuesResponse struct {
 	// Total is the total number of issues matching the request across all pages.
 	Total int64 `json:"total,omitempty"`
 }
+
+// GetPolicyComplianceResultsRequest is the request body for the compliance
+// results endpoint (POST /api/orgs/{orgName}/policy-results/compliance).
+type GetPolicyComplianceResultsRequest struct {
+	// Entity is how to group results: "stack", "account", or "severity".
+	Entity string `json:"entity"`
+	// ContinuationToken is the pagination token from a previous response.
+	ContinuationToken *string `json:"continuationToken,omitempty"`
+	// Size is the number of results per page (max 1000).
+	Size *int `json:"size,omitempty"`
+}
+
+// GetPolicyComplianceResultsResponse is the response from the compliance
+// results endpoint.
+type GetPolicyComplianceResultsResponse struct {
+	// Columns lists the policy group/pack identifiers or severity levels.
+	Columns []string `json:"columns"`
+	// Rows contains one entry per entity (stack, account, or policy pack).
+	Rows []PolicyComplianceResult `json:"rows"`
+	// ContinuationToken is set when more pages are available.
+	ContinuationToken *string `json:"continuationToken,omitempty"`
+}
+
+// PolicyComplianceResult is a single row in the compliance results table.
+type PolicyComplianceResult struct {
+	// EntityName identifies the entity (e.g. "project/stack" or account name).
+	EntityName string `json:"entityName"`
+	// Scores is an array correlating 1:1 with Columns. Values are 0-100
+	// (compliance %), -1 (N/A), or -2 (config error).
+	Scores []int `json:"scores"`
+}


### PR DESCRIPTION
The clanker seems to have forgotten about this, let's implement it now.

example output:
```
$ PULUMI_HOME=~/.pulumi4 pulumi policy compliance list --org pat-staging-org  --group-by account --output json
{
  "results": [
    {
      "entity": "cloud-cli-fixture-account",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 100,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    },
    {
      "entity": "cloud-cli-fixture-account/global",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 86,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    },
    {
      "entity": "test-account",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 100,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    },
    {
      "entity": "test-account-2",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 100,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    },
    {
      "entity": "test-account-2/global",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 100,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    },
    {
      "entity": "test-account/global",
      "scores": {
        "default-accounts-policy-group@hitrust-aws": 100,
        "default-accounts-policy-group@hitrust-azure": 100,
        "default-accounts-policy-group@pulumi-best-practices-aws": 100,
        "default-accounts-policy-group@pulumi-best-practices-azure": 100
      }
    }
  ],
  "count": 6
}

$ PULUMI_HOME=~/.pulumi4 pulumi policy compliance list --org pat-staging-org  --group-by severity
┌───────────────────────────────────────────────────────────┬──────────┬──────┬────────┬─────┬──────┐
│ ENTITY                                                    │ CRITICAL │ HIGH │ MEDIUM │ LOW │ NA   │
├───────────────────────────────────────────────────────────┼──────────┼──────┼────────┼─────┼──────┤
│ cloud-cli-fixture-group@cloud-cli-fixture-pack            │ N/A      │ N/A  │ N/A    │ N/A │ 0%   │
│ default-accounts-policy-group@hitrust-aws                 │ N/A      │ N/A  │ N/A    │ N/A │ 86%  │
│ default-accounts-policy-group@hitrust-azure               │ N/A      │ N/A  │ N/A    │ N/A │ 100% │
│ default-accounts-policy-group@pulumi-best-practices-aws   │ N/A      │ N/A  │ N/A    │ N/A │ 100% │
│ default-accounts-policy-group@pulumi-best-practices-azure │ N/A      │ N/A  │ N/A    │ N/A │ 100% │
└───────────────────────────────────────────────────────────┴──────────┴──────┴────────┴─────┴──────┘
```

Fixes https://github.com/pulumi/pulumi/issues/22994