### PR TITLE
Fix `pulumi deployment settings get`

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -110,20 +110,27 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 	require.NotNil(t, captured.patch)
 	assert.JSONEq(t, patchJSON, string(captured.patch))
 
-	assert.Equal(t, `Executor image:          pulumi/pulumi:latest
-Working directory:       /work
-Source repo URL:         https://github.com/acme/infra
-Source branch:           main
-Source commit:           abc123
-Source repo dir:         stacks/prod
-GitHub repository:       acme/infra
-GitHub deploy commits:   true
-GitHub preview PRs:      true
-GitHub PR template:      false
-GitHub paths:            1
-Agent pool ID:           pool-1
-Env var keys:            2
-Pre-run commands:        1
+	assert.Equal(t, `Source: GitHub
+  Repository:               acme/infra
+  Branch:                   main
+  Commit:                   abc123
+  Pulumi.yaml folder:       stacks/prod
+  Run previews for PRs:     yes
+  Run updates on push:      yes
+  PR stack template:        no
+  Path filters:             stacks/prod/**
+
+Deployment runner
+  Runner pool:              pool-1
+  Executor image:           pulumi/pulumi:latest
+  Working directory:        /work
+
+Pre-run commands
+  echo hi
+
+Environment variables
+  BAZ
+  FOO
 `, buf.String())
 }
 
@@ -142,34 +149,24 @@ func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
-		"executorContext": {
-			"workingDirectory": "/work",
-			"executorImage": "pulumi/pulumi:latest"
-		},
-		"sourceContext": {
-			"git": {
-				"repoUrl": "https://github.com/acme/infra",
-				"branch": "main",
-				"commit": "abc123",
-				"repoDir": "stacks/prod"
-			}
-		},
-		"gitHub": {
+		"source": {
+			"kind": "github",
 			"repository": "acme/infra",
-			"pullRequestTemplate": false,
-			"deployCommits": true,
+			"branch": "main",
+			"commit": "abc123",
+			"folder": "stacks/prod",
 			"previewPullRequests": true,
-			"paths": ["stacks/prod/**"]
+			"runUpdatesOnPush": true,
+			"pullRequestTemplate": false,
+			"pathFilters": ["stacks/prod/**"]
 		},
-		"operationContext": {
-			"preRunCommands": ["echo hi"],
-			"operation": "update",
-			"environmentVariables": {
-				"FOO": "bar",
-				"BAZ": "qux"
-			}
+		"runner": {
+			"pool": "pool-1",
+			"executorImage": "pulumi/pulumi:latest",
+			"workingDirectory": "/work"
 		},
-		"agentPoolID": "pool-1"
+		"preRunCommands": ["echo hi"],
+		"environmentVariables": ["BAZ", "FOO"]
 	}`, buf.String())
 }
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -22,6 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -82,9 +85,8 @@ func newDeploymentSettingsGetCmdWith(factory deploymentSettingsGetClientFactory)
 	args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get",
-		Short:  "[EXPERIMENTAL] Retrieve the deployment settings for a stack",
+		Use:   "get",
+		Short: "[EXPERIMENTAL] Retrieve the deployment settings for a stack",
 		Long: "[EXPERIMENTAL] Retrieve the deployment settings for a stack.\n" +
 			"\n" +
 			"Returns the saved Pulumi Deployments configuration for the selected stack,\n" +
@@ -175,152 +177,371 @@ func runDeploymentSettingsGet(
 
 type deploymentSettingsGetRenderFunc func(w io.Writer, settings apitype.DeploymentSettings) error
 
-// renderDeploymentSettingsGetText prints a human-readable summary as aligned
-// key/value pairs. Secrets (git auth, environment variable values) are never
-// emitted; only counts and keys.
-func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) error {
-	executorImage := "-"
-	if s.Executor != nil && s.Executor.ExecutorImage != nil && s.Executor.ExecutorImage.Reference != "" {
-		executorImage = s.Executor.ExecutorImage.Reference
-	}
-	workingDir := "-"
-	if s.Executor != nil && s.Executor.WorkingDirectory != "" {
-		workingDir = s.Executor.WorkingDirectory
-	}
-
-	repoURL, branch, commit, repoDir := "-", "-", "-", "-"
-	if s.SourceContext != nil && s.SourceContext.Git != nil {
-		git := s.SourceContext.Git
-		if git.RepoURL != "" {
-			repoURL = git.RepoURL
-		}
-		if git.Branch != "" {
-			branch = git.Branch
-		}
-		if git.Commit != "" {
-			commit = git.Commit
-		}
-		if git.RepoDir != "" {
-			repoDir = git.RepoDir
-		}
-	}
-
-	agentPool := "-"
-	if s.AgentPoolID != nil && *s.AgentPoolID != "" {
-		agentPool = *s.AgentPoolID
-	}
-
-	githubRepo := "-"
-	deployCommits, previewPRs, prTemplate := false, false, false
-	var githubPaths []string
-	if s.GitHub != nil {
-		if s.GitHub.Repository != "" {
-			githubRepo = s.GitHub.Repository
-		}
-		deployCommits = s.GitHub.DeployCommits
-		previewPRs = s.GitHub.PreviewPullRequests
-		prTemplate = s.GitHub.PullRequestTemplate
-		githubPaths = s.GitHub.Paths
-	}
-
-	envVarCount := 0
-	preRunCount := 0
-	if s.Operation != nil {
-		envVarCount = len(s.Operation.EnvironmentVariables)
-		preRunCount = len(s.Operation.PreRunCommands)
-	}
-
-	fmt.Fprintf(w, "%-24s %s\n", "Executor image:", executorImage)
-	fmt.Fprintf(w, "%-24s %s\n", "Working directory:", workingDir)
-	fmt.Fprintf(w, "%-24s %s\n", "Source repo URL:", repoURL)
-	fmt.Fprintf(w, "%-24s %s\n", "Source branch:", branch)
-	fmt.Fprintf(w, "%-24s %s\n", "Source commit:", commit)
-	fmt.Fprintf(w, "%-24s %s\n", "Source repo dir:", repoDir)
-	fmt.Fprintf(w, "%-24s %s\n", "GitHub repository:", githubRepo)
-	fmt.Fprintf(w, "%-24s %t\n", "GitHub deploy commits:", deployCommits)
-	fmt.Fprintf(w, "%-24s %t\n", "GitHub preview PRs:", previewPRs)
-	fmt.Fprintf(w, "%-24s %t\n", "GitHub PR template:", prTemplate)
-	fmt.Fprintf(w, "%-24s %d\n", "GitHub paths:", len(githubPaths))
-	fmt.Fprintf(w, "%-24s %s\n", "Agent pool ID:", agentPool)
-	fmt.Fprintf(w, "%-24s %d\n", "Env var keys:", envVarCount)
-	fmt.Fprintf(w, "%-24s %d\n", "Pre-run commands:", preRunCount)
-	return nil
+// deploymentSettingsView is the shared shape for both text and JSON output.
+// Secret material (env var values, git auth) is intentionally not surfaced.
+type deploymentSettingsView struct {
+	Tag                  string        `json:"tag,omitempty"`
+	Source               *sourceView   `json:"source,omitempty"`
+	Runner               *runnerView   `json:"runner,omitempty"`
+	PreRunCommands       []string      `json:"preRunCommands,omitempty"`
+	EnvironmentVariables []string      `json:"environmentVariables,omitempty"`
+	OIDC                 *oidcView     `json:"oidc,omitempty"`
+	Advanced             *advancedView `json:"advanced,omitempty"`
 }
 
-// getDeploymentSettingsJSON is the JSON envelope for
-// `pulumi deployment settings get --output=json`. It mirrors
-// apitype.DeploymentSettings but normalizes nil slices to empty arrays so
-// scripts can rely on the keys always being JSON arrays.
-type getDeploymentSettingsJSON struct {
-	Tag           string                              `json:"tag,omitempty"`
-	Executor      *apitype.ExecutorContext            `json:"executorContext,omitempty"`
-	SourceContext *apitype.SourceContext              `json:"sourceContext,omitempty"`
-	GitHub        *getDeploymentSettingsGitHubJSON    `json:"gitHub,omitempty"`
-	Operation     *getDeploymentSettingsOperationJSON `json:"operationContext,omitempty"`
-	AgentPoolID   *string                             `json:"agentPoolID,omitempty"`
-}
-
-type getDeploymentSettingsGitHubJSON struct {
+type sourceView struct {
+	Kind                string   `json:"kind"`
 	Repository          string   `json:"repository,omitempty"`
-	PullRequestTemplate bool     `json:"pullRequestTemplate"`
-	DeployCommits       bool     `json:"deployCommits"`
-	PreviewPullRequests bool     `json:"previewPullRequests"`
-	DeployPullRequest   *int64   `json:"deployPullRequest,omitempty"`
-	Paths               []string `json:"paths"`
+	Branch              string   `json:"branch,omitempty"`
+	Commit              string   `json:"commit,omitempty"`
+	Folder              string   `json:"folder,omitempty"`
+	PreviewPullRequests *bool    `json:"previewPullRequests,omitempty"`
+	RunUpdatesOnPush    *bool    `json:"runUpdatesOnPush,omitempty"`
+	PullRequestTemplate *bool    `json:"pullRequestTemplate,omitempty"`
+	PathFilters         []string `json:"pathFilters,omitempty"`
 }
 
-type getDeploymentSettingsOperationJSON struct {
-	OIDC                 *apitype.OperationContextOIDCConfiguration `json:"oidc,omitempty"`
-	PreRunCommands       []string                                   `json:"preRunCommands"`
-	Operation            apitype.PulumiOperation                    `json:"operation"`
-	EnvironmentVariables map[string]apitype.SecretValue             `json:"environmentVariables"`
-	Options              *apitype.OperationContextOptions           `json:"options,omitempty"`
+type runnerView struct {
+	Pool             string `json:"pool,omitempty"`
+	ExecutorImage    string `json:"executorImage,omitempty"`
+	WorkingDirectory string `json:"workingDirectory,omitempty"`
 }
 
-func toGetDeploymentSettingsJSON(s apitype.DeploymentSettings) getDeploymentSettingsJSON {
-	out := getDeploymentSettingsJSON{
-		Tag:           s.Tag,
-		Executor:      s.Executor,
-		SourceContext: s.SourceContext,
-		AgentPoolID:   s.AgentPoolID,
-	}
-	if s.GitHub != nil {
-		paths := s.GitHub.Paths
-		if paths == nil {
-			paths = []string{}
-		}
-		out.GitHub = &getDeploymentSettingsGitHubJSON{
-			Repository:          s.GitHub.Repository,
-			PullRequestTemplate: s.GitHub.PullRequestTemplate,
-			DeployCommits:       s.GitHub.DeployCommits,
-			PreviewPullRequests: s.GitHub.PreviewPullRequests,
-			DeployPullRequest:   s.GitHub.DeployPullRequest,
-			Paths:               paths,
-		}
-	}
+type oidcView struct {
+	AWS   *oidcAWSView   `json:"aws,omitempty"`
+	Azure *oidcAzureView `json:"azure,omitempty"`
+	GCP   *oidcGCPView   `json:"gcp,omitempty"`
+}
+
+type oidcAWSView struct {
+	RoleARN         string   `json:"roleArn"`
+	SessionName     string   `json:"sessionName,omitempty"`
+	SessionDuration string   `json:"sessionDuration,omitempty"`
+	PolicyARNs      []string `json:"policyArns,omitempty"`
+}
+
+type oidcAzureView struct {
+	ClientID       string `json:"clientId,omitempty"`
+	TenantID       string `json:"tenantId,omitempty"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+}
+
+type oidcGCPView struct {
+	ProjectNumber  string `json:"projectNumber,omitempty"`
+	WorkloadPool   string `json:"workloadPoolId,omitempty"`
+	Provider       string `json:"providerId,omitempty"`
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+	Region         string `json:"region,omitempty"`
+	TokenLifetime  string `json:"tokenLifetime,omitempty"`
+}
+
+type advancedView struct {
+	SkipInstallDependencies     bool   `json:"skipInstallDependencies,omitempty"`
+	SkipIntermediateDeployments bool   `json:"skipIntermediateDeployments,omitempty"`
+	Shell                       string `json:"shell,omitempty"`
+	DeleteAfterDestroy          bool   `json:"deleteAfterDestroy,omitempty"`
+}
+
+func toDeploymentSettingsView(s apitype.DeploymentSettings) deploymentSettingsView {
+	v := deploymentSettingsView{Tag: s.Tag}
+	v.Source = buildSourceView(s)
+	v.Runner = buildRunnerView(s)
 	if s.Operation != nil {
-		preRun := s.Operation.PreRunCommands
-		if preRun == nil {
-			preRun = []string{}
+		if len(s.Operation.PreRunCommands) > 0 {
+			v.PreRunCommands = s.Operation.PreRunCommands
 		}
-		envVars := s.Operation.EnvironmentVariables
-		if envVars == nil {
-			envVars = map[string]apitype.SecretValue{}
+		if len(s.Operation.EnvironmentVariables) > 0 {
+			names := make([]string, 0, len(s.Operation.EnvironmentVariables))
+			for k := range s.Operation.EnvironmentVariables {
+				names = append(names, k)
+			}
+			sort.Strings(names)
+			v.EnvironmentVariables = names
 		}
-		out.Operation = &getDeploymentSettingsOperationJSON{
-			OIDC:                 s.Operation.OIDC,
-			PreRunCommands:       preRun,
-			Operation:            s.Operation.Operation,
-			EnvironmentVariables: envVars,
-			Options:              s.Operation.Options,
+		v.OIDC = buildOIDCView(s.Operation.OIDC)
+		v.Advanced = buildAdvancedView(s.Operation.Options)
+	}
+	return v
+}
+
+func buildSourceView(s apitype.DeploymentSettings) *sourceView {
+	hasGitHub := s.GitHub != nil && s.GitHub.Repository != ""
+	var git *apitype.SourceContextGit
+	if s.SourceContext != nil {
+		git = s.SourceContext.Git
+	}
+	hasGit := git != nil && (git.RepoURL != "" || git.Branch != "" || git.Commit != "" || git.RepoDir != "")
+	if !hasGitHub && !hasGit {
+		return nil
+	}
+	out := &sourceView{}
+	if hasGitHub {
+		out.Kind = "github"
+		out.Repository = s.GitHub.Repository
+		preview := s.GitHub.PreviewPullRequests
+		push := s.GitHub.DeployCommits
+		template := s.GitHub.PullRequestTemplate
+		out.PreviewPullRequests = &preview
+		out.RunUpdatesOnPush = &push
+		out.PullRequestTemplate = &template
+		if len(s.GitHub.Paths) > 0 {
+			out.PathFilters = s.GitHub.Paths
 		}
+	} else {
+		out.Kind = "git"
+		if git != nil {
+			out.Repository = git.RepoURL
+		}
+	}
+	if git != nil {
+		out.Branch = git.Branch
+		out.Commit = git.Commit
+		out.Folder = git.RepoDir
 	}
 	return out
+}
+
+func buildRunnerView(s apitype.DeploymentSettings) *runnerView {
+	out := &runnerView{}
+	if s.AgentPoolID != nil {
+		out.Pool = *s.AgentPoolID
+	}
+	if s.Executor != nil {
+		if s.Executor.ExecutorImage != nil {
+			out.ExecutorImage = s.Executor.ExecutorImage.Reference
+		}
+		out.WorkingDirectory = s.Executor.WorkingDirectory
+	}
+	if out.Pool == "" && out.ExecutorImage == "" && out.WorkingDirectory == "" {
+		return nil
+	}
+	return out
+}
+
+func buildOIDCView(o *apitype.OperationContextOIDCConfiguration) *oidcView {
+	if o == nil {
+		return nil
+	}
+	out := &oidcView{}
+	if o.AWS != nil && o.AWS.RoleARN != "" {
+		out.AWS = &oidcAWSView{
+			RoleARN:         o.AWS.RoleARN,
+			SessionName:     o.AWS.SessionName,
+			SessionDuration: formatDuration(o.AWS.Duration),
+			PolicyARNs:      o.AWS.PolicyARNs,
+		}
+	}
+	if o.Azure != nil && (o.Azure.ClientID != "" || o.Azure.TenantID != "" || o.Azure.SubscriptionID != "") {
+		out.Azure = &oidcAzureView{
+			ClientID:       o.Azure.ClientID,
+			TenantID:       o.Azure.TenantID,
+			SubscriptionID: o.Azure.SubscriptionID,
+		}
+	}
+	if o.GCP != nil && o.GCP.ProjectID != "" {
+		out.GCP = &oidcGCPView{
+			ProjectNumber:  o.GCP.ProjectID,
+			WorkloadPool:   o.GCP.WorkloadPoolID,
+			Provider:       o.GCP.ProviderID,
+			ServiceAccount: o.GCP.ServiceAccount,
+			Region:         o.GCP.Region,
+			TokenLifetime:  formatDuration(o.GCP.TokenLifetime),
+		}
+	}
+	if out.AWS == nil && out.Azure == nil && out.GCP == nil {
+		return nil
+	}
+	return out
+}
+
+func formatDuration(d apitype.DeploymentDuration) string {
+	if d == 0 {
+		return ""
+	}
+	return time.Duration(d).String()
+}
+
+func buildAdvancedView(o *apitype.OperationContextOptions) *advancedView {
+	if o == nil {
+		return nil
+	}
+	if !o.SkipInstallDependencies && !o.SkipIntermediateDeployments &&
+		o.Shell == "" && !o.DeleteAfterDestroy {
+		return nil
+	}
+	return &advancedView{
+		SkipInstallDependencies:     o.SkipInstallDependencies,
+		SkipIntermediateDeployments: o.SkipIntermediateDeployments,
+		Shell:                       o.Shell,
+		DeleteAfterDestroy:          o.DeleteAfterDestroy,
+	}
+}
+
+// renderDeploymentSettingsGetText prints a sectioned summary.
+// Empty sections are skipped entirely.
+func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) error {
+	v := toDeploymentSettingsView(s)
+
+	// Value column is the same across all sections
+	const valueColumn = 29
+	kv := func(indent int, label, value string) {
+		prefix := strings.Repeat(" ", indent) + label + ":"
+		fmt.Fprintf(w, "%-*s %s\n", valueColumn-2, prefix, value)
+	}
+	first := true
+	section := func(title string) {
+		if !first {
+			fmt.Fprintln(w)
+		}
+		first = false
+		fmt.Fprintln(w, title)
+	}
+	yesno := func(b bool) string {
+		if b {
+			return "yes"
+		}
+		return "no"
+	}
+
+	if v.Tag != "" {
+		kv(0, "Tag", v.Tag)
+		first = false
+	}
+
+	if v.Source != nil {
+		switch v.Source.Kind {
+		case "github":
+			section("Source: GitHub")
+		case "git":
+			section("Source: Git")
+		default:
+			section("Source")
+		}
+		if v.Source.Repository != "" {
+			kv(2, "Repository", v.Source.Repository)
+		}
+		if v.Source.Branch != "" {
+			kv(2, "Branch", v.Source.Branch)
+		}
+		if v.Source.Commit != "" {
+			kv(2, "Commit", v.Source.Commit)
+		}
+		if v.Source.Folder != "" {
+			kv(2, "Pulumi.yaml folder", v.Source.Folder)
+		}
+		if v.Source.PreviewPullRequests != nil {
+			kv(2, "Run previews for PRs", yesno(*v.Source.PreviewPullRequests))
+		}
+		if v.Source.RunUpdatesOnPush != nil {
+			kv(2, "Run updates on push", yesno(*v.Source.RunUpdatesOnPush))
+		}
+		if v.Source.PullRequestTemplate != nil {
+			kv(2, "PR stack template", yesno(*v.Source.PullRequestTemplate))
+		}
+		if len(v.Source.PathFilters) > 0 {
+			kv(2, "Path filters", strings.Join(v.Source.PathFilters, ", "))
+		}
+	}
+
+	if v.Runner != nil {
+		section("Deployment runner")
+		if v.Runner.Pool != "" {
+			kv(2, "Runner pool", v.Runner.Pool)
+		}
+		if v.Runner.ExecutorImage != "" {
+			kv(2, "Executor image", v.Runner.ExecutorImage)
+		}
+		if v.Runner.WorkingDirectory != "" {
+			kv(2, "Working directory", v.Runner.WorkingDirectory)
+		}
+	}
+
+	if len(v.PreRunCommands) > 0 {
+		section("Pre-run commands")
+		for _, c := range v.PreRunCommands {
+			fmt.Fprintf(w, "  %s\n", c)
+		}
+	}
+
+	if len(v.EnvironmentVariables) > 0 {
+		section("Environment variables")
+		for _, n := range v.EnvironmentVariables {
+			fmt.Fprintf(w, "  %s\n", n)
+		}
+	}
+
+	if v.OIDC != nil {
+		section("OIDC")
+		if v.OIDC.AWS != nil {
+			fmt.Fprintln(w, "  AWS")
+			kv(4, "Role ARN", v.OIDC.AWS.RoleARN)
+			if v.OIDC.AWS.SessionName != "" {
+				kv(4, "Session name", v.OIDC.AWS.SessionName)
+			}
+			if v.OIDC.AWS.SessionDuration != "" {
+				kv(4, "Session duration", v.OIDC.AWS.SessionDuration)
+			}
+			if len(v.OIDC.AWS.PolicyARNs) > 0 {
+				kv(4, "Policy ARNs", strings.Join(v.OIDC.AWS.PolicyARNs, ", "))
+			}
+		}
+		if v.OIDC.Azure != nil {
+			fmt.Fprintln(w, "  Azure")
+			if v.OIDC.Azure.ClientID != "" {
+				kv(4, "Client ID", v.OIDC.Azure.ClientID)
+			}
+			if v.OIDC.Azure.TenantID != "" {
+				kv(4, "Tenant ID", v.OIDC.Azure.TenantID)
+			}
+			if v.OIDC.Azure.SubscriptionID != "" {
+				kv(4, "Subscription ID", v.OIDC.Azure.SubscriptionID)
+			}
+		}
+		if v.OIDC.GCP != nil {
+			fmt.Fprintln(w, "  GCP")
+			if v.OIDC.GCP.ProjectNumber != "" {
+				kv(4, "Project number", v.OIDC.GCP.ProjectNumber)
+			}
+			if v.OIDC.GCP.WorkloadPool != "" {
+				kv(4, "Workload pool", v.OIDC.GCP.WorkloadPool)
+			}
+			if v.OIDC.GCP.Provider != "" {
+				kv(4, "Provider", v.OIDC.GCP.Provider)
+			}
+			if v.OIDC.GCP.ServiceAccount != "" {
+				kv(4, "Service account", v.OIDC.GCP.ServiceAccount)
+			}
+			if v.OIDC.GCP.Region != "" {
+				kv(4, "Region", v.OIDC.GCP.Region)
+			}
+			if v.OIDC.GCP.TokenLifetime != "" {
+				kv(4, "Token lifetime", v.OIDC.GCP.TokenLifetime)
+			}
+		}
+	}
+
+	if v.Advanced != nil {
+		section("Advanced")
+		if v.Advanced.SkipInstallDependencies {
+			kv(2, "Skip install dependencies", "yes")
+		}
+		if v.Advanced.SkipIntermediateDeployments {
+			kv(2, "Skip intermediate", "yes")
+		}
+		if v.Advanced.Shell != "" {
+			kv(2, "Shell", v.Advanced.Shell)
+		}
+		if v.Advanced.DeleteAfterDestroy {
+			kv(2, "Delete after destroy", "yes")
+		}
+	}
+
+	return nil
 }
 
 func renderDeploymentSettingsGetJSON(w io.Writer, s apitype.DeploymentSettings) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
-	return enc.Encode(toGetDeploymentSettingsJSON(s))
+	return enc.Encode(toDeploymentSettingsView(s))
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -106,20 +107,27 @@ func TestDeploymentSettingsGet_DefaultOutput(t *testing.T) {
 		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()})
 	require.NoError(t, err)
 
-	assert.Equal(t, `Executor image:          pulumi/pulumi:latest
-Working directory:       /work
-Source repo URL:         https://github.com/acme/infra
-Source branch:           main
-Source commit:           abc123
-Source repo dir:         stacks/prod
-GitHub repository:       acme/infra
-GitHub deploy commits:   true
-GitHub preview PRs:      true
-GitHub PR template:      false
-GitHub paths:            1
-Agent pool ID:           pool-1
-Env var keys:            2
-Pre-run commands:        1
+	assert.Equal(t, `Source: GitHub
+  Repository:               acme/infra
+  Branch:                   main
+  Commit:                   abc123
+  Pulumi.yaml folder:       stacks/prod
+  Run previews for PRs:     yes
+  Run updates on push:      yes
+  PR stack template:        no
+  Path filters:             stacks/prod/**
+
+Deployment runner
+  Runner pool:              pool-1
+  Executor image:           pulumi/pulumi:latest
+  Working directory:        /work
+
+Pre-run commands
+  echo hi
+
+Environment variables
+  BAZ
+  FOO
 `, buf.String())
 }
 
@@ -132,21 +140,8 @@ func TestDeploymentSettingsGet_DefaultOutput_Empty(t *testing.T) {
 		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()})
 	require.NoError(t, err)
 
-	assert.Equal(t, `Executor image:          -
-Working directory:       -
-Source repo URL:         -
-Source branch:           -
-Source commit:           -
-Source repo dir:         -
-GitHub repository:       -
-GitHub deploy commits:   false
-GitHub preview PRs:      false
-GitHub PR template:      false
-GitHub paths:            0
-Agent pool ID:           -
-Env var keys:            0
-Pre-run commands:        0
-`, buf.String())
+	// Nothing configured, hide all sections
+	assert.Empty(t, buf.String())
 }
 
 func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
@@ -159,46 +154,50 @@ func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
-		"executorContext": {
-			"workingDirectory": "/work",
-			"executorImage": "pulumi/pulumi:latest"
-		},
-		"sourceContext": {
-			"git": {
-				"repoUrl": "https://github.com/acme/infra",
-				"branch": "main",
-				"commit": "abc123",
-				"repoDir": "stacks/prod"
-			}
-		},
-		"gitHub": {
+		"source": {
+			"kind": "github",
 			"repository": "acme/infra",
-			"pullRequestTemplate": false,
-			"deployCommits": true,
+			"branch": "main",
+			"commit": "abc123",
+			"folder": "stacks/prod",
 			"previewPullRequests": true,
-			"paths": ["stacks/prod/**"]
+			"runUpdatesOnPush": true,
+			"pullRequestTemplate": false,
+			"pathFilters": ["stacks/prod/**"]
 		},
-		"operationContext": {
-			"preRunCommands": ["echo hi"],
-			"operation": "update",
-			"environmentVariables": {
-				"FOO": "bar",
-				"BAZ": "qux"
-			}
+		"runner": {
+			"pool": "pool-1",
+			"executorImage": "pulumi/pulumi:latest",
+			"workingDirectory": "/work"
 		},
-		"agentPoolID": "pool-1"
+		"preRunCommands": ["echo hi"],
+		"environmentVariables": ["BAZ", "FOO"]
 	}`, buf.String())
 }
 
-func TestDeploymentSettingsGet_JSONOutput_NilSlicesNormalized(t *testing.T) {
+func TestDeploymentSettingsGet_JSONOutput_Empty(t *testing.T) {
 	t.Parallel()
 
-	// GitHub set with nil Paths, Operation set with nil PreRunCommands and nil
-	// EnvironmentVariables — JSON should expose them as empty arrays / object.
+	var buf bytes.Buffer
+	c := &mockDeploymentSettingsGetClient{resp: &apitype.DeploymentSettings{}}
+	err := runDeploymentSettingsGet(t.Context(), &buf, stubSettingsGetFactory(c),
+		deploymentSettingsGetJSONArgs(t))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{}`, buf.String())
+}
+
+func TestDeploymentSettingsGet_JSONOutput_GitSource(t *testing.T) {
+	t.Parallel()
+
+	// No GitHub block. The raw git source falls through to source.kind == "git",
+	// and the GitHub-only toggles must NOT appear in the JSON.
 	settings := &apitype.DeploymentSettings{
-		GitHub: &apitype.DeploymentSettingsGitHub{Repository: "acme/infra"},
-		Operation: &apitype.OperationContext{
-			Operation: apitype.Preview,
+		SourceContext: &apitype.SourceContext{
+			Git: &apitype.SourceContextGit{
+				RepoURL: "git@example.com:acme/infra.git",
+				Branch:  "main",
+			},
 		},
 	}
 
@@ -209,19 +208,67 @@ func TestDeploymentSettingsGet_JSONOutput_NilSlicesNormalized(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
-		"gitHub": {
-			"repository": "acme/infra",
-			"pullRequestTemplate": false,
-			"deployCommits": false,
-			"previewPullRequests": false,
-			"paths": []
-		},
-		"operationContext": {
-			"preRunCommands": [],
-			"operation": "preview",
-			"environmentVariables": {}
+		"source": {
+			"kind": "git",
+			"repository": "git@example.com:acme/infra.git",
+			"branch": "main"
 		}
 	}`, buf.String())
+}
+
+func TestDeploymentSettingsGet_RichSections(t *testing.T) {
+	t.Parallel()
+
+	thirtyMin, err := time.ParseDuration("30m")
+	require.NoError(t, err)
+	settings := &apitype.DeploymentSettings{
+		Tag: "rev-42",
+		Operation: &apitype.OperationContext{
+			Operation: apitype.Update,
+			OIDC: &apitype.OperationContextOIDCConfiguration{
+				AWS: &apitype.OperationContextAWSOIDCConfiguration{
+					RoleARN:     "arn:aws:iam::123:role/pulumi-deploy",
+					SessionName: "pulumi-deploy",
+					Duration:    apitype.DeploymentDuration(thirtyMin),
+					PolicyARNs:  []string{"arn:aws:iam::aws:policy/ReadOnlyAccess"},
+				},
+				GCP: &apitype.OperationContextGCPOIDCConfiguration{
+					ProjectID:      "123456",
+					WorkloadPoolID: "pulumi-pool",
+					ProviderID:     "pulumi",
+					ServiceAccount: "pulumi@my-project.iam.gserviceaccount.com",
+				},
+			},
+			Options: &apitype.OperationContextOptions{
+				SkipInstallDependencies: true,
+				Shell:                   "bash",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	c := &mockDeploymentSettingsGetClient{resp: settings}
+	require.NoError(t, runDeploymentSettingsGet(t.Context(), &buf, stubSettingsGetFactory(c),
+		deploymentSettingsGetArgs{outputFormat: defaultDeploymentSettingsGetOutputFormat()}))
+
+	assert.Equal(t, `Tag:                        rev-42
+
+OIDC
+  AWS
+    Role ARN:               arn:aws:iam::123:role/pulumi-deploy
+    Session name:           pulumi-deploy
+    Session duration:       30m0s
+    Policy ARNs:            arn:aws:iam::aws:policy/ReadOnlyAccess
+  GCP
+    Project number:         123456
+    Workload pool:          pulumi-pool
+    Provider:               pulumi
+    Service account:        pulumi@my-project.iam.gserviceaccount.com
+
+Advanced
+  Skip install dependencies: yes
+  Shell:                    bash
+`, buf.String())
 }
 
 func TestDeploymentSettingsGet_ClientError(t *testing.T) {


### PR DESCRIPTION
Align this with the cloud UI

Text
```
% pulumi deployment settings get
Source: GitHub
  Repository:               julienp-test-org/random-python
  Branch:                   main
  Run previews for PRs:     no
  Run updates on push:      no
  PR stack template:        no
  Path filters:             !/miaow-exclude-2

Deployment runner
  Executor image:           pulumi/pulumi-python-3.14

Pre-run commands
  pulumi install

Environment variables
  FOO
  FOO_IS_SECRET

OIDC
  GCP
    Project number:         1234

Advanced
  Skip install dependencies: yes
```

JSON:
```
% pulumi deployment settings get --output json
{
  "source": {
    "kind": "github",
    "repository": "julienp-test-org/random-python",
    "branch": "main",
    "previewPullRequests": false,
    "runUpdatesOnPush": false,
    "pullRequestTemplate": false,
    "pathFilters": [
      "!/miaow-exclude-2"
    ]
  },
  "runner": {
    "executorImage": "pulumi/pulumi-python-3.14"
  },
  "preRunCommands": [
    "pulumi install"
  ],
  "environmentVariables": [
    "FOO",
    "FOO_IS_SECRET"
  ],
  "oidc": {
    "gcp": {
      "projectNumber": "1234"
    }
  },
  "advanced": {
    "skipInstallDependencies": true
  }
}
```
