### PR TITLE
Hide experimental settings commands

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -25,9 +25,8 @@ func NewDeploymentCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		// This is temporarily hidden while we iterate over the new set of commands,
 		// we will remove before releasing these new set of features.
-		Hidden: true,
-		Use:    "deployment",
-		Short:  "Manage stack deployments on Pulumi Cloud",
+		Use:   "deployment",
+		Short: "Manage stack deployments on Pulumi Cloud",
 		Long: "Manage stack deployments on Pulumi Cloud.\n" +
 			"\n" +
 			"Use this command to trigger deployment jobs and manage deployment settings.",

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -179,6 +179,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 	var gitSSHPrivateKeyValue string
 
 	cmd := &cobra.Command{
+		Hidden:     true,
 		Use:        "init",
 		SuggestFor: []string{"new", "create"},
 		Short:      "Initialize the stack's deployment.yaml file",
@@ -294,9 +295,10 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 	var gitSSHPrivateKeyValue string
 
 	cmd := &cobra.Command{
-		Use:   "configure",
-		Short: "Updates stack's deployment settings secrets",
-		Long:  "",
+		Hidden: true,
+		Use:    "configure",
+		Short:  "Updates stack's deployment settings secrets",
+		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmdutil.Interactive() {
 				return errors.New("configure command is only supported in interactive mode")

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -41,9 +41,10 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 	var stack string
 
 	cmd := &cobra.Command{
-		Use:   "pull",
-		Short: "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
-		Long:  "",
+		Hidden: true,
+		Use:    "pull",
+		Short:  "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
+		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
 			if err != nil {
@@ -82,6 +83,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
+		Hidden:     true,
 		Use:        "push",
 		Aliases:    []string{"update", "up"},
 		SuggestFor: []string{"apply", "deploy", "push"},
@@ -137,6 +139,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
+		Hidden:     true,
 		Use:        "destroy",
 		Aliases:    []string{"down", "dn", "clear"},
 		SuggestFor: []string{"delete", "kill", "remove", "rm", "stop"},
@@ -189,9 +192,10 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 	var remove bool
 
 	cmd := &cobra.Command{
-		Use:   "env",
-		Short: "Update stack's deployment settings secrets",
-		Long:  "",
+		Hidden: true,
+		Use:    "env",
+		Short:  "Update stack's deployment settings secrets",
+		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)


### PR DESCRIPTION
These commands are different from the new settings edit/get, using a deployment.yaml for configuration.

That whole feature is still experimental, and separate from the cloud based config for deployments.
