### PR TITLE
CONTRIBUTING: strip "$ " prompt prefixes from shell snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,22 +36,22 @@ For contributors we use the [standard fork based workflow](https://gist.github.c
 Before you open a pull request, make sure all lint checks pass:
 
 ```bash
-$ make lint
+make lint
 ```
 
 If you see formatting failures, fix them with `make format`. To format a single file or directory directly:
 
 ```bash
-$ golangci-lint fmt path/to/file.go
+golangci-lint fmt path/to/file.go
 # or
-$ golangci-lint fmt path/to/dir
+golangci-lint fmt path/to/dir
 ```
 
 We require a changelog entry for all PRs that aren't labeled `impact/no-changelog-required`. To generate a new changelog entry, run…
 
 ```bash
-$ make changelog
-````
+make changelog
+```
 …and follow the prompts on screen.
 
 ### Pull Request Descriptions


### PR DESCRIPTION
## Summary

Four shell snippets in `CONTRIBUTING.md` are prefixed with `$ `:

```
$ make lint
$ golangci-lint fmt path/to/file.go
$ golangci-lint fmt path/to/dir
$ make changelog
```

When a reader clicks GitHub's copy-to-clipboard button on these blocks, the `$ ` comes along — pasting yields `$ make lint`, which doesn't run. Dropping the prompt makes the snippets directly paste-runnable.

Also fixed a stray fourth backtick on the closing fence of the `make changelog` block (renders OK today, but was inconsistent with the other fences).

## Test plan

- [x] Render CONTRIBUTING.md on GitHub and confirm: snippets show without `$ `, copy-button output runs as-is.