### PR TITLE
Cleanup unused mmap cache

### DIFF
--- a/pkg/codegen/schema/loader_mmap.go
+++ b/pkg/codegen/schema/loader_mmap.go
@@ -24,17 +24,11 @@ import (
 	"github.com/edsrzf/mmap-go"
 )
 
-var mmapedFiles = make(map[string]mmap.MMap)
-
 // loadCachedSchemaBytes returns the cached schema at path if the cache file is newer than
 // pluginInstallTime (i.e. the schema was written after the plugin was last installed).
 func (l *pluginLoader) loadCachedSchemaBytes(path string, pluginInstallTime time.Time) ([]byte, bool) {
 	if l.cacheOptions.disableFileCache {
 		return nil, false
-	}
-
-	if schemaMmap, ok := mmapedFiles[path]; ok {
-		return schemaMmap, true
 	}
 
 	success := false


### PR DESCRIPTION
This cache was never written to, but also I don't think we want or need it.
We don't want it because it's a global variable that we'd never clean, even for long lasting operations where we'd reset contexts.
We don't need it because we cache at the in-memory schema level anyway in `cachedLoader`.