### PR TITLE
use latest version of gotestsum

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -281,7 +281,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: gotestyourself/gotestsum
-          tag: v1.8.1
+          tag: v1.13.0
           cache: enable
       - name: Install goteststats
         uses: jaxxstorm/action-install-gh-release@v3.0.0


### PR DESCRIPTION
Claude claims this version of gotestsum does better with outputting the race detector backtraces, which helps when diagnosing racy tests. Even if it's wrong, upgrading this won't hurt, so it's worth doing either way.