### PR TITLE
cli/neo: add --print/-p for non-interactive one-shot prompts

### DIFF
--- a/changelog/pending/20260518--cli-neo--add-print-flag-for-non-interactive-one-shot-prompts.yaml
+++ b/changelog/pending/20260518--cli-neo--add-print-flag-for-non-interactive-one-shot-prompts.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Add `--print`/`-p` to `pulumi neo` to run a single prompt non-interactively and print the agent's final response to stdout

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -42,6 +42,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// nonInteractivePromptPreamble is prepended to the user's prompt in --print
+// mode and the no-TTY path. The agent has no way to ask follow-up questions
+// since stdin isn't wired and the caller (typically another AI agent) is
+// blocked waiting on stdout — anything that requires more input would hang.
+const nonInteractivePromptPreamble = "You are running in non-interactive mode: " +
+	"your final response will be written to stdout and consumed by another agent " +
+	"or script. Do not ask follow-up questions; make any reasonable assumptions " +
+	"explicit and return a complete final answer."
+
 // createNeoTaskWithEntityRetry creates a Neo task; if the backend rejects the
 // attached stack with "invalid entities" (typically a permissions issue) it retries
 // once without the stack so the task is still created. onEntityDropped, if non-nil,
@@ -116,6 +125,7 @@ func NewNeoCmd() *cobra.Command {
 		cwdFlag            string
 		approvalModeFlag   string
 		permissionModeFlag string
+		printMode          bool
 	)
 
 	cmd := &cobra.Command{
@@ -140,7 +150,18 @@ func NewNeoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runNeo(ctx, prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode)
+			// In --print mode there's no UI to approve from. Reject an explicit manual
+			// (would deadlock); default to auto if the user didn't pick something.
+			if printMode {
+				if cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual {
+					return errors.New(
+						"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
+				}
+				if !cmd.Flags().Changed("approval-mode") {
+					approvalMode = client.NeoApprovalModeAuto
+				}
+			}
+			return runNeo(ctx, prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode)
 		},
 	}
 
@@ -156,6 +177,9 @@ func NewNeoCmd() *cobra.Command {
 	cmd.Flags().StringVar(&permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
 		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
 			"'read-only' blocks state-mutating operations")
+	cmd.Flags().BoolVarP(&printMode, "print", "p", false,
+		"Run a single prompt non-interactively, print the agent's final response to "+
+			"stdout, and exit. Intended for use with other AI agents and scripts.")
 
 	return cmd
 }
