### PR TITLE
cli/cloud: fix `pulumi insights account scan log` pagination

### DIFF
--- a/changelog/pending/20260519--cli-cloud--fix-pulumi-insights-account-scan-log.yaml
+++ b/changelog/pending/20260519--cli-cloud--fix-pulumi-insights-account-scan-log.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/cloud
+  description: Fix `pulumi insights account scan log --all` to follow the server's pagination cursor through the end of the log, and render `--job/--step` mode as structured lines instead of an empty raw-string blob

--- a/pkg/backend/httpstate/client/client_insights_test.go
+++ b/pkg/backend/httpstate/client/client_insights_test.go
@@ -568,7 +568,7 @@ func TestGetInsightsScanLogs(t *testing.T) {
 					Line:      "finished scan",
 				},
 			},
-			ContinuationToken: "next-page",
+			NextToken: "next-page",
 		}
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -588,8 +588,13 @@ func TestGetInsightsScanLogs(t *testing.T) {
 		t.Parallel()
 
 		want := apitype.InsightsScanLogs{
-			Type:       "step",
-			Output:     "scan output text\n",
+			Type: "DeploymentLogsStep",
+			Lines: []apitype.InsightsScanLogLine{
+				{
+					Timestamp: time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+					Line:      "scan output text\n",
+				},
+			},
 			NextOffset: 1024,
 		}
 

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log.go
@@ -203,16 +203,16 @@ func (c *insightsAccountScanLogCmd) fetchContinuationMode(
 			acc.Type = resp.Type
 		}
 		acc.Lines = append(acc.Lines, resp.Lines...)
-		acc.ContinuationToken = resp.ContinuationToken
+		acc.NextToken = resp.NextToken
 
 		if want > 0 && len(acc.Lines) >= want {
 			acc.Lines = acc.Lines[:want]
 			break
 		}
-		if resp.ContinuationToken == "" || len(resp.Lines) == 0 || want == 0 {
+		if resp.NextToken == "" || len(resp.Lines) == 0 || want == 0 {
 			break
 		}
-		token = resp.ContinuationToken
+		token = resp.NextToken
 	}
 	return acc, nil
 }
