### PR TITLE
Unify on cgstrings in codegen

### DIFF
--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -115,11 +116,11 @@ func (d DocLanguageHelper) GetFunctionName(f *schema.Function) string {
 // an existing resource.
 func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *schema.Function) string {
 	funcName := d.GetFunctionName(f)
-	return title(funcName) + "Result"
+	return cgstrings.UppercaseFirst(funcName) + "Result"
 }
 
 func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
-	return camel(m.Name)
+	return cgstrings.Camel(m.Name)
 }
 
 func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource,
@@ -150,7 +151,7 @@ func (d DocLanguageHelper) GetMethodResultName(pkg schema.PackageReference, modN
 		}
 		return modCtx.typeString(objectReturnType.Properties[0].Type, false, nil)
 	}
-	return fmt.Sprintf("%s.%sResult", resourceName(r), title(d.GetMethodName(m)))
+	return fmt.Sprintf("%s.%sResult", resourceName(r), cgstrings.UppercaseFirst(d.GetMethodName(m)))
 }
 
 // GetPropertyName returns the property name specific to NodeJS.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -33,9 +33,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/nodejs/tstypes"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
@@ -60,45 +60,6 @@ type typeDetails struct {
 	usedInFunctionOutputVersionInputs bool // helps decide naming under the tfbridge20 flag
 }
 
-// title capitalizes the first rune in s.
-//
-// Examples:
-// "hello"   => "Hello"
-// "hiAlice" => "HiAlice"
-// "hi.Bob"  => "Hi.Bob"
-//
-// Note: This is expected to work on strings which are not valid identifiers.
-func title(s string) string {
-	if s == "" {
-		return ""
-	}
-	runes := []rune(s)
-	return string(append([]rune{unicode.ToUpper(runes[0])}, runes[1:]...))
-}
-
-// camel converts s to camel case.
-//
-// Examples:
-// "helloWorld"    => "helloWorld"
-// "HelloWorld"    => "helloWorld"
-// "JSONObject"    => "jsonobject"
-// "My-FRIEND.Bob" => "my-FRIEND.Bob"
-func camel(s string) string {
-	if s == "" {
-		return ""
-	}
-	runes := []rune(s)
-	res := slice.Prealloc[rune](len(runes))
-	for i, r := range runes {
-		if unicode.IsLower(r) {
-			res = append(res, runes[i:]...)
-			break
-		}
-		res = append(res, unicode.ToLower(r))
-	}
-	return string(res)
-}
-
 // pascal converts s to pascal case. Word breaks are signified by illegal
 // identifier runes (excluding '.'). These are found by use of
 // isLegalIdentifierPart.
