### PR TITLE
Require `--yes` to confirm when running

### DIFF
--- a/changelog/pending/20260519--cli--require-yes-flag-for-destructive-commands-in-non-interactive-mode.yaml
+++ b/changelog/pending/20260519--cli--require-yes-flag-for-destructive-commands-in-non-interactive-mode.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli
+  description: Require `--yes` to confirm `pulumi deployment cancel`, `pulumi stack schedule remove`, `pulumi org webhook remove`, and `pulumi stack webhook remove` when running non-interactively

--- a/pkg/cmd/pulumi/deployment/deployment_cancel.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cancel.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -35,32 +36,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// deploymentCancelClient is the subset of cloud-API operations the cancel
-// command needs. Defined here so tests can stub a thin interface rather than
-// the full HTTP client surface.
 type deploymentCancelClient interface {
 	CancelStackDeployment(ctx context.Context, stack client.StackIdentifier, deploymentID string) error
 }
 
-// deploymentCancelClientFactory resolves a cloud client and the
-// StackIdentifier the deployment lives under. stackFlag carries the raw value
-// of `--stack` (empty means "use the current stack"). The returned stackName
-// is the human-readable label used in the confirmation prompt and success
-// message; it deliberately mirrors what the user passed/selected rather than
-// the canonical `org/project/stack` form so error and confirmation text stays
-// terse.
 type deploymentCancelClientFactory func(
 	ctx context.Context, stackFlag string,
 ) (deploymentCancelClient, client.StackIdentifier, string, error)
 
-// deploymentCancelRender renders a successful cancellation to w. It is the
-// renderer type plugged into [outputflag.OutputFlag] so `--output` selects
-// between human-readable and JSON output.
 type deploymentCancelRender func(w io.Writer, deploymentID, stackName string) error
 
