### PR TITLE
`pulumi deployment settings edit` no longer clears fields that the patch does not mention

### DIFF
--- a/changelog/pending/20260516--cli-cloud--pulumi-deployment-settings-edit-shallow-merge-fix.yaml
+++ b/changelog/pending/20260516--cli-cloud--pulumi-deployment-settings-edit-shallow-merge-fix.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/cloud
+  description: "`pulumi deployment settings edit` no longer clears fields that the patch does not mention"

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2169,8 +2169,11 @@ func (pc *Client) UpdateStackDeploymentSettings(ctx context.Context, stack Stack
 // For each property in the patch, the server starts with the current value,
 // removes it if the patch specifies null, or merges the new non-null value
 // with the existing one. Non-object properties are replaced entirely.
+//
+// Note we use json.RawMessage and not DeploymentSettings so that we can send
+// partial objects (ie undefined values) or null values to delete settings.
 func (pc *Client) PatchStackDeploymentSettings(ctx context.Context, stack StackIdentifier,
-	patch *apitype.DeploymentSettings,
+	patch json.RawMessage,
 ) error {
 	return pc.restCall(ctx, http.MethodPost, getStackPath(stack, "deployments", "settings"), nil, patch, nil)
 }

--- a/pkg/backend/httpstate/client/client_deployments_test.go
+++ b/pkg/backend/httpstate/client/client_deployments_test.go
@@ -162,37 +162,33 @@ func TestPatchStackDeploymentSettings(t *testing.T) {
 		Stack:   tokens.MustParseStackName("prod"),
 	}
 
-	t.Run("posts patch to settings endpoint", func(t *testing.T) {
+	t.Run("posts patch verbatim to settings endpoint", func(t *testing.T) {
 		t.Parallel()
 
 		var (
 			capturedMethod string
 			capturedURI    string
-			capturedBody   apitype.DeploymentSettings
+			capturedBody   []byte
 		)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			capturedMethod = r.Method
 			capturedURI = r.URL.RequestURI()
 			body, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
-			require.NoError(t, json.Unmarshal(body, &capturedBody))
+			capturedBody = body
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer server.Close()
 
 		c := newMockClient(server)
-		patch := &apitype.DeploymentSettings{
-			SourceContext: &apitype.SourceContext{
-				Git: &apitype.SourceContextGit{Branch: "feature"},
-			},
-		}
+		patch := json.RawMessage(`{"operationContext":{"preRunCommands":["echo hi"]}}`)
 		require.NoError(t, c.PatchStackDeploymentSettings(t.Context(), stackID, patch))
 
 		assert.Equal(t, http.MethodPost, capturedMethod)
 		assert.Equal(t, "/api/stacks/acme/web/prod/deployments/settings", capturedURI)
-		require.NotNil(t, capturedBody.SourceContext)
-		require.NotNil(t, capturedBody.SourceContext.Git)
-		assert.Equal(t, "feature", capturedBody.SourceContext.Git.Branch)
+		assert.JSONEq(t, string(patch), string(capturedBody))
+		assert.NotContains(t, string(capturedBody), "environmentVariables",
+			"patch must not introduce keys the caller did not write")
 	})
 
 	t.Run("propagates HTTP errors", func(t *testing.T) {
@@ -205,7 +201,7 @@ func TestPatchStackDeploymentSettings(t *testing.T) {
 		defer server.Close()
 
 		c := newMockClient(server)
-		err := c.PatchStackDeploymentSettings(t.Context(), stackID, &apitype.DeploymentSettings{})
+		err := c.PatchStackDeploymentSettings(t.Context(), stackID, json.RawMessage(`{}`))
 		require.Error(t, err)
 	})
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -17,6 +17,7 @@ package deployment
 // AI Generated - needs human review
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -43,7 +44,7 @@ import (
 // on.
 type deploymentSettingsEditClient interface {
 	PatchStackDeploymentSettings(
-		ctx context.Context, stack client.StackIdentifier, patch *apitype.DeploymentSettings,
+		ctx context.Context, stack client.StackIdentifier, patch json.RawMessage,
 	) error
 	GetStackDeploymentSettings(
 		ctx context.Context, stack client.StackIdentifier,
@@ -185,9 +186,12 @@ func runDeploymentSettingsEdit(
 }
 
 // readDeploymentSettingsPatch reads the JSON patch from path (or stdin when
-// path is `-`) and unmarshals it into an apitype.DeploymentSettings. Empty
-// content is rejected so a typo doesn't silently send an empty patch.
-func readDeploymentSettingsPatch(path string, stdin io.Reader) (*apitype.DeploymentSettings, error) {
+// path is `-`). The bytes are validated against apitype.DeploymentSettings
+// (with unknown fields rejected) so typos surface here instead of silently
+// no-op'ing on the server, but the original bytes are sent through verbatim
+// so that we can send partial objects (undefined fields) or null for deleting
+// fields.
+func readDeploymentSettingsPatch(path string, stdin io.Reader) (json.RawMessage, error) {
 	var raw []byte
 	var err error
 	if path == "-" {
@@ -209,11 +213,13 @@ func readDeploymentSettingsPatch(path string, stdin io.Reader) (*apitype.Deploym
 		return nil, errors.New("patch file is empty")
 	}
 
-	var patch apitype.DeploymentSettings
-	if err := json.Unmarshal(raw, &patch); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var probe apitype.DeploymentSettings
+	if err := dec.Decode(&probe); err != nil {
 		return nil, err
 	}
-	return &patch, nil
+	return json.RawMessage(raw), nil
 }
 
 func isAllWhitespace(b []byte) bool {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -78,9 +78,8 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 	args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit",
-		Short:  "[EXPERIMENTAL] Create or update deployment settings for a stack",
+		Use:   "edit",
+		Short: "[EXPERIMENTAL] Create or update deployment settings for a stack",
 		Long: "[EXPERIMENTAL] Create or update deployment settings for a stack.\n" +
 			"\n" +
 			"Applies a JSON patch to the stack's Pulumi Deployments settings. If no\n" +

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -35,7 +36,7 @@ import (
 // tests can assert the call shape.
 type capturedEditPatch struct {
 	stack client.StackIdentifier
-	patch *apitype.DeploymentSettings
+	patch json.RawMessage
 }
 
 // mockDeploymentSettingsEditClient stubs the patch + get pair. patchErr fires
@@ -49,7 +50,7 @@ type mockDeploymentSettingsEditClient struct {
 }
 
 func (m *mockDeploymentSettingsEditClient) PatchStackDeploymentSettings(
-	_ context.Context, stack client.StackIdentifier, patch *apitype.DeploymentSettings,
+	_ context.Context, stack client.StackIdentifier, patch json.RawMessage,
 ) error {
 	if m.captured != nil {
 		m.captured.stack = stack
@@ -107,9 +108,7 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 
 	assert.Equal(t, testStackID, captured.stack)
 	require.NotNil(t, captured.patch)
-	require.NotNil(t, captured.patch.SourceContext)
-	require.NotNil(t, captured.patch.SourceContext.Git)
-	assert.Equal(t, "feature", captured.patch.SourceContext.Git.Branch)
+	assert.JSONEq(t, patchJSON, string(captured.patch))
 
 	assert.Equal(t, `Executor image:          pulumi/pulumi:latest
 Working directory:       /work
@@ -284,7 +283,8 @@ func TestDeploymentSettingsEdit_StdinPatch(t *testing.T) {
 		captured: captured,
 	}
 
-	stdin := strings.NewReader(`{"sourceContext":{"git":{"branch":"from-stdin"}}}`)
+	patchJSON := `{"sourceContext":{"git":{"branch":"from-stdin"}}}`
+	stdin := strings.NewReader(patchJSON)
 
 	var buf bytes.Buffer
 	err := runDeploymentSettingsEdit(t.Context(), &buf, stdin,
@@ -293,7 +293,50 @@ func TestDeploymentSettingsEdit_StdinPatch(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, captured.patch)
-	require.NotNil(t, captured.patch.SourceContext)
-	require.NotNil(t, captured.patch.SourceContext.Git)
-	assert.Equal(t, "from-stdin", captured.patch.SourceContext.Git.Branch)
+	assert.JSONEq(t, patchJSON, string(captured.patch))
+}
+
+// TestDeploymentSettingsEdit_ForwardsExplicitNull pins the documented
+// "null property means delete" semantic: if the user writes a literal null,
+// the bytes must reach the server unchanged so the server-side merge clears
+// the field.
+func TestDeploymentSettingsEdit_ForwardsExplicitNull(t *testing.T) {
+	t.Parallel()
+
+	patchJSON := `{"operationContext":{"environmentVariables":null}}`
+	patchFile := writePatchFile(t, patchJSON)
+
+	captured := &capturedEditPatch{}
+	c := &mockDeploymentSettingsEditClient{
+		getResp:  &apitype.DeploymentSettings{},
+		captured: captured,
+	}
+
+	var buf bytes.Buffer
+	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
+		stubSettingsEditFactory(c),
+		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	require.NoError(t, err)
+
+	require.NotNil(t, captured.patch)
+	assert.JSONEq(t, patchJSON, string(captured.patch),
+		"explicit null must reach the server so the merge deletes the property")
+	assert.Contains(t, string(captured.patch), "null",
+		"the literal null must survive — JSONEq alone wouldn't catch a re-encoding that dropped it")
+}
+
+func TestDeploymentSettingsEdit_RejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	// Typo: enviornmentVariables instead of environmentVariables.
+	patchFile := writePatchFile(t, `{"operationContext":{"enviornmentVariables":{"X":"y"}}}`)
+
+	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
+
+	var buf bytes.Buffer
+	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
+		stubSettingsEditFactory(c),
+		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "enviornmentVariables")
 }


### PR DESCRIPTION
The server's patch endpoint distinguishes three states per field: absent = preserve, null = delete, value = set. Go's encoding/json collapses absent and null into the same zero value when unmarshaling into a struct, so any round-trip through apitype.DeploymentSettings loses that signal.

Ideally we’d be able to share something like https://github.com/pulumi/pulumi-service/blob/e4cd2203074bfb143c53ccb054b6882fb67f3006/pkg/apitype/deployment_settings_request_.go#L18  which uses the service’s [jsonvalue.Value](https://github.com/pulumi/pulumi-service/blob/e4cd2203074bfb143c53ccb054b6882fb67f3006/pkg/apitype/jsonvalue/value.go#L16) to help deal with this.
