### PR TITLE
Fix optional nested types in TypedDicts

### DIFF
--- a/changelog/pending/20260518--sdkgen-python--fix-usage-of-argsdict-types-in-typed-dictionaries.yaml
+++ b/changelog/pending/20260518--sdkgen-python--fix-usage-of-argsdict-types-in-typed-dictionaries.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdkgen/python
+  description: Fix usage of ArgsDict types in typed dictionaries

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2556,10 +2556,16 @@ func (mod *modContext) typeString(t schema.Type, opts typeStringOpts) string {
 	case *schema.OptionalType:
 		// Rewrite Optional(Input(T)) to Input(Optional(T)) so that it accepts Output(Optional(T))
 		if lifted := codegen.PushOptionalIntoInput(t); lifted != t {
-			// Clear forDict so the inner Optional renders as Optional, not NotRequired.
-			innerOpts := opts
-			innerOpts.forDict = false
-			result := mod.typeString(lifted, innerOpts)
+			innerElem := lifted.(*schema.InputType).ElementType.(*schema.OptionalType).ElementType
+			elemStr := mod.typeString(innerElem, opts)
+			if elemStr == "Any" {
+				// Drop the Input wrapper around Optional[Any]: Any already accepts Output[...] values
+				if opts.forDict {
+					return "NotRequired[Any]"
+				}
+				return "Optional[Any]"
+			}
+			result := fmt.Sprintf("pulumi.Input[Optional[%s]]", elemStr)
 			if opts.forDict {
 				return fmt.Sprintf("NotRequired[%s]", result)
 			}

--- a/pkg/testing/pulumi-test-language/providers/ref_ref_provider.go
+++ b/pkg/testing/pulumi-test-language/providers/ref_ref_provider.go
@@ -94,6 +94,12 @@ func (p *RefRefProvider) GetSchema(
 			Ref:  "#/types/ref-ref:index:InnerData",
 		},
 	}
+	dataProperties["optionalInner"] = schema.PropertySpec{
+		TypeSpec: schema.TypeSpec{
+			Type: "ref",
+			Ref:  "#/types/ref-ref:index:InnerData",
+		},
+	}
 	dataRequired := append(typeRequired, "innerData")
 
 	resourceProperties := map[string]schema.PropertySpec{

--- a/sdk/go/pulumi-language-go/testdata/extra-types/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
@@ -14,13 +14,14 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type Data struct {
-	BoolArray []bool            `pulumi:"boolArray"`
-	Boolean   bool              `pulumi:"boolean"`
-	Float     float64           `pulumi:"float"`
-	InnerData InnerData         `pulumi:"innerData"`
-	Integer   int               `pulumi:"integer"`
-	String    string            `pulumi:"string"`
-	StringMap map[string]string `pulumi:"stringMap"`
+	BoolArray     []bool            `pulumi:"boolArray"`
+	Boolean       bool              `pulumi:"boolean"`
+	Float         float64           `pulumi:"float"`
+	InnerData     InnerData         `pulumi:"innerData"`
+	Integer       int               `pulumi:"integer"`
+	OptionalInner *InnerData        `pulumi:"optionalInner"`
+	String        string            `pulumi:"string"`
+	StringMap     map[string]string `pulumi:"stringMap"`
 }
 
 // DataInput is an input type that accepts DataArgs and DataOutput values.
@@ -35,13 +36,14 @@ type DataInput interface {
 }
 
 type DataArgs struct {
-	BoolArray pulumi.BoolArrayInput `pulumi:"boolArray"`
-	Boolean   pulumi.BoolInput      `pulumi:"boolean"`
-	Float     pulumi.Float64Input   `pulumi:"float"`
-	InnerData InnerDataInput        `pulumi:"innerData"`
-	Integer   pulumi.IntInput       `pulumi:"integer"`
-	String    pulumi.StringInput    `pulumi:"string"`
-	StringMap pulumi.StringMapInput `pulumi:"stringMap"`
+	BoolArray     pulumi.BoolArrayInput `pulumi:"boolArray"`
+	Boolean       pulumi.BoolInput      `pulumi:"boolean"`
+	Float         pulumi.Float64Input   `pulumi:"float"`
+	InnerData     InnerDataInput        `pulumi:"innerData"`
+	Integer       pulumi.IntInput       `pulumi:"integer"`
+	OptionalInner InnerDataPtrInput     `pulumi:"optionalInner"`
+	String        pulumi.StringInput    `pulumi:"string"`
+	StringMap     pulumi.StringMapInput `pulumi:"stringMap"`
 }
 
 func (DataArgs) ElementType() reflect.Type {
@@ -88,6 +90,10 @@ func (o DataOutput) InnerData() InnerDataOutput {
 
 func (o DataOutput) Integer() pulumi.IntOutput {
 	return o.ApplyT(func(v Data) int { return v.Integer }).(pulumi.IntOutput)
+}
+
+func (o DataOutput) OptionalInner() InnerDataPtrOutput {
+	return o.ApplyT(func(v Data) *InnerData { return v.OptionalInner }).(InnerDataPtrOutput)
 }
 
 func (o DataOutput) String() pulumi.StringOutput {
@@ -139,6 +145,47 @@ func (i InnerDataArgs) ToInnerDataOutputWithContext(ctx context.Context) InnerDa
 	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput)
 }
 
+func (i InnerDataArgs) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i InnerDataArgs) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput).ToInnerDataPtrOutputWithContext(ctx)
+}
+
+// InnerDataPtrInput is an input type that accepts InnerDataArgs, InnerDataPtr and InnerDataPtrOutput values.
+// You can construct a concrete instance of `InnerDataPtrInput` via:
+//
+//	        InnerDataArgs{...}
+//
+//	or:
+//
+//	        nil
+type InnerDataPtrInput interface {
+	pulumi.Input
+
+	ToInnerDataPtrOutput() InnerDataPtrOutput
+	ToInnerDataPtrOutputWithContext(context.Context) InnerDataPtrOutput
+}
+
+type innerDataPtrType InnerDataArgs
+
+func InnerDataPtr(v *InnerDataArgs) InnerDataPtrInput {
+	return (*innerDataPtrType)(v)
+}
+
+func (*innerDataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataPtrOutput)
+}
+
 type InnerDataOutput struct{ *pulumi.OutputState }
 
 func (InnerDataOutput) ElementType() reflect.Type {
@@ -151,6 +198,16 @@ func (o InnerDataOutput) ToInnerDataOutput() InnerDataOutput {
 
 func (o InnerDataOutput) ToInnerDataOutputWithContext(ctx context.Context) InnerDataOutput {
 	return o
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v InnerData) *InnerData {
+		return &v
+	}).(InnerDataPtrOutput)
 }
 
 func (o InnerDataOutput) BoolArray() pulumi.BoolArrayOutput {
@@ -177,9 +234,89 @@ func (o InnerDataOutput) StringMap() pulumi.StringMapOutput {
 	return o.ApplyT(func(v InnerData) map[string]string { return v.StringMap }).(pulumi.StringMapOutput)
 }
 
+type InnerDataPtrOutput struct{ *pulumi.OutputState }
+
+func (InnerDataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) Elem() InnerDataOutput {
+	return o.ApplyT(func(v *InnerData) InnerData {
+		if v != nil {
+			return *v
+		}
+		var ret InnerData
+		return ret
+	}).(InnerDataOutput)
+}
+
+func (o InnerDataPtrOutput) BoolArray() pulumi.BoolArrayOutput {
+	return o.ApplyT(func(v *InnerData) []bool {
+		if v == nil {
+			return nil
+		}
+		return v.BoolArray
+	}).(pulumi.BoolArrayOutput)
+}
+
+func (o InnerDataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *InnerData) *bool {
+		if v == nil {
+			return nil
+		}
+		return &v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o InnerDataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *InnerData) *float64 {
+		if v == nil {
+			return nil
+		}
+		return &v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o InnerDataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *InnerData) *int {
+		if v == nil {
+			return nil
+		}
+		return &v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o InnerDataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *InnerData) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.String
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o InnerDataPtrOutput) StringMap() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *InnerData) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.StringMap
+	}).(pulumi.StringMapOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataInput)(nil)).Elem(), InnerDataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataPtrInput)(nil)).Elem(), InnerDataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
 	pulumi.RegisterOutputType(InnerDataOutput{})
