### PR TITLE
fix: close HTTP response body in ExchangeOidcToken

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -439,6 +439,7 @@ func (pc *Client) ExchangeOidcToken(
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

`ExchangeOidcToken` in `pkg/backend/httpstate/client/client.go` calls `pc.restClient.HTTPClient().Do(req, retryAllMethods)` but never closes `resp.Body`. This leaks the underlying TCP connection on every OIDC token exchange call.

Per Go's [`net/http` documentation](https://pkg.go.dev/net/http#Response): *"It is the caller's responsibility to close Body."*

Every other `Do()` call site in the same file correctly closes the response body. This appears to have been an oversight when the function was introduced in PR #20974.

## Fix

Add `defer resp.Body.Close()` immediately after the successful `Do()` call, consistent with all other HTTP call sites in this file.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes

## Validation

- [x] `make lint` equivalent checks pass
- [x] Verified all other `Do()` call sites close `resp.Body`
