### PR TITLE
Ignore new lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ venv/
 # Ignore VSCode created solution file
 /pulumi.sln
 .mono
+# Ignore VSCode created cache files (https://github.com/microsoft/vscode-dotnettools/issues/2952)
+*.lscache
 
 # Ignore user-provided go.work files.
 /go.work


### PR DESCRIPTION
vscode C# dev kit is now making ".lscache" files next to ".csproj" files. See https://github.com/microsoft/vscode-dotnettools/issues/2952 for discussion on it.

For now just mark these as .gitignore, not clear that it's worth checking them in, and its probably just going to be noise.