### PR TITLE
Add dedicated flags for each deployment setting

### DIFF
--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -11,6 +11,7 @@ scopes:
     - about
     - cloud
     - config
+    - deployment
     - display
     - engine
     - env

--- a/changelog/pending/20260518--cli-deployment--add-dedicated-flags-for-each-deployment-setting.yaml
+++ b/changelog/pending/20260518--cli-deployment--add-dedicated-flags-for-each-deployment-setting.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/deployment
+  description: Add dedicated flags for each deployment setting

--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -23,8 +23,6 @@ import (
 
 func NewDeploymentCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		// This is temporarily hidden while we iterate over the new set of commands,
-		// we will remove before releasing these new set of features.
 		Use:   "deployment",
 		Short: "Manage stack deployments on Pulumi Cloud",
 		Long: "Manage stack deployments on Pulumi Cloud.\n" +

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -73,12 +73,15 @@ func newDeploymentSettingsCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
+	// Commands to edit `Pulumi.<stack>.deployment.yaml`
 	cmd.AddCommand(newDeploymentSettingsInitCmd())
 	cmd.AddCommand(newDeploymentSettingsPullCmd())
 	cmd.AddCommand(newDeploymentSettingsUpdateCmd())
 	cmd.AddCommand(newDeploymentSettingsDestroyCmd())
 	cmd.AddCommand(newDeploymentSettingsEnvCmd())
 	cmd.AddCommand(newDeploymentSettingsConfigureCmd())
+
+	// Edit the settings in cloud
 	cmd.AddCommand(newDeploymentSettingsGetCmd())
 	cmd.AddCommand(newDeploymentSettingsEditCmd())
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -145,11 +145,11 @@ const (
 	flagOIDCAzureClear          = "oidc-azure-clear"
 
 	flagOIDCGCPProjectNumber  = "oidc-gcp-project-number"
-	flagOIDCGCPWorkloadPoolID = "oidc-gcp-workload-pool-id"
+	flagOIDCGCPWorkloadPoolID = "oidc-gcp-workload-pool-id" //nolint:gosec // flag name, not a credential
 	flagOIDCGCPProviderID     = "oidc-gcp-provider-id"
 	flagOIDCGCPServiceAccount = "oidc-gcp-service-account"
 	flagOIDCGCPRegion         = "oidc-gcp-region"
-	flagOIDCGCPTokenLifetime  = "oidc-gcp-token-lifetime"
+	flagOIDCGCPTokenLifetime  = "oidc-gcp-token-lifetime" //nolint:gosec // flag name, not a credential
 	flagOIDCGCPClear          = "oidc-gcp-clear"
 )
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"
@@ -23,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -40,8 +37,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// deploymentSettingsEditClient is the narrow API surface this command depends
-// on.
 type deploymentSettingsEditClient interface {
 	PatchStackDeploymentSettings(
 		ctx context.Context, stack client.StackIdentifier, patch json.RawMessage,
@@ -49,25 +44,113 @@ type deploymentSettingsEditClient interface {
 	GetStackDeploymentSettings(
 		ctx context.Context, stack client.StackIdentifier,
 	) (*apitype.DeploymentSettings, error)
+	EncryptStackDeploymentSettingsSecret(
+		ctx context.Context, stack client.StackIdentifier, secret string,
+	) (*apitype.SecretValue, error)
 }
 
-// deploymentSettingsEditClientFactory resolves a client and StackIdentifier
-// for the edit command. stackFlag carries the raw `--stack` value (empty means
-// "use the current stack").
 type deploymentSettingsEditClientFactory func(
 	ctx context.Context, stackFlag string,
 ) (deploymentSettingsEditClient, client.StackIdentifier, error)
 
-// deploymentSettingsEditArgs collects the resolved flag values so Run can be
-// driven directly from tests.
 type deploymentSettingsEditArgs struct {
 	stack        string
-	file         string
 	outputFormat outputflag.OutputFlag[deploymentSettingsGetRenderFunc]
+
+	// Source — github and git URLs are mutually exclusive
+	githubRepo string
+	gitURL     string
+	branch     string
+	commit     string
+	folder     string
+
+	// GitHub-only toggles
+	previewPRs   bool
+	pushToDeploy bool
+	prTemplate   bool
+	pathFilters  []string
+
+	// Runner
+	runnerPool    string
+	executorImage string
+
+	// Operation
+	preRunCommands []string
+	envVars        []string // each "KEY=VALUE"; plaintext.
+	secretEnvVars  []string // each "KEY=VALUE"; encrypted before send.
+	removeEnv      []string // each "KEY"; sent as null to delete.
+
+	skipInstallDeps    bool
+	skipIntermediate   bool
+	shell              string
+	deleteAfterDestroy bool
+
+	// OIDC — AWS
+	oidcAWSRoleARN     string
+	oidcAWSSessionName string
+	oidcAWSDuration    string
+	oidcAWSPolicyARNs  []string
+	oidcAWSClear       bool
+
+	// OIDC — Azure
+	oidcAzureClientID       string
+	oidcAzureTenantID       string
+	oidcAzureSubscriptionID string
+	oidcAzureClear          bool
+
+	// OIDC — GCP
+	oidcGCPProjectNumber  string
+	oidcGCPWorkloadPoolID string
+	oidcGCPProviderID     string
+	oidcGCPServiceAccount string
+	oidcGCPRegion         string
+	oidcGCPTokenLifetime  string
+	oidcGCPClear          bool
+
+	flagsChanged func(name string) bool
 }
 
-// newDeploymentSettingsEditCmd builds `pulumi deployment settings edit` wired
-// to the real cloud client factory.
+const (
+	flagGitHubRepo         = "github-repo"
+	flagGitURL             = "git-url"
+	flagBranch             = "branch"
+	flagCommit             = "commit"
+	flagFolder             = "folder"
+	flagPreviewPRs         = "preview-prs"
+	flagPushToDeploy       = "push-to-deploy"
+	flagPRTemplate         = "pr-template"
+	flagPathFilter         = "path-filter"
+	flagRunnerPool         = "runner-pool"
+	flagExecutorImage      = "executor-image"
+	flagPreRunCommand      = "pre-run-command"
+	flagEnv                = "env"
+	flagSecretEnv          = "secret-env"
+	flagRemoveEnv          = "remove-env"
+	flagSkipInstallDeps    = "skip-install-deps"
+	flagSkipIntermediate   = "skip-intermediate-deployments"
+	flagShell              = "shell"
+	flagDeleteAfterDestroy = "delete-after-destroy"
+
+	flagOIDCAWSRoleARN     = "oidc-aws-role-arn"
+	flagOIDCAWSSessionName = "oidc-aws-session-name"
+	flagOIDCAWSDuration    = "oidc-aws-duration"
+	flagOIDCAWSPolicyARN   = "oidc-aws-policy-arn"
+	flagOIDCAWSClear       = "oidc-aws-clear"
+
+	flagOIDCAzureClientID       = "oidc-azure-client-id"
+	flagOIDCAzureTenantID       = "oidc-azure-tenant-id"
+	flagOIDCAzureSubscriptionID = "oidc-azure-subscription-id"
+	flagOIDCAzureClear          = "oidc-azure-clear"
+
+	flagOIDCGCPProjectNumber  = "oidc-gcp-project-number"
+	flagOIDCGCPWorkloadPoolID = "oidc-gcp-workload-pool-id"
+	flagOIDCGCPProviderID     = "oidc-gcp-provider-id"
+	flagOIDCGCPServiceAccount = "oidc-gcp-service-account"
+	flagOIDCGCPRegion         = "oidc-gcp-region"
+	flagOIDCGCPTokenLifetime  = "oidc-gcp-token-lifetime"
+	flagOIDCGCPClear          = "oidc-gcp-clear"
+)
+
 func newDeploymentSettingsEditCmd() *cobra.Command {
 	return newDeploymentSettingsEditCmdWith(defaultDeploymentSettingsEditClientFactory)
 }
@@ -80,37 +163,119 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "[EXPERIMENTAL] Create or update deployment settings for a stack",
-		Long: "[EXPERIMENTAL] Create or update deployment settings for a stack.\n" +
-			"\n" +
-			"Applies a JSON patch to the stack's Pulumi Deployments settings. If no\n" +
-			"settings exist they are created from the patch.\n" +
-			"\n" +
-			"Use --file to point at a JSON document containing the patch; pass `-` to\n" +
-			"read the patch from stdin. On success the resulting settings are printed\n" +
-			"in the same format as `pulumi deployment settings get`.\n" +
-			"\n" +
-			"Default output is a human-readable summary; pass --output=json for the\n" +
-			"raw response as JSON.",
-		RunE: func(cmd *cobra.Command, posArgs []string) error {
-			return runDeploymentSettingsEdit(cmd.Context(), cmd.OutOrStdout(), os.Stdin, factory, args)
+		Long:  "[EXPERIMENTAL] Create or update deployment settings for a stack.",
+		Example: "  # Switch the deployment source branch.\n" +
+			"  pulumi deployment settings edit --branch feature-x\n\n" +
+			"  # Configure a GitHub source.\n" +
+			"  pulumi deployment settings edit \\\n" +
+			"    --github-repo acme/infra --branch main --folder stacks/prod \\\n" +
+			"    --preview-prs --push-to-deploy\n\n" +
+			"  # Set environment variables (plaintext and encrypted).\n" +
+			"  pulumi deployment settings edit --env LOG_LEVEL=info --secret-env API_KEY=s3cret\n\n" +
+			"  # Remove an environment variable.\n" +
+			"  pulumi deployment settings edit --remove-env STALE_VAR\n\n" +
+			"  # Configure AWS OIDC.\n" +
+			"  pulumi deployment settings edit \\\n" +
+			"    --oidc-aws-role-arn arn:aws:iam::123:role/pulumi-deploy \\\n" +
+			"    --oidc-aws-session-name pulumi-deploy --oidc-aws-duration 30m\n\n" +
+			"  # Remove the AWS OIDC configuration entirely.\n" +
+			"  pulumi deployment settings edit --oidc-aws-clear\n\n" +
+			"  # Clear the agent pool back to the Pulumi-hosted default.\n" +
+			"  pulumi deployment settings edit --runner-pool \"\"",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			args.flagsChanged = cmd.Flags().Changed
+			return runDeploymentSettingsEdit(cmd.Context(), cmd.OutOrStdout(), factory, args)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.Flags().StringVarP(&args.stack, "stack", "s", "",
+	f := cmd.Flags()
+	f.StringVarP(&args.stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVarP(&args.file, "file", "f", "",
-		"Read settings patch from file; `-` reads stdin")
-	outputflag.VarP(cmd.Flags(), &args.outputFormat)
-	contract.AssertNoErrorf(cmd.MarkFlagRequired("file"), "marking --file required")
+	outputflag.VarP(f, &args.outputFormat)
+
+	// Source
+	f.StringVar(&args.githubRepo, flagGitHubRepo, "",
+		"GitHub source: organization/repository (mutually exclusive with --git-url)")
+	f.StringVar(&args.gitURL, flagGitURL, "",
+		"Git source: full repository URL (mutually exclusive with --github-repo)")
+	f.StringVar(&args.branch, flagBranch, "", "Source branch")
+	f.StringVar(&args.commit, flagCommit, "", "Source commit hash")
+	f.StringVar(&args.folder, flagFolder, "", "Path to the Pulumi.yaml folder within the source repo")
+	f.BoolVar(&args.previewPRs, flagPreviewPRs, false, "GitHub: run previews for pull requests")
+	f.BoolVar(&args.pushToDeploy, flagPushToDeploy, false, "GitHub: run updates for pushed commits")
+	f.BoolVar(&args.prTemplate, flagPRTemplate, false, "GitHub: use this stack as a template for PR review stacks")
+	f.StringSliceVar(&args.pathFilters, flagPathFilter, nil,
+		"GitHub: replace the path filter list (repeatable, comma-separated)")
+
+	// Runner
+	f.StringVar(&args.runnerPool, flagRunnerPool, "",
+		"Deployment runner pool ID; empty string clears it to the Pulumi-hosted pool")
+	f.StringVar(&args.executorImage, flagExecutorImage, "",
+		"Custom executor image; empty string clears it to the default image")
+
+	// Operation
+	f.StringArrayVar(&args.preRunCommands, flagPreRunCommand, nil,
+		"Replace the pre-run command list (repeatable; pass once per command")
+	f.StringArrayVar(&args.envVars, flagEnv, nil,
+		"Set a plaintext environment variable (repeatable, KEY=VALUE)")
+	f.StringArrayVar(&args.secretEnvVars, flagSecretEnv, nil,
+		"Set an encrypted environment variable (repeatable, KEY=VALUE)")
+	f.StringSliceVar(&args.removeEnv, flagRemoveEnv, nil,
+		"Delete an environment variable by key (repeatable, comma-separated)")
+
+	f.BoolVar(&args.skipInstallDeps, flagSkipInstallDeps, false,
+		"Skip automatic dependency installation")
+	f.BoolVar(&args.skipIntermediate, flagSkipIntermediate, false,
+		"Skip intermediate deployments")
+	f.StringVar(&args.shell, flagShell, "", "Shell to use for pre-run commands")
+	f.BoolVar(&args.deleteAfterDestroy, flagDeleteAfterDestroy, false,
+		"Delete the stack after a successful destroy")
+
+	// OIDC — AWS
+	f.StringVar(&args.oidcAWSRoleARN, flagOIDCAWSRoleARN, "",
+		"AWS OIDC: IAM role ARN to assume")
+	f.StringVar(&args.oidcAWSSessionName, flagOIDCAWSSessionName, "",
+		"AWS OIDC: assume-role session name")
+	f.StringVar(&args.oidcAWSDuration, flagOIDCAWSDuration, "",
+		"AWS OIDC: assume-role session duration (e.g. 30m, 1h)")
+	f.StringSliceVar(&args.oidcAWSPolicyARNs, flagOIDCAWSPolicyARN, nil,
+		"AWS OIDC: replace the session policy ARN list (repeatable, comma-separated)")
+	f.BoolVar(&args.oidcAWSClear, flagOIDCAWSClear, false,
+		"Remove the entire AWS OIDC configuration")
+
+	// OIDC — Azure
+	f.StringVar(&args.oidcAzureClientID, flagOIDCAzureClientID, "",
+		"Azure OIDC: federated workload identity client ID")
+	f.StringVar(&args.oidcAzureTenantID, flagOIDCAzureTenantID, "",
+		"Azure OIDC: federated workload identity tenant ID")
+	f.StringVar(&args.oidcAzureSubscriptionID, flagOIDCAzureSubscriptionID, "",
+		"Azure OIDC: federated workload identity subscription ID")
+	f.BoolVar(&args.oidcAzureClear, flagOIDCAzureClear, false,
+		"Remove the entire Azure OIDC configuration")
+
+	// OIDC — GCP
+	f.StringVar(&args.oidcGCPProjectNumber, flagOIDCGCPProjectNumber, "",
+		"GCP OIDC: numerical project number (e.g. 987654321)")
+	f.StringVar(&args.oidcGCPWorkloadPoolID, flagOIDCGCPWorkloadPoolID, "",
+		"GCP OIDC: workload identity pool ID")
+	f.StringVar(&args.oidcGCPProviderID, flagOIDCGCPProviderID, "",
+		"GCP OIDC: identity provider ID within the workload pool")
+	f.StringVar(&args.oidcGCPServiceAccount, flagOIDCGCPServiceAccount, "",
+		"GCP OIDC: service account email")
+	f.StringVar(&args.oidcGCPRegion, flagOIDCGCPRegion, "",
+		"GCP OIDC: region")
+	f.StringVar(&args.oidcGCPTokenLifetime, flagOIDCGCPTokenLifetime, "",
+		"GCP OIDC: lifetime of the temporary credentials (e.g. 30m, 1h)")
+	f.BoolVar(&args.oidcGCPClear, flagOIDCGCPClear, false,
+		"Remove the entire GCP OIDC configuration")
+
+	cmd.MarkFlagsMutuallyExclusive(flagGitHubRepo, flagGitURL)
 
 	return cmd
 }
 
-// defaultDeploymentSettingsEditClientFactory mirrors the production wiring
-// used elsewhere: resolve the stack, ensure we're on the Pulumi Cloud backend,
-// and hand back the underlying *client.Client.
 func defaultDeploymentSettingsEditClientFactory(
 	ctx context.Context, stackFlag string,
 ) (deploymentSettingsEditClient, client.StackIdentifier, error) {
@@ -148,20 +313,16 @@ func defaultDeploymentSettingsEditClientFactory(
 	return be.Client(), stackID, nil
 }
 
-// runDeploymentSettingsEdit is the cobra-decoupled entry point so tests can
-// drive the command without parsing flags. stdin is an injectable reader used
-// when --file is `-`.
 func runDeploymentSettingsEdit(
-	ctx context.Context, w io.Writer, stdin io.Reader,
+	ctx context.Context, w io.Writer,
 	factory deploymentSettingsEditClientFactory, args deploymentSettingsEditArgs,
 ) error {
-	if args.file == "" {
-		return errors.New("--file is required (use `-` to read the patch from stdin)")
+	if !anyEditFlagSet(args) {
+		return errors.New("nothing to do: pass one of the edit flags (see --help)")
 	}
 
-	patch, err := readDeploymentSettingsPatch(args.file, stdin)
-	if err != nil {
-		return fmt.Errorf("reading deployment settings patch: %w", err)
+	if err := validateEditArgs(args); err != nil {
+		return err
 	}
 
 	c, stackID, err := factory(ctx, args.stack)
@@ -169,7 +330,18 @@ func runDeploymentSettingsEdit(
 		return err
 	}
 
-	if err := c.PatchStackDeploymentSettings(ctx, stackID, patch); err != nil {
+	secretValues, err := encryptSecretEnvVars(ctx, c, stackID, args.secretEnvVars)
+	if err != nil {
+		return fmt.Errorf("encrypting secret environment variables: %w", err)
+	}
+
+	patch := buildEditFlagPatch(args, secretValues)
+	raw, err := marshalAndValidatePatch(patch)
+	if err != nil {
+		return fmt.Errorf("validating patch: %w", err)
+	}
+
+	if err := c.PatchStackDeploymentSettings(ctx, stackID, raw); err != nil {
 		return fmt.Errorf("editing deployment settings: %w", err)
 	}
 
@@ -184,51 +356,20 @@ func runDeploymentSettingsEdit(
 	return args.outputFormat.Get()(w, *resp)
 }
 
-// readDeploymentSettingsPatch reads the JSON patch from path (or stdin when
-// path is `-`). The bytes are validated against apitype.DeploymentSettings
-// (with unknown fields rejected) so typos surface here instead of silently
-// no-op'ing on the server, but the original bytes are sent through verbatim
-// so that we can send partial objects (undefined fields) or null for deleting
-// fields.
-func readDeploymentSettingsPatch(path string, stdin io.Reader) (json.RawMessage, error) {
-	var raw []byte
-	var err error
-	if path == "-" {
-		if stdin == nil {
-			return nil, errors.New("no stdin reader available")
-		}
-		raw, err = io.ReadAll(stdin)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		raw, err = os.ReadFile(path)
-		if err != nil {
-			return nil, err
-		}
+// marshalAndValidatePatch turns the constructed map into bytes, then decodes those bytes into
+// apitype.DeploymentSettings with DisallowUnknownFields for validation. Note that we don't pass a typed
+// `apitype.DeploymentSettings` to the API client because we need to be able to send partial payloads, potentially will
+// `null` fields, which we can't easily handle via Go's JSON struct tags.
+func marshalAndValidatePatch(patch map[string]any) (json.RawMessage, error) {
+	raw, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
 	}
-
-	if len(raw) == 0 || isAllWhitespace(raw) {
-		return nil, errors.New("patch file is empty")
-	}
-
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.DisallowUnknownFields()
 	var probe apitype.DeploymentSettings
 	if err := dec.Decode(&probe); err != nil {
 		return nil, err
 	}
-	return json.RawMessage(raw), nil
-}
-
-func isAllWhitespace(b []byte) bool {
-	for _, c := range b {
-		switch c {
-		case ' ', '\t', '\n', '\r':
-			continue
-		default:
-			return false
-		}
-	}
-	return true
+	return raw, nil
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -71,8 +71,9 @@ type deploymentSettingsEditArgs struct {
 	pathFilters  []string
 
 	// Runner
-	runnerPool    string
-	executorImage string
+	runnerPool       string
+	executorImage    string
+	executorRootPath string
 
 	// Operation
 	preRunCommands []string
@@ -122,6 +123,7 @@ const (
 	flagPathFilter         = "path-filter"
 	flagRunnerPool         = "runner-pool"
 	flagExecutorImage      = "executor-image"
+	flagExecutorRootPath   = "executor-root-path"
 	flagPreRunCommand      = "pre-run-command"
 	flagEnv                = "env"
 	flagSecretEnv          = "secret-env"
@@ -214,6 +216,8 @@ func newDeploymentSettingsEditCmdWith(factory deploymentSettingsEditClientFactor
 		"Deployment runner pool ID; empty string clears it to the Pulumi-hosted pool")
 	f.StringVar(&args.executorImage, flagExecutorImage, "",
 		"Custom executor image; empty string clears it to the default image")
+	f.StringVar(&args.executorRootPath, flagExecutorRootPath, "",
+		"Executor root path; empty string clears it to the default (/)")
 
 	// Operation
 	f.StringArrayVar(&args.preRunCommands, flagPreRunCommand, nil,

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
@@ -30,7 +30,7 @@ import (
 var editFlagNames = []string{
 	flagGitHubRepo, flagGitURL, flagBranch, flagCommit, flagFolder,
 	flagPreviewPRs, flagPushToDeploy, flagPRTemplate, flagPathFilter,
-	flagRunnerPool, flagExecutorImage,
+	flagRunnerPool, flagExecutorImage, flagExecutorRootPath,
 	flagPreRunCommand, flagEnv, flagSecretEnv, flagRemoveEnv,
 	flagSkipInstallDeps, flagSkipIntermediate, flagShell, flagDeleteAfterDestroy,
 	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagOIDCAWSClear,
@@ -193,6 +193,13 @@ func buildEditFlagPatch(
 			v = nil
 		}
 		setNested(patch, []string{"executorContext", "executorImage"}, v)
+	}
+	if changed(flagExecutorRootPath) {
+		var v any = args.executorRootPath
+		if args.executorRootPath == "" {
+			v = nil
+		}
+		setNested(patch, []string{"executorContext", "executorRootPath"}, v)
 	}
 
 	if changed(flagPreRunCommand) {

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch.go
@@ -1,0 +1,300 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+// Helpers that turn the parsed cobra flags into the JSON patch body sent to the Pulumi Cloud PATCH
+// /deployments/settings endpoint. The endpoint applies a deep merge: keys present in the patch overwrite the stored
+// value, a literal null deletes the key, and absent keys are preserved.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+)
+
+var editFlagNames = []string{
+	flagGitHubRepo, flagGitURL, flagBranch, flagCommit, flagFolder,
+	flagPreviewPRs, flagPushToDeploy, flagPRTemplate, flagPathFilter,
+	flagRunnerPool, flagExecutorImage,
+	flagPreRunCommand, flagEnv, flagSecretEnv, flagRemoveEnv,
+	flagSkipInstallDeps, flagSkipIntermediate, flagShell, flagDeleteAfterDestroy,
+	flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN, flagOIDCAWSClear,
+	flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID, flagOIDCAzureClear,
+	flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID, flagOIDCGCPProviderID,
+	flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime, flagOIDCGCPClear,
+}
+
+// oidcProviderFlags lists the field-setter flags for each OIDC provider so
+// validateEditArgs can refuse combining --oidc-<provider>-clear with any of them.
+var oidcProviderFlags = map[string][]string{
+	flagOIDCAWSClear: {
+		flagOIDCAWSRoleARN, flagOIDCAWSSessionName, flagOIDCAWSDuration, flagOIDCAWSPolicyARN,
+	},
+	flagOIDCAzureClear: {
+		flagOIDCAzureClientID, flagOIDCAzureTenantID, flagOIDCAzureSubscriptionID,
+	},
+	flagOIDCGCPClear: {
+		flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID, flagOIDCGCPProviderID,
+		flagOIDCGCPServiceAccount, flagOIDCGCPRegion, flagOIDCGCPTokenLifetime,
+	},
+}
+
+func anyEditFlagSet(args deploymentSettingsEditArgs) bool {
+	if args.flagsChanged == nil {
+		return false
+	}
+	return slices.ContainsFunc(editFlagNames, args.flagsChanged)
+}
+
+// validateEditArgs catches conflicts that cobra can't express on its own
+// (e.g. setting and removing the same env var)
+func validateEditArgs(args deploymentSettingsEditArgs) error {
+	envKeys := map[string]string{}
+	check := func(spec, flag string) error {
+		key, _, ok := strings.Cut(spec, "=")
+		if !ok {
+			return fmt.Errorf("--%s expects KEY=VALUE, got %q", flag, spec)
+		}
+		if key == "" {
+			return fmt.Errorf("--%s key must not be empty", flag)
+		}
+		if prev, dup := envKeys[key]; dup {
+			return fmt.Errorf("--env / --secret-env / --remove-env set %q multiple times (previously via --%s)", key, prev)
+		}
+		envKeys[key] = flag
+		return nil
+	}
+	for _, s := range args.envVars {
+		if err := check(s, flagEnv); err != nil {
+			return err
+		}
+	}
+	for _, s := range args.secretEnvVars {
+		if err := check(s, flagSecretEnv); err != nil {
+			return err
+		}
+	}
+	for _, k := range args.removeEnv {
+		if k == "" {
+			return fmt.Errorf("--%s key must not be empty", flagRemoveEnv)
+		}
+		if prev, dup := envKeys[k]; dup {
+			return fmt.Errorf("--env / --secret-env / --remove-env set %q multiple times (previously via --%s)", k, prev)
+		}
+		envKeys[k] = flagRemoveEnv
+	}
+	if args.flagsChanged != nil {
+		for clearFlag, fieldFlags := range oidcProviderFlags {
+			if !args.flagsChanged(clearFlag) {
+				continue
+			}
+			for _, f := range fieldFlags {
+				if args.flagsChanged(f) {
+					return fmt.Errorf("--%s cannot be combined with --%s", clearFlag, f)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// encryptSecretEnvVars converts each "KEY=VALUE" --secret-env entry into a {"ciphertext": ...} JSON object by calling
+// the cloud encrypt endpoint per value.
+func encryptSecretEnvVars(
+	ctx context.Context, c deploymentSettingsEditClient, stack client.StackIdentifier,
+	specs []string,
+) (map[string]map[string]any, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := map[string]map[string]any{}
+	for _, spec := range specs {
+		key, value, _ := strings.Cut(spec, "=")
+		sv, err := c.EncryptStackDeploymentSettingsSecret(ctx, stack, value)
+		if err != nil {
+			return nil, fmt.Errorf("encrypting %q: %w", key, err)
+		}
+		if sv == nil || sv.Ciphertext == "" {
+			return nil, fmt.Errorf("encrypting %q: server returned empty ciphertext", key)
+		}
+		out[key] = map[string]any{"ciphertext": sv.Ciphertext}
+	}
+	return out, nil
+}
+
+// buildEditFlagPatch turns the parsed flag values into a JSON-shaped map that mirrors apitype.DeploymentSettings.
+func buildEditFlagPatch(
+	args deploymentSettingsEditArgs,
+	secretEnv map[string]map[string]any,
+) map[string]any {
+	patch := map[string]any{}
+	changed := args.flagsChanged
+	if changed == nil {
+		changed = func(string) bool { return false }
+	}
+
+	if changed(flagGitHubRepo) {
+		setNested(patch, []string{"gitHub", "repository"}, args.githubRepo)
+	}
+	if changed(flagGitURL) {
+		setNested(patch, []string{"sourceContext", "git", "repoUrl"}, args.gitURL)
+	}
+	if changed(flagBranch) {
+		setNested(patch, []string{"sourceContext", "git", "branch"}, args.branch)
+	}
+	if changed(flagCommit) {
+		setNested(patch, []string{"sourceContext", "git", "commit"}, args.commit)
+	}
+	if changed(flagFolder) {
+		setNested(patch, []string{"sourceContext", "git", "repoDir"}, args.folder)
+	}
+	if changed(flagPreviewPRs) {
+		setNested(patch, []string{"gitHub", "previewPullRequests"}, args.previewPRs)
+	}
+	if changed(flagPushToDeploy) {
+		setNested(patch, []string{"gitHub", "deployCommits"}, args.pushToDeploy)
+	}
+	if changed(flagPRTemplate) {
+		setNested(patch, []string{"gitHub", "pullRequestTemplate"}, args.prTemplate)
+	}
+	if changed(flagPathFilter) {
+		setNested(patch, []string{"gitHub", "paths"}, args.pathFilters)
+	}
+
+	if changed(flagRunnerPool) {
+		// Map empty string back to null so the server clears the field. `--runner-pool ""` means "go back to the
+		// Pulumi-hosted pool".
+		var v any = args.runnerPool
+		if args.runnerPool == "" {
+			v = nil
+		}
+		patch["agentPoolID"] = v
+	}
+	if changed(flagExecutorImage) {
+		// Map empty string to null so `--executor-image ""` clears the field
+		// back to the default image. Matches the --runner-pool convention.
+		var v any = args.executorImage
+		if args.executorImage == "" {
+			v = nil
+		}
+		setNested(patch, []string{"executorContext", "executorImage"}, v)
+	}
+
+	if changed(flagPreRunCommand) {
+		setNested(patch, []string{"operationContext", "preRunCommands"}, args.preRunCommands)
+	}
+	envEntries := map[string]any{}
+	for _, spec := range args.envVars {
+		key, value, _ := strings.Cut(spec, "=")
+		envEntries[key] = value
+	}
+	for key, wire := range secretEnv {
+		envEntries[key] = wire
+	}
+	for _, key := range args.removeEnv {
+		envEntries[key] = nil
+	}
+	if len(envEntries) > 0 {
+		setNested(patch, []string{"operationContext", "environmentVariables"}, envEntries)
+	}
+
+	if changed(flagSkipInstallDeps) {
+		setNested(patch, []string{"operationContext", "options", "skipInstallDependencies"}, args.skipInstallDeps)
+	}
+	if changed(flagSkipIntermediate) {
+		setNested(patch, []string{"operationContext", "options", "skipIntermediateDeployments"}, args.skipIntermediate)
+	}
+	if changed(flagShell) {
+		setNested(patch, []string{"operationContext", "options", "shell"}, args.shell)
+	}
+	if changed(flagDeleteAfterDestroy) {
+		setNested(patch, []string{"operationContext", "options", "deleteAfterDestroy"}, args.deleteAfterDestroy)
+	}
+
+	// OIDC — AWS
+	if changed(flagOIDCAWSClear) && args.oidcAWSClear {
+		setNested(patch, []string{"operationContext", "oidc", "aws"}, nil)
+	}
+	if changed(flagOIDCAWSRoleARN) {
+		setNested(patch, []string{"operationContext", "oidc", "aws", "roleArn"}, args.oidcAWSRoleARN)
+	}
+	if changed(flagOIDCAWSSessionName) {
+		setNested(patch, []string{"operationContext", "oidc", "aws", "sessionName"}, args.oidcAWSSessionName)
+	}
+	if changed(flagOIDCAWSDuration) {
+		setNested(patch, []string{"operationContext", "oidc", "aws", "duration"}, args.oidcAWSDuration)
+	}
+	if changed(flagOIDCAWSPolicyARN) {
+		setNested(patch, []string{"operationContext", "oidc", "aws", "policyArns"}, args.oidcAWSPolicyARNs)
+	}
+
+	// OIDC — Azure
+	if changed(flagOIDCAzureClear) && args.oidcAzureClear {
+		setNested(patch, []string{"operationContext", "oidc", "azure"}, nil)
+	}
+	if changed(flagOIDCAzureClientID) {
+		setNested(patch, []string{"operationContext", "oidc", "azure", "clientId"}, args.oidcAzureClientID)
+	}
+	if changed(flagOIDCAzureTenantID) {
+		setNested(patch, []string{"operationContext", "oidc", "azure", "tenantId"}, args.oidcAzureTenantID)
+	}
+	if changed(flagOIDCAzureSubscriptionID) {
+		setNested(patch, []string{"operationContext", "oidc", "azure", "subscriptionId"}, args.oidcAzureSubscriptionID)
+	}
+
+	// OIDC — GCP
+	if changed(flagOIDCGCPClear) && args.oidcGCPClear {
+		setNested(patch, []string{"operationContext", "oidc", "gcp"}, nil)
+	}
+	if changed(flagOIDCGCPProjectNumber) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "projectId"}, args.oidcGCPProjectNumber)
+	}
+	if changed(flagOIDCGCPWorkloadPoolID) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "workloadPoolId"}, args.oidcGCPWorkloadPoolID)
+	}
+	if changed(flagOIDCGCPProviderID) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "providerId"}, args.oidcGCPProviderID)
+	}
+	if changed(flagOIDCGCPServiceAccount) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "serviceAccount"}, args.oidcGCPServiceAccount)
+	}
+	if changed(flagOIDCGCPRegion) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "region"}, args.oidcGCPRegion)
+	}
+	if changed(flagOIDCGCPTokenLifetime) {
+		setNested(patch, []string{"operationContext", "oidc", "gcp", "tokenLifetime"}, args.oidcGCPTokenLifetime)
+	}
+
+	return patch
+}
+
+func setNested(m map[string]any, path []string, value any) {
+	cur := m
+	for i, k := range path {
+		if i == len(path)-1 {
+			cur[k] = value
+			return
+		}
+		next, ok := cur[k].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			cur[k] = next
+		}
+		cur = next
+	}
+}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_patch_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetNested(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates intermediate maps", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{}
+		setNested(m, []string{"a", "b", "c"}, "v")
+		assert.Equal(t, map[string]any{
+			"a": map[string]any{"b": map[string]any{"c": "v"}},
+		}, m)
+	})
+
+	t.Run("single-element path", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{}
+		setNested(m, []string{"k"}, 42)
+		assert.Equal(t, map[string]any{"k": 42}, m)
+	})
+
+	t.Run("preserves siblings", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{
+			"a": map[string]any{
+				"existing": "leaf",
+				"nested":   map[string]any{"k1": "v1"},
+			},
+			"top": "scalar",
+		}
+		setNested(m, []string{"a", "nested", "k2"}, "v2")
+		assert.Equal(t, map[string]any{
+			"a": map[string]any{
+				"existing": "leaf",
+				"nested":   map[string]any{"k1": "v1", "k2": "v2"},
+			},
+			"top": "scalar",
+		}, m)
+	})
+
+	t.Run("overwrites leaf", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{"k": "old"}
+		setNested(m, []string{"k"}, "new")
+		assert.Equal(t, map[string]any{"k": "new"}, m)
+	})
+
+	t.Run("replaces non-map intermediate", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{"a": "scalar"}
+		setNested(m, []string{"a", "b"}, "v")
+		assert.Equal(t, map[string]any{"a": map[string]any{"b": "v"}}, m)
+	})
+
+	t.Run("accepts nil leaf value", func(t *testing.T) {
+		t.Parallel()
+		m := map[string]any{}
+		setNested(m, []string{"operationContext", "environmentVariables", "STALE"}, nil)
+		assert.Equal(t, map[string]any{
+			"operationContext": map[string]any{
+				"environmentVariables": map[string]any{"STALE": nil},
+			},
+		}, m)
+	})
+}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -145,7 +145,6 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 Deployment runner
   Runner pool:              pool-1
   Executor image:           pulumi/pulumi:latest
