### PR TITLE
cli/neo: Esc clears the input box when it has text

### DIFF
--- a/changelog/pending/20260520--cli-neo--esc-clears-input-when-non-empty.yaml
+++ b/changelog/pending/20260520--cli-neo--esc-clears-input-when-non-empty.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/neo
+  description: Pressing Esc in `pulumi neo` now clears the input box when it has text; with an empty box, Esc still cancels the agent's current turn

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -685,13 +685,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// ESC asks the agent to abort the current turn. Posts user_cancel
-		// upstream and flips the local cancelling flag so the spinner label
-		// switches to "Cancelling..." until the backend acknowledges via
-		// cancelled / error / a new final assistant_message. Ignored when the
-		// TUI isn't busy or is already waiting on an approval (where the
-		// agent is paused for us anyway).
+		// ESC has two roles, dispatched on whether there's a draft in the
+		// textarea. With content, it clears the draft (so users can wipe a
+		// half-written message without reaching for Backspace or Ctrl+C).
+		// With an empty textarea, it falls back to asking the agent to abort
+		// the current turn: posts user_cancel upstream and flips the local
+		// cancelling flag so the spinner label switches to "Cancelling..."
+		// until the backend acknowledges via cancelled / error / a new final
+		// assistant_message. The cancel branch is ignored when the TUI isn't
+		// busy or is already waiting on an approval (where the agent is
+		// paused for us anyway).
 		if keyStr == "esc" {
+			if m.textInput.Value() != "" {
+				m.textInput.Reset()
+				return m, nil
+			}
 			if m.busy && !m.pendingApproval && !m.cancelling {
 				m.sendOut(outboundEvent{event: apitype.AgentUserEventCancel{Type: userEventUserCancel}})
 				m.cancelling = true

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -685,16 +685,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// ESC has two roles, dispatched on whether there's a draft in the
-		// textarea. With content, it clears the draft (so users can wipe a
-		// half-written message without reaching for Backspace or Ctrl+C).
-		// With an empty textarea, it falls back to asking the agent to abort
-		// the current turn: posts user_cancel upstream and flips the local
-		// cancelling flag so the spinner label switches to "Cancelling..."
-		// until the backend acknowledges via cancelled / error / a new final
-		// assistant_message. The cancel branch is ignored when the TUI isn't
-		// busy or is already waiting on an approval (where the agent is
-		// paused for us anyway).
+		// ESC clears a non-empty textarea; with an empty box it asks the
+		// agent to abort. The cancelling flag overrides the spinner label
+		// until the backend acknowledges via cancelled / error / a new
+		// final assistant_message. Skipped during a pending approval — the
+		// agent is already paused for us there.
 		if keyStr == "esc" {
 			if m.textInput.Value() != "" {
 				m.textInput.Reset()

--- a/pkg/cmd/pulumi/neo/tui_busy_test.go
+++ b/pkg/cmd/pulumi/neo/tui_busy_test.go
@@ -204,6 +204,47 @@ func TestBusy_EscIgnoredWhenIdle(t *testing.T) {
 	}
 }
 
+// TestBusy_EscClearsDraftBeforeCancel — ESC with a draft in the textarea
+// wipes the draft instead of cancelling, so users can scrap a half-typed
+// message without taking down the agent's current turn. The cancel branch
+// only fires once the textarea is empty (see TestBusy_CancellingSubstate).
+func TestBusy_EscClearsDraftBeforeCancel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		busy bool
+	}{
+		{"idle", false},
+		{"busy", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ch := make(chan UIEvent, 4)
+			outCh := make(chan outboundEvent, 4)
+			model := tea.Model(NewModel(ModelConfig{EventCh: ch, OutCh: outCh, Busy: tc.busy}))
+			m := model.(Model)
+			m.textInput.SetValue("half-written draft")
+			require.Equal(t, "half-written draft", m.textInput.Value())
+
+			model, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+			um := model.(Model)
+
+			assert.Equal(t, "", um.textInput.Value(), "ESC with content must clear the textarea")
+			assert.False(t, um.cancelling, "ESC must not cancel while the textarea has a draft")
+			assert.Equal(t, tc.busy, um.busy, "ESC must not change the busy flag when clearing a draft")
+
+			select {
+			case ev := <-outCh:
+				t.Fatalf("ESC must not post any user event when clearing a draft, got %T", ev.event)
+			default:
+			}
+		})
+	}
+}
+
 // TestBusy_EscIgnoredWhileApprovalPending — the agent is already paused
 // waiting for us during an approval; ESC should be a no-op here.
 func TestBusy_EscIgnoredWhileApprovalPending(t *testing.T) {


### PR DESCRIPTION
## Summary

- Pressing Esc in `pulumi neo` now clears the textarea when it contains a draft, so half-written messages can be scrapped without reaching for Backspace or Ctrl+C.
- With an empty textarea, Esc retains its existing behavior of posting `user_cancel` while the agent is mid-turn — the "esc or ctrl+c to cancel" affordance is unchanged.

Fixes pulumi/pulumi-service#42959

## Test plan

- [ ] `go test ./pkg/cmd/pulumi/neo/...` passes (covers new `TestBusy_EscClearsDraftBeforeCancel` + existing `TestBusy_CancellingSubstate` / `TestBusy_EscIgnoredWhenIdle` / `TestBusy_EscIgnoredWhileApprovalPending`)
- [ ] Manual: type a draft, press Esc → box empties, no cancel event
- [ ] Manual: while agent is working with empty box, press Esc → "Cancelling..." appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)