@@ -222,18 +222,22 @@ func (c *insightsAccountScanLogCmd) fetchStepMode(
 	org, account, scanID string,
 ) (apitype.InsightsScanLogs, error) {
 	job, step := c.job, c.step
-	params := apitype.InsightsScanLogsParams{Job: &job, Step: &step}
-	resp, err := client.GetInsightsScanLogs(ctx, org, account, scanID, params)
+	resp, err := client.GetInsightsScanLogs(ctx, org, account, scanID,
+		apitype.InsightsScanLogsParams{Job: &job, Step: &step})
 	if err != nil {
 		return apitype.InsightsScanLogs{}, err
 	}
 
-	// --count doesn't apply in step mode (the API paginates by bytes, not
-	// by entries), so default and --count behave identically.
+	// --count doesn't apply in step mode (the API paginates by line
+	// offset, not by entry count), so default and --count behave
+	// identically here.
 	if !c.all {
 		return resp, nil
 	}
 
+	// In step mode the server emits `lines` plus a `nextOffset` pointing
+	// at the next line index to start from. Follow the offset chain until
+	// the server stops returning one, accumulating Lines.
 	acc := resp
 	for acc.NextOffset > 0 {
 		offset := acc.NextOffset
@@ -242,40 +246,17 @@ func (c *insightsAccountScanLogCmd) fetchStepMode(
 		if err != nil {
 			return apitype.InsightsScanLogs{}, err
 		}
-		acc.Output += more.Output
+		acc.Lines = append(acc.Lines, more.Lines...)
 		acc.NextOffset = more.NextOffset
-		if more.Output == "" && more.NextOffset == 0 {
-			break
-		}
 	}
 	return acc, nil
 }
 
-// renderText dispatches by mode: step mode emits a raw text blob, continuation
-// mode emits structured records.
+// renderText prints the log entries one per line. The shape is the same for
+// both modes — the server returns `lines` in either case — only the
+// "more available" footer differs (cursor token in continuation mode,
+// line-offset in step mode).
 func (c *insightsAccountScanLogCmd) renderText(r apitype.InsightsScanLogs) error {
-	if c.jobSet {
-		return c.renderStepText(r)
-	}
-	return c.renderContinuationText(r)
-}
-
-func (c *insightsAccountScanLogCmd) renderStepText(r apitype.InsightsScanLogs) error {
-	if _, err := io.WriteString(c.w, r.Output); err != nil {
-		return err
-	}
-	// Force a trailing newline so the hint below sits on its own line.
-	if len(r.Output) > 0 && r.Output[len(r.Output)-1] != '\n' {
-		fmt.Fprintln(c.w)
-	}
-	if r.NextOffset > 0 {
-		fmt.Fprintf(c.w,
-			"More output available. Re-run with --all to fetch the rest.\n")
-	}
-	return nil
-}
-
-func (c *insightsAccountScanLogCmd) renderContinuationText(r apitype.InsightsScanLogs) error {
 	if len(r.Lines) == 0 {
 		fmt.Fprintln(c.w, "No log entries.")
 		return nil
@@ -300,7 +281,11 @@ func (c *insightsAccountScanLogCmd) renderContinuationText(r apitype.InsightsSca
 			fmt.Fprintln(c.w, text)
 		}
 	}
-	if r.ContinuationToken != "" {
+	switch {
+	case c.jobSet && r.NextOffset > 0:
+		fmt.Fprintln(c.w,
+			"\nMore output available. Re-run with --all to fetch the rest.")
+	case !c.jobSet && r.NextToken != "":
 		fmt.Fprintln(c.w,
 			"\nMore entries available. Re-run with --count <N> or --all to fetch more.")
 	}

--- a/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
+++ b/pkg/cmd/pulumi/insights/insights_account_scan_log_test.go
@@ -100,9 +100,26 @@ func continuationPage(lines int, token string) apitype.InsightsScanLogs {
 		})
 	}
 	return apitype.InsightsScanLogs{
-		Type:              "continuation",
-		Lines:             entries,
-		ContinuationToken: token,
+		Type:      "continuation",
+		Lines:     entries,
+		NextToken: token,
+	}
+}
+
+// stepPage builds a step-mode response: structured lines plus an optional
+// nextOffset cursor mirroring what the live API returns.
+func stepPage(lines int, prefix string, nextOffset int64) apitype.InsightsScanLogs {
+	entries := make([]apitype.InsightsScanLogLine, 0, lines)
+	for i := 0; i < lines; i++ {
+		entries = append(entries, apitype.InsightsScanLogLine{
+			Timestamp: time.Date(2026, 5, 1, 14, 30, i, 0, time.UTC),
+			Line:      prefix + "-" + string(rune('0'+i)) + "\n",
+		})
+	}
+	return apitype.InsightsScanLogs{
+		Type:       "DeploymentLogsStep",
+		Lines:      entries,
+		NextOffset: nextOffset,
 	}
 }
 
