### PR TITLE
unhide `org role` commands

### DIFF
--- a/pkg/cmd/pulumi/org/org_role.go
+++ b/pkg/cmd/pulumi/org/org_role.go
@@ -33,10 +33,9 @@ import (
 
 func newOrgRoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "role",
-		Short:  "[EXPERIMENTAL] Manage organization custom roles",
-		Long:   "[EXPERIMENTAL] Manage organization custom roles.",
+		Use:   "role",
+		Short: "[EXPERIMENTAL] Manage organization custom roles",
+		Long:  "[EXPERIMENTAL] Manage organization custom roles.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},

--- a/pkg/cmd/pulumi/org/org_role_assign.go
+++ b/pkg/cmd/pulumi/org/org_role_assign.go
@@ -48,9 +48,8 @@ func newOrgRoleAssignCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleAssignOutput()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "assign <role-id> <team>",
-		Short:  "[EXPERIMENTAL] Assign a role to a team",
+		Use:   "assign <role-id> <team>",
+		Short: "[EXPERIMENTAL] Assign a role to a team",
 		Long: "[EXPERIMENTAL] Assign a custom role to a team.\n" +
 			"\n" +
 			"Each team can hold a single custom role at a time, so running this command\n" +

--- a/pkg/cmd/pulumi/org/org_role_edit.go
+++ b/pkg/cmd/pulumi/org/org_role_edit.go
@@ -45,9 +45,8 @@ func newOrgRoleEditCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleSingleOutput()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "edit <role-id>",
-		Short:  "[EXPERIMENTAL] Update a custom role's name, description, or permissions",
+		Use:   "edit <role-id>",
+		Short: "[EXPERIMENTAL] Update a custom role's name, description, or permissions",
 		Long: "[EXPERIMENTAL] Update a custom role's name, description, or permissions.\n" +
 			"\n" +
 			"Each field follows ternary semantics: a flag that is not passed leaves the\n" +

--- a/pkg/cmd/pulumi/org/org_role_list.go
+++ b/pkg/cmd/pulumi/org/org_role_list.go
@@ -49,9 +49,8 @@ func newOrgRoleListCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "list",
-		Short:  "[EXPERIMENTAL] List custom roles for an organization",
+		Use:   "list",
+		Short: "[EXPERIMENTAL] List custom roles for an organization",
 		Long: "[EXPERIMENTAL] List custom roles for an organization.\n" +
 			"\n" +
 			"Displays the ID, name, description, UX purpose, and version of each role.\n" +

--- a/pkg/cmd/pulumi/org/org_role_new.go
+++ b/pkg/cmd/pulumi/org/org_role_new.go
@@ -44,9 +44,8 @@ func newOrgRoleNewCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	output := defaultRoleSingleOutput()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "new <name> <details-file>",
-		Short:  "[EXPERIMENTAL] Create a new custom role for an organization",
+		Use:   "new <name> <details-file>",
+		Short: "[EXPERIMENTAL] Create a new custom role for an organization",
 		Long: "[EXPERIMENTAL] Create a new custom role for an organization.\n" +
 			"\n" +
 			"The role's permission tree is read from the JSON file at <details-file>.\n" +

--- a/pkg/cmd/pulumi/org/org_role_remove.go
+++ b/pkg/cmd/pulumi/org/org_role_remove.go
@@ -73,9 +73,8 @@ func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory, confirm confirmFunc) 
 	output := defaultRoleRemoveOutput()
 
 	cmd := &cobra.Command{
-		Hidden: true,
-		Use:    "remove <role-id>",
-		Short:  "[EXPERIMENTAL] Delete a custom role from an organization",
+		Use:   "remove <role-id>",
+		Short: "[EXPERIMENTAL] Delete a custom role from an organization",
 		Long: "[EXPERIMENTAL] Delete a custom role from an organization.\n" +
 			"\n" +
 			"Removing a role revokes any permissions it had granted to members and\n" +


### PR DESCRIPTION
Associated issues are closed:

`role assign`: https://github.com/pulumi/pulumi/issues/23004
`role remove`: https://github.com/pulumi/pulumi/issues/23005
`role edit`: https://github.com/pulumi/pulumi/issues/23006
`role new`: https://github.com/pulumi/pulumi/issues/23007
`role list`: https://github.com/pulumi/pulumi/issues/23008