@@ -108,8 +69,9 @@ func camel(s string) string {
 // "JSONObject"     => "JSONObject"'
 // "a-glad-dayTime" => "AGladDayTime"
 //
-// Note: because camel aggressively down-cases the first continuous sub-string
-// of uppercase characters, we cannot define pascal as title(camel(x)).
+// Note: because cgstrings.Camel aggressively down-cases the first continuous
+// sub-string of uppercase characters, we cannot define pascal as
+// cgstrings.UppercaseFirst(cgstrings.Camel(x)).
 func pascal(s string) string {
 	split := [][]rune{{}}
 	for _, r := range s {
@@ -121,7 +83,7 @@ func pascal(s string) string {
 	}
 	words := make([]string, len(split))
 	for i, v := range split {
-		words[i] = title(string(v))
+		words[i] = cgstrings.UppercaseFirst(string(v))
 	}
 	return strings.Join(words, "")
 }
@@ -231,7 +193,7 @@ func (mod *modContext) objectType(pkg schema.PackageReference, details *typeDeta
 		if external {
 			prefix = pkgName
 		}
-		return prefix + modName + title(name)
+		return prefix + modName + cgstrings.UppercaseFirst(name)
 	}
 
 	if args && input && details != nil && details.usedInFunctionOutputVersionInputs {
@@ -240,7 +202,7 @@ func (mod *modContext) objectType(pkg schema.PackageReference, details *typeDeta
 		name += "Args"
 	}
 
-	return pkgName + root + modName + title(name)
+	return pkgName + root + modName + cgstrings.UppercaseFirst(name)
 }
 
 func (mod *modContext) resourceType(r *schema.ResourceType) string {
@@ -261,19 +223,19 @@ func (mod *modContext) resourceType(r *schema.ResourceType) string {
 	namingCtx, pkgName, external := mod.namingContext(pkg)
 	if !external {
 		name := tokenToName(r.Token)
-		return title(name)
+		return cgstrings.UppercaseFirst(name)
 	}
 
 	pkgName = externalModuleName(pkgName)
 	modName, name := namingCtx.tokenToModName(r.Token), tokenToName(r.Token)
 
-	return pkgName + modName + title(name)
+	return pkgName + modName + cgstrings.UppercaseFirst(name)
 }
 
 func tokenToName(tok string) string {
 	components := strings.Split(tok, ":")
 	contract.Assertf(len(components) == 3, "malformed token %v", tok)
-	return title(components[2])
+	return cgstrings.UppercaseFirst(components[2])
 }
 
 func resourceName(r *schema.Resource) string {
@@ -284,15 +246,15 @@ func resourceName(r *schema.Resource) string {
 }
 
 func (mod *modContext) resourceFileName(r *schema.Resource) string {
-	fileName := camel(resourceName(r)) + ".ts"
+	fileName := cgstrings.Camel(resourceName(r)) + ".ts"
 	if mod.isReservedSourceFileName(fileName) {
-		fileName = camel(resourceName(r)) + "_.ts"
+		fileName = cgstrings.Camel(resourceName(r)) + "_.ts"
 	}
 	return fileName
 }
 
 func tokenToFunctionName(tok string) string {
-	return camel(tokenToName(tok))
+	return cgstrings.Camel(tokenToName(tok))
 }
 
 func (mod *modContext) typeAst(t schema.Type, input bool, constValue any) tstypes.TypeAst {
@@ -525,8 +487,8 @@ func provideDefaultsFuncNameFromName(typeName string) string {
 	if in := strings.LastIndex(typeName, "."); in != -1 {
 		i = in
 	}
-	// path + camel(name) + ProvideDefaults suffix
-	return typeName[:i] + camel(typeName[i:]) + "ProvideDefaults"
+	// path + cgstrings.Camel(name) + ProvideDefaults suffix
+	return typeName[:i] + cgstrings.Camel(typeName[i:]) + "ProvideDefaults"
 }
 
 // The name of the function used to set defaults on the plain type.
@@ -954,7 +916,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 
 	// Generate methods.
 	genMethod := func(method *schema.Method) {
-		methodName := camel(method.Name)
+		methodName := cgstrings.Camel(method.Name)
 		fun := method.Function
 
 		var objectReturnType *schema.ObjectType
@@ -997,7 +959,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 				if argsOptional {
 					optFlag = "?"
 				}
-				argsig = fmt.Sprintf("args%s: %s.%sArgs", optFlag, name, title(method.Name))
+				argsig = fmt.Sprintf("args%s: %s.%sArgs", optFlag, name, cgstrings.UppercaseFirst(method.Name))
 			}
 		}
 		var retty string
@@ -1008,13 +970,13 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 			if objectReturnType == nil {
 				innerType = mod.typeString(fun.ReturnType, false, nil)
 			} else {
-				innerType = fmt.Sprintf("%s.%sResult", name, title(method.Name))
+				innerType = fmt.Sprintf("%s.%sResult", name, cgstrings.UppercaseFirst(method.Name))
 			}
 			retty = fmt.Sprintf("Promise<%s>", innerType)
 		} else if liftReturn {
 			retty = fmt.Sprintf("pulumi.Output<%s>", mod.typeString(objectReturnType.Properties[0].Type, false, nil))
 		} else {
-			retty = fmt.Sprintf("pulumi.Output<%s.%sResult>", name, title(method.Name))
+			retty = fmt.Sprintf("pulumi.Output<%s.%sResult>", name, cgstrings.UppercaseFirst(method.Name))
 		}
 		fmt.Fprintf(w, "    %s(%s): %s {\n", methodName, argsig, retty)
 		if fun.DeprecationMessage != "" {
@@ -1031,7 +993,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		var ret string
 		if fun.ReturnType != nil {
 			if liftReturn {
-				ret = fmt.Sprintf("const result: pulumi.Output<%s.%sResult> = ", name, title(method.Name))
+				ret = fmt.Sprintf("const result: pulumi.Output<%s.%sResult> = ", name, cgstrings.UppercaseFirst(method.Name))
 			} else {
 				ret = "return "
 			}
@@ -1074,7 +1036,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 		fmt.Fprintf(w, ");\n")
 
 		if liftReturn {
-			fmt.Fprintf(w, "        return result.%s;\n", camel(objectReturnType.Properties[0].Name))
+			fmt.Fprintf(w, "        return result.%s;\n", cgstrings.Camel(objectReturnType.Properties[0].Name))
 		}
 		fmt.Fprintf(w, "    }\n")
 	}
@@ -1107,7 +1069,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) (resourceFil
 	// https://www.typescriptlang.org/docs/handbook/declaration-merging.html#merging-namespaces-with-classes
 	genMethodTypes := func(w io.Writer, method *schema.Method) error {
 		fun := method.Function
-		methodName := title(method.Name)
+		methodName := cgstrings.UppercaseFirst(method.Name)
 		if fun.Inputs != nil {
 			args := slice.Prealloc[*schema.Property](len(fun.Inputs.InputShape.Properties))
 			for _, arg := range fun.Inputs.InputShape.Properties {
@@ -1172,7 +1134,7 @@ func (mod *modContext) functionReturnType(fun *schema.Function) string {
 	}
 
 	if _, isObject := fun.ReturnType.(*schema.ObjectType); isObject && fun.InlineObjectAsReturnType {
-		return title(name) + "Result"
+		return cgstrings.UppercaseFirst(name) + "Result"
 	}
 
 	return mod.typeString(fun.ReturnType, false, nil)
@@ -1232,7 +1194,7 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 			suffix = "OutputArgs"
 		}
 
-		argsType := title(name) + suffix
+		argsType := cgstrings.UppercaseFirst(name) + suffix
 		argsig = fmt.Sprintf("args%s: %s, ", optFlag, argsType)
 
 		if !plain && len(fun.Inputs.Properties) == 0 {
@@ -1341,11 +1303,11 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 	// If there are argument and/or return types, emit them.
 	if fun.Inputs != nil && !fun.MultiArgumentInputs {
 		fmt.Fprintf(w, "\n")
-		argsInterfaceName := title(name) + "Args"
+		argsInterfaceName := cgstrings.UppercaseFirst(name) + "Args"
 		info.functionArgsInterfaceName = argsInterfaceName
 		properties := fun.Inputs.Properties
 		if !plain {
-			argsInterfaceName = title(name) + "OutputArgs"
+			argsInterfaceName = cgstrings.UppercaseFirst(name) + "OutputArgs"
 			properties = fun.Inputs.InputShape.Properties
 			info.functionOutputVersionArgsInterfaceName = argsInterfaceName
 		} else {
@@ -1370,7 +1332,7 @@ func (mod *modContext) genFunctionDefinition(w io.Writer, fun *schema.Function, 
 		}
 	}
 
-	resultInterfaceName := title(name) + "Result"
+	resultInterfaceName := cgstrings.UppercaseFirst(name) + "Result"
 	// if the return type is an inline object definition (not a reference), emit it.
 	// only emit the plain result type T since output-versioned invokes will use Output<T> for the non-plain variant
 	if fun.ReturnType != nil {
@@ -2117,9 +2079,9 @@ func (mod *modContext) gen(fs codegen.Fs) error {
 			return err
 		}
 
-		fileName := camel(tokenToName(f.Token)) + ".ts"
+		fileName := cgstrings.Camel(tokenToName(f.Token)) + ".ts"
 		if mod.isReservedSourceFileName(fileName) {
-			fileName = camel(tokenToName(f.Token)) + "_.ts"
+			fileName = cgstrings.Camel(tokenToName(f.Token)) + "_.ts"
 		}
 		addFunctionFile(funInfo, fileName, buffer.String())
 	}

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -1109,7 +1110,7 @@ func resourceTypeName(r *pcl.Resource) (string, string, string, hcl.Diagnostics)
 		module = moduleName(module, r.Schema.PackageReference)
 	}
 
-	return pkg, module, title(member), diagnostics
+	return pkg, module, cgstrings.UppercaseFirst(member), diagnostics
 }
 
 func readResourceTypeName(r *pcl.ReadResource) (string, string, string, hcl.Diagnostics) {
@@ -1119,7 +1120,7 @@ func readResourceTypeName(r *pcl.ReadResource) (string, string, string, hcl.Diag
 		module = moduleName(module, r.Schema.PackageReference)
 	}
 
-	return pkg, module, title(member), diagnostics
+	return pkg, module, cgstrings.UppercaseFirst(member), diagnostics
 }
 
 func moduleName(module string, pkg schema.PackageReference) string {
@@ -1759,7 +1760,7 @@ func (g *generator) genComponent(w io.Writer, component *pcl.Component) {
 			g.Fgenf(w, "%s", g.Indent)
 			g.Fgenf(w, "const [%s, resolve%s] = pulumi.deferredOutput<%s>();\n",
 				output.Name,
-				title(output.Name),
+				cgstrings.UppercaseFirst(output.Name),
 				typeParameter)
 		}
 	}
@@ -1849,9 +1850,9 @@ func (g *generator) genComponent(w io.Writer, component *pcl.Component) {
 			g.Fgenf(w, "%s", g.Indent)
 			expr := g.lowerExpression(output.Expr, output.Expr.Type())
 			if _, ok := output.Expr.(*model.ScopeTraversalExpression); ok {
-				g.Fgenf(w, "resolve%s(%v);\n", title(output.Name), expr)
+				g.Fgenf(w, "resolve%s(%v);\n", cgstrings.UppercaseFirst(output.Name), expr)
 			} else {
-				g.Fgenf(w, "resolve%s(pulumi.output(%v));\n", title(output.Name), expr)
+				g.Fgenf(w, "resolve%s(pulumi.output(%v));\n", cgstrings.UppercaseFirst(output.Name), expr)
 			}
 		}
 	}

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/cgstrings"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -117,7 +118,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 	}
 
 	// Capitalize and make a valid identifier.
-	safeName = makeValidIdentifier(title(safeName))
+	safeName = makeValidIdentifier(cgstrings.UppercaseFirst(safeName))
 
 	// If there are multiple underscores in a row, replace with one.
 	regex := regexp.MustCompile(`_+`)


### PR DESCRIPTION
Update nodejs to use the helpers from cgstrings rather than defining its own title and camel case functions.