### PR TITLE
Add list to provider

### DIFF
--- a/changelog/pending/20260519--sdk--add-list-to-the-go-provider-interface.yaml
+++ b/changelog/pending/20260519--sdk--add-list-to-the-go-provider-interface.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdk
+  description: Add `List` to the Go `plugin.Provider` interface, wired to the streaming `ResourceProvider.List` RPC

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -271,6 +271,10 @@ func (p *builtinProvider) Delete(_ context.Context, req plugin.DeleteRequest) (p
 	return plugin.DeleteResponse{Status: resource.StatusOK}, nil
 }
 
+func (p *builtinProvider) List(context.Context, plugin.ListRequest) (*plugin.ListStream, error) {
+	return nil, errors.New("the builtin provider does not support List")
+}
+
 func (p *builtinProvider) Read(_ context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
 	contract.Requiref(req.URN != "", "urn", "must not be empty")
 	contract.Requiref(req.ID != "", "id", "must not be empty")

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -51,6 +51,7 @@ type Provider struct {
 	CreateF       func(context.Context, plugin.CreateRequest) (plugin.CreateResponse, error)
 	UpdateF       func(context.Context, plugin.UpdateRequest) (plugin.UpdateResponse, error)
 	DeleteF       func(context.Context, plugin.DeleteRequest) (plugin.DeleteResponse, error)
+	ListF         func(context.Context, plugin.ListRequest) (*plugin.ListStream, error)
 	ReadF         func(context.Context, plugin.ReadRequest) (plugin.ReadResponse, error)
 	ConstructF    func(context.Context, plugin.ConstructRequest, *ResourceMonitor) (plugin.ConstructResponse, error)
 	InvokeF       func(context.Context, plugin.InvokeRequest) (plugin.InvokeResponse, error)
@@ -177,6 +178,13 @@ func (prov *Provider) Delete(ctx context.Context, req plugin.DeleteRequest) (plu
 		return plugin.DeleteResponse{Status: resource.StatusOK}, nil
 	}
 	return prov.DeleteF(ctx, req)
+}
+
+func (prov *Provider) List(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+	if prov.ListF == nil {
+		return plugin.NewListStream(nil, ""), nil
+	}
+	return prov.ListF(ctx, req)
 }
 
 func (prov *Provider) Read(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -1036,6 +1036,10 @@ func (r *Registry) Read(context.Context, plugin.ReadRequest) (plugin.ReadRespons
 	return plugin.ReadResponse{}, errors.New("provider resources may not be read")
 }
 
+func (r *Registry) List(context.Context, plugin.ListRequest) (*plugin.ListStream, error) {
+	return nil, errors.New("provider resources may not be listed")
+}
+
 func (r *Registry) Construct(context.Context, plugin.ConstructRequest) (plugin.ConstructResponse, error) {
 	return plugin.ConstructResult{}, errors.New("provider resources may not be constructed")
 }

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -168,6 +168,7 @@ type MockProvider struct {
 	ReadF               func(context.Context, ReadRequest) (ReadResponse, error)
 	UpdateF             func(context.Context, UpdateRequest) (UpdateResponse, error)
 	DeleteF             func(context.Context, DeleteRequest) (DeleteResponse, error)
+	ListF               func(context.Context, ListRequest) (*ListStream, error)
 	ConstructF          func(context.Context, ConstructRequest) (ConstructResponse, error)
 	InvokeF             func(context.Context, InvokeRequest) (InvokeResponse, error)
 	CallF               func(context.Context, CallRequest) (CallResponse, error)
@@ -277,6 +278,13 @@ func (m *MockProvider) Delete(ctx context.Context, req DeleteRequest) (DeleteRes
 		return m.DeleteF(ctx, req)
 	}
 	return DeleteResponse{}, errors.New("Delete not implemented")
+}
+
+func (m *MockProvider) List(ctx context.Context, req ListRequest) (*ListStream, error) {
+	if m.ListF != nil {
+		return m.ListF(ctx, req)
+	}
+	return nil, errors.New("List not implemented")
 }
 
 func (m *MockProvider) Construct(ctx context.Context, req ConstructRequest) (ConstructResponse, error) {

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"iter"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -339,6 +340,91 @@ type DeleteResponse struct {
 	Status resource.Status
 }
 
+// ListRequest is the type of requests sent as part of a [Provider.List] call.
+type ListRequest struct {
+	// Token is the resource type to enumerate.
+	Token tokens.Type
+	// Query is an optional provider-defined filter over resource state. It may contain unknown values, in which case
+	// the provider should respond with a [ListResponse] whose Computed flag is set.
+	Query resource.PropertyMap
+	// Limit caps the total number of results across the entire enumeration. A value of zero means "no limit". The
+	// provider may return fewer results than Limit even when more match.
+	Limit int64
+	// PageSize is the maximum number of results the caller wants in a single page. The provider is free to return
+	// fewer than PageSize, but should not exceed it. A value of zero lets the provider choose.
+	PageSize int64
+	// ContinuationToken is the opaque token returned by a previous List call. Empty for the first page; non-empty to
+	// fetch the next page using the same Token/Query/Limit as the original call.
+	ContinuationToken string
+}
+
+// ListResult is a single resource returned by a [Provider.List] call.
+type ListResult struct {
+	// ID is an importable identifier for the resource. It can be passed to [Provider.Read] to fetch full state.
+	ID resource.ID
+	// Name is the provider-supplied name for the resource, or empty if the provider does not supply one.
+	Name string
+}
+
+// ListStream is the streamed response of a [Provider.List] call. The caller iterates Items to receive each
+// resource one at a time; after iteration completes, Computed and ContinuationToken hold any trailing metadata
+// the provider returned.
+//
+// The contract for Items is:
+//
+//   - Each yield delivers either (item, nil) for a successful result, or (zero, err) for an error. An error pair is
+//     always the final yield — the iterator returns immediately afterwards.
+//   - Items must be drained to completion to ensure the underlying transport is closed and Computed /
+//     ContinuationToken are populated. Stopping early (e.g. break out of the range loop) is allowed but those
+//     metadata fields may not reflect the full stream.
+//   - Items may only be iterated once.
+//
+// A typical caller looks like:
+//
+//	stream, err := p.List(req)
+//	if err != nil { return err }
+//	for item, err := range stream.Items {
+//	    if err != nil { return err }
+//	    // process item
+//	}
+//	if stream.Computed { /* query had unknowns */ }
+//	next := stream.ContinuationToken
+type ListStream struct {
+	// Items yields each list result. See the [ListStream] doc comment for the iteration contract.
+	Items iter.Seq2[ListResult, error]
+	// Computed is set after Items completes if the provider could not compute the list, typically because the query
+	// contained unknown values. When true, no items will have been yielded.
+	Computed bool
+	// ContinuationToken is set after Items completes to the cursor for the next page. Empty when there are no more
+	// pages.
+	ContinuationToken string
+}
+
+// NewListStream builds a ListStream that yields each entry in results, then exposes the supplied continuationToken.
+// It is intended for synthetic implementations such as test doubles. The returned stream's Items can be iterated
+// exactly once.
+func NewListStream(results []ListResult, continuationToken string) *ListStream {
+	return &ListStream{
+		Items: func(yield func(ListResult, error) bool) {
+			for _, r := range results {
+				if !yield(r, nil) {
+					return
+				}
+			}
+		},
+		ContinuationToken: continuationToken,
+	}
+}
+
+// NewComputedListStream builds a ListStream that yields no items and reports Computed=true. It is intended for
+// providers that detect unknown values in the query at construction time.
+func NewComputedListStream() *ListStream {
+	return &ListStream{
+		Items:    func(yield func(ListResult, error) bool) {},
+		Computed: true,
+	}
+}
+
 type ConstructRequest struct {
 	Info    ConstructInfo
 	Type    tokens.Type
@@ -448,6 +534,11 @@ type Provider interface {
 	Update(context.Context, UpdateRequest) (UpdateResponse, error)
 	// Delete tears down an existing resource. The inputs and outputs are the last recorded ones from state.
 	Delete(context.Context, DeleteRequest) (DeleteResponse, error)
+	// List enumerates resources of the given type managed by this provider. The returned ListStream yields each
+	// resource one at a time; after Items has finished iterating, ContinuationToken (if non-empty) can be passed
+	// back in a follow-up ListRequest to fetch the next page, and Computed reports whether the provider could not
+	// compute the list (typically because the query contained unknown values).
+	List(context.Context, ListRequest) (*ListStream, error)
 
 	// Construct creates a new component resource.
 	Construct(context.Context, ConstructRequest) (ConstructResponse, error)

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1811,6 +1812,83 @@ func (p *provider) Delete(ctx context.Context, req DeleteRequest) (DeleteRespons
 
 	logging.V(7).Infof("%s success", label)
 	return DeleteResponse{Status: resource.StatusOK}, err
+}
+
+func (p *provider) List(ctx context.Context, req ListRequest) (*ListStream, error) {
+	label := fmt.Sprintf("%s.List(%s)", p.label(), req.Token)
+	logging.V(7).Infof("%s executing (#query=%d)", label, len(req.Query))
+
+	client := p.clientRaw
+	protocol, pcfg, err := p.getPluginConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !pcfg.known {
+		return NewComputedListStream(), nil
+	}
+
+	query, err := MarshalProperties(req.Query, MarshalOptions{
+		Label:         label + ".query",
+		KeepSecrets:   protocol.acceptSecrets,
+		KeepResources: protocol.acceptResources,
+		PropagateNil:  true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Use a cancellable child of the context. We hold onto the cancel so we can release the underlying gRPC stream
+	// resources on every exit path from the iterator below — including when the caller breaks out of the range loop
+	// early (gRPC server streams only release on EOF, error, or context cancel).
+	streamCtx, cancel := context.WithCancel(ctx)
+	rpcStream, err := client.List(streamCtx, &pulumirpc.ListRequest{
+		Token:             string(req.Token),
+		Query:             query,
+		Limit:             req.Limit,
+		PageSize:          req.PageSize,
+		ContinuationToken: req.ContinuationToken,
+	})
+	if err != nil {
+		cancel()
+		rpcError := rpcerror.Convert(err)
+		logging.V(7).Infof("%s failed: err=%v", label, rpcError.Message())
+		return nil, rpcError
+	}
+
+	// Drain the gRPC stream lazily. The closure mutates stream.Computed and stream.ContinuationToken as the
+	// trailing metadata arrives, so callers must iterate Items to completion to observe accurate values.
+	stream := &ListStream{}
+	stream.Items = func(yield func(ListResult, error) bool) {
+		defer cancel()
+		for {
+			item, err := rpcStream.Recv()
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			if err != nil {
+				rpcError := rpcerror.Convert(err)
+				logging.V(7).Infof("%s failed: err=%v", label, rpcError.Message())
+				yield(ListResult{}, rpcError)
+				return
+			}
+
+			switch item.GetResponse().(type) {
+			case *pulumirpc.ListResponse_Computed_:
+				stream.Computed = true
+			case *pulumirpc.ListResponse_Result_:
+				result := item.GetResult()
+				if !yield(ListResult{
+					ID:   resource.ID(result.GetId()),
+					Name: result.GetName(),
+				}, nil) {
+					return
+				}
+			case *pulumirpc.ListResponse_Continuation_:
+				stream.ContinuationToken = item.GetContinuation().GetContinuationToken()
+			}
+		}
+	}
+	return stream, nil
 }
 
 // Construct creates a new component resource from the given type, name, parent, options, and inputs, and returns

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -816,6 +817,7 @@ type stubClient struct {
 	DeleteF        func(*pulumirpc.DeleteRequest) error
 	GetSchemaF     func(*pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error)
 	GetPluginInfoF func() (*pulumirpc.PluginInfo, error)
+	ListF          func(context.Context, *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error)
 	ReadF          func(*pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error)
 	UpdateF        func(*pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error)
 }
@@ -898,6 +900,17 @@ func (c *stubClient) GetPluginInfo(
 	return c.ResourceProviderClient.GetPluginInfo(ctx, in, opts...)
 }
 
+func (c *stubClient) List(
+	ctx context.Context,
+	req *pulumirpc.ListRequest,
+	opts ...grpc.CallOption,
+) (pulumirpc.ResourceProvider_ListClient, error) {
+	if f := c.ListF; f != nil {
+		return f(ctx, req)
+	}
+	return c.ResourceProviderClient.List(ctx, req, opts...)
+}
+
 func (c *stubClient) Read(
 	ctx context.Context,
 	req *pulumirpc.ReadRequest,
@@ -909,6 +922,28 @@ func (c *stubClient) Read(
 	return c.ResourceProviderClient.Read(ctx, req, opts...)
 }
 
+// stubListStream is a fake [pulumirpc.ResourceProvider_ListClient] that drains a pre-populated slice of responses.
+// It only implements the Recv method exercised by [provider.List]; other grpc.ClientStream methods panic on the
+// embedded nil interface if invoked.
+type stubListStream struct {
+	grpc.ClientStream
+
+	responses []*pulumirpc.ListResponse
+	err       error
+}
+
+func (s *stubListStream) Recv() (*pulumirpc.ListResponse, error) {
+	if len(s.responses) == 0 {
+		if s.err != nil {
+			return nil, s.err
+		}
+		return nil, io.EOF
+	}
+	resp := s.responses[0]
+	s.responses = s.responses[1:]
+	return resp, nil
+}
+
 func (c *stubClient) Update(
 	ctx context.Context,
 	req *pulumirpc.UpdateRequest,
@@ -918,6 +953,304 @@ func (c *stubClient) Update(
 		return f(req)
 	}
 	return c.ResourceProviderClient.Update(ctx, req, opts...)
+}
+
+// drainListStream iterates stream.Items, collecting results into a slice and stopping at the first error.
+func drainListStream(t *testing.T, stream *ListStream) []ListResult {
+	t.Helper()
+	var got []ListResult //nolint:prealloc // Items is an iter
+	for item, err := range stream.Items {
+		require.NoError(t, err)
+		got = append(got, item)
+	}
+	return got
+}
+
+func TestProvider_List(t *testing.T) {
+	t.Parallel()
+
+	resultMsg := func(id, name string) *pulumirpc.ListResponse {
+		return &pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{Id: id, Name: name},
+			},
+		}
+	}
+	continuationMsg := func(token string) *pulumirpc.ListResponse {
+		return &pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Continuation_{
+				Continuation: &pulumirpc.ListResponse_Continuation{ContinuationToken: token},
+			},
+		}
+	}
+	computedMsg := &pulumirpc.ListResponse{
+		Response: &pulumirpc.ListResponse_Computed_{
+			Computed: &pulumirpc.ListResponse_Computed{},
+		},
+	}
+
+	tests := []struct {
+		desc                  string
+		responses             []*pulumirpc.ListResponse
+		wantResults           []ListResult
+		wantComputed          bool
+		wantContinuationToken string
+	}{
+		{
+			desc: "single page",
+			responses: []*pulumirpc.ListResponse{
+				resultMsg("id-a", "alpha"),
+				resultMsg("id-b", "beta"),
+			},
+			wantResults: []ListResult{
+				{ID: "id-a", Name: "alpha"},
+				{ID: "id-b", Name: "beta"},
+			},
+		},
+		{
+			desc: "page with continuation",
+			responses: []*pulumirpc.ListResponse{
+				resultMsg("id-a", "alpha"),
+				continuationMsg("next-cursor"),
+			},
+			wantResults:           []ListResult{{ID: "id-a", Name: "alpha"}},
+			wantContinuationToken: "next-cursor",
+		},
+		{
+			desc:      "empty page",
+			responses: nil,
+		},
+		{
+			desc:         "computed",
+			responses:    []*pulumirpc.ListResponse{computedMsg},
+			wantComputed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			var got *pulumirpc.ListRequest
+			client := &stubClient{
+				ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+					return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+				},
+				ListF: func(_ context.Context, req *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+					got = req
+					return &stubListStream{responses: tt.responses}, nil
+				},
+			}
+
+			p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+			_, err := p.Configure(t.Context(), ConfigureRequest{})
+			require.NoError(t, err)
+
+			stream, err := p.List(t.Context(), ListRequest{
+				Token:             tokens.Type("pkgA:index:Thing"),
+				Limit:             10,
+				PageSize:          5,
+				ContinuationToken: "cursor",
+			})
+			require.NoError(t, err)
+
+			gotResults := drainListStream(t, stream)
+			assert.Equal(t, tt.wantResults, gotResults)
+			assert.Equal(t, tt.wantComputed, stream.Computed)
+			assert.Equal(t, tt.wantContinuationToken, stream.ContinuationToken)
+
+			require.NotNil(t, got, "List was not called")
+			assert.Equal(t, "pkgA:index:Thing", got.Token)
+			assert.Equal(t, int64(10), got.Limit)
+			assert.Equal(t, int64(5), got.PageSize)
+			assert.Equal(t, "cursor", got.ContinuationToken)
+		})
+	}
+}
+
+func TestProvider_List_YieldsStreamError(t *testing.T) {
+	t.Parallel()
+
+	streamErr := status.Error(codes.Internal, "upstream blew up")
+	client := &stubClient{
+		ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+		},
+		ListF: func(context.Context, *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+			return &stubListStream{err: streamErr}, nil
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
+	require.NoError(t, err)
+
+	var gotErr error
+	var gotItems []ListResult
+	for item, err := range stream.Items {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		gotItems = append(gotItems, item)
+	}
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "upstream blew up")
+	assert.Empty(t, gotItems)
+}
+
+// TestProvider_List_EarlyBreakCancelsRPC asserts that breaking out of the Items range loop early cancels the
+// context that was passed to the underlying gRPC call. Without that, the server stream would leak until the
+// provider's request context tears down.
+func TestProvider_List_EarlyBreakCancelsRPC(t *testing.T) {
+	t.Parallel()
+
+	resultMsg := func(id string) *pulumirpc.ListResponse {
+		return &pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{Id: id},
+			},
+		}
+	}
+	var rpcCtx context.Context
+	client := &stubClient{
+		ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+		},
+		ListF: func(ctx context.Context, _ *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+			rpcCtx = ctx
+			return &stubListStream{responses: []*pulumirpc.ListResponse{
+				resultMsg("id-a"), resultMsg("id-b"), resultMsg("id-c"),
+			}}, nil
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
+	require.NoError(t, err)
+	require.NotNil(t, rpcCtx, "ListF should have been called")
+	require.NoError(t, rpcCtx.Err(), "context should be live before iteration starts")
+
+	for item := range stream.Items {
+		_ = item
+		break
+	}
+
+	assert.Error(t, rpcCtx.Err(), "context should be cancelled after early break")
+	assert.ErrorIs(t, rpcCtx.Err(), context.Canceled)
+}
+
+// TestProvider_List_FullDrainCancelsRPC asserts that draining Items naturally (via EOF) also cancels the
+// per-call context so gRPC resources are released.
+func TestProvider_List_FullDrainCancelsRPC(t *testing.T) {
+	t.Parallel()
+
+	resultMsg := func(id string) *pulumirpc.ListResponse {
+		return &pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{Id: id},
+			},
+		}
+	}
+	var rpcCtx context.Context
+	client := &stubClient{
+		ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+		},
+		ListF: func(ctx context.Context, _ *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+			rpcCtx = ctx
+			return &stubListStream{responses: []*pulumirpc.ListResponse{
+				resultMsg("id-a"),
+			}}, nil
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
+	require.NoError(t, err)
+	for item, err := range stream.Items {
+		_ = item
+		require.NoError(t, err)
+	}
+	assert.ErrorIs(t, rpcCtx.Err(), context.Canceled)
+}
+
+// TestProvider_List_StreamErrorCancelsRPC asserts that mid-stream errors also release the per-call context.
+func TestProvider_List_StreamErrorCancelsRPC(t *testing.T) {
+	t.Parallel()
+
+	streamErr := status.Error(codes.Internal, "boom")
+	var rpcCtx context.Context
+	client := &stubClient{
+		ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+		},
+		ListF: func(ctx context.Context, _ *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+			rpcCtx = ctx
+			return &stubListStream{err: streamErr}, nil
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
+	require.NoError(t, err)
+	for _, err := range stream.Items {
+		if err != nil {
+			break
+		}
+	}
+	assert.ErrorIs(t, rpcCtx.Err(), context.Canceled)
+}
+
+func TestProvider_List_StopsEarly(t *testing.T) {
+	t.Parallel()
+
+	resultMsg := func(id string) *pulumirpc.ListResponse {
+		return &pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{Id: id},
+			},
+		}
+	}
+	client := &stubClient{
+		ConfigureF: func(*pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+			return &pulumirpc.ConfigureResponse{AcceptSecrets: true}, nil
+		},
+		ListF: func(context.Context, *pulumirpc.ListRequest) (pulumirpc.ResourceProvider_ListClient, error) {
+			return &stubListStream{responses: []*pulumirpc.ListResponse{
+				resultMsg("id-a"), resultMsg("id-b"), resultMsg("id-c"),
+			}}, nil
+		},
+	}
+
+	p := NewProviderWithClient(newTestContext(t), "pkgA", client, false /* disablePreview */)
+	_, err := p.Configure(t.Context(), ConfigureRequest{})
+	require.NoError(t, err)
+
+	stream, err := p.List(t.Context(), ListRequest{Token: "pkgA:index:Thing"})
+	require.NoError(t, err)
+
+	var got []ListResult
+	for item, err := range stream.Items {
+		require.NoError(t, err)
+		got = append(got, item)
+		if len(got) == 1 {
+			break
+		}
+	}
+	require.Len(t, got, 1)
 }
 
 // Test for https://github.com/pulumi/pulumi/issues/14529, ensure a kubernetes DiffConfig error is ignored

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -651,9 +651,52 @@ func (p *providerServer) List(
 	req *pulumirpc.ListRequest,
 	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
 ) error {
-	_ = req
-	_ = stream
-	return status.Error(codes.Unimplemented, "List is not yet implemented")
+	query, err := UnmarshalProperties(req.GetQuery(), p.unmarshalOptions("list.query", false))
+	if err != nil {
+		return err
+	}
+	listStream, err := p.provider.List(stream.Context(), ListRequest{
+		Token:             tokens.Type(req.GetToken()),
+		Query:             query,
+		Limit:             req.GetLimit(),
+		PageSize:          req.GetPageSize(),
+		ContinuationToken: req.GetContinuationToken(),
+	})
+	if err != nil {
+		return err
+	}
+	for result, err := range listStream.Items {
+		if err != nil {
+			return err
+		}
+		if err := stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{
+					Id:   string(result.ID),
+					Name: result.Name,
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	if listStream.Computed {
+		return stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Computed_{
+				Computed: &pulumirpc.ListResponse_Computed{},
+			},
+		})
+	}
+	if listStream.ContinuationToken != "" {
+		return stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Continuation_{
+				Continuation: &pulumirpc.ListResponse_Continuation{
+					ContinuationToken: listStream.ContinuationToken,
+				},
+			},
+		})
+	}
+	return nil
 }
 
 func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {

--- a/sdk/go/common/resource/plugin/provider_server_test.go
+++ b/sdk/go/common/resource/plugin/provider_server_test.go
@@ -16,9 +16,15 @@ package plugin
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +71,8 @@ type stubProvider struct {
 	) (ReadResult, resource.Status, error)
 
 	ConfigureFunc func(resource.PropertyMap) error
+
+	ListFunc func(ListRequest) (*ListStream, error)
 }
 
 func (p *stubProvider) Configure(ctx context.Context, req ConfigureRequest) (ConfigureResponse, error) {
@@ -113,4 +121,177 @@ func TestProviderServer_Read_respects_ID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEqual(t, secret, resp.Id)
+}
+
+func (p *stubProvider) List(ctx context.Context, req ListRequest) (*ListStream, error) {
+	if p.ListFunc != nil {
+		return p.ListFunc(req)
+	}
+	return p.Provider.List(ctx, req)
+}
+
+// fakeListServerStream captures messages sent by a server-streaming List call. Only Context and Send are exercised
+// by the provider server; the embedded ServerStream is nil so other methods will panic if invoked.
+type fakeListServerStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	sent []*pulumirpc.ListResponse
+}
+
+func (s *fakeListServerStream) Context() context.Context { return s.ctx }
+
+func (s *fakeListServerStream) Send(m *pulumirpc.ListResponse) error {
+	s.sent = append(s.sent, m)
+	return nil
+}
+
+func (s *fakeListServerStream) SetHeader(metadata.MD) error  { return nil }
+func (s *fakeListServerStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeListServerStream) SetTrailer(metadata.MD)       {}
+
+func TestProviderServer_List_streamsResults(t *testing.T) {
+	t.Parallel()
+
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			assert.Equal(t, tokens.Type("pkgA:index:Thing"), req.Token)
+			assert.Equal(t, int64(7), req.Limit)
+			assert.Equal(t, int64(3), req.PageSize)
+			assert.Equal(t, "cursor-in", req.ContinuationToken)
+			return NewListStream([]ListResult{
+				{ID: "id-a", Name: "alpha"},
+				{ID: "id-b", Name: "beta"},
+			}, "cursor-out"), nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{
+		Token:             "pkgA:index:Thing",
+		Limit:             7,
+		PageSize:          3,
+		ContinuationToken: "cursor-in",
+	}, stream)
+	require.NoError(t, err)
+
+	require.Len(t, stream.sent, 3)
+	r0 := stream.sent[0].GetResult()
+	require.NotNil(t, r0)
+	assert.Equal(t, "id-a", r0.GetId())
+	assert.Equal(t, "alpha", r0.GetName())
+	r1 := stream.sent[1].GetResult()
+	require.NotNil(t, r1)
+	assert.Equal(t, "id-b", r1.GetId())
+	assert.Equal(t, "beta", r1.GetName())
+	cont := stream.sent[2].GetContinuation()
+	require.NotNil(t, cont)
+	assert.Equal(t, "cursor-out", cont.GetContinuationToken())
+}
+
+// Results that the provider yields lazily via iter.Seq2 must reach the wire in order.
+func TestProviderServer_List_streamsLazyResults(t *testing.T) {
+	t.Parallel()
+
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			return &ListStream{
+				Items: func(yield func(ListResult, error) bool) {
+					for i := 0; i < 3; i++ {
+						if !yield(ListResult{ID: resource.ID(fmt.Sprintf("id-%d", i))}, nil) {
+							return
+						}
+					}
+				},
+			}, nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{Token: "pkgA:index:Thing"}, stream)
+	require.NoError(t, err)
+
+	require.Len(t, stream.sent, 3)
+	for i, msg := range stream.sent {
+		r := msg.GetResult()
+		require.NotNil(t, r)
+		assert.Equal(t, fmt.Sprintf("id-%d", i), r.GetId())
+	}
+}
+
+func TestProviderServer_List_sendsComputed(t *testing.T) {
+	t.Parallel()
+
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			return NewComputedListStream(), nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{Token: "pkgA:index:Thing"}, stream)
+	require.NoError(t, err)
+
+	require.Len(t, stream.sent, 1)
+	require.NotNil(t, stream.sent[0].GetComputed())
+}
+
+func TestProviderServer_List_sendsNothingForEmptyPage(t *testing.T) {
+	t.Parallel()
+
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			return NewListStream(nil, ""), nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{Token: "pkgA:index:Thing"}, stream)
+	require.NoError(t, err)
+	assert.Empty(t, stream.sent)
+}
+
+func TestProviderServer_List_propagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("provider exploded")
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			return nil, wantErr
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{Token: "pkgA:index:Thing"}, stream)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Empty(t, stream.sent)
+}
+
+func TestProviderServer_List_propagatesItemError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("midstream error")
+	provider := stubProvider{
+		ListFunc: func(req ListRequest) (*ListStream, error) {
+			return &ListStream{
+				Items: func(yield func(ListResult, error) bool) {
+					if !yield(ListResult{ID: "id-a"}, nil) {
+						return
+					}
+					yield(ListResult{}, wantErr)
+				},
+			}, nil
+		},
+	}
+	srv := NewProviderServer(&provider)
+
+	stream := &fakeListServerStream{ctx: t.Context()}
+	err := srv.List(&pulumirpc.ListRequest{Token: "pkgA:index:Thing"}, stream)
+	assert.ErrorIs(t, err, wantErr)
+	require.Len(t, stream.sent, 1)
+	assert.Equal(t, "id-a", stream.sent[0].GetResult().GetId())
 }

--- a/sdk/go/common/resource/plugin/provider_unimplemented.go
+++ b/sdk/go/common/resource/plugin/provider_unimplemented.go
@@ -97,6 +97,10 @@ func (p *UnimplementedProvider) Delete(context.Context, DeleteRequest) (DeleteRe
 	return DeleteResponse{}, status.Error(codes.Unimplemented, "Delete is not yet implemented")
 }
 
+func (p *UnimplementedProvider) List(context.Context, ListRequest) (*ListStream, error) {
+	return nil, status.Error(codes.Unimplemented, "List is not yet implemented")
+}
+
 func (p *UnimplementedProvider) Construct(context.Context, ConstructRequest) (ConstructResponse, error) {
 	return ConstructResponse{}, status.Error(codes.Unimplemented, "Construct is not yet implemented")
 }


### PR DESCRIPTION
This adds `List` to the provider interface in the Go code. This is a pretty thin wrapper over the streaming grpc interface. I considered a few variations for the streaming result but this seems fairly idiomatic for Go, just got to be a bit careful with how you use it (drain Items before looking at Computed)