### PR TITLE
Fix `pulumi org role list` to supply a valid default purpose

### DIFF
--- a/changelog/pending/20260518--cli--fix-pulumi-org-role-list-to-send-the-uxpurpose-query-parameter-the-service-requires.yaml
+++ b/changelog/pending/20260518--cli--fix-pulumi-org-role-list-to-send-the-uxpurpose-query-parameter-the-service-requires.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Fix `pulumi org role list` to send the `uxPurpose` query parameter the service requires

--- a/pkg/cmd/pulumi/org/org_role_list.go
+++ b/pkg/cmd/pulumi/org/org_role_list.go
@@ -32,13 +32,6 @@ import (
 // roleListRender renders a list of roles.
 type roleListRender func(w io.Writer, orgName string, roles []apitype.Role) error
 
-func defaultRoleListOutput() outputflag.OutputFlag[roleListRender] {
-	return outputflag.OutputFlag[roleListRender]{
-		RenderForTerminal: renderRoleListTable,
-		RenderJSON:        renderRoleListJSON,
-	}
-}
-
 func newOrgRoleListCmd() *cobra.Command {
 	return newOrgRoleListCmdWith(defaultOrgRoleClientFactory)
 }
@@ -50,7 +43,10 @@ func newOrgRoleListCmdWith(factory orgRoleClientFactory) *cobra.Command {
 		org     string
 		purpose string
 	)
-	output := defaultRoleListOutput()
+	output := outputflag.OutputFlag[roleListRender]{
+		RenderForTerminal: renderRoleListTable,
+		RenderJSON:        renderRoleListJSON,
+	}
 
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -70,9 +66,9 @@ func newOrgRoleListCmdWith(factory orgRoleClientFactory) *cobra.Command {
 
 	cmd.Flags().StringVar(&org, "org", "",
 		"The organization to list roles for. Defaults to the current default organization")
-	cmd.Flags().StringVar(&purpose, "purpose", "",
-		"Filter by UX purpose: organization, team, or token")
-	outputflag.VarP(cmd.Flags(), &output)
+	cmd.Flags().StringVar(&purpose, "purpose", "role",
+		"Filter by UX purpose: role, role_private, role_temporary, policy, or set")
+	outputflag.Var(cmd.Flags(), &output)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/org/org_role_list_test.go
+++ b/pkg/cmd/pulumi/org/org_role_list_test.go
@@ -196,19 +196,3 @@ func TestOrgRoleList_FactoryError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
-
-func TestOrgRoleList_CobraFlagBinding(t *testing.T) {
-	t.Parallel()
-
-	c := &mockOrgRoleClient{roles: sampleRoles()}
-	cmd := newOrgRoleListCmdWith(stubRoleFactory(c, "my-org"))
-
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--output", "json", "--purpose", "organization"})
-
-	err := cmd.ExecuteContext(t.Context())
-	require.NoError(t, err)
-	assert.Contains(t, buf.String(), `"count": 2`)
-	assert.Equal(t, "organization", c.capturedPurpose)
-}


### PR DESCRIPTION
This changes the CLI behavior to reflect the actual service behavior, not the behavior documented in the OpenAPI spec.

https://github.com/pulumi/pulumi-service/pull/43394 follows up in the service, updating the OpenAPI spec to reflect the services actual behavior.