### PR TITLE
login: honor optional defaultOrg query param from browser-login redirect

### DIFF
--- a/changelog/pending/20260519--cli-login--honor-defaultorg-query-param-from-browser-login.yaml
+++ b/changelog/pending/20260519--cli-login--honor-defaultorg-query-param-from-browser-login.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/login
+  description: Honor an optional `defaultOrg` query parameter on the browser-login redirect, so a default organization picked on the Console can be persisted automatically (equivalent to `pulumi org set-default`). Older Consoles that don't send the parameter are unaffected.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -299,7 +299,7 @@ func loginWithBrowser(
 	}
 
 	// Listen on localhost, have the kernel pick a random port for us
-	c := make(chan string)
+	c := make(chan browserLoginResult)
 	l, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
 		return nil, fmt.Errorf("could not start listener: %w", err)
@@ -352,7 +352,8 @@ func loginWithBrowser(
 
 	fmt.Println("\nWaiting for login to complete...")
 
-	accessToken := <-c
+	result := <-c
+	accessToken := result.accessToken
 
 	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken)
 	if err != nil {
@@ -369,6 +370,15 @@ func loginWithBrowser(
 	}
 	if err = workspace.StoreAccount(cloudURL, account, current); err != nil {
 		return nil, err
+	}
+
+	// Persist the default organization the user selected on the Console's post-OAuth
+	// org-picker page, if any. Best-effort: warn but don't fail the login — the user
+	// has a working token and can run `pulumi org set-default` manually if this fails.
+	if result.defaultOrg != "" {
+		if err := workspace.SetBackendConfigDefaultOrg(cloudURL, result.defaultOrg); err != nil {
+			fmt.Printf("warning: could not set default organization to %q: %s\n", result.defaultOrg, err)
+		}
 	}
 
 	// Welcome the user since this was an interactive login.
@@ -990,10 +1000,19 @@ func (b *cloudBackend) CloudConsoleURL(paths ...string) string {
 }
 
 // serveBrowserLoginServer hosts the server that completes the browser based login flow.
-func serveBrowserLoginServer(l net.Listener, expectedNonce string, destinationURL string, c chan<- string) {
+// browserLoginResult is what the browser-side flow sends back to the CLI loopback
+// handler: the issued access token, and (optionally) a default organization the
+// user selected on the Console's post-OAuth org-picker page.
+type browserLoginResult struct {
+	accessToken string
+	defaultOrg  string
+}
+
+func serveBrowserLoginServer(l net.Listener, expectedNonce string, destinationURL string, c chan<- browserLoginResult) {
 	handler := func(res http.ResponseWriter, req *http.Request) {
 		tok := req.URL.Query().Get("accessToken")
 		nonce := req.URL.Query().Get("nonce")
+		defaultOrg := req.URL.Query().Get("defaultOrg")
 
 		if tok == "" || nonce != expectedNonce {
 			res.WriteHeader(400)
@@ -1001,7 +1020,7 @@ func serveBrowserLoginServer(l net.Listener, expectedNonce string, destinationUR
 		}
 
 		http.Redirect(res, req, destinationURL, http.StatusTemporaryRedirect)
-		c <- tok
+		c <- browserLoginResult{accessToken: tok, defaultOrg: defaultOrg}
 	}
 
 	mux := &http.ServeMux{}

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1529,4 +1530,85 @@ func TestCreateNeoTaskOnError(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, resp)
 	})
+}
+
+func TestServeBrowserLoginServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		query         string
+		expectedNonce string
+		wantStatus    int
+		wantResult    *browserLoginResult
+	}{
+		{
+			name:          "valid token and nonce, no defaultOrg",
+			query:         "accessToken=tok1&nonce=N",
+			expectedNonce: "N",
+			wantStatus:    http.StatusTemporaryRedirect,
+			wantResult:    &browserLoginResult{accessToken: "tok1"},
+		},
+		{
+			name:          "valid token, nonce, and defaultOrg",
+			query:         "accessToken=tok2&nonce=N&defaultOrg=acme-cloud",
+			expectedNonce: "N",
+			wantStatus:    http.StatusTemporaryRedirect,
+			wantResult:    &browserLoginResult{accessToken: "tok2", defaultOrg: "acme-cloud"},
+		},
+		{
+			name:          "missing token returns 400",
+			query:         "nonce=N",
+			expectedNonce: "N",
+			wantStatus:    http.StatusBadRequest,
+			wantResult:    nil,
+		},
+		{
+			name:          "mismatched nonce returns 400",
+			query:         "accessToken=tok&nonce=X",
+			expectedNonce: "N",
+			wantStatus:    http.StatusBadRequest,
+			wantResult:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l, err := net.Listen("tcp", "127.0.0.1:")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = l.Close() })
+
+			ch := make(chan browserLoginResult, 1)
+			go serveBrowserLoginServer(l, tt.expectedNonce, "/welcome", ch)
+
+			// Don't follow the redirect so we can observe the response code directly.
+			client := &http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+			resp, err := client.Get("http://" + l.Addr().String() + "/?" + tt.query)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.wantResult != nil {
+				select {
+				case got := <-ch:
+					assert.Equal(t, *tt.wantResult, got)
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for channel result")
+				}
+			} else {
+				select {
+				case got := <-ch:
+					t.Fatalf("unexpected channel result on bad request: %+v", got)
+				case <-time.After(100 * time.Millisecond):
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Teaches `pulumi login`'s browser-login loopback handler to read an optional `defaultOrg` query parameter from the redirect URL and, when present, persist it via `workspace.SetBackendConfigDefaultOrg` — equivalent to running `pulumi org set-default <name>` immediately after login.

This is the CLI half of a feature in `pulumi/pulumi-service` that adds a post-OAuth "pick your default organization" page to the browser-login flow. The page hands the selected org name to the CLI through the existing localhost redirect URL.

## Compatibility

The new query parameter is strictly additive. All four version combinations behave correctly:

| Service | CLI | Behavior |
|---|---|---|
| Old (no `defaultOrg`) | Old | Unchanged — `accessToken` only |
| New (sends `defaultOrg`) | Old | Unchanged for the user — CLI ignores unknown query params |
| Old (no `defaultOrg`) | New | Unchanged — `result.defaultOrg == ""` skips the call |
| New | New | Default org persisted automatically after login |

So the service-side and CLI-side changes can land independently and roll out in either order.

## Error handling

Persisting the default org is best-effort: a failure logs a warning but does **not** fail the login. The user already has a working access token and can recover with a manual `pulumi org set-default` if needed.

## Test plan

- [x] New unit test `TestServeBrowserLoginServer` covers four cases on the loopback handler:
  - valid token + nonce, no `defaultOrg` → existing behavior preserved
  - valid token + nonce + `defaultOrg=acme-cloud` → new field populated on the result channel
  - missing token → `400`, no channel send
  - mismatched nonce → `400`, no channel send
- [x] `go build ./pkg/backend/httpstate/...` and `go vet ./pkg/backend/httpstate/...` clean
- [ ] Manual end-to-end test against a pulumi-service build that emits `defaultOrg`

## Notes for reviewer

- `workspace.SetBackendConfigDefaultOrg` already exists and is the same function called by `pulumi login --default-org=<name>` (`pkg/cmd/pulumi/auth/login.go`).
- The new internal type `browserLoginResult` replaces a `chan string` so we can carry both the token and the optional org name across the goroutine boundary cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)