### PR TITLE
Fix panic, body leak, and FD leaks in templates_zip.go

### DIFF
--- a/sdk/go/common/workspace/templates_zip.go
+++ b/sdk/go/common/workspace/templates_zip.go
@@ -99,6 +99,9 @@ func shouldRetry(err error, resp *http.Response) bool {
 }
 
 func drainBody(resp *http.Response) {
+	if resp == nil {
+		return
+	}
 	if resp.Body != nil {
 		_, err := io.Copy(io.Discard, resp.Body)
 		if err != nil {
@@ -172,6 +175,7 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string, opts ...Req
 	if err != nil {
 		return "", err
 	}
+	defer packageResponse.Body.Close()
 	if packageResponse.StatusCode == http.StatusUnauthorized && isPulumiHostResponse(packageResponse) {
 		return "", fmt.Errorf("failed to download template from pulumi host: %w", ErrPulumiCloudUnauthorized)
 	}
@@ -199,31 +203,37 @@ func RetrieveZIPTemplateFolder(templateURL *url.URL, tempDir string, opts ...Req
 	}
 
 	for _, file := range archive.File {
-		filePath, err := sanitizeArchivePath(tempDir, file.Name)
-		if err != nil {
+		if err := extractZipFile(file, tempDir); err != nil {
 			return "", err
-		}
-		if file.FileHeader.FileInfo().IsDir() {
-			err = os.MkdirAll(filePath, 0o777)
-			if err != nil {
-				return "", err
-			}
-		} else {
-			fileReader, err := file.Open()
-			if err != nil {
-				return "", err
-			}
-			defer fileReader.Close()
-			destinationFile, err := os.Create(filePath)
-			if err != nil {
-				return "", err
-			}
-			defer destinationFile.Close()
-			_, err = io.Copy(destinationFile, fileReader) // #nosec G110
-			if err != nil {
-				return "", err
-			}
 		}
 	}
 	return tempDir, nil
+}
+
+// extractZipFile extracts a single file from a zip archive into tempDir.
+// It is factored out of the loop so that defer runs per file rather than
+// accumulating open file descriptors until the calling function returns.
+func extractZipFile(file *zip.File, tempDir string) error {
+	filePath, err := sanitizeArchivePath(tempDir, file.Name)
+	if err != nil {
+		return err
+	}
+	if file.FileHeader.FileInfo().IsDir() {
+		return os.MkdirAll(filePath, 0o777)
+	}
+
+	fileReader, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer fileReader.Close()
+
+	destinationFile, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	_, err = io.Copy(destinationFile, fileReader) // #nosec G110
+	return err
 }

--- a/sdk/go/common/workspace/templates_zip_test.go
+++ b/sdk/go/common/workspace/templates_zip_test.go
@@ -28,6 +28,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDrainBody_NilResponse(t *testing.T) {
+	t.Parallel()
+	// drainBody must not panic when called with a nil response,
+	// which happens when RoundTrip returns (nil, err).
+	assert.NotPanics(t, func() {
+		drainBody(nil)
+	})
+}
+
 func TestSanitizeArchivePath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fix three bugs in `sdk/go/common/workspace/templates_zip.go`:

1. **Nil pointer dereference in `drainBody`**: When `RoundTrip` returns `(nil, err)` on a transport error, the retry loop calls `drainBody(resp)` with a nil `resp`, which panics dereferencing `resp.Body`. Fixed by adding a nil check at function entry.

2. **HTTP response body never closed in `RetrieveZIPTemplateFolder`**: `packageResponse.Body` is never closed on any code path (401 return, ReadAll error, non-200 status, or success), leaking the underlying TCP connection on every template download. Fixed by adding `defer packageResponse.Body.Close()` after the error check.

3. **Defer-in-loop leaks file descriptors**: `defer fileReader.Close()` and `defer destinationFile.Close()` inside a `for` loop accumulate 2*N open FDs until the function returns. Extracted the loop body into `extractZipFile()` so defers fire per iteration.

## Test plan

- Added `TestDrainBody_NilResponse` that calls `drainBody(nil)` and verifies no panic.
- All 9 existing tests in `templates_zip_test.go` continue to pass, including the integration-style `TestRetrieveZIPTemplates_SucceedsWhenPulumiYAMLIsPresent` which exercises the full download-to-extract flow including the refactored `extractZipFile`.

## Validation

- `go vet ./sdk/go/common/workspace/...` passes
- `go build ./sdk/go/common/workspace/...` passes
- `go test ./sdk/go/common/workspace/... -count=1` passes (9 tests)

## Changelog

> **Note:** This is a small internal bug-fix with no user-facing behavioral change under normal operation. Please apply the `impact/no-changelog-required` label.

- [ ] Yes, there are changes in this PR that warrants a changelog entry.

## Risk

**Low.** All three changes are additive guards or mechanical refactors:
- Fix 1 adds a nil check with zero behavioral change for non-nil inputs.
- Fix 2 adds a defer-close that was always missing.
- Fix 3 is a pure extract-method refactor preserving identical logic.