+	pulumi.RegisterOutputType(InnerDataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-proxy-index/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-proxy-index/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
@@ -14,13 +14,14 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type Data struct {
-	BoolArray []bool            `pulumi:"boolArray"`
-	Boolean   bool              `pulumi:"boolean"`
-	Float     float64           `pulumi:"float"`
-	InnerData InnerData         `pulumi:"innerData"`
-	Integer   int               `pulumi:"integer"`
-	String    string            `pulumi:"string"`
-	StringMap map[string]string `pulumi:"stringMap"`
+	BoolArray     []bool            `pulumi:"boolArray"`
+	Boolean       bool              `pulumi:"boolean"`
+	Float         float64           `pulumi:"float"`
+	InnerData     InnerData         `pulumi:"innerData"`
+	Integer       int               `pulumi:"integer"`
+	OptionalInner *InnerData        `pulumi:"optionalInner"`
+	String        string            `pulumi:"string"`
+	StringMap     map[string]string `pulumi:"stringMap"`
 }
 
 // DataInput is an input type that accepts DataArgs and DataOutput values.
@@ -35,13 +36,14 @@ type DataInput interface {
 }
 
 type DataArgs struct {
-	BoolArray pulumi.BoolArrayInput `pulumi:"boolArray"`
-	Boolean   pulumi.BoolInput      `pulumi:"boolean"`
-	Float     pulumi.Float64Input   `pulumi:"float"`
-	InnerData InnerDataInput        `pulumi:"innerData"`
-	Integer   pulumi.IntInput       `pulumi:"integer"`
-	String    pulumi.StringInput    `pulumi:"string"`
-	StringMap pulumi.StringMapInput `pulumi:"stringMap"`
+	BoolArray     pulumi.BoolArrayInput `pulumi:"boolArray"`
+	Boolean       pulumi.BoolInput      `pulumi:"boolean"`
+	Float         pulumi.Float64Input   `pulumi:"float"`
+	InnerData     InnerDataInput        `pulumi:"innerData"`
+	Integer       pulumi.IntInput       `pulumi:"integer"`
+	OptionalInner InnerDataPtrInput     `pulumi:"optionalInner"`
+	String        pulumi.StringInput    `pulumi:"string"`
+	StringMap     pulumi.StringMapInput `pulumi:"stringMap"`
 }
 
 func (DataArgs) ElementType() reflect.Type {
@@ -88,6 +90,10 @@ func (o DataOutput) InnerData() InnerDataOutput {
 
 func (o DataOutput) Integer() pulumi.IntOutput {
 	return o.ApplyT(func(v Data) int { return v.Integer }).(pulumi.IntOutput)
+}
+
+func (o DataOutput) OptionalInner() InnerDataPtrOutput {
+	return o.ApplyT(func(v Data) *InnerData { return v.OptionalInner }).(InnerDataPtrOutput)
 }
 
 func (o DataOutput) String() pulumi.StringOutput {
@@ -139,6 +145,47 @@ func (i InnerDataArgs) ToInnerDataOutputWithContext(ctx context.Context) InnerDa
 	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput)
 }
 
+func (i InnerDataArgs) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i InnerDataArgs) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput).ToInnerDataPtrOutputWithContext(ctx)
+}
+
+// InnerDataPtrInput is an input type that accepts InnerDataArgs, InnerDataPtr and InnerDataPtrOutput values.
+// You can construct a concrete instance of `InnerDataPtrInput` via:
+//
+//	        InnerDataArgs{...}
+//
+//	or:
+//
+//	        nil
+type InnerDataPtrInput interface {
+	pulumi.Input
+
+	ToInnerDataPtrOutput() InnerDataPtrOutput
+	ToInnerDataPtrOutputWithContext(context.Context) InnerDataPtrOutput
+}
+
+type innerDataPtrType InnerDataArgs
+
+func InnerDataPtr(v *InnerDataArgs) InnerDataPtrInput {
+	return (*innerDataPtrType)(v)
+}
+
+func (*innerDataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataPtrOutput)
+}
+
 type InnerDataOutput struct{ *pulumi.OutputState }
 
 func (InnerDataOutput) ElementType() reflect.Type {
@@ -151,6 +198,16 @@ func (o InnerDataOutput) ToInnerDataOutput() InnerDataOutput {
 
 func (o InnerDataOutput) ToInnerDataOutputWithContext(ctx context.Context) InnerDataOutput {
 	return o
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v InnerData) *InnerData {
+		return &v
+	}).(InnerDataPtrOutput)
 }
 
 func (o InnerDataOutput) BoolArray() pulumi.BoolArrayOutput {
@@ -177,9 +234,89 @@ func (o InnerDataOutput) StringMap() pulumi.StringMapOutput {
 	return o.ApplyT(func(v InnerData) map[string]string { return v.StringMap }).(pulumi.StringMapOutput)
 }
 
+type InnerDataPtrOutput struct{ *pulumi.OutputState }
+
+func (InnerDataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) Elem() InnerDataOutput {
+	return o.ApplyT(func(v *InnerData) InnerData {
+		if v != nil {
+			return *v
+		}
+		var ret InnerData
+		return ret
+	}).(InnerDataOutput)
+}
+
+func (o InnerDataPtrOutput) BoolArray() pulumi.BoolArrayOutput {
+	return o.ApplyT(func(v *InnerData) []bool {
+		if v == nil {
+			return nil
+		}
+		return v.BoolArray
+	}).(pulumi.BoolArrayOutput)
+}
+
+func (o InnerDataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *InnerData) *bool {
+		if v == nil {
+			return nil
+		}
+		return &v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o InnerDataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *InnerData) *float64 {
+		if v == nil {
+			return nil
+		}
+		return &v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o InnerDataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *InnerData) *int {
+		if v == nil {
+			return nil
+		}
+		return &v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o InnerDataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *InnerData) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.String
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o InnerDataPtrOutput) StringMap() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *InnerData) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.StringMap
+	}).(pulumi.StringMapOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataInput)(nil)).Elem(), InnerDataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataPtrInput)(nil)).Elem(), InnerDataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
 	pulumi.RegisterOutputType(InnerDataOutput{})
