### PR TITLE
Accept a deployment version in `pulumi deployment get`

### DIFF
--- a/changelog/pending/20260518--cli-cloud--add-pulumi-deployment-get.yaml
+++ b/changelog/pending/20260518--cli-cloud--add-pulumi-deployment-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi deployment get` to retrieve details for a specific deployment

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2276,7 +2276,11 @@ func (pc *Client) GetStackDeploymentSettings(ctx context.Context,
 
 func getDeploymentPath(stack StackIdentifier, components ...string) string {
 	prefix := fmt.Sprintf("/api/stacks/%s/%s/%s/deployments", stack.Owner, stack.Project, stack.Stack)
-	return path.Join(append([]string{prefix}, components...)...)
+	escaped := make([]string, len(components))
+	for i, c := range components {
+		escaped[i] = url.PathEscape(c)
+	}
+	return path.Join(append([]string{prefix}, escaped...)...)
 }
 
 func (pc *Client) CreateDeployment(ctx context.Context, stack StackIdentifier,
@@ -2304,6 +2308,22 @@ func (pc *Client) GetDeployment(
 	err := pc.restCall(ctx, http.MethodGet, getDeploymentPath(stack, id), nil, nil, &resp)
 	if err != nil {
 		return apitype.GetDeploymentResponse{}, fmt.Errorf("getting deployment %s failed: %w", id, err)
+	}
+	return resp, nil
+}
+
+// GetDeploymentByVersion retrieves a single deployment for a stack by its
+// per-program version number. It wraps the Pulumi Cloud REST endpoint
+// (GET /api/stacks/{org}/{project}/{stack}/deployments/version/{version}).
+// The response is the same shape as GetDeployment; in particular `ID` is the
+// deployment's UUID, which can be passed to the other per-deployment routes.
+func (pc *Client) GetDeploymentByVersion(
+	ctx context.Context, stack StackIdentifier, version string,
+) (apitype.GetDeploymentResponse, error) {
+	var resp apitype.GetDeploymentResponse
+	err := pc.restCall(ctx, http.MethodGet, getDeploymentPath(stack, "version", version), nil, nil, &resp)
+	if err != nil {
+		return apitype.GetDeploymentResponse{}, fmt.Errorf("getting deployment by version %s failed: %w", version, err)
 	}
 	return resp, nil
 }

--- a/pkg/backend/httpstate/client/client_deployments_test.go
+++ b/pkg/backend/httpstate/client/client_deployments_test.go
@@ -250,3 +250,33 @@ func TestCancelStackDeployment(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestGetDeploymentLogs(t *testing.T) {
+	t.Parallel()
+
+	stackID := StackIdentifier{
+		Owner:   "acme",
+		Project: "web",
+		Stack:   tokens.MustParseStackName("prod"),
+	}
+
+	// A deployment id containing a URL-special character must be percent-
+	// encoded into the path; otherwise `#` is parsed as a fragment delimiter
+	// and the server silently receives a request against /deployments/.
+	t.Run("escapes URL-special characters in the deployment id", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedURI string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedURI = r.URL.RequestURI()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"lines":[]}`))
+		}))
+		defer server.Close()
+
+		c := newMockClient(server)
+		_, err := c.GetDeploymentLogs(t.Context(), stackID, "#9410", GetDeploymentLogsOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "/api/stacks/acme/web/prod/deployments/%239410/logs", capturedURI)
+	})
+}

--- a/pkg/cmd/pulumi/deployment/deployment_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_get.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"
@@ -44,6 +42,9 @@ import (
 type deploymentGetClient interface {
 	GetDeployment(
 		ctx context.Context, stack client.StackIdentifier, id string,
+	) (apitype.GetDeploymentResponse, error)
+	GetDeploymentByVersion(
+		ctx context.Context, stack client.StackIdentifier, version string,
 	) (apitype.GetDeploymentResponse, error)
 }
 
@@ -84,14 +85,17 @@ func newDeploymentGetCmdWith(factory deploymentGetClientFactory) *cobra.Command 
 
 	cmd := &cobra.Command{
 		Hidden: true,
-		Use:    "get <deployment-id>",
+		Use:    "get <deployment-version>",
 		Short:  "[EXPERIMENTAL] Get details for a specific deployment",
 		Long: "[EXPERIMENTAL] Get details for a specific deployment.\n" +
 			"\n" +
-			"Retrieves detailed information about a single Pulumi Deployments execution\n" +
-			"by its deployment ID. The response includes the deployment's current status,\n" +
-			"creation and modification timestamps, version number, the user who requested\n" +
-			"the deployment, the Pulumi operation type, the list of jobs (with their\n" +
+			"The deployment may be referenced by its UUID or by its per-stack version\n" +
+			"number (the integer shown in the Pulumi Cloud UI, e.g. 9410 or #9410).\n" +
+			"\n" +
+			"Retrieves detailed information about a single Pulumi Deployments execution.\n" +
+			"The response includes the deployment's current status, creation and\n" +
+			"modification timestamps, version number, the user who requested the\n" +
+			"deployment, the Pulumi operation type, the list of jobs (with their\n" +
 			"step-level status), and any stack updates produced by the deployment.\n" +
 			"\n" +
 			"Default output is a human-readable summary; pass --output=json for the full\n" +
@@ -103,7 +107,7 @@ func newDeploymentGetCmdWith(factory deploymentGetClientFactory) *cobra.Command 
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
 		Arguments: []constrictor.Argument{
-			{Name: "deployment-id"},
+			{Name: "deployment-version"},
 		},
 		Required: 1,
 	})
@@ -157,17 +161,24 @@ func defaultDeploymentGetClientFactory(
 }
 
 // runDeploymentGet is the cobra-decoupled command body so tests can drive it
-// directly without spinning up the flag parser.
+// directly without spinning up the flag parser. `deploymentRef` is either a
+// UUID or a per-stack version number (see deploymentVersionRef); the two
+// forms hit different endpoints but return the same shape.
 func runDeploymentGet(
 	ctx context.Context, w io.Writer,
-	factory deploymentGetClientFactory, deploymentID string, args deploymentGetArgs,
+	factory deploymentGetClientFactory, deploymentRef string, args deploymentGetArgs,
 ) error {
 	c, stackID, err := factory(ctx, args.stack)
 	if err != nil {
 		return err
 	}
 
-	resp, err := c.GetDeployment(ctx, stackID, deploymentID)
+	var resp apitype.GetDeploymentResponse
+	if version, ok := deploymentVersionRef(deploymentRef); ok {
+		resp, err = c.GetDeploymentByVersion(ctx, stackID, version)
+	} else {
+		resp, err = c.GetDeployment(ctx, stackID, deploymentRef)
+	}
 	if err != nil {
 		return fmt.Errorf("getting deployment: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_get.go
@@ -84,9 +84,8 @@ func newDeploymentGetCmdWith(factory deploymentGetClientFactory) *cobra.Command 
 	args.outputFormat = defaultDeploymentGetOutputFormat()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "get <deployment-version>",
-		Short:  "[EXPERIMENTAL] Get details for a specific deployment",
+		Use:   "get <deployment-version>",
+		Short: "[EXPERIMENTAL] Get details for a specific deployment",
 		Long: "[EXPERIMENTAL] Get details for a specific deployment.\n" +
 			"\n" +
 			"The deployment may be referenced by its UUID or by its per-stack version\n" +

--- a/pkg/cmd/pulumi/deployment/deployment_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_get.go
@@ -96,10 +96,7 @@ func newDeploymentGetCmdWith(factory deploymentGetClientFactory) *cobra.Command 
 			"The response includes the deployment's current status, creation and\n" +
 			"modification timestamps, version number, the user who requested the\n" +
 			"deployment, the Pulumi operation type, the list of jobs (with their\n" +
-			"step-level status), and any stack updates produced by the deployment.\n" +
-			"\n" +
-			"Default output is a human-readable summary; pass --output=json for the full\n" +
-			"response as JSON.",
+			"step-level status), and any stack updates produced by the deployment.",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
 			return runDeploymentGet(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},

--- a/pkg/cmd/pulumi/deployment/deployment_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_get_test.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"
@@ -29,11 +27,19 @@ import (
 )
 
 // mockDeploymentGetClient stubs deploymentGetClient. It returns a fixed
-// response (or error) and records the deployment ID it was called with.
+// response (or error) and records which endpoint was called and with what
+// argument.
 type mockDeploymentGetClient struct {
 	resp  apitype.GetDeploymentResponse
 	err   error
 	gotID string
+
+	// Version-resolution stubs. byVersionResp is returned for any
+	// GetDeploymentByVersion call; byVersionErr forces a failure.
+	// gotVersion records the version the command asked us to resolve.
+	byVersionResp apitype.GetDeploymentResponse
+	byVersionErr  error
+	gotVersion    string
 }
 
 func (m *mockDeploymentGetClient) GetDeployment(
@@ -44,6 +50,16 @@ func (m *mockDeploymentGetClient) GetDeployment(
 		return apitype.GetDeploymentResponse{}, m.err
 	}
 	return m.resp, nil
+}
+
+func (m *mockDeploymentGetClient) GetDeploymentByVersion(
+	_ context.Context, _ client.StackIdentifier, version string,
+) (apitype.GetDeploymentResponse, error) {
+	m.gotVersion = version
+	if m.byVersionErr != nil {
+		return apitype.GetDeploymentResponse{}, m.byVersionErr
+	}
+	return m.byVersionResp, nil
 }
 
 func stubGetFactory(c deploymentGetClient) deploymentGetClientFactory {
@@ -224,4 +240,55 @@ func TestDeploymentGet_DeploymentIDPropagation(t *testing.T) {
 		deploymentGetArgs{outputFormat: defaultDeploymentGetOutputFormat()})
 	require.NoError(t, err)
 	assert.Equal(t, "my-dep-id", c.gotID)
+}
+
+func TestDeploymentGet_ResolvesVersionRef(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{"#9410", "9410"} {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+
+			c := &mockDeploymentGetClient{
+				byVersionResp: sampleGetResponse(),
+			}
+
+			var buf bytes.Buffer
+			err := runDeploymentGet(t.Context(), &buf, stubGetFactory(c), ref,
+				deploymentGetArgs{outputFormat: defaultDeploymentGetOutputFormat()})
+			require.NoError(t, err)
+
+			assert.Equal(t, "9410", c.gotVersion)
+			assert.Equal(t, "", c.gotID, "version ref must not hit the by-id endpoint")
+		})
+	}
+}
+
+func TestDeploymentGet_PassesUUIDThrough(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeploymentGetClient{resp: sampleGetResponse()}
+
+	var buf bytes.Buffer
+	err := runDeploymentGet(t.Context(), &buf, stubGetFactory(c),
+		"0a1b2c3d-1111-2222-3333-444455556666",
+		deploymentGetArgs{outputFormat: defaultDeploymentGetOutputFormat()})
+	require.NoError(t, err)
+
+	assert.Equal(t, "", c.gotVersion, "non-numeric ref must not trigger a version lookup")
+	assert.Equal(t, "0a1b2c3d-1111-2222-3333-444455556666", c.gotID)
+}
+
+func TestDeploymentGet_VersionLookupError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeploymentGetClient{byVersionErr: errors.New("not found")}
+
+	var buf bytes.Buffer
+	err := runDeploymentGet(t.Context(), &buf, stubGetFactory(c), "#9410",
+		deploymentGetArgs{outputFormat: defaultDeploymentGetOutputFormat()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting deployment")
+	assert.Contains(t, err.Error(), "not found")
+	assert.Equal(t, "", c.gotID, "by-id endpoint must not be called when resolution fails")
 }

--- a/pkg/cmd/pulumi/deployment/deployment_log.go
+++ b/pkg/cmd/pulumi/deployment/deployment_log.go
@@ -14,14 +14,14 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,6 +40,9 @@ import (
 
 // deploymentLogClient is the narrow API surface the log command depends on.
 type deploymentLogClient interface {
+	GetDeploymentByVersion(
+		ctx context.Context, stack client.StackIdentifier, version string,
+	) (apitype.GetDeploymentResponse, error)
 	GetDeploymentLogs(
 		ctx context.Context, stack client.StackIdentifier, id string,
 		opts client.GetDeploymentLogsOptions,
@@ -57,33 +60,22 @@ type deploymentLogClientFactory func(
 // directly from tests. Sentinel values (-1 for job/step, 0 for offset/count)
 // mean "unset" and are not sent to the API.
 type deploymentLogArgs struct {
-	stack        string
-	job          int
-	step         int
-	offset       int
-	count        int
-	all          bool
-	outputFormat outputflag.OutputFlag[deploymentLogRenderFunc]
+	stack  string
+	job    int
+	step   int
+	offset int
+	count  int
+	all    bool
 }
 
 // defaultDeploymentLogArgs returns the zero-args value with the documented
 // sentinel defaults (job/step = -1, offset/count = 0).
 func defaultDeploymentLogArgs() deploymentLogArgs {
 	return deploymentLogArgs{
-		job:          -1,
-		step:         -1,
-		offset:       0,
-		count:        0,
-		outputFormat: defaultDeploymentLogOutputFormat(),
-	}
-}
-
-// defaultDeploymentLogOutputFormat wires the OutputFlag to the per-format
-// renderers so `--output` selects between them.
-func defaultDeploymentLogOutputFormat() outputflag.OutputFlag[deploymentLogRenderFunc] {
-	return outputflag.OutputFlag[deploymentLogRenderFunc]{
-		RenderForTerminal: renderDeploymentLogText,
-		RenderJSON:        renderDeploymentLogJSON,
+		job:    -1,
+		step:   -1,
+		offset: 0,
+		count:  0,
 	}
 }
 
@@ -94,12 +86,17 @@ func newDeploymentLogCmd() *cobra.Command {
 func newDeploymentLogCmdWith(factory deploymentLogClientFactory) *cobra.Command {
 	contract.Assertf(factory != nil, "deploymentLogClientFactory must not be nil")
 	args := defaultDeploymentLogArgs()
-
+	output := outputflag.OutputFlag[deploymentLogRenderFunc]{
+		RenderForTerminal: renderDeploymentLogText,
+		RenderJSON:        renderDeploymentLogJSON,
+	}
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "log <deployment-id>",
-		Short:  "[EXPERIMENTAL] Retrieve execution logs for a deployment",
+		Use:   "log <deployment-version>",
+		Short: "[EXPERIMENTAL] Retrieve execution logs for a deployment",
 		Long: "[EXPERIMENTAL] Retrieve execution logs for a deployment.\n" +
+			"\n" +
+			"The deployment may be referenced by its UUID or by its per-stack version\n" +
+			"number (the integer shown in the Pulumi Cloud UI, e.g. 9410 or #9410).\n" +
 			"\n" +
 			"Returns log lines from a deployment. Pass --job and --step to scope to a\n" +
 			"specific step within a specific job; in step mode --count must be 1-499\n" +
@@ -110,13 +107,13 @@ func newDeploymentLogCmdWith(factory deploymentLogClientFactory) *cobra.Command 
 			"Default output prints one log line per row; pass --output=json for a\n" +
 			"structured envelope.",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
-			return runDeploymentLog(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
+			return runDeploymentLog(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args, output.Get())
 		},
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
 		Arguments: []constrictor.Argument{
-			{Name: "deployment-id"},
+			{Name: "deployment-version"},
 		},
 		Required: 1,
 	})
@@ -134,7 +131,7 @@ func newDeploymentLogCmdWith(factory deploymentLogClientFactory) *cobra.Command 
 	cmd.Flags().BoolVar(&args.all, "all", false,
 		"Fetch every available log line, following server-side pagination; mutually exclusive with --count")
 	cmd.MarkFlagsMutuallyExclusive("count", "all")
-	outputflag.VarP(cmd.Flags(), &args.outputFormat)
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -184,6 +181,7 @@ func defaultDeploymentLogClientFactory(
 func runDeploymentLog(
 	ctx context.Context, w io.Writer,
 	factory deploymentLogClientFactory, deploymentID string, args deploymentLogArgs,
+	render deploymentLogRenderFunc,
 ) error {
 	if args.step >= 0 && args.job < 0 {
 		return errors.New("--step requires --job to also be set (>= 0)")
@@ -212,6 +210,14 @@ func runDeploymentLog(
 		return err
 	}
 
+	if version, ok := deploymentVersionRef(deploymentID); ok {
+		dep, err := c.GetDeploymentByVersion(ctx, stackID, version)
+		if err != nil {
+			return fmt.Errorf("resolving deployment version %s: %w", version, err)
+		}
+		deploymentID = dep.ID
+	}
+
 	resp, err := c.GetDeploymentLogs(ctx, stackID, deploymentID, opts)
 	if err != nil {
 		return fmt.Errorf("getting deployment logs: %w", err)
@@ -237,13 +243,30 @@ func runDeploymentLog(
 		}
 	}
 
-	return args.outputFormat.Get()(w, *resp)
+	return render(w, *resp)
+}
+
+// deploymentVersionPattern matches a per-stack deployment version number, with
+// an optional leading `#` for the convention used in the Pulumi Cloud UI and
+// chat. Deployment UUIDs (the other accepted form) contain hyphens and so are
+// never matched here.
+var deploymentVersionPattern = regexp.MustCompile(`^#?[0-9]+$`)
+
+// deploymentVersionRef reports whether `ref` is a version reference (e.g.
+// "9410" or "#9410") rather than a UUID, returning the bare version string.
+func deploymentVersionRef(ref string) (string, bool) {
+	if !deploymentVersionPattern.MatchString(ref) {
+		return "", false
+	}
+	return strings.TrimPrefix(ref, "#"), true
 }
 
 type deploymentLogRenderFunc func(w io.Writer, logs apitype.DeploymentLogs) error
 
