### PR TITLE
unhide `org member` commands

### DIFF
--- a/pkg/cmd/pulumi/org/org_member.go
+++ b/pkg/cmd/pulumi/org/org_member.go
@@ -23,10 +23,9 @@ import (
 // TODO[https://github.com/pulumi/pulumi/issues/23009]: Not yet implemented.
 func newOrgMemberCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "member",
-		Short:  "[EXPERIMENTAL] Manage organization members",
-		Long:   "[EXPERIMENTAL] Manage organization members.",
+		Use:   "member",
+		Short: "[EXPERIMENTAL] Manage organization members",
+		Long:  "[EXPERIMENTAL] Manage organization members.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/pkg/cmd/pulumi/org/org_member_list.go
+++ b/pkg/cmd/pulumi/org/org_member_list.go
@@ -78,9 +78,8 @@ func newOrgMemberListCmdWith(factory orgMemberListClientFactory) *cobra.Command 
 	}
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "[EXPERIMENTAL] List members of an organization",
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List members of an organization",
 		Long: "[EXPERIMENTAL] List members of an organization.\n" +
 			"\n" +
 			"Returns the members of the organization, showing each member's user name,\n" +


### PR DESCRIPTION
`org member` has valid subcommands, and the issue for `org member list` is closed (https://github.com/pulumi/pulumi/issues/23013)
