### PR TITLE
cli/cloud: add `pulumi insights account scan list` and `scan get`

### DIFF
--- a/changelog/pending/20260518--cli-cloud--add-pulumi-insights-account-scan-get.yaml
+++ b/changelog/pending/20260518--cli-cloud--add-pulumi-insights-account-scan-get.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi insights account scan get <account> <scan-id>` to show the full workflow run for a single Insights scan

--- a/changelog/pending/20260518--cli-cloud--add-pulumi-insights-account-scan-list.yaml
+++ b/changelog/pending/20260518--cli-cloud--add-pulumi-insights-account-scan-list.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/cloud
+  description: Add `pulumi insights account scan list <account>` to discover recent scan IDs to feed into `pulumi insights account scan log`

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -3218,6 +3218,50 @@ func (pc *Client) ListInsightsAccounts(
 	return resp, nil
 }
 
+// GetInsightsScan fetches the full workflow run for a single Pulumi Insights
+// scan, including jobs and steps. The list endpoint (ListInsightsAccountScans)
+// only returns the per-scan summary; this is the only way to see the run's
+// jobs/steps and per-step status.
+//
+// `account` and `scanId` are both path parameters; the service double-decodes
+// `account`, so we double-URL-encode it — same convention as GetInsightsAccount
+// / CreateInsightsAccount / GetInsightsResource.
+func (pc *Client) GetInsightsScan(
+	ctx context.Context, org, account, scanID string,
+) (apitype.InsightsScanResponse, error) {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s/scans/%s",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+		url.PathEscape(scanID),
+	)
+	var resp apitype.InsightsScanResponse
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &resp); err != nil {
+		return apitype.InsightsScanResponse{}, err
+	}
+	return resp, nil
+}
+
+// ListInsightsAccountScans fetches a page of recent scans for an Insights account.
+// For parent accounts the endpoint returns scans across all child accounts,
+// so it is the recommended way to discover scan IDs to feed into GetInsightsScanLogs.
+//
+// The `accountName` path parameter is double-decoded on the service side
+func (pc *Client) ListInsightsAccountScans(
+	ctx context.Context, org, account string, params apitype.ListInsightsAccountScansParams,
+) (apitype.ListInsightsAccountScansResponse, error) {
+	path := fmt.Sprintf(
+		"/api/preview/insights/%s/accounts/%s/scans",
+		url.PathEscape(org),
+		url.PathEscape(url.PathEscape(account)),
+	)
+	var resp apitype.ListInsightsAccountScansResponse
+	if err := pc.restCall(ctx, "GET", path, &params, nil, &resp); err != nil {
+		return apitype.ListInsightsAccountScansResponse{}, err
+	}
+	return resp, nil
+}
+
 // CreateInsightsAccount creates a new Pulumi Insights account.
 //
 // The `accountName` path parameter is double-decoded on the service side, so

--- a/pkg/cmd/pulumi/insights/insights_account_scan.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan.go
@@ -129,6 +129,8 @@ func newInsightsAccountScanCmd(factory scanClientFactory) *cobra.Command {
 	outputflag.VarP(cmd.Flags(), &args.output)
 
 	cmd.AddCommand(newInsightsAccountScanLogCmd(nil))
+	cmd.AddCommand(newInsightsAccountScanListCmd(nil))
+	cmd.AddCommand(newInsightsAccountScanGetCmd(nil))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/insights/insights_account_scan_get.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_get.go
@@ -1,0 +1,223 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// insightsAccountScanGetClient is the subset of cloud-API operations the
+// scan get command needs. Defined inside this package so unit tests can stub
+// it without touching the full HTTP client surface.
+type insightsAccountScanGetClient interface {
+	GetInsightsScan(
+		ctx context.Context, org, account, scanID string,
+	) (apitype.InsightsScanResponse, error)
+}
+
+// accountScanGetClientFactory resolves the cloud client and the effective
+// org for the call.
+type accountScanGetClientFactory func(
+	ctx context.Context, orgOverride string,
+) (insightsAccountScanGetClient, string, error)
+
+type accountScanGetRender func(io.Writer, apitype.InsightsScanResponse) error
+
+func defaultAccountScanGetOutputFormat() outputflag.OutputFlag[accountScanGetRender] {
+	return outputflag.OutputFlag[accountScanGetRender]{
+		RenderForTerminal: renderScanGetText,
+		RenderJSON:        renderScanGetJSON,
+	}
+}
+
+type insightsAccountScanGetArgs struct {
+	org    string
+	output outputflag.OutputFlag[accountScanGetRender]
+}
+
+type insightsAccountScanGetCmd struct {
+	clientFactory accountScanGetClientFactory
+}
+
+// newInsightsAccountScanGetCmd builds the `pulumi insights account scan get`
+// command. factory produces the cloud client and resolves the effective org;
+// pass nil to use the production factory backed by [cloud.ResolveContext].
+func newInsightsAccountScanGetCmd(factory accountScanGetClientFactory) *cobra.Command {
+	if factory == nil {
+		factory = defaultScanGetClientFactory
+	}
+
+	get := &insightsAccountScanGetCmd{clientFactory: factory}
+	args := insightsAccountScanGetArgs{output: defaultAccountScanGetOutputFormat()}
+
+	cmd := &cobra.Command{
+		Use:   "get <account> <scan-id>",
+		Short: "[EXPERIMENTAL] Get details for a specific Insights scan",
+		Long: "[EXPERIMENTAL] Get details for a specific Pulumi Insights scan.\n" +
+			"\n" +
+			"Returns the workflow run for a single scan: status, timing, and the\n" +
+			"list of jobs (with their step-level status). Use `account scan list`\n" +
+			"to discover recent scan IDs, and `account scan log` to fetch the raw\n" +
+			"log output for a step.\n" +
+			"\n" +
+			"Default output is a human-readable summary; pass --output=json for\n" +
+			"the full response as JSON.",
+		Example: "  # Get the details of a specific scan.\n" +
+			"  pulumi insights account scan get prod-aws/us-east-1 7bb80f16-…\n\n" +
+			"  # Pipe a recent scan ID into `get` for the full workflow run.\n" +
+			"  pulumi insights account scan list prod-aws --output json |\n" +
+			"    jq -r '.scans[0].id' | xargs pulumi insights account scan get prod-aws/us-east-1\n\n" +
+			"  # Emit JSON for scripting (includes the per-step status).\n" +
+			"  pulumi insights account scan get prod-aws/us-east-1 7bb80f16-… --output json",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			return get.Run(cmd.Context(), cmd.OutOrStdout(), posArgs[0], posArgs[1], args)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{
+			{Name: "account"},
+			{Name: "scan-id"},
+		},
+		Required: 2,
+	})
+
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"Organization that owns the Insights account (defaults to the current default org)")
+	outputflag.Var(cmd.Flags(), &args.output)
+
+	return cmd
+}
+
+// Run executes the get operation. ctx and out are decoupled from cobra so
+// the function is straightforward to drive from tests.
+func (c *insightsAccountScanGetCmd) Run(
+	ctx context.Context, out io.Writer, account, scanID string, args insightsAccountScanGetArgs,
+) error {
+	client, org, err := c.clientFactory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.GetInsightsScan(ctx, org, account, scanID)
+	if err != nil {
+		return fmt.Errorf("getting insights scan: %w", err)
+	}
+
+	return args.output.Get()(out, resp)
+}
+
+// renderScanGetText prints a human-readable summary of a single scan as
+// aligned key/value pairs. The shape mirrors `deployment get` so the two
+// workflow-detail views feel like the same family of commands — only summary
+// metadata in text; the full per-job/per-step structure is in `--output json`.
+func renderScanGetText(w io.Writer, r apitype.InsightsScanResponse) error {
+	fmt.Fprintf(w, "%-18s %s\n", "ID:", r.ID)
+	fmt.Fprintf(w, "%-18s %s\n", "Status:", r.Status)
+	if !r.StartedAt.IsZero() {
+		fmt.Fprintf(w, "%-18s %s\n", "Started:", r.StartedAt.UTC().Format(time.RFC3339))
+	}
+	// FinishedAt is required by the schema but zero when the run is still in
+	// flight; skip the line in that case so "Finished: 0001-01-01" doesn't
+	// look like an outage.
+	if !r.FinishedAt.IsZero() {
+		fmt.Fprintf(w, "%-18s %s\n", "Finished:", r.FinishedAt.UTC().Format(time.RFC3339))
+		if !r.StartedAt.IsZero() {
+			d := r.FinishedAt.Sub(r.StartedAt).Round(time.Second)
+			fmt.Fprintf(w, "%-18s %s\n", "Duration:", d)
+		}
+	}
+	if !r.LastUpdatedAt.IsZero() {
+		fmt.Fprintf(w, "%-18s %s\n", "Last updated:", r.LastUpdatedAt.UTC().Format(time.RFC3339))
+	}
+	fmt.Fprintf(w, "%-18s %d\n", "Jobs:", len(r.Jobs))
+	return nil
+}
+
+// scanGetJSON is the JSON envelope emitted by
+// `pulumi insights account scan get --output=json`. Nil slices are normalized
+// to `[]` so consumers can rely on `jobs` being a JSON array — matching the
+// shape used by `deployment get`.
+type scanGetJSON struct {
+	ID            string                       `json:"id"`
+	OrgID         string                       `json:"orgId"`
+	UserID        string                       `json:"userId"`
+	Status        string                       `json:"status"`
+	StartedAt     time.Time                    `json:"startedAt"`
+	FinishedAt    time.Time                    `json:"finishedAt"`
+	LastUpdatedAt time.Time                    `json:"lastUpdatedAt"`
+	JobTimeout    time.Time                    `json:"jobTimeout"`
+	Jobs          []apitype.InsightsScanJobRun `json:"jobs"`
+}
+
+func toScanGetJSON(r apitype.InsightsScanResponse) scanGetJSON {
+	jobs := r.Jobs
+	if jobs == nil {
+		jobs = []apitype.InsightsScanJobRun{}
+	}
+	return scanGetJSON{
+		ID:            r.ID,
+		OrgID:         r.OrgID,
+		UserID:        r.UserID,
+		Status:        r.Status,
+		StartedAt:     r.StartedAt,
+		FinishedAt:    r.FinishedAt,
+		LastUpdatedAt: r.LastUpdatedAt,
+		JobTimeout:    r.JobTimeout,
+		Jobs:          jobs,
+	}
+}
+
+func renderScanGetJSON(w io.Writer, r apitype.InsightsScanResponse) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toScanGetJSON(r))
+}
+
+func defaultScanGetClientFactory(
+	ctx context.Context, orgOverride string,
+) (insightsAccountScanGetClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_get_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_get_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturedScanGetCall struct {
+	org     string
+	account string
+	scanID  string
+}
+
+type mockInsightsAccountScanGetClient struct {
+	resp  apitype.InsightsScanResponse
+	calls []capturedScanGetCall
+	err   error
+}
+
+func (m *mockInsightsAccountScanGetClient) GetInsightsScan(
+	_ context.Context, org, account, scanID string,
+) (apitype.InsightsScanResponse, error) {
+	m.calls = append(m.calls, capturedScanGetCall{org: org, account: account, scanID: scanID})
+	if m.err != nil {
+		return apitype.InsightsScanResponse{}, m.err
+	}
+	return m.resp, nil
+}
+
+func stubScanGetFactory(
+	client insightsAccountScanGetClient, defaultOrg string,
+) accountScanGetClientFactory {
+	return func(_ context.Context, orgOverride string) (insightsAccountScanGetClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return client, org, nil
+	}
+}
+
+func failingScanGetFactory(err error) accountScanGetClientFactory {
+	return func(_ context.Context, _ string) (insightsAccountScanGetClient, string, error) {
+		return nil, "", err
+	}
+}
+
+func defaultScanGetArgs() insightsAccountScanGetArgs {
+	return insightsAccountScanGetArgs{output: defaultAccountScanGetOutputFormat()}
+}
+
+func withScanGetOutput(args insightsAccountScanGetArgs, format string) insightsAccountScanGetArgs {
+	if err := args.output.Set(format); err != nil {
+		panic(err)
+	}
+	return args
+}
+
+// fullScanResponse returns a populated InsightsScanResponse with a single job
+// and a few steps — the typical shape for a completed account scan.
+func fullScanResponse() apitype.InsightsScanResponse {
+	started := time.Date(2026, 1, 21, 15, 58, 47, 0, time.UTC)
+	finished := time.Date(2026, 1, 21, 16, 43, 16, 0, time.UTC)
+	return apitype.InsightsScanResponse{
+		ID:            "scan-1",
+		OrgID:         "org-1",
+		UserID:        "user-1",
+		Status:        "succeeded",
+		StartedAt:     started,
+		FinishedAt:    finished,
+		LastUpdatedAt: finished,
+		Jobs: []apitype.InsightsScanJobRun{{
+			Status:      "succeeded",
+			Started:     started,
+			LastUpdated: finished,
+			Timeout:     int64(12 * time.Hour),
+			Steps: []apitype.InsightsScanStepRun{
+				{Name: "Setup", Status: "succeeded"},
+				{Name: "Scan account", Status: "succeeded"},
+			},
+		}},
+	}
+}
+
+// TestInsightsAccountScanGetCmd_DefaultOutput covers the human-readable
+// summary. We deliberately mirror `deployment get`'s "Jobs: <count>" style:
+// the per-job/per-step breakdown lives in --output json so the text view
+// stays scan-summary at-a-glance.
+func TestInsightsAccountScanGetCmd_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanGetClient{resp: fullScanResponse()}
+	c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws/us-east-1", "scan-1", defaultScanGetArgs())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "ID:")
+	assert.Contains(t, output, "scan-1")
+	assert.Contains(t, output, "Status:")
+	assert.Contains(t, output, "succeeded")
+	assert.Contains(t, output, "Started:")
+	assert.Contains(t, output, "2026-01-21T15:58:47Z")
+	assert.Contains(t, output, "Finished:")
+	assert.Contains(t, output, "2026-01-21T16:43:16Z")
+	assert.Contains(t, output, "Duration:")
+	assert.Contains(t, output, "44m29s")
+	assert.Contains(t, output, "Last updated:")
+	assert.Contains(t, output, "Jobs:")
+	assert.Contains(t, output, " 1")
+
+	// Per-step breakdown is intentionally NOT in the text view — match
+	// `deployment get`. Catches accidental re-introduction of step lines.
+	assert.NotContains(t, output, "Setup")
+	assert.NotContains(t, output, "Scan account")
+	assert.NotContains(t, output, "Job 1:")
+}
+
+// TestInsightsAccountScanGetCmd_InFlight covers an in-flight scan: FinishedAt
+// is zero, so the Finished / Duration lines are omitted (avoids
+// "Finished: 0001-01-01" rendering as if the run completed in 1AD).
+func TestInsightsAccountScanGetCmd_InFlight(t *testing.T) {
+	t.Parallel()
+
+	resp := fullScanResponse()
+	resp.Status = "running"
+	resp.FinishedAt = time.Time{}
+	resp.Jobs[0].Status = "running"
+
+	client := &mockInsightsAccountScanGetClient{resp: resp}
+	c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, "acme")}
+
+	var out bytes.Buffer
+	require.NoError(t, c.Run(t.Context(), &out, "prod-aws/us-east-1", "scan-1", defaultScanGetArgs()))
+
+	output := out.String()
+	assert.Contains(t, output, "running")
+	assert.NotContains(t, output, "Finished:")
+	assert.NotContains(t, output, "Duration:")
+	assert.NotContains(t, output, "0001-01-01")
+}
+
+func TestInsightsAccountScanGetCmd_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	want := fullScanResponse()
+	client := &mockInsightsAccountScanGetClient{resp: want}
+	c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out,
+		"prod-aws/us-east-1", "scan-1",
+		withScanGetOutput(defaultScanGetArgs(), "json"))
+	require.NoError(t, err)
+
+	// Decode into the envelope so we can assert the normalised shape.
+	var got scanGetJSON
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Status, got.Status)
+	assert.Equal(t, want.StartedAt.UTC(), got.StartedAt.UTC())
+	require.Len(t, got.Jobs, 1)
+	require.Len(t, got.Jobs[0].Steps, 2)
+	assert.Equal(t, "Setup", got.Jobs[0].Steps[0].Name)
+}
+
+// TestInsightsAccountScanGetCmd_JSONOutput_EmptyJobs ensures a nil Jobs slice
+// serialises to `[]` rather than `null` — matches the contract that other
+// insights commands keep so jq scripts can iterate without a nil-check.
+func TestInsightsAccountScanGetCmd_JSONOutput_EmptyJobs(t *testing.T) {
+	t.Parallel()
+
+	resp := fullScanResponse()
+	resp.Jobs = nil
+
+	client := &mockInsightsAccountScanGetClient{resp: resp}
+	c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, "acme")}
+
+	var out bytes.Buffer
+	require.NoError(t, c.Run(t.Context(), &out,
+		"prod-aws/us-east-1", "scan-1",
+		withScanGetOutput(defaultScanGetArgs(), "json")))
+
+	// Round-trip through generic map to catch `"jobs": null` regressions.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(out.Bytes(), &raw))
+	jobs, ok := raw["jobs"]
+	require.True(t, ok)
+	require.NotNil(t, jobs)
+	assert.Empty(t, jobs)
+}
+
+func TestInsightsAccountScanGetCmd_OrgAndArgsPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mutate      func(*insightsAccountScanGetArgs)
+		defaultOrg  string
+		account     string
+		scanID      string
+		wantOrg     string
+		wantAccount string
+		wantScanID  string
+	}{
+		{
+			name:        "default org used when --org omitted",
+			defaultOrg:  "acme",
+			account:     "prod-aws",
+			scanID:      "scan-1",
+			wantOrg:     "acme",
+			wantAccount: "prod-aws",
+			wantScanID:  "scan-1",
+		},
+		{
+			name:        "--org overrides default",
+			mutate:      func(a *insightsAccountScanGetArgs) { a.org = "other-co" },
+			defaultOrg:  "acme",
+			account:     "prod-aws",
+			scanID:      "scan-1",
+			wantOrg:     "other-co",
+			wantAccount: "prod-aws",
+			wantScanID:  "scan-1",
+		},
+		{
+			name:        "account names with slashes pass through unmodified",
+			defaultOrg:  "acme",
+			account:     "prod-aws/us-east-1",
+			scanID:      "scan-1",
+			wantOrg:     "acme",
+			wantAccount: "prod-aws/us-east-1",
+			wantScanID:  "scan-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &mockInsightsAccountScanGetClient{resp: fullScanResponse()}
+			c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, tc.defaultOrg)}
+
+			args := defaultScanGetArgs()
+			if tc.mutate != nil {
+				tc.mutate(&args)
+			}
+
+			var out bytes.Buffer
+			require.NoError(t, c.Run(t.Context(), &out, tc.account, tc.scanID, args))
+			require.Len(t, client.calls, 1)
+			assert.Equal(t, tc.wantOrg, client.calls[0].org)
+			assert.Equal(t, tc.wantAccount, client.calls[0].account)
+			assert.Equal(t, tc.wantScanID, client.calls[0].scanID)
+		})
+	}
+}
+
+func TestInsightsAccountScanGetCmd_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("not logged in")
+	c := &insightsAccountScanGetCmd{clientFactory: failingScanGetFactory(wantErr)}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", "scan-1", defaultScanGetArgs())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestInsightsAccountScanGetCmd_ClientErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("[404] Not Found")
+	client := &mockInsightsAccountScanGetClient{err: wantErr}
+	c := &insightsAccountScanGetCmd{clientFactory: stubScanGetFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", "scan-1", defaultScanGetArgs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "getting insights scan")
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_list.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_list.go
@@ -1,0 +1,287 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// scanListPageLimit caps the number of pages we'll follow before bailing out,
+// so a pathological server can't loop us forever. See the matching constant
+// listPageLimit in insights_account_list.go for the rationale.
+const scanListPageLimit = 1000
+
+// insightsAccountScanListClient is the subset of cloud-API operations the
+// scan list command needs.
+type insightsAccountScanListClient interface {
+	ListInsightsAccountScans(
+		ctx context.Context, org, account string, params apitype.ListInsightsAccountScansParams,
+	) (apitype.ListInsightsAccountScansResponse, error)
+}
+
+// accountScanListClientFactory resolves the cloud client and the effective
+// org for the call. orgOverride wins when non-empty; otherwise the default
+// org from the cloud context is used.
+type accountScanListClientFactory func(
+	ctx context.Context, orgOverride string,
+) (insightsAccountScanListClient, string, error)
+
+// accountScanListRender is the function signature stored in the OutputFlag —
+// one per supported output format.
+type accountScanListRender func(*insightsAccountScanListCmd, io.Writer, []apitype.InsightsAccountScanStatus) error
+
+func defaultAccountScanListOutputFormat() outputflag.OutputFlag[accountScanListRender] {
+	return outputflag.OutputFlag[accountScanListRender]{
+		RenderForTerminal: (*insightsAccountScanListCmd).renderTable,
+		RenderJSON:        (*insightsAccountScanListCmd).renderJSON,
+	}
+}
+
+type insightsAccountScanListArgs struct {
+	org string
+	// count and countSet form a ternary flag (see insights_account_list.go):
+	// unset means "one server page", --count 0 is a synonym for --all,
+	// --count N>0 means "at most N results".
+	count    int
+	countSet bool
+	all      bool
+	output   outputflag.OutputFlag[accountScanListRender]
+}
+
+type insightsAccountScanListCmd struct {
+	clientFactory accountScanListClientFactory
+}
+
+// newInsightsAccountScanListCmd builds the `pulumi insights account scan list`
+// command. factory produces the cloud client and resolves the effective org;
+// pass nil to use the production factory backed by [cloud.ResolveContext].
+func newInsightsAccountScanListCmd(factory accountScanListClientFactory) *cobra.Command {
+	if factory == nil {
+		factory = defaultScanListClientFactory
+	}
+
+	list := &insightsAccountScanListCmd{clientFactory: factory}
+	args := insightsAccountScanListArgs{output: defaultAccountScanListOutputFormat()}
+
+	cmd := &cobra.Command{
+		Use:     "list <account>",
+		Aliases: []string{"ls"},
+		Short:   "[EXPERIMENTAL] List recent scans for an Insights account",
+		Long: "[EXPERIMENTAL] List recent scans for a Pulumi Insights account.\n" +
+			"\n" +
+			"The positional argument is the Insights account. For parent accounts the\n" +
+			"endpoint returns scans across every child account, so this is the\n" +
+			"recommended way to discover scan IDs to feed into `account scan log`.\n" +
+			"\n" +
+			"By default the command returns a single page of results. --count N\n" +
+			"returns at most N results. --all (equivalent to --count 0) returns every\n" +
+			"matching scan. --count and --all are mutually exclusive.",
+		Example: "  # List the most recent scans for an account.\n" +
+			"  pulumi insights account scan list prod-aws\n\n" +
+			"  # For a parent account, the result spans every child account.\n" +
+			"  pulumi insights account scan list prod-aws\n\n" +
+			"  # Narrow to a single child by passing its full account path.\n" +
+			"  pulumi insights account scan list prod-aws/us-east-1\n\n" +
+			"  # Return at most 25 scans.\n" +
+			"  pulumi insights account scan list prod-aws --count 25\n\n" +
+			"  # Return every scan.\n" +
+			"  pulumi insights account scan list prod-aws --all\n\n" +
+			"  # Emit JSON for scripting.\n" +
+			"  pulumi insights account scan list prod-aws --output json",
+		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			args.countSet = cmd.Flags().Changed("count")
+			return list.Run(cmd.Context(), cmd.OutOrStdout(), posArgs[0], args)
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "account"}},
+		Required:  1,
+	})
+
+	cmd.Flags().StringVar(&args.org, "org", "",
+		"Organization that owns the Insights account (defaults to the current default org)")
+	cmd.Flags().IntVar(&args.count, "count", 0,
+		"Return at most this many scans (--count 0 is equivalent to --all)")
+	cmd.Flags().BoolVar(&args.all, "all", false,
+		"Return every matching scan")
+	cmd.MarkFlagsMutuallyExclusive("count", "all")
+	outputflag.Var(cmd.Flags(), &args.output)
+
+	return cmd
+}
+
+// Run executes the list operation. ctx and out are decoupled from cobra so
+// the function is straightforward to drive from tests.
+func (c *insightsAccountScanListCmd) Run(
+	ctx context.Context, out io.Writer, account string, args insightsAccountScanListArgs,
+) error {
+	if args.countSet && args.count < 0 {
+		return fmt.Errorf("--count must be non-negative, got %d", args.count)
+	}
+
+	client, org, err := c.clientFactory(ctx, args.org)
+	if err != nil {
+		return err
+	}
+
+	scans, err := collectInsightsAccountScans(ctx, client, org, account, args)
+	if err != nil {
+		return fmt.Errorf("listing insights scans: %w", err)
+	}
+	return args.output.Get()(c, out, scans)
+}
+
+// collectInsightsAccountScans pulls scans from the server, following the
+// continuation cursor when more than one page is required. The shape mirrors
+// collectInsightsAccounts in insights_account_list.go.
+func collectInsightsAccountScans(
+	ctx context.Context,
+	client insightsAccountScanListClient,
+	org, account string,
+	args insightsAccountScanListArgs,
+) ([]apitype.InsightsAccountScanStatus, error) {
+	limit := 0
+	exhaust := args.all
+	if args.countSet {
+		if args.count == 0 {
+			exhaust = true
+		} else {
+			limit = args.count
+		}
+	}
+
+	var (
+		scans  []apitype.InsightsAccountScanStatus
+		cursor string
+	)
+	for page := 0; page < scanListPageLimit; page++ {
+		resp, err := client.ListInsightsAccountScans(ctx, org, account, apitype.ListInsightsAccountScansParams{
+			ContinuationToken: cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+		scans = append(scans, resp.ScanStatuses...)
+
+		if resp.ContinuationToken == "" {
+			return scans, nil
+		}
+		if !exhaust && limit == 0 {
+			// Default single-page mode.
+			return scans, nil
+		}
+		if limit > 0 && len(scans) >= limit {
+			return scans[:limit], nil
+		}
+		cursor = resp.ContinuationToken
+	}
+	return nil, fmt.Errorf("pagination exceeded %d pages; the server may be looping", scanListPageLimit)
+}
+
+// renderTable writes a human-readable view of the scans. The chosen columns
+// identify each row (Scan ID, Account) and surface the most useful
+// operational context (Status, Started, Finished, Duration).
+func (c *insightsAccountScanListCmd) renderTable(
+	w io.Writer, scans []apitype.InsightsAccountScanStatus,
+) error {
+	if len(scans) == 0 {
+		fmt.Fprintln(w, "No scans found.")
+		return nil
+	}
+
+	t := table.NewWriter()
+	t.SetOutputMirror(w)
+	t.SetStyle(table.StyleLight)
+	t.Style().Format.Header = text.FormatDefault
+	t.AppendHeader(table.Row{"Scan ID", "Account", "Status", "Started", "Duration"})
+	for _, s := range scans {
+		started := "-"
+		if !s.StartedAt.IsZero() {
+			started = s.StartedAt.UTC().Format(time.RFC3339)
+		}
+		// Duration is more useful than the finish timestamp at a glance —
+		// Started + Duration tells you the same story without a redundant
+		// column. For an in-flight scan we fall back to "-" instead of a
+		// number computed from `now`, so a quick glance still distinguishes
+		// completed runs from running ones.
+		duration := "-"
+		if s.FinishedAt != nil && !s.FinishedAt.IsZero() && !s.StartedAt.IsZero() {
+			duration = s.FinishedAt.Sub(s.StartedAt).Round(time.Second).String()
+		}
+		t.AppendRow(table.Row{
+			s.ID,
+			s.AccountName,
+			s.Status,
+			started,
+			duration,
+		})
+	}
+	t.Render()
+	return nil
+}
+
+// renderJSON writes the scans as indented JSON. Wrapping in a `{"scans": ...}`
+// envelope leaves room to add pagination metadata later without a breaking
+// change, matching the shape used by `account list`.
+func (c *insightsAccountScanListCmd) renderJSON(
+	w io.Writer, scans []apitype.InsightsAccountScanStatus,
+) error {
+	if scans == nil {
+		scans = []apitype.InsightsAccountScanStatus{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}{Scans: scans})
+}
+
+func defaultScanListClientFactory(
+	ctx context.Context, orgOverride string,
+) (insightsAccountScanListClient, string, error) {
+	resolved, err := cloud.ResolveContext(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving cloud context: %w", err)
+	}
+	if !resolved.LoggedIn {
+		return nil, "", errors.New("not logged in to Pulumi Cloud; run `pulumi login` first")
+	}
+
+	org := orgOverride
+	if org == "" {
+		org = resolved.OrgName
+	}
+	if org == "" {
+		return nil, "", errors.New(
+			"no organization available; pass --org or set a default with `pulumi org set-default`")
+	}
+
+	return resolved.Client, org, nil
+}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_list_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_list_test.go
@@ -1,0 +1,533 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturedScanListCall records the most recent call to
+// ListInsightsAccountScans so tests can assert that flags propagate correctly
+// to the cloud client.
+type capturedScanListCall struct {
+	org     string
+	account string
+	params  apitype.ListInsightsAccountScansParams
+}
+
+// mockInsightsAccountScanListClient stubs insightsAccountScanListClient.
+// Successive invocations return the next entry of `pages`, simulating
+// server-side pagination via continuationToken.
+type mockInsightsAccountScanListClient struct {
+	pages []apitype.ListInsightsAccountScansResponse
+	calls []capturedScanListCall
+	err   error
+}
+
+func (m *mockInsightsAccountScanListClient) ListInsightsAccountScans(
+	_ context.Context, org, account string, params apitype.ListInsightsAccountScansParams,
+) (apitype.ListInsightsAccountScansResponse, error) {
+	m.calls = append(m.calls, capturedScanListCall{org: org, account: account, params: params})
+	if m.err != nil {
+		return apitype.ListInsightsAccountScansResponse{}, m.err
+	}
+	if len(m.pages) == 0 {
+		return apitype.ListInsightsAccountScansResponse{}, nil
+	}
+	resp := m.pages[0]
+	m.pages = m.pages[1:]
+	return resp, nil
+}
+
+func stubScanListFactory(
+	client insightsAccountScanListClient, defaultOrg string,
+) accountScanListClientFactory {
+	return func(_ context.Context, orgOverride string) (insightsAccountScanListClient, string, error) {
+		org := orgOverride
+		if org == "" {
+			org = defaultOrg
+		}
+		return client, org, nil
+	}
+}
+
+func failingScanListFactory(err error) accountScanListClientFactory {
+	return func(_ context.Context, _ string) (insightsAccountScanListClient, string, error) {
+		return nil, "", err
+	}
+}
+
+func defaultScanListArgs() insightsAccountScanListArgs {
+	return insightsAccountScanListArgs{output: defaultAccountScanListOutputFormat()}
+}
+
+func withScanListOutput(args insightsAccountScanListArgs, format string) insightsAccountScanListArgs {
+	if err := args.output.Set(format); err != nil {
+		panic(err)
+	}
+	return args
+}
+
+// sampleScan returns a fully populated scan status. `id` doubles as a sort key
+// so tests can assert ordering trivially.
+func sampleScan(id, account string) apitype.InsightsAccountScanStatus {
+	started := time.Date(2026, 1, 21, 15, 58, 47, 0, time.UTC)
+	finished := time.Date(2026, 1, 21, 16, 43, 16, 0, time.UTC)
+	return apitype.InsightsAccountScanStatus{
+		ID:            id,
+		OrgID:         "org-1",
+		UserID:        "user-1",
+		AccountName:   account,
+		Status:        "succeeded",
+		StartedAt:     started,
+		FinishedAt:    &finished,
+		LastUpdatedAt: finished,
+		JobTimeout:    started.Add(12 * time.Hour),
+		ResourceCount: 42,
+	}
+}
+
+func TestInsightsAccountScanListCmd_DefaultOutput(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{{
+			ScanStatuses: []apitype.InsightsAccountScanStatus{
+				sampleScan("scan-1", "prod-aws/us-east-1"),
+				sampleScan("scan-2", "prod-aws/us-west-2"),
+			},
+		}},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", defaultScanListArgs())
+	require.NoError(t, err)
+
+	output := out.String()
+	// Headers
+	assert.Contains(t, output, "Scan ID")
+	assert.Contains(t, output, "Account")
+	assert.Contains(t, output, "Status")
+	assert.Contains(t, output, "Started")
+	assert.Contains(t, output, "Duration")
+	// Finished column was intentionally dropped — Started + Duration tells the
+	// same story without the extra column.
+	assert.NotContains(t, output, "Finished")
+	// Row contents
+	assert.Contains(t, output, "scan-1")
+	assert.Contains(t, output, "scan-2")
+	assert.Contains(t, output, "prod-aws/us-east-1")
+	assert.Contains(t, output, "succeeded")
+	assert.Contains(t, output, "2026-01-21T15:58:47Z") // started
+	assert.Contains(t, output, "44m29s")               // duration
+}
+
+func TestInsightsAccountScanListCmd_DefaultOutput_NoResults(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{{ScanStatuses: nil}},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", defaultScanListArgs())
+	require.NoError(t, err)
+	assert.Equal(t, "No scans found.\n", out.String())
+}
+
+// TestInsightsAccountScanListCmd_InFlight covers the row layout for a scan
+// that is still running — Duration renders as `-` because we deliberately do
+// not compute "now - StartedAt" (a moving target on a live re-run).
+func TestInsightsAccountScanListCmd_InFlight(t *testing.T) {
+	t.Parallel()
+
+	inflight := sampleScan("running-scan", "prod-aws/us-east-1")
+	inflight.Status = "running"
+	inflight.FinishedAt = nil
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{{
+			ScanStatuses: []apitype.InsightsAccountScanStatus{inflight},
+		}},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", defaultScanListArgs())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "running-scan")
+	assert.Contains(t, output, "running")
+	// Started is still concrete, but Duration is `-` because the scan hasn't
+	// finished. We assert the literal " - " filler appears so a future change
+	// to compute a moving "now-Started" gets noticed.
+	assert.Contains(t, output, " - ")
+}
+
+func TestInsightsAccountScanListCmd_JSONOutput(t *testing.T) {
+	t.Parallel()
+
+	want := []apitype.InsightsAccountScanStatus{
+		sampleScan("scan-1", "prod-aws/us-east-1"),
+		sampleScan("scan-2", "prod-aws/us-west-2"),
+	}
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{{ScanStatuses: want}},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", withScanListOutput(defaultScanListArgs(), "json"))
+	require.NoError(t, err)
+
+	var got struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	assert.Equal(t, want, got.Scans)
+}
+
+// TestInsightsAccountScanListCmd_JSONOutput_EmptyList ensures an empty result
+// serialises to `[]` rather than `null`, so jq scripting can iterate without
+// a nil-check — same contract as `account list`.
+func TestInsightsAccountScanListCmd_JSONOutput_EmptyList(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{{ScanStatuses: nil}},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", withScanListOutput(defaultScanListArgs(), "json"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"scans":[]}`, out.String())
+}
+
+// TestInsightsAccountScanListCmd_DefaultStopsAfterFirstPage: without --count
+// or --all the command returns exactly the first server-side page even when
+// a continuationToken is available — matches the epic's "default is the size
+// of the first page" rule.
+func TestInsightsAccountScanListCmd_DefaultStopsAfterFirstPage(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{
+			{
+				ScanStatuses: []apitype.InsightsAccountScanStatus{
+					sampleScan("s1", "prod-aws/us-east-1"),
+					sampleScan("s2", "prod-aws/us-east-1"),
+				},
+				ContinuationToken: "cursor-1",
+			},
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s3", "prod-aws/us-east-1")},
+				ContinuationToken: "",
+			},
+		},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", withScanListOutput(defaultScanListArgs(), "json"))
+	require.NoError(t, err)
+
+	var got struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.Scans, 2)
+	assert.Equal(t, "s1", got.Scans[0].ID)
+	assert.Equal(t, "s2", got.Scans[1].ID)
+	require.Len(t, client.calls, 1, "should not follow continuationToken without --count/--all")
+}
+
+// TestInsightsAccountScanListCmd_AllFollowsPagination: --all keeps following
+// the continuationToken cursor until the server reports an empty token.
+func TestInsightsAccountScanListCmd_AllFollowsPagination(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s1", "prod-aws/us-east-1")},
+				ContinuationToken: "cursor-1",
+			},
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s2", "prod-aws/us-east-1")},
+				ContinuationToken: "cursor-2",
+			},
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s3", "prod-aws/us-east-1")},
+				ContinuationToken: "",
+			},
+		},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	args := withScanListOutput(defaultScanListArgs(), "json")
+	args.all = true
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", args)
+	require.NoError(t, err)
+
+	var got struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.Scans, 3)
+	require.Len(t, client.calls, 3)
+	assert.Empty(t, client.calls[0].params.ContinuationToken)
+	assert.Equal(t, "cursor-1", client.calls[1].params.ContinuationToken)
+	assert.Equal(t, "cursor-2", client.calls[2].params.ContinuationToken)
+}
+
+// TestInsightsAccountScanListCmd_CountPaginatesUntilSatisfied: --count N
+// pages across as many server pages as needed and truncates the last page so
+// the user sees exactly N.
+func TestInsightsAccountScanListCmd_CountPaginatesUntilSatisfied(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{
+			{
+				ScanStatuses: []apitype.InsightsAccountScanStatus{
+					sampleScan("s1", "prod-aws/us-east-1"),
+					sampleScan("s2", "prod-aws/us-east-1"),
+				},
+				ContinuationToken: "cursor-1",
+			},
+			{
+				ScanStatuses: []apitype.InsightsAccountScanStatus{
+					sampleScan("s3", "prod-aws/us-east-1"),
+					sampleScan("s4", "prod-aws/us-east-1"),
+				},
+				ContinuationToken: "cursor-2",
+			},
+			// The third page must never be requested — --count=3 is satisfied
+			// after page 2.
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s5", "prod-aws/us-east-1")},
+				ContinuationToken: "",
+			},
+		},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	args := withScanListOutput(defaultScanListArgs(), "json")
+	args.count = 3
+	args.countSet = true
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", args)
+	require.NoError(t, err)
+
+	var got struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.Scans, 3, "result should be truncated to --count")
+	assert.Equal(t, []string{"s1", "s2", "s3"},
+		[]string{got.Scans[0].ID, got.Scans[1].ID, got.Scans[2].ID})
+	require.Len(t, client.calls, 2, "should stop paginating once --count is satisfied")
+}
+
+// TestInsightsAccountScanListCmd_CountZeroEqualsAll: --count 0 is a synonym
+// for --all per #22959 — paginate to exhaustion.
+func TestInsightsAccountScanListCmd_CountZeroEqualsAll(t *testing.T) {
+	t.Parallel()
+
+	client := &mockInsightsAccountScanListClient{
+		pages: []apitype.ListInsightsAccountScansResponse{
+			{
+				ScanStatuses: []apitype.InsightsAccountScanStatus{
+					sampleScan("s1", "prod-aws/us-east-1"),
+					sampleScan("s2", "prod-aws/us-east-1"),
+				},
+				ContinuationToken: "cursor-1",
+			},
+			{
+				ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s3", "prod-aws/us-east-1")},
+				ContinuationToken: "",
+			},
+		},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	args := withScanListOutput(defaultScanListArgs(), "json")
+	args.count = 0
+	args.countSet = true
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", args)
+	require.NoError(t, err)
+
+	var got struct {
+		Scans []apitype.InsightsAccountScanStatus `json:"scans"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got))
+	require.Len(t, got.Scans, 3)
+	require.Len(t, client.calls, 2)
+}
+
+func TestInsightsAccountScanListCmd_NegativeCountRejected(t *testing.T) {
+	t.Parallel()
+
+	c := &insightsAccountScanListCmd{
+		clientFactory: stubScanListFactory(&mockInsightsAccountScanListClient{}, "acme"),
+	}
+
+	args := defaultScanListArgs()
+	args.count = -3
+	args.countSet = true
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--count must be non-negative")
+}
+
+func TestInsightsAccountScanListCmd_OrgAndAccountPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mutate      func(*insightsAccountScanListArgs)
+		defaultOrg  string
+		account     string
+		wantOrg     string
+		wantAccount string
+	}{
+		{
+			name:        "default org used when --org omitted",
+			defaultOrg:  "acme",
+			account:     "prod-aws",
+			wantOrg:     "acme",
+			wantAccount: "prod-aws",
+		},
+		{
+			name:        "--org overrides default",
+			mutate:      func(a *insightsAccountScanListArgs) { a.org = "other-co" },
+			defaultOrg:  "acme",
+			account:     "prod-aws",
+			wantOrg:     "other-co",
+			wantAccount: "prod-aws",
+		},
+		{
+			name:        "account names with slashes pass through unmodified",
+			defaultOrg:  "acme",
+			account:     "prod-aws/us-east-1",
+			wantOrg:     "acme",
+			wantAccount: "prod-aws/us-east-1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &mockInsightsAccountScanListClient{
+				pages: []apitype.ListInsightsAccountScansResponse{{ScanStatuses: nil}},
+			}
+			c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, tc.defaultOrg)}
+
+			args := defaultScanListArgs()
+			if tc.mutate != nil {
+				tc.mutate(&args)
+			}
+
+			var out bytes.Buffer
+			require.NoError(t, c.Run(t.Context(), &out, tc.account, args))
+			require.Len(t, client.calls, 1)
+			assert.Equal(t, tc.wantOrg, client.calls[0].org)
+			assert.Equal(t, tc.wantAccount, client.calls[0].account)
+		})
+	}
+}
+
+func TestInsightsAccountScanListCmd_FactoryError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("not logged in")
+	c := &insightsAccountScanListCmd{clientFactory: failingScanListFactory(wantErr)}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", defaultScanListArgs())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestInsightsAccountScanListCmd_ClientErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("[404] Not Found")
+	client := &mockInsightsAccountScanListClient{err: wantErr}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", defaultScanListArgs())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listing insights scans")
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// TestInsightsAccountScanListCmd_PageLoopBudget covers the safety net against
+// a misbehaving server that returns a non-empty continuationToken forever.
+func TestInsightsAccountScanListCmd_PageLoopBudget(t *testing.T) {
+	t.Parallel()
+
+	// Looping client: every call returns the same non-empty token.
+	client := &endlessScanListClient{
+		page: apitype.ListInsightsAccountScansResponse{
+			ScanStatuses:      []apitype.InsightsAccountScanStatus{sampleScan("s", "prod-aws/us-east-1")},
+			ContinuationToken: "cursor-1",
+		},
+	}
+	c := &insightsAccountScanListCmd{clientFactory: stubScanListFactory(client, "acme")}
+
+	args := defaultScanListArgs()
+	args.all = true
+
+	var out bytes.Buffer
+	err := c.Run(t.Context(), &out, "prod-aws", args)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pagination exceeded")
+}
+
+// endlessScanListClient always returns the same page. Used to exercise the
+// pagination safety net without storing 1000+ pages in memory.
+type endlessScanListClient struct {
+	page  apitype.ListInsightsAccountScansResponse
+	calls int
+}
+
+func (e *endlessScanListClient) ListInsightsAccountScans(
+	_ context.Context, _, _ string, _ apitype.ListInsightsAccountScansParams,
+) (apitype.ListInsightsAccountScansResponse, error) {
+	e.calls++
+	return e.page, nil
+}

--- a/sdk/go/common/apitype/insights.go
+++ b/sdk/go/common/apitype/insights.go
@@ -193,6 +193,25 @@ type ListInsightsAccountsResponse struct {
 	NextToken string            `json:"nextToken,omitempty"`
 }
 
+// ListInsightsAccountScansParams are the query parameters for the Pulumi
+// Insights ListAccountScans endpoint.
+type ListInsightsAccountScansParams struct {
+	// ContinuationToken is the opaque cursor returned by a previous response;
+	// pass it on subsequent calls to fetch the next page.
+	ContinuationToken string `url:"continuationToken,omitempty"`
+	// PageSize is the maximum number of scans returned on a single page.
+	// Defaults to the server-side default when zero.
+	PageSize int `url:"pageSize,omitempty"`
+}
+
+// ListInsightsAccountScansResponse is the envelope returned by the
+// ListAccountScans endpoint. For parent accounts the result includes scans
+// across all child accounts. ContinuationToken is empty on the last page.
+type ListInsightsAccountScansResponse struct {
+	ScanStatuses      []InsightsAccountScanStatus `json:"scanStatuses"`
+	ContinuationToken string                      `json:"continuationToken,omitempty"`
+}
+
 // InsightsAccount describes a single Pulumi Insights account as returned by
 // the ListAccounts endpoint. The shape mirrors the OpenAPI schema of the same
 // name in the Pulumi Cloud REST API.


### PR DESCRIPTION
## Summary

Fixes "no way to discover scan IDs from the CLI."

Two new subcommands fill in the gap between triggering a scan and reading its logs:

- `pulumi insights account scan list <account>` — recent scans, with IDs.
- `pulumi insights account scan get <account> <scan-id>` — full workflow run for one scan.

Combined with the existing `account scan` (trigger) and `account scan log` (logs), users can now drive the entire create → scan → debug flow without going to the UI.

## Analogous to `pulumi deployment …`

Insights scans and Pulumi Deployments share a server-side workflow handler, so this PR deliberately mirrors the existing `deployment` command family:

| Concept | Deployments | Insights scans |
|---|---|---|
| List runs | [`pulumi deployment list`](pkg/cmd/pulumi/deployment/deployment_list.go) | `pulumi insights account scan list` (new) |
| Get a single run | [`pulumi deployment get`](pkg/cmd/pulumi/deployment/deployment_get.go) | `pulumi insights account scan get` (new) |
| Fetch logs | [`pulumi deployment log`](pkg/cmd/pulumi/deployment/deployment_log.go) | `pulumi insights account scan log` (existing) |

Where they overlap, the new commands copy the deployments-side shape so the two surfaces feel like the same family:

- `scan get` text view follows `deployment get` (`%-18s` key/value alignment, summary fields, `Jobs: <count>` only — the full per-job/per-step structure lives in `--output json`).
- `scan list` follows the `--count` / `--all` pagination convention (mutually exclusive; `--count 0` is a synonym for `--all`) established by `insights account list`.
- Both commands accept the same `--org` / `--output` global flags as the rest of the Cloud-Ready CLI surface.

## Sample output

### `account scan list <parent>` (spans every child account)

```
$ pulumi insights account scan list "Michael-Test-AWS" --org pulumi --count 5
┌──────────────────────────────────────┬────────────────────────────┬───────────┬──────────────────────┬──────────┐
│ Scan ID                              │ Account                    │ Status    │ Started              │ Duration │
├──────────────────────────────────────┼────────────────────────────┼───────────┼──────────────────────┼──────────┤
│ 724db660-7363-469a-96dd-50eeddedf08c │ Michael-Test-AWS/us-west-1 │ succeeded │ 2026-01-21T15:58:49Z │ 5m30s    │
│ 7bb80f16-8793-4b7c-bbf8-11e8d81f6ca7 │ Michael-Test-AWS/us-east-2 │ succeeded │ 2026-01-21T15:58:47Z │ 44m29s   │
│ 135a8707-0297-48b0-bdf8-0c460ae837d2 │ Michael-Test-AWS/global    │ succeeded │ 2026-01-21T15:58:44Z │ 2m54s    │
│ b4e5a5d2-b9ad-47ee-bc6e-7ec3fb643345 │ Michael-Test-AWS/us-west-1 │ succeeded │ 2026-01-15T22:17:50Z │ 5m35s    │
│ 33f4591d-6f52-494b-8bc8-22356fac0857 │ Michael-Test-AWS/us-east-2 │ succeeded │ 2026-01-15T22:07:16Z │ 45m16s   │
└──────────────────────────────────────┴────────────────────────────┴───────────┴──────────────────────┴──────────┘
```

### `account scan get` (default text)

```
$ pulumi insights account scan get "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi
ID:                7bb80f16-8793-4b7c-bbf8-11e8d81f6ca7
Status:            succeeded
Started:           2026-01-21T15:58:47Z
Finished:          2026-01-21T16:43:16Z
Duration:          44m29s
Last updated:      2026-05-19T00:10:57Z
Jobs:              1
```

### `account scan get --output json` (full workflow run)

```json
{
  "id": "7bb80f16-…",
  "status": "succeeded",
  "startedAt": "2026-01-21T15:58:47.305Z",
  "finishedAt": "2026-01-21T16:43:16.079Z",
  "jobs": [
    {
      "status": "succeeded",
      "started": "2026-01-21T15:59:15.852Z",
      "timeout": 43200000000000,
      "steps": [
        { "name": "Setup", "status": "succeeded" },
        { "name": "Download scanner", "status": "succeeded" },
        { "name": "Install provider", "status": "succeeded" },
        { "name": "Scan account", "status": "succeeded" }
      ],
      "worker": "i-020f6b242e2452051"
    }
  ]
}
```

## Test plan

- [x] Unit tests: 12 cases for `scan list`, 7 for `scan get` (table/JSON rendering, in-flight scans, pagination defaults / `--all` / `--count` / `--count 0`, org+account propagation incl. slash names, factory + client errors, page-loop safety net).
- [x] `mise exec -- make format`
- [x] `mise exec -- make lint` (0 issues across 7 packages)
- [x] Live smoke against the `pulumi` org on `Michael-Test-AWS` (parent) and `Michael-Test-AWS/us-east-2` (leaf), end-to-end `scan list` → copy ID → `scan get <leaf> <id>` → `scan log <leaf> <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)