-// renderDeploymentLogText prints one log line per row, prefixing each line
-// with `[header] ` when a header is present.
+// renderDeploymentLogText prints one log line per row. Header rows mark the
+// boundary between steps; body rows already carry a trailing newline from the
+// workflow runner, so we write them verbatim to avoid emitting a blank line
+// between every log entry.
 func renderDeploymentLogText(w io.Writer, logs apitype.DeploymentLogs) error {
 	if len(logs.Lines) == 0 {
 		fmt.Fprintln(w, "No log lines available.")
@@ -251,9 +274,11 @@ func renderDeploymentLogText(w io.Writer, logs apitype.DeploymentLogs) error {
 	}
 	for _, l := range logs.Lines {
 		if l.Header != "" {
-			fmt.Fprintf(w, "[%s] %s\n", l.Header, l.Line)
-		} else {
-			fmt.Fprintf(w, "%s\n", l.Line)
+			fmt.Fprintf(w, "[%s]\n", l.Header)
+			continue
+		}
+		if _, err := io.WriteString(w, l.Line); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/cmd/pulumi/deployment/deployment_log_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_log_test.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"
@@ -39,6 +37,23 @@ type mockDeploymentLogClient struct {
 	gotID       string
 	gotOpts     client.GetDeploymentLogsOptions
 	gotOptsAll  []client.GetDeploymentLogsOptions
+
+	// Version-resolution stubs. byVersionResp is returned for any
+	// GetDeploymentByVersion call; byVersionErr forces a failure. gotVersion
+	// records the version the command asked us to resolve.
+	byVersionResp apitype.GetDeploymentResponse
+	byVersionErr  error
+	gotVersion    string
+}
+
+func (m *mockDeploymentLogClient) GetDeploymentByVersion(
+	_ context.Context, _ client.StackIdentifier, version string,
+) (apitype.GetDeploymentResponse, error) {
+	m.gotVersion = version
+	if m.byVersionErr != nil {
+		return apitype.GetDeploymentResponse{}, m.byVersionErr
+	}
+	return m.byVersionResp, nil
 }
 
 func (m *mockDeploymentLogClient) GetDeploymentLogs(
@@ -74,20 +89,24 @@ func failingLogFactory(err error) deploymentLogClientFactory {
 func TestDeploymentLog_DefaultOutput(t *testing.T) {
 	t.Parallel()
 
+	// Real server payloads put Header on its own row (no Line) and end
+	// each body Line with "\n" — the workflow runner appends the newline
+	// when it stores the log row. The renderer must trust that.
 	resp := &apitype.DeploymentLogs{
 		Lines: []apitype.DeploymentLogLine{
-			{Header: "pulumi up", Line: "running update"},
-			{Line: "plain log line"},
+			{Header: "pulumi up"},
+			{Line: "running update\n"},
+			{Line: "plain log line\n"},
 		},
 	}
 	c := &mockDeploymentLogClient{resp: resp}
 
 	var buf bytes.Buffer
 	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1",
-		defaultDeploymentLogArgs())
+		defaultDeploymentLogArgs(), renderDeploymentLogText)
 	require.NoError(t, err)
 
-	assert.Equal(t, "[pulumi up] running update\nplain log line\n", buf.String())
+	assert.Equal(t, "[pulumi up]\nrunning update\nplain log line\n", buf.String())
 }
 
 func TestDeploymentLog_DefaultOutput_Empty(t *testing.T) {
@@ -96,7 +115,7 @@ func TestDeploymentLog_DefaultOutput_Empty(t *testing.T) {
 	c := &mockDeploymentLogClient{resp: &apitype.DeploymentLogs{}}
 	var buf bytes.Buffer
 	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1",
-		defaultDeploymentLogArgs())
+		defaultDeploymentLogArgs(), renderDeploymentLogText)
 	require.NoError(t, err)
 
 	assert.Equal(t, "No log lines available.\n", buf.String())
@@ -113,11 +132,9 @@ func TestDeploymentLog_JSONOutput(t *testing.T) {
 	}
 	c := &mockDeploymentLogClient{resp: resp}
 
-	args := defaultDeploymentLogArgs()
-	require.NoError(t, args.outputFormat.Set("json"))
-
 	var buf bytes.Buffer
-	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1", args)
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1",
+		defaultDeploymentLogArgs(), renderDeploymentLogJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -132,11 +149,10 @@ func TestDeploymentLog_JSONOutput_NilLinesNormalized(t *testing.T) {
 	t.Parallel()
 
 	c := &mockDeploymentLogClient{resp: &apitype.DeploymentLogs{}}
-	args := defaultDeploymentLogArgs()
-	require.NoError(t, args.outputFormat.Set("json"))
 
 	var buf bytes.Buffer
-	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1", args)
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1",
+		defaultDeploymentLogArgs(), renderDeploymentLogJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{"lines": []}`, buf.String())
@@ -150,7 +166,7 @@ func TestDeploymentLog_StepRequiresJob(t *testing.T) {
 	args.step = 2 // job stays at -1
 
 	var buf bytes.Buffer
-	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1", args)
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-1", args, renderDeploymentLogText)
 	require.Error(t, err)
 	assert.Equal(t, "--step requires --job to also be set (>= 0)", err.Error())
 }
@@ -161,7 +177,7 @@ func TestDeploymentLog_ClientError(t *testing.T) {
 	c := &mockDeploymentLogClient{err: errors.New("not found")}
 	var buf bytes.Buffer
 	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-missing",
-		defaultDeploymentLogArgs())
+		defaultDeploymentLogArgs(), renderDeploymentLogText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "getting deployment logs")
 	assert.Contains(t, err.Error(), "not found")
@@ -172,7 +188,8 @@ func TestDeploymentLog_FactoryError(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := runDeploymentLog(t.Context(), &buf,
-		failingLogFactory(errors.New("not logged in")), "dep-1", defaultDeploymentLogArgs())
+		failingLogFactory(errors.New("not logged in")), "dep-1", defaultDeploymentLogArgs(),
+		renderDeploymentLogText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
@@ -188,7 +205,7 @@ func TestDeploymentLog_OptionsPropagation(t *testing.T) {
 	args.count = 4
 
 	var buf bytes.Buffer
-	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-id", args)
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-id", args, renderDeploymentLogText)
 	require.NoError(t, err)
 
 	job, step, offset, count := 1, 2, 3, 4
@@ -208,10 +225,65 @@ func TestDeploymentLog_OptionsPropagation_AllUnset(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-id",
-		defaultDeploymentLogArgs())
+		defaultDeploymentLogArgs(), renderDeploymentLogText)
 	require.NoError(t, err)
 
 	assert.Equal(t, client.GetDeploymentLogsOptions{}, c.gotOpts)
+}
+
+func TestDeploymentLog_ResolvesVersionRef(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{"#9410", "9410"} {
+		t.Run(ref, func(t *testing.T) {
+			t.Parallel()
+
+			c := &mockDeploymentLogClient{
+				resp:          &apitype.DeploymentLogs{},
+				byVersionResp: apitype.GetDeploymentResponse{ID: "uuid-from-version"},
+			}
+
+			var buf bytes.Buffer
+			err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), ref,
+				defaultDeploymentLogArgs(), renderDeploymentLogText)
+			require.NoError(t, err)
+
+			assert.Equal(t, "9410", c.gotVersion)
+			assert.Equal(t, "uuid-from-version", c.gotID)
+		})
+	}
+}
+
+func TestDeploymentLog_PassesUUIDThrough(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeploymentLogClient{resp: &apitype.DeploymentLogs{}}
+
+	var buf bytes.Buffer
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c),
+		"0a1b2c3d-1111-2222-3333-444455556666", defaultDeploymentLogArgs(),
+		renderDeploymentLogText)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", c.gotVersion, "non-numeric ref must not trigger a version lookup")
+	assert.Equal(t, "0a1b2c3d-1111-2222-3333-444455556666", c.gotID)
+}
+
+func TestDeploymentLog_VersionLookupError(t *testing.T) {
+	t.Parallel()
+
+	c := &mockDeploymentLogClient{
+		resp:         &apitype.DeploymentLogs{},
+		byVersionErr: errors.New("not found"),
+	}
+
+	var buf bytes.Buffer
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "#9410",
+		defaultDeploymentLogArgs(), renderDeploymentLogText)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving deployment version 9410")
+	assert.Contains(t, err.Error(), "not found")
+	assert.Equal(t, "", c.gotID, "logs endpoint must not be called when resolution fails")
 }
 
 func TestDeploymentLog_AllFollowsContinuationToken(t *testing.T) {
@@ -219,9 +291,9 @@ func TestDeploymentLog_AllFollowsContinuationToken(t *testing.T) {
 
 	c := &mockDeploymentLogClient{
 		queuedResps: []*apitype.DeploymentLogs{
-			{Lines: []apitype.DeploymentLogLine{{Line: "page-1"}}, NextToken: "tok-1"},
-			{Lines: []apitype.DeploymentLogLine{{Line: "page-2"}}, NextToken: "tok-2"},
-			{Lines: []apitype.DeploymentLogLine{{Line: "page-3"}}, NextToken: ""},
+			{Lines: []apitype.DeploymentLogLine{{Line: "page-1\n"}}, NextToken: "tok-1"},
+			{Lines: []apitype.DeploymentLogLine{{Line: "page-2\n"}}, NextToken: "tok-2"},
+			{Lines: []apitype.DeploymentLogLine{{Line: "page-3\n"}}, NextToken: ""},
 		},
 	}
 
@@ -229,7 +301,7 @@ func TestDeploymentLog_AllFollowsContinuationToken(t *testing.T) {
 	args.all = true
 
 	var buf bytes.Buffer
-	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-id", args)
+	err := runDeploymentLog(t.Context(), &buf, stubLogFactory(c), "dep-id", args, renderDeploymentLogText)
 	require.NoError(t, err)
 
 	assert.Equal(t, "page-1\npage-2\npage-3\n", buf.String())


### PR DESCRIPTION
## Summary
`pulumi deployment get` is now visible (the `Hidden: true` gate is removed, matching its siblings `list`, `log`, `cancel`) and accepts a per-stack deployment version number (e.g. `9410` or `#9410`) as well as a deployment UUID, matching the convention used in the Pulumi Cloud UI and in chat. Version refs are resolved through the `GetDeploymentByVersion` endpoint added in #23233; UUIDs continue to go through `GetDeployment`. The command stays `[EXPERIMENTAL]` for now.

Mirrors the parallel change applied to `pulumi deployment logs` in #23233, on which this PR is **stacked** — once #23233 merges, this PR will rebase down to its own commits.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - N/A
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - N/A
- [ ] Added a golden test in `pkg/backend/display` - N/A

New tests cover three branches in `deployment_get_test.go`:
- `TestDeploymentGet_ResolvesVersionRef` (sub-tests `9410` and `#9410`) — version refs dispatch to `GetDeploymentByVersion`.
- `TestDeploymentGet_PassesUUIDThrough` — UUID refs go through `GetDeployment`.
- `TestDeploymentGet_VersionLookupError` — resolution error is propagated and the by-id endpoint is never called.

## Validation
- [x] `make lint` — clean
- [ ] `make test_fast` — failed locally with `compile: version "go1.25.8" does not match go tool version "go1.25.7"`, an environment-level Go version mismatch (mise/toolchain), not related to this change. The `deployment` and `httpstate/client` packages pass individually.
- [ ] `make tidy_fix` — N/A (no module changes)
- [x] `make format` — clean
- [ ] Relevant SDK tests pass - N/A (no SDK changes)
- [ ] `make check_proto` — N/A (no proto changes)

## Changelog
- [x] Changelog entry added — the command becomes user-visible.

## Risk
Low. The command is still marked `[EXPERIMENTAL]`. The new dispatch logic is a single conditional in the command body — UUID input continues to flow through the original endpoint unchanged. Version refs are matched by the existing `^#?[0-9]+$` regex introduced in #23233, so deployment UUIDs (which contain hyphens) are never misclassified.