### PR TITLE
Fix importer dropping asset/archive map entries and PCL recursive-type binding

### DIFF
--- a/changelog/pending/20260516--cli-import--preserve-asset-archive-map-entries-and-escape-template-keys.yaml
+++ b/changelog/pending/20260516--cli-import--preserve-asset-archive-map-entries-and-escape-template-keys.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/import
+  description: Preserve asset/archive/resource-reference values inside map and array inputs, and HCL-escape map keys containing `${` or `%{` template sequences

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -41,7 +41,7 @@ func diagf(severity hcl.DiagnosticSeverity, subject hcl.Range, f string, args ..
 }
 
 func ExprNotConvertible(destType Type, expr Expression) *hcl.Diagnostic {
-	conversionKind, whyF := destType.conversionFrom(expr.Type(), false, map[Type]struct{}{})
+	conversionKind, whyF := destType.conversionFrom(expr.Type(), false, cycleSet{})
 	contract.Assertf(whyF != nil, "destType.conversionFrom (kind: %#v) should always have a reason: %T\n",
 		conversionKind, destType)
 	why := whyF()
@@ -60,10 +60,6 @@ func typeNotConvertible(dest, src Type) *hcl.Diagnostic {
 func tuplesHaveDifferentLengths(dest, src *TupleType) *hcl.Diagnostic {
 	return &hcl.Diagnostic{Severity: hcl.DiagError, Summary: fmt.Sprintf("tuples %v and %v have different lengths",
 		dest, src)}
-}
-
-func invalidRecursiveType(t Type) *hcl.Diagnostic {
-	return errorf(t.SyntaxNode().Range(), "invalid recursive type")
 }
 
 func objectKeysMustBeStrings(expr Expression) *hcl.Diagnostic {

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -90,7 +90,7 @@ type Type interface {
 	Pretty() pretty.Formatter
 
 	equals(other Type, seen map[Type]struct{}) bool
-	conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics)
+	conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics)
 	string(seen map[Type]struct{}) string
 	unify(other Type) (Type, ConversionKind)
 	isType()
@@ -126,7 +126,27 @@ type cacheEntry struct {
 	diags lazyDiagnostics
 }
 
-func conversionFrom(dest, src Type, unifying bool, seen map[Type]struct{},
+// cycleSet tracks `(destination, source)` pairs currently mid-flight in a
+// recursive [Type.conversionFrom] computation. Cycle detection is keyed by
+// the pair rather than the destination alone: re-entering the same destination
+// with a different source is a different question and must be checked, not
+// short-circuited.
+type cycleSet map[[2]Type]struct{}
+
+func (c cycleSet) has(dst, src Type) bool {
+	_, ok := c[[2]Type{dst, src}]
+	return ok
+}
+
+func (c cycleSet) push(dst, src Type) {
+	c[[2]Type{dst, src}] = struct{}{}
+}
+
+func (c cycleSet) pop(dst, src Type) {
+	delete(c, [2]Type{dst, src})
+}
+
+func conversionFrom(dest, src Type, unifying bool, seen cycleSet,
 	cache *gsync.Map[Type, cacheEntry],
 	conversionFromImpl func() (ConversionKind, lazyDiagnostics),
 ) (ConversionKind, lazyDiagnostics) {

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -104,7 +104,7 @@ func (t *ConstType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *ConstType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *ConstType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if t.Type.ConversionFrom(src) != NoConversion {
 			return UnsafeConversion, nil

--- a/pkg/codegen/hcl2/model/type_enum.go
+++ b/pkg/codegen/hcl2/model/type_enum.go
@@ -152,7 +152,7 @@ func (t *EnumType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *EnumType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *EnumType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		// We have a constant, of the correct type, so we might have a safe
 		// conversion.

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -123,7 +123,7 @@ func (t *ListType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *ListType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ListType:

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -118,7 +118,7 @@ func (t *MapType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *MapType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *MapType:

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -60,7 +60,7 @@ func (noneType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (noneType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(NoneType, src, unifying, seen, &gsync.Map[Type, cacheEntry]{},
 		func() (ConversionKind, lazyDiagnostics) {
 			return NoConversion, func() hcl.Diagnostics {

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -273,19 +273,21 @@ func (t *ObjectType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *ObjectType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *ObjectType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ObjectType:
-			if seen != nil {
-				if _, ok := seen[t]; ok {
-					return NoConversion, func() hcl.Diagnostics { return hcl.Diagnostics{invalidRecursiveType(t)} }
-				}
-			} else {
-				seen = map[Type]struct{}{}
+			// A `(t, src)` pair already in flight is a true coinductive cycle:
+			// assume it converts and let the outer frame's per-property checks
+			// verify the (always finite) leaves.
+			if seen.has(t, src) {
+				return SafeConversion, nil
 			}
-			seen[t] = struct{}{}
-			defer delete(seen, t)
+			if seen == nil {
+				seen = cycleSet{}
+			}
+			seen.push(t, src)
+			defer seen.pop(t, src)
 
 			if unifying {
 				var unifier objectTypeUnifier

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -65,7 +65,7 @@ func (t *OpaqueType) AssignableFrom(src Type) bool {
 }
 
 func (t *OpaqueType) conversionFromImpl(
-	src Type, unifying, checkUnsafe bool, seen map[Type]struct{},
+	src Type, unifying, checkUnsafe bool, seen cycleSet,
 ) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(
 		t, src, unifying, seen, &gsync.Map[Type, cacheEntry]{}, func() (ConversionKind, lazyDiagnostics) {
@@ -124,7 +124,7 @@ func (t *OpaqueType) conversionFromImpl(
 		})
 }
 
-func (t *OpaqueType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *OpaqueType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return t.conversionFromImpl(src, unifying, true, seen)
 }
 

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -105,7 +105,7 @@ func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *OutputType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *OutputType:

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -104,7 +104,7 @@ func (t *PromiseType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *PromiseType) conversionFrom(
-	src Type, unifying bool, seen map[Type]struct{},
+	src Type, unifying bool, seen cycleSet,
 ) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		if src, ok := src.(*PromiseType); ok {

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -80,7 +80,7 @@ func (t *SetType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *SetType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *SetType:

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -726,6 +726,91 @@ func TestRecursiveObjectType(t *testing.T) {
 	assert.True(t, hasOutputs)
 }
 
+// TestRecursiveObjectTypeConvertsFromFiniteSource verifies that a finite source
+// value can be converted to a self-referential ObjectType.
+func TestRecursiveObjectTypeConvertsFromFiniteSource(t *testing.T) {
+	t.Parallel()
+
+	// Build a self-referential object type: Obj { a: Optional<Obj> }.
+	props := map[string]Type{}
+	recursive := NewObjectType(props)
+	props["a"] = NewOptionalType(recursive)
+
+	// Optional `a` means the property may be absent, so an empty source satisfies.
+	t.Run("empty source converts safely", func(t *testing.T) {
+		t.Parallel()
+		empty := NewObjectType(map[string]Type{})
+		assert.Equal(t, SafeConversion, recursive.ConversionFrom(empty))
+	})
+
+	t.Run("none source converts safely", func(t *testing.T) {
+		t.Parallel()
+		// Source: { a: <recursive itself absent> } — the recursive property is Optional.
+		src := NewObjectType(map[string]Type{"a": NoneType})
+		assert.Equal(t, SafeConversion, recursive.ConversionFrom(src))
+	})
+
+	t.Run("source mirroring schema converges", func(t *testing.T) {
+		t.Parallel()
+		// Source: { a: { a: {} } } has finite depth and matches the recursive shape.
+		outer := NewObjectType(map[string]Type{
+			"a": NewObjectType(map[string]Type{
+				"a": NewObjectType(map[string]Type{}),
+			}),
+		})
+		assert.Equal(t, SafeConversion, recursive.ConversionFrom(outer))
+	})
+
+	t.Run("source with incompatible property still rejected", func(t *testing.T) {
+		t.Parallel()
+		// Coinductive cycle handling shouldn't make conversions universally permissive:
+		// a source whose recursive property has a primitive type that can't satisfy the
+		// recursive target should still fail to convert.
+		src := NewObjectType(map[string]Type{"a": StringType})
+		assert.Equal(t, NoConversion, recursive.ConversionFrom(src))
+	})
+
+	t.Run("source with deeply incompatible nested property still rejected", func(t *testing.T) {
+		t.Parallel()
+		// Source: { a: { a: "string" } }. The OUTER "a" matches the recursive shape
+		// (it's an object), but the INNER nested "a" is a string and can never satisfy
+		// Optional<recursive>. The conversion check must descend into the source rather
+		// than short-circuit on the destination cycle.
+		src := NewObjectType(map[string]Type{
+			"a": NewObjectType(map[string]Type{
+				"a": StringType,
+			}),
+		})
+		assert.Equal(t, NoConversion, recursive.ConversionFrom(src))
+	})
+}
+
+// TestRecursiveObjectTypeViaInputUnion mirrors the InputShape/PlainShape
+// pattern produced by codegen/pcl.schemaTypeToType: the schema property is
+// reachable as `Optional<Union<recursiveInputObj | Output<recursivePlainObj>>>`,
+// and the value is an empty object that should satisfy `recursiveInputObj`.
+// Before the cycle-handling fix, the conversion bailed out with NoConversion.
+func TestRecursiveObjectTypeViaInputUnion(t *testing.T) {
+	t.Parallel()
+
+	inputProps := map[string]Type{}
+	inputObj := NewObjectType(inputProps)
+	inputProps["a"] = NewOptionalType(inputObj)
+
+	plainProps := map[string]Type{}
+	plainObj := NewObjectType(plainProps)
+	plainProps["a"] = NewOptionalType(plainObj)
+
+	schemaTyp := NewOptionalType(NewUnionType(inputObj, NewOutputType(plainObj)))
+
+	// Value type: { a: {} } - finite, satisfies inputObj.
+	value := NewObjectType(map[string]Type{
+		"a": NewObjectType(map[string]Type{}),
+	})
+
+	assert.Equal(t, SafeConversion, schemaTyp.ConversionFrom(value))
+}
+
 // Tests that object type annotations can be added and queried correctly.
 func TestObjectTypeAnnotations(t *testing.T) {
 	t.Parallel()

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -186,7 +186,7 @@ func (t *TupleType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *TupleType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *TupleType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *TupleType:

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -235,7 +235,7 @@ func (t *UnionType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *UnionType) conversionFrom(src Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	return conversionFrom(t, src, unifying, seen, t.cache, func() (ConversionKind, lazyDiagnostics) {
 		var conversionKind ConversionKind
 		var diags []lazyDiagnostics
@@ -271,7 +271,7 @@ func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct
 // If all conversions to a dest type from a union type are safe, the conversion is safe.
 // If no conversions to a dest type from a union type exist, the conversion does not exist.
 // Otherwise, the conversion is unsafe.
-func (t *UnionType) conversionTo(dest Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+func (t *UnionType) conversionTo(dest Type, unifying bool, seen cycleSet) (ConversionKind, lazyDiagnostics) {
 	conversionKind, exists := SafeConversion, false
 	for _, t := range t.ElementTypes {
 		switch kind, _ := dest.conversionFrom(t, unifying, seen); kind {

--- a/pkg/importer/hcl2.go
+++ b/pkg/importer/hcl2.go
@@ -749,6 +749,42 @@ removeNonStructuralTypes:
 				}
 			}
 		}
+
+	case value.IsArchive():
+		if schemaType == schema.ArchiveType {
+			return true
+		}
+		if union, ok := schemaType.(*schema.UnionType); ok {
+			for _, elementType := range union.ElementTypes {
+				if valueStructurallyTypedAs(value, elementType) {
+					return true
+				}
+			}
+		}
+
+	case value.IsAsset():
+		if schemaType == schema.AssetType {
+			return true
+		}
+		if union, ok := schemaType.(*schema.UnionType); ok {
+			for _, elementType := range union.ElementTypes {
+				if valueStructurallyTypedAs(value, elementType) {
+					return true
+				}
+			}
+		}
+
+	case value.IsResourceReference():
+		if _, ok := schemaType.(*schema.ResourceType); ok {
+			return true
+		}
+		if union, ok := schemaType.(*schema.UnionType); ok {
+			for _, elementType := range union.ElementTypes {
+				if valueStructurallyTypedAs(value, elementType) {
+					return true
+				}
+			}
+		}
 	}
 
 	return false
@@ -925,12 +961,9 @@ func generateValue(
 					return nil, err
 				}
 
-				// Always quote the key in case it includes invalid identifier characters (like '/' or ':')
-				propKey := fmt.Sprintf("%q", k)
-
 				items = append(items, model.ObjectConsItem{
 					Key: &model.LiteralValueExpression{
-						Value: cty.StringVal(propKey),
+						Value: cty.StringVal(`"` + model.EscapeString(k) + `"`),
 					},
 					Value: x,
 				})

--- a/pkg/importer/hcl2_rapid_test.go
+++ b/pkg/importer/hcl2_rapid_test.go
@@ -110,28 +110,6 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 			t.Skip("inputs contain a `__`-prefixed map key; production drops them silently")
 		}
 
-		if checkPropertyMap(sample.State.Inputs, func(p property.Value) bool {
-			if !p.IsMap() {
-				return false
-			}
-			for _, v := range p.AsMap().All {
-				if containsAssetOrArchive(v) {
-					return true
-				}
-			}
-			return false
-		}) {
-			// TODO: real bug — when an input contains a Map value whose
-			// entries transitively contain an Asset or Archive,
-			// generateValue (pkg/importer/hcl2.go:890) renders the map as
-			// `{}` and loses every entry. Top-level Asset/Archive values
-			// round-trip fine; only Asset/Archive values nested inside a
-			// Map are dropped, even when wrapped in arrays or nested maps.
-			// Skip until the importer preserves these entries.
-			// See pulumi/pulumi#23220.
-			t.Skip("inputs contain a Map value with nested Asset/Archive; production drops them silently (#23220)")
-		}
-
 		loader := &stubSchemaLoader{pkg: pkg}
 		importState := buildImportState(sample)
 
@@ -165,29 +143,6 @@ func TestRapidGenerateHCL2Definition(t *testing.T) {
 		require.Truef(t, sample.State.Inputs.DeepEquals(gotInputs),
 			"inputs differ\nwant: %#v\ngot:  %#v\nblock:\n%s", sample.State.Inputs, gotInputs, text)
 	})
-}
-
-// containsAssetOrArchive reports whether v transitively contains an Asset
-// or Archive value, descending through arrays and maps.
-func containsAssetOrArchive(v property.Value) bool {
-	if v.IsAsset() || v.IsArchive() {
-		return true
-	}
-	if v.IsArray() {
-		for _, c := range v.AsArray().All {
-			if containsAssetOrArchive(c) {
-				return true
-			}
-		}
-	}
-	if v.IsMap() {
-		for _, c := range v.AsMap().All {
-			if containsAssetOrArchive(c) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // archiveHasNonNFC reports whether a contains, transitively, any string that

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -999,6 +999,10 @@ func makeArrayType(elementType schema.Type) *schema.ArrayType {
 	return &schema.ArrayType{ElementType: elementType}
 }
 
+func makeMapType(elementType schema.Type) *schema.MapType {
+	return &schema.MapType{ElementType: elementType}
+}
+
 func makeProperty(name string, t schema.Type) *schema.Property {
 	return &schema.Property{Name: name, Type: t}
 }
@@ -1322,6 +1326,63 @@ func TestStructuralTypeChecks(t *testing.T) {
 				&schema.InputType{ElementType: schema.NumberType},
 			)))
 	})
+
+	t.Run("Archive", func(t *testing.T) {
+		t.Parallel()
+		value := property.New(&archive.Archive{Sig: archive.ArchiveSig, Assets: map[string]any{}})
+
+		assert.True(t, valueStructurallyTypedAs(value, schema.ArchiveType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.AnyType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.JSONType))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(schema.ArchiveType)))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(schema.ArchiveType, schema.StringType)))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(schema.StringType, schema.ArchiveType)))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New(map[string]property.Value{"k": value}),
+			makeMapType(schema.ArchiveType)))
+
+		assert.False(t, valueStructurallyTypedAs(value, schema.AssetType))
+		assert.False(t, valueStructurallyTypedAs(value, schema.StringType))
+		assert.False(t, valueStructurallyTypedAs(value, makeUnionType(schema.AssetType, schema.StringType)))
+	})
+
+	t.Run("Asset", func(t *testing.T) {
+		t.Parallel()
+		a, err := asset.FromText("hello")
+		require.NoError(t, err)
+		value := property.New(a)
+
+		assert.True(t, valueStructurallyTypedAs(value, schema.AssetType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.AnyType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.JSONType))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(schema.AssetType)))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(schema.AssetType, schema.StringType)))
+		assert.True(t, valueStructurallyTypedAs(
+			property.New([]property.Value{value}),
+			makeArrayType(schema.AssetType)))
+
+		assert.False(t, valueStructurallyTypedAs(value, schema.ArchiveType))
+		assert.False(t, valueStructurallyTypedAs(value, schema.StringType))
+		assert.False(t, valueStructurallyTypedAs(value, makeUnionType(schema.ArchiveType, schema.StringType)))
+	})
+
+	t.Run("ResourceReference", func(t *testing.T) {
+		t.Parallel()
+		value := property.New(property.ResourceReference{
+			URN: "urn:pulumi:s::p::pkg:index:R::r",
+			ID:  property.New("id"),
+		})
+		resType := &schema.ResourceType{Token: "pkg:index:R"}
+
+		assert.True(t, valueStructurallyTypedAs(value, resType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.AnyResourceType))
+		assert.True(t, valueStructurallyTypedAs(value, schema.AnyType))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(resType)))
+		assert.True(t, valueStructurallyTypedAs(value, makeUnionType(resType, schema.StringType)))
+
+		assert.False(t, valueStructurallyTypedAs(value, schema.StringType))
+		assert.False(t, valueStructurallyTypedAs(value, schema.ArchiveType))
+	})
 }
 
 func TestGenerateValuePreservesProviderDiscriminators(t *testing.T) {
@@ -1377,6 +1438,44 @@ func TestGenerateValueDropsNonConformingMapEntries(t *testing.T) {
 		"\"good1\"": property.New("hello"),
 		"\"good2\"": property.New("world"),
 	}, rendered.AsMap().AsMap())
+}
+
+// TestGenerateValueEscapesTemplateMapKeys verifies that map keys containing
+// HCL template-interpolation sequences (`${`, `%{`) are escaped so the
+// resulting text round-trips through the HCL parser without losing one of
+// the leading sigils.
+func TestGenerateValueEscapesTemplateMapKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		key string
+		hcl string
+	}{
+		{"$${", `"$$${"`},
+		{"%{", `"%%{"`},
+		{"${foo}", `"$${foo}"`},
+		{"plain", `"plain"`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			t.Parallel()
+			value := property.New(map[string]property.Value{
+				c.key: property.New("v"),
+			})
+			expr, err := generateValue(
+				&schema.MapType{ElementType: schema.StringType},
+				value, ImportState{}, func(string) {},
+			)
+			require.NoError(t, err)
+			obj, ok := expr.(*model.ObjectConsExpression)
+			require.True(t, ok)
+			require.Len(t, obj.Items, 1)
+			lit, ok := obj.Items[0].Key.(*model.LiteralValueExpression)
+			require.True(t, ok)
+			assert.Equal(t, c.hcl, lit.Value.AsString())
+		})
+	}
 }
 
 func TestReduceUnionTypeEliminatesUnionsBasicCase(t *testing.T) {


### PR DESCRIPTION
## Summary

- **importer**: `valueStructurallyTypedAs` had no cases for `IsArchive`, `IsAsset`, or `IsResourceReference`, so the structural check for elements of a `Map<Archive>`, `Array<Asset>`, etc. fell through to `return false` and `generateValue` silently dropped those entries. Fixed by adding the missing cases.
- **importer**: Map keys with HCL template-interpolation sequences (`\${`, `%{`) were quoted with Go's `%q`, which doesn't escape templates — so a literal key `\$\${` parsed back as `\${`. Switched to `model.EscapeString` with manual quote wrapping.
- **codegen/hcl2/model**: `ObjectType.conversionFrom` rejected any source whose recursive property was absent or Optional, because the cycle guard tripped on the destination alone. Tracked `(dst, src)` pairs instead, so true coinductive cycles short-circuit while different sources still get checked.
- **test**: Reverted #23221, the skip-based workaround for the asset/archive symptom — the underlying bug is now fixed.

## Test plan

- [x] New regression tests in `pkg/codegen/hcl2/model/type_test.go` for the recursive-conversion cycle behavior (empty source, mirroring source, deeply incompatible source, etc.).
- [x] New regression tests in `pkg/importer/hcl2_test.go` for `valueStructurallyTypedAs` on archive/asset/resource references and for HCL template-key escaping.
- [x] `TestRapidGenerateHCL2Definition` ran clean at `-rapid.checks=200000` locally (500k run in progress).
- [x] Full `pkg/codegen/hcl2/model`, `pkg/codegen/pcl`, and `pkg/importer` test suites pass; `make lint` clean.

I've run back the seed that motivated #23221, as well as 500k other iterations locally (over 15 minutes), and all pass with these changes.

Fixes https://github.com/pulumi/pulumi/issues/23220
Fixes https://github.com/pulumi/pulumi/issues/23105