-  Working directory:        /work
 
 Pre-run commands
   echo hi
@@ -182,8 +181,7 @@ func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 		},
 		"runner": {
 			"pool": "pool-1",
-			"executorImage": "pulumi/pulumi:latest",
-			"workingDirectory": "/work"
+			"executorImage": "pulumi/pulumi:latest"
 		},
 		"preRunCommands": ["echo hi"],
 		"environmentVariables": ["BAZ", "FOO"]

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -99,7 +99,9 @@ func branchArgs() deploymentSettingsEditArgs {
 	}
 }
 
-func captureEditPatch(t *testing.T, args deploymentSettingsEditArgs, c *mockDeploymentSettingsEditClient) json.RawMessage {
+func captureEditPatch(
+	t *testing.T, args deploymentSettingsEditArgs, c *mockDeploymentSettingsEditClient,
+) json.RawMessage {
 	t.Helper()
 	captured := &capturedEditPatch{}
 	c.captured = captured

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit_test.go
@@ -14,16 +14,11 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -32,21 +27,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// capturedEditPatch records what was sent to PatchStackDeploymentSettings so
-// tests can assert the call shape.
 type capturedEditPatch struct {
 	stack client.StackIdentifier
 	patch json.RawMessage
 }
 
-// mockDeploymentSettingsEditClient stubs the patch + get pair. patchErr fires
-// from PatchStackDeploymentSettings; getResp / getErr come from the follow-up
-// GetStackDeploymentSettings.
 type mockDeploymentSettingsEditClient struct {
-	patchErr error
-	getResp  *apitype.DeploymentSettings
-	getErr   error
-	captured *capturedEditPatch
+	patchErr   error
+	getResp    *apitype.DeploymentSettings
+	getErr     error
+	captured   *capturedEditPatch
+	encryptErr error
 }
 
 func (m *mockDeploymentSettingsEditClient) PatchStackDeploymentSettings(
@@ -68,6 +59,15 @@ func (m *mockDeploymentSettingsEditClient) GetStackDeploymentSettings(
 	return m.getResp, nil
 }
 
+func (m *mockDeploymentSettingsEditClient) EncryptStackDeploymentSettingsSecret(
+	_ context.Context, _ client.StackIdentifier, secret string,
+) (*apitype.SecretValue, error) {
+	if m.encryptErr != nil {
+		return nil, m.encryptErr
+	}
+	return &apitype.SecretValue{Ciphertext: "cipher:" + secret, Secret: true}, nil
+}
+
 func stubSettingsEditFactory(c deploymentSettingsEditClient) deploymentSettingsEditClientFactory {
 	return func(_ context.Context, _ string) (deploymentSettingsEditClient, client.StackIdentifier, error) {
 		return c, testStackID, nil
@@ -80,19 +80,42 @@ func failingSettingsEditFactory(err error) deploymentSettingsEditClientFactory {
 	}
 }
 
-// writePatchFile writes content to a temp file and returns its absolute path.
-func writePatchFile(t *testing.T, content string) string {
+// flagsSet builds the args.flagsChanged predicate from a list of flag names to simulate cobra having parsed those
+// flags.
+func flagsSet(names ...string) func(string) bool {
+	m := map[string]bool{}
+	for _, n := range names {
+		m[n] = true
+	}
+	return func(name string) bool { return m[name] }
+}
+
+// branchArgs is the smallest valid args fixture: --branch=feature.
+func branchArgs() deploymentSettingsEditArgs {
+	return deploymentSettingsEditArgs{
+		branch:       "feature",
+		flagsChanged: flagsSet(flagBranch),
+		outputFormat: defaultDeploymentSettingsGetOutputFormat(),
+	}
+}
+
+func captureEditPatch(t *testing.T, args deploymentSettingsEditArgs, c *mockDeploymentSettingsEditClient) json.RawMessage {
 	t.Helper()
-	p := filepath.Join(t.TempDir(), "patch.json")
-	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
-	return p
+	captured := &capturedEditPatch{}
+	c.captured = captured
+	if c.getResp == nil {
+		c.getResp = &apitype.DeploymentSettings{}
+	}
+	args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
+	var buf bytes.Buffer
+	require.NoError(t, runDeploymentSettingsEdit(t.Context(), &buf,
+		stubSettingsEditFactory(c), args))
+	require.NotNil(t, captured.patch)
+	return captured.patch
 }
 
 func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 	t.Parallel()
-
-	patchJSON := `{"sourceContext":{"git":{"branch":"feature"}}}`
-	patchFile := writePatchFile(t, patchJSON)
 
 	captured := &capturedEditPatch{}
 	c := &mockDeploymentSettingsEditClient{
@@ -101,14 +124,13 @@ func TestDeploymentSettingsEdit_DefaultOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
+		stubSettingsEditFactory(c), branchArgs())
 	require.NoError(t, err)
 
 	assert.Equal(t, testStackID, captured.stack)
 	require.NotNil(t, captured.patch)
-	assert.JSONEq(t, patchJSON, string(captured.patch))
+	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature"}}}`, string(captured.patch))
 
 	assert.Equal(t, `Source: GitHub
   Repository:               acme/infra
@@ -137,14 +159,12 @@ Environment variables
 func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 	t.Parallel()
 
-	patchFile := writePatchFile(t, `{"sourceContext":{"git":{"branch":"feature"}}}`)
-
 	c := &mockDeploymentSettingsEditClient{getResp: sampleDeploymentSettings()}
 
-	args := deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()}
+	args := branchArgs()
 	require.NoError(t, args.outputFormat.Set("json"))
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
 		stubSettingsEditFactory(c), args)
 	require.NoError(t, err)
 
@@ -170,73 +190,27 @@ func TestDeploymentSettingsEdit_JSONOutput(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestDeploymentSettingsEdit_EmptyFileFlag(t *testing.T) {
+func TestDeploymentSettingsEdit_NoInput(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
 
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
 		stubSettingsEditFactory(c),
 		deploymentSettingsEditArgs{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--file is required")
-}
-
-func TestDeploymentSettingsEdit_FileDoesNotExist(t *testing.T) {
-	t.Parallel()
-
-	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
-
-	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: filepath.Join(t.TempDir(), "missing.json")})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reading deployment settings patch")
-}
-
-func TestDeploymentSettingsEdit_EmptyFileContent(t *testing.T) {
-	t.Parallel()
-
-	patchFile := writePatchFile(t, "   \n\t")
-
-	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
-
-	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "patch file is empty")
-}
-
-func TestDeploymentSettingsEdit_MalformedJSON(t *testing.T) {
-	t.Parallel()
-
-	patchFile := writePatchFile(t, `{"sourceContext": `) // unterminated
-
-	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
-
-	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reading deployment settings patch")
+	assert.Contains(t, err.Error(), "nothing to do")
 }
 
 func TestDeploymentSettingsEdit_PatchError(t *testing.T) {
 	t.Parallel()
 
-	patchFile := writePatchFile(t, `{}`)
-
 	c := &mockDeploymentSettingsEditClient{patchErr: errors.New("boom")}
 
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
+		stubSettingsEditFactory(c), branchArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "editing deployment settings")
 	assert.Contains(t, err.Error(), "boom")
@@ -245,14 +219,11 @@ func TestDeploymentSettingsEdit_PatchError(t *testing.T) {
 func TestDeploymentSettingsEdit_GetAfterPatchError(t *testing.T) {
 	t.Parallel()
 
-	patchFile := writePatchFile(t, `{}`)
-
 	c := &mockDeploymentSettingsEditClient{getErr: errors.New("get boom")}
 
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
+		stubSettingsEditFactory(c), branchArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting deployment settings")
 	assert.Contains(t, err.Error(), "get boom")
@@ -261,79 +232,305 @@ func TestDeploymentSettingsEdit_GetAfterPatchError(t *testing.T) {
 func TestDeploymentSettingsEdit_FactoryError(t *testing.T) {
 	t.Parallel()
 
-	patchFile := writePatchFile(t, `{}`)
-
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		failingSettingsEditFactory(errors.New("not logged in")),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
+		failingSettingsEditFactory(errors.New("not logged in")), branchArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
 
-func TestDeploymentSettingsEdit_StdinPatch(t *testing.T) {
+func TestDeploymentSettingsEdit_BranchFlag(t *testing.T) {
 	t.Parallel()
-
-	captured := &capturedEditPatch{}
-	c := &mockDeploymentSettingsEditClient{
-		getResp:  &apitype.DeploymentSettings{},
-		captured: captured,
-	}
-
-	patchJSON := `{"sourceContext":{"git":{"branch":"from-stdin"}}}`
-	stdin := strings.NewReader(patchJSON)
-
-	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, stdin,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: "-", outputFormat: defaultDeploymentSettingsGetOutputFormat()})
-	require.NoError(t, err)
-
-	require.NotNil(t, captured.patch)
-	assert.JSONEq(t, patchJSON, string(captured.patch))
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		branch:       "feature",
+		flagsChanged: flagsSet(flagBranch),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{"sourceContext":{"git":{"branch":"feature"}}}`, string(got))
 }
 
-// TestDeploymentSettingsEdit_ForwardsExplicitNull pins the documented
-// "null property means delete" semantic: if the user writes a literal null,
-// the bytes must reach the server unchanged so the server-side merge clears
-// the field.
-func TestDeploymentSettingsEdit_ForwardsExplicitNull(t *testing.T) {
+func TestDeploymentSettingsEdit_GitHubSourceFlags(t *testing.T) {
 	t.Parallel()
-
-	patchJSON := `{"operationContext":{"environmentVariables":null}}`
-	patchFile := writePatchFile(t, patchJSON)
-
-	captured := &capturedEditPatch{}
-	c := &mockDeploymentSettingsEditClient{
-		getResp:  &apitype.DeploymentSettings{},
-		captured: captured,
-	}
-
-	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
-		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
-	require.NoError(t, err)
-
-	require.NotNil(t, captured.patch)
-	assert.JSONEq(t, patchJSON, string(captured.patch),
-		"explicit null must reach the server so the merge deletes the property")
-	assert.Contains(t, string(captured.patch), "null",
-		"the literal null must survive — JSONEq alone wouldn't catch a re-encoding that dropped it")
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		githubRepo:   "acme/infra",
+		branch:       "main",
+		folder:       "stacks/prod",
+		previewPRs:   true,
+		pushToDeploy: true,
+		pathFilters:  []string{"stacks/prod/**"},
+		flagsChanged: flagsSet(flagGitHubRepo, flagBranch, flagFolder,
+			flagPreviewPRs, flagPushToDeploy, flagPathFilter),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"gitHub": {
+			"repository": "acme/infra",
+			"previewPullRequests": true,
+			"deployCommits": true,
+			"paths": ["stacks/prod/**"]
+		},
+		"sourceContext": {"git": {"branch": "main", "repoDir": "stacks/prod"}}
+	}`, string(got))
 }
 
-func TestDeploymentSettingsEdit_RejectsUnknownFields(t *testing.T) {
+func TestDeploymentSettingsEdit_TristateFalse(t *testing.T) {
 	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		previewPRs:   false,
+		flagsChanged: flagsSet(flagPreviewPRs),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{"gitHub":{"previewPullRequests":false}}`, string(got))
+}
 
-	// Typo: enviornmentVariables instead of environmentVariables.
-	patchFile := writePatchFile(t, `{"operationContext":{"enviornmentVariables":{"X":"y"}}}`)
+func TestDeploymentSettingsEdit_RunnerPoolEmptyClears(t *testing.T) {
+	t.Parallel()
+	// --runner-pool "" maps to JSON null so the server clears the field
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		runnerPool:   "",
+		flagsChanged: flagsSet(flagRunnerPool),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{"agentPoolID":null}`, string(got))
+}
 
+func TestDeploymentSettingsEdit_ExecutorImageEmptyClears(t *testing.T) {
+	t.Parallel()
+	// --executor-image "" maps to JSON null so the server clears the field
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		executorImage: "",
+		flagsChanged:  flagsSet(flagExecutorImage),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{"executorContext":{"executorImage":null}}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_EnvVarsAndRemove(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		envVars:       []string{"FOO=bar", "BAZ=qux"},
+		secretEnvVars: []string{"API_KEY=s3cret"},
+		removeEnv:     []string{"STALE"},
+		flagsChanged:  flagsSet(flagEnv, flagSecretEnv, flagRemoveEnv),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"environmentVariables": {
+				"FOO": "bar",
+				"BAZ": "qux",
+				"API_KEY": {"ciphertext": "cipher:s3cret"},
+				"STALE": null
+			}
+		}
+	}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_DuplicateEnvKey(t *testing.T) {
+	t.Parallel()
 	c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
-
 	var buf bytes.Buffer
-	err := runDeploymentSettingsEdit(t.Context(), &buf, nil,
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
 		stubSettingsEditFactory(c),
-		deploymentSettingsEditArgs{file: patchFile, outputFormat: defaultDeploymentSettingsGetOutputFormat()})
+		deploymentSettingsEditArgs{
+			envVars:      []string{"FOO=bar"},
+			removeEnv:    []string{"FOO"},
+			flagsChanged: flagsSet(flagEnv, flagRemoveEnv),
+			outputFormat: defaultDeploymentSettingsGetOutputFormat(),
+		})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "enviornmentVariables")
+	assert.Contains(t, err.Error(), "FOO")
+}
+
+func TestDeploymentSettingsEdit_OIDCAWS(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		oidcAWSRoleARN:     "arn:aws:iam::123:role/pulumi-deploy",
+		oidcAWSSessionName: "pulumi-deploy",
+		oidcAWSDuration:    "30m",
+		oidcAWSPolicyARNs:  []string{"arn:aws:iam::aws:policy/ReadOnlyAccess"},
+		flagsChanged: flagsSet(flagOIDCAWSRoleARN, flagOIDCAWSSessionName,
+			flagOIDCAWSDuration, flagOIDCAWSPolicyARN),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"oidc": {
+				"aws": {
+					"roleArn": "arn:aws:iam::123:role/pulumi-deploy",
+					"sessionName": "pulumi-deploy",
+					"duration": "30m",
+					"policyArns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+				}
+			}
+		}
+	}`, string(got))
+}
+
+// Setting a single OIDC field must only touch that field — relies on the
+// server's deep merge to leave the rest of the AWS config alone.
+func TestDeploymentSettingsEdit_OIDCPartialUpdate(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		oidcAWSRoleARN: "arn:aws:iam::123:role/pulumi-deploy",
+		flagsChanged:   flagsSet(flagOIDCAWSRoleARN),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"oidc": {"aws": {"roleArn": "arn:aws:iam::123:role/pulumi-deploy"}}
+		}
+	}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_OIDCClearFlags(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args deploymentSettingsEditArgs
+		want string
+	}{
+		{
+			"aws",
+			deploymentSettingsEditArgs{oidcAWSClear: true, flagsChanged: flagsSet(flagOIDCAWSClear)},
+			`{"operationContext":{"oidc":{"aws":null}}}`,
+		},
+		{
+			"azure",
+			deploymentSettingsEditArgs{oidcAzureClear: true, flagsChanged: flagsSet(flagOIDCAzureClear)},
+			`{"operationContext":{"oidc":{"azure":null}}}`,
+		},
+		{
+			"gcp",
+			deploymentSettingsEditArgs{oidcGCPClear: true, flagsChanged: flagsSet(flagOIDCGCPClear)},
+			`{"operationContext":{"oidc":{"gcp":null}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := captureEditPatch(t, tc.args, &mockDeploymentSettingsEditClient{})
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}
+
+func TestDeploymentSettingsEdit_OIDCClearConflictsWithSetters(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		args deploymentSettingsEditArgs
+	}{
+		{
+			"aws-clear with aws-role-arn",
+			deploymentSettingsEditArgs{
+				oidcAWSClear:   true,
+				oidcAWSRoleARN: "arn:aws:iam::123:role/x",
+				flagsChanged:   flagsSet(flagOIDCAWSClear, flagOIDCAWSRoleARN),
+			},
+		},
+		{
+			"azure-clear with azure-client-id",
+			deploymentSettingsEditArgs{
+				oidcAzureClear:    true,
+				oidcAzureClientID: "cid",
+				flagsChanged:      flagsSet(flagOIDCAzureClear, flagOIDCAzureClientID),
+			},
+		},
+		{
+			"gcp-clear with gcp-project-number",
+			deploymentSettingsEditArgs{
+				oidcGCPClear:         true,
+				oidcGCPProjectNumber: "123",
+				flagsChanged:         flagsSet(flagOIDCGCPClear, flagOIDCGCPProjectNumber),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := tc.args
+			args.outputFormat = defaultDeploymentSettingsGetOutputFormat()
+			c := &mockDeploymentSettingsEditClient{getResp: &apitype.DeploymentSettings{}}
+			var buf bytes.Buffer
+			err := runDeploymentSettingsEdit(t.Context(), &buf,
+				stubSettingsEditFactory(c), args)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be combined")
+		})
+	}
+}
+
+func TestDeploymentSettingsEdit_OIDCAzure(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		oidcAzureClientID:       "11111111-1111-1111-1111-111111111111",
+		oidcAzureTenantID:       "22222222-2222-2222-2222-222222222222",
+		oidcAzureSubscriptionID: "33333333-3333-3333-3333-333333333333",
+		flagsChanged: flagsSet(flagOIDCAzureClientID, flagOIDCAzureTenantID,
+			flagOIDCAzureSubscriptionID),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"oidc": {
+				"azure": {
+					"clientId": "11111111-1111-1111-1111-111111111111",
+					"tenantId": "22222222-2222-2222-2222-222222222222",
+					"subscriptionId": "33333333-3333-3333-3333-333333333333"
+				}
+			}
+		}
+	}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_OIDCGCP(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		oidcGCPProjectNumber:  "123456",
+		oidcGCPWorkloadPoolID: "pulumi-pool",
+		oidcGCPProviderID:     "pulumi",
+		oidcGCPServiceAccount: "pulumi@my-project.iam.gserviceaccount.com",
+		oidcGCPRegion:         "us-central1",
+		oidcGCPTokenLifetime:  "1h",
+		flagsChanged: flagsSet(flagOIDCGCPProjectNumber, flagOIDCGCPWorkloadPoolID,
+			flagOIDCGCPProviderID, flagOIDCGCPServiceAccount, flagOIDCGCPRegion,
+			flagOIDCGCPTokenLifetime),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"oidc": {
+				"gcp": {
+					"projectId": "123456",
+					"workloadPoolId": "pulumi-pool",
+					"providerId": "pulumi",
+					"serviceAccount": "pulumi@my-project.iam.gserviceaccount.com",
+					"region": "us-central1",
+					"tokenLifetime": "1h"
+				}
+			}
+		}
+	}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_AdvancedToggles(t *testing.T) {
+	t.Parallel()
+	got := captureEditPatch(t, deploymentSettingsEditArgs{
+		skipInstallDeps: true,
+		shell:           "bash",
+		flagsChanged:    flagsSet(flagSkipInstallDeps, flagShell),
+	}, &mockDeploymentSettingsEditClient{})
+	assert.JSONEq(t, `{
+		"operationContext": {
+			"options": {"skipInstallDependencies": true, "shell": "bash"}
+		}
+	}`, string(got))
+}
+
+func TestDeploymentSettingsEdit_EncryptError(t *testing.T) {
+	t.Parallel()
+	c := &mockDeploymentSettingsEditClient{
+		getResp:    &apitype.DeploymentSettings{},
+		encryptErr: errors.New("encrypt failed"),
+	}
+	var buf bytes.Buffer
+	err := runDeploymentSettingsEdit(t.Context(), &buf,
+		stubSettingsEditFactory(c),
+		deploymentSettingsEditArgs{
+			secretEnvVars: []string{"API=foo"},
+			flagsChanged:  flagsSet(flagSecretEnv),
+			outputFormat:  defaultDeploymentSettingsGetOutputFormat(),
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "encrypting")
+	assert.Contains(t, err.Error(), "encrypt failed")
 }

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"
@@ -41,31 +39,21 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// deploymentSettingsGetClient is the narrow API surface this command depends
-// on. Defined per-command so tests can stub it without implementing the full
-// cloud client.
 type deploymentSettingsGetClient interface {
 	GetStackDeploymentSettings(
 		ctx context.Context, stack client.StackIdentifier,
 	) (*apitype.DeploymentSettings, error)
 }
 
-// deploymentSettingsGetClientFactory resolves a client and StackIdentifier
-// for the get command. stackFlag carries the raw `--stack` value (empty means
-// "use the current stack").
 type deploymentSettingsGetClientFactory func(
 	ctx context.Context, stackFlag string,
 ) (deploymentSettingsGetClient, client.StackIdentifier, error)
 
-// deploymentSettingsGetArgs collects the resolved flag values so Run can be
-// driven directly from tests.
 type deploymentSettingsGetArgs struct {
 	stack        string
 	outputFormat outputflag.OutputFlag[deploymentSettingsGetRenderFunc]
 }
 
-// defaultDeploymentSettingsGetOutputFormat wires the OutputFlag to the
-// per-format renderers so `--output` selects between them.
 func defaultDeploymentSettingsGetOutputFormat() outputflag.OutputFlag[deploymentSettingsGetRenderFunc] {
 	return outputflag.OutputFlag[deploymentSettingsGetRenderFunc]{
 		RenderForTerminal: renderDeploymentSettingsGetText,
@@ -73,8 +61,6 @@ func defaultDeploymentSettingsGetOutputFormat() outputflag.OutputFlag[deployment
 	}
 }
 
-// newDeploymentSettingsGetCmd builds `pulumi deployment settings get` wired to
-// the real cloud client factory.
 func newDeploymentSettingsGetCmd() *cobra.Command {
 	return newDeploymentSettingsGetCmdWith(defaultDeploymentSettingsGetClientFactory)
 }
@@ -87,18 +73,7 @@ func newDeploymentSettingsGetCmdWith(factory deploymentSettingsGetClientFactory)
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "[EXPERIMENTAL] Retrieve the deployment settings for a stack",
-		Long: "[EXPERIMENTAL] Retrieve the deployment settings for a stack.\n" +
-			"\n" +
-			"Returns the saved Pulumi Deployments configuration for the selected stack,\n" +
-			"including source context (git repository, branch, commit, working directory),\n" +
-			"executor context (image), operation context (environment variable names and\n" +
-			"pre-run commands), GitHub integration triggers, and the agent pool ID if set.\n" +
-			"\n" +
-			"Secret material (git credentials and environment variable values) is never\n" +
-			"emitted by this command.\n" +
-			"\n" +
-			"Default output is a human-readable summary; pass --output=json for the raw\n" +
-			"response as JSON.",
+		Long:  "[EXPERIMENTAL] Retrieve the deployment settings for a stack.",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
 			return runDeploymentSettingsGet(cmd.Context(), cmd.OutOrStdout(), factory, args)
 		},
@@ -113,9 +88,6 @@ func newDeploymentSettingsGetCmdWith(factory deploymentSettingsGetClientFactory)
 	return cmd
 }
 
-// defaultDeploymentSettingsGetClientFactory mirrors the production wiring used
-// by `pulumi deployment get`: resolve the stack, ensure we're on the Pulumi
-// Cloud backend, and hand back the underlying *client.Client.
 func defaultDeploymentSettingsGetClientFactory(
 	ctx context.Context, stackFlag string,
 ) (deploymentSettingsGetClient, client.StackIdentifier, error) {
@@ -153,8 +125,6 @@ func defaultDeploymentSettingsGetClientFactory(
 	return be.Client(), stackID, nil
 }
 
-// runDeploymentSettingsGet is the cobra-decoupled entry point so tests can
-// drive the command without parsing flags.
 func runDeploymentSettingsGet(
 	ctx context.Context, w io.Writer,
 	factory deploymentSettingsGetClientFactory, args deploymentSettingsGetArgs,
@@ -323,7 +293,7 @@ func buildOIDCView(o *apitype.OperationContextOIDCConfiguration) *oidcView {
 		return nil
 	}
 	out := &oidcView{}
-	if o.AWS != nil && o.AWS.RoleARN != "" {
+	if o.AWS != nil {
 		out.AWS = &oidcAWSView{
 			RoleARN:         o.AWS.RoleARN,
 			SessionName:     o.AWS.SessionName,
@@ -331,14 +301,14 @@ func buildOIDCView(o *apitype.OperationContextOIDCConfiguration) *oidcView {
 			PolicyARNs:      o.AWS.PolicyARNs,
 		}
 	}
-	if o.Azure != nil && (o.Azure.ClientID != "" || o.Azure.TenantID != "" || o.Azure.SubscriptionID != "") {
+	if o.Azure != nil {
 		out.Azure = &oidcAzureView{
 			ClientID:       o.Azure.ClientID,
 			TenantID:       o.Azure.TenantID,
 			SubscriptionID: o.Azure.SubscriptionID,
 		}
 	}
-	if o.GCP != nil && o.GCP.ProjectID != "" {
+	if o.GCP != nil {
 		out.GCP = &oidcGCPView{
 			ProjectNumber:  o.GCP.ProjectID,
 			WorkloadPool:   o.GCP.WorkloadPoolID,
@@ -474,7 +444,9 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		section("OIDC")
 		if v.OIDC.AWS != nil {
 			fmt.Fprintln(w, "  AWS")
-			kv(4, "Role ARN", v.OIDC.AWS.RoleARN)
+			if v.OIDC.AWS.RoleARN != "" {
+				kv(4, "Role ARN", v.OIDC.AWS.RoleARN)
+			}
 			if v.OIDC.AWS.SessionName != "" {
 				kv(4, "Session name", v.OIDC.AWS.SessionName)
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -174,7 +174,7 @@ type sourceView struct {
 type runnerView struct {
 	Pool             string `json:"pool,omitempty"`
 	ExecutorImage    string `json:"executorImage,omitempty"`
-	WorkingDirectory string `json:"workingDirectory,omitempty"`
+	ExecutorRootPath string `json:"executorRootPath,omitempty"`
 }
 
 type oidcView struct {
@@ -280,9 +280,11 @@ func buildRunnerView(s apitype.DeploymentSettings) *runnerView {
 		if s.Executor.ExecutorImage != nil {
 			out.ExecutorImage = s.Executor.ExecutorImage.Reference
 		}
-		out.WorkingDirectory = s.Executor.WorkingDirectory
+		if s.Executor.ExecutorRootPath != nil {
+			out.ExecutorRootPath = *s.Executor.ExecutorRootPath
+		}
 	}
-	if out.Pool == "" && out.ExecutorImage == "" && out.WorkingDirectory == "" {
+	if out.Pool == "" && out.ExecutorImage == "" && out.ExecutorRootPath == "" {
 		return nil
 	}
 	return out
@@ -421,8 +423,8 @@ func renderDeploymentSettingsGetText(w io.Writer, s apitype.DeploymentSettings) 
 		if v.Runner.ExecutorImage != "" {
 			kv(2, "Executor image", v.Runner.ExecutorImage)
 		}
-		if v.Runner.WorkingDirectory != "" {
-			kv(2, "Working directory", v.Runner.WorkingDirectory)
+		if v.Runner.ExecutorRootPath != "" {
+			kv(2, "Executor root path", v.Runner.ExecutorRootPath)
 		}
 	}
 

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
@@ -120,7 +120,6 @@ func TestDeploymentSettingsGet_DefaultOutput(t *testing.T) {
 Deployment runner
   Runner pool:              pool-1
   Executor image:           pulumi/pulumi:latest
-  Working directory:        /work
 
 Pre-run commands
   echo hi
@@ -167,8 +166,7 @@ func TestDeploymentSettingsGet_JSONOutput(t *testing.T) {
 		},
 		"runner": {
 			"pool": "pool-1",
-			"executorImage": "pulumi/pulumi:latest",
-			"workingDirectory": "/work"
+			"executorImage": "pulumi/pulumi:latest"
 		},
 		"preRunCommands": ["echo hi"],
 		"environmentVariables": ["BAZ", "FOO"]

--- a/sdk/go/common/apitype/deployments.go
+++ b/sdk/go/common/apitype/deployments.go
@@ -157,6 +157,10 @@ type ExecutorContext struct {
 
 	// Defines the image that the pulumi operations should run in.
 	ExecutorImage *DockerImage `json:"executorImage,omitempty" yaml:"executorImage,omitempty"`
+
+	// ExecutorRootPath overrides the default root path (`/`) used by the deployment executor. Useful when running
+	// with non-root users (e.g. set to `/tmp`).
+	ExecutorRootPath *string `json:"executorRootPath,omitempty" yaml:"executorRootPath,omitempty"`
 }
 
 // A DockerImage describes a Docker image reference + optional credentials for use with a job definition.


### PR DESCRIPTION
This previously used a file to send a JSON patch. Instead we add a dedicated flag for each setting.

Users can use `pulumi api ...` to send a JSON file if needed.

Fixes https://github.com/pulumi/pulumi/issues/22983
Fixes https://github.com/pulumi/pulumi/issues/22984