### PR TITLE
[test] skip TestRapidGenerateHCL2Definition cases with Map-nested assets

### DIFF
--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -110,6 +110,28 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 			t.Skip("inputs contain a `__`-prefixed map key; production drops them silently")
 		}
 
+		if checkPropertyMap(sample.State.Inputs, func(p property.Value) bool {
+			if !p.IsMap() {
+				return false
+			}
+			for _, v := range p.AsMap().All {
+				if containsAssetOrArchive(v) {
+					return true
+				}
+			}
+			return false
+		}) {
+			// TODO: real bug — when an input contains a Map value whose
+			// entries transitively contain an Asset or Archive,
+			// generateValue (pkg/importer/hcl2.go:890) renders the map as
+			// `{}` and loses every entry. Top-level Asset/Archive values
+			// round-trip fine; only Asset/Archive values nested inside a
+			// Map are dropped, even when wrapped in arrays or nested maps.
+			// Skip until the importer preserves these entries.
+			// See pulumi/pulumi#23220.
+			t.Skip("inputs contain a Map value with nested Asset/Archive; production drops them silently (#23220)")
+		}
+
 		loader := &stubSchemaLoader{pkg: pkg}
 		importState := buildImportState(sample)
 
@@ -143,6 +165,29 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 		require.Truef(t, sample.State.Inputs.DeepEquals(gotInputs),
 			"inputs differ\nwant: %#v\ngot:  %#v\nblock:\n%s", sample.State.Inputs, gotInputs, text)
 	})
+}
+
+// containsAssetOrArchive reports whether v transitively contains an Asset
+// or Archive value, descending through arrays and maps.
+func containsAssetOrArchive(v property.Value) bool {
+	if v.IsAsset() || v.IsArchive() {
+		return true
+	}
+	if v.IsArray() {
+		for _, c := range v.AsArray().All {
+			if containsAssetOrArchive(c) {
+				return true
+			}
+		}
+	}
+	if v.IsMap() {
+		for _, c := range v.AsMap().All {
+			if containsAssetOrArchive(c) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // archiveHasNonNFC reports whether a contains, transitively, any string that


### PR DESCRIPTION
These changes add a `t.Skip` to `TestRapidGenerateHCL2Definition` for inputs that contain a `Map` value whose entries transitively contain an `Asset` or `Archive`. The HCL2 importer (`generateValue` in `pkg/importer/hcl2.go:890`) silently drops those entries: the round-trip renders the map as `{}` and loses every key. The skip joins the existing skip patterns in this file -- non-NFC strings, `__`-prefixed map keys, control bytes -- which all work around known importer bugs.

The underlying importer bug is tracked at #23220 and the skip references it. Once the importer is fixed, the skip should be removed.

## Why now

Over the last 24h the property test has dequeued at least three PRs from the merge queue (most recently #23204), each on a different rapid seed and finding a different counter-example -- but always the same bug class.

## Reproducer (without this skip)

```
$ cd pkg
$ go test -count=1 -tags all -race -run TestRapidGenerateHCL2Definition \
    ./importer -rapid.checks=1000 -timeout=180s
...
want: "a":resource.PropertyMap{"":resource.PropertyValue{V:(*archive.Archive)(...)},
                               "A":resource.PropertyValue{V:(*archive.Archive)(...)}}
got:  "a":resource.PropertyMap{}
```

Top-level `Asset`/`Archive` values round-trip correctly (the same test's outputs render `c = assetArchive({})` fine for a top-level archive); only `Asset`/`Archive` values that sit inside a `Map` -- directly, inside an array, or inside another map -- are silently dropped.

## With the skip

Three consecutive 5000-check runs all pass:

```
ok  	github.com/pulumi/pulumi/pkg/v3/importer	49.773s
ok  	github.com/pulumi/pulumi/pkg/v3/importer	52.609s
ok  	github.com/pulumi/pulumi/pkg/v3/importer	54.513s
```

Without the skip, the test finds a fresh counter-example on roughly every other 1000-check run.

## Test plan

- [ ] CI on this PR passes `pkg N/7 on ubuntu-latest/current` (the shard that owns `pkg/v3/importer`)
- [ ] Watch the next several merge_group runs after this lands; confirm the rate of `TestRapidGenerateHCL2Definition` failures drops to zero