### PR TITLE
cli/neo: set AI_AGENT=neo for shell-tool child processes

### DIFF
--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -108,6 +109,20 @@ func (s *Shell) resolveDir(dir string) (string, error) {
 	return resolveUnderRoots(s.allowedRoots, dir, false)
 }
 
+// childEnvWithAgent returns parent with any existing AI_AGENT entry stripped
+// and AI_AGENT=neo appended, so nested `pulumi` invocations attribute the run
+// to Neo (via metadata.DetectAIAgent) rather than to whatever upstream agent
+// launched `pulumi neo`.
+func childEnvWithAgent(parent []string) []string {
+	out := make([]string, 0, len(parent)+1)
+	for _, kv := range parent {
+		if !strings.HasPrefix(kv, "AI_AGENT=") {
+			out = append(out, kv)
+		}
+	}
+	return append(out, "AI_AGENT=neo")
+}
+
 // maxOutputBytes is the maximum number of bytes captured from stdout or stderr.
 // Output beyond this limit is silently discarded and "truncated" is set in the result.
 const maxOutputBytes = 1 << 20 // 1 MiB
@@ -143,6 +158,7 @@ func (s *Shell) run(ctx context.Context, command string, dir string, timeout tim
 		cmd = exec.CommandContext(runCtx, "sh", "-c", command)
 	}
 	cmd.Dir = dir
+	cmd.Env = childEnvWithAgent(os.Environ())
 
 	// Run the command in its own process group so we can SIGKILL the whole tree
 	// (and not just sh) when the deadline fires; without this, long-running

--- a/pkg/cmd/pulumi/neo/tools/shell.go
+++ b/pkg/cmd/pulumi/neo/tools/shell.go
@@ -110,9 +110,7 @@ func (s *Shell) resolveDir(dir string) (string, error) {
 }
 
 // childEnvWithAgent returns parent with any existing AI_AGENT entry stripped
-// and AI_AGENT=neo appended, so nested `pulumi` invocations attribute the run
-// to Neo (via metadata.DetectAIAgent) rather than to whatever upstream agent
-// launched `pulumi neo`.
+// and AI_AGENT=neo appended.
 func childEnvWithAgent(parent []string) []string {
 	out := make([]string, 0, len(parent)+1)
 	for _, kv := range parent {

--- a/pkg/cmd/pulumi/neo/tools/shell_test.go
+++ b/pkg/cmd/pulumi/neo/tools/shell_test.go
@@ -285,3 +285,50 @@ func TestNewShell_RejectsExtraRootThatIsAFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "is not a directory")
 }
+
+func TestShell_InjectsAIAgent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh semantics")
+	}
+	// Set AI_AGENT in the parent so we can prove the shell handler overrides
+	// (not just appends to) a pre-existing value. t.Setenv precludes t.Parallel.
+	t.Setenv("AI_AGENT", "claude")
+
+	sh, err := NewShell(t.TempDir())
+	require.NoError(t, err)
+	res, err := sh.Invoke(t.Context(), "shell_execute",
+		json.RawMessage(`{"command":"printenv AI_AGENT"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "neo\n", res.(map[string]any)["stdout"])
+}
+
+func TestChildEnvWithAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty parent", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"AI_AGENT=neo"}, childEnvWithAgent(nil))
+	})
+
+	t.Run("no AI_AGENT in parent", func(t *testing.T) {
+		t.Parallel()
+		parent := []string{"PATH=/usr/bin", "HOME=/home/x"}
+		got := childEnvWithAgent(parent)
+		assert.Equal(t, []string{"PATH=/usr/bin", "HOME=/home/x", "AI_AGENT=neo"}, got)
+	})
+
+	t.Run("strips existing AI_AGENT", func(t *testing.T) {
+		t.Parallel()
+		parent := []string{"PATH=/usr/bin", "AI_AGENT=claude", "HOME=/home/x"}
+		got := childEnvWithAgent(parent)
+		assert.Equal(t, []string{"PATH=/usr/bin", "HOME=/home/x", "AI_AGENT=neo"}, got)
+		// No duplicate AI_AGENT entries.
+		count := 0
+		for _, kv := range got {
+			if strings.HasPrefix(kv, "AI_AGENT=") {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count)
+	})
+}


### PR DESCRIPTION
## Summary

- Set `AI_AGENT=neo` on the env of every child process spawned by Neo's shell tool
- Override (not append): a pre-existing `AI_AGENT` in the parent (e.g. `claude` when Neo is launched from inside Claude Code) is stripped, then `AI_AGENT=neo` is appended.

## Test plan

- [x] `cd pkg && go test -count=1 -tags all ./cmd/pulumi/neo/tools/...`
- [x] `mise exec -- make lint` (0 issues)
- [ ] Manual: launch `pulumi neo` from inside Claude Code, have the agent `shell_execute` `printenv AI_AGENT` — expect `neo`