@@ -188,6 +212,7 @@ func runNeo(
 	prompt, stackName, orgFlag, cwdFlag string,
 	approvalMode client.NeoApprovalMode,
 	permissionMode client.NeoPermissionMode,
+	printMode bool,
 ) error {
 	if cwdFlag == "" {
 		var err error
@@ -249,13 +274,18 @@ func runNeo(
 	}
 	handlers["pulumi"] = pu
 
-	// Non-interactive mode requires a prompt — there's no input mechanism.
-	if !isInteractive() {
+	// --print or no TTY: run the task non-interactively. Print mode writes the
+	// agent's final response to stdout and exits; status output goes to stderr.
+	if printMode || !isInteractive() {
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
+		// Tell the agent up front it can't ask follow-ups — its final response
+		// will be piped to another agent or script, so anything that requires
+		// further user input will hang the caller.
+		taskPrompt := nonInteractivePromptPreamble + "\n\n" + prompt
 		resp, err := createNeoTaskWithEntityRetry(
-			ctx, pc, orgName, prompt, stackRefName, projectName, client.CreateNeoTaskOptions{
+			ctx, pc, orgName, taskPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
 				ToolExecutionMode: "cli",
 				ApprovalMode:      approvalMode,
 				PermissionMode:    permissionMode,
@@ -265,9 +295,9 @@ func runNeo(
 		}
 		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
 		if consoleURL != "" {
-			fmt.Println(consoleURL)
+			fmt.Fprintln(os.Stderr, consoleURL)
 		} else {
-			fmt.Printf("Neo task created (id %s)\n", resp.TaskID)
+			fmt.Fprintf(os.Stderr, "Neo task created (id %s)\n", resp.TaskID)
 		}
 		session := &Session{
 			Client:   pc,
@@ -275,6 +305,9 @@ func runNeo(
 			OrgName:  orgName,
 			TaskID:   resp.TaskID,
 			Log:      os.Stderr,
+		}
+		if printMode {
+			session.Output = os.Stdout
 		}
 		return session.Run(ctx)
 	}

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -288,11 +288,13 @@ func runNeo(
 		if err != nil {
 			return err
 		}
-		consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
-		if consoleURL != "" {
-			fmt.Fprintln(os.Stderr, consoleURL)
-		} else {
-			fmt.Fprintf(os.Stderr, "Neo task created (id %s)\n", resp.TaskID)
+		if !printMode {
+			consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
+			if consoleURL != "" {
+				fmt.Fprintln(os.Stderr, consoleURL)
+			} else {
+				fmt.Fprintf(os.Stderr, "Neo task created (id %s)\n", resp.TaskID)
+			}
 		}
 		session := &Session{
 			Client:   pc,

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -42,14 +42,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// nonInteractivePromptPreamble is prepended to the user's prompt in --print
-// mode and the no-TTY path. The agent has no way to ask follow-up questions
-// since stdin isn't wired and the caller (typically another AI agent) is
-// blocked waiting on stdout — anything that requires more input would hang.
+// nonInteractivePromptPreamble nudges the agent away from follow-up questions
+// in modes where there's no way to send another user message: stdin isn't
+// wired and the caller (typically another agent or a script) is blocked
+// reading stdout, so anything that needs more input would hang.
 const nonInteractivePromptPreamble = "You are running in non-interactive mode: " +
-	"your final response will be written to stdout and consumed by another agent " +
-	"or script. Do not ask follow-up questions; make any reasonable assumptions " +
-	"explicit and return a complete final answer."
+	"your final response will be written to stdout. Do not ask follow-up " +
+	"questions; make any reasonable assumptions explicit and return a complete " +
+	"final answer."
 
 // createNeoTaskWithEntityRetry creates a Neo task; if the backend rejects the
 // attached stack with "invalid entities" (typically a permissions issue) it retries
@@ -150,14 +150,14 @@ func NewNeoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			// In --print mode there's no UI to approve from. Reject an explicit manual
-			// (would deadlock); default to auto if the user didn't pick something.
+			// --print has no UI; manual approval would deadlock. Reject if explicit,
+			// otherwise upgrade the default.
 			if printMode {
-				if cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual {
+				switch {
+				case cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual:
 					return errors.New(
 						"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
-				}
-				if !cmd.Flags().Changed("approval-mode") {
+				case !cmd.Flags().Changed("approval-mode"):
 					approvalMode = client.NeoApprovalModeAuto
 				}
 			}
@@ -274,15 +274,10 @@ func runNeo(
 	}
 	handlers["pulumi"] = pu
 
-	// --print or no TTY: run the task non-interactively. Print mode writes the
-	// agent's final response to stdout and exits; status output goes to stderr.
 	if printMode || !isInteractive() {
 		if prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
-		// Tell the agent up front it can't ask follow-ups — its final response
-		// will be piped to another agent or script, so anything that requires
-		// further user input will hang the caller.
 		taskPrompt := nonInteractivePromptPreamble + "\n\n" + prompt
 		resp, err := createNeoTaskWithEntityRetry(
 			ctx, pc, orgName, taskPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -45,11 +45,14 @@ import (
 // nonInteractivePromptPreamble nudges the agent away from follow-up questions
 // in modes where there's no way to send another user message: stdin isn't
 // wired and the caller (typically another agent or a script) is blocked
-// reading stdout, so anything that needs more input would hang.
-const nonInteractivePromptPreamble = "You are running in non-interactive mode: " +
-	"your final response will be written to stdout. Do not ask follow-up " +
-	"questions; make any reasonable assumptions explicit and return a complete " +
-	"final answer."
+// reading stdout, so anything that needs more input would hang. Wrapped in
+// <details> so it collapses in the rendered task view and doesn't clutter
+// the user's prompt.
+const nonInteractivePromptPreamble = "<details><summary>non-interactive mode</summary>\n\n" +
+	"You are running in non-interactive mode: your final response will be written " +
+	"to stdout. Do not ask follow-up questions; make any reasonable assumptions " +
+	"explicit and return a complete final answer.\n\n" +
+	"</details>"
 
 // createNeoTaskWithEntityRetry creates a Neo task; if the backend rejects the
 // attached stack with "invalid entities" (typically a permissions issue) it retries

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -294,7 +294,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
 	select {
@@ -380,7 +380,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
 	select {
@@ -408,7 +408,7 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	err := runNeo(t.Context(), "" /*prompt*/, "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
 
@@ -434,7 +434,7 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
 	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
 		"non-cloud backends must surface a clear error rather than panic on the type assertion")
@@ -465,7 +465,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
 		done <- runNeo(t.Context(), "do a thing", "", "test-org", "", /*cwd*/
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
 	select {
@@ -489,7 +489,7 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 
 	missing := t.TempDir() + "/does-not-exist"
 	err := runNeo(t.Context(), "do a thing", "", "test-org", missing,
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
 	// path should be referenced so the user can see what went wrong.
@@ -518,7 +518,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 	}
 
 	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
 	assert.Empty(t, srv.recordedPosts(),
@@ -563,7 +563,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
 	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
@@ -636,7 +636,7 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
 	select {

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -337,10 +337,29 @@ func TestNewNeoCmd_RegistersFlags(t *testing.T) {
 	require.NotNil(t, cmd.Flags().Lookup("org"), "--org flag must be registered")
 	require.NotNil(t, cmd.Flags().Lookup("cwd"), "--cwd flag must be registered")
 
+	print := cmd.Flags().Lookup("print")
+	require.NotNil(t, print, "--print flag must be registered")
+	assert.Equal(t, "p", print.Shorthand)
+
 	// cobra.MaximumNArgs(1): 0 or 1 prompt args OK, 2+ rejected.
 	require.NoError(t, cmd.Args(cmd, []string{}))
 	require.NoError(t, cmd.Args(cmd, []string{"hello"}))
 	require.Error(t, cmd.Args(cmd, []string{"a", "b"}), "more than one positional arg must be rejected")
+}
+
+// TestNewNeoCmd_PrintRejectsManualApproval pins the RunE pre-check that refuses
+// `--print --approval-mode=manual` before any network call: there is no UI to
+// approve from, so the agent would deadlock on the first approval prompt.
+func TestNewNeoCmd_PrintRejectsManualApproval(t *testing.T) {
+	t.Parallel()
+	cmd := NewNeoCmd()
+	cmd.SetContext(t.Context())
+	require.NoError(t, cmd.Flags().Set("print", "true"))
+	require.NoError(t, cmd.Flags().Set("approval-mode", "manual"))
+
+	err := cmd.RunE(cmd, []string{"hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--approval-mode=manual is incompatible with --print")
 }
 
 func TestDedupeExistingRoots(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -40,10 +40,9 @@ var (
 	reconnectTotalBudget    = 5 * time.Minute
 )
 
-// errSessionDone is returned from handleEvent when Output is set and the agent
-// has emitted its final assistant message. Run treats it as a clean exit so
-// `pulumi neo --print` terminates without waiting for the server to close the
-// SSE stream (which it won't, since the task stays "active" awaiting more input).
+// errSessionDone short-circuits Run after the agent's final assistant message in
+// Output mode. The server keeps the SSE stream open in case more user input
+// arrives, so the loop has to terminate itself.
 var errSessionDone = errors.New("session done")
 
 // ToolHandler executes a single named method on a Neo CLI-local tool. The method is the
@@ -81,9 +80,9 @@ type Session struct {
 	// other writers (dispatchUserEvents, createTask, the pulumi sink), and closing
 	// from here races them (pulumi/pulumi-service#42773).
 	UIEvents chan<- UIEvent
-	// Output, when non-nil, makes the session single-shot: it writes the Content
-	// of the agent's first assistant_message with IsFinal=true and no pending CLI
-	// tool calls to Output, then Run returns nil. Used by `pulumi neo --print`.
+	// Output, when non-nil, makes the session single-shot: the first IsFinal
+	// assistant_message with no pending CLI tool calls is written to it and Run
+	// returns nil.
 	Output io.Writer
 }
 

--- a/pkg/cmd/pulumi/neo/session.go
+++ b/pkg/cmd/pulumi/neo/session.go
@@ -40,6 +40,12 @@ var (
 	reconnectTotalBudget    = 5 * time.Minute
 )
 
+// errSessionDone is returned from handleEvent when Output is set and the agent
+// has emitted its final assistant message. Run treats it as a clean exit so
+// `pulumi neo --print` terminates without waiting for the server to close the
+// SSE stream (which it won't, since the task stays "active" awaiting more input).
+var errSessionDone = errors.New("session done")
+
 // ToolHandler executes a single named method on a Neo CLI-local tool. The method is the
 // part of the agent's full tool name after the "<server>__" prefix; args is the raw JSON
 // arguments object. The returned value is JSON-encoded into the AgentUserEventToolResultItem
@@ -75,6 +81,10 @@ type Session struct {
 	// other writers (dispatchUserEvents, createTask, the pulumi sink), and closing
 	// from here races them (pulumi/pulumi-service#42773).
 	UIEvents chan<- UIEvent
+	// Output, when non-nil, makes the session single-shot: it writes the Content
+	// of the agent's first assistant_message with IsFinal=true and no pending CLI
+	// tool calls to Output, then Run returns nil. Used by `pulumi neo --print`.
+	Output io.Writer
 }
 
 // Run drives the loop. It blocks until ctx is cancelled (clean shutdown, returns nil),
@@ -105,7 +115,7 @@ func (s *Session) Run(ctx context.Context) error {
 				failures = 0
 				deadline = time.Time{}
 			}
-			if drainErr == nil {
+			if drainErr == nil || errors.Is(drainErr, errSessionDone) {
 				return nil
 			}
 			if !isTransientStreamError(drainErr) {
@@ -256,6 +266,12 @@ func (s *Session) handleEvent(ctx context.Context, raw []byte) error {
 		// the turn is complete and the TUI can re-enable input.
 		if msg.IsFinal {
 			sendUI(s.UIEvents, UITaskIdle{})
+			if s.Output != nil {
+				if msg.Content != "" {
+					fmt.Fprintln(s.Output, msg.Content)
+				}
+				return errSessionDone
+			}
 		}
 		return nil
 	}

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -356,10 +356,8 @@ func TestSession_OutputWritesFinalContentAndReturnsCleanly(t *testing.T) {
 
 	streamer := newFakeStreamer()
 
-	// The agent never closes the SSE stream on its own — the task stays "active"
-	// in case more user input arrives. With Output set, Session.Run must detect
-	// the final-no-cli message, write its Content, and return promptly anyway.
-	// Crucially: the stream is NOT closed here.
+	// Note: the stream is intentionally NOT closed. Output mode has to terminate
+	// itself; the server keeps the SSE channel open waiting for more user input.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type:    backendEventAssistantMessage,
 		Content: "the final answer",
@@ -394,7 +392,6 @@ func TestSession_OutputSkipsEmptyContent(t *testing.T) {
 
 	streamer := newFakeStreamer()
 
-	// Empty Content still ends the run cleanly — we just don't write anything.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type:    backendEventAssistantMessage,
 		IsFinal: true,
@@ -427,9 +424,8 @@ func TestSession_OutputRunsCliCallsThenWritesFinal(t *testing.T) {
 
 	streamer := newFakeStreamer()
 
-	// Two-message turn: first message has a CLI tool call (the agent is paused
-	// waiting for the result). After the CLI runs the tool, the agent posts the
-	// final response with no more CLI calls. Output captures only the second.
+	// First message has a CLI tool call; the agent only resumes once the CLI
+	// posts a tool_result. The second message is the real final answer.
 	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
 		Type:    backendEventAssistantMessage,
 		IsFinal: true,
@@ -469,7 +465,6 @@ func TestSession_OutputRunsCliCallsThenWritesFinal(t *testing.T) {
 
 	assert.Equal(t, "done.\n", out.String(), "Output must carry the final message's Content only")
 
-	// Sanity: tool execution still happened (exec_tool_call + tool_result posts).
 	streamer.mu.Lock()
 	defer streamer.mu.Unlock()
 	require.Len(t, streamer.posted, 2, "expected exec_tool_call then tool_result")

--- a/pkg/cmd/pulumi/neo/session_test.go
+++ b/pkg/cmd/pulumi/neo/session_test.go
@@ -351,6 +351,130 @@ func TestSession_FinalAssistantMessageWithoutCliCallsEmitsTaskIdle(t *testing.T)
 	assert.True(t, hasUIEvent[UITaskIdle](events), "expected UITaskIdle after final assistant_message with no cli calls")
 }
 
+func TestSession_OutputWritesFinalContentAndReturnsCleanly(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+
+	// The agent never closes the SSE stream on its own — the task stays "active"
+	// in case more user input arrives. With Output set, Session.Run must detect
+	// the final-no-cli message, write its Content, and return promptly anyway.
+	// Crucially: the stream is NOT closed here.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		Content: "the final answer",
+		IsFinal: true,
+	})}
+
+	var out strings.Builder
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{},
+		OrgName:  "o",
+		TaskID:   "t",
+		Output:   &out,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Session.Run did not return after the final assistant message — " +
+			"Output mode must terminate without relying on the server to close the stream")
+	}
+
+	assert.Equal(t, "the final answer\n", out.String())
+}
+
+func TestSession_OutputSkipsEmptyContent(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+
+	// Empty Content still ends the run cleanly — we just don't write anything.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+	})}
+
+	var out strings.Builder
+	s := &Session{
+		Client:   streamer,
+		Handlers: map[string]ToolHandler{},
+		OrgName:  "o",
+		TaskID:   "t",
+		Output:   &out,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Session.Run did not return after a final empty assistant message")
+	}
+
+	assert.Empty(t, out.String())
+}
+
+func TestSession_OutputRunsCliCallsThenWritesFinal(t *testing.T) {
+	t.Parallel()
+
+	streamer := newFakeStreamer()
+
+	// Two-message turn: first message has a CLI tool call (the agent is paused
+	// waiting for the result). After the CLI runs the tool, the agent posts the
+	// final response with no more CLI calls. Output captures only the second.
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		IsFinal: true,
+		ToolCalls: []apitype.AgentBackendEventToolCall{{
+			ToolCallID:    "call-1",
+			Name:          "filesystem__read",
+			Args:          json.RawMessage(`{"file_path":"x"}`),
+			ExecutionMode: toolExecutionModeCLI,
+		}},
+	})}
+	streamer.stream <- client.NeoStreamEvent{Data: mustAgentResponseEnvelope(t, apitype.AgentBackendEventAssistantMessage{
+		Type:    backendEventAssistantMessage,
+		Content: "done.",
+		IsFinal: true,
+	})}
+
+	var out strings.Builder
+	s := &Session{
+		Client: streamer,
+		Handlers: map[string]ToolHandler{
+			"filesystem": &fakeHandler{wantMethod: "read", result: map[string]string{"text": "hi"}},
+		},
+		OrgName: "o",
+		TaskID:  "t",
+		Output:  &out,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(t.Context()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Session.Run did not return after the final assistant message")
+	}
+
+	assert.Equal(t, "done.\n", out.String(), "Output must carry the final message's Content only")
+
+	// Sanity: tool execution still happened (exec_tool_call + tool_result posts).
+	streamer.mu.Lock()
+	defer streamer.mu.Unlock()
+	require.Len(t, streamer.posted, 2, "expected exec_tool_call then tool_result")
+}
+
 func TestSession_StreamingAssistantMessageDoesNotEmitTaskIdle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds `pulumi neo -p "<prompt>"` for AI-agent interop: run a single prompt, execute CLI tool calls locally, and print the agent's final response to stdout (status to stderr).

`Session` learns an `Output io.Writer` that, when set, captures the `Content` of the first `IsFinal=true` assistant message with no pending CLI tool calls and ends `Run` via an `errSessionDone` sentinel — the SSE stream stays open on its own. The prompt is wrapped with a brief preamble telling Neo it's running headless so it does not ask follow-up questions.

`--print` + `--approval-mode=manual` is rejected at flag-parse time (no UI to approve from); when unset, `--print` defaults the approval mode to `auto`.

Fixes pulumi/pulumi-service#43402

```
> pulumi neo -p "say hi"
Hi! I can see you're working with the `aws_neo/dev` stack in the `pulumi` organization. Let me know if there's anything I can help you with — whether it's infrastructure changes, debugging, policy issues, or anything else related to your cloud setup.
```

## Test plan
- [ ] `pulumi neo -p "list files in this dir and summarize the project" 1>answer 2>status` prints the answer to stdout, URL/logs to stderr, exits 0
- [ ] `pulumi neo -p "..." | cat` produces only the answer (no ANSI/extra noise)
- [ ] `pulumi neo --print --approval-mode=manual "x"` errors before any network call
- [ ] CI green