### PR TITLE
fix data race in `TerminateProcessGroup`

### DIFF
--- a/sdk/go/common/util/cmdutil/term.go
+++ b/sdk/go/common/util/cmdutil/term.go
@@ -101,11 +101,10 @@ func TerminateProcessGroup(proc *os.Process, cooldown time.Duration) (ok bool, e
 		return false, killProcessGroup(proc)
 	}
 
-	var waitErr error
+	waitErrCh := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), cooldown)
+	defer cancel()
 	go func() {
-		defer cancel()
-
 		state, err := proc.Wait()
 		switch {
 		case err == nil && !state.Success():
@@ -116,7 +115,8 @@ func TerminateProcessGroup(proc *os.Process, cooldown time.Duration) (ok bool, e
 			err = nil
 		}
 
-		waitErr = err
+		waitErrCh <- err
+		cancel()
 	}()
 
 	// The context will be canceled when the timeout expires,
@@ -129,5 +129,5 @@ func TerminateProcessGroup(proc *os.Process, cooldown time.Duration) (ok bool, e
 		return false, killProcessGroup(proc)
 	}
 
-	return true, waitErr
+	return true, <-waitErrCh
 }


### PR DESCRIPTION
It is possible for access to waitErr to race with writing to it, since `ctx.Done()` can be because of other sources as well, not only the `cancel()` call.  This can lead to flaky tests as seen in https://github.com/pulumi/pulumi/issues/23271.

Unfortunately the test logs don't contain the exact backtrace from the race detector, but claude says this is a plausible reason, and it definitely is a potential race.

Fixes https://github.com/pulumi/pulumi/issues/23271
