### PR TITLE
docs(contributing): minor grammar fixes (`PR` -> `PRs`, `Here's` -> `Here are`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ $ golangci-lint fmt path/to/file.go
 $ golangci-lint fmt path/to/dir
 ```
 
-We require a changelog entry for all PR that aren't labeled `impact/no-changelog-required`. To generate a new changelog entry, run…
+We require a changelog entry for all PRs that aren't labeled `impact/no-changelog-required`. To generate a new changelog entry, run…
 
 ```bash
 $ make changelog
@@ -77,7 +77,7 @@ Good examples for changelog entries are:
 - Exit immediately from state edit when no change was made
 - Fix root and program paths to always be absolute
 
-Here's some examples of what we're trying to avoid:
+Here are some examples of what we're trying to avoid:
 - Fixes a bug
 - Adds a feature
 - Feature now does something

--- a/changelog/pending/20260518--contributing--fix-grammar-typos.yaml
+++ b/changelog/pending/20260518--contributing--fix-grammar-typos.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: contributing
+  description: Fix minor grammar typos in CONTRIBUTING.md (PR -> PRs, Here's -> Here are)

--- a/changelog/pending/20260518--contributing--fix-grammar-typos.yaml
+++ b/changelog/pending/20260518--contributing--fix-grammar-typos.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: contributing
-  description: Fix minor grammar typos in CONTRIBUTING.md (PR -> PRs, Here's -> Here are)


### PR DESCRIPTION
Two small grammar tweaks in `CONTRIBUTING.md`.

```diff
-We require a changelog entry for all PR that aren't labeled `impact/no-changelog-required`.
+We require a changelog entry for all PRs that aren't labeled `impact/no-changelog-required`.
```

```diff
-Here's some examples of what we're trying to avoid:
+Here are some examples of what we're trying to avoid:
```