### PR TITLE
[ci] free more disk on Ubuntu integration test runners

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -115,10 +115,21 @@ jobs:
         name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
+          # tool-cache stays off: tests need Node and Python from /opt/hostedtoolcache.
           tool-cache: false
           swap-storage: false
-          large-packages: false
-          dotnet: false
+          large-packages: true
+          dotnet: true
+
+      # `large-packages: true` strips the runner's pre-installed `azure-cli`,
+      # which TestAzureLoginAzLogin in tests/integration/backend/diy invokes
+      # via exec.Command("az", "login", ...) when the AZURE_CLIENT_* secrets
+      # are set. Put it back. None of the other packages stripped by
+      # `large-packages` are exercised by these tests.
+      - if: contains(inputs.platform, 'ubuntu')
+        name: Reinstall Azure CLI
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.


### PR DESCRIPTION
The `sdk/nodejs/cmd/pulumi-language-nodejs 3/3 on ubuntu-latest/minimum` shard has been failing on a small fraction of runs since 2026-05-14 with `No space left on device` -- the GHA runner agent crashes trying to write its own diag log. (The other annotation, `The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.`, is the same root cause: the agent dies and the run aborts.)

The runner starts each integration test job with 90 GiB free. The existing `Free Disk Space (Ubuntu)` step strips Android (~10 GiB), Haskell (~3.6 GiB), and Docker images (~1.8 GiB), bringing the budget up to ~105 GiB. These changes enable two more flags on the same action:

- `large-packages: true` -- strips firefox, chromium, powershell, mssql, etc. (~6 GiB). None of these are exercised by Pulumi's tests.
- `dotnet: true` -- strips the pre-installed `.NET` SDK (~2 GiB). `actions/setup-dotnet@v5` reinstalls cleanly when a job needs it.

`tool-cache` stays off because the Node and Python toolchains under `/opt/hostedtoolcache` are needed by the tests. The other unused flag, `swap-storage`, is left alone -- the savings are smaller and stripping swap reduces tolerance for transient memory pressure.

The extra prune adds roughly two to three minutes to the `Free Disk Space` step on every Ubuntu integration test job (`large-packages` does the bulk of this, since it uses `apt-get remove`). If that turns out to be too expensive in aggregate, we can scope the extra flags down to the nodejs language host shard, or partition that shard further (`scripts/get-job-matrix.py` and `.github/workflows/ci.yml`).

## Test plan

- [ ] Re-run the failing shard in this PR's CI; confirm the disk-saved line in the `Free Disk Space (Ubuntu)` step is in the 22-24 GiB range rather than ~15 GiB
- [ ] Watch the next few merge_group runs after this lands to confirm the failure rate on `pulumi-language-nodejs 3/3 on ubuntu-latest/minimum` drops to zero