### PR TITLE
Enforce usage of `(*cobra.Command).{OutOrStdout,ErrOrStderr}`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,6 +134,15 @@ linters:
           msg: Use resource.NewProperty instead
         - pattern: ^os.Rename$
           msg: "`os.Rename` does not work across file systems and is not atomic for windows. Use with caution"
+        # Scoped to non-test code under pkg/cmd/ via exclusion rules below.
+        # Cobra commands should use cmd.OutOrStdout() / cmd.ErrOrStderr() so
+        # output can be captured, redirected, or tested.
+        - pattern: ^os\.Stdout$
+          msg: "use cmd.OutOrStdout() instead of os.Stdout in pkg/cmd"
+        - pattern: ^os\.Stderr$
+          msg: "use cmd.ErrOrStderr() instead of os.Stderr in pkg/cmd"
+        - pattern: ^fmt\.Print(f|ln)?$
+          msg: "use fmt.Fprint*(cmd.OutOrStdout(), ...) instead of fmt.Print* in pkg/cmd"
     revive:
       rules:
         - name: use-any
@@ -177,6 +186,17 @@ linters:
       - linters:
           - goheader
         path: pkg/cmd/pulumi/logs/timestamp\.go$
+      # Scope the cmd.OutOrStdout/ErrOrStderr/fmt.Fprint* forbidigo rules to
+      # non-test code under pkg/cmd/. Paths reported by golangci-lint are
+      # relative to the repo root regardless of which module is being linted.
+      - linters:
+          - forbidigo
+        path-except: ^pkg/cmd/
+        text: 'use (cmd\.OutOrStdout|cmd\.ErrOrStderr|fmt\.Fprint\*)'
+      - linters:
+          - forbidigo
+        path: _test\.go$
+        text: 'use (cmd\.OutOrStdout|cmd\.ErrOrStderr|fmt\.Fprint\*)'
     paths:
       - Godeps$
       - builtin$

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"sort"
@@ -70,9 +71,9 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 			ctx := cmd.Context()
 			summary := getSummaryAbout(ctx, ws, cmdBackend.DefaultLoginManager, transitiveDependencies, stack)
 			if jsonOut {
-				return ui.PrintJSON(summary)
+				return ui.FprintJSON(cmd.OutOrStdout(), summary)
 			}
-			summary.Print()
+			summary.Print(cmd.OutOrStdout())
 			return nil
 		},
 	}
@@ -204,28 +205,28 @@ func getSummaryAbout(
 	return result
 }
 
