### PR TITLE
Expand `TestPackageBinds` to test the full round trip

### DIFF
--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -18,8 +18,11 @@ import (
 	"cmp"
 	"context"
 	_ "embed"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash"
+	"hash/fnv"
 	"io"
 	"maps"
 	"math"
@@ -320,7 +323,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 		resources:    map[string]*ResourceType{},
 		arrays:       map[Type]*ArrayType{},
 		maps:         map[Type]*MapType{},
-		unions:       map[string]*UnionType{},
+		unions:       map[typeHash]*UnionType{},
 		tokens:       map[string]*TokenType{},
 		inputs:       map[Type]*InputType{},
 		optionals:    map[Type]*OptionalType{},
@@ -469,7 +472,7 @@ type types struct {
 	resources map[string]*ResourceType
 	arrays    map[Type]*ArrayType
 	maps      map[Type]*MapType
-	unions    map[string]*UnionType
+	unions    map[typeHash]*UnionType
 	tokens    map[string]*TokenType
 	inputs    map[Type]*InputType
 	optionals map[Type]*OptionalType
@@ -773,11 +776,94 @@ func (t *types) newUnionType(
 		Discriminator: discriminator,
 		Mapping:       mapping,
 	}
-	if typ, ok := t.unions[union.String()]; ok {
+	key := hashType(union)
+	if typ, ok := t.unions[key]; ok {
 		return typ
 	}
-	t.unions[union.String()] = union
+	t.unions[key] = union
 	return union
+}
+
+// typeHash is a structural fingerprint of a Type.
+//
+// It should be used for structural type comparisions, instead of [(Type).String()].
+type typeHash uint64
+
+// hashType returns the structural hash of t.
+func hashType(t Type) typeHash {
+	h := fnv.New64a()
+	hashTypeInto(h, t)
+	return typeHash(h.Sum64())
+}
+
+// hashTypeInto is the recursive worker behind hashType. It mirrors the
+// kinds handled by compareTypes; any new Type kind added there must be
+// added here too.
+func hashTypeInto(h hash.Hash64, t Type) {
+	var buf [8]byte
+	writeTag := func(b byte) { _, _ = h.Write([]byte{b}) }
+	writeUint := func(u uint64) {
+		binary.LittleEndian.PutUint64(buf[:], u)
+		_, _ = h.Write(buf[:])
+	}
+	writeStr := func(s string) {
+		writeUint(uint64(len(s)))
+		_, _ = h.Write([]byte(s))
+	}
+
+	switch t := t.(type) {
+	case nil:
+		writeTag(0)
+	case primitiveType:
+		writeTag(1)
+		writeUint(uint64(t))
+	case *ArrayType:
+		writeTag(2)
+		hashTypeInto(h, t.ElementType)
+	case *MapType:
+		writeTag(3)
+		hashTypeInto(h, t.ElementType)
+	case *OptionalType:
+		writeTag(4)
+		hashTypeInto(h, t.ElementType)
+	case *InputType:
+		writeTag(5)
+		hashTypeInto(h, t.ElementType)
+	case *UnionType:
+		writeTag(6)
+		writeUint(uint64(len(t.ElementTypes)))
+		for _, el := range t.ElementTypes {
+			hashTypeInto(h, el)
+		}
+		hashTypeInto(h, t.DefaultType)
+		writeStr(t.Discriminator)
+		writeUint(uint64(len(t.Mapping)))
+		for _, k := range slices.Sorted(maps.Keys(t.Mapping)) {
+			writeStr(k)
+			writeStr(t.Mapping[k])
+		}
+	case *ObjectType:
+		writeTag(7)
+		writeStr(t.Token)
+		if t.IsInputShape() {
+			writeTag(1)
+		} else {
+			writeTag(0)
+		}
+	case *ResourceType:
+		writeTag(8)
+		writeStr(t.Token)
+	case *EnumType:
+		writeTag(9)
+		writeStr(t.Token)
+	case *TokenType:
+		writeTag(10)
+		writeStr(t.Token)
+	case *InvalidType:
+		writeTag(11)
+	default:
+		contract.Failf("unknown type %T", t)
+	}
 }
 
 func (t *types) bindTypeDef(token string, options ValidationOptions) (Type, hcl.Diagnostics, error) {

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -1139,22 +1140,27 @@ func bindConstValue(path, kind string, value any, typ Type) (any, hcl.Diagnostic
 		}
 		return v, nil
 	case IntType:
-		v, ok := value.(int)
-		if !ok {
-			v, ok := value.(float64)
-			if !ok {
-				return 0, typeError("integer")
+		clamp := func(i int) (any, hcl.Diagnostics) {
+			if i < math.MinInt32 || i > math.MaxInt32 {
+				return nil, typeError("integer")
 			}
-			if math.Trunc(v) != v || v < math.MinInt32 || v > math.MaxInt32 {
-				return 0, typeError("integer")
-			}
-			return int32(v), nil
+			//nolint:gosec // int -> int32 conversion is guarded above.
+			return int32(i), nil
 		}
-		if v < math.MinInt32 || v > math.MaxInt32 {
+
+		switch v := value.(type) {
+		case int:
+			return clamp(v)
+		case int32:
+			return v, nil
+		case float64:
+			if math.Trunc(v) != v {
+				return 0, typeError("integer")
+			}
+			return clamp(int(v))
+		default:
 			return 0, typeError("integer")
 		}
-		//nolint:gosec // int -> int32 conversion is guarded above.
-		return int32(v), nil
 	case NumberType:
 		v, ok := value.(float64)
 		if !ok {
@@ -1521,11 +1527,117 @@ func (t *types) finishTypes(tokens []string, options ValidationOptions) ([]Type,
 		typeList = append(typeList, t)
 	}
 
-	sort.Slice(typeList, func(i, j int) bool {
-		return typeList[i].String() < typeList[j].String()
-	})
+	slices.SortFunc(typeList, compareTypes)
 
 	return typeList, diags, nil
+}
+
+// compareTypes is a total order on Type values used to sort the package's
+// type list deterministically.
+func compareTypes(a, b Type) int {
+	if c := cmp.Compare(typeOrder(a), typeOrder(b)); c != 0 {
+		return c
+	}
+
+	switch a := a.(type) {
+	case primitiveType:
+		return cmp.Compare(a, b.(primitiveType))
+	case *ArrayType:
+		return compareTypes(a.ElementType, b.(*ArrayType).ElementType)
+	case *MapType:
+		return compareTypes(a.ElementType, b.(*MapType).ElementType)
+	case *OptionalType:
+		return compareTypes(a.ElementType, b.(*OptionalType).ElementType)
+	case *UnionType:
+		b := b.(*UnionType)
+		if c := cmp.Compare(len(a.ElementTypes), len(b.ElementTypes)); c != 0 {
+			return c
+		}
+		for i := range a.ElementTypes {
+			if c := compareTypes(a.ElementTypes[i], b.ElementTypes[i]); c != 0 {
+				return c
+			}
+		}
+		if c := compareTypes(a.DefaultType, b.DefaultType); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Discriminator, b.Discriminator); c != 0 {
+			return c
+		}
+
+		if c := cmp.Compare(len(a.Mapping), len(b.Mapping)); c != 0 {
+			return c
+		}
+		aKeys, bKeys := slices.Sorted(maps.Keys(a.Mapping)), slices.Sorted(maps.Keys(b.Mapping))
+		if c := slices.Compare(aKeys, bKeys); c != 0 {
+			return c
+		}
+		for _, k := range aKeys {
+			if c := strings.Compare(a.Mapping[k], b.Mapping[k]); c != 0 {
+				return c
+			}
+		}
+
+		return 0
+	case *ObjectType:
+		b := b.(*ObjectType)
+		if c := strings.Compare(a.Token, b.Token); c != 0 {
+			return c
+		}
+		bToI := func(b bool) int8 {
+			if b {
+				return 1
+			}
+			return 0
+		}
+
+		return cmp.Compare(bToI(a.IsInputShape()), bToI(b.IsInputShape()))
+	case *ResourceType:
+		return strings.Compare(a.Token, b.(*ResourceType).Token)
+	case *EnumType:
+		return strings.Compare(a.Token, b.(*EnumType).Token)
+	case *InvalidType, nil:
+		return 0 // All invalid types are the same
+	case *TokenType:
+		return strings.Compare(a.Token, b.(*TokenType).Token)
+	case *InputType:
+		return compareTypes(a.ElementType, b.(*InputType).ElementType)
+	default:
+		contract.Failf("unknown type %T", a)
+		return -1
+	}
+}
+
+func typeOrder(t Type) int {
+	switch t.(type) {
+	case nil:
+		return 0
+	case primitiveType:
+		return 1
+	case *ArrayType:
+		return 2
+	case *MapType:
+		return 3
+	case *OptionalType:
+		return 4
+	case *UnionType:
+		return 5
+	case *ObjectType:
+		return 6
+	case *EnumType:
+		return 7
+	case *ResourceType:
+		return 8
+	case *InvalidType:
+		return 9
+	case *TokenType:
+		return 10
+	case *InputType:
+		return 11
+	default:
+		contract.Failf("unknown type %T", t)
+		return -1
+	}
 }
 
 func checkDuplicates(

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -786,7 +786,7 @@ func (t *types) newUnionType(
 
 // typeHash is a structural fingerprint of a Type.
 //
-// It should be used for structural type comparisions, instead of [(Type).String()].
+// It should be used for structural type comparisons, instead of [(Type).String()].
 type typeHash uint64
 
 // hashType returns the structural hash of t.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -45,7 +45,7 @@ type Type interface {
 	isType()
 }
 
-type primitiveType int
+type primitiveType uint16
 
 const (
 	boolType        primitiveType = 1

--- a/pkg/codegen/testing/utils/rapidschema/rapidschema_test.go
+++ b/pkg/codegen/testing/utils/rapidschema/rapidschema_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVersionRoundTrips(t *testing.T) {
@@ -33,13 +34,21 @@ func TestVersionRoundTrips(t *testing.T) {
 	})
 }
 
-// TestPackageBinds is implicit: Package() fails the rapid test if BindSpec
-// ever returns an error or any diagnostics. This test exercises that contract
-// by drawing the default rapid.Check budget of packages.
-func TestPackageBinds(t *testing.T) {
+// TestPackageBindsMarshalsAndRoundTrips validates that a generated package is
+// round-tripable through a schema spec.
+//
+// Since all valid schemas must be round-trippable, this tests that we are
+// marshaling valid schemas.
+func TestPackageBindsMarshalsAndRoundTrips(t *testing.T) {
 	t.Parallel()
 	rapid.Check(t, func(t *rapid.T) {
-		Package().Draw(t, "pkg")
+		pkg := Package().Draw(t, "pkg")
+		spec, err := pkg.MarshalSpec()
+		require.NoError(t, err)
+		pkg2, diags, err := schema.BindSpec(*spec, schema.Loader(nil), schema.ValidationOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, diags)
+		assert.Equal(t, pkg, pkg2)
 	})
 }
 

--- a/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-resource-schema/python/pulumi_example/_inputs.py
@@ -18,10 +18,10 @@ from .resource import Resource
 __all__ = [
     'ConfigMapArgs',
     'ConfigMapArgsDict',
-    'ObjectWithNodeOptionalInputsArgs',
-    'ObjectWithNodeOptionalInputsArgsDict',
     'ObjectArgs',
     'ObjectArgsDict',
+    'ObjectWithNodeOptionalInputsArgs',
+    'ObjectWithNodeOptionalInputsArgsDict',
     'SomeOtherObjectArgs',
     'SomeOtherObjectArgsDict',
 ]
@@ -44,38 +44,6 @@ class ConfigMapArgs:
     @config.setter
     def config(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "config", value)
-
-
-class ObjectWithNodeOptionalInputsArgsDict(TypedDict):
-    foo: pulumi.Input[_builtins.str]
-    bar: NotRequired[pulumi.Input[Optional[_builtins.int]]]
-
-@pulumi.input_type
-class ObjectWithNodeOptionalInputsArgs:
-    def __init__(__self__, *,
-                 foo: pulumi.Input[_builtins.str],
-                 bar: pulumi.Input[Optional[_builtins.int]] = None):
-        pulumi.set(__self__, "foo", foo)
-        if bar is not None:
-            pulumi.set(__self__, "bar", bar)
-
-    @_builtins.property
-    @pulumi.getter
-    def foo(self) -> pulumi.Input[_builtins.str]:
-        return pulumi.get(self, "foo")
-
-    @foo.setter
-    def foo(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "foo", value)
-
-    @_builtins.property
-    @pulumi.getter
-    def bar(self) -> pulumi.Input[Optional[_builtins.int]]:
-        return pulumi.get(self, "bar")
-
-    @bar.setter
-    def bar(self, value: pulumi.Input[Optional[_builtins.int]]):
-        pulumi.set(self, "bar", value)
 
 
 class ObjectArgsDict(TypedDict):
@@ -164,6 +132,38 @@ class ObjectArgs:
     @still_others.setter
     def still_others(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "still_others", value)
+
+
+class ObjectWithNodeOptionalInputsArgsDict(TypedDict):
+    foo: pulumi.Input[_builtins.str]
+    bar: NotRequired[pulumi.Input[Optional[_builtins.int]]]
+
+@pulumi.input_type
+class ObjectWithNodeOptionalInputsArgs:
+    def __init__(__self__, *,
+                 foo: pulumi.Input[_builtins.str],
+                 bar: pulumi.Input[Optional[_builtins.int]] = None):
+        pulumi.set(__self__, "foo", foo)
+        if bar is not None:
+            pulumi.set(__self__, "bar", bar)
+
+    @_builtins.property
+    @pulumi.getter
+    def foo(self) -> pulumi.Input[_builtins.str]:
+        return pulumi.get(self, "foo")
+
+    @foo.setter
+    def foo(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "foo", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def bar(self) -> pulumi.Input[Optional[_builtins.int]]:
+        return pulumi.get(self, "bar")
+
+    @bar.setter
+    def bar(self, value: pulumi.Input[Optional[_builtins.int]]):
+        pulumi.set(self, "bar", value)
 
 
 class SomeOtherObjectArgsDict(TypedDict):

--- a/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
+++ b/tests/testdata/codegen/simple-yaml-schema/python/pulumi_example/_inputs.py
@@ -19,10 +19,10 @@ from .resource import Resource
 __all__ = [
     'ConfigMapArgs',
     'ConfigMapArgsDict',
-    'ObjectWithNodeOptionalInputsArgs',
-    'ObjectWithNodeOptionalInputsArgsDict',
     'ObjectArgs',
     'ObjectArgsDict',
+    'ObjectWithNodeOptionalInputsArgs',
+    'ObjectWithNodeOptionalInputsArgsDict',
     'SomeOtherObjectArgs',
     'SomeOtherObjectArgsDict',
 ]
@@ -45,38 +45,6 @@ class ConfigMapArgs:
     @config.setter
     def config(self, value: pulumi.Input[Optional[_builtins.str]]):
         pulumi.set(self, "config", value)
-
-
-class ObjectWithNodeOptionalInputsArgsDict(TypedDict):
-    foo: pulumi.Input[_builtins.str]
-    bar: NotRequired[pulumi.Input[Optional[_builtins.int]]]
-
-@pulumi.input_type
-class ObjectWithNodeOptionalInputsArgs:
-    def __init__(__self__, *,
-                 foo: pulumi.Input[_builtins.str],
-                 bar: pulumi.Input[Optional[_builtins.int]] = None):
-        pulumi.set(__self__, "foo", foo)
-        if bar is not None:
-            pulumi.set(__self__, "bar", bar)
-
-    @_builtins.property
-    @pulumi.getter
-    def foo(self) -> pulumi.Input[_builtins.str]:
-        return pulumi.get(self, "foo")
-
-    @foo.setter
-    def foo(self, value: pulumi.Input[_builtins.str]):
-        pulumi.set(self, "foo", value)
-
-    @_builtins.property
-    @pulumi.getter
-    def bar(self) -> pulumi.Input[Optional[_builtins.int]]:
-        return pulumi.get(self, "bar")
-
-    @bar.setter
-    def bar(self, value: pulumi.Input[Optional[_builtins.int]]):
-        pulumi.set(self, "bar", value)
 
 
 class ObjectArgsDict(TypedDict):
@@ -165,6 +133,38 @@ class ObjectArgs:
     @still_others.setter
     def still_others(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input['SomeOtherObjectArgs']]]]]]):
         pulumi.set(self, "still_others", value)
+
+
+class ObjectWithNodeOptionalInputsArgsDict(TypedDict):
+    foo: pulumi.Input[_builtins.str]
+    bar: NotRequired[pulumi.Input[Optional[_builtins.int]]]
+
+@pulumi.input_type
+class ObjectWithNodeOptionalInputsArgs:
+    def __init__(__self__, *,
+                 foo: pulumi.Input[_builtins.str],
+                 bar: pulumi.Input[Optional[_builtins.int]] = None):
+        pulumi.set(__self__, "foo", foo)
+        if bar is not None:
+            pulumi.set(__self__, "bar", bar)
+
+    @_builtins.property
+    @pulumi.getter
+    def foo(self) -> pulumi.Input[_builtins.str]:
+        return pulumi.get(self, "foo")
+
+    @foo.setter
+    def foo(self, value: pulumi.Input[_builtins.str]):
+        pulumi.set(self, "foo", value)
+
+    @_builtins.property
+    @pulumi.getter
+    def bar(self) -> pulumi.Input[Optional[_builtins.int]]:
+        return pulumi.get(self, "bar")
+
+    @bar.setter
+    def bar(self, value: pulumi.Input[Optional[_builtins.int]]):
+        pulumi.set(self, "bar", value)
 
 
 class SomeOtherObjectArgsDict(TypedDict):


### PR DESCRIPTION
This was discovered as part of testing https://github.com/pulumi-labs/pulumi-hcl/pull/149, where I noticed that calling `(*schema.Package).MarshalSpec` on the result of `rapidschema.Package().Draw(t, label)` would panic. This PR expands the rapid test `TestPackageBinds` to `TestPackageBindsMarshalsAndRoundTrips`. The full test is now:

```go
func TestPackageBindsMarshalsAndRoundTrips(t *testing.T) {
	t.Parallel()
	rapid.Check(t, func(t *rapid.T) {
		pkg := Package().Draw(t, "pkg")
		spec, err := pkg.MarshalSpec()
		require.NoError(t, err)
		pkg2, diags, err := schema.BindSpec(*spec, schema.Loader(nil), schema.ValidationOptions{})
		require.NoError(t, err)
		assert.Empty(t, diags)
		assert.Equal(t, pkg, pkg2)
	})
}
```

Initially, this test failed for a couple of reasons, now all fixed:

- We now handle marshaling enum values from int32, the format we unmarshal them into.
- We now deterministically sort types when binding.
- We no longer (incorrectly) de-duplicate different enums into the same type.

I've verified the test now passes up to 100,000 runs:

```console
$ go test -test.run \^TestPackageBindsMarshalsAndRoundTrips\$ -rapid.checks=100_000
PASS
ok  	github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils/rapidschema	115.453s

```