-// defaultDeploymentCancelOutputFormat returns the OutputFlag wired up with
-// every supported format. Callers (cobra constructors and tests) install this
-// on deploymentCancelArgs so `--output` selects between them.
 func defaultDeploymentCancelOutputFormat() outputflag.OutputFlag[deploymentCancelRender] {
 	return outputflag.OutputFlag[deploymentCancelRender]{
 		RenderForTerminal: renderDeploymentCancelText,
@@ -68,34 +53,17 @@ func defaultDeploymentCancelOutputFormat() outputflag.OutputFlag[deploymentCance
 	}
 }
 
-// deploymentCancelArgs collects the flag values for the cancel command, so
-// Run can be driven directly from tests.
 type deploymentCancelArgs struct {
 	stack  string
 	yes    bool
 	output outputflag.OutputFlag[deploymentCancelRender]
 }
 
-// confirmFunc abstracts the interactive confirmation so tests can inject a
-// deterministic answer without driving a fake terminal. A nil value resolves
-// to the default production prompt at runDeploymentCancel time —
-// terminal-attached sessions ask the user to type `cancel` (matching the
-// pattern used for other destructive `remove`-style commands where the
-// natural identifier — here, a UUID — would be hostile to ask for verbatim),
-// non-interactive sessions (CI, piped stdin, scripts) implicitly accept so
-// they don't block on input that can never arrive.
-type confirmFunc func(prompt string) bool
-
-// newDeploymentCancelCmd builds `pulumi deployment cancel` with the production
-// client factory and confirmation prompt. Test entrypoint is
-// [newDeploymentCancelCmdWith].
 func newDeploymentCancelCmd() *cobra.Command {
-	return newDeploymentCancelCmdWith(nil, nil)
+	return newDeploymentCancelCmdWith(nil)
 }
 
-func newDeploymentCancelCmdWith(
-	factory deploymentCancelClientFactory, confirm confirmFunc,
-) *cobra.Command {
+func newDeploymentCancelCmdWith(factory deploymentCancelClientFactory) *cobra.Command {
 	args := deploymentCancelArgs{output: defaultDeploymentCancelOutputFormat()}
 
 	cmd := &cobra.Command{
@@ -118,7 +86,7 @@ func newDeploymentCancelCmdWith(
 			"  # Emit JSON for scripting.\n" +
 			"  pulumi deployment cancel dep-abc123 --yes --output json",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
-			return runDeploymentCancel(cmd.Context(), cmd.OutOrStdout(), factory, confirm, posArgs[0], args)
+			return runDeploymentCancel(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
 	}
 
@@ -136,14 +104,9 @@ func newDeploymentCancelCmdWith(
 	return cmd
 }
 
-// runDeploymentCancel is the cobra-decoupled body so tests can drive it
-// without going through the flag parser. Passing nil for factory or confirm
-// installs the production defaults — useful for the cobra wiring above, and
-// also lets us exercise the default-resolution path from a test without
-// stubbing every input.
 func runDeploymentCancel(
 	ctx context.Context, w io.Writer,
-	factory deploymentCancelClientFactory, confirm confirmFunc,
+	factory deploymentCancelClientFactory,
 	deploymentID string, args deploymentCancelArgs,
 ) error {
 	render := args.output.Get()
@@ -151,33 +114,21 @@ func runDeploymentCancel(
 	if factory == nil {
 		factory = defaultDeploymentCancelClientFactory
 	}
-	if confirm == nil {
-		// Non-interactive sessions (CI, piped stdin, scripts) implicitly
-		// accept so the command doesn't block on input that can never
-		// arrive. The interactive branch asks the user to type "cancel" —
-		// the deployment ID is a UUID so making them paste that verbatim
-		// (the usual ConfirmPrompt pattern) would be hostile.
-		confirm = func(prompt string) bool {
-			if !cmdutil.Interactive() {
-				return true
-			}
-			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-			return ui.ConfirmPrompt(prompt, "cancel", opts)
-		}
-	}
 
 	c, stackID, stackName, err := factory(ctx, args.stack)
 	if err != nil {
 		return err
 	}
 
-	// Ask before doing anything destructive. We skip the prompt only when
-	// --yes is set.
 	if !args.yes {
+		if !cmdutil.Interactive() {
+			return backenderr.NonInteractiveRequiresYesError{}
+		}
+		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 		prompt := fmt.Sprintf(
-			"Cancel deployment '%s' for stack '%s'?",
+			"This will cancel deployment '%s' for stack '%s'!",
 			deploymentID, stackName)
-		if !confirm(prompt) {
+		if !ui.ConfirmPrompt(prompt, "cancel", opts) {
 			return errors.New("confirmation declined")
 		}
 	}
@@ -189,9 +140,6 @@ func runDeploymentCancel(
 	return render(w, deploymentID, stackName)
 }
 
-// defaultDeploymentCancelClientFactory is the production wiring: resolve the
-// stack via RequireStack (non-prompting beyond the standard select flow), cast
-// to the cloud-backend types, and hand back the underlying *client.Client.
 func defaultDeploymentCancelClientFactory(
 	ctx context.Context, stackFlag string,
 ) (deploymentCancelClient, client.StackIdentifier, string, error) {
@@ -220,10 +168,6 @@ func defaultDeploymentCancelClientFactory(
 		Project: project,
 		Stack:   ref.Name(),
 	}
-	// The Stack→Backend type pair is guaranteed by the cloud backend
-	// implementation: any httpstate.Stack's Backend() returns an
-	// httpstate.Backend, so a second type assertion would be unreachable
-	// defensiveness rather than useful safety.
 	return cloudStack.Backend().(httpstate.Backend).Client(), stackID, ref.Name().String(), nil
 }
 
@@ -235,10 +179,6 @@ func renderDeploymentCancelText(w io.Writer, deploymentID, _ string) error {
 	return nil
 }
 
-// deploymentCancelEnvelope is the JSON shape emitted by
-// `pulumi deployment cancel --output=json`. Returning the inputs back to the
-// caller keeps scripts that pipe one cancel into another from having to
-// remember their own state.
 type deploymentCancelEnvelope struct {
 	DeploymentID string `json:"deploymentId"`
 	Stack        string `json:"stack"`

--- a/pkg/cmd/pulumi/deployment/deployment_cancel_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cancel_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,13 +63,6 @@ func failingCancelFactory(err error) deploymentCancelClientFactory {
 	}
 }
 
-// alwaysConfirm/alwaysDecline make the confirmation deterministic in tests.
-// The default --yes flag bypasses the prompt entirely; these are used to cover
-// the interactive paths.
-func alwaysConfirm(string) bool { return true }
-
-func alwaysDecline(string) bool { return false }
-
 // cancelArgs builds a deploymentCancelArgs with the production OutputFlag
 // pre-wired so tests don't have to repeat the boilerplate. Pass "" for
 // outputFormat to keep the default (terminal) renderer.
@@ -79,8 +73,6 @@ func cancelArgs(stack string, yes bool, outputFormat string) deploymentCancelArg
 		output: defaultDeploymentCancelOutputFormat(),
 	}
 	if outputFormat != "" {
-		// Errors from Set bubble up via cobra in production; the tests that
-		// exercise an unsupported value drive cobra directly instead.
 		_ = args.output.Set(outputFormat)
 	}
 	return args
@@ -91,7 +83,7 @@ func TestDeploymentCancel_DefaultOutput(t *testing.T) {
 
 	c := &mockDeploymentCancelClient{}
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysConfirm,
+	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"),
 		"dep-123", cancelArgs("", true, ""))
 	require.NoError(t, err)
 	assert.Equal(t, "Cancellation requested for deployment 'dep-123'.\n", buf.String())
@@ -102,7 +94,7 @@ func TestDeploymentCancel_JSONOutput(t *testing.T) {
 
 	c := &mockDeploymentCancelClient{}
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysConfirm,
+	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"),
 		"dep-123", cancelArgs("", true, "json"))
 	require.NoError(t, err)
 
@@ -121,7 +113,7 @@ func TestDeploymentCancel_PropagatesIDAndStack(t *testing.T) {
 	var captured capturedCancelCall
 	c := &mockDeploymentCancelClient{captured: &captured}
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysConfirm,
+	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"),
 		"dep-xyz", cancelArgs("", true, ""))
 	require.NoError(t, err)
 	assert.Equal(t, capturedCancelCall{stack: testStackID, deploymentID: "dep-xyz"}, captured)
@@ -137,7 +129,7 @@ func TestDeploymentCancel_StackFlagPropagatesToFactory(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, factory, alwaysConfirm,
+	err := runDeploymentCancel(t.Context(), &buf, factory,
 		"dep-123", cancelArgs("acme/web/staging", true, ""))
 	require.NoError(t, err)
 	assert.Equal(t, "acme/web/staging", capturedStack)
@@ -148,7 +140,7 @@ func TestNewDeploymentCancelCmd_InvalidOutputRejected(t *testing.T) {
 
 	// Unsupported --output values are caught by the OutputFlag at flag-parse
 	// time, so the API is never reached.
-	cmd := newDeploymentCancelCmdWith(stubCancelFactory(&mockDeploymentCancelClient{}, "prod"), alwaysConfirm)
+	cmd := newDeploymentCancelCmdWith(stubCancelFactory(&mockDeploymentCancelClient{}, "prod"))
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
@@ -163,7 +155,7 @@ func TestDeploymentCancel_ClientError(t *testing.T) {
 
 	c := &mockDeploymentCancelClient{err: errors.New("server boom")}
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysConfirm,
+	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"),
 		"dep-123", cancelArgs("", true, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canceling deployment")
@@ -175,141 +167,21 @@ func TestDeploymentCancel_FactoryError(t *testing.T) {
 
 	var buf bytes.Buffer
 	err := runDeploymentCancel(t.Context(), &buf,
-		failingCancelFactory(errors.New("not logged in")), alwaysConfirm,
+		failingCancelFactory(errors.New("not logged in")),
 		"dep-123", cancelArgs("", true, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
 
-func TestDeploymentCancel_ConfirmDeclined(t *testing.T) {
+func TestDeploymentCancel_NonInteractiveRequiresYes(t *testing.T) {
 	t.Parallel()
 
-	// Without --yes the prompt fires; if the user declines, we must bail out
-	// before touching the client.
 	var captured capturedCancelCall
 	c := &mockDeploymentCancelClient{captured: &captured}
 	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysDecline,
+	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"),
 		"dep-123", cancelArgs("", false, ""))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "confirmation declined")
-	assert.Equal(t, capturedCancelCall{}, captured, "client must not be called when confirmation declines")
-}
-
-func TestDeploymentCancel_ConfirmAccepted(t *testing.T) {
-	t.Parallel()
-
-	// Without --yes, an accepting confirmer must let the cancel through.
-	var captured capturedCancelCall
-	c := &mockDeploymentCancelClient{captured: &captured}
-	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysConfirm,
-		"dep-123", cancelArgs("", false, ""))
-	require.NoError(t, err)
-	assert.Equal(t, capturedCancelCall{stack: testStackID, deploymentID: "dep-123"}, captured)
-}
-
-func TestDeploymentCancel_ConfirmPromptReceivesIDAndStack(t *testing.T) {
-	t.Parallel()
-
-	// The y/n prompt surfaces the deployment ID and stack to the user —
-	// assert they propagate verbatim.
-	var gotPrompt string
-	confirm := func(prompt string) bool {
-		gotPrompt = prompt
-		return true
-	}
-
-	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf,
-		stubCancelFactory(&mockDeploymentCancelClient{}, "prod"), confirm,
-		"dep-abc123", cancelArgs("", false, ""))
-	require.NoError(t, err)
-	assert.Contains(t, gotPrompt, "dep-abc123")
-	assert.Contains(t, gotPrompt, "prod")
-}
-
-func TestDeploymentCancel_NilConfirm_NonInteractiveAccepts(t *testing.T) {
-	t.Parallel()
-
-	// Passing nil for confirm installs the production prompt. Tests don't
-	// have a TTY, so cmdutil.Interactive() returns false and the inline
-	// non-interactive branch accepts without prompting — verify that the
-	// cancel still reaches the client.
-	var captured capturedCancelCall
-	c := &mockDeploymentCancelClient{captured: &captured}
-	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), nil,
-		"dep-123", cancelArgs("", false, ""))
-	require.NoError(t, err)
-	assert.Equal(t, capturedCancelCall{stack: testStackID, deploymentID: "dep-123"}, captured)
-}
-
-func TestDeploymentCancel_NilFactory_UsesDefaultAndPropagatesError(t *testing.T) {
-	t.Parallel()
-
-	// Passing nil for the factory installs defaultDeploymentCancelClientFactory,
-	// which drives cmdStack.RequireStack — that fails when run outside a
-	// Pulumi project. The deeper branches of the factory (cloud-backend type
-	// assertion, success path) are left to integration tests; this guards the
-	// nil-default wire-up plus the resolving-stack early-error path.
-	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, nil, alwaysConfirm,
-		"dep-123", cancelArgs("", true, ""))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "resolving stack")
-}
-
-func TestDeploymentCancel_YesSkipsPrompt(t *testing.T) {
-	t.Parallel()
-
-	// With --yes the confirm callback must not be invoked; if it is, the
-	// test fails because alwaysDecline would otherwise abort the run.
-	var captured capturedCancelCall
-	c := &mockDeploymentCancelClient{captured: &captured}
-	var buf bytes.Buffer
-	err := runDeploymentCancel(t.Context(), &buf, stubCancelFactory(c, "prod"), alwaysDecline,
-		"dep-123", cancelArgs("", true, ""))
-	require.NoError(t, err)
-	assert.Equal(t, capturedCancelCall{stack: testStackID, deploymentID: "dep-123"}, captured)
-}
-
-func TestNewDeploymentCancelCmd_CobraFlagBinding(t *testing.T) {
-	t.Parallel()
-
-	var captured capturedCancelCall
-	c := &mockDeploymentCancelClient{captured: &captured}
-	cmd := newDeploymentCancelCmdWith(stubCancelFactory(c, "prod"), alwaysConfirm)
-
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{
-		"--stack", "acme/web/prod",
-		"--yes",
-		"--output", "json",
-		"dep-123",
-	})
-	require.NoError(t, cmd.ExecuteContext(t.Context()))
-
-	assert.Equal(t, capturedCancelCall{stack: testStackID, deploymentID: "dep-123"}, captured)
-
-	var env deploymentCancelEnvelope
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &env))
-	assert.Equal(t, "dep-123", env.DeploymentID)
-	assert.Equal(t, "prod", env.Stack)
-	assert.True(t, env.Canceled)
-}
-
-func TestNewDeploymentCancelCmd_RequiresDeploymentID(t *testing.T) {
-	t.Parallel()
-
-	cmd := newDeploymentCancelCmdWith(stubCancelFactory(&mockDeploymentCancelClient{}, "prod"), alwaysConfirm)
-	cmd.SetArgs([]string{})
-
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-	cmd.SetErr(&buf)
-	err := cmd.ExecuteContext(t.Context())
-	require.Error(t, err)
+	assert.ErrorIs(t, err, backenderr.NonInteractiveRequiresYesError{})
+	assert.Equal(t, capturedCancelCall{}, captured, "client must not be called when confirmation is refused")
 }

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -85,6 +86,9 @@ func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	if !c.yes {
+		if !cmdutil.Interactive() {
+			return backenderr.NonInteractiveRequiresYesError{}
+		}
 		prompt := fmt.Sprintf(
 			"This will permanently remove the webhook '%s'!", webhookName)
 		if !ui.ConfirmPrompt(prompt, webhookName, opts) {

--- a/pkg/cmd/pulumi/stack/stack_schedule_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_remove.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -102,6 +103,9 @@ func runStackScheduleRemove(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	if !yes {
+		if !cmdutil.Interactive() {
+			return backenderr.NonInteractiveRequiresYesError{}
+		}
 		prompt := fmt.Sprintf("This will remove the schedule '%s'!", scheduleID)
 		if !ui.ConfirmPrompt(prompt, "remove", opts) {
 			return result.FprintBailf(os.Stdout, "confirmation declined")

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -106,6 +107,9 @@ func runStackWebhookRemove(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	if !yes {
+		if !cmdutil.Interactive() {
+			return backenderr.NonInteractiveRequiresYesError{}
+		}
 		prompt := fmt.Sprintf(
 			"This will permanently remove the webhook '%s'!",
 			webhookName)


### PR DESCRIPTION
When running non-interactively the user must pass `--yes` for the commands:

* `pulumi deployment cancel`
* `pulumi stack schedule remove`
* `pulumi org webhook remove`
* `pulumi stack webhook remove`