@@ -266,11 +283,7 @@ func TestScanLog_StepDefault(t *testing.T) {
 	t.Parallel()
 
 	client := &mockScanLogClient{
-		responses: []apitype.InsightsScanLogs{{
-			Type:       "step",
-			Output:     "step output chunk 1\n",
-			NextOffset: 1024,
-		}},
+		responses: []apitype.InsightsScanLogs{stepPage(2, "setup", 1024)},
 	}
 	cmd, buf := newTestScanLogCmd()
 	cmd.jobSet = true
@@ -289,7 +302,8 @@ func TestScanLog_StepDefault(t *testing.T) {
 	assert.Nil(t, client.calls[0].params.Offset, "default mode never sets offset")
 
 	out := buf.String()
-	assert.Contains(t, out, "step output chunk 1")
+	assert.Contains(t, out, "setup-0")
+	assert.Contains(t, out, "setup-1")
 	assert.Contains(t, out, "More output available. Re-run with --all")
 }
 
@@ -298,9 +312,9 @@ func TestScanLog_StepAll(t *testing.T) {
 
 	client := &mockScanLogClient{
 		responses: []apitype.InsightsScanLogs{
-			{Type: "step", Output: "chunk-1\n", NextOffset: 1024},
-			{Type: "step", Output: "chunk-2\n", NextOffset: 2048},
-			{Type: "step", Output: "chunk-3\n", NextOffset: 0},
+			stepPage(2, "page0", 1024),
+			stepPage(2, "page1", 2048),
+			stepPage(1, "page2", 0),
 		},
 	}
 	cmd, buf := newTestScanLogCmd()
@@ -326,9 +340,12 @@ func TestScanLog_StepAll(t *testing.T) {
 	}
 
 	out := buf.String()
-	assert.Contains(t, out, "chunk-1")
-	assert.Contains(t, out, "chunk-2")
-	assert.Contains(t, out, "chunk-3")
+	// Every line from every page is accumulated and rendered.
+	assert.Contains(t, out, "page0-0")
+	assert.Contains(t, out, "page0-1")
+	assert.Contains(t, out, "page1-0")
+	assert.Contains(t, out, "page1-1")
+	assert.Contains(t, out, "page2-0")
 	assert.NotContains(t, out, "More output available")
 }
 
@@ -469,9 +486,7 @@ func TestNewInsightsAccountScanLogCmd_FlagBinding_StepMode(t *testing.T) {
 	t.Parallel()
 
 	client := &mockScanLogClient{
-		responses: []apitype.InsightsScanLogs{{
-			Type: "step", Output: "data\n",
-		}},
+		responses: []apitype.InsightsScanLogs{stepPage(1, "data", 0)},
 	}
 	cmd := newInsightsAccountScanLogCmd(stubScanLogFactory(client, "acme"))
 

--- a/sdk/go/common/apitype/insights.go
+++ b/sdk/go/common/apitype/insights.go
@@ -361,13 +361,20 @@ type InsightsScanLogsParams struct {
 
 // InsightsScanLogs is the response from GetScanLogs. Type is the
 // DeploymentLogsBase discriminator; only the fields relevant to the active
-// mode (continuation-token vs step) are populated.
+// mode (continuation vs step) are populated:
+//
+//   - continuation mode (no Job/Step in the request): the server emits a
+//     `lines` array spanning every step, paginated with `nextToken`.
+//   - step mode (Job and Step set): the server emits a `lines` array scoped
+//     to one step, paginated with `nextOffset` (a line index).
+//
+// The wire field name (`nextToken`) matches `apitype.DeploymentLogs`, since
+// both endpoints share a server-side handler.
 type InsightsScanLogs struct {
-	Type              string                `json:"__type,omitempty"`
-	Lines             []InsightsScanLogLine `json:"lines,omitempty"`
-	ContinuationToken string                `json:"continuationToken,omitempty"`
-	Output            string                `json:"output,omitempty"`
-	NextOffset        int64                 `json:"nextOffset,omitempty"`
+	Type       string                `json:"__type,omitempty"`
+	Lines      []InsightsScanLogLine `json:"lines,omitempty"`
+	NextToken  string                `json:"nextToken,omitempty"`
+	NextOffset int64                 `json:"nextOffset,omitempty"`
 }
 
 // InsightsScanLogLine mirrors apitype.DeploymentLogLine.


### PR DESCRIPTION
## Summary

`scan log --all` doesn't paginate to the end; and step mode comes back empty."

The Insights scan-logs endpoint and the Pulumi Deployments logs endpoint are served by the same server handler. The insights apitype had drifted away from that shape, which is the whole reason the bugs existed.

**What this PR copies from [`apitype.DeploymentLogs`](sdk/go/common/apitype/deployments.go#L351-L354) / [`deployment_log.go`](pkg/cmd/pulumi/deployment/deployment_log.go):**

- The response field is `NextToken` with `json:"nextToken,omitempty"` — matches what the server emits.
- Step mode returns a `Lines` array (not a raw `Output` string).
- The `--all` loop terminates only when the server emits an empty cursor.

### Bug 1 — continuation mode (`--all`)

The server emits `nextToken` on the wire but [`apitype.InsightsScanLogs`](sdk/go/common/apitype/insights.go) had the field tagged `continuationToken`. The struct field decoded to `""` on every response, so the page loop terminated after the first page. Renamed `ContinuationToken` → `NextToken` with the matching JSON tag — same shape as [`apitype.DeploymentLogs`](sdk/go/common/apitype/deployments.go), which is the same server handler.

### Bug 2 — step mode (`--job N --step M`)

The server returns `{lines: [{timestamp, line}, …]}` in step mode too — same envelope as continuation mode, just scoped to one step, with `nextOffset` (an int line index) instead of `nextToken`. The previous step renderer wrote `r.Output` (a never-populated string field), so the command printed nothing. Dropped the dead `Output` field; both modes now share one line-oriented renderer.

`--all` in step mode follows the `nextOffset` chain to accumulate every page of lines.


**What this PR deliberately does NOT copy from Deployments:**

- The `--count` / `--all` semantics on `insights account scan log` are kept as-is (matching the rest of the Cloud-Ready Insights CLI surface — `account list`, `account scan list`).
- The `--org` + positional `<account>` scoping stays — Insights scopes by account, deployments scope by stack.

## Follow-up worth considering (not in this PR)

`apitype.DeploymentLogs` and `apitype.InsightsScanLogs` are now literally the same shape (`Lines []…`, `NextToken string`, plus step-mode `NextOffset int64`). They could be unified into a single `apitype.WorkflowLogs` struct shared between the two endpoints. Similarly, the `--all` loops in [`deployment_log.go`](pkg/cmd/pulumi/deployment/deployment_log.go) and [`insights_account_scan_log.go`](pkg/cmd/pulumi/insights/insights_account_scan_log.go) are nearly identical and could share a helper. Both would be refactors that should touch deployments and insights together, not be smuggled into a bug fix.

## Sample output (before / after)

### `--all` continuation mode

```
# Before: stops after one page (~100 lines)
$ pulumi insights account scan log "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi --all | wc -l
100

# After: follows the cursor to the end
$ pulumi insights account scan log "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi --all | wc -l
8099
```

### `--job N --step M --all` step mode

```
# Before: empty output
$ pulumi insights account scan log "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi --job 0 --step 0 --all
(empty)

# After: prints the step's log lines and follows nextOffset
$ pulumi insights account scan log "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi --job 0 --step 0 --all
2026-01-21T15:59:15Z Preparing environment
2026-01-21T15:59:17Z Using runner default image with Pulumi version 3.216.0 …
2026-01-21T15:59:17Z Starting container
2026-01-21T15:59:26Z Container created …
2026-01-21T15:59:26Z Container started …
…
```

For a step whose log spans multiple `nextOffset` pages (step 3 in the example above), `--all` now fetches the full content:

```
$ pulumi insights account scan log "Michael-Test-AWS/us-east-2" 7bb80f16-… --org pulumi --job 0 --step 3 --all | wc -l
8081
```

## Test plan

- [x] Updated unit tests for both modes to use the real server response shape (`lines` array in step mode, `nextToken` in continuation mode).
- [x] Updated [`client_insights_test.go`](pkg/backend/httpstate/client/client_insights_test.go) to round-trip the same shape.
- [x] `mise exec -- make format`
- [x] `mise exec -- make lint` (0 issues across 7 packages)
- [x] Live smoke against the `pulumi` org: continuation `--all` returns 8099 lines (was ~100), step-mode `--job 0 --step 0 --all` returns the step's log content (was empty), step 3 `--all` fetches 8081 lines across multiple `nextOffset` pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
