### PR TITLE
Fix PCL discriminator panic and rapidresource union stack overflow

### DIFF
--- a/changelog/pending/engine-fix-20260706-112015.yaml
+++ b/changelog/pending/engine-fix-20260706-112015.yaml
@@ -1,0 +1,6 @@
+component: engine
+kind: fix
+body: Fix PCL binder panicking with "not a string" when an object expression used as a union member has a non-string literal at the discriminator key
+time: 2026-07-06T11:20:15.982839+02:00
+custom:
+    PR: "23298"

--- a/pkg/codegen/pcl/binder_resource.go
+++ b/pkg/codegen/pcl/binder_resource.go
@@ -285,20 +285,42 @@ func AnnotateResourceInputs(node *Resource) {
 // then tries to find out which type from the union is the one that matches the object expression.
 // We do this based on the discriminator field in the object expression.
 func resolveUnionOfObjects(objectExpr *model.ObjectConsExpression, union *schema.UnionType) schema.Type {
+	// A discriminator value is always a string (it indexes union.Mapping,
+	// which is keyed by string). The key matched against union.Discriminator
+	// must likewise be a string. Non-string literals (e.g. a bool literal at
+	// the discriminator slot in a malformed input) must not panic AsString —
+	// fall through and leave the union unresolved so binding can continue
+	// (and the malformed input surfaces as a normal type-check diagnostic
+	// rather than a panic). See pkg/importer/hcl2_rapid_test.go for an input
+	// that previously crashed here.
+	asLiteralString := func(v cty.Value) (string, bool) {
+		if v.Type() != cty.String {
+			return "", false
+		}
+		return v.AsString(), true
+	}
+
 	var discriminatorValue string
 	for _, item := range objectExpr.Items {
-		if key, ok := item.Key.(*model.LiteralValueExpression); ok {
-			if key.Value.AsString() == union.Discriminator {
-				if value, ok := item.Value.(*model.LiteralValueExpression); ok {
-					discriminatorValue = value.Value.AsString()
+		key, ok := item.Key.(*model.LiteralValueExpression)
+		if !ok {
+			continue
+		}
+		keyStr, ok := asLiteralString(key.Value)
+		if !ok || keyStr != union.Discriminator {
+			continue
+		}
+		if value, ok := item.Value.(*model.LiteralValueExpression); ok {
+			if s, ok := asLiteralString(value.Value); ok {
+				discriminatorValue = s
+				break
+			}
+		}
+		if value, ok := item.Value.(*model.TemplateExpression); ok && len(value.Parts) == 1 {
+			if literalValue, ok := value.Parts[0].(*model.LiteralValueExpression); ok {
+				if s, ok := asLiteralString(literalValue.Value); ok {
+					discriminatorValue = s
 					break
-				}
-
-				if value, ok := item.Value.(*model.TemplateExpression); ok && len(value.Parts) == 1 {
-					if literalValue, ok := value.Parts[0].(*model.LiteralValueExpression); ok {
-						discriminatorValue = literalValue.Value.AsString()
-						break
-					}
 				}
 			}
 		}

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -643,6 +643,77 @@ func TestBindResourceQuotedPropertyKeys(t *testing.T) {
 	requireAnnotatedWith(outer.Items[0].Value, "foo:index:Template")
 }
 
+func TestResolveUnionOfObjectsToleratesNonStringDiscriminatorValue(t *testing.T) {
+	t.Parallel()
+
+	// resolveUnionOfObjects looks up the value at the discriminator key in
+	// the object expression. When that value is a non-string literal (e.g.
+	// `false` against a discriminator whose union mapping is keyed by
+	// string), AsString() used to panic with "not a string." The function
+	// must instead skip over the non-string value and leave the union
+	// unresolved so binding can continue.
+	obj := &model.ObjectConsExpression{
+		Items: []model.ObjectConsItem{{
+			Key: &model.LiteralValueExpression{
+				Value: cty.StringVal("kind"),
+			},
+			Value: &model.LiteralValueExpression{
+				Value: cty.False,
+			},
+		}},
+	}
+	union := &schema.UnionType{
+		Discriminator: "kind",
+		Mapping:       map[string]string{"a": "pkg:index:A"},
+		ElementTypes: []schema.Type{
+			&schema.ObjectType{Token: "pkg:index:A"},
+			&schema.ObjectType{Token: "pkg:index:B"},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		got := resolveUnionOfObjects(obj, union)
+		// With a non-string discriminator value, the union cannot be
+		// reduced; the function returns the union unchanged.
+		require.Same(t, union, got)
+	})
+}
+
+func TestResolveUnionOfObjectsResolvesStringDiscriminatorValue(t *testing.T) {
+	t.Parallel()
+
+	// Sanity check that the non-panic path still resolves a well-formed
+	// discriminator. A string literal value at the discriminator key
+	// selects the corresponding object type via union.Mapping.
+	objA := &schema.ObjectType{Token: "pkg:index:A"}
+	objB := &schema.ObjectType{Token: "pkg:index:B"}
+	union := &schema.UnionType{
+		Discriminator: "kind",
+		Mapping:       map[string]string{"a": "pkg:index:A", "b": "pkg:index:B"},
+		ElementTypes:  []schema.Type{objA, objB},
+	}
+
+	obj := &model.ObjectConsExpression{
+		Items: []model.ObjectConsItem{{
+			Key:   &model.LiteralValueExpression{Value: cty.StringVal("kind")},
+			Value: &model.LiteralValueExpression{Value: cty.StringVal("b")},
+		}},
+	}
+	require.Same(t, objB, resolveUnionOfObjects(obj, union))
+
+	// Same input, expressed as a one-part TemplateExpression — the
+	// importer round-trips literal strings through TemplateExpression.
+	objTpl := &model.ObjectConsExpression{
+		Items: []model.ObjectConsItem{{
+			Key: &model.LiteralValueExpression{Value: cty.StringVal("kind")},
+			Value: &model.TemplateExpression{Parts: []model.Expression{
+				&model.LiteralValueExpression{Value: cty.StringVal("a")},
+			}},
+		}},
+	}
+	require.Same(t, objA, resolveUnionOfObjects(objTpl, union))
+}
+
 type stubSchemaLoader struct {
 	Package *schema.Package
 }

--- a/pkg/codegen/testing/utils/rapidresource/rapidresource.go
+++ b/pkg/codegen/testing/utils/rapidresource/rapidresource.go
@@ -273,8 +273,53 @@ func drawUnionValue(t *rapid.T, u *schema.UnionType, label string, depth int) pr
 	if len(u.ElementTypes) == 0 {
 		return property.Value{}
 	}
-	idx := rapid.IntRange(0, len(u.ElementTypes)-1).Draw(t, label+":uidx")
-	return drawValue(t, u.ElementTypes[idx], fmt.Sprintf("%s:u%d", label, idx), depth)
+	// At low depth, prefer a "terminal-friendly" element: anything that won't
+	// drive further required-property recursion. rapidschema marks a union
+	// required only when at least one branch is safe (a primitive, an
+	// archive, etc.), but the value generator was previously free to pick a
+	// non-safe branch (e.g. an ObjectType containing another required union
+	// that loops back). At depth ≤ 0, restrict the draw to the non-recursive
+	// branches so the recursion bottoms out; if no such branch exists, fall
+	// through to the original behavior (the schema generator's
+	// isSafeForRequired check guarantees this only happens at higher
+	// depths).
+	candidates := u.ElementTypes
+	if depth <= 0 {
+		var safe []schema.Type
+		for _, t := range u.ElementTypes {
+			if isTerminalFriendly(t) {
+				safe = append(safe, t)
+			}
+		}
+		if len(safe) > 0 {
+			candidates = safe
+		}
+	}
+	idx := rapid.IntRange(0, len(candidates)-1).Draw(t, label+":uidx")
+	return drawValue(t, candidates[idx], fmt.Sprintf("%s:u%d", label, idx), depth)
+}
+
+// isTerminalFriendly reports whether drawValue(t) at depth ≤ 0 will produce
+// a value without descending into required-property recursion. The
+// ObjectType branch of drawValue ignores depth (objects must satisfy their
+// required-property schema), so any ObjectType — even nested inside an
+// Input/Optional/Union — is unsafe at depth ≤ 0. Array/Map already return
+// empty at depth ≤ 0, so they are always safe.
+func isTerminalFriendly(t schema.Type) bool {
+	t = codegen.UnwrapType(t)
+	switch tt := t.(type) {
+	case *schema.ObjectType:
+		return false
+	case *schema.UnionType:
+		for _, e := range tt.ElementTypes {
+			if isTerminalFriendly(e) {
+				return true
+			}
+		}
+		return false
+	default:
+		return true
+	}
 }
 
 // drawEnumValue samples one of the enum's declared values and lifts it into a


### PR DESCRIPTION
## Summary

Two unrelated issues surfaced by `TestRapidGenerateHCL2Definition`, fixed independently.

- **PCL binder**: `resolveUnionOfObjects` (`pkg/codegen/pcl/binder_resource.go`) called `cty.Value.AsString()` on the value at the discriminator key without first checking the literal's type, so a non-string literal at that key (e.g. `false` in a malformed input against a discriminator-by-string union) panicked with `"not a string"`. Now guards both the key and value lookups with a `cty.Type == cty.String` check and falls through on mismatch, leaving the union unresolved so binding can continue and the malformed input surfaces as a normal type-check diagnostic instead of a crash.
- **rapidresource (test infra)**: `drawUnionValue` (`pkg/codegen/testing/utils/rapidresource/rapidresource.go`) picked any branch of the union uniformly. `rapidschema.isSafeForRequired` already restricts required properties to unions with at least one terminal-friendly branch, but the value generator was free to keep picking the recursive object branch and overflow the stack. At depth ≤ 0, restricts the draw to terminal-friendly elements; if none exist, falls back to the original behavior. New helper `isTerminalFriendly` identifies the safe set.

## Test plan

- [x] New unit tests in `pkg/codegen/pcl/binder_resource_test.go`:
  - `TestResolveUnionOfObjectsToleratesNonStringDiscriminatorValue` — panic-tolerant path.
  - `TestResolveUnionOfObjectsResolvesStringDiscriminatorValue` — happy path with both `LiteralValueExpression` and one-part `TemplateExpression` discriminator values.
- [x] `pkg/codegen/pcl` and `pkg/codegen/testing/utils/rapidresource` test suites pass.
- [x] `TestRapidGenerateHCL2Definition` clean at `-rapid.checks=100000` on top of current master.