### PR TITLE
plugin ls -> list, rm -> remove

### DIFF
--- a/changelog/pending/20260520--cli-plugin--rename-plugin-ls-to-list-and-rm-remove.yaml
+++ b/changelog/pending/20260520--cli-plugin--rename-plugin-ls-to-list-and-rm-remove.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/plugin
+  description: Rename plugin ls to list and rm remove

--- a/changelog/pending/20260520--cli-plugin--rename-plugin-ls-to-list-and-rm-remove.yaml
+++ b/changelog/pending/20260520--cli-plugin--rename-plugin-ls-to-list-and-rm-remove.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: cli/plugin
-  description: Rename plugin ls to list and rm remove
+  description: Rename plugin ls to list and rm to remove

--- a/pkg/cmd/pulumi/plugin/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin/plugin_ls.go
@@ -35,8 +35,9 @@ func newPluginLsCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var projectOnly bool
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "List plugins",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List plugins",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Produce a list of plugins, sorted by name and version.
 			var plugins []workspace.PluginInfo

--- a/pkg/cmd/pulumi/plugin/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin/plugin_rm.go
@@ -40,8 +40,9 @@ func newPluginRmCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var all bool
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "rm",
-		Short: "Remove one or more plugins from the download cache",
+		Use:     "remove",
+		Aliases: []string{"rm"},
+		Short:   "Remove one or more plugins from the download cache",
 		Long: "Remove one or more plugins from the download cache.\n" +
 			"\n" +
 			"Specify KIND, NAME, and/or VERSION to narrow down what will be removed.\n" +


### PR DESCRIPTION
Rename these commands to use the recommended `list` and `remove` verbs,
with aliases to maintain backwards compatbility.
