### PR TITLE
Update docs hint placeholder to `<type-token>`

### DIFF
--- a/changelog/pending/20260520--cli-package--registry-docs-hint-type-token-placeholder.yaml
+++ b/changelog/pending/20260520--cli-package--registry-docs-hint-type-token-placeholder.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: chore
   scope: cli/package
-  description: Update the `pulumi package add --agent` documentation hint to use `<type-token>` as the placeholder for the `/docs/...` URL, matching the renamed path parameter in the public registry API
+  description: Update the `pulumi package add --agent` documentation hint to use `<type-token>` as the placeholder for the `/docs/...` URL

--- a/changelog/pending/20260520--cli-package--registry-docs-hint-type-token-placeholder.yaml
+++ b/changelog/pending/20260520--cli-package--registry-docs-hint-type-token-placeholder.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/package
+  description: Update the `pulumi package add --agent` documentation hint to use `<type-token>` as the placeholder for the `/docs/...` URL, matching the renamed path parameter in the public registry API

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -121,7 +121,8 @@ from the parameters, as in:
 						Runtime: workspace.NewProjectRuntimeInfo(cmdCmd.NormalizeRuntimeName(language), nil),
 					},
 					reg: cmdCmd.NewDefaultRegistry(
-						cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
+						cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global(),
+					),
 				}
 			}
 
@@ -251,7 +252,7 @@ func printRegistryDocsHint(
 		{"/readme", "                    # package readme"},
 		{"/nav", "                       # doc tree (modules)"},
 		{"/nav?q=<term>&depth=full", "   # search for resources/functions"},
-		{"/docs/<token>", "              # one resource or function (token from /nav)"},
+		{"/docs/<type-token>", "         # one resource or function (type token from /nav)"},
 	}
 	fmt.Fprintln(w, "Documentation:")
 	for _, h := range hints {
@@ -283,7 +284,8 @@ func loadEnclosingTarget(ctx context.Context, wd string) (addTarget, error) {
 			installRoot:     filepath.Dir(filePath),
 			projectFilePath: &filePath,
 			reg: cmdCmd.NewDefaultRegistry(
-				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, baseProject, cmdutil.Diag(), env.Global()),
+				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, baseProject, cmdutil.Diag(), env.Global(),
+			),
 			proj: baseProject,
 		}, nil
 	case *workspace.PluginProject:

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -121,8 +121,7 @@ from the parameters, as in:
 						Runtime: workspace.NewProjectRuntimeInfo(cmdCmd.NormalizeRuntimeName(language), nil),
 					},
 					reg: cmdCmd.NewDefaultRegistry(
-						cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global(),
-					),
+						cmd.Context(), cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, nil, cmdutil.Diag(), env.Global()),
 				}
 			}
 
@@ -284,8 +283,7 @@ func loadEnclosingTarget(ctx context.Context, wd string) (addTarget, error) {
 			installRoot:     filepath.Dir(filePath),
 			projectFilePath: &filePath,
 			reg: cmdCmd.NewDefaultRegistry(
-				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, baseProject, cmdutil.Diag(), env.Global(),
-			),
+				ctx, cmdBackend.DefaultLoginManager, pkgWorkspace.Instance, baseProject, cmdutil.Diag(), env.Global()),
 			proj: baseProject,
 		}, nil
 	case *workspace.PluginProject:

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -249,7 +249,7 @@ func TestPrintRegistryDocsHint(t *testing.T) {
 		cmdLine("/readme", "                    # package readme") +
 		cmdLine("/nav", "                       # doc tree (modules)") +
 		cmdLine("/nav?q=<term>&depth=full", "   # search for resources/functions") +
-		cmdLine("/docs/<token>", "              # one resource or function (token from /nav)")
+		cmdLine("/docs/<type-token>", "         # one resource or function (type token from /nav)")
 
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

The registry docs endpoint path parameter has been renamed from `token` to `typeToken` in the Pulumi Cloud public API. Update the `pulumi package add` agent-mode help hint to print `/docs/<type-token>` to match.

Service-side rename: https://github.com/pulumi/pulumi-service/pull/43530.

## Test plan

- `go test -run TestPrintRegistryDocsHint ./pkg/cmd/pulumi/packagecmd/` passes