+	pulumi.RegisterOutputType(InnerDataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-ref-ref/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-ref-ref/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
@@ -14,13 +14,14 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type Data struct {
-	BoolArray []bool            `pulumi:"boolArray"`
-	Boolean   bool              `pulumi:"boolean"`
-	Float     float64           `pulumi:"float"`
-	InnerData InnerData         `pulumi:"innerData"`
-	Integer   int               `pulumi:"integer"`
-	String    string            `pulumi:"string"`
-	StringMap map[string]string `pulumi:"stringMap"`
+	BoolArray     []bool            `pulumi:"boolArray"`
+	Boolean       bool              `pulumi:"boolean"`
+	Float         float64           `pulumi:"float"`
+	InnerData     InnerData         `pulumi:"innerData"`
+	Integer       int               `pulumi:"integer"`
+	OptionalInner *InnerData        `pulumi:"optionalInner"`
+	String        string            `pulumi:"string"`
+	StringMap     map[string]string `pulumi:"stringMap"`
 }
 
 // DataInput is an input type that accepts DataArgs and DataOutput values.
@@ -35,13 +36,14 @@ type DataInput interface {
 }
 
 type DataArgs struct {
-	BoolArray pulumi.BoolArrayInput `pulumi:"boolArray"`
-	Boolean   pulumi.BoolInput      `pulumi:"boolean"`
-	Float     pulumi.Float64Input   `pulumi:"float"`
-	InnerData InnerDataInput        `pulumi:"innerData"`
-	Integer   pulumi.IntInput       `pulumi:"integer"`
-	String    pulumi.StringInput    `pulumi:"string"`
-	StringMap pulumi.StringMapInput `pulumi:"stringMap"`
+	BoolArray     pulumi.BoolArrayInput `pulumi:"boolArray"`
+	Boolean       pulumi.BoolInput      `pulumi:"boolean"`
+	Float         pulumi.Float64Input   `pulumi:"float"`
+	InnerData     InnerDataInput        `pulumi:"innerData"`
+	Integer       pulumi.IntInput       `pulumi:"integer"`
+	OptionalInner InnerDataPtrInput     `pulumi:"optionalInner"`
+	String        pulumi.StringInput    `pulumi:"string"`
+	StringMap     pulumi.StringMapInput `pulumi:"stringMap"`
 }
 
 func (DataArgs) ElementType() reflect.Type {
@@ -88,6 +90,10 @@ func (o DataOutput) InnerData() InnerDataOutput {
 
 func (o DataOutput) Integer() pulumi.IntOutput {
 	return o.ApplyT(func(v Data) int { return v.Integer }).(pulumi.IntOutput)
+}
+
+func (o DataOutput) OptionalInner() InnerDataPtrOutput {
+	return o.ApplyT(func(v Data) *InnerData { return v.OptionalInner }).(InnerDataPtrOutput)
 }
 
 func (o DataOutput) String() pulumi.StringOutput {
@@ -139,6 +145,47 @@ func (i InnerDataArgs) ToInnerDataOutputWithContext(ctx context.Context) InnerDa
 	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput)
 }
 
+func (i InnerDataArgs) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i InnerDataArgs) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput).ToInnerDataPtrOutputWithContext(ctx)
+}
+
+// InnerDataPtrInput is an input type that accepts InnerDataArgs, InnerDataPtr and InnerDataPtrOutput values.
+// You can construct a concrete instance of `InnerDataPtrInput` via:
+//
+//	        InnerDataArgs{...}
+//
+//	or:
+//
+//	        nil
+type InnerDataPtrInput interface {
+	pulumi.Input
+
+	ToInnerDataPtrOutput() InnerDataPtrOutput
+	ToInnerDataPtrOutputWithContext(context.Context) InnerDataPtrOutput
+}
+
+type innerDataPtrType InnerDataArgs
+
+func InnerDataPtr(v *InnerDataArgs) InnerDataPtrInput {
+	return (*innerDataPtrType)(v)
+}
+
+func (*innerDataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataPtrOutput)
+}
+
 type InnerDataOutput struct{ *pulumi.OutputState }
 
 func (InnerDataOutput) ElementType() reflect.Type {
@@ -151,6 +198,16 @@ func (o InnerDataOutput) ToInnerDataOutput() InnerDataOutput {
 
 func (o InnerDataOutput) ToInnerDataOutputWithContext(ctx context.Context) InnerDataOutput {
 	return o
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v InnerData) *InnerData {
+		return &v
+	}).(InnerDataPtrOutput)
 }
 
 func (o InnerDataOutput) BoolArray() pulumi.BoolArrayOutput {
@@ -177,9 +234,89 @@ func (o InnerDataOutput) StringMap() pulumi.StringMapOutput {
 	return o.ApplyT(func(v InnerData) map[string]string { return v.StringMap }).(pulumi.StringMapOutput)
 }
 
+type InnerDataPtrOutput struct{ *pulumi.OutputState }
+
+func (InnerDataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) Elem() InnerDataOutput {
+	return o.ApplyT(func(v *InnerData) InnerData {
+		if v != nil {
+			return *v
+		}
+		var ret InnerData
+		return ret
+	}).(InnerDataOutput)
+}
+
+func (o InnerDataPtrOutput) BoolArray() pulumi.BoolArrayOutput {
+	return o.ApplyT(func(v *InnerData) []bool {
+		if v == nil {
+			return nil
+		}
+		return v.BoolArray
+	}).(pulumi.BoolArrayOutput)
+}
+
+func (o InnerDataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *InnerData) *bool {
+		if v == nil {
+			return nil
+		}
+		return &v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o InnerDataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *InnerData) *float64 {
+		if v == nil {
+			return nil
+		}
+		return &v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o InnerDataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *InnerData) *int {
+		if v == nil {
+			return nil
+		}
+		return &v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o InnerDataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *InnerData) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.String
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o InnerDataPtrOutput) StringMap() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *InnerData) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.StringMap
+	}).(pulumi.StringMapOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataInput)(nil)).Elem(), InnerDataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataPtrInput)(nil)).Elem(), InnerDataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
 	pulumi.RegisterOutputType(InnerDataOutput{})
