### PR TITLE
fix `pulumi org audit-log list`

### DIFF
--- a/changelog/pending/20260515--cli--add-pulumi-org-audit-log-list.yaml
+++ b/changelog/pending/20260515--cli--add-pulumi-org-audit-log-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi org audit-log list`

--- a/pkg/cmd/pulumi/org/org_audit_log.go
+++ b/pkg/cmd/pulumi/org/org_audit_log.go
@@ -22,10 +22,9 @@ import (
 
 func newOrgAuditLogCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "audit-log",
-		Short:  "Inspect organization audit logs",
-		Long:   "[EXPERIMENTAL] Inspect organization audit logs.",
+		Use:   "audit-log",
+		Short: "Inspect organization audit logs",
+		Long:  "[EXPERIMENTAL] Inspect organization audit logs.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/pkg/cmd/pulumi/org/org_audit_log_export.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_export.go
@@ -90,9 +90,8 @@ func newOrgAuditLogExportCmdWith(factory orgAuditLogExportClientFactory) *cobra.
 	args.outputFormat = defaultOrgAuditLogExportOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "export",
-		Short:  "[EXPERIMENTAL] Export audit log events for an organization",
+		Use:   "export",
+		Short: "[EXPERIMENTAL] Export audit log events for an organization",
 		Long: "[EXPERIMENTAL] Export audit log events for an organization.\n" +
 			"\n" +
 			"Streams an export of audit log events for the organization in the\n" +

--- a/pkg/cmd/pulumi/org/org_audit_log_list.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_list.go
@@ -88,9 +88,8 @@ func newOrgAuditLogListCmdWith(factory orgAuditLogListClientFactory) *cobra.Comm
 	args.outputFormat = defaultOrgAuditLogListOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "[EXPERIMENTAL] List audit log events for an organization",
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List audit log events for an organization",
 		Long: "[EXPERIMENTAL] List audit log events for an organization.\n" +
 			"\n" +
 			"Returns audit log events for the organization. Results may be filtered\n" +
@@ -237,7 +236,7 @@ func renderOrgAuditLogListTable(
 	t := table.NewWriter()
 	t.SetOutputMirror(w)
 	t.SetStyle(table.StyleLight)
-	t.AppendHeader(table.Row{"TIMESTAMP", "USER", "EVENT", "NAME", "SOURCE IP"})
+	t.AppendHeader(table.Row{"TIMESTAMP", "USER", "EVENT", "DESCRIPTION", "SOURCE IP"})
 
 	for _, ev := range resp.AuditLogEvents {
 		user := ev.User.GitHubLogin
@@ -248,9 +247,9 @@ func renderOrgAuditLogListTable(
 		if event == "" {
 			event = "-"
 		}
-		name := ev.Name
-		if name == "" {
-			name = "-"
+		description := ev.Description
+		if description == "" {
+			description = "-"
 		}
 		sourceIP := ev.SourceIP
 		if sourceIP == "" {
@@ -260,7 +259,7 @@ func renderOrgAuditLogListTable(
 			formatAuditLogTimestamp(ev.Timestamp),
 			user,
 			event,
-			name,
+			description,
 			sourceIP,
 		})
 	}

--- a/pkg/cmd/pulumi/org/org_audit_log_list_test.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_list_test.go
@@ -80,14 +80,13 @@ func sampleAuditLogEvent() apitype.AuditLogEvent {
 	return apitype.AuditLogEvent{
 		// 2025-01-02T03:04:05Z
 		Timestamp:   1735787045,
-		Name:        "stack.create",
+		Event:       "stack.create",
 		SourceIP:    "203.0.113.7",
 		Description: "Created stack acme/web/prod",
 		User: apitype.UserInfo{
 			Name:        "Alice Example",
 			GitHubLogin: "alice",
 		},
-		Event: "stack",
 	}
 }
 
@@ -123,11 +122,11 @@ func TestOrgAuditLogList_DefaultOutput(t *testing.T) {
 	}, c.calls)
 
 	expected := "" +
-		"┌──────────────────────┬───────┬───────┬──────────────┬─────────────┐\n" +
-		"│ TIMESTAMP            │ USER  │ EVENT │ NAME         │ SOURCE IP   │\n" +
-		"├──────────────────────┼───────┼───────┼──────────────┼─────────────┤\n" +
-		"│ 2025-01-02T03:04:05Z │ alice │ stack │ stack.create │ 203.0.113.7 │\n" +
-		"└──────────────────────┴───────┴───────┴──────────────┴─────────────┘\n"
+		"┌──────────────────────┬───────┬──────────────┬─────────────────────────────┬─────────────┐\n" +
+		"│ TIMESTAMP            │ USER  │ EVENT        │ DESCRIPTION                 │ SOURCE IP   │\n" +
+		"├──────────────────────┼───────┼──────────────┼─────────────────────────────┼─────────────┤\n" +
+		"│ 2025-01-02T03:04:05Z │ alice │ stack.create │ Created stack acme/web/prod │ 203.0.113.7 │\n" +
+		"└──────────────────────┴───────┴──────────────┴─────────────────────────────┴─────────────┘\n"
 	assert.Equal(t, expected, buf.String())
 }
 
@@ -152,7 +151,7 @@ func TestOrgAuditLogList_AutoPaginatesWithCount(t *testing.T) {
 	// First page has 1 event with a continuation token; second page has another
 	// event. --count=2 should drive a second call.
 	page2Event := sampleAuditLogEvent()
-	page2Event.Name = "stack.delete"
+	page2Event.Event = "stack.delete"
 
 	calls := 0
 	c := &fakeAuditLogListClient{
@@ -214,15 +213,14 @@ func TestOrgAuditLogList_JSONOutput(t *testing.T) {
 	assert.JSONEq(t, `{
 		"events": [{
 			"timestamp": 1735787045,
-			"name": "stack.create",
+			"event": "stack.create",
 			"sourceIP": "203.0.113.7",
 			"description": "Created stack acme/web/prod",
 			"user": {
 				"name": "Alice Example",
 				"githubLogin": "alice",
 				"avatarUrl": ""
-			},
-			"event": "stack"
+			}
 		}],
 		"count": 1
 	}`, buf.String())

--- a/sdk/go/common/apitype/organizations.go
+++ b/sdk/go/common/apitype/organizations.go
@@ -91,18 +91,18 @@ type ListOrganizationMembersResponse struct {
 type AuditLogEvent struct {
 	// Timestamp is the Unix epoch (in seconds) at which the event occurred.
 	Timestamp int64 `json:"timestamp"`
-	// Name is the short, machine-readable identifier of the event (e.g.
-	// "stack.create").
-	Name string `json:"name"`
-	// SourceIP is the IP address from which the event originated.
-	SourceIP string `json:"sourceIP"`
+	// Event is the event type identifier (e.g. "stack.update", "member.added").
+	Event string `json:"event"`
 	// Description is the human-readable description of the event.
 	Description string `json:"description"`
 	// User is the user that triggered the event.
 	User UserInfo `json:"user"`
-	// Event is the event-type bucket (e.g. "auth", "stack"). The cloud docs
-	// distinguish this from Name.
-	Event string `json:"event"`
+	// SourceIP is the IP address from which the event originated.
+	SourceIP string `json:"sourceIP"`
+	// TokenID is the ID of the access token used, if any.
+	TokenID string `json:"tokenID,omitempty"`
+	// TokenName is the name of the access token used, if any.
+	TokenName string `json:"tokenName,omitempty"`
 }
 
 // ListAuditLogEventsResponse is the response body returned by the


### PR DESCRIPTION
Update an incorrect field, and unhide the command.

Example output:

```
$ PULUMI_HOME=~/.pulumi4 pulumi org audit-log list --org pat-staging-org --count 2 
┌──────────────────────┬───────────┬──────────────────────┬──────┬──────────────┐
│ TIMESTAMP            │ USER      │ EVENT                │ NAME │ SOURCE IP    │
├──────────────────────┼───────────┼──────────────────────┼──────┼──────────────┤
│ 2026-05-15T14:50:53Z │ tgummerer │ policy-group-deleted │ -    │ 86.127.224.7 │
│ 2026-05-15T14:50:26Z │ tgummerer │ policy-group-created │ -    │ 86.127.224.7 │
└──────────────────────┴───────────┴──────────────────────┴──────┴──────────────┘

$ PULUMI_HOME=~/.pulumi4 pulumi org audit-log list --org pat-staging-org --count 2 
┌──────────────────────┬───────────┬──────────────────────┬───────────────────────────────┬──────────────┐
│ TIMESTAMP            │ USER      │ EVENT                │ DESCRIPTION                   │ SOURCE IP    │
├──────────────────────┼───────────┼──────────────────────┼───────────────────────────────┼──────────────┤
│ 2026-05-15T14:50:53Z │ tgummerer │ policy-group-deleted │ Deleted policy group tg-test2 │ 86.127.224.7 │
│ 2026-05-15T14:50:26Z │ tgummerer │ policy-group-created │ Created policy group tg-test2 │ 86.127.224.7 │
└──────────────────────┴───────────┴──────────────────────┴───────────────────────────────┴──────────────┘
```

Fixes https://github.com/pulumi/pulumi/issues/23001