### PR TITLE
improve `audit-log export` output, unhide it

### DIFF
--- a/changelog/pending/20260515--cli--add-pulumi-audit-log-export-command.yaml
+++ b/changelog/pending/20260515--cli--add-pulumi-audit-log-export-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Add `pulumi audit-log export` command

--- a/pkg/cmd/pulumi/org/org_audit_log_export.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_export.go
@@ -17,8 +17,9 @@ package org
 // AI Generated - needs human review
 
 import (
+	"bytes"
 	"context"
-	"encoding/base64"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -219,23 +220,76 @@ func renderOrgAuditLogExportRaw(w io.Writer, data []byte, _ string) error {
 	return nil
 }
 
-// renderOrgAuditLogExportJSON wraps the body in a JSON envelope with the
-// response format and base64-encoded data.
+// renderOrgAuditLogExportJSON parses the export data and emits structured JSON.
+// For CSV exports, each row becomes a JSON object keyed by the CSV header.
+// For CEF exports, the raw lines are emitted as a string array.
 func renderOrgAuditLogExportJSON(w io.Writer, data []byte, format string) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	return enc.Encode(auditLogExportEnvelope{
+
+	if format == "csv" {
+		return renderCSVAsJSON(w, data, enc)
+	}
+	// CEF or unknown: emit raw lines.
+	lines := splitLines(data)
+	return enc.Encode(struct {
+		Format string   `json:"format"`
+		Lines  []string `json:"lines"`
+		Count  int      `json:"count"`
+	}{
 		Format: format,
-		Data:   base64.StdEncoding.EncodeToString(data),
+		Lines:  lines,
+		Count:  len(lines),
 	})
 }
 
-// auditLogExportEnvelope is the JSON shape emitted by
-// `pulumi org audit-log export --output=json`. The raw response body is
-// base64-encoded so it survives transport through JSON regardless of which
-// format (CSV or CEF) the server produced.
-type auditLogExportEnvelope struct {
-	Format string `json:"format"`
-	Data   string `json:"data"`
+func renderCSVAsJSON(w io.Writer, data []byte, enc *json.Encoder) error {
+	reader := csv.NewReader(bytes.NewReader(data))
+	records, err := reader.ReadAll()
+	if err != nil {
+		return fmt.Errorf("parsing CSV export: %w", err)
+	}
+	if len(records) == 0 {
+		return enc.Encode(struct {
+			Events []map[string]string `json:"events"`
+			Count  int                 `json:"count"`
+		}{
+			Events: []map[string]string{},
+			Count:  0,
+		})
+	}
+
+	headers := records[0]
+	events := make([]map[string]string, 0, len(records)-1)
+	for _, row := range records[1:] {
+		event := make(map[string]string, len(headers))
+		for i, h := range headers {
+			if i < len(row) {
+				event[h] = row[i]
+			}
+		}
+		events = append(events, event)
+	}
+
+	return enc.Encode(struct {
+		Events []map[string]string `json:"events"`
+		Count  int                 `json:"count"`
+	}{
+		Events: events,
+		Count:  len(events),
+	})
+}
+
+func splitLines(data []byte) []string {
+	s := string(bytes.TrimRight(data, "\n\r"))
+	if s == "" {
+		return []string{}
+	}
+	lines := bytes.Split([]byte(s), []byte("\n"))
+	result := make([]string, len(lines))
+	for i, l := range lines {
+		result[i] = string(bytes.TrimRight(l, "\r"))
+	}
+	return result
 }

--- a/pkg/cmd/pulumi/org/org_audit_log_export_test.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_export_test.go
@@ -19,7 +19,6 @@ package org
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"io"
 	"strings"
@@ -150,10 +149,10 @@ func TestOrgAuditLogExport_JSONOutput(t *testing.T) {
 		},
 	}, c.calls)
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(fixture))
 	assert.JSONEq(t, `{
 		"format": "cef",
-		"data": "`+encoded+`"
+		"lines": ["timestamp,user,event", "2025-01-02T03:04:05Z,alice,stack.create"],
+		"count": 2
 	}`, buf.String())
 }
 


### PR DESCRIPTION
Example output:
```
$ PULUMI_HOME=~/.pulumi4 pulumi org audit-log export  --output json
{
  "events": [
    {
      "ActorName": "",
      "ActorUrn": "",
      "AuthenticationFailure": "false",
      "Description": "User \"tgummerer\" logged into the Pulumi Console.",
      "Event": "User Login",
      "Login": "tgummerer",
      "Name": "Thomas Gummerer",
      "RequireOrgAdmin": "false",
      "RequireStackAdmin": "false",
      "SourceIP": "...",
      "Timestamp": "2026-05-14T13:44:46Z",
      "TokenID": "",
      "TokenName": ""
    },
    {
      "ActorName": "",
      "ActorUrn": "",
      "AuthenticationFailure": "false",
      "Description": "User \"tgummerer\" logged into the Pulumi Console.",
      "Event": "User Login",
      "Login": "tgummerer",
      "Name": "Thomas Gummerer",
      "RequireOrgAdmin": "false",
      "RequireStackAdmin": "false",
      "SourceIP": "...",
      "Timestamp": "2025-06-12T09:02:50Z",
      "TokenID": "",
      "TokenName": ""
    },
    {
      "ActorName": "",
      "ActorUrn": "",
      "AuthenticationFailure": "false",
      "Description": "User \"tgummerer\" logged into the Pulumi Console.",
      "Event": "User Login",
      "Login": "tgummerer",
      "Name": "Thomas Gummerer",
      "RequireOrgAdmin": "false",
      "RequireStackAdmin": "false",
      "SourceIP": "...",
      "Timestamp": "2025-06-11T08:31:03Z",
      "TokenID": "",
      "TokenName": ""
    }
  ],
  "count": 3
}

$ PULUMI_HOME=~/.pulumi4 pulumi org audit-log export
Timestamp,Name,Login,Event,Description,SourceIP,TokenID,TokenName,ActorName,ActorUrn,RequireOrgAdmin,RequireStackAdmin,AuthenticationFailure
2026-05-14T13:44:46Z,Thomas Gummerer,tgummerer,User Login,"User ""tgummerer"" logged into the Pulumi Console.",...,,,,,false,false,false
2025-06-12T09:02:50Z,Thomas Gummerer,tgummerer,User Login,"User ""tgummerer"" logged into the Pulumi Console.",...,,,,,false,false,false
2025-06-11T08:31:03Z,Thomas Gummerer,tgummerer,User Login,"User ""tgummerer"" logged into the Pulumi Console.",...,,,,,false,false,false
```

Fixes https://github.com/pulumi/pulumi/issues/23000