+	pulumi.RegisterOutputType(InnerDataPtrOutput{})
 }

--- a/sdk/go/pulumi-language-go/testdata/published/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
+++ b/sdk/go/pulumi-language-go/testdata/published/sdks/ref-ref-12.0.0/refref/pulumiTypes.go
@@ -14,13 +14,14 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type Data struct {
-	BoolArray []bool            `pulumi:"boolArray"`
-	Boolean   bool              `pulumi:"boolean"`
-	Float     float64           `pulumi:"float"`
-	InnerData InnerData         `pulumi:"innerData"`
-	Integer   int               `pulumi:"integer"`
-	String    string            `pulumi:"string"`
-	StringMap map[string]string `pulumi:"stringMap"`
+	BoolArray     []bool            `pulumi:"boolArray"`
+	Boolean       bool              `pulumi:"boolean"`
+	Float         float64           `pulumi:"float"`
+	InnerData     InnerData         `pulumi:"innerData"`
+	Integer       int               `pulumi:"integer"`
+	OptionalInner *InnerData        `pulumi:"optionalInner"`
+	String        string            `pulumi:"string"`
+	StringMap     map[string]string `pulumi:"stringMap"`
 }
 
 // DataInput is an input type that accepts DataArgs and DataOutput values.
@@ -35,13 +36,14 @@ type DataInput interface {
 }
 
 type DataArgs struct {
-	BoolArray pulumi.BoolArrayInput `pulumi:"boolArray"`
-	Boolean   pulumi.BoolInput      `pulumi:"boolean"`
-	Float     pulumi.Float64Input   `pulumi:"float"`
-	InnerData InnerDataInput        `pulumi:"innerData"`
-	Integer   pulumi.IntInput       `pulumi:"integer"`
-	String    pulumi.StringInput    `pulumi:"string"`
-	StringMap pulumi.StringMapInput `pulumi:"stringMap"`
+	BoolArray     pulumi.BoolArrayInput `pulumi:"boolArray"`
+	Boolean       pulumi.BoolInput      `pulumi:"boolean"`
+	Float         pulumi.Float64Input   `pulumi:"float"`
+	InnerData     InnerDataInput        `pulumi:"innerData"`
+	Integer       pulumi.IntInput       `pulumi:"integer"`
+	OptionalInner InnerDataPtrInput     `pulumi:"optionalInner"`
+	String        pulumi.StringInput    `pulumi:"string"`
+	StringMap     pulumi.StringMapInput `pulumi:"stringMap"`
 }
 
 func (DataArgs) ElementType() reflect.Type {
@@ -88,6 +90,10 @@ func (o DataOutput) InnerData() InnerDataOutput {
 
 func (o DataOutput) Integer() pulumi.IntOutput {
 	return o.ApplyT(func(v Data) int { return v.Integer }).(pulumi.IntOutput)
+}
+
+func (o DataOutput) OptionalInner() InnerDataPtrOutput {
+	return o.ApplyT(func(v Data) *InnerData { return v.OptionalInner }).(InnerDataPtrOutput)
 }
 
 func (o DataOutput) String() pulumi.StringOutput {
@@ -139,6 +145,47 @@ func (i InnerDataArgs) ToInnerDataOutputWithContext(ctx context.Context) InnerDa
 	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput)
 }
 
+func (i InnerDataArgs) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i InnerDataArgs) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataOutput).ToInnerDataPtrOutputWithContext(ctx)
+}
+
+// InnerDataPtrInput is an input type that accepts InnerDataArgs, InnerDataPtr and InnerDataPtrOutput values.
+// You can construct a concrete instance of `InnerDataPtrInput` via:
+//
+//	        InnerDataArgs{...}
+//
+//	or:
+//
+//	        nil
+type InnerDataPtrInput interface {
+	pulumi.Input
+
+	ToInnerDataPtrOutput() InnerDataPtrOutput
+	ToInnerDataPtrOutputWithContext(context.Context) InnerDataPtrOutput
+}
+
+type innerDataPtrType InnerDataArgs
+
+func InnerDataPtr(v *InnerDataArgs) InnerDataPtrInput {
+	return (*innerDataPtrType)(v)
+}
+
+func (*innerDataPtrType) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return i.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (i *innerDataPtrType) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(InnerDataPtrOutput)
+}
+
 type InnerDataOutput struct{ *pulumi.OutputState }
 
 func (InnerDataOutput) ElementType() reflect.Type {
@@ -151,6 +198,16 @@ func (o InnerDataOutput) ToInnerDataOutput() InnerDataOutput {
 
 func (o InnerDataOutput) ToInnerDataOutputWithContext(ctx context.Context) InnerDataOutput {
 	return o
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o.ToInnerDataPtrOutputWithContext(context.Background())
+}
+
+func (o InnerDataOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v InnerData) *InnerData {
+		return &v
+	}).(InnerDataPtrOutput)
 }
 
 func (o InnerDataOutput) BoolArray() pulumi.BoolArrayOutput {
@@ -177,9 +234,89 @@ func (o InnerDataOutput) StringMap() pulumi.StringMapOutput {
 	return o.ApplyT(func(v InnerData) map[string]string { return v.StringMap }).(pulumi.StringMapOutput)
 }
 
+type InnerDataPtrOutput struct{ *pulumi.OutputState }
+
+func (InnerDataPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**InnerData)(nil)).Elem()
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutput() InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) ToInnerDataPtrOutputWithContext(ctx context.Context) InnerDataPtrOutput {
+	return o
+}
+
+func (o InnerDataPtrOutput) Elem() InnerDataOutput {
+	return o.ApplyT(func(v *InnerData) InnerData {
+		if v != nil {
+			return *v
+		}
+		var ret InnerData
+		return ret
+	}).(InnerDataOutput)
+}
+
+func (o InnerDataPtrOutput) BoolArray() pulumi.BoolArrayOutput {
+	return o.ApplyT(func(v *InnerData) []bool {
+		if v == nil {
+			return nil
+		}
+		return v.BoolArray
+	}).(pulumi.BoolArrayOutput)
+}
+
+func (o InnerDataPtrOutput) Boolean() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *InnerData) *bool {
+		if v == nil {
+			return nil
+		}
+		return &v.Boolean
+	}).(pulumi.BoolPtrOutput)
+}
+
+func (o InnerDataPtrOutput) Float() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *InnerData) *float64 {
+		if v == nil {
+			return nil
+		}
+		return &v.Float
+	}).(pulumi.Float64PtrOutput)
+}
+
+func (o InnerDataPtrOutput) Integer() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *InnerData) *int {
+		if v == nil {
+			return nil
+		}
+		return &v.Integer
+	}).(pulumi.IntPtrOutput)
+}
+
+func (o InnerDataPtrOutput) String() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *InnerData) *string {
+		if v == nil {
+			return nil
+		}
+		return &v.String
+	}).(pulumi.StringPtrOutput)
+}
+
+func (o InnerDataPtrOutput) StringMap() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *InnerData) map[string]string {
+		if v == nil {
+			return nil
+		}
+		return v.StringMap
+	}).(pulumi.StringMapOutput)
+}
+
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*DataInput)(nil)).Elem(), DataArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataInput)(nil)).Elem(), InnerDataArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*InnerDataPtrInput)(nil)).Elem(), InnerDataArgs{})
 	pulumi.RegisterOutputType(DataOutput{})
 	pulumi.RegisterOutputType(InnerDataOutput{})