-func (summary *summaryAbout) Print() {
-	fmt.Println(summary.CLI)
+func (summary *summaryAbout) Print(w io.Writer) {
+	fmt.Fprintln(w, summary.CLI)
 	if summary.Plugins != nil {
-		fmt.Println(formatPlugins(summary.Plugins))
+		fmt.Fprintln(w, formatPlugins(summary.Plugins))
 	}
 	if summary.Host != nil {
-		fmt.Println(summary.Host)
+		fmt.Fprintln(w, summary.Host)
 	}
 	if summary.Runtime != nil {
-		fmt.Println(summary.Runtime)
+		fmt.Fprintln(w, summary.Runtime)
 	}
 	if summary.CurrentStack != nil {
-		fmt.Println(summary.CurrentStack)
+		fmt.Fprintln(w, summary.CurrentStack)
 	}
 	if summary.Backend != nil {
-		fmt.Println(summary.Backend)
+		fmt.Fprintln(w, summary.Backend)
 	}
-	formatEnvironmentVariables(env.ConfiguredVariables())
+	formatEnvironmentVariables(w, env.ConfiguredVariables())
 	if summary.Dependencies != nil {
-		fmt.Println(formatProgramDependenciesAbout(summary.Dependencies))
+		fmt.Fprintln(w, formatProgramDependenciesAbout(summary.Dependencies))
 	}
-	fmt.Println(summary.LogMessage)
+	fmt.Fprintln(w, summary.LogMessage)
 	for _, err := range summary.Errors {
 		cmdutil.Diag().Warningf(&diag.Diag{Message: err.Error()})
 	}
@@ -484,7 +485,7 @@ type programDependencyAbout struct {
 	Version string `json:"version"`
 }
 
-func formatEnvironmentVariables(vars map[string]string) {
+func formatEnvironmentVariables(w io.Writer, vars map[string]string) {
 	table := cmdutil.Table{
 		Headers: []string{"Name", "Value"},
 		Rows:    []cmdutil.TableRow{},
@@ -497,8 +498,8 @@ func formatEnvironmentVariables(vars map[string]string) {
 	}
 
 	if len(table.Rows) > 0 {
-		fmt.Println("Environment Variables:")
-		fmt.Println(table.String())
+		fmt.Fprintln(w, "Environment Variables:")
+		fmt.Fprintln(w, table.String())
 	}
 }
 
@@ -608,6 +609,12 @@ func (runtime projectRuntimeAbout) String() string {
 
 // This is necessary because dotnet invokes build during the call to
 // getProjectPlugins.
+//
+// We swap out the process-wide os.Stdout because the dotnet build prints
+// to its file descriptor directly; capturing via cmd.OutOrStdout() would
+// not redirect those writes.
+//
+//nolint:forbidigo
 func getProjectPluginsSilently(
 	ctx *plugin.Context, proj *workspace.Project, pwd, main string,
 ) ([]workspace.PluginDescriptor, error) {

--- a/pkg/cmd/pulumi/about/about_env.go
+++ b/pkg/cmd/pulumi/about/about_env.go
@@ -46,7 +46,7 @@ func newAboutEnvCmd() *cobra.Command {
 					Columns: []string{v.Name(), v.Description, v.Value.String()},
 				})
 			}
-			ui.PrintTable(table, nil)
+			ui.FprintTable(cmd.OutOrStdout(), table, nil)
 			if foundError {
 				return errors.New("invalid environmental variables found")
 			}

--- a/pkg/cmd/pulumi/ai/ai.go
+++ b/pkg/cmd/pulumi/ai/ai.go
@@ -17,7 +17,6 @@ package ai
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -30,7 +29,7 @@ import (
 )
 
 type aiCmd struct {
-	Stdout io.Writer // defaults to os.Stdout
+	Stdout io.Writer
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
@@ -40,10 +39,6 @@ type aiCmd struct {
 }
 
 func (cmd *aiCmd) Run(ctx context.Context, args []string) error {
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
-	}
-
 	if cmd.currentBackend == nil {
 		cmd.currentBackend = cmdBackend.CurrentBackend
 	}
@@ -61,6 +56,9 @@ func NewAICommand() *cobra.Command {
 			ctx := cmd.Context()
 			if len(args) == 0 {
 				return cmd.Help()
+			}
+			if aiCommand.Stdout == nil {
+				aiCommand.Stdout = cmd.OutOrStdout()
 			}
 			return aiCommand.Run(ctx, args)
 		},

--- a/pkg/cmd/pulumi/ai/ai_web.go
+++ b/pkg/cmd/pulumi/ai/ai_web.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"strings"
 
 	"github.com/pkg/browser"
@@ -78,7 +77,7 @@ type aiWebCmd struct {
 	disableAutoSubmit bool
 	language          PulumiAILanguage
 
-	Stdout io.Writer // defaults to os.Stdout
+	Stdout io.Writer
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
@@ -88,10 +87,6 @@ type aiWebCmd struct {
 }
 
 func (cmd *aiWebCmd) Run(ctx context.Context, args []string) error {
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
-	}
-
 	if cmd.currentBackend == nil {
 		cmd.currentBackend = cmdBackend.CurrentBackend
 	}
@@ -120,7 +115,7 @@ func (cmd *aiWebCmd) Run(ctx context.Context, args []string) error {
 
 	requestURL.RawQuery = query.Encode()
 	if err = browser.OpenURL(requestURL.String()); err != nil {
-		fmt.Printf("We couldn't launch your web browser for some reason. Please visit:\n\n%s\n\n"+
+		fmt.Fprintf(cmd.Stdout, "We couldn't launch your web browser for some reason. Please visit:\n\n%s\n\n"+
 			"to continue your Pulumi AI session.\n", requestURL)
 		return errors.Join(err, fmt.Errorf("failed to open URL: %s", requestURL.String()))
 	}
@@ -151,6 +146,9 @@ Example:
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if aiwebcmd.Stdout == nil {
+				aiwebcmd.Stdout = cmd.OutOrStdout()
+			}
 			return aiwebcmd.Run(ctx, args)
 		},
 	}

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -226,9 +226,9 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Comman
 
 			if currentUser, _, _, err := be.CurrentUser(); err == nil {
 				// TODO should we print the token information here? (via team MyTeam token MyToken)
-				fmt.Printf("Logged in to %s as %s (%s)\n", be.Name(), currentUser, be.URL())
+				fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s as %s (%s)\n", be.Name(), currentUser, be.URL())
 			} else {
-				fmt.Printf("Logged in to %s (%s)\n", be.Name(), be.URL())
+				fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (%s)\n", be.Name(), be.URL())
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -65,7 +65,7 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 			var err error
 			if all {
 				err = workspace.DeleteAllAccounts()
-				fmt.Println("Logged out of everything")
+				fmt.Fprintln(cmd.OutOrStdout(), "Logged out of everything")
 			} else {
 				if cloudURL == "" {
 					// Try to read the current project
@@ -85,7 +85,7 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 				}
 
 				err = workspace.DeleteAccount(cloudURL)
-				fmt.Printf("Logged out of %s\n", cloudURL)
+				fmt.Fprintf(cmd.OutOrStdout(), "Logged out of %s\n", cloudURL)
 			}
 
 			return err

--- a/pkg/cmd/pulumi/cancel/cancel.go
+++ b/pkg/cmd/pulumi/cancel/cancel.go
@@ -17,7 +17,6 @@ package cancel
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -78,7 +77,7 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 			stackName := s.Ref().Name().String()
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
 			if cmdutil.Interactive() && (!yes && !ui.ConfirmPrompt(prompt, stackName, opts)) {
-				return result.FprintBailf(os.Stdout, "confirmation declined")
+				return result.FprintBailf(cmd.OutOrStdout(), "confirmation declined")
 			}
 
 			// Cancel the update.
@@ -89,7 +88,7 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 			msg := fmt.Sprintf(
 				"%sThe currently running update for '%s' has been canceled!%s",
 				colors.SpecAttention, stackName, colors.Reset)
-			fmt.Println(opts.Color.Colorize(msg))
+			fmt.Fprintln(cmd.OutOrStdout(), opts.Color.Colorize(msg))
 
 			return nil
 		},

--- a/pkg/cmd/pulumi/cloud/api.go
+++ b/pkg/cmd/pulumi/cloud/api.go
@@ -424,7 +424,7 @@ func handleResponse(w, errW io.Writer, resp *http.Response, api *apiCommand) err
 		return nil
 	}
 
-	return renderBody(w, resp.Header.Get("Content-Type"), body)
+	return renderBody(w, errW, resp.Header.Get("Content-Type"), body)
 }
 
 // writeStatusAndHeaders writes the status line + sorted headers to w.
@@ -507,7 +507,7 @@ func isJSONContentType(ct string) bool {
 // renderBody writes body to w, pretty-printing JSON when the content type
 // indicates JSON, passing through text/binary otherwise. A thin adapter
 // over format.go's existing helpers.
-func renderBody(w io.Writer, contentType string, body []byte) error {
+func renderBody(w, errW io.Writer, contentType string, body []byte) error {
 	ct := strings.ToLower(contentType)
 	switch {
 	case isJSONContentType(contentType), ct == "":
@@ -518,9 +518,9 @@ func renderBody(w io.Writer, contentType string, body []byte) error {
 		return formatText(w, body)
 	case strings.Contains(ct, "application/x-tar"),
 		strings.Contains(ct, "application/octet-stream"):
-		return formatBinary(w, body)
+		return formatBinary(w, errW, body)
 	default:
-		return formatBinary(w, body)
+		return formatBinary(w, errW, body)
 	}
 }
 

--- a/pkg/cmd/pulumi/cloud/format.go
+++ b/pkg/cmd/pulumi/cloud/format.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"golang.org/x/term"
 )
 
 // formatJSON pretty-prints JSON output to w, falling back to raw bytes when
@@ -52,12 +53,17 @@ func formatText(w io.Writer, body []byte) error {
 }
 
 // formatBinary writes binary content to w when not interactive, or prints a
-// hint to stderr when w is the terminal so we don't blast bytes at the user.
-func formatBinary(w io.Writer, body []byte) error {
-	if w == os.Stdout && cmdutil.Interactive() {
-		fmt.Fprintf(os.Stderr, "Binary response (%d bytes). Redirect stdout to save to a file.\n", len(body))
+// hint to errW when w is a terminal so we don't blast bytes at the user.
+func formatBinary(w, errW io.Writer, body []byte) error {
+	if isTerminal(w) && cmdutil.Interactive() {
+		fmt.Fprintf(errW, "Binary response (%d bytes). Redirect stdout to save to a file.\n", len(body))
 		return nil
 	}
 	_, err := w.Write(body)
 	return err
+}
+
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
 }

--- a/pkg/cmd/pulumi/cloud/ls.go
+++ b/pkg/cmd/pulumi/cloud/ls.go
@@ -202,7 +202,7 @@ func emitLsTable(w io.Writer, idx *Index) error {
 		}
 	}
 	summaryWidth := min(maxSummary, lsSummaryHardMax)
-	cols := stdoutWidth(lsFallbackCols)
+	cols := writerWidth(w, lsFallbackCols)
 	pathWidth := max(lsMinPathWidth, min(maxPath, cols-maxTag-lsMethodWidth-summaryWidth-lsBorderWidth))
 
 	t := table.NewWriter()
@@ -223,13 +223,17 @@ func emitLsTable(w io.Writer, idx *Index) error {
 	return nil
 }
 
-// stdoutWidth reports the column count of stdout, falling back to fallback
-// when stdout isn't a terminal or the size can't be determined (e.g. when
-// the user piped --output=table to a file but still wants the table).
-func stdoutWidth(fallback int) int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w <= 0 {
+// writerWidth reports the column count of w when it is a terminal, falling
+// back to fallback otherwise (e.g. when --output=table is piped to a file
+// but the user still wants table formatting).
+func writerWidth(w io.Writer, fallback int) int {
+	f, ok := w.(*os.File)
+	if !ok {
 		return fallback
 	}
-	return w
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols <= 0 {
+		return fallback
+	}
+	return cols
 }

--- a/pkg/cmd/pulumi/cmd/terminal.go
+++ b/pkg/cmd/pulumi/cmd/terminal.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
 	"golang.org/x/term"
@@ -22,14 +23,19 @@ import (
 
 const defaultTerminalWidth = 120
 
-// StdoutWidth returns the width of stdout in columns, falling back to a reasonable default
-// when stdout is not a terminal (e.g. when piped or redirected).
-func StdoutWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w <= 0 {
+// WriterWidth returns the width in columns of w when it is a terminal,
+// falling back to a reasonable default otherwise (piped output, CI, or
+// non-file writers such as a bytes.Buffer in tests).
+func WriterWidth(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok {
 		return defaultTerminalWidth
 	}
-	return w
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols <= 0 {
+		return defaultTerminalWidth
+	}
+	return cols
 }
 
 type OptimalPageSizeOpts struct {

--- a/pkg/cmd/pulumi/completion/gen.go
+++ b/pkg/cmd/pulumi/completion/gen.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/spf13/cobra"
@@ -31,13 +30,14 @@ func NewGenCompletionCmd(root *cobra.Command) *cobra.Command {
 		Aliases: []string{"completion"},
 		Short:   "Generate completion scripts for the Pulumi CLI",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			out := cmd.OutOrStdout()
 			switch args[0] {
 			case "bash":
-				return root.GenBashCompletion(os.Stdout)
+				return root.GenBashCompletion(out)
 			case "zsh":
-				return genZshCompletion(os.Stdout, root)
+				return genZshCompletion(out, root)
 			case "fish":
-				return root.GenFishCompletion(os.Stdout, true)
+				return root.GenFishCompletion(out, true)
 			default:
 				return fmt.Errorf("%q is not a supported shell", args[0])
 			}

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -114,7 +114,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 			return listConfig(
 				ctx,
 				ssml,
-				os.Stdout,
+				cmd.OutOrStdout(),
 				project,
 				stack,
 				ps,
@@ -323,7 +323,7 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 			}
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-			return getConfig(ctx, cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open)
+			return getConfig(ctx, cmd.OutOrStdout(), cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open)
 		},
 	}
 	constrictor.AttachArguments(getCmd, &constrictor.Arguments{
@@ -614,7 +614,7 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.Log
 						return fmt.Errorf("backing up existing configuration file: %w", err)
 					}
 
-					fmt.Printf("backed up existing configuration file to %s\n", backupFile)
+					fmt.Fprintf(cmd.OutOrStdout(), "backed up existing configuration file to %s\n", backupFile)
 					break
 				} else if err != nil {
 					return fmt.Errorf("backing up existing configuration file: %w", err)
@@ -625,7 +625,7 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.Log
 
 			err = ps.Save(configPath)
 			if err == nil {
-				fmt.Printf("refreshed configuration for stack '%s'\n", s.Ref().Name())
+				fmt.Fprintf(cmd.OutOrStdout(), "refreshed configuration for stack '%s'\n", s.Ref().Name())
 			}
 			return err
 		},
@@ -1206,6 +1206,7 @@ func listConfig(
 
 func getConfig(
 	ctx context.Context,
+	out io.Writer,
 	sink diag.Sink,
 	ssml cmdStack.SecretsManagerLoader,
 	ws pkgWorkspace.Context,
@@ -1310,19 +1311,19 @@ func getConfig(
 				value.ObjectValue = obj
 			}
 
-			out, err := json.MarshalIndent(value, "", "  ")
+			marshaled, err := json.MarshalIndent(value, "", "  ")
 			if err != nil {
 				return err
 			}
-			fmt.Println(string(out))
+			fmt.Fprintln(out, string(marshaled))
 		} else {
-			fmt.Printf("%v\n", raw)
+			fmt.Fprintf(out, "%v\n", raw)
 		}
 
 		if len(diags) != 0 {
-			fmt.Println()
-			fmt.Println("Environment diagnostics:")
-			printESCDiagnostics(os.Stdout, diags)
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "Environment diagnostics:")
+			printESCDiagnostics(out, diags)
 		}
 
 		cmdStack.Log3rdPartySecretsProviderDecryptionEvent(ctx, stack, key.Name(), "")

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -39,7 +39,6 @@ import (
 func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string) *cobra.Command {
 	impl := configEnvCmd{
 		stdin:            os.Stdin,
-		stdout:           os.Stdout,
 		diags:            cmdutil.Diag(),
 		ws:               ws,
 		requireStack:     cmdStack.RequireStack,
@@ -53,6 +52,9 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string) *cobra.Command {
 		Short: "Manage ESC environments for a stack",
 		Long: "Manages the ESC environment associated with a specific stack. To create a new environment\n" +
 			"from a stack's configuration, use `pulumi config env init`.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			impl.stdout = cmd.OutOrStdout()
+		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -122,13 +122,15 @@ func getStackConfigurationFromProjectStack(
 		return backend.StackConfiguration{}, fmt.Errorf("opening environment: %w", err)
 	}
 	if len(diags) != 0 {
-		printESCDiagnostics(os.Stderr, diags)
+		// This is a non-command helper; we don't have a *cobra.Command writer
+		// to thread through here. Writes go to the process streams directly.
+		printESCDiagnostics(os.Stderr, diags) //nolint:forbidigo
 		return backend.StackConfiguration{}, errors.New("opening environment: too many errors")
 	}
 
 	var pulumiEnv esc.Value
 	if env != nil {
-		warnOnNoEnvironmentEffects(os.Stdout, env)
+		warnOnNoEnvironmentEffects(os.Stdout, env) //nolint:forbidigo
 
 		pulumiEnv = env.Properties["pulumiConfig"]
 

--- a/pkg/cmd/pulumi/console/console.go
+++ b/pkg/cmd/pulumi/console/console.go
@@ -17,6 +17,7 @@ package console
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -70,7 +71,7 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return err
 					}
 					if stack == nil {
-						fmt.Printf("Stack '%s' does not exist. "+
+						fmt.Fprintf(cmd.OutOrStdout(), "Stack '%s' does not exist. "+
 							"Run `pulumi stack init` to create a new stack.\n", ref.Name())
 						return nil
 					}
@@ -80,7 +81,7 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return err
 					}
 					if stack == nil {
-						fmt.Println("No stack is currently selected. " +
+						fmt.Fprintln(cmd.OutOrStdout(), "No stack is currently selected. "+
 							"Run `pulumi stack select` to select a stack.")
 						return nil
 					}
@@ -95,11 +96,11 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 					// console URL fails.
 					url = cloudBackend.URL()
 				}
-				launchConsole(url)
+				launchConsole(cmd.OutOrStdout(), url)
 				return nil
 			}
-			fmt.Println("This command is not available for your backend. " +
-				"To migrate to the Pulumi Cloud backend, " +
+			fmt.Fprintln(cmd.OutOrStdout(), "This command is not available for your backend. "+
+				"To migrate to the Pulumi Cloud backend, "+
 				"please see https://www.pulumi.com/docs/intro/concepts/state/#pulumi-cloud-backend")
 			return nil
 		},
@@ -112,9 +113,9 @@ func NewConsoleCmd(ws pkgWorkspace.Context) *cobra.Command {
 }
 
 // launchConsole attempts to open the console in the browser using the specified URL.
-func launchConsole(url string) {
+func launchConsole(out io.Writer, url string) {
 	if openErr := browser.OpenURL(url); openErr != nil {
-		fmt.Printf("We couldn't launch your web browser for some reason. \n"+
+		fmt.Fprintf(out, "We couldn't launch your web browser for some reason. \n"+
 			"Please visit: %s", url)
 	}
 }

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -97,6 +98,8 @@ func NewConvertCmd(lm cmdBackend.LoginManager, ws pkgWorkspace.Context) *cobra.C
 
 			return runConvert(
 				cmd.Context(),
+				cmd.OutOrStdout(),
+				cmd.ErrOrStderr(),
 				lm,
 				ws,
 				env.Global(),
@@ -183,6 +186,7 @@ type projectGeneratorFunction func(
 
 func runConvert(
 	ctx context.Context,
+	stdout, stderr io.Writer,
 	lm cmdBackend.LoginManager,
 	ws pkgWorkspace.Context,
 	e env.Env,
@@ -302,6 +306,7 @@ func runConvert(
 
 			err = generateAndLinkSdksForPackages(
 				pCtx,
+				stdout,
 				language,
 				targetDirectory,
 				packageBlockDescriptors,
@@ -444,12 +449,12 @@ func runConvert(
 	if diagnostics.HasErrors() {
 		// Don't print the notice about this being a bug if we're in strict mode
 		if !strict {
-			fmt.Fprintln(os.Stderr, "================================================================================")
-			fmt.Fprintln(os.Stderr, "The Pulumi CLI encountered a code generation error. This is a bug!")
-			fmt.Fprintln(os.Stderr, "We would appreciate a report: https://github.com/pulumi/pulumi/issues/")
-			fmt.Fprintln(os.Stderr, "Please provide all of the below text in your report.")
-			fmt.Fprintln(os.Stderr, "================================================================================")
-			fmt.Fprintf(os.Stderr, "Pulumi Version:   %s\n", version.Version)
+			fmt.Fprintln(stderr, "================================================================================")
+			fmt.Fprintln(stderr, "The Pulumi CLI encountered a code generation error. This is a bug!")
+			fmt.Fprintln(stderr, "We would appreciate a report: https://github.com/pulumi/pulumi/issues/")
+			fmt.Fprintln(stderr, "Please provide all of the below text in your report.")
+			fmt.Fprintln(stderr, "================================================================================")
+			fmt.Fprintf(stderr, "Pulumi Version:   %s\n", version.Version)
 		}
 		cmdDiag.PrintDiagnostics(pCtx.Diag, diagnostics)
 		if err != nil {
@@ -531,6 +536,7 @@ func getPackagesToGenerateSdks(
 
 func generateAndLinkSdksForPackages(
 	pctx *plugin.Context,
+	stdout io.Writer,
 	language string,
 	targetDirectory string,
 	pkgs map[string]*schema.PackageDescriptor,
@@ -602,11 +608,11 @@ func generateAndLinkSdksForPackages(
 
 		packagesToLink = append(packagesToLink, packages.PackageToLink{Pkg: pkgSchema, Out: sdkOut})
 
-		fmt.Printf("Generated local SDK for package '%s:%s'\n", pkg.Name, pkg.Parameterization.Name)
+		fmt.Fprintf(stdout, "Generated local SDK for package '%s:%s'\n", pkg.Name, pkg.Parameterization.Name)
 	}
 
 	if err := packages.LinkPackages(&packages.LinkPackagesContext{
-		Writer:        os.Stdout,
+		Writer:        stdout,
 		Project:       proj,
 		Language:      language,
 		Root:          targetDirectory,

--- a/pkg/cmd/pulumi/convert/convert_test.go
+++ b/pkg/cmd/pulumi/convert/convert_test.go
@@ -15,6 +15,7 @@
 package convert
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,7 +54,8 @@ func TestYamlConvert(t *testing.T) {
 	require.NoError(t, err)
 
 	result := runConvert(
-		t.Context(), &cmdBackend.MockLoginManager{}, pkgWorkspace.Instance, env.Global(), []string{}, cwd, []string{},
+		t.Context(), io.Discard, io.Discard, &cmdBackend.MockLoginManager{}, pkgWorkspace.Instance,
+		env.Global(), []string{}, cwd, []string{},
 		"yaml", "go", "testdata/go", true, true, "")
 	require.Nil(t, result, "convert failed: %v", result)
 }
@@ -68,7 +70,8 @@ func TestPclConvert(t *testing.T) {
 	require.NoError(t, err)
 
 	result := runConvert(
-		t.Context(), &cmdBackend.MockLoginManager{}, pkgWorkspace.Instance, env.Global(), []string{}, cwd,
+		t.Context(), io.Discard, io.Discard, &cmdBackend.MockLoginManager{}, pkgWorkspace.Instance,
+		env.Global(), []string{}, cwd,
 		[]string{}, "pcl", "pcl", tmp, true, true, "")
 	assert.Nil(t, result)
 
@@ -102,6 +105,8 @@ func TestProjectNameDefaults(t *testing.T) {
 	// Act.
 	err = runConvert(
 		t.Context(),
+		io.Discard,
+		io.Discard,
 		&cmdBackend.MockLoginManager{},
 		pkgWorkspace.Instance,
 		env.Global(),
@@ -137,6 +142,8 @@ func TestProjectNameOverrides(t *testing.T) {
 	// Act.
 	err = runConvert(
 		t.Context(),
+		io.Discard,
+		io.Discard,
 		&cmdBackend.MockLoginManager{},
 		pkgWorkspace.Instance,
 		env.Global(),

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -100,7 +101,7 @@ type deploymentSettingsCommandDependencies struct {
 }
 
 func initializeDeploymentSettingsCmd(
-	ctx context.Context, ws pkgWorkspace.Context, stack string,
+	ctx context.Context, stdout io.Writer, ws pkgWorkspace.Context, stack string,
 ) (*deploymentSettingsCommandDependencies, error) {
 	interactive := cmdutil.Interactive()
 
@@ -132,9 +133,9 @@ func initializeDeploymentSettingsCmd(
 		unsupportedBackendMsg = colors.Highlight(unsupportedBackendMsg,
 			"https://www.pulumi.com/docs/pulumi-cloud/deployments/", colors.BrightBlue+colors.Underline+colors.Bold)
 
-		fmt.Println()
-		fmt.Println(displayOpts.Color.Colorize(unsupportedBackendMsg))
-		fmt.Println()
+		fmt.Fprintln(stdout)
+		fmt.Fprintln(stdout, displayOpts.Color.Colorize(unsupportedBackendMsg))
+		fmt.Fprintln(stdout)
 
 		return nil, fmt.Errorf("unable to manage stack deployments for backend type: %s",
 			be.Name())
@@ -188,7 +189,7 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		Short:      "Initialize the stack's deployment.yaml file",
 		Long:       "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -307,7 +308,7 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 				return errors.New("configure command is only supported in interactive mode")
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -46,7 +46,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 		Short:  "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
 		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -152,7 +152,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}
@@ -198,7 +198,7 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
@@ -96,7 +96,9 @@ func (promptHandlers) PromptForValue(
 }
 
 func (promptHandlers) Print(prompt string) {
-	fmt.Println(prompt)
+	// `prompts` is consumed by command code; this default writes to the
+	// process stdout when no command-bound writer is plumbed.
+	fmt.Println(prompt) //nolint:forbidigo
 }
 
 type repoLookup interface {

--- a/pkg/cmd/pulumi/insights/insights_resource_search.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_search.go
@@ -319,7 +319,7 @@ func renderSearchTable(w io.Writer, r apitype.InsightsResourceSearchResponse) er
 	// Let the URN column absorb whatever width is left after the other
 	// columns and the borders. 3 chars per column separator + 1 outer border
 	// each side = 3*ncols + 1.
-	cols := termWidth(searchTableFallbackCols)
+	cols := termWidth(w, searchTableFallbackCols)
 	borderWidth := 3*len(header) + 1
 	urnWidth := cols - borderWidth - fixedTableColsWidth
 	if urnWidth < minURNColWidth {
@@ -344,14 +344,18 @@ func renderSearchTable(w io.Writer, r apitype.InsightsResourceSearchResponse) er
 	return nil
 }
 
-// termWidth reports the column count of stdout, falling back to fallback when
-// stdout isn't a terminal or the size can't be determined (piped output, CI).
-func termWidth(fallback int) int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w <= 0 {
+// termWidth reports the column count of w when it is a terminal, falling
+// back to fallback otherwise (piped output, CI, non-file writers).
+func termWidth(w io.Writer, fallback int) int {
+	f, ok := w.(*os.File)
+	if !ok {
 		return fallback
 	}
-	return w
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols <= 0 {
+		return fallback
+	}
+	return cols
 }
 
 // renderSearchJSON writes the full response as indented JSON.

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -73,7 +73,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return policy.InstallPluginDependencies(ctx, root, proj.Runtime)
+					return policy.InstallPluginDependencies(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), root, proj.Runtime)
 				}
 			}
 
@@ -107,7 +107,8 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return fmt.Errorf("installing `packages` from PulumiPlugin.yaml: %w", err)
 					}
 
-					return policy.InstallPluginDependencies(ctx, filepath.Dir(pluginPath), proj.Runtime)
+					return policy.InstallPluginDependencies(
+						ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), filepath.Dir(pluginPath), proj.Runtime)
 				}
 			}
 

--- a/pkg/cmd/pulumi/logs/decrypt.go
+++ b/pkg/cmd/pulumi/logs/decrypt.go
@@ -76,7 +76,7 @@ func newDecryptCmd(ws pkgWorkspace.Context) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(os.Stderr, "Decrypting %s\n", filename)
+				fmt.Fprintf(cmd.ErrOrStderr(), "Decrypting %s\n", filename)
 			}
 
 			f, err := os.Open(filename)
@@ -93,7 +93,7 @@ func newDecryptCmd(ws pkgWorkspace.Context) *cobra.Command {
 				return fmt.Errorf("seeking log file: %w", err)
 			}
 
-			out := bufio.NewWriter(os.Stdout)
+			out := bufio.NewWriter(cmd.OutOrStdout())
 			defer out.Flush()
 
 			if string(magic[:]) == encryptedlog.Magic {

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -110,8 +110,10 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 				resourceFilter = &rf
 			}
 
+			out := cobraCmd.OutOrStdout()
 			if !jsonOut {
-				fmt.Printf(
+				fmt.Fprintf(
+					out,
 					opts.Color.Colorize(colors.BrightMagenta+"Collecting logs for stack %s since %s.\n\n"+colors.Reset),
 					s.Ref().String(),
 					cmd.FormatTime(*startTime),
@@ -152,7 +154,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 						}
 					}
 
-					return ui.PrintJSON(entries)
+					return ui.FprintJSON(out, entries)
 				}
 
 				for _, logEntry := range logs {
@@ -160,14 +162,15 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 						eventTime := time.Unix(0, logEntry.Timestamp*1000000)
 
 						if !jsonOut {
-							fmt.Printf(
+							fmt.Fprintf(
+								out,
 								"%30.30s[%30.30s] %v\n",
 								cmd.FormatTime(eventTime),
 								logEntry.ID,
 								strings.TrimRight(logEntry.Message, "\n"),
 							)
 						} else {
-							err = ui.PrintJSON(logEntryJSON{
+							err = ui.FprintJSON(out, logEntryJSON{
 								ID:        logEntry.ID,
 								Timestamp: cmd.FormatTime(eventTime.UTC()),
 								Message:   logEntry.Message,

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -32,6 +32,11 @@ import (
 // finished should be set to false when the handler is deferred and set to true as the
 // last statement in the scope. This trick is necessary to avoid catching and then
 // discarding a panic(nil).
+//
+// The panic handler runs before (and around) the cobra command, so it writes
+// directly to os.Stderr rather than going through cmd.ErrOrStderr().
+//
+//nolint:forbidigo
 func panicHandler(finished *bool) {
 	if panicPayload := recover(); !*finished {
 		stack := string(debug.Stack())

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -164,7 +165,9 @@ func NewNeoCmd() *cobra.Command {
 					approvalMode = client.NeoApprovalModeAuto
 				}
 			}
-			return runNeo(ctx, prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode)
+			return runNeo(
+				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode)
 		},
 	}
 
@@ -212,6 +215,7 @@ func parsePermissionMode(s string) (client.NeoPermissionMode, error) {
 
 func runNeo(
 	ctx context.Context,
+	stdout, stderr io.Writer,
 	prompt, stackName, orgFlag, cwdFlag string,
 	approvalMode client.NeoApprovalMode,
 	permissionMode client.NeoPermissionMode,
@@ -244,7 +248,7 @@ func runNeo(
 	pc := cloudBe.Client()
 
 	if msg := neoUpgradeMessage(cloudBe.Capabilities(ctx), version.Version); msg != "" {
-		return result.FprintBailf(os.Stderr, "%s", msg)
+		return result.FprintBailf(stderr, "%s", msg)
 	}
 
 	orgName, projectName, stackRefName, err := resolveTaskTarget(ctx, ws, cloudBe, project, stackName, orgFlag)
@@ -294,9 +298,9 @@ func runNeo(
 		if !printMode {
 			consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
 			if consoleURL != "" {
-				fmt.Fprintln(os.Stderr, consoleURL)
+				fmt.Fprintln(stderr, consoleURL)
 			} else {
-				fmt.Fprintf(os.Stderr, "Neo task created (id %s)\n", resp.TaskID)
+				fmt.Fprintf(stderr, "Neo task created (id %s)\n", resp.TaskID)
 			}
 		}
 		session := &Session{
@@ -304,10 +308,10 @@ func runNeo(
 			Handlers: handlers,
 			OrgName:  orgName,
 			TaskID:   resp.TaskID,
-			Log:      os.Stderr,
+			Log:      stderr,
 		}
 		if printMode {
-			session.Output = os.Stdout
+			session.Output = stdout
 		}
 		return session.Run(ctx)
 	}

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -293,7 +293,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// rather than relying on `go test -timeout` to catch a hang.
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
 			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
@@ -379,7 +379,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
 			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
@@ -407,7 +407,7 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	srv := newNeoFakeServer(t)
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
-	err := runNeo(t.Context(), "" /*prompt*/, "", "test-org", t.TempDir(),
+	err := runNeo(t.Context(), io.Discard, io.Discard, "" /*prompt*/, "", "test-org", t.TempDir(),
 		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
@@ -433,7 +433,7 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
 		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
@@ -464,7 +464,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// cwdFlag empty → runNeo calls os.Getwd. The test's own working
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
-		done <- runNeo(t.Context(), "do a thing", "", "test-org", "", /*cwd*/
+		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", "", /*cwd*/
 			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 
@@ -488,7 +488,7 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	missing := t.TempDir() + "/does-not-exist"
-	err := runNeo(t.Context(), "do a thing", "", "test-org", missing,
+	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", missing,
 		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
@@ -517,7 +517,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 		},
 	}
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
 		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
@@ -562,7 +562,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	isInteractive = func() bool { return false }
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
-	err := runNeo(t.Context(), "do a thing", "", "test-org", t.TempDir(),
+	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
 		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
@@ -635,7 +635,7 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), "do a thing", "" /*stack*/, "test-org", t.TempDir(),
+		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
 			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
 	}()
 

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -621,6 +621,8 @@ func (c *ctxOnlyCancellationScope) Close()                   { c.src.Cancel() }
 // the originals remain in place. bubbletea's tea.NewProgram captures a stable
 // reference to the terminal at construction, so this swap does not affect the
 // TUI's rendering; it only catches writes that look up os.Stdout dynamically.
+//
+//nolint:forbidigo
 func silenceStd() func() {
 	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
 	if err != nil {

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -308,8 +308,9 @@ func NewDestroyCmd() *cobra.Command {
 					return err
 				} else if protectedCount == len(snapshot.Resources) {
 					if !jsonDisplay && output != "json" {
-						fmt.Printf("There were no unprotected resources to destroy. There are still %d"+
-							" protected resources associated with this stack.\n", protectedCount)
+						fmt.Fprintf(cmd.OutOrStdout(),
+							"There were no unprotected resources to destroy. There are still %d"+
+								" protected resources associated with this stack.\n", protectedCount)
 					}
 					// We need to return now. Otherwise the update will conclude we tried to destroy
 					// everything and error for trying to destroy a protected resource. _Unless_ there are no
@@ -351,12 +352,13 @@ func NewDestroyCmd() *cobra.Command {
 				Scopes:             backend.CancellationScopes,
 			})
 
+			out := cmd.OutOrStdout()
 			if destroyErr == nil && protectedCount > 0 && !jsonDisplay && output != "json" {
-				fmt.Printf("All unprotected resources were destroyed. There are still %d protected resources"+
+				fmt.Fprintf(out, "All unprotected resources were destroyed. There are still %d protected resources"+
 					" associated with this stack.\n", protectedCount)
 			} else if destroyErr == nil && len(*targets) == 0 {
 				if !jsonDisplay && output != "json" && !remove && !previewOnly {
-					fmt.Printf("The resources in the stack have been deleted, but the history and configuration "+
+					fmt.Fprintf(out, "The resources in the stack have been deleted, but the history and configuration "+
 						"associated with the stack are still maintained. \nIf you want to remove the stack "+
 						"completely, run `pulumi stack rm %s`.\n", s.Ref())
 				} else if remove {
@@ -369,7 +371,7 @@ func NewDestroyCmd() *cobra.Command {
 						if detectErr = os.Remove(path); detectErr != nil && !os.IsNotExist(detectErr) {
 							return detectErr
 						} else if !jsonDisplay && output != "json" {
-							fmt.Printf("The resources in the stack have been deleted, and the history and " +
+							fmt.Fprintf(out, "The resources in the stack have been deleted, and the history and "+
 								"configuration removed.\n")
 						}
 					}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -545,7 +545,7 @@ func generateImportedDefinitions(ctx *plugin.Context,
 				errMsg.WriteString("You will need to copy and paste the generated code into your Pulumi application and manually edit it to correct any errors.\n\n") //nolint:lll
 			}
 			fmt.Fprintf(&errMsg, "%v\n", v)
-			fmt.Print(errMsg.String())
+			fmt.Fprint(out, errMsg.String())
 		}
 	}()
 
@@ -845,7 +845,7 @@ func NewImportCmd() *cobra.Command {
 			}
 
 			if !generateCode && outputFilePath != "" {
-				fmt.Fprintln(os.Stderr, "Output file will not be used as --generate-code is false.")
+				fmt.Fprintln(cmd.ErrOrStderr(), "Output file will not be used as --generate-code is false.")
 			}
 
 			var outputResult bytes.Buffer
@@ -1036,15 +1036,17 @@ func NewImportCmd() *cobra.Command {
 					// It's a little bit more memory but is a better experience that writing to stdout and then an error
 					// occurring
 					if outputFilePath == "" && !jsonDisplay && outputFormat != "json" {
-						fmt.Print("Please copy the following code into your Pulumi application. Not doing so\n" +
-							"will cause Pulumi to report that an update will happen on the next update command.\n\n")
+						outW := cmd.OutOrStdout()
+						fmt.Fprint(outW,
+							"Please copy the following code into your Pulumi application. Not doing so\n"+
+								"will cause Pulumi to report that an update will happen on the next update command.\n\n")
 						if protectResources {
-							fmt.Print(("Please note that the imported resources are marked as protected. " +
-								"To destroy them\n" +
-								"you will need to remove the `protect` option and run `pulumi update` *before*\n" +
-								"the destroy will take effect.\n\n"))
+							fmt.Fprint(outW, "Please note that the imported resources are marked as protected. "+
+								"To destroy them\n"+
+								"you will need to remove the `protect` option and run `pulumi update` *before*\n"+
+								"the destroy will take effect.\n\n")
 						}
-						fmt.Print(outputResult.String())
+						fmt.Fprint(outW, outputResult.String())
 					}
 				}
 			}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -263,7 +262,7 @@ func NewRefreshCmd() *cobra.Command {
 			if importPendingCreates != nil && len(*importPendingCreates) > 0 {
 				stderr := opts.Display.Stderr
 				if stderr == nil {
-					stderr = os.Stderr
+					stderr = cmd.ErrOrStderr()
 				}
 				if unused, err := pendingCreatesToImports(ctx, s, yes, opts.Display, *importPendingCreates); err != nil {
 					return err

--- a/pkg/cmd/pulumi/org/org.go
+++ b/pkg/cmd/pulumi/org/org.go
@@ -65,11 +65,12 @@ func NewOrgCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Current Backend: %s\n", cloudURL)
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Current Backend: %s\n", cloudURL)
 			if defaultOrg != "" {
-				fmt.Printf("Default Org: %s\n", defaultOrg)
+				fmt.Fprintf(out, "Default Org: %s\n", defaultOrg)
 			} else {
-				fmt.Println("No Default Org Specified")
+				fmt.Fprintln(out, "No Default Org Specified")
 			}
 
 			return nil
@@ -185,9 +186,9 @@ func newOrgGetDefaultCmd() *cobra.Command {
 			}
 
 			if defaultOrg != "" {
-				fmt.Println(defaultOrg)
+				fmt.Fprintln(cmd.OutOrStdout(), defaultOrg)
 			} else {
-				fmt.Println("No Default Org Specified")
+				fmt.Fprintln(cmd.OutOrStdout(), "No Default Org Specified")
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/org/org_search.go
+++ b/pkg/cmd/pulumi/org/org_search.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strconv"
 
@@ -109,10 +108,6 @@ type orgSearchCmd struct {
 func (cmd *orgSearchCmd) Run(ctx context.Context, args []string) error {
 	interactive := cmdutil.Interactive()
 
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
-	}
-
 	if cmd.currentBackend == nil {
 		cmd.currentBackend = cmdBackend.CurrentBackend
 	}
@@ -185,6 +180,9 @@ func newSearchCmd() *cobra.Command {
 			ctx := cmd.Context()
 			if len(scmd.queryParams) == 0 {
 				return cmd.Help()
+			}
+			if scmd.Stdout == nil {
+				scmd.Stdout = cmd.OutOrStdout()
 			}
 			return scmd.Run(ctx, args)
 		},

--- a/pkg/cmd/pulumi/org/org_search_ai.go
+++ b/pkg/cmd/pulumi/org/org_search_ai.go
@@ -42,10 +42,6 @@ type searchAICmd struct {
 func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	interactive := cmdutil.Interactive()
 
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
-	}
-
 	if cmd.currentBackend == nil {
 		cmd.currentBackend = cmdBackend.CurrentBackend
 	}
@@ -101,7 +97,8 @@ func (cmd *searchAICmd) Run(ctx context.Context, args []string) error {
 	}
 	err = cmd.outputFormat.Get()(&cmd.searchCmd, res)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "rendering error: %s\n", err)
+		// Stderr is not threaded through this helper; defer to process stderr.
+		fmt.Fprintf(os.Stderr, "rendering error: %s\n", err) //nolint:forbidigo
 	}
 	if cmd.openWeb {
 		err = browser.OpenURL(res.URL)
@@ -121,6 +118,9 @@ func newSearchAICmd() *cobra.Command {
 		Long:  "Search for resources in Pulumi Cloud using Pulumi AI",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if scmd.Stdout == nil {
+				scmd.Stdout = cmd.OutOrStdout()
+			}
 			return scmd.Run(ctx, args)
 		},
 	}

--- a/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
@@ -165,7 +165,7 @@ func (c *orgWebhookDeliveryListCmd) renderTable(deliveries []apitype.WebhookDeli
 		t.AppendRow(table.Row{d.ID, d.Kind, ts, duration, d.ResponseCode})
 	}
 
-	t.SetAllowedRowLength(cmdCmd.StdoutWidth())
+	t.SetAllowedRowLength(cmdCmd.WriterWidth(c.w))
 	t.Render()
 
 	fmt.Fprintf(c.w, "\n%d delivery(ies)\n", len(deliveries))

--- a/pkg/cmd/pulumi/org/org_webhook_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_list.go
@@ -305,7 +305,7 @@ func (c *orgWebhookListCmd) renderTable(webhooks []apitype.Webhook) error {
 	}
 
 	// Wrap flexible columns to fit the terminal.
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(c.w)
 	borderWidth := 3*len(header) + 1
 	fixedWidth := borderWidth + 12 + 6 // ID + ACTIVE
 	if hasName {

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -137,6 +137,7 @@ from the parameters, as in:
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
 
 			pkg, packageSpec, diags, err := packages.InstallPackage(
+				cmd.OutOrStdout(),
 				pkgWorkspace.Instance,
 				target.proj,
 				pctx,

--- a/pkg/cmd/pulumi/packagecmd/package_delete.go
+++ b/pkg/cmd/pulumi/packagecmd/package_delete.go
@@ -109,13 +109,13 @@ You must have publish permissions for the package to delete it.`,
 				if suggested := filterPrivate(registry.GetSuggestedPackages(err)); len(suggested) > 0 {
 					fmt.Fprintf(cmd.ErrOrStderr(), "No matching package was found. Did you mean")
 					if len(suggested) == 1 {
-						fmt.Println(cmd.ErrOrStderr(), opts.Color.Colorize(fmt.Sprintf(" %s%s%s?",
+						fmt.Fprintln(cmd.ErrOrStderr(), opts.Color.Colorize(fmt.Sprintf(" %s%s%s?",
 							colors.SpecInfo, formatPkg(suggested[0]), colors.Reset,
 						)))
 					}
 					fmt.Fprintln(cmd.ErrOrStderr(), " one of:")
 					for _, pkg := range suggested {
-						fmt.Println(cmd.ErrOrStderr(), opts.Color.Colorize(fmt.Sprintf("- %s%s%s",
+						fmt.Fprintln(cmd.ErrOrStderr(), opts.Color.Colorize(fmt.Sprintf("- %s%s%s",
 							colors.SpecInfo, formatPkg(pkg), colors.Reset,
 						)))
 					}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -96,7 +96,7 @@ empty string.`,
 				return fmt.Errorf("no mapping found for key %q", key)
 			}
 
-			fmt.Fprintf(os.Stderr, "%s maps to provider %s\n", source, mapping.Provider)
+			fmt.Fprintf(cmd.ErrOrStderr(), "%s maps to provider %s\n", source, mapping.Provider)
 
 			// If the user has specified out, then write out the mapping data
 			// to a file.
@@ -107,7 +107,7 @@ empty string.`,
 				}
 			} else {
 				// Otherwise, just write it to stdout
-				_, err := os.Stdout.Write(mapping.Data)
+				_, err := cmd.OutOrStdout().Write(mapping.Data)
 				if err != nil {
 					return fmt.Errorf("failed to write mapping data to stdout: %w", err)
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -70,7 +70,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 				return err
 			}
 			bytes = append(bytes, '\n')
-			n, err := os.Stdout.Write(bytes)
+			n, err := cmd.OutOrStdout().Write(bytes)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -100,8 +100,8 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 						return err
 					}
 				}
-				fmt.Fprintf(os.Stderr, "SDKs have been written to %s\n", out)
-				printRegistryDocsHint(os.Stderr, agent, cmd.Context(), registry, pkg)
+				fmt.Fprintf(cmd.ErrOrStderr(), "SDKs have been written to %s\n", out)
+				printRegistryDocsHint(cmd.ErrOrStderr(), agent, cmd.Context(), registry, pkg)
 				return nil
 			}
 			diags, err := packages.GenSDK(cmd.Context(), language, out, pkg, overlays, local)
@@ -109,8 +109,8 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "SDK has been written to %s\n", filepath.Join(out, language))
-			printRegistryDocsHint(os.Stderr, agent, cmd.Context(), registry, pkg)
+			fmt.Fprintf(cmd.ErrOrStderr(), "SDK has been written to %s\n", filepath.Join(out, language))
+			printRegistryDocsHint(cmd.ErrOrStderr(), agent, cmd.Context(), registry, pkg)
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_new.go
+++ b/pkg/cmd/pulumi/packagecmd/package_new.go
@@ -271,7 +271,7 @@ func runNewPackage(ctx context.Context, out io.Writer, args newPackageArgs) erro
 	}
 
 	if !args.generateOnly {
-		if err := policy.InstallPluginDependencies(ctx, cwd, plugin.Runtime); err != nil {
+		if err := policy.InstallPluginDependencies(ctx, out, out, cwd, plugin.Runtime); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -57,7 +57,7 @@ func newPackagePackSdkCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("%s", artifact)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s", artifact)
 
 			return nil
 		},

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -60,6 +60,8 @@ type publishPackageArgs struct {
 }
 
 type packagePublishCmd struct {
+	stdout io.Writer
+
 	extractSchema func(
 		ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
 		registry registry.Registry, e env.Env, concurrency int,
@@ -93,6 +95,7 @@ func newPackagePublishCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, cliArgs []string) error {
 			ctx := cmd.Context()
 			pkgPublishCmd.extractSchema = packages.SchemaFromSchemaSource
+			pkgPublishCmd.stdout = cmd.OutOrStdout()
 			parameters := &plugin.ParameterizeArgs{Args: cliArgs[1:]}
 			return pkgPublishCmd.Run(ctx, args, cliArgs[0], parameters)
 		},
@@ -271,7 +274,7 @@ func (cmd *packagePublishCmd) Run(
 		return fmt.Errorf("failed to publish package: %w", err)
 	}
 
-	fmt.Printf("Successfully published package %s/%s@%s\n", publisher, name, version)
+	fmt.Fprintf(cmd.stdout, "Successfully published package %s/%s@%s\n", publisher, name, version)
 
 	return nil
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -145,6 +145,9 @@ func (cmd *packagePublishCmd) Run(
 	packageSrc string,
 	packageParams plugin.ParameterizeParameters,
 ) error {
+	if cmd.stdout == nil {
+		cmd.stdout = io.Discard
+	}
 	project, _, err := pkgWorkspace.Instance.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return fmt.Errorf("failed to determine current project: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_publish_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_sdk.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,7 +46,7 @@ func newPackagePublishSdkCmd() *cobra.Command {
 
 			switch lang {
 			case "nodejs":
-				err := publishToNPM(path)
+				err := publishToNPM(cmd.OutOrStdout(), cmd.ErrOrStderr(), path)
 				if err != nil {
 					return err
 				}
@@ -111,7 +112,7 @@ func determineNPMTagForStableVersion(npm, pkgName, currentVersion string) (strin
 	return determineNPMTagFromCommandResult(currentVersion, string(output), stderr.String(), err)
 }
 
-func publishToNPM(path string) error {
+func publishToNPM(stdout, stderr io.Writer, path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("reading path %s: %w", path, err)
@@ -128,7 +129,7 @@ func publishToNPM(path string) error {
 
 	// verify auth for npm
 	whoamiCmd := exec.Command(npm, "whoami")
-	whoamiCmd.Stderr = os.Stderr
+	whoamiCmd.Stderr = stderr
 	whoami, err := whoamiCmd.Output()
 	if err != nil {
 		return err
@@ -178,40 +179,40 @@ func publishToNPM(path string) error {
 
 	// Verify version doesn't already exist
 	infoCmd := exec.Command(npm, "info", pkgNameWithVersion)
-	infoCmd.Stderr = os.Stderr
+	infoCmd.Stderr = stderr
 	logging.V(1).Infof("Running %s", infoCmd)
 	// we actually do not care about the error here; we care whether the output is empty.
 	output, _ := infoCmd.Output()
 
 	if len(output) > 0 {
 		// the package already exists, and we no-op.
-		fmt.Printf("did not publish %s because version %s already exists\n", pkgInfo.Name, pkgNameWithVersion)
+		fmt.Fprintf(stdout, "did not publish %s because version %s already exists\n", pkgInfo.Name, pkgNameWithVersion)
 		return nil
 	}
 
 	logging.V(1).Infof("The version does not exist yet, and it is safe to publish")
-	fmt.Printf("Publishing %s to npm package registry...\n", pkgInfo.Name)
+	fmt.Fprintf(stdout, "Publishing %s to npm package registry...\n", pkgInfo.Name)
 	npmPublishCmd := exec.Command(npm, "publish", path, "-tag", npmTag)
-	npmPublishCmd.Stdout = os.Stdout
-	npmPublishCmd.Stderr = os.Stderr
+	npmPublishCmd.Stdout = stdout
+	npmPublishCmd.Stderr = stderr
 	err = npmPublishCmd.Run()
 	if err != nil {
 		logging.V(1).Infof("error publishing package, verifying...")
 		// first, check if the package was published after all, by re-running npm info
 		// to verify we're not encountering a time-of-check to time-of-use (TOC/TOU) issue.
 		infoCheckCmd := exec.Command("npm", "info", pkgNameWithVersion)
-		infoCheckCmd.Stderr = os.Stderr
+		infoCheckCmd.Stderr = stderr
 		// Ignore error. stdout will be empty if the package was not published.
 		checkOutput, _ := infoCheckCmd.Output()
 
 		if len(checkOutput) > 0 {
 			// this means the package was published after all
-			fmt.Println("success! published to npm")
+			fmt.Fprintln(stdout, "success! published to npm")
 			return nil
 		}
 		// if we get here, this means the package was not published. We bail.
 		return fmt.Errorf("publish package: %w", err)
 	}
-	fmt.Println("success! published to npm")
+	fmt.Fprintln(stdout, "success! published to npm")
 	return nil
 }

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -66,7 +66,7 @@ func BindSpec(spec schema.PackageSpec) (*schema.Package, error) {
 
 // InstallPackage installs a package to the project by generating an SDK and linking it.
 // It returns the path to the installed package.
-func InstallPackage(ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *plugin.Context,
+func InstallPackage(stdout io.Writer, ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *plugin.Context,
 	language, root, schemaSource string, parameters plugin.ParameterizeParameters,
 	registry registry.Registry, e env.Env, concurrency int,
 ) (*schema.Package, *workspace.PackageSpec, hcl.Diagnostics, error) {
@@ -110,7 +110,7 @@ func InstallPackage(ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *p
 	}
 
 	out := filepath.Join(root, "sdks")
-	fmt.Printf("Successfully generated an SDK for the %s package at %s\n", pkg.Name, out)
+	fmt.Fprintf(stdout, "Successfully generated an SDK for the %s package at %s\n", pkg.Name, out)
 
 	err = os.MkdirAll(out, 0o755)
 	if err != nil {
@@ -137,7 +137,7 @@ func InstallPackage(ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *p
 
 	// Link the package to the project
 	if err := LinkPackages(&LinkPackagesContext{
-		Writer:        os.Stdout,
+		Writer:        stdout,
 		Project:       proj,
 		Language:      language,
 		Root:          root,
@@ -326,7 +326,9 @@ func LinkPackages(ctx *LinkPackagesContext) error {
 }
 
 func NewPluginContext(cwd string) (*plugin.Context, error) {
-	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
+	// Helper used by callers without a *cobra.Command writer; emits to
+	// process stderr.
+	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{ //nolint:forbidigo
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, nil, nil, cwd, nil, true, nil,
@@ -460,6 +462,8 @@ func ProviderFromSource(
 		}
 	}
 
+	// Helper without a *cobra.Command writer; plumbing the writer into
+	// packageworkspace.New would require a much larger API change.
 	f, spec, err := packageinstallation.InstallPlugin(pctx.Request(), packageSpec, nil, "", packageinstallation.Options{
 		Options: packageresolution.Options{
 			ResolveWithRegistry:                        !e.GetBool(env.DisableRegistryResolve),
@@ -467,7 +471,7 @@ func ProviderFromSource(
 			AllowNonInvertableLocalWorkspaceResolution: true,
 		},
 		Concurrency: concurrency,
-	}, reg, packageworkspace.New(pluginstorage.Instance, ws, pctx.Host, os.Stderr, os.Stderr,
+	}, reg, packageworkspace.New(pluginstorage.Instance, ws, pctx.Host, os.Stderr, os.Stderr, //nolint:forbidigo
 		nil, packageworkspace.Options{}))
 	if err != nil {
 		return nil, workspace.PackageSpec{}, fmt.Errorf("unable to install %s: %w", packageSpec, err)

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/dustin/go-humanize"
@@ -71,9 +72,9 @@ func newPluginLsCmd(pluginContext pluginstorage.Context) *cobra.Command {
 			})
 
 			if jsonOut {
-				return formatPluginsJSON(plugins)
+				return formatPluginsJSON(cmd.OutOrStdout(), plugins)
 			}
-			return formatPluginConsole(plugins)
+			return formatPluginConsole(cmd.OutOrStdout(), plugins)
 		},
 	}
 
@@ -100,7 +101,7 @@ type pluginInfoJSON struct {
 	LastUsedTime *string `json:"lastUsedTime,omitempty"`
 }
 
-func formatPluginsJSON(plugins []workspace.PluginInfo) error {
+func formatPluginsJSON(w io.Writer, plugins []workspace.PluginInfo) error {
 	makeStringRef := func(s string) *string {
 		return &s
 	}
@@ -129,10 +130,10 @@ func formatPluginsJSON(plugins []workspace.PluginInfo) error {
 		}
 	}
 
-	return ui.PrintJSON(jsonPluginInfo)
+	return ui.FprintJSON(w, jsonPluginInfo)
 }
 
-func formatPluginConsole(plugins []workspace.PluginInfo) error {
+func formatPluginConsole(w io.Writer, plugins []workspace.PluginInfo) error {
 	var totalSize uint64
 
 	rows := slice.Prealloc[cmdutil.TableRow](len(plugins))
@@ -170,13 +171,13 @@ func formatPluginConsole(plugins []workspace.PluginInfo) error {
 		totalSize += plugin.Size()
 	}
 
-	ui.PrintTable(cmdutil.Table{
+	ui.FprintTable(w, cmdutil.Table{
 		Headers: []string{"NAME", "KIND", "VERSION", "SIZE", "INSTALLED", "LAST USED"},
 		Rows:    rows,
 	}, nil)
 
-	fmt.Printf("\n")
-	fmt.Printf("TOTAL plugin cache size: %s\n", humanize.Bytes(totalSize))
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "TOTAL plugin cache size: %s\n", humanize.Bytes(totalSize))
 
 	return nil
 }

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -101,18 +101,19 @@ func newPluginRmCmd(pluginContext pluginstorage.Context) *cobra.Command {
 				return nil
 			}
 
+			out := cmd.OutOrStdout()
 			// Confirm that the user wants to do this (unless --yes was passed).
 			if !yes {
 				var suffix string
 				if len(deletes) != 1 {
 					suffix = "s"
 				}
-				fmt.Print(
+				fmt.Fprint(out,
 					opts.Color.Colorize(
 						fmt.Sprintf("%sThis will remove %d plugin%s from the cache:%s\n",
 							colors.SpecAttention, len(deletes), suffix, colors.Reset)))
 				for _, del := range deletes {
-					fmt.Printf("    %s %s\n", del.Kind, del.String())
+					fmt.Fprintf(out, "    %s %s\n", del.Kind, del.String())
 				}
 				if !ui.ConfirmPrompt("", "yes", opts) {
 					return nil
@@ -123,7 +124,7 @@ func newPluginRmCmd(pluginContext pluginstorage.Context) *cobra.Command {
 			var result error
 			for _, plugin := range deletes {
 				if err := plugin.Delete(); err == nil {
-					fmt.Printf("removed: %s %v\n", plugin.Kind, plugin)
+					fmt.Fprintf(out, "removed: %s %v\n", plugin.Kind, plugin)
 				} else {
 					result = multierror.Append(
 						result, fmt.Errorf("failed to delete %s plugin %s: %w", plugin.Kind, plugin, err))

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -102,7 +102,8 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 					source = fmt.Sprintf("%s@%s", source, pluginSpec.Version)
 				}
 
-				d := diag.DefaultSink(os.Stdout, os.Stderr, diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
+				d := diag.DefaultSink(
+					cmd.OutOrStdout(), cmd.ErrOrStderr(), diag.FormatOptions{Color: cmdutil.GetGlobalColorization()})
 
 				pluginPath, err = workspace.GetPluginPath(ctx, d, pluginSpec, nil)
 				if err != nil {
@@ -165,20 +166,21 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 			// For stdin, we start a copy goroutine but don't wait for it since it will block
 			// indefinitely if there's no stdin input.
 
+			stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 			var wg sync.WaitGroup
 			wg.Add(2) // Only wait for stdout and stderr, not stdin
 			go func() {
 				defer wg.Done()
-				_, err := io.Copy(os.Stdout, plugin.Stdout)
+				_, err := io.Copy(stdout, plugin.Stdout)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "error reading plugin stdout: %v\n", err)
+					fmt.Fprintf(stderr, "error reading plugin stdout: %v\n", err)
 				}
 			}()
 			go func() {
 				defer wg.Done()
-				_, err := io.Copy(os.Stderr, plugin.Stderr)
+				_, err := io.Copy(stderr, plugin.Stderr)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "error reading plugin stderr: %v\n", err)
+					fmt.Fprintf(stderr, "error reading plugin stderr: %v\n", err)
 				}
 			}()
 			// Copy stdin in a separate goroutine but don't wait for it.

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -17,7 +17,7 @@ package policy
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"path/filepath"
 
 	"github.com/opentracing/opentracing-go"
@@ -48,7 +48,9 @@ func ReadPolicyProject(pwd string) (*workspace.PolicyPackProject, string, string
 	return proj, path, filepath.Dir(path), nil
 }
 
-func InstallPluginDependencies(ctx context.Context, root string, projRuntime workspace.ProjectRuntimeInfo) error {
+func InstallPluginDependencies(
+	ctx context.Context, stdout, stderr io.Writer, root string, projRuntime workspace.ProjectRuntimeInfo,
+) error {
 	span := opentracing.SpanFromContext(ctx)
 	// Bit of a hack here. Creating a plugin context requires a "program project", but we've only got a
 	// policy project. Ideally we should be able to make a plugin context without any related project. But
@@ -82,7 +84,7 @@ func InstallPluginDependencies(ctx context.Context, root string, projRuntime wor
 	err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
 		Info:     programInfo,
 		IsPlugin: true,
-	}, os.Stdout, os.Stderr)
+	}, stdout, stderr)
 	if err != nil {
 		return fmt.Errorf("installing dependencies failed: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_compliance_list.go
+++ b/pkg/cmd/pulumi/policy/policy_compliance_list.go
@@ -242,7 +242,7 @@ func (c *complianceListCmd) renderTable(
 
 	// Score columns are short (e.g. "100%", "N/A"). Let the ENTITY column
 	// and any long column headers wrap to fit the terminal.
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(c.w)
 	// Each score column needs ~6 chars + borders. Reserve the rest for ENTITY.
 	scoreCols := len(columns)
 	borders := 3*(scoreCols+1) + 1

--- a/pkg/cmd/pulumi/policy/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_group_ls.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -104,9 +105,9 @@ func newPolicyGroupLsCmd() *cobra.Command {
 			}
 
 			if jsonOut {
-				return formatPolicyGroupsJSON(allPolicyGroups)
+				return formatPolicyGroupsJSON(cmd.OutOrStdout(), allPolicyGroups)
 			}
-			return formatPolicyGroupsConsole(allPolicyGroups)
+			return formatPolicyGroupsConsole(cmd.OutOrStdout(), allPolicyGroups)
 		},
 	}
 
@@ -122,7 +123,7 @@ func newPolicyGroupLsCmd() *cobra.Command {
 	return cmd
 }
 
-func formatPolicyGroupsConsole(policyGroups []apitype.PolicyGroupSummary) error {
+func formatPolicyGroupsConsole(w io.Writer, policyGroups []apitype.PolicyGroupSummary) error {
 	// Header string and formatting options to align columns.
 	headers := []string{"NAME", "DEFAULT", "ENABLED POLICY PACKS", "STACKS"}
 
@@ -150,7 +151,7 @@ func formatPolicyGroupsConsole(policyGroups []apitype.PolicyGroupSummary) error 
 		columns := []string{name, defaultGroup, numPolicyPacks, numStacks}
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
-	ui.PrintTable(cmdutil.Table{
+	ui.FprintTable(w, cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
 	}, nil)
@@ -167,7 +168,7 @@ type policyGroupsJSON struct {
 	NumStacks      int    `json:"numStacks"`
 }
 
-func formatPolicyGroupsJSON(policyGroups []apitype.PolicyGroupSummary) error {
+func formatPolicyGroupsJSON(w io.Writer, policyGroups []apitype.PolicyGroupSummary) error {
 	output := make([]policyGroupsJSON, len(policyGroups))
 	for i, group := range policyGroups {
 		output[i] = policyGroupsJSON{
@@ -177,5 +178,5 @@ func formatPolicyGroupsJSON(policyGroups []apitype.PolicyGroupSummary) error {
 			NumStacks:      group.NumStacks,
 		}
 	}
-	return ui.PrintJSON(output)
+	return ui.FprintJSON(w, output)
 }

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -49,6 +49,9 @@ func newPolicyInstallCmd() *cobra.Command {
 			"This command installs the policy packs required by the stack's organization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if policyInstallCmd.stderr == nil {
+				policyInstallCmd.stderr = cmd.ErrOrStderr()
+			}
 			return policyInstallCmd.Run(ctx, stack)
 		},
 	}
@@ -82,10 +85,6 @@ func (cmd *policyInstallCmd) Run(
 	if cmd.diag == nil {
 		cmd.diag = cmdutil.Diag()
 	}
-	if cmd.stderr == nil {
-		cmd.stderr = os.Stderr
-	}
-
 	if cmd.requireStack == nil {
 		cmd.requireStack = func(ctx context.Context, stackName string) (backend.Stack, error) {
 			displayOpts := display.Options{

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -85,6 +85,9 @@ func (cmd *policyInstallCmd) Run(
 	if cmd.diag == nil {
 		cmd.diag = cmdutil.Diag()
 	}
+	if cmd.stderr == nil {
+		cmd.stderr = io.Discard
+	}
 	if cmd.requireStack == nil {
 		cmd.requireStack = func(ctx context.Context, stackName string) (backend.Stack, error) {
 			displayOpts := display.Options{

--- a/pkg/cmd/pulumi/policy/policy_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_ls.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -88,9 +89,9 @@ func newPolicyLsCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.
 			}
 
 			if jsonOut {
-				return formatPolicyPacksJSON(allPolicyPacks)
+				return formatPolicyPacksJSON(cmd.OutOrStdout(), allPolicyPacks)
 			}
-			return formatPolicyPacksConsole(allPolicyPacks)
+			return formatPolicyPacksConsole(cmd.OutOrStdout(), allPolicyPacks)
 		},
 	}
 
@@ -106,7 +107,7 @@ func newPolicyLsCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.
 	return cmd
 }
 
-func formatPolicyPacksConsole(policyPacks []apitype.PolicyPackWithVersions) error {
+func formatPolicyPacksConsole(w io.Writer, policyPacks []apitype.PolicyPackWithVersions) error {
 	// Header string and formatting options to align columns.
 	headers := []string{"NAME", "VERSIONS"}
 
@@ -123,7 +124,7 @@ func formatPolicyPacksConsole(policyPacks []apitype.PolicyPackWithVersions) erro
 		columns := []string{name, versionTags}
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
-	ui.PrintTable(cmdutil.Table{
+	ui.FprintTable(w, cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
 	}, nil)
@@ -138,7 +139,7 @@ type policyPacksJSON struct {
 	Versions []string `json:"versions"`
 }
 
-func formatPolicyPacksJSON(policyPacks []apitype.PolicyPackWithVersions) error {
+func formatPolicyPacksJSON(w io.Writer, policyPacks []apitype.PolicyPackWithVersions) error {
 	output := make([]policyPacksJSON, len(policyPacks))
 	for i, pack := range policyPacks {
 		output[i] = policyPacksJSON{
@@ -146,5 +147,5 @@ func formatPolicyPacksJSON(policyPacks []apitype.PolicyPackWithVersions) error {
 			Versions: pack.VersionTags,
 		}
 	}
-	return ui.PrintJSON(output)
+	return ui.FprintJSON(w, output)
 }

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -43,6 +44,7 @@ type newPolicyArgs struct {
 	generateOnly      bool
 	offline           bool
 	templateNameOrURL string
+	stdout            io.Writer
 }
 
 func newPolicyNewCmd() *cobra.Command {
@@ -65,6 +67,7 @@ func newPolicyNewCmd() *cobra.Command {
 			if len(cliArgs) > 0 {
 				args.templateNameOrURL = cliArgs[0]
 			}
+			args.stdout = cmd.OutOrStdout()
 			return runNewPolicyPack(ctx, args)
 		},
 	}
@@ -172,7 +175,7 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 		return err
 	}
 
-	fmt.Println("Created Policy Pack!")
+	fmt.Fprintln(args.stdout, "Created Policy Pack!")
 
 	proj, projPath, root, err := ReadPolicyProject(cwd)
 	if err != nil {
@@ -193,23 +196,25 @@ func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
 
 	// Install dependencies.
 	if !args.generateOnly {
-		if err := InstallPluginDependencies(ctx, root, proj.Runtime); err != nil {
+		if err := InstallPluginDependencies(ctx, args.stdout, args.stdout, root, proj.Runtime); err != nil {
 			return err
 		}
 	}
 
-	fmt.Println(
+	fmt.Fprintln(args.stdout,
 		opts.Color.Colorize(
-			colors.BrightGreen+colors.Bold+"Your new Policy Pack is ready to go!"+colors.Reset) +
-			" " + cmdutil.EmojiOr("✨", ""))
-	fmt.Println()
+			colors.BrightGreen+colors.Bold+"Your new Policy Pack is ready to go!"+colors.Reset)+
+			" "+cmdutil.EmojiOr("✨", ""))
+	fmt.Fprintln(args.stdout)
 
-	printPolicyPackNextSteps(proj, root, args.generateOnly, opts)
+	printPolicyPackNextSteps(args.stdout, proj, root, args.generateOnly, opts)
 
 	return nil
 }
 
-func printPolicyPackNextSteps(proj *workspace.PolicyPackProject, root string, generateOnly bool, opts display.Options) {
+func printPolicyPackNextSteps(
+	w io.Writer, proj *workspace.PolicyPackProject, root string, generateOnly bool, opts display.Options,
+) {
 	var commands []string
 	if generateOnly {
 		// We didn't install dependencies, so instruct the user to do so.
@@ -219,18 +224,18 @@ func printPolicyPackNextSteps(proj *workspace.PolicyPackProject, root string, ge
 	if len(commands) == 1 {
 		installMsg := fmt.Sprintf("To install dependencies for the Policy Pack, run `%s`", commands[0])
 		installMsg = colors.Highlight(installMsg, commands[0], colors.BrightBlue+colors.Bold)
-		fmt.Println(opts.Color.Colorize(installMsg))
-		fmt.Println()
+		fmt.Fprintln(w, opts.Color.Colorize(installMsg))
+		fmt.Fprintln(w)
 	}
 
 	if len(commands) > 1 {
-		fmt.Println("To install dependencies for the Policy Pack, run the following commands:")
-		fmt.Println()
+		fmt.Fprintln(w, "To install dependencies for the Policy Pack, run the following commands:")
+		fmt.Fprintln(w)
 		for i, cmd := range commands {
 			cmdColors := colors.BrightBlue + colors.Bold + cmd + colors.Reset
-			fmt.Printf("   %d. %s\n", i+1, opts.Color.Colorize(cmdColors))
+			fmt.Fprintf(w, "   %d. %s\n", i+1, opts.Color.Colorize(cmdColors))
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 
 	usageCommandPreambles := []string{
@@ -251,16 +256,16 @@ func printPolicyPackNextSteps(proj *workspace.PolicyPackProject, root string, ge
 		usageMsg := fmt.Sprintf("Once you're done editing your Policy Pack, to %s `%s`", usageCommandPreambles[0],
 			usageCommands[0])
 		usageMsg = colors.Highlight(usageMsg, usageCommands[0], colors.BrightBlue+colors.Bold)
-		fmt.Println(opts.Color.Colorize(usageMsg))
-		fmt.Println()
+		fmt.Fprintln(w, opts.Color.Colorize(usageMsg))
+		fmt.Fprintln(w)
 	} else {
-		fmt.Println("Once you're done editing your Policy Pack:")
-		fmt.Println()
+		fmt.Fprintln(w, "Once you're done editing your Policy Pack:")
+		fmt.Fprintln(w)
 		for i, cmd := range usageCommands {
 			cmdColors := colors.BrightBlue + colors.Bold + cmd + colors.Reset
-			fmt.Printf("   * To %s `%s`\n", usageCommandPreambles[i], opts.Color.Colorize(cmdColors))
+			fmt.Fprintf(w, "   * To %s `%s`\n", usageCommandPreambles[i], opts.Color.Colorize(cmdColors))
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 }
 

--- a/pkg/cmd/pulumi/policy/policy_new.go
+++ b/pkg/cmd/pulumi/policy/policy_new.go
@@ -96,6 +96,9 @@ func newPolicyNewCmd() *cobra.Command {
 }
 
 func runNewPolicyPack(ctx context.Context, args newPolicyArgs) error {
+	if args.stdout == nil {
+		args.stdout = io.Discard
+	}
 	// Prepare options.
 	opts := display.Options{
 		Color:         cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/policy/policy_rm.go
+++ b/pkg/cmd/pulumi/policy/policy_rm.go
@@ -16,7 +16,6 @@ package policy
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
@@ -63,7 +62,7 @@ func newPolicyRmCmd() *cobra.Command {
 
 			prompt := fmt.Sprintf("This will permanently remove the '%s' policy!", args[0])
 			if !yes && !ui.ConfirmPrompt(prompt, args[0], opts) {
-				return result.FprintBailf(os.Stdout, "confirmation declined")
+				return result.FprintBailf(cmd.OutOrStdout(), "confirmation declined")
 			}
 
 			// Attempt to remove the Policy Pack.

--- a/pkg/cmd/pulumi/policy/policy_validate.go
+++ b/pkg/cmd/pulumi/policy/policy_validate.go
@@ -60,7 +60,7 @@ func newPolicyValidateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Println("Policy Pack configuration is valid.")
+			fmt.Fprintln(cmd.OutOrStdout(), "Policy Pack configuration is valid.")
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -107,8 +107,9 @@ func HandleConfig(
 			return fmt.Errorf("saving config: %w", err)
 		}
 
-		fmt.Println("Saved config")
-		fmt.Println()
+		// Helper used by multiple commands; output goes to process stdout.
+		fmt.Println("Saved config") //nolint:forbidigo
+		fmt.Println()               //nolint:forbidigo
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -47,10 +47,12 @@ func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 	}
 
 	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, runtime.Options())
+	// Helper used by multiple commands; output goes to the process streams
+	// directly when not given a writer.
 	err = cmdutil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
 		Info:     programInfo,
 		IsPlugin: false,
-	}, os.Stdout, os.Stderr)
+	}, os.Stdout, os.Stderr) //nolint:forbidigo
 	if err != nil {
 		//revive:disable-next-line:error-strings // This error message is user facing.
 		return fmt.Errorf("installing dependencies failed: %w\nRun `pulumi install` to complete the installation.", err)

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -102,6 +102,14 @@ func runNew(ctx context.Context, args newArgs) error {
 		return backenderr.NonInteractiveRequiresYesError{}
 	}
 
+	// Default to discarding output when callers (e.g. tests) don't provide writers.
+	if args.stdout == nil {
+		args.stdout = io.Discard
+	}
+	if args.stderr == nil {
+		args.stderr = io.Discard
+	}
+
 	// Prepare options.
 	opts := display.Options{
 		Color:         cmdutil.GetGlobalColorization(),

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -93,6 +93,8 @@ type newArgs struct {
 	templateMode          bool
 	runtimeOptions        []string
 	remoteStackConfig     bool
+	stdout                io.Writer
+	stderr                io.Writer
 }
 
 func runNew(ctx context.Context, args newArgs) error {
@@ -255,16 +257,16 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Show instructions, if we're going to show at least one prompt.
 	hasAtLeastOnePrompt := (args.name == "") || (args.description == "") || (!args.generateOnly && args.stack == "")
 	if !args.yes && hasAtLeastOnePrompt {
-		fmt.Println("This command will walk you through creating a new Pulumi project.")
-		fmt.Println()
-		fmt.Println(
+		fmt.Fprintln(args.stdout, "This command will walk you through creating a new Pulumi project.")
+		fmt.Fprintln(args.stdout)
+		fmt.Fprintln(args.stdout,
 			opts.Color.Colorize(
 				colors.Highlight("Enter a value or leave blank to accept the (default), and press <ENTER>.",
 					"<ENTER>", colors.BrightCyan+colors.Bold)))
-		fmt.Println(
+		fmt.Fprintln(args.stdout,
 			opts.Color.Colorize(
 				colors.Highlight("Press ^C at any time to quit.", "^C", colors.BrightCyan+colors.Bold)))
-		fmt.Println()
+		fmt.Fprintln(args.stdout)
 	}
 
 	// Prompt for the project name, if it wasn't already specified.
@@ -308,8 +310,8 @@ func runNew(ctx context.Context, args newArgs) error {
 		return err
 	}
 
-	fmt.Printf("Created project '%s'\n", args.name)
-	fmt.Println()
+	fmt.Fprintf(args.stdout, "Created project '%s'\n", args.name)
+	fmt.Fprintln(args.stdout)
 
 	// Load the project, update the name & description, remove the template section, and save it.
 	proj, root, err := ws.ReadProject()
@@ -358,7 +360,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			return err
 		}
 		// The backend will print "Created stack '<stack>'" on success.
-		fmt.Println()
+		fmt.Fprintln(args.stdout)
 	}
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
@@ -443,7 +445,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		registry := cmdCmd.NewDefaultRegistry(
 			ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, proj, cmdutil.Diag(), env.Global())
 		if err := InstallPackagesFromProject(ctx, proj, root,
-			registry, -1, false, os.Stderr, os.Stderr, env.Global()); err != nil {
+			registry, -1, false, args.stderr, args.stderr, env.Global()); err != nil {
 			return err
 		}
 		if err := InstallDependencies(pluginCtx, &proj.Runtime, entryPoint); err != nil {
@@ -451,17 +453,17 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 	}
 
-	fmt.Println(
+	fmt.Fprintln(args.stdout,
 		opts.Color.Colorize(
-			colors.BrightGreen+colors.Bold+"Your new project is ready to go!"+colors.Reset) +
-			" " + cmdutil.EmojiOr("✨", ""))
-	fmt.Println()
+			colors.BrightGreen+colors.Bold+"Your new project is ready to go!"+colors.Reset)+
+			" "+cmdutil.EmojiOr("✨", ""))
+	fmt.Fprintln(args.stdout)
 
 	// Print out next steps.
-	printNextSteps(proj, originalCwd, cwd, args.generateOnly, opts)
+	printNextSteps(args.stdout, proj, originalCwd, cwd, args.generateOnly, opts)
 
 	if template.Quickstart != "" {
-		fmt.Println(template.Quickstart)
+		fmt.Fprintln(args.stdout, template.Quickstart)
 	}
 
 	return nil
@@ -573,6 +575,8 @@ func NewNewCmd() *cobra.Command {
 
 			args.yes = args.yes || env.SkipConfirmations.Value()
 			args.interactive = isInteractive()
+			args.stdout = cmd.OutOrStdout()
+			args.stderr = cmd.ErrOrStderr()
 			return runNew(ctx, args)
 		},
 	}
@@ -853,7 +857,9 @@ func makePromptValidator(prompt plugin.RuntimeOptionPrompt) func(string) error {
 }
 
 // printNextSteps prints out a series of commands that the user needs to run before their stack is able to be updated.
-func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOnly bool, opts display.Options) {
+func printNextSteps(
+	w io.Writer, proj *workspace.Project, originalCwd, cwd string, generateOnly bool, opts display.Options,
+) {
 	var commands []string
 
 	// If the target working directory is not the same as our current WD, tell the user to
@@ -886,8 +892,8 @@ func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOn
 	if len(commands) == 0 { // No additional commands need to be run.
 		deployMsg := "To perform an initial deployment, run `pulumi up`"
 		deployMsg = colors.Highlight(deployMsg, "pulumi up", colors.BrightBlue+colors.Bold)
-		fmt.Println(opts.Color.Colorize(deployMsg))
-		fmt.Println()
+		fmt.Fprintln(w, opts.Color.Colorize(deployMsg))
+		fmt.Fprintln(w)
 		return
 	}
 
@@ -895,23 +901,23 @@ func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOn
 		deployMsg := fmt.Sprintf("To perform an initial deployment, run '%s', then, run `pulumi up`", commands[0])
 		deployMsg = colors.Highlight(deployMsg, commands[0], colors.BrightBlue+colors.Bold)
 		deployMsg = colors.Highlight(deployMsg, "pulumi up", colors.BrightBlue+colors.Bold)
-		fmt.Println(opts.Color.Colorize(deployMsg))
-		fmt.Println()
+		fmt.Fprintln(w, opts.Color.Colorize(deployMsg))
+		fmt.Fprintln(w)
 		return
 	}
 
 	// One or more additional commands needs to be run.
-	fmt.Println("To perform an initial deployment, run the following commands:")
-	fmt.Println()
+	fmt.Fprintln(w, "To perform an initial deployment, run the following commands:")
+	fmt.Fprintln(w)
 	for i, cmd := range commands {
 		cmdColors := colors.BrightBlue + colors.Bold + cmd + colors.Reset
-		fmt.Printf("   %d. %s\n", i+1, opts.Color.Colorize(cmdColors))
+		fmt.Fprintf(w, "   %d. %s\n", i+1, opts.Color.Colorize(cmdColors))
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 
 	upMsg := colors.Highlight("Then, run `pulumi up`", "pulumi up", colors.BrightBlue+colors.Bold)
-	fmt.Println(opts.Color.Colorize(upMsg))
-	fmt.Println()
+	fmt.Fprintln(w, opts.Color.Colorize(upMsg))
+	fmt.Fprintln(w)
 }
 
 // compareStackProjectName takes a stack name and a project name and returns an error if they are not the same.

--- a/pkg/cmd/pulumi/project/newcmd/new_ai.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_ai.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -112,6 +113,7 @@ func runAINew(
 
 func sendPromptToPulumiAI(
 	ctx context.Context,
+	stdout io.Writer,
 	backend httpstate.Backend,
 	promptMessage string,
 	conversationID string,
@@ -133,23 +135,23 @@ func sendPromptToPulumiAI(
 		ConversationID: conversationID,
 		ConnectionID:   connectionID,
 	}
-	fmt.Println("Sending prompt to Pulumi AI...")
+	fmt.Fprintln(stdout, "Sending prompt to Pulumi AI...")
 	res, err := backend.PromptAI(ctx, requestBody)
 	if err != nil {
 		return "", "", "", err
 	}
 	defer res.Body.Close()
 	reader := bufio.NewReader(res.Body)
-	fmt.Println("Pulumi AI response:")
+	fmt.Fprintln(stdout, "Pulumi AI response:")
 	for {
 		chunk, err := reader.ReadByte()
 		if err != nil && err.Error() != "EOF" {
 			return "", "", "", err
 		}
-		fmt.Print(string(chunk))
+		fmt.Fprint(stdout, string(chunk))
 		if err != nil && err.Error() == "EOF" {
 			// Add a newline to ensure we don't overwrite the last line of the Pulumi AI response
-			fmt.Println()
+			fmt.Fprintln(stdout)
 			break
 		}
 	}
@@ -157,7 +159,7 @@ func sendPromptToPulumiAI(
 	connectionID = res.Header.Get("x-connection-id")
 	projectURL := parsedURL.JoinPath("api", "project", url.PathEscape(conversationID+".zip")).String()
 	conversationURL := parsedURL.JoinPath("conversations", conversationID).String()
-	fmt.Println("View this conversation at: ", conversationURL)
+	fmt.Fprintln(stdout, "View this conversation at: ", conversationURL)
 	return projectURL, connectionID, conversationID, nil
 }
 
@@ -175,12 +177,14 @@ func isValidAiPrompt(prompt string) error {
 	return nil
 }
 
-func promptForAiMessage(prompt promptForValueFunc, opts display.Options, isInitial bool) (string, error) {
+func promptForAiMessage(
+	stdout io.Writer, prompt promptForValueFunc, opts display.Options, isInitial bool,
+) (string, error) {
 	for {
 		if isInitial {
-			fmt.Println(initialPromptPrompt)
+			fmt.Fprintln(stdout, initialPromptPrompt)
 		} else {
-			fmt.Println(refinePromptPrompt)
+			fmt.Fprintln(stdout, refinePromptPrompt)
 		}
 		promptMessage, err := prompt(false, "", "", false, isValidAiPrompt, opts)
 		if err != nil {
@@ -213,7 +217,7 @@ func runAINewPromptStep(
 	var promptMessage string
 	if args.aiPrompt == "" || currentContinueSelection != "" {
 		isInitial := currentContinueSelection == ""
-		promptMessage, err = promptForAiMessage(args.prompt, opts, isInitial)
+		promptMessage, err = promptForAiMessage(args.stdout, args.prompt, opts, isInitial)
 		if err != nil {
 			return "", "", "", "", err
 		}
@@ -222,6 +226,7 @@ func runAINewPromptStep(
 	}
 	conversationURLReturn, connectionIDReturn, conversationIDReturn, err = sendPromptToPulumiAI(
 		ctx,
+		args.stdout,
 		backend,
 		promptMessage,
 		conversationID,
@@ -233,7 +238,7 @@ func runAINewPromptStep(
 	}
 	if connectionID != "" && connectionID != connectionIDReturn {
 		connectionIDReturn = connectionID
-		fmt.Println("Connection ID changed, please restart the prompt")
+		fmt.Fprintln(args.stdout, "Connection ID changed, please restart the prompt")
 	}
 	if conversationID != "" && conversationID != conversationIDReturn {
 		return "", "", "", "", fmt.Errorf("conversation id %s changed to %s", conversationID, conversationIDReturn)

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -78,7 +78,8 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 	}
 
 	if b.SupportsOrganizations() {
-		fmt.Print("Please enter your desired stack name.\n" +
+		// Helper used by multiple commands; uses process stdout.
+		fmt.Print("Please enter your desired stack name.\n" + //nolint:forbidigo
 			"To create a stack in an organization, " +
 			"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
 	}
@@ -96,7 +97,7 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		if err != nil {
 			if !yes {
 				// Let the user know about the error and loop around to try again.
-				fmt.Printf("Sorry, could not create stack '%s': %v\n", stackName, err)
+				fmt.Printf("Sorry, could not create stack '%s': %v\n", stackName, err) //nolint:forbidigo
 				continue
 			}
 			return nil, err

--- a/pkg/cmd/pulumi/project/project_ls.go
+++ b/pkg/cmd/pulumi/project/project_ls.go
@@ -142,42 +142,43 @@ func newProjectLsCmd() *cobra.Command {
 				results = append(results, project)
 			}
 
+			out := cmd.OutOrStdout()
 			// If no projects, return empty array for JSON output
 			if len(results) == 0 {
 				if jsonOut {
-					fmt.Println("[]")
+					fmt.Fprintln(out, "[]")
 					return nil
 				}
 
 				if orgName != "" {
-					fmt.Println("No projects found in organization", orgName)
+					fmt.Fprintln(out, "No projects found in organization", orgName)
 				} else {
-					fmt.Println("No projects found")
+					fmt.Fprintln(out, "No projects found")
 				}
 				return nil
 			}
 
 			// Output the results
 			if jsonOut {
-				out, err := json.MarshalIndent(results, "", "    ")
+				marshaled, err := json.MarshalIndent(results, "", "    ")
 				if err != nil {
 					return err
 				}
-				fmt.Println(string(out))
+				fmt.Fprintln(out, string(marshaled))
 			} else {
 				// Display header
 				if orgName != "" {
-					fmt.Printf("PROJECTS IN ORGANIZATION %s:\n", orgName)
+					fmt.Fprintf(out, "PROJECTS IN ORGANIZATION %s:\n", orgName)
 				} else {
-					fmt.Println("PROJECTS:")
+					fmt.Fprintln(out, "PROJECTS:")
 				}
 
 				// Display all projects consistently with organization if available
 				for _, result := range results {
 					if result.Organization != "" {
-						fmt.Printf("  %s (org: %s, stacks: %d)\n", result.Name, result.Organization, result.StackCount)
+						fmt.Fprintf(out, "  %s (org: %s, stacks: %d)\n", result.Name, result.Organization, result.StackCount)
 					} else {
-						fmt.Printf("  %s (stacks: %d)\n", result.Name, result.StackCount)
+						fmt.Fprintf(out, "  %s (stacks: %d)\n", result.Name, result.StackCount)
 					}
 				}
 			}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -118,7 +119,7 @@ func (c *commandGroup) commandWidth() int {
 	return width
 }
 
-func displayCommands(cgs []commandGroup) {
+func displayCommands(w io.Writer, cgs []commandGroup) {
 	width := 0
 	for _, cg := range cgs {
 		newWidth := cg.commandWidth()
@@ -131,15 +132,15 @@ func displayCommands(cgs []commandGroup) {
 		if cg.commandWidth() == 0 {
 			continue
 		}
-		fmt.Printf("%s:\n", cg.Name)
+		fmt.Fprintf(w, "%s:\n", cg.Name)
 		for _, com := range cg.Commands {
 			if com.Hidden {
 				continue
 			}
 			spacing := strings.Repeat(" ", width-len(com.Name()))
-			fmt.Println("  " + com.Name() + spacing + strings.Repeat(" ", 8) + com.Short)
+			fmt.Fprintln(w, "  "+com.Name()+spacing+strings.Repeat(" ", 8)+com.Short)
 		}
-		fmt.Println()
+		fmt.Fprintln(w)
 	}
 }
 
@@ -151,31 +152,32 @@ func setCommandGroups(cmd *cobra.Command, rootCgs []commandGroup) {
 	}
 
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		w := c.OutOrStdout()
 		header := c.Long
 		if header == "" {
 			header = c.Short
 		}
 
 		if header != "" {
-			fmt.Println(strings.TrimSpace(header))
-			fmt.Println()
+			fmt.Fprintln(w, strings.TrimSpace(header))
+			fmt.Fprintln(w)
 		}
 
 		if c != cmd.Root() {
-			fmt.Print(c.UsageString())
+			fmt.Fprint(w, c.UsageString())
 			return
 		}
 
-		fmt.Println("Usage:")
-		fmt.Println("  pulumi [command]")
-		fmt.Println()
+		fmt.Fprintln(w, "Usage:")
+		fmt.Fprintln(w, "  pulumi [command]")
+		fmt.Fprintln(w)
 
-		displayCommands(rootCgs)
+		displayCommands(w, rootCgs)
 
-		fmt.Println("Flags:")
-		fmt.Println(cmd.Flags().FlagUsages())
+		fmt.Fprintln(w, "Flags:")
+		fmt.Fprintln(w, cmd.Flags().FlagUsages())
 
-		fmt.Println("Use `pulumi [command] --help` for more information about a command.")
+		fmt.Fprintln(w, "Use `pulumi [command] --help` for more information about a command.")
 	})
 }
 
@@ -205,6 +207,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 
 	updateCheckResult := make(chan *updateCheckResult)
 
+	var cmd *cobra.Command
 	cleanup := func() {
 		// Logger.Close is a no-op when autoLogger is nil.
 		if err := autoLogger.Close(); err != nil {
@@ -224,7 +227,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 				logging.Warningf("could not find the log file: %s", err)
 				logging.Flush()
 			} else {
-				fmt.Fprintf(os.Stderr, "The log file for this run is at %s\n", logFile)
+				fmt.Fprintf(cmd.ErrOrStderr(), "The log file for this run is at %s\n", logFile)
 			}
 		}
 
@@ -239,7 +242,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	// to understand ANSI escape codes.
 	_, _, _ = term.StdStreams()
 
-	cmd := &cobra.Command{
+	cmd = &cobra.Command{
 		Use:           "pulumi",
 		Short:         "Pulumi command line",
 		SilenceErrors: true,

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -66,7 +66,7 @@ or a JSON/YAML schema file. Pass "-" to read a JSON schema from stdin.`,
 			_, diags, err := schema.BindSpec(*spec, nil, schema.ValidationOptions{
 				AllowDanglingReferences: schemaCheckArgs.allowDanglingReferences,
 			})
-			diagWriter := hcl.NewDiagnosticTextWriter(os.Stderr, nil, 0, true)
+			diagWriter := hcl.NewDiagnosticTextWriter(cmd.ErrOrStderr(), nil, 0, true)
 			wrErr := diagWriter.WriteDiagnostics(diags)
 			contract.IgnoreError(wrErr)
 			if err == nil && diags.HasErrors() {

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -150,9 +150,11 @@ func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, 
 	}
 
 	// No stack was found.  If we're in a terminal, prompt to create one.
+	// Writes go to the process streams: this helper is shared across many
+	// commands and is only reached in interactive terminal sessions.
 	if lopt.OfferNew() && cmdutil.Interactive() {
-		fmt.Printf("The stack '%s' does not exist.\n", stackName)
-		fmt.Printf("\n")
+		fmt.Printf("The stack '%s' does not exist.\n", stackName) //nolint:forbidigo
+		fmt.Printf("\n")                                          //nolint:forbidigo
 		_, err = cmdutil.ReadConsole("If you would like to create this stack now, please press <ENTER>, otherwise " +
 			"press ^C")
 		if err != nil {
@@ -410,7 +412,8 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	}
 
 	if escEnvironment != "" {
-		fmt.Printf("Created environment %s for stack configuration\n", escEnvironment)
+		// Shared helper without a *cobra.Command writer; uses process stdout.
+		fmt.Printf("Created environment %s for stack configuration\n", escEnvironment) //nolint:forbidigo
 	}
 
 	// Now that we've created the stack, we'll write out any necessary configuration changes.

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -86,7 +85,7 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
-			return runStack(ctx, s, os.Stdout, args)
+			return runStack(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
 
@@ -217,7 +216,7 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 			}
 		}
 
-		ui.PrintTable(cmdutil.Table{
+		ui.FprintTable(out, cmdutil.Table{
 			Headers: []string{"TYPE", "NAME"},
 			Rows:    rows,
 			Prefix:  "    ",
@@ -226,7 +225,7 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 		outputs, err := getStackOutputs(snap, args.showSecrets)
 		if err == nil {
 			fmt.Fprintf(out, "\n")
-			_ = fprintStackOutputs(os.Stdout, outputs)
+			_ = fprintStackOutputs(out, outputs)
 		}
 
 		if args.showSecrets {

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -69,6 +68,9 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 			"* `pulumi stack change-secrets-provider \"hashivault://mykey\"`",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if scspcmd.stdout == nil {
+				scspcmd.stdout = cmd.OutOrStdout()
+			}
 			return scspcmd.Run(ctx, args)
 		},
 	}
@@ -89,9 +91,6 @@ func newStackChangeSecretsProviderCmd() *cobra.Command {
 
 func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string) error {
 	stdout := cmd.stdout
-	if stdout == nil {
-		stdout = os.Stdout
-	}
 	if cmd.secretsProvider == nil {
 		cmd.secretsProvider = backend_secrets.DefaultProvider
 	}

--- a/pkg/cmd/pulumi/stack/stack_drift_list.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_list.go
@@ -245,7 +245,7 @@ func (c *driftListCmd) renderTable(runs []apitype.DriftRun, total int) error {
 	// Let go-pretty wrap columns to fit the terminal. Fixed-width columns
 	// (CREATED, STATUS, DRIFT) are short enough to never need wrapping.
 	// ID, DETECT, and REMEDIATE get max widths so they wrap if needed.
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(c.w)
 	// CREATED(25) + STATUS(11) + DRIFT(5) + borders(~22) = 63 fixed
 	flexible := cols - 63
 	if flexible < 30 {

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func newStackExportCmd() *cobra.Command {
@@ -93,12 +94,14 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Read from stdin or a specified file.
-			writer := os.Stdout
+			writer := cmd.OutOrStdout()
 			if file != "" {
-				writer, err = os.Create(file)
+				f, err := os.Create(file)
 				if err != nil {
 					return fmt.Errorf("could not open file: %w", err)
 				}
+				defer contract.IgnoreClose(f)
+				writer = f
 			}
 
 			if showSecrets {

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -17,6 +17,7 @@ package stack
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -106,10 +107,10 @@ This command displays data about previous updates for a stack.`,
 			}
 
 			if jsonOut {
-				return displayUpdatesJSON(updates, decrypter)
+				return displayUpdatesJSON(cmd.OutOrStdout(), updates, decrypter)
 			}
 
-			return displayUpdatesConsole(updates, page, opts, showFullDates)
+			return displayUpdatesConsole(cmd.OutOrStdout(), updates, page, opts, showFullDates)
 		},
 	}
 
@@ -214,38 +215,40 @@ func buildUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter) 
 	return updatesJSON, nil
 }
 
-func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter) error {
+func displayUpdatesJSON(w io.Writer, updates []backend.UpdateInfo, decrypter config.Decrypter) error {
 	updatesJSON, err := buildUpdatesJSON(updates, decrypter)
 	if err != nil {
 		return err
 	}
-	return ui.PrintJSON(updatesJSON)
+	return ui.FprintJSON(w, updatesJSON)
 }
 
-func displayUpdatesConsole(updates []backend.UpdateInfo, page int, opts display.Options, noHumanize bool) error {
+func displayUpdatesConsole(
+	w io.Writer, updates []backend.UpdateInfo, page int, opts display.Options, noHumanize bool,
+) error {
 	if len(updates) == 0 {
 		if page > 1 {
-			fmt.Printf("No stack updates found on page '%d'\n", page)
+			fmt.Fprintf(w, "No stack updates found on page '%d'\n", page)
 			return nil
 		}
-		fmt.Println("Stack has never been updated")
+		fmt.Fprintln(w, "Stack has never been updated")
 		return nil
 	}
 
 	printResourceChanges := func(background, text, sign, reset string, amount int) {
 		msg := opts.Color.Colorize(fmt.Sprintf("%s%s%s%v%s", background, text, sign, amount, reset))
-		fmt.Print(msg)
+		fmt.Fprint(w, msg)
 	}
 
 	for _, update := range updates {
-		fmt.Printf("Version: %d\n", update.Version)
-		fmt.Printf("UpdateKind: %v\n", update.Kind)
+		fmt.Fprintf(w, "Version: %d\n", update.Version)
+		fmt.Fprintf(w, "UpdateKind: %v\n", update.Kind)
 		if update.Result == "succeeded" {
-			fmt.Print(opts.Color.Colorize(fmt.Sprintf("%sStatus: %v%s\n", colors.Green, update.Result, colors.Reset)))
+			fmt.Fprint(w, opts.Color.Colorize(fmt.Sprintf("%sStatus: %v%s\n", colors.Green, update.Result, colors.Reset)))
 		} else {
-			fmt.Print(opts.Color.Colorize(fmt.Sprintf("%sStatus: %v%s\n", colors.Red, update.Result, colors.Reset)))
+			fmt.Fprint(w, opts.Color.Colorize(fmt.Sprintf("%sStatus: %v%s\n", colors.Red, update.Result, colors.Reset)))
 		}
-		fmt.Printf("Message: %v\n", update.Message)
+		fmt.Fprintf(w, "Message: %v\n", update.Message)
 
 		printResourceChanges(colors.GreenBackground, colors.Black, "+", colors.Reset, update.ResourceChanges["create"])
 		printResourceChanges(colors.RedBackground, colors.Black, "-", colors.Reset, update.ResourceChanges["delete"])
@@ -261,7 +264,7 @@ func displayUpdatesConsole(updates []backend.UpdateInfo, page int, opts display.
 		}
 		timeEnd := time.Unix(update.EndTime, 0)
 		duration := timeEnd.Sub(timeStart)
-		fmt.Printf("%sUpdated %s took %s\n", " ", timeCreated, duration)
+		fmt.Fprintf(w, "%sUpdated %s took %s\n", " ", timeCreated, duration)
 
 		isEmpty := func(s string) bool {
 			return len(strings.TrimSpace(s)) == 0
@@ -274,13 +277,13 @@ func displayUpdatesConsole(updates []backend.UpdateInfo, page int, opts display.
 		indent := 4
 		for _, k := range keys {
 			if k == backend.GitHead && !isEmpty(update.Environment[k]) {
-				fmt.Print(opts.Color.Colorize(
+				fmt.Fprint(w, opts.Color.Colorize(
 					fmt.Sprintf("%*s%s%s: %s%s\n", indent, "", colors.Yellow, k, update.Environment[k], colors.Reset)))
 			} else if !isEmpty(update.Environment[k]) {
-				fmt.Printf("%*s%s: %s\n", indent, "", k, update.Environment[k])
+				fmt.Fprintf(w, "%*s%s: %s\n", indent, "", k, update.Environment[k])
 			}
 		}
-		fmt.Println("")
+		fmt.Fprintln(w, "")
 	}
 
 	return nil

--- a/pkg/cmd/pulumi/stack/stack_history_events.go
+++ b/pkg/cmd/pulumi/stack/stack_history_events.go
@@ -304,7 +304,7 @@ func renderHistoryEventsTable(
 		return nil
 	}
 
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(w)
 	// Borders and separators take ~3 chars per column plus 1 outer border each side.
 	borderWidth := 3*3 + 1
 	detailsWidth := cols - borderWidth - historyEventsFixedColsWidth

--- a/pkg/cmd/pulumi/stack/stack_init.go
+++ b/pkg/cmd/pulumi/stack/stack_init.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -73,6 +74,7 @@ func newStackInitCmd() *cobra.Command {
 			"* `pulumi stack init --copy-config-from dev`",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			sicmd.stdout = cmd.OutOrStdout()
 			return sicmd.Run(ctx, args)
 		},
 	}
@@ -110,6 +112,7 @@ type stackInitCmd struct {
 	noSelect        bool
 	teams           []string
 	remoteConfig    bool
+	stdout          io.Writer
 
 	// currentBackend is a reference to the top-level currentBackend function.
 	// This is used to override the default implementation for testing purposes.
@@ -160,8 +163,8 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 
 	if cmd.stackName == "" && cmdutil.Interactive() {
 		if b.SupportsOrganizations() {
-			fmt.Print("Please enter your desired stack name.\n" +
-				"To create a stack in an organization, " +
+			fmt.Fprint(cmd.stdout, "Please enter your desired stack name.\n"+
+				"To create a stack in an organization, "+
 				"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
 		}
 

--- a/pkg/cmd/pulumi/stack/stack_ls.go
+++ b/pkg/cmd/pulumi/stack/stack_ls.go
@@ -103,6 +103,9 @@ type stackLSArgs struct {
 }
 
 func runStackLS(ctx context.Context, args stackLSArgs) error {
+	if args.stdout == nil {
+		args.stdout = io.Discard
+	}
 	// Build up the stack filters. We do not support accepting empty strings as filters
 	// from command-line arguments, though the API technically supports it.
 	strPtrIfSet := func(s string) *string {

--- a/pkg/cmd/pulumi/stack/stack_ls.go
+++ b/pkg/cmd/pulumi/stack/stack_ls.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -70,6 +69,7 @@ func newStackLsCmd() *cobra.Command {
 				orgFilter:  orgFilter,
 				projFilter: projFilter,
 				tagFilter:  tagFilter,
+				stdout:     cmd.OutOrStdout(),
 			}
 			return runStackLS(ctx, cmdArgs)
 		},
@@ -103,9 +103,6 @@ type stackLSArgs struct {
 }
 
 func runStackLS(ctx context.Context, args stackLSArgs) error {
-	if args.stdout == nil {
-		args.stdout = os.Stdout
-	}
 	// Build up the stack filters. We do not support accepting empty strings as filters
 	// from command-line arguments, though the API technically supports it.
 	strPtrIfSet := func(s string) *string {
@@ -198,7 +195,7 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 		return formatStackSummariesJSON(b, current, allStackSummaries, args.stdout)
 	}
 
-	return formatStackSummariesConsole(b, current, allStackSummaries)
+	return formatStackSummariesConsole(args.stdout, b, current, allStackSummaries)
 }
 
 // parseTagFilter parses a tag filter into its separate name and value parts, separatedby an equal sign.
@@ -260,7 +257,9 @@ func formatStackSummariesJSON(
 	return ui.FprintJSON(stdout, output)
 }
 
-func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSummaries []backend.StackSummary) error {
+func formatStackSummariesConsole(
+	w io.Writer, b backend.Backend, currentStack string, stackSummaries []backend.StackSummary,
+) error {
 	_, showURLColumn := b.(httpstate.Backend)
 
 	// Header string and formatting options to align columns.
@@ -313,7 +312,7 @@ func formatStackSummariesConsole(b backend.Backend, currentStack string, stackSu
 		rows = append(rows, cmdutil.TableRow{Columns: columns})
 	}
 
-	ui.PrintTable(cmdutil.Table{
+	ui.FprintTable(w, cmdutil.Table{
 		Headers: headers,
 		Rows:    rows,
 	}, nil)

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"runtime"
 	"sort"
 	"strings"
@@ -53,6 +52,9 @@ func newStackOutputCmd() *cobra.Command {
 			"By default, this command lists all output properties exported from a stack.\n" +
 			"If a specific property-name is supplied, just that property's value is shown.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if socmd.Stdout == nil {
+				socmd.Stdout = cmd.OutOrStdout()
+			}
 			return socmd.Run(cmd.Context(), args)
 		},
 	}
@@ -115,10 +117,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 		osys = cmd.OS
 	}
 
-	stdout := io.Writer(os.Stdout)
-	if cmd.Stdout != nil {
-		stdout = cmd.Stdout
-	}
+	stdout := cmd.Stdout
 
 	var outw stackOutputWriter
 	if cmd.shellOut && cmd.jsonOut {

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -101,7 +101,7 @@ func newStackRenameCmd() *cobra.Command {
 				return fmt.Errorf("setting current stack: %w", err)
 			}
 
-			fmt.Printf("Renamed %s to %s\n", s.Ref().String(), newStackRef.String())
+			fmt.Fprintf(cmd.OutOrStdout(), "Renamed %s to %s\n", s.Ref().String(), newStackRef.String())
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -90,7 +90,7 @@ func newStackRmCmd() *cobra.Command {
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
 			if !yes && !ui.ConfirmPrompt(prompt, s.Ref().String(), opts) {
-				return result.FprintBailf(os.Stdout, "confirmation declined")
+				return result.FprintBailf(cmd.OutOrStdout(), "confirmation declined")
 			}
 
 			hasResources, err := backend.RemoveStack(ctx, s, force, removeBackups)
@@ -120,7 +120,7 @@ func newStackRmCmd() *cobra.Command {
 			}
 
 			msg := fmt.Sprintf("%sStack '%s' has been removed!%s", colors.SpecAttention, s.Ref(), colors.Reset)
-			fmt.Println(opts.Color.Colorize(msg))
+			fmt.Fprintln(cmd.OutOrStdout(), opts.Color.Colorize(msg))
 
 			contract.IgnoreError(state.SetCurrentStack(ws, ""))
 			return nil

--- a/pkg/cmd/pulumi/stack/stack_schedule_list.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_list.go
@@ -167,7 +167,7 @@ func renderScheduleListTable(w io.Writer, schedules []apitype.ScheduledAction) e
 	}
 
 	// Let SETTINGS absorb extra width when the terminal is wide.
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(w)
 	borderWidth := 3*len(header) + 1
 	fixedColsWidth := 100
 	settingsWidth := max(cols-borderWidth-fixedColsWidth, 20)

--- a/pkg/cmd/pulumi/stack/stack_schedule_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_remove.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -108,7 +107,7 @@ func runStackScheduleRemove(
 		}
 		prompt := fmt.Sprintf("This will remove the schedule '%s'!", scheduleID)
 		if !ui.ConfirmPrompt(prompt, "remove", opts) {
-			return result.FprintBailf(os.Stdout, "confirmation declined")
+			return result.FprintBailf(w, "confirmation declined")
 		}
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -16,6 +16,7 @@ package stack
 
 import (
 	"fmt"
+	"io"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -86,7 +87,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 
 			tags := s.Tags()
 			if value, ok := tags[name]; ok {
-				fmt.Printf("%v\n", value)
+				fmt.Fprintf(cmd.OutOrStdout(), "%v\n", value)
 				return nil
 			}
 
@@ -133,10 +134,10 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 			tags := s.Tags()
 
 			if jsonOut {
-				return ui.PrintJSON(tags)
+				return ui.FprintJSON(cmd.OutOrStdout(), tags)
 			}
 
-			printStackTags(tags)
+			printStackTags(cmd.OutOrStdout(), tags)
 			return nil
 		},
 	}
@@ -149,7 +150,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 	return cmd
 }
 
-func printStackTags(tags map[apitype.StackTagName]string) {
+func printStackTags(w io.Writer, tags map[apitype.StackTagName]string) {
 	names := slice.Prealloc[string](len(tags))
 	for n := range tags {
 		names = append(names, n)
@@ -161,7 +162,7 @@ func printStackTags(tags map[apitype.StackTagName]string) {
 		rows = append(rows, cmdutil.TableRow{Columns: []string{name, tags[name]}})
 	}
 
-	ui.PrintTable(cmdutil.Table{
+	ui.FprintTable(w, cmdutil.Table{
 		Headers: []string{"NAME", "VALUE"},
 		Rows:    rows,
 	}, nil)

--- a/pkg/cmd/pulumi/stack/stack_unselect.go
+++ b/pkg/cmd/pulumi/stack/stack_unselect.go
@@ -47,9 +47,9 @@ func newStackUnselectCmd() *cobra.Command {
 				err = currentWorkspace.Save()
 				if err == nil {
 					// saving changes was successful
-					fmt.Println("Stack was unselected")
+					fmt.Fprintln(cmd.OutOrStdout(), "Stack was unselected")
 				} else {
-					fmt.Printf("Could not unselect the current stack from the workspace: %s", err)
+					fmt.Fprintf(cmd.OutOrStdout(), "Could not unselect the current stack from the workspace: %s", err)
 				}
 
 				return err

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -279,7 +279,7 @@ func renderWebhookListTable(w io.Writer, webhooks []apitype.Webhook) error {
 	// Wrap URL, EVENT GROUPS, and EVENTS to fit the terminal.
 	// Compute actual widths of fixed columns from the data so flex columns
 	// get an accurate share of the remaining space.
-	cols := cmdCmd.StdoutWidth()
+	cols := cmdCmd.WriterWidth(w)
 	borderWidth := 3*len(header) + 1
 	idWidth, nameWidth, activeWidth, formatWidth := len("ID"), len("NAME"), len("ACTIVE"), len("FORMAT")
 	for _, r := range rows {

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -109,7 +109,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 			webhookArgs, err := resolveNewArgs(
-				skipPrompts, name, url, format,
+				cmd.OutOrStdout(), skipPrompts, name, url, format,
 				filters, groups, opts,
 			)
 			if err != nil {
@@ -270,6 +270,7 @@ func filtersNotCoveredByGroups(selectedGroups []string) []string {
 
 // resolveNewArgs prompts for any required values not provided via flags.
 func resolveNewArgs(
+	stdout io.Writer,
 	skipPrompts bool,
 	name, url, format string,
 	filters, groups []string,
@@ -299,7 +300,7 @@ func resolveNewArgs(
 	// URL is required.
 	if url == "" {
 		if !skipPrompts {
-			fmt.Println("Enter the URL that will receive webhook payloads " +
+			fmt.Fprintln(stdout, "Enter the URL that will receive webhook payloads "+
 				"(e.g. https://example.com/webhook).")
 		}
 		urlErrMsg := "a payload URL is required (use --url)"

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -209,7 +210,7 @@ func TestStackWebhookNew_ResolveArgs_Yes(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true and --name/--url set, should use values without prompting.
-	args, err := resolveNewArgs(true, "My Hook", "https://example.com", "raw",
+	args, err := resolveNewArgs(io.Discard, true, "My Hook", "https://example.com", "raw",
 		nil, nil, display.Options{})
 	require.NoError(t, err)
 
@@ -224,7 +225,7 @@ func TestStackWebhookNew_ResolveArgs_YesNoName(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true but no name, should error because name is required.
-	_, err := resolveNewArgs(true, "", "https://example.com", "raw",
+	_, err := resolveNewArgs(io.Discard, true, "", "https://example.com", "raw",
 		nil, nil, display.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "webhook name is required")
@@ -235,7 +236,7 @@ func TestStackWebhookNew_ResolveArgs_YesNoURL(t *testing.T) {
 	t.Parallel()
 
 	// With skipPrompts=true but no URL, should error because URL is required.
-	_, err := resolveNewArgs(true, "My Hook", "", "raw",
+	_, err := resolveNewArgs(io.Discard, true, "My Hook", "", "raw",
 		nil, nil, display.Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "payload URL is required")

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -114,7 +113,7 @@ func runStackWebhookRemove(
 			"This will permanently remove the webhook '%s'!",
 			webhookName)
 		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
-			return result.FprintBailf(os.Stdout, "confirmation declined")
+			return result.FprintBailf(w, "confirmation declined")
 		}
 	}
 

--- a/pkg/cmd/pulumi/state/io.go
+++ b/pkg/cmd/pulumi/state/io.go
@@ -130,7 +130,8 @@ func TotalStateEdit(
 		if err = survey.AskOne(&survey.Confirm{
 			Message: prompt,
 		}, &confirm, ui.SurveyIcons(opts.Color)); err != nil || !confirm {
-			return result.FprintBailf(os.Stdout, "confirmation declined")
+			// Shared helper; uses process stdout when not given a writer.
+			return result.FprintBailf(os.Stdout, "confirmation declined") //nolint:forbidigo
 		}
 	}
 

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -134,11 +134,11 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				}
 			}
 			if all {
-				fmt.Println("Resources deleted")
+				fmt.Fprintln(cmd.OutOrStdout(), "Resources deleted")
 			} else if nDeleted == 1 {
-				fmt.Println("Resource deleted")
+				fmt.Fprintln(cmd.OutOrStdout(), "Resource deleted")
 			} else {
-				fmt.Printf("%d resources deleted\n", nDeleted)
+				fmt.Fprintf(cmd.OutOrStdout(), "%d resources deleted\n", nDeleted)
 			}
 			return nil
 		},

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -79,6 +79,9 @@ a preview showing a diff of the altered state.`,
 			if err != nil {
 				return err
 			}
+			if stateEdit.Stdout == nil {
+				stateEdit.Stdout = cmd.OutOrStdout()
+			}
 			if err := stateEdit.Run(ctx, s); err != nil {
 				return err
 			}
@@ -149,9 +152,6 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 
 	if cmd.Stdin == nil {
 		cmd.Stdin = os.Stdin
-	}
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
 	}
 
 	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
@@ -277,10 +277,13 @@ func openInEditorInternal(editor, filename string) error {
 	}
 	args = append(args, filename)
 
+	// Launching an editor subprocess; wire it to the actual terminal so the
+	// user can interact with it. Using the cobra writers (which may be
+	// buffered or piped) would break vim/emacs/etc.
 	cmd := exec.Command(args[0], args[1:]...) //nolint:gosec
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout //nolint:forbidigo
+	cmd.Stderr = os.Stderr //nolint:forbidigo
 
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(cmd.Stdout, "Failed to exec EDITOR: %v\n", err)

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -121,6 +121,9 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 				StackName: destStack.Ref().FullyQualifiedName().String(),
 			}
 
+			if stateMove.Stdout == nil {
+				stateMove.Stdout = cmd.OutOrStdout()
+			}
 			return stateMove.Run(ctx, sourceStack, destStack, args, sourceSecretsProvider, destSecretsProvider)
 		},
 	}
@@ -148,9 +151,6 @@ func (cmd *stateMoveCmd) Run(
 ) error {
 	if cmd.Stdin == nil {
 		cmd.Stdin = os.Stdin
-	}
-	if cmd.Stdout == nil {
-		cmd.Stdout = os.Stdout
 	}
 	if cmd.ws == nil {
 		cmd.ws = pkgWorkspace.Instance
@@ -457,7 +457,7 @@ func (cmd *stateMoveCmd) Run(
 		case yes:
 		// continue
 		case no:
-			fmt.Println("Confirmation denied, not proceeding with the state move")
+			fmt.Fprintln(cmd.Stdout, "Confirmation denied, not proceeding with the state move")
 			return nil
 		}
 	}

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -152,6 +152,9 @@ func (cmd *stateMoveCmd) Run(
 	if cmd.Stdin == nil {
 		cmd.Stdin = os.Stdin
 	}
+	if cmd.Stdout == nil {
+		cmd.Stdout = io.Discard
+	}
 	if cmd.ws == nil {
 		cmd.ws = pkgWorkspace.Instance
 	}

--- a/pkg/cmd/pulumi/state/state_protect.go
+++ b/pkg/cmd/pulumi/state/state_protect.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -71,12 +72,12 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 			showPrompt := !yes
 
 			if protectAll {
-				return protectAllResources(ctx, sink, ws, stack, showPrompt)
+				return protectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
 			}
 
 			// If URN arguments were provided, use those
 			if len(args) > 0 {
-				return protectMultipleResources(ctx, sink, ws, stack, args, showPrompt)
+				return protectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
 			}
 
 			// Otherwise, use interactive selection
@@ -89,7 +90,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return protectMultipleResources(ctx, sink, ws, stack, []string{string(urn)}, showPrompt)
+			return protectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, []string{string(urn)}, showPrompt)
 		},
 	}
 
@@ -111,7 +112,8 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 }
 
 func protectAllResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
 ) error {
 	err := runTotalStateEditWithPrompt(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -133,7 +135,7 @@ func protectAllResources(
 	if err != nil {
 		return err
 	}
-	fmt.Println("All resources protected")
+	fmt.Fprintln(stdout, "All resources protected")
 	return nil
 }
 
@@ -171,7 +173,8 @@ func protectResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []er
 
 // protectMultipleResources protects multiple resources specified by their URNs.
 func protectMultipleResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
 ) error {
 	return runTotalStateEditWithPrompt(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot,
@@ -179,7 +182,7 @@ func protectMultipleResources(
 			resourceCount, errs := protectResourcesInSnapshot(snap, urns)
 
 			if resourceCount > 0 && len(errs) == 0 {
-				fmt.Printf("%d resources protected\n", resourceCount)
+				fmt.Fprintf(stdout, "%d resources protected\n", resourceCount)
 			}
 
 			if len(errs) > 0 {

--- a/pkg/cmd/pulumi/state/state_rename.go
+++ b/pkg/cmd/pulumi/state/state_rename.go
@@ -241,7 +241,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				return err
 			}
 
-			fmt.Println("Resource renamed")
+			fmt.Fprintln(cmd.OutOrStdout(), "Resource renamed")
 			return nil
 		},
 	}

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -73,9 +73,11 @@ func newStateRepairCommand() *cobra.Command {
 		Args: &stateRepairArgs{
 			Colorizer: cmdutil.GetGlobalColorization(),
 		},
-		Stdin:        os.Stdin,
-		Stdout:       os.Stdout,
-		Stderr:       os.Stderr,
+		Stdin: os.Stdin,
+		// Survey terminal.FileWriter requires a *os.File so we can't thread
+		// the cobra writer here without changing the contract.
+		Stdout:       os.Stdout, //nolint:forbidigo
+		Stderr:       os.Stderr, //nolint:forbidigo
 		Workspace:    pkgWorkspace.Instance,
 		LoginManager: cmdBackend.DefaultLoginManager,
 	}

--- a/pkg/cmd/pulumi/state/state_taint.go
+++ b/pkg/cmd/pulumi/state/state_taint.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -57,7 +58,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 			// If URN arguments were provided, use those:
 			if len(args) > 0 {
-				return taintMultipleResources(ctx, sink, ws, stack, args, showPrompt)
+				return taintMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
 			}
 
 			// Otherwise, use interactive selection:
@@ -78,7 +79,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return taintResource(ctx, sink, ws, stack, urn, showPrompt)
+			return taintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
 		},
 	}
 
@@ -132,7 +133,8 @@ func taintResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []erro
 
 // taintMultipleResources taints multiple resources specified by their URNs.
 func taintMultipleResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
 ) error {
 	return runTotalStateEdit(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -140,7 +142,7 @@ func taintMultipleResources(
 			resourceCount, errs := taintResourcesInSnapshot(snap, urns)
 
 			if resourceCount > 0 && len(errs) == 0 {
-				fmt.Printf("%d resources tainted\n", resourceCount)
+				fmt.Fprintf(stdout, "%d resources tainted\n", resourceCount)
 			}
 
 			if len(errs) > 0 {
@@ -156,7 +158,8 @@ func taintMultipleResources(
 }
 
 func taintResource(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
 ) error {
-	return taintMultipleResources(ctx, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return taintMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
 }

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -56,12 +57,12 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 			showPrompt := !yes
 
 			if unprotectAll {
-				return unprotectAllResources(ctx, sink, ws, stack, showPrompt)
+				return unprotectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
 			}
 
 			// If URN arguments were provided, use those
 			if len(args) > 0 {
-				return unprotectMultipleResources(ctx, sink, ws, stack, args, showPrompt)
+				return unprotectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
 			}
 
 			// Otherwise, use interactive selection
@@ -82,7 +83,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return unprotectResource(ctx, sink, ws, stack, urn, showPrompt)
+			return unprotectResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
 		},
 	}
 
@@ -104,7 +105,8 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 }
 
 func unprotectAllResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
 ) error {
 	err := runTotalStateEdit(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -126,7 +128,7 @@ func unprotectAllResources(
 	if err != nil {
 		return err
 	}
-	fmt.Println("All resources unprotected")
+	fmt.Fprintln(stdout, "All resources unprotected")
 	return nil
 }
 
@@ -164,7 +166,8 @@ func unprotectResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []
 
 // unprotectMultipleResources unprotects multiple resources specified by their URNs.
 func unprotectMultipleResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
 ) error {
 	return runTotalStateEdit(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -172,7 +175,7 @@ func unprotectMultipleResources(
 			resourceCount, errs := unprotectResourcesInSnapshot(snap, urns)
 
 			if resourceCount > 0 && len(errs) == 0 {
-				fmt.Printf("%d resources unprotected\n", resourceCount)
+				fmt.Fprintf(stdout, "%d resources unprotected\n", resourceCount)
 			}
 
 			if len(errs) > 0 {
@@ -188,7 +191,8 @@ func unprotectMultipleResources(
 }
 
 func unprotectResource(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
 ) error {
-	return unprotectMultipleResources(ctx, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return unprotectMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
 }

--- a/pkg/cmd/pulumi/state/state_untaint.go
+++ b/pkg/cmd/pulumi/state/state_untaint.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -57,12 +58,12 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 			showPrompt := !yes
 
 			if untaintAll {
-				return untaintAllResources(ctx, sink, ws, stack, showPrompt)
+				return untaintAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
 			}
 
 			// If URN arguments were provided, use those:
 			if len(args) > 0 {
-				return untaintMultipleResources(ctx, sink, ws, stack, args, showPrompt)
+				return untaintMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
 			}
 
 			// Otherwise, use interactive selection:
@@ -83,7 +84,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return untaintResource(ctx, sink, ws, stack, urn, showPrompt)
+			return untaintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
 		},
 	}
 
@@ -105,7 +106,8 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 }
 
 func untaintAllResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
 ) error {
 	err := runTotalStateEdit(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -127,7 +129,7 @@ func untaintAllResources(
 	if err != nil {
 		return err
 	}
-	fmt.Println("All resources untainted")
+	fmt.Fprintln(stdout, "All resources untainted")
 	return nil
 }
 
@@ -165,7 +167,8 @@ func untaintResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []er
 
 // untaintMultipleResources untaints multiple resources specified by their URNs.
 func untaintMultipleResources(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
 ) error {
 	return runTotalStateEdit(
 		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
@@ -173,7 +176,7 @@ func untaintMultipleResources(
 			resourceCount, errs := untaintResourcesInSnapshot(snap, urns)
 
 			if resourceCount > 0 && len(errs) == 0 {
-				fmt.Printf("%d resources untainted\n", resourceCount)
+				fmt.Fprintf(stdout, "%d resources untainted\n", resourceCount)
 			}
 
 			if len(errs) > 0 {
@@ -189,7 +192,8 @@ func untaintMultipleResources(
 }
 
 func untaintResource(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	ctx context.Context, stdout io.Writer,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
 ) error {
-	return untaintMultipleResources(ctx, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return untaintMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
 }

--- a/pkg/cmd/pulumi/trace/convert.go
+++ b/pkg/cmd/pulumi/trace/convert.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -271,7 +271,7 @@ func convertTraceToSamples(root *appdash.Trace, start time.Time, quantum time.Du
 	return result, nil
 }
 
-func convertTraceToPprof(quantum time.Duration, querier appdash.Queryer) error {
+func convertTraceToPprof(w io.Writer, quantum time.Duration, querier appdash.Queryer) error {
 	roots, err := traceRoots(querier)
 	if err != nil {
 		return err
@@ -349,7 +349,7 @@ func convertTraceToPprof(quantum time.Duration, querier appdash.Queryer) error {
 		Function: functions,
 	}
 
-	return p.Write(os.Stdout)
+	return p.Write(w)
 }
 
 type otelSpan struct {
@@ -651,8 +651,8 @@ func (t *otelTrace) getNextSpanID() trace.SpanID {
 	return id
 }
 
-func exportTraceToOtel(querier appdash.Queryer, ignoreLogSpans bool) error {
-	fmt.Printf("converting trace...\n")
+func exportTraceToOtel(w io.Writer, querier appdash.Queryer, ignoreLogSpans bool) error {
+	fmt.Fprintf(w, "converting trace...\n")
 
 	roots, err := traceRoots(querier)
 	if err != nil {
@@ -677,13 +677,13 @@ func exportTraceToOtel(querier appdash.Queryer, ignoreLogSpans bool) error {
 	}
 
 	// Export the results to the collector.
-	fmt.Print("dialing collector...\n")
+	fmt.Fprint(w, "dialing collector...\n")
 	exporter, err := otlptracegrpc.New(context.Background())
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("exporting spans for trace %v...\n", t.id)
+	fmt.Fprintf(w, "exporting spans for trace %v...\n", t.id)
 	spans := t.spans
 	for len(spans) > 0 {
 		batchSize := 1
@@ -696,7 +696,7 @@ func exportTraceToOtel(querier appdash.Queryer, ignoreLogSpans bool) error {
 		spans = spans[batchSize:]
 	}
 
-	fmt.Printf("shutting down...\n")
+	fmt.Fprintf(w, "shutting down...\n")
 	return exporter.Shutdown(context.Background())
 }
 
@@ -720,9 +720,9 @@ func NewConvertTraceCmd() *cobra.Command {
 				return err
 			}
 			if otel {
-				return exportTraceToOtel(store, ignoreLogSpans)
+				return exportTraceToOtel(cmd.OutOrStdout(), store, ignoreLogSpans)
 			}
-			return convertTraceToPprof(quantum, store)
+			return convertTraceToPprof(cmd.OutOrStdout(), quantum, store)
 		},
 	}
 

--- a/pkg/cmd/pulumi/trace/view.go
+++ b/pkg/cmd/pulumi/trace/view.go
@@ -58,7 +58,7 @@ func NewViewTraceCmd() *cobra.Command {
 			}
 			app.Store, app.Queryer = store, store
 
-			fmt.Printf("Displaying trace at %v\n", url)
+			fmt.Fprintf(cmd.OutOrStdout(), "Displaying trace at %v\n", url)
 			return http.ListenAndServe(fmt.Sprintf(":%d", port), app) //nolint:gosec
 		},
 	}

--- a/pkg/cmd/pulumi/ui/json.go
+++ b/pkg/cmd/pulumi/ui/json.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 )
 
 // MakeJSONString turns the given value into a JSON string. If multiline is true, the JSON will be formatted with
@@ -49,11 +48,6 @@ func MakeJSONString(v any, multiline bool) (string, error) {
 	}
 
 	return string(bs), nil
-}
-
-// PrintJSON simply prints out some object, formatted as JSON, using standard indentation.
-func PrintJSON(v any) error {
-	return FprintJSON(os.Stdout, v)
 }
 
 // FprintJSON simply prints out some object, formatted as JSON, using standard indentation.

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -145,7 +145,9 @@ func PromptForValue(
 				if yes {
 					return "", err
 				}
-				fmt.Printf("%s\n", err)
+				// Helper used by many commands; uses process stdout for
+				// interactive prompt validation feedback.
+				fmt.Printf("%s\n", err) //nolint:forbidigo
 				continue
 			}
 		}
@@ -240,7 +242,8 @@ func PromptUserMulti(msg string, options []string, defaultOptions []string, colo
 func ConfirmPrompt(prompt string, name string, opts display.Options) bool {
 	out := opts.Stdout
 	if out == nil {
-		out = os.Stdout
+		// Helper used by many commands without a *cobra.Command writer.
+		out = os.Stdout //nolint:forbidigo
 	}
 	in := opts.Stdin
 	if in == nil {

--- a/pkg/cmd/pulumi/ui/table.go
+++ b/pkg/cmd/pulumi/ui/table.go
@@ -17,15 +17,10 @@ package ui
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
-
-func PrintTable(table cmdutil.Table, opts *cmdutil.TableRenderOptions) {
-	FprintTable(os.Stdout, table, opts)
-}
 
 func FprintTable(out io.Writer, table cmdutil.Table, opts *cmdutil.TableRenderOptions) {
 	fmt.Fprint(out, renderTable(table, opts))

--- a/pkg/cmd/pulumi/version/version.go
+++ b/pkg/cmd/pulumi/version/version.go
@@ -27,7 +27,7 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print Pulumi's version number",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("%v\n", version.Version)
+			fmt.Fprintf(cmd.OutOrStdout(), "%v\n", version.Version)
 			return nil
 		},
 	}


### PR DESCRIPTION
Right now, the lint is limited to enforcing that in `pkg/cmd`.