### PR TITLE
cli/neo: unhide `pulumi neo` by removing the PULUMI_EXPERIMENTAL gate

### DIFF
--- a/changelog/pending/20260518--cli-neo--unhide-pulumi-neo-command.yaml
+++ b/changelog/pending/20260518--cli-neo--unhide-pulumi-neo-command.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Make `pulumi neo` visible by default; the `PULUMI_EXPERIMENTAL` gate has been removed

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -36,7 +36,6 @@ import (
 	displaytypes "github.com/pulumi/pulumi/pkg/v3/display"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
@@ -126,8 +125,7 @@ func NewNeoCmd() *cobra.Command {
 			"tool loop. Filesystem and shell tool calls from the agent run on this machine, " +
 			"in the working directory you select, instead of in the cloud agent container. " +
 			"If no prompt is provided, the TUI starts and waits for your first message.",
-		Hidden: !env.Experimental.Value(),
-		Args:   cobra.MaximumNArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			var prompt string

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -661,7 +661,6 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 //nolint:paralleltest // mutates package globals
 func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
 	isolateWorkspace(t)
-	t.Setenv("PULUMI_EXPERIMENTAL", "true")
 
 	srv := newNeoFakeServer(t)
 	installNeoTestEnv(t, srv, false /*interactive*/)

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -321,15 +321,14 @@ func ws() pkgWorkspace.Context { return &pkgWorkspace.MockContext{} }
 // NewNeoCmd
 // -----------------------------------------------------------------------------
 
-//nolint:paralleltest // uses t.Setenv to toggle PULUMI_EXPERIMENTAL
 func TestNewNeoCmd_RegistersFlags(t *testing.T) {
+	t.Parallel()
 	// Flag surface is part of the public CLI contract — renaming or dropping any
 	// of these breaks users' scripts. Pin the shape.
-	t.Setenv("PULUMI_EXPERIMENTAL", "true")
 	cmd := NewNeoCmd()
 
 	assert.Equal(t, "neo [prompt]", cmd.Use)
-	assert.False(t, cmd.Hidden, "with PULUMI_EXPERIMENTAL=true the command must be visible")
+	assert.False(t, cmd.Hidden, "the command must be visible")
 
 	stack := cmd.Flags().Lookup("stack")
 	require.NotNil(t, stack, "--stack flag must be registered")
@@ -342,16 +341,6 @@ func TestNewNeoCmd_RegistersFlags(t *testing.T) {
 	require.NoError(t, cmd.Args(cmd, []string{}))
 	require.NoError(t, cmd.Args(cmd, []string{"hello"}))
 	require.Error(t, cmd.Args(cmd, []string{"a", "b"}), "more than one positional arg must be rejected")
-}
-
-//nolint:paralleltest // uses t.Setenv to toggle PULUMI_EXPERIMENTAL
-func TestNewNeoCmd_HiddenWhenNotExperimental(t *testing.T) {
-	// env.Experimental.Value() is read at command construction; clearing the
-	// env var and re-constructing must hide the command so users on stable
-	// channels don't see it in `pulumi --help`.
-	t.Setenv("PULUMI_EXPERIMENTAL", "")
-	cmd := NewNeoCmd()
-	assert.True(t, cmd.Hidden, "without PULUMI_EXPERIMENTAL the command must be hidden")
 }
 
 func TestDedupeExistingRoots(t *testing.T) {


### PR DESCRIPTION
## Summary
- `NewNeoCmd` no longer sets `Hidden: !env.Experimental.Value()`, so `pulumi neo` shows up in `pulumi --help` and tab completion without `PULUMI_EXPERIMENTAL=true`.
- Drops the now-unused `env` import and the `TestNewNeoCmd_HiddenWhenNotExperimental` test, and removes the `PULUMI_EXPERIMENTAL` setup from the remaining two tests that needed it only to clear the gate.

## Test plan
- [x] `go test ./cmd/pulumi/neo/...`
- [x] `go build ./cmd/pulumi/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)