+	pulumi.RegisterOutputType(InnerDataPtrOutput{})
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/ref-ref-12.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/ref-ref-12.0.0/types/input.ts
@@ -11,6 +11,7 @@ export interface DataArgs {
     float: pulumi.Input<number>;
     innerData: pulumi.Input<inputs.InnerDataArgs>;
     integer: pulumi.Input<number>;
+    optionalInner?: pulumi.Input<inputs.InnerDataArgs | undefined>;
     string: pulumi.Input<string>;
     stringMap: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/ref-ref-12.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/sdks/ref-ref-12.0.0/types/output.ts
@@ -11,6 +11,7 @@ export interface Data {
     float: number;
     innerData: outputs.InnerData;
     integer: number;
+    optionalInner?: outputs.InnerData;
     string: string;
     stringMap: {[key: string]: string};
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/ref-ref-12.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/ref-ref-12.0.0/types/input.ts
@@ -11,6 +11,7 @@ export interface DataArgs {
     float: pulumi.Input<number>;
     innerData: pulumi.Input<inputs.InnerDataArgs>;
     integer: pulumi.Input<number>;
+    optionalInner?: pulumi.Input<inputs.InnerDataArgs | undefined>;
     string: pulumi.Input<string>;
     stringMap: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/ref-ref-12.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/sdks/ref-ref-12.0.0/types/output.ts
@@ -11,6 +11,7 @@ export interface Data {
     float: number;
     innerData: outputs.InnerData;
     integer: number;
+    optionalInner?: outputs.InnerData;
     string: string;
     stringMap: {[key: string]: string};
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/ref-ref-12.0.0/types/input.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/ref-ref-12.0.0/types/input.ts
@@ -11,6 +11,7 @@ export interface DataArgs {
     float: pulumi.Input<number>;
     innerData: pulumi.Input<inputs.InnerDataArgs>;
     integer: pulumi.Input<number>;
+    optionalInner?: pulumi.Input<inputs.InnerDataArgs | undefined>;
     string: pulumi.Input<string>;
     stringMap: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/ref-ref-12.0.0/types/output.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/sdks/ref-ref-12.0.0/types/output.ts
@@ -11,6 +11,7 @@ export interface Data {
     float: number;
     innerData: outputs.InnerData;
     integer: number;
+    optionalInner?: outputs.InnerData;
     string: string;
     stringMap: {[key: string]: string};
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -23,7 +23,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -31,6 +32,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -94,6 +97,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 @pulumi.input_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -26,6 +26,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -45,7 +47,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -53,6 +56,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -88,6 +93,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -23,7 +23,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -31,6 +32,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -94,6 +97,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 @pulumi.input_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -26,6 +26,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -45,7 +47,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -53,6 +56,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -88,6 +93,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -29,6 +29,7 @@ class DataArgsDict(TypedDict):
     integer: pulumi.Input[_builtins.int]
     string: pulumi.Input[_builtins.str]
     string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]
+    optional_inner: NotRequired[pulumi.Input[Optional['InnerDataArgsDict']]]
 
 @pulumi.input_type
 class DataArgs:
@@ -39,7 +40,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -47,6 +49,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -110,6 +114,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 class InnerDataArgsDict(TypedDict):

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -31,6 +31,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -50,7 +52,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -58,6 +61,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -93,6 +98,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -29,6 +29,7 @@ class DataArgsDict(TypedDict):
     integer: pulumi.Input[_builtins.int]
     string: pulumi.Input[_builtins.str]
     string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]
+    optional_inner: NotRequired[pulumi.Input[Optional['InnerDataArgsDict']]]
 
 @pulumi.input_type
 class DataArgs:
@@ -39,7 +40,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -47,6 +49,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -110,6 +114,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 class InnerDataArgsDict(TypedDict):

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -31,6 +31,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -50,7 +52,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -58,6 +61,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -93,6 +98,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -29,6 +29,7 @@ class DataArgsDict(TypedDict):
     integer: pulumi.Input[_builtins.int]
     string: pulumi.Input[_builtins.str]
     string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]
+    optional_inner: NotRequired[pulumi.Input[Optional['InnerDataArgsDict']]]
 
 @pulumi.input_type
 class DataArgs:
@@ -39,7 +40,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -47,6 +49,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -110,6 +114,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 class InnerDataArgsDict(TypedDict):

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -31,6 +31,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -50,7 +52,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -58,6 +61,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -93,6 +98,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/_inputs.py
@@ -29,6 +29,7 @@ class DataArgsDict(TypedDict):
     integer: pulumi.Input[_builtins.int]
     string: pulumi.Input[_builtins.str]
     string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]
+    optional_inner: NotRequired[pulumi.Input[Optional['InnerDataArgsDict']]]
 
 @pulumi.input_type
 class DataArgs:
@@ -39,7 +40,8 @@ class DataArgs:
                  inner_data: pulumi.Input['InnerDataArgs'],
                  integer: pulumi.Input[_builtins.int],
                  string: pulumi.Input[_builtins.str],
-                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
+                 string_map: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]],
+                 optional_inner: pulumi.Input[Optional['InnerDataArgs']] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -47,6 +49,8 @@ class DataArgs:
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -110,6 +114,15 @@ class DataArgs:
     @string_map.setter
     def string_map(self, value: pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]):
         pulumi.set(self, "string_map", value)
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> pulumi.Input[Optional['InnerDataArgs']]:
+        return pulumi.get(self, "optional_inner")
+
+    @optional_inner.setter
+    def optional_inner(self, value: pulumi.Input[Optional['InnerDataArgs']]):
+        pulumi.set(self, "optional_inner", value)
 
 
 class InnerDataArgsDict(TypedDict):

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/ref-ref-12.0.0/pulumi_ref_ref/outputs.py
@@ -31,6 +31,8 @@ class Data(dict):
             suggest = "inner_data"
         elif key == "stringMap":
             suggest = "string_map"
