### PR TITLE
Silence cobra’s error and usage print on error

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -283,6 +283,8 @@ func NewDoCmd(
 			current = nextParent
 			parent = parent.Parent()
 		}
+		current.SilenceErrors = true
+		current.SilenceUsage = true
 		current.SetArgs(fullArgs)
 
 		return current, cleanup, nil


### PR DESCRIPTION
We set these options on the [root command](https://github.com/pulumi/pulumi/blob/92400de2983103cde0ea39bd59c12ea7bc4a631a/pkg/cmd/pulumi/pulumi.go#L245-L247) but we have a separate root here do deal with the dynamic nature of `pulumi do`.
