### PR TITLE
Fix file descriptor leak in ParseFiles

### DIFF
--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -479,6 +479,7 @@ func ParseFiles(parser *syntax.Parser, directory string, files []fs.DirEntry) (h
 			}
 
 			err = parser.ParseFile(file, filepath.Base(path))
+			contract.IgnoreClose(file)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

`ParseFiles` in `pkg/codegen/pcl/binder.go` opens files in a loop via `os.Open` but never closes them, leaking one file descriptor per parsed file.

The sister function `ParseDirectory` in `binder_component.go` correctly calls `contract.IgnoreClose(file)` after `parser.ParseFile()`. This PR adds the same close call to `ParseFiles`.

## Failure scenario

`ParseFiles` is called by `ParseDirectory` (same file, line 500), which is the entry point for codegen tools processing entire project directories. For large Pulumi projects with many `.pp` files, this leaks one fd per file per invocation. In long-running processes (IDE language servers, automation pipelines), this accumulates and can hit OS ulimits.

## Bug origin

Introduced in commit `5c999e28ca` by Fraser Waters on 2023-05-26 ("Test components in convert"). The same commit correctly includes `contract.IgnoreClose(file)` in the sister function in `binder_component.go`, so the omission in `ParseFiles` was an oversight.

## Test plan

- `go test ./codegen/pcl/... -count=1` passes (20.6s, 20+ tests)
- `gofmt`, `go vet`, `go build` all clean

## Changelog

Not applicable (1-line bug fix, no user-facing behavioral change on the success path). Requesting `impact/no-changelog-required` label.