+        elif key == "optionalInner":
+            suggest = "optional_inner"
 
         if suggest:
             pulumi.log.warn(f"Key '{key}' not found in Data. Access the value via the '{suggest}' property getter instead.")
@@ -50,7 +52,8 @@ class Data(dict):
                  inner_data: 'outputs.InnerData',
                  integer: _builtins.int,
                  string: _builtins.str,
-                 string_map: Mapping[str, _builtins.str]):
+                 string_map: Mapping[str, _builtins.str],
+                 optional_inner: Optional['outputs.InnerData'] = None):
         pulumi.set(__self__, "bool_array", bool_array)
         pulumi.set(__self__, "boolean", boolean)
         pulumi.set(__self__, "float", float)
@@ -58,6 +61,8 @@ class Data(dict):
         pulumi.set(__self__, "integer", integer)
         pulumi.set(__self__, "string", string)
         pulumi.set(__self__, "string_map", string_map)
+        if optional_inner is not None:
+            pulumi.set(__self__, "optional_inner", optional_inner)
 
     @_builtins.property
     @pulumi.getter(name="boolArray")
@@ -93,6 +98,11 @@ class Data(dict):
     @pulumi.getter(name="stringMap")
     def string_map(self) -> Mapping[str, _builtins.str]:
         return pulumi.get(self, "string_map")
