### PR TITLE
Go Automation API: Change output directory and clean up comments

### DIFF
--- a/sdk/go/auto/automation/base/base.go
+++ b/sdk/go/auto/automation/base/base.go
@@ -14,10 +14,6 @@
 
 // Package base is the shared foundation consumed by generated command methods
 // and their per-command option packages.
-//
-// The integration PR (#4) will swap PulumiCommand here for the real interface
-// exported from sdk/go/auto. For the standalone code generator it is a
-// structural copy so the generated output compiles in isolation.
 package base
 
 import (
@@ -57,9 +53,9 @@ type CommandResult struct {
 }
 
 // PulumiCommand is the structural contract the API calls into. It mirrors
-// `github.com/pulumi/pulumi/sdk/v3/go/auto.PulumiCommand` so that the
-// integration PR can drop the real type in here without touching the
-// generator.
+// `github.com/pulumi/pulumi/sdk/v3/go/auto.PulumiCommand` so that callers
+// of the generated wrapper can substitute the real type without the
+// generator having to depend on sdk/go/auto.
 type PulumiCommand interface {
 	Run(
 		ctx context.Context,

--- a/sdk/go/tools/automation/boilerplate/standard/standard.go
+++ b/sdk/go/tools/automation/boilerplate/standard/standard.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/tools/automation/boilerplate/base"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/automation/base"
 )
 
 // API wraps a PulumiCommand and exposes one Go method per pulumi CLI

--- a/sdk/go/tools/automation/boilerplate/testing/testing.go
+++ b/sdk/go/tools/automation/boilerplate/testing/testing.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/tools/automation/boilerplate/base"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/automation/base"
 )
 
 // API is the same public shape as the production boilerplate. The generator

--- a/sdk/go/tools/automation/main.go
+++ b/sdk/go/tools/automation/main.go
@@ -348,12 +348,8 @@ func buildOptionsImports() *ast.GenDecl {
 }
 
 // basePackageImportPath is the canonical location of the `base` package
-// that generated code consumes. Today only commands.go imports it (to
-// build a base.BaseOptions value when calling a.run); per-command
-// Options structs embed the BaseOptions fields directly so that callers
-// can initialise them via composite literals. The integration PR (#4) is
-// where this flips over to the real sdk/go/auto address.
-const basePackageImportPath = "github.com/pulumi/pulumi/sdk/v3/go/tools/automation/boilerplate/base"
+// that generated code consumes.
+const basePackageImportPath = "github.com/pulumi/pulumi/sdk/v3/go/auto/automation/base"
 
 // defaultAPIImportBase is the Go import path of the default outputDir.
 // It anchors the per-command opt-package imports emitted by commands.go
@@ -684,6 +680,25 @@ func toComment(desc string) *ast.CommentGroup {
 	return &ast.CommentGroup{List: list}
 }
 
+// docCommentLines splits a CLI description into trimmed non-empty lines,
+// ready to be rendered as a `// `-prefixed comment block in commands.go.
+// Embedding a multi-line description as a single `// {{.DocComment}}` line
+// would push the body of the description outside the comment block and
+// break gofmt; callers that need a Go doc comment must iterate over the
+// returned lines.
+func docCommentLines(desc string) []string {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return nil
+	}
+	raw := strings.Split(desc, "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		lines = append(lines, strings.TrimRight(line, " \t"))
+	}
+	return lines
+}
+
 func astTypeFor(typ string, repeatable bool) (ast.Expr, error) {
 	var base *ast.Ident
 	switch typ {
@@ -781,13 +796,17 @@ func readBoilerplateFile(dir string) ([]byte, error) {
 
 // commandMethod is the template payload for one generated method.
 type commandMethod struct {
-	Name         string
-	OptPkg       string
-	Breadcrumbs  []string
-	DocComment   string
-	RequiredArgs []methodArg
-	OptionalArgs []methodArg
-	VariadicArg  *methodArg
+	Name        string
+	OptPkg      string
+	Breadcrumbs []string
+	// DocCommentLines is the per-line breakdown of the spec's description.
+	// The template emits one `// ` prefixed line per entry so multi-line
+	// descriptions (e.g. for `pulumi new`, `pulumi cancel`) stay inside the
+	// comment block and survive gofmt.
+	DocCommentLines []string
+	RequiredArgs    []methodArg
+	OptionalArgs    []methodArg
+	VariadicArg     *methodArg
 	// Presets are pre-rendered Go statements appending preset flag values.
 	Presets []string
 	// Flags are pre-rendered Go statements appending user-supplied flag values.
@@ -901,10 +920,10 @@ func walkCommands(
 // node: method name, positional arguments, pre-rendered preset/flag bodies.
 func buildCommandMethod(node Structure, breadcrumbs []string, flags map[string]Flag) (commandMethod, error) {
 	m := commandMethod{
-		Name:        methodNameFor(breadcrumbs),
-		OptPkg:      packageNameFor(breadcrumbs),
-		Breadcrumbs: append([]string(nil), breadcrumbs...),
-		DocComment:  strings.TrimSpace(node.Description),
+		Name:            methodNameFor(breadcrumbs),
+		OptPkg:          packageNameFor(breadcrumbs),
+		Breadcrumbs:     append([]string(nil), breadcrumbs...),
+		DocCommentLines: docCommentLines(node.Description),
 	}
 
 	// Positional arguments. When `requiredArguments` is absent from the spec
@@ -1140,11 +1159,13 @@ var _ = fmt.Sprint
 var _ = context.Background
 
 {{range .Methods}}
-{{if .DocComment}}// {{.Name}} corresponds to ` + "`pulumi {{range $i, $c := .Breadcrumbs}}{{if $i}} {{end}}{{$c}}{{end}}`" + `.
+// {{.Name}} corresponds to ` + "`pulumi {{range $i, $c := .Breadcrumbs}}{{if $i}} {{end}}{{$c}}{{end}}`" + `.
+{{- if .DocCommentLines}}
 //
-// {{.DocComment}}
-{{else}}// {{.Name}} corresponds to ` + "`pulumi {{range $i, $c := .Breadcrumbs}}{{if $i}} {{end}}{{$c}}{{end}}`" + `.
-{{end -}}
+{{- range .DocCommentLines}}
+// {{.}}
+{{- end}}
+{{- end}}
 func (a *API) {{.Name}}(
 	ctx context.Context,
 {{- range .RequiredArgs}}


### PR DESCRIPTION
Two little things - put the code in the right place for integration _and_ fix a little comments rendering issue