+
+    @_builtins.property
+    @pulumi.getter(name="optionalInner")
+    def optional_inner(self) -> Optional['outputs.InnerData']:
+        return pulumi.get(self, "optional_inner")
 
 
 @pulumi.output_type

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/_inputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/_inputs.py
@@ -44,7 +44,7 @@ class ConfigMapArgsDict(TypedDict):
     """
     Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
     """
-    metadata: NotRequired[pulumi.Input[Optional['_meta.v1.ObjectMetaArgs']]]
+    metadata: NotRequired[pulumi.Input[Optional['_meta.v1.ObjectMetaArgsDict']]]
     """
     Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
     """

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/_inputs.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/meta/v1/_inputs.py
@@ -131,7 +131,7 @@ class ManagedFieldsEntryArgsDict(TypedDict):
     """
     FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
     """
-    fields_v1: NotRequired[Optional[Any]]
+    fields_v1: NotRequired[Any]
     """
     FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
     """
@@ -321,7 +321,7 @@ class ObjectMetaArgsDict(TypedDict):
     """
     Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
     """
-    managed_fields: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ManagedFieldsEntryArgs']]]]]
+    managed_fields: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ManagedFieldsEntryArgsDict']]]]]
     """
     ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
     """
@@ -335,7 +335,7 @@ class ObjectMetaArgsDict(TypedDict):
 
     Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
     """
-    owner_references: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['OwnerReferenceArgs']]]]]
+    owner_references: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['OwnerReferenceArgsDict']]]]]
     """
     List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
     """

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/_inputs.py
@@ -195,7 +195,7 @@ class KubeClientSettingsArgsDict(TypedDict):
     """
     Maximum queries per second (QPS) to the API server from this client. Default value is 5.
     """
-    rec_test: NotRequired[pulumi.Input[Optional['KubeClientSettingsArgs']]]
+    rec_test: NotRequired[pulumi.Input[Optional['KubeClientSettingsArgsDict']]]
 
 @pulumi.input_type
 class KubeClientSettingsArgs:
@@ -275,7 +275,7 @@ class LayeredTypeArgsDict(TypedDict):
     """
     The question already answered
     """
-    recursive: NotRequired[pulumi.Input[Optional['LayeredTypeArgs']]]
+    recursive: NotRequired[pulumi.Input[Optional['LayeredTypeArgsDict']]]
 
 @pulumi.input_type
 class LayeredTypeArgs:
@@ -382,8 +382,8 @@ class TypArgsDict(TypedDict):
     """
     A test for namespaces (mod main)
     """
-    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgs']]]
-    mod2: NotRequired[pulumi.Input[Optional['_mod2.TypArgs']]]
+    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgsDict']]]
+    mod2: NotRequired[pulumi.Input[Optional['_mod2.TypArgsDict']]]
     val: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/mod2/_inputs.py
@@ -24,7 +24,7 @@ class TypArgsDict(TypedDict):
     """
     A test for namespaces (mod 2)
     """
-    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgs']]]
+    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgsDict']]]
     val: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/_inputs.py
@@ -195,7 +195,7 @@ class KubeClientSettingsArgsDict(TypedDict):
     """
     Maximum queries per second (QPS) to the API server from this client. Default value is 5.
     """
-    rec_test: NotRequired[pulumi.Input[Optional['KubeClientSettingsArgs']]]
+    rec_test: NotRequired[pulumi.Input[Optional['KubeClientSettingsArgsDict']]]
 
 @pulumi.input_type
 class KubeClientSettingsArgs:
@@ -275,7 +275,7 @@ class LayeredTypeArgsDict(TypedDict):
     """
     The question already answered
     """
-    recursive: NotRequired[pulumi.Input[Optional['LayeredTypeArgs']]]
+    recursive: NotRequired[pulumi.Input[Optional['LayeredTypeArgsDict']]]
 
 @pulumi.input_type
 class LayeredTypeArgs:
@@ -382,8 +382,8 @@ class TypArgsDict(TypedDict):
     """
     A test for namespaces (mod main)
     """
-    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgs']]]
-    mod2: NotRequired[pulumi.Input[Optional['_mod2.TypArgs']]]
+    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgsDict']]]
+    mod2: NotRequired[pulumi.Input[Optional['_mod2.TypArgsDict']]]
     val: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/mod2/_inputs.py
@@ -24,7 +24,7 @@ class TypArgsDict(TypedDict):
     """
     A test for namespaces (mod 2)
     """
-    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgs']]]
+    mod1: NotRequired[pulumi.Input[Optional['_mod1.TypArgsDict']]]
     val: NotRequired[pulumi.Input[Optional[_builtins.str]]]
 
 @pulumi.input_type

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -80,13 +80,13 @@ class ObjectWithNodeOptionalInputsArgs:
 
 class ObjectArgsDict(TypedDict):
     bar: NotRequired[pulumi.Input[Optional[_builtins.str]]]
-    configs: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]]
+    configs: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgsDict']]]]]
     foo: NotRequired[pulumi.Input[Optional['Resource']]]
-    others: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]]
+    others: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgsDict']]]]]]]
     """
     List of lists of other objects
     """
-    still_others: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]]
+    still_others: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgsDict']]]]]]]
     """
     Mapping from string to list of some other object
     """

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -81,13 +81,13 @@ class ObjectWithNodeOptionalInputsArgs:
 
 class ObjectArgsDict(TypedDict):
     bar: NotRequired[pulumi.Input[Optional[_builtins.str]]]
-    configs: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgs']]]]]
+    configs: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input['ConfigMapArgsDict']]]]]
     foo: NotRequired[pulumi.Input[Optional['Resource']]]
-    others: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]]
+    others: NotRequired[pulumi.Input[Optional[Sequence[pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgsDict']]]]]]]
     """
     List of lists of other objects
     """
-    still_others: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]]
+    still_others: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgsDict']]]]]]]
     """
     Mapping from string to list of some other object
     """


### PR DESCRIPTION
I broke this in https://github.com/pulumi/pulumi/pull/22552. Nested optional types were not generated with the `Dict` suffix in Python.

There was a codegen test covering this, but the change was lost in the noise. I also added a conformance test, extending `RefRefProvider` to have an optional nested type input. This is a sdk-gen test only, no runtime behaviour is tested.

Fixes https://github.com/pulumi/pulumi/issues/23246