### PR TITLE
Plumb context through LanguageRuntime methods

### DIFF
--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -564,7 +564,7 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 	}
 
 	info := plugin.NewProgramInfo(finalDir, finalDir, ".", proj.Runtime.Options())
-	err = pkgCmdUtil.InstallDependencies(language, plugin.InstallDependenciesRequest{
+	err = pkgCmdUtil.InstallDependencies(ctx.Request(), language, plugin.InstallDependenciesRequest{
 		Info:                    info,
 		UseLanguageVersionTools: false,
 		IsPlugin:                true,

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -159,7 +159,7 @@ func getSummaryAbout(
 				addError(err, "Failed to load language plugin "+proj.Runtime.Name())
 			} else {
 				programInfo := plugin.NewProgramInfo(projinfo.Root, pwd, program, proj.Runtime.Options())
-				aboutResponse, err := lang.About(programInfo)
+				aboutResponse, err := lang.About(ctx, programInfo)
 				if err != nil {
 					addError(err, "Failed to get information about the project runtime")
 				} else {
@@ -171,7 +171,7 @@ func getSummaryAbout(
 					}
 				}
 
-				deps, err := lang.GetProgramDependencies(programInfo, transitiveDependencies)
+				deps, err := lang.GetProgramDependencies(ctx, programInfo, transitiveDependencies)
 				if err != nil {
 					addError(err, "Failed to get information about the Pulumi program's dependencies")
 				} else {
@@ -628,5 +628,5 @@ func getProjectPluginsSilently(
 
 	programInfo := plugin.NewProgramInfo(ctx.Root, pwd, main, proj.Runtime.Options())
 	runtimeName := proj.Runtime.Name()
-	return engine.GetRequiredPlugins(ctx.Host, runtimeName, programInfo)
+	return engine.GetRequiredPlugins(ctx.Request(), ctx.Host, runtimeName, programInfo)
 }

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -264,7 +264,7 @@ func runConvert(
 			projectJSON := string(projectBytes)
 
 			var diags hcl.Diagnostics
-			ds, err := languagePlugin.GenerateProject(
+			ds, err := languagePlugin.GenerateProject(ctx,
 				sourceDirectory, targetDirectory, projectJSON,
 				strict, grpcServer.Addr(), nil /*localDependencies*/)
 			diags = append(diags, ds...)

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -158,7 +158,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			programInfo := plugin.NewProgramInfo(pctx.Root, pwd, main, runtime.Options())
 
 			if !noDependencies {
-				err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
+				err = pkgCmdUtil.InstallDependencies(ctx, lang, plugin.InstallDependenciesRequest{
 					Info:                    programInfo,
 					UseLanguageVersionTools: useLanguageVersionTools,
 					IsPlugin:                false,
@@ -170,7 +170,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 			if !noPlugins {
 				// Compute the set of plugins the current project needs.
-				packages, err := lang.GetRequiredPackages(programInfo)
+				packages, err := lang.GetRequiredPackages(ctx, programInfo)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -84,7 +84,7 @@ func GetLanguageRuntimeMetadata(
 			return nil, err
 		}
 
-		res, err := lang.About(programInfo)
+		res, err := lang.About(ctx, programInfo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -966,7 +966,8 @@ func NewImportCmd() *cobra.Command {
 				// this is because we might generate unbound variables in the generated code that reference
 				// a parent resource or a provider
 				strict := false
-				files, diagnostics, err := languagePlugin.GenerateProgram(program.Source(), grpcServer.Addr(), strict)
+				files, diagnostics, err := languagePlugin.GenerateProgram(
+					pCtx.Request(), program.Source(), grpcServer.Addr(), strict)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -52,7 +52,7 @@ func newPackagePackSdkCmd() *cobra.Command {
 				return err
 			}
 
-			artifact, err := languagePlugin.Pack(path, cwd)
+			artifact, err := languagePlugin.Pack(pCtx.Request(), path, cwd)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -201,7 +201,8 @@ func GenSDK(
 		}
 		defer contract.IgnoreClose(grpcServer)
 
-		diags, err := languagePlugin.GeneratePackage(directory, string(jsonBytes), extraFiles, grpcServer.Addr(), nil, local)
+		diags, err := languagePlugin.GeneratePackage(
+			ctx, directory, string(jsonBytes), extraFiles, grpcServer.Addr(), nil, local)
 		if err != nil {
 			return diags, err
 		}
@@ -308,15 +309,16 @@ func LinkPackages(ctx *LinkPackagesContext) error {
 		})
 	}
 	programInfo := plugin.NewProgramInfo(root, root, ".", ctx.Project.RuntimeInfo().Options())
-	instructions, err := languagePlugin.Link(programInfo, deps, grpcServer.Addr())
+	instructions, err := languagePlugin.Link(ctx.PluginContext.Request(), programInfo, deps, grpcServer.Addr())
 	if err != nil {
 		return fmt.Errorf("linking package: %w", err)
 	}
 
 	if ctx.Install {
-		if err = pkgCmdUtil.InstallDependencies(languagePlugin, plugin.InstallDependenciesRequest{
-			Info: programInfo,
-		}, ctx.Writer, ctx.Writer); err != nil {
+		if err = pkgCmdUtil.InstallDependencies(
+			ctx.PluginContext.Request(), languagePlugin, plugin.InstallDependenciesRequest{
+				Info: programInfo,
+			}, ctx.Writer, ctx.Writer); err != nil {
 			return errutil.ErrorWithStderr(err, "installing dependencies")
 		}
 	}

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -115,7 +115,7 @@ func (w Workspace) InstallPluginAt(ctx context.Context, dirPath string, project 
 	}
 
 	info := plugin.NewProgramInfo(dirPath, dirPath, ".", project.Runtime.Options())
-	return cmdutil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
+	return cmdutil.InstallDependencies(ctx, lang, plugin.InstallDependenciesRequest{
 		Info:                    info,
 		UseLanguageVersionTools: w.options.UseLanguageVersionTools,
 		IsPlugin:                true,
@@ -137,7 +137,7 @@ func (w Workspace) GetRequiredPackages(
 			return nil, err
 		}
 	}
-	return lang.GetRequiredPackages(plugin.NewProgramInfo(dirPath, dirPath, ".", project.Runtime.Options()))
+	return lang.GetRequiredPackages(ctx, plugin.NewProgramInfo(dirPath, dirPath, ".", project.Runtime.Options()))
 }
 
 // IsExecutable returns if the file at binaryPath can be executed.
@@ -315,6 +315,7 @@ func (w Workspace) LinkIntoProject(
 	}
 
 	instructions, err := servers.lang.Link(
+		ctx,
 		plugin.NewProgramInfo(projectDir, projectDir, ".", runtimeInfo.Options()),
 		packageDescriptors,
 		servers.grpc.Addr(),
@@ -396,7 +397,7 @@ func (w Workspace) genSDK(ctx context.Context, language string, pkg *schema.Pack
 		return "", errors.Join(err, os.RemoveAll(tmpDir))
 	}
 
-	diags, err := s.lang.GeneratePackage(tmpDir, string(jsonBytes), nil, s.grpc.Addr(), nil, true /* local */)
+	diags, err := s.lang.GeneratePackage(ctx, tmpDir, string(jsonBytes), nil, s.grpc.Addr(), nil, true /* local */)
 	if err != nil {
 		return "", errors.Join(err, s.Close(), os.RemoveAll(tmpDir))
 	}

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -79,6 +79,7 @@ func getProjectPlugins(ctx context.Context) ([]workspace.PluginDescriptor, error
 	// Get the required plugins and then ensure they have metadata populated about them.  Because it's possible
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	plugins, err := engine.GetRequiredPlugins(
+		pctx.Request(),
 		pctx.Host,
 		proj.Runtime.Name(),
 		programInfo)

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -81,10 +81,11 @@ func InstallPluginDependencies(
 	}
 
 	programInfo := plugin.NewProgramInfo(pluginCtx.Root, pluginCtx.Pwd, main, projRuntime.Options())
-	err = pkgCmdUtil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
-		Info:     programInfo,
-		IsPlugin: true,
-	}, stdout, stderr)
+	err = pkgCmdUtil.InstallDependencies(pluginCtx.Request(),
+		lang, plugin.InstallDependenciesRequest{
+			Info:     programInfo,
+			IsPlugin: true,
+		}, stdout, stderr)
 	if err != nil {
 		return fmt.Errorf("installing dependencies failed: %w", err)
 	}

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -49,7 +49,7 @@ func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 	programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, runtime.Options())
 	// Helper used by multiple commands; output goes to the process streams
 	// directly when not given a writer.
-	err = cmdutil.InstallDependencies(lang, plugin.InstallDependenciesRequest{
+	err = cmdutil.InstallDependencies(ctx.Request(), lang, plugin.InstallDependenciesRequest{
 		Info:     programInfo,
 		IsPlugin: false,
 	}, os.Stdout, os.Stderr) //nolint:forbidigo

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -62,7 +62,7 @@ type chooseTemplateFunc func(templates []cmdTemplates.Template, opts display.Opt
 type runtimeOptionsFunc func(ctx *plugin.Context, language plugin.LanguageRuntime, info *workspace.ProjectRuntimeInfo,
 	main string, opts display.Options, yes, interactive bool, prompt promptForValueFunc) (map[string]any, error)
 
-type languageTemplateFunc func(language plugin.LanguageRuntime, programInfo plugin.ProgramInfo,
+type languageTemplateFunc func(ctx context.Context, language plugin.LanguageRuntime, programInfo plugin.ProgramInfo,
 	projectName tokens.PackageName) error
 
 type promptForAIProjectURLFunc func(ctx context.Context,
@@ -445,7 +445,7 @@ func runNew(ctx context.Context, args newArgs) error {
 		}
 
 		// Let the language runtime do some templating
-		if err := args.languageTemplate(lang, programInfo, proj.Name); err != nil {
+		if err := args.languageTemplate(pluginCtx.Request(), lang, programInfo, proj.Name); err != nil {
 			return fmt.Errorf("language template: %w", err)
 		}
 	}
@@ -518,10 +518,10 @@ func NewNewCmd() *cobra.Command {
 		prompt:               ui.PromptForValue,
 		chooseTemplate:       ChooseTemplate,
 		promptRuntimeOptions: promptRuntimeOptions,
-		languageTemplate: func(language plugin.LanguageRuntime, programInfo plugin.ProgramInfo,
+		languageTemplate: func(ctx context.Context, language plugin.LanguageRuntime, programInfo plugin.ProgramInfo,
 			projectName tokens.PackageName,
 		) error {
-			return language.Template(programInfo, projectName)
+			return language.Template(ctx, programInfo, projectName)
 		},
 		promptForAIProjectURL: promptForAIProjectURL,
 	}
@@ -766,7 +766,7 @@ func promptRuntimeOptions(ctx *plugin.Context, language plugin.LanguageRuntime, 
 	for {
 		// Update the program info with the latest runtime options.
 		programInfo := plugin.NewProgramInfo(ctx.Root, ctx.Pwd, main, options)
-		prompts, err := language.RuntimeOptionsPrompts(programInfo)
+		prompts, err := language.RuntimeOptionsPrompts(ctx.Request(), programInfo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get runtime options prompts: %w", err)
 		}

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1376,7 +1376,7 @@ func TestNoPromptWithYes(t *testing.T) {
 	}
 }
 
-func languageTemplateMock(language plugin.LanguageRuntime, info plugin.ProgramInfo,
+func languageTemplateMock(ctx context.Context, language plugin.LanguageRuntime, info plugin.ProgramInfo,
 	projectName tokens.PackageName,
 ) error {
 	return nil

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -41,7 +41,7 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 	client := pulumirpc.NewLanguageRuntimeClient(conn)
 	return &clientLanguageRuntimeHost{
 		Host:            ctx.Host,
-		languageRuntime: plugin.NewLanguageRuntimeClient(ctx, clientRuntimeName, client),
+		languageRuntime: plugin.NewLanguageRuntimeClient(clientRuntimeName, client),
 	}, nil
 }
 

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -280,6 +280,7 @@ func (p PackageSet) UpdatesTo(old PackageSet) []PackageUpdate {
 
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
 func GetRequiredPlugins(
+	ctx context.Context,
 	host plugin.Host,
 	runtime string,
 	info plugin.ProgramInfo,
@@ -293,7 +294,7 @@ func GetRequiredPlugins(
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
 	// Query the language runtime plugin for its version.
-	langInfo, err := lang.GetPluginInfo()
+	langInfo, err := lang.GetPluginInfo(ctx)
 	if err != nil {
 		// Don't error if this fails, just warn and return the version as unknown.
 		host.Log(diag.Warning, "", fmt.Sprintf("failed to get plugin info for language plugin %s: %v", runtime, err), 0)
@@ -313,7 +314,7 @@ func GetRequiredPlugins(
 	// TODO: we want to support loading precisely what the project needs, rather than doing a static scan of resolved
 	//     packages.  Doing this requires that we change our RPC interface and figure out how to configure plugins
 	//     later than we do (right now, we do it up front, but at that point we don't know the version).
-	deps, err := lang.GetRequiredPackages(info)
+	deps, err := lang.GetRequiredPackages(ctx, info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover plugin requirements: %w", err)
 	}
@@ -334,7 +335,7 @@ func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plu
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
 
-	pkgs, err := lang.GetRequiredPackages(info)
+	pkgs, err := lang.GetRequiredPackages(plugctx.Request(), info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover package requirements: %w", err)
 	}

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -69,18 +69,22 @@ func (p *languageRuntime) Close() error {
 	return nil
 }
 
-func (p *languageRuntime) GetRequiredPackages(info plugin.ProgramInfo) ([]workspace.PackageDescriptor, error) {
+func (p *languageRuntime) GetRequiredPackages(
+	ctx context.Context, info plugin.ProgramInfo,
+) ([]workspace.PackageDescriptor, error) {
 	if p.closed {
 		return nil, ErrLanguageRuntimeIsClosed
 	}
 	return p.requiredPackages, nil
 }
 
-func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
+func (p *languageRuntime) Run(
+	ctx context.Context, info plugin.RunInfo,
+) (string, bool, error) {
 	if p.closed {
 		return "", false, ErrLanguageRuntimeIsClosed
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	monitor, err := dialMonitor(ctx, info.MonitorAddress)
 	if err != nil {
@@ -117,7 +121,7 @@ func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
 	return "", false, nil
 }
 
-func (p *languageRuntime) GetPluginInfo() (plugin.PluginInfo, error) {
+func (p *languageRuntime) GetPluginInfo(ctx context.Context) (plugin.PluginInfo, error) {
 	if p.closed {
 		return plugin.PluginInfo{}, ErrLanguageRuntimeIsClosed
 	}
@@ -125,6 +129,7 @@ func (p *languageRuntime) GetPluginInfo() (plugin.PluginInfo, error) {
 }
 
 func (p *languageRuntime) InstallDependencies(
+	context.Context,
 	plugin.InstallDependenciesRequest,
 ) (io.Reader, io.Reader, <-chan error, error) {
 	if p.closed {
@@ -142,21 +147,25 @@ func (p *languageRuntime) InstallDependencies(
 	return stdout, stderr, done, nil
 }
 
-func (p *languageRuntime) RuntimeOptionsPrompts(info plugin.ProgramInfo) ([]plugin.RuntimeOptionPrompt, error) {
+func (p *languageRuntime) RuntimeOptionsPrompts(
+	ctx context.Context, info plugin.ProgramInfo,
+) ([]plugin.RuntimeOptionPrompt, error) {
 	if p.closed {
 		return []plugin.RuntimeOptionPrompt{}, ErrLanguageRuntimeIsClosed
 	}
 	return []plugin.RuntimeOptionPrompt{}, nil
 }
 
-func (p *languageRuntime) Template(info plugin.ProgramInfo, projectName tokens.PackageName) error {
+func (p *languageRuntime) Template(
+	ctx context.Context, info plugin.ProgramInfo, projectName tokens.PackageName,
+) error {
 	if p.closed {
 		return ErrLanguageRuntimeIsClosed
 	}
 	return nil
 }
 
-func (p *languageRuntime) About(info plugin.ProgramInfo) (plugin.AboutInfo, error) {
+func (p *languageRuntime) About(ctx context.Context, info plugin.ProgramInfo) (plugin.AboutInfo, error) {
 	if p.closed {
 		return plugin.AboutInfo{}, ErrLanguageRuntimeIsClosed
 	}
@@ -164,6 +173,7 @@ func (p *languageRuntime) About(info plugin.ProgramInfo) (plugin.AboutInfo, erro
 }
 
 func (p *languageRuntime) GetProgramDependencies(
+	ctx context.Context,
 	info plugin.ProgramInfo, transitiveDependencies bool,
 ) ([]plugin.DependencyInfo, error) {
 	if p.closed {
@@ -178,31 +188,35 @@ func (p *languageRuntime) RunPlugin(ctx context.Context, info plugin.RunPluginIn
 	return nil, nil, nil, errors.New("inline plugins are not currently supported")
 }
 
-func (p *languageRuntime) GenerateProject(string, string, string,
+func (p *languageRuntime) GenerateProject(context.Context, string, string, string,
 	bool, string, map[string]string,
 ) (hcl.Diagnostics, error) {
 	return nil, errors.New("GenerateProject is not supported")
 }
 
-func (p *languageRuntime) GeneratePackage(
+func (p *languageRuntime) GeneratePackage(context.Context,
 	string, string, map[string][]byte, string, map[string]string, bool,
 ) (hcl.Diagnostics, error) {
 	return nil, errors.New("GeneratePackage is not supported")
 }
 
-func (p *languageRuntime) GenerateProgram(map[string]string, string, bool) (map[string][]byte, hcl.Diagnostics, error) {
+func (p *languageRuntime) GenerateProgram(
+	context.Context, map[string]string, string, bool,
+) (map[string][]byte, hcl.Diagnostics, error) {
 	return nil, nil, errors.New("GenerateProgram is not supported")
 }
 
-func (p *languageRuntime) Pack(string, string) (string, error) {
+func (p *languageRuntime) Pack(context.Context, string, string) (string, error) {
 	return "", errors.New("Pack is not supported")
 }
 
-func (p *languageRuntime) Link(plugin.ProgramInfo, []workspace.LinkablePackageDescriptor, string) (string, error) {
+func (p *languageRuntime) Link(
+	context.Context, plugin.ProgramInfo, []workspace.LinkablePackageDescriptor, string,
+) (string, error) {
 	return "", errors.New("Link is not supported")
 }
 
-func (p *languageRuntime) Cancel() error {
+func (p *languageRuntime) Cancel(context.Context) error {
 	p.closed = true
 
 	if p.shutdown != nil {

--- a/pkg/resource/deploy/deploytest/languageruntime_test.go
+++ b/pkg/resource/deploy/deploytest/languageruntime_test.go
@@ -38,43 +38,43 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("Run", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, _, err := p.Run(plugin.RunInfo{})
+			_, _, err := p.Run(t.Context(), plugin.RunInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("GetRequiredPackages", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.GetRequiredPackages(plugin.ProgramInfo{})
+			_, err := p.GetRequiredPackages(t.Context(), plugin.ProgramInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("GetPluginInfo", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.GetPluginInfo()
+			_, err := p.GetPluginInfo(t.Context())
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, _, _, err := p.InstallDependencies(plugin.InstallDependenciesRequest{})
+			_, _, _, err := p.InstallDependencies(t.Context(), plugin.InstallDependenciesRequest{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("RuntimeOptionsPrompts", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.RuntimeOptionsPrompts(plugin.ProgramInfo{})
+			_, err := p.RuntimeOptionsPrompts(t.Context(), plugin.ProgramInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("About", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.About(plugin.ProgramInfo{})
+			_, err := p.About(t.Context(), plugin.ProgramInfo{})
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 		t.Run("GetProgramDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{closed: true}
-			_, err := p.GetProgramDependencies(plugin.ProgramInfo{}, false)
+			_, err := p.GetProgramDependencies(t.Context(), plugin.ProgramInfo{}, false)
 			assert.ErrorIs(t, err, ErrLanguageRuntimeIsClosed)
 		})
 	})
@@ -83,7 +83,7 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("Run", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			_, _, err := p.Run(plugin.RunInfo{})
+			_, _, err := p.Run(t.Context(), plugin.RunInfo{})
 			assert.ErrorContains(t, err, "could not determine whether secrets are supported")
 		})
 	})
@@ -92,34 +92,34 @@ func TestLanguageRuntime(t *testing.T) {
 		t.Run("GetPluginInfo", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			res, err := p.GetPluginInfo()
+			res, err := p.GetPluginInfo(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, plugin.PluginInfo{}, res)
 		})
 		t.Run("InstallDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			_, _, _, err := p.InstallDependencies(plugin.InstallDependenciesRequest{})
+			_, _, _, err := p.InstallDependencies(t.Context(), plugin.InstallDependenciesRequest{})
 			require.NoError(t, err)
 		})
 		t.Run("RuntimeOptionsPrompts", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			options, err := p.RuntimeOptionsPrompts(plugin.ProgramInfo{})
+			options, err := p.RuntimeOptionsPrompts(t.Context(), plugin.ProgramInfo{})
 			require.NoError(t, err)
 			assert.Equal(t, []plugin.RuntimeOptionPrompt{}, options)
 		})
 		t.Run("About", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			about, err := p.About(plugin.ProgramInfo{})
+			about, err := p.About(t.Context(), plugin.ProgramInfo{})
 			require.NoError(t, err)
 			assert.Equal(t, plugin.AboutInfo{}, about)
 		})
 		t.Run("GetProgramDependencies", func(t *testing.T) {
 			t.Parallel()
 			p := &languageRuntime{}
-			res, err := p.GetProgramDependencies(plugin.ProgramInfo{}, false)
+			res, err := p.GetProgramDependencies(t.Context(), plugin.ProgramInfo{}, false)
 			require.NoError(t, err)
 			assert.Nil(t, res)
 		})
@@ -133,22 +133,22 @@ func TestLanguageRuntime(t *testing.T) {
 		})
 		t.Run("GenerateProject", func(t *testing.T) {
 			t.Parallel()
-			_, err := p.GenerateProject("", "", "", false, "", nil)
+			_, err := p.GenerateProject(t.Context(), "", "", "", false, "", nil)
 			assert.ErrorContains(t, err, "is not supported")
 		})
 		t.Run("GeneratePackage", func(t *testing.T) {
 			t.Parallel()
-			_, err := p.GeneratePackage("", "", nil, "", nil, false)
+			_, err := p.GeneratePackage(t.Context(), "", "", nil, "", nil, false)
 			assert.ErrorContains(t, err, "is not supported")
 		})
 		t.Run("GenerateProgram", func(t *testing.T) {
 			t.Parallel()
-			_, _, err := p.GenerateProgram(nil, "", false)
+			_, _, err := p.GenerateProgram(t.Context(), nil, "", false)
 			assert.ErrorContains(t, err, "is not supported")
 		})
 		t.Run("Pack", func(t *testing.T) {
 			t.Parallel()
-			_, err := p.Pack("", "")
+			_, err := p.Pack(t.Context(), "", "")
 			assert.ErrorContains(t, err, "is not supported")
 		})
 	})

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -485,7 +485,7 @@ func (host *pluginHost) SignalCancellation() error {
 	}
 
 	if host.languageRuntime != nil {
-		if lErr := host.languageRuntime.Cancel(); lErr != nil {
+		if lErr := host.languageRuntime.Cancel(context.TODO()); lErr != nil {
 			err = lErr
 		}
 	}
@@ -585,7 +585,7 @@ func (host *pluginHost) GetRequiredPackages(
 	info plugin.ProgramInfo,
 	kinds plugin.Flags,
 ) ([]workspace.PackageDescriptor, error) {
-	return host.languageRuntime.GetRequiredPackages(info)
+	return host.languageRuntime.GetRequiredPackages(context.TODO(), info)
 }
 
 func (host *pluginHost) GetProjectPlugins() []workspace.ProjectPlugin {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -302,7 +302,7 @@ func (iter *evalSourceIterator) forkRun(
 				/* options */ rtopts)
 
 			// Now run the actual program.
-			progerr, bail, err := langhost.Run(plugin.RunInfo{
+			progerr, bail, err := langhost.Run(iter.src.plugctx.Request(), plugin.RunInfo{
 				MonitorAddress:   iter.mon.Address(),
 				Stack:            iter.src.runinfo.Target.Name.String(),
 				Project:          string(iter.src.runinfo.Proj.Name),

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -94,12 +94,13 @@ func NewLanguageTestServer(testdata fs.FS, languageTests map[string]tests.Langua
 }
 
 func installDependencies(
+	ctx context.Context,
 	languageClient plugin.LanguageRuntime,
 	programInfo plugin.ProgramInfo,
 	isPlugin bool,
 ) *testingrpc.RunLanguageTestResponse {
 	installStdout, installStderr, installDone, err := languageClient.InstallDependencies(
-		plugin.InstallDependenciesRequest{Info: programInfo, IsPlugin: isPlugin},
+		ctx, plugin.InstallDependenciesRequest{Info: programInfo, IsPlugin: isPlugin},
 	)
 	programOrPlugin := "program"
 	if isPlugin {
@@ -546,7 +547,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 	}
 
 	languageClient := plugin.NewLanguageRuntimeClient(
-		pctx, req.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
+		req.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// Setup the artifacts directory
 	err = os.MkdirAll(filepath.Join(req.TemporaryDirectory, "artifacts"), 0o755)
@@ -556,7 +557,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 
 	var coreArtifact string
 	if req.CoreSdkDirectory != "" {
-		coreArtifact, err = languageClient.Pack(
+		coreArtifact, err = languageClient.Pack(ctx,
 			req.CoreSdkDirectory, filepath.Join(req.TemporaryDirectory, "artifacts"))
 		if err != nil {
 			return nil, fmt.Errorf("pack core SDK: %w", err)
@@ -721,7 +722,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	}
 
 	languageClient := plugin.NewLanguageRuntimeClient(
-		pctx, token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
+		token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	// And now replace the context host with our own test host
 	host := &testHost{
@@ -805,12 +806,12 @@ func (eng *languageTestServer) RunLanguageTest(
 						},
 					},
 				}}
-				_, err = languageClient.Link(providerInfo, linkDeps, grpcServer.Addr())
+				_, err = languageClient.Link(ctx, providerInfo, linkDeps, grpcServer.Addr())
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("link program: %v", err)), nil
 				}
 
-				resp := installDependencies(languageClient, providerInfo, true /* isPlugin */)
+				resp := installDependencies(ctx, languageClient, providerInfo, true /* isPlugin */)
 				if resp != nil {
 					return resp, nil
 				}
@@ -951,7 +952,7 @@ func (eng *languageTestServer) RunLanguageTest(
 					return nil, fmt.Errorf("marshal schema for provider %s: %w", pkg.Name, err)
 				}
 
-				diags, err := languageClient.GeneratePackage(
+				diags, err := languageClient.GeneratePackage(ctx,
 					sdkTempDir, string(schemaBytes), nil, grpcServer.Addr(), localDependencies, false)
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("generate package %s: %v", pkg.Name, err)), nil
@@ -985,7 +986,7 @@ func (eng *languageTestServer) RunLanguageTest(
 
 				// Pack the SDK and add it to the artifact dependencies, we do this in the temporary directory so that
 				// any intermediate build files don't end up getting captured in the snapshot folder.
-				sdkArtifact, err = languageClient.Pack(sdkTempDir, artifactsDir)
+				sdkArtifact, err = languageClient.Pack(ctx, sdkTempDir, artifactsDir)
 				if err != nil {
 					return nil, fmt.Errorf("sdk packing for %s: %w", pkg.Name, err)
 				}
@@ -1224,7 +1225,7 @@ func runLanguageTests(
 						return nil, fmt.Errorf("marshal schema for provider %s: %w", pkg.Name, err)
 					}
 
-					diags, err := languageClient.GeneratePackage(
+					diags, err := languageClient.GeneratePackage(ctx,
 						sdkTargetDir, string(schemaBytes), nil, grpcServer.Addr(), localDependencies, false)
 					if err != nil {
 						return makeTestResponse(fmt.Sprintf("generate package %s: %v", pkg.Name, err)), nil
@@ -1246,6 +1247,7 @@ func runLanguageTests(
 				}
 			} else {
 				diagnostics, err = languageClient.GenerateProject(
+					ctx,
 					sourceDir, projectDir, projectJSON, true, grpcServer.Addr(), localDependencies)
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("generate project: %v", err)), nil
@@ -1302,7 +1304,7 @@ func runLanguageTests(
 			main,
 			project.Runtime.Options())
 
-		resp := installDependencies(languageClient, programInfo, false /* isPlugin */)
+		resp := installDependencies(ctx, languageClient, programInfo, false /* isPlugin */)
 		if resp != nil {
 			return resp, nil
 		}
@@ -1313,7 +1315,7 @@ func runLanguageTests(
 		// We make a transitive query here because some languages (e.g. Python) treat dependencies as transitive if any of
 		// their dependencies has a dependency on the package, even if the program also directly lists it as a dependency as
 		// well.
-		dependencies, err := languageClient.GetProgramDependencies(programInfo, true)
+		dependencies, err := languageClient.GetProgramDependencies(ctx, programInfo, true)
 		if err != nil {
 			return makeTestResponse(fmt.Sprintf("get program dependencies: %v", err)), nil
 		}
@@ -1389,7 +1391,7 @@ func runLanguageTests(
 		}
 
 		// Query the language plugin for what it thinks the project packages are, we expect to see the SDKs.
-		packages, err := languageClient.GetRequiredPackages(programInfo)
+		packages, err := languageClient.GetRequiredPackages(ctx, programInfo)
 		if err != nil {
 			return makeTestResponse(fmt.Sprintf("get required packages: %v", err)), nil
 		}
@@ -1557,13 +1559,13 @@ func runLanguageTests(
 					},
 				},
 			}}
-			_, err = languageClient.Link(policyInfo, linkDeps, grpcServer.Addr())
+			_, err = languageClient.Link(ctx, policyInfo, linkDeps, grpcServer.Addr())
 			if err != nil {
 				return makeTestResponse(fmt.Sprintf("link program: %v", err)), nil
 			}
 
 			// Install the dependencies for the policy pack
-			resp := installDependencies(languageClient, policyInfo, true /* isPlugin */)
+			resp := installDependencies(ctx, languageClient, policyInfo, true /* isPlugin */)
 			if resp != nil {
 				return resp, nil
 			}
@@ -1732,7 +1734,7 @@ type roundTripClient struct {
 	ejectSnapshotBaseDir string
 }
 
-func (rtc roundTripClient) GenerateProject(
+func (rtc roundTripClient) GenerateProject(ctx context.Context,
 	sourceDirectory, targetDirectory, project string,
 	strict bool, loaderTarget string, localDependencies map[string]string,
 ) (hcl.Diagnostics, error) {
@@ -1764,12 +1766,12 @@ func (rtc roundTripClient) GenerateProject(
 		}
 	}
 
-	diags2, err := rtc.LanguageRuntime.GenerateProject(pclDir, targetDirectory, project,
+	diags2, err := rtc.LanguageRuntime.GenerateProject(ctx, pclDir, targetDirectory, project,
 		strict, loaderTarget, localDependencies)
 	return diags.Extend(diags2), err
 }
 
-func (rtc roundTripClient) GenerateProgram(
+func (rtc roundTripClient) GenerateProgram(ctx context.Context,
 	program map[string]string, loaderTarget string, strict bool,
 ) (map[string][]byte, hcl.Diagnostics, error) {
 	sourceDir, err := os.MkdirTemp("", "lang-to-pcl-source-*")
@@ -1789,7 +1791,7 @@ func (rtc roundTripClient) GenerateProgram(
 	}
 
 	project := "{\"name\": \"roundtrip\"}"
-	pclDir, diags, err := rtc.roundTrip(context.TODO(), sourceDir, project, loaderTarget, strict, nil)
+	pclDir, diags, err := rtc.roundTrip(ctx, sourceDir, project, loaderTarget, strict, nil)
 	if err != nil || diags.HasErrors() {
 		return nil, diags, err
 	}
@@ -1811,7 +1813,7 @@ func (rtc roundTripClient) GenerateProgram(
 		return nil, diags, err
 	}
 	// TODO: Snapshot files
-	lang, diags2, err := rtc.LanguageRuntime.GenerateProgram(pclFiles, loaderTarget, strict)
+	lang, diags2, err := rtc.LanguageRuntime.GenerateProgram(ctx, pclFiles, loaderTarget, strict)
 	return lang, diags.Extend(diags2), err
 }
 
@@ -1826,7 +1828,7 @@ func (rtc roundTripClient) roundTrip(
 	}
 	defer func() { contract.IgnoreError(os.RemoveAll(tmpDir)) }()
 
-	diags, err := rtc.LanguageRuntime.GenerateProject(
+	diags, err := rtc.LanguageRuntime.GenerateProject(ctx,
 		sourceDirectory, tmpDir, project, strict, loaderTarget, localDependencies)
 	if err != nil || diags.HasErrors() {
 		return "", diags, err

--- a/pkg/util/cmdutil/install_dependencies.go
+++ b/pkg/util/cmdutil/install_dependencies.go
@@ -15,6 +15,7 @@
 package cmdutil
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -26,10 +27,11 @@ import (
 // complete. Standard output and error are streamed to os.Stdout and os.Stderr, respectively, and any errors encountered
 // during the installation or streaming of its output are returned.
 func InstallDependencies(
+	ctx context.Context,
 	lang plugin.LanguageRuntime, req plugin.InstallDependenciesRequest,
 	stdout, stderr io.Writer,
 ) error {
-	stdoutPipe, stderrPipe, done, err := lang.InstallDependencies(req)
+	stdoutPipe, stderrPipe, done, err := lang.InstallDependencies(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -181,7 +181,7 @@ func InstallPluginAtPath(pctx *plugin.Context, proj *workspace.PluginProject, st
 	}
 	entryPoint := "." // Plugin's are not able to set a non-standard entry point.
 	pInfo := plugin.NewProgramInfo(pctx.Root, pctx.Pwd, entryPoint, proj.Runtime.Options())
-	return cmdutil.InstallDependencies(runtime, plugin.InstallDependenciesRequest{
+	return cmdutil.InstallDependencies(pctx.Request(), runtime, plugin.InstallDependenciesRequest{
 		Info:                    pInfo,
 		UseLanguageVersionTools: false,
 		IsPlugin:                true,

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -599,7 +599,7 @@ func (host *defaultHost) LanguageRuntime(runtime string,
 		// If not, allocate a new one.
 		plug, err := NewLanguageRuntime(host, host.ctx, runtime, host.ctx.Pwd)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo()
+			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
@@ -699,7 +699,7 @@ func (host *defaultHost) SignalCancellation() error {
 
 		for _, plug := range host.languagePlugins {
 			wg.Go(func() {
-				if err := plug.Plugin.Cancel(); err != nil {
+				if err := plug.Plugin.Cancel(cancelCtx); err != nil {
 					mu.Lock()
 					errs = append(errs, fmt.Errorf(
 						"error signaling cancellation to language runtime '%s': %w", plug.Name, err))
@@ -750,7 +750,7 @@ func (host *defaultHost) Close() (err error) {
 
 		for _, plug := range host.languagePlugins {
 			wg.Go(func() {
-				contract.IgnoreError(plug.Plugin.Cancel())
+				contract.IgnoreError(plug.Plugin.Cancel(cancelCtx))
 				if err := plug.Plugin.Close(); err != nil {
 					logging.V(5).Infof("Error closing '%s' language plugin during shutdown; ignoring: %v", plug.Name, err)
 				}

--- a/sdk/go/common/resource/plugin/langruntime.go
+++ b/sdk/go/common/resource/plugin/langruntime.go
@@ -123,7 +123,7 @@ type LanguageRuntime interface {
 	// Closer closes any underlying OS resources associated with this plugin (like processes, RPC channels, etc).
 	io.Closer
 	// GetRequiredPackages computes the complete set of anticipated packages required by a program.
-	GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDescriptor, error)
+	GetRequiredPackages(ctx context.Context, info ProgramInfo) ([]workspace.PackageDescriptor, error)
 	// Run executes a program in the language runtime for planning or deployment purposes.  If
 	// info.DryRun is true, the code must not assume that side-effects or final values resulting
 	// from resource deployments are actually available.  If it is false, on the other hand, a real
@@ -131,57 +131,62 @@ type LanguageRuntime interface {
 	//
 	// Returns a triple of "error message", "bail", or real "error".  If "bail", the caller should
 	// return result.Bail immediately and not print any further messages to the user.
-	Run(info RunInfo) (string, bool, error)
+	Run(ctx context.Context, info RunInfo) (string, bool, error)
 	// GetPluginInfo returns this plugin's information.
-	GetPluginInfo() (PluginInfo, error)
+	GetPluginInfo(ctx context.Context) (PluginInfo, error)
 
 	// InstallDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
 	// It returns io.Readers for stdout and stderr as well as a channel that will be closed when the operation is
 	// complete, producing an error if one occurred. Callers *must* drain the stdout and stderr readers if they await the
 	// done channel to avoid deadlocks.
-	InstallDependencies(request InstallDependenciesRequest) (io.Reader, io.Reader, <-chan error, error)
+	InstallDependencies(
+		ctx context.Context, request InstallDependenciesRequest,
+	) (io.Reader, io.Reader, <-chan error, error)
 
 	// RuntimeOptionsPrompts returns additional options that can be set for the runtime.
-	RuntimeOptionsPrompts(info ProgramInfo) ([]RuntimeOptionPrompt, error)
+	RuntimeOptionsPrompts(ctx context.Context, info ProgramInfo) ([]RuntimeOptionPrompt, error)
 
 	// Template allows the language runtime to perform additional templating on a newly instantiated project template.
-	Template(info ProgramInfo, projectName tokens.PackageName) error
+	Template(ctx context.Context, info ProgramInfo, projectName tokens.PackageName) error
 
 	// About returns information about the language runtime.
-	About(info ProgramInfo) (AboutInfo, error)
+	About(ctx context.Context, info ProgramInfo) (AboutInfo, error)
 
 	// GetProgramDependencies returns information about the dependencies for the given program.
-	GetProgramDependencies(info ProgramInfo, transitiveDependencies bool) ([]DependencyInfo, error)
+	GetProgramDependencies(ctx context.Context, info ProgramInfo, transitiveDependencies bool) ([]DependencyInfo, error)
 
 	// RunPlugin executes a plugin program and returns its result asynchronously.
 	RunPlugin(ctx context.Context, info RunPluginInfo) (io.Reader, io.Reader, *promise.Promise[int32], error)
 
 	// GenerateProject generates a program project in the given directory. This will include metadata files such
 	// as Pulumi.yaml and package.json.
-	GenerateProject(sourceDirectory, targetDirectory, project string,
+	GenerateProject(ctx context.Context, sourceDirectory, targetDirectory, project string,
 		strict bool, loaderTarget string, localDependencies map[string]string) (hcl.Diagnostics, error)
 
 	// GeneratePackage generates an SDK package.
 	GeneratePackage(
-		directory string, schema string, extraFiles map[string][]byte,
+		ctx context.Context, directory string, schema string, extraFiles map[string][]byte,
 		loaderTarget string, localDependencies map[string]string,
 		local bool,
 	) (hcl.Diagnostics, error)
 
 	// GenerateProgram is similar to GenerateProject but doesn't include any metadata files, just the program
 	// source code.
-	GenerateProgram(program map[string]string, loaderTarget string,
+	GenerateProgram(ctx context.Context, program map[string]string, loaderTarget string,
 		strict bool) (map[string][]byte, hcl.Diagnostics, error)
 
 	// Pack packs a library package into a language specific artifact in the given destination directory.
-	Pack(packageDirectory string, destinationDirectory string) (string, error)
+	Pack(ctx context.Context, packageDirectory string, destinationDirectory string) (string, error)
 
 	// Link links a set of local dependencies into the given program directory.
-	Link(info ProgramInfo, localDependencies []workspace.LinkablePackageDescriptor, loaderTarget string) (string, error)
+	Link(
+		ctx context.Context, info ProgramInfo, localDependencies []workspace.LinkablePackageDescriptor,
+		loaderTarget string,
+	) (string, error)
 
 	// Cancel signals the language runtime to gracefully shut down and abort any ongoing operations.
 	// Operations aborted in this way will return an error.
-	Cancel() error
+	Cancel(ctx context.Context) error
 }
 
 // DependencyInfo contains information about a dependency reported by a language runtime.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -48,7 +48,6 @@ import (
 
 // langhost reflects a language host plugin, loaded dynamically for a single language/runtime pair.
 type langhost struct {
-	ctx     *Context
 	runtime string
 	plug    *Plugin
 	client  pulumirpc.LanguageRuntimeClient
@@ -148,7 +147,6 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 	contract.Assertf(plug != nil, "unexpected nil language plugin for %s", runtime)
 
 	return &langhost{
-		ctx:     ctx,
 		runtime: runtime,
 		plug:    plug,
 		client:  client,
@@ -213,16 +211,15 @@ func buildArgsForNewPlugin(host Host) ([]string, error) {
 	return args, nil
 }
 
-func NewLanguageRuntimeClient(ctx *Context, runtime string, client pulumirpc.LanguageRuntimeClient) LanguageRuntime {
+func NewLanguageRuntimeClient(runtime string, client pulumirpc.LanguageRuntimeClient) LanguageRuntime {
 	return &langhost{
-		ctx:     ctx,
 		runtime: runtime,
 		client:  client,
 	}
 }
 
 // GetRequiredPackages computes the complete set of anticipated plugins required by a program.
-func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDescriptor, error) {
+func (h *langhost) GetRequiredPackages(ctx context.Context, info ProgramInfo) ([]workspace.PackageDescriptor, error) {
 	logging.V(7).Infof("langhost[%v].GetRequiredPackages(%s) executing",
 		h.runtime, info)
 
@@ -231,7 +228,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 		return nil, err
 	}
 
-	resp, err := h.client.GetRequiredPackages(h.ctx.Request(), &pulumirpc.GetRequiredPackagesRequest{
+	resp, err := h.client.GetRequiredPackages(ctx, &pulumirpc.GetRequiredPackagesRequest{
 		Info: minfo,
 	})
 	if err != nil {
@@ -242,7 +239,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 		// It's possible this is just an older language host, prior to the emergence of the GetRequiredPackages
 		// method.  In such cases, fallback to using GetRequiredPlugins and don't report any parameterized packages.
 		if rpcError.Code() == codes.Unimplemented {
-			plugins, err := h.getRequiredPlugins(info)
+			plugins, err := h.getRequiredPlugins(ctx, info)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +302,7 @@ func (h *langhost) GetRequiredPackages(info ProgramInfo) ([]workspace.PackageDes
 }
 
 // getRequiredPlugins computes the complete set of anticipated plugins required by a program.
-func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginDescriptor, error) {
+func (h *langhost) getRequiredPlugins(ctx context.Context, info ProgramInfo) ([]workspace.PluginDescriptor, error) {
 	logging.V(7).Infof("langhost[%v].GetRequiredPlugins(%s) executing",
 		h.runtime, info)
 
@@ -316,7 +313,7 @@ func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginDescr
 
 	// this is deprecated and will be removed in a future release, but we use it for backcompat for now until
 	// all language hosts are update to GetRequiredPackages.
-	resp, err := h.client.GetRequiredPlugins(h.ctx.Request(), &pulumirpc.GetRequiredPluginsRequest{ //nolint:staticcheck
+	resp, err := h.client.GetRequiredPlugins(ctx, &pulumirpc.GetRequiredPluginsRequest{ //nolint:staticcheck
 		Project: "deprecated",
 		Pwd:     info.ProgramDirectory(),
 		Program: info.EntryPoint(),
@@ -367,7 +364,7 @@ func (h *langhost) getRequiredPlugins(info ProgramInfo) ([]workspace.PluginDescr
 // info.DryRun is true, the code must not assume that side-effects or final values resulting from
 // resource deployments are actually available.  If it is false, on the other hand, a real
 // deployment is occurring and it may safely depend on these.
-func (h *langhost) Run(info RunInfo) (string, bool, error) {
+func (h *langhost) Run(ctx context.Context, info RunInfo) (string, bool, error) {
 	logging.V(7).Infof("langhost[%v].Run(pwd=%v,%s,#args=%v,proj=%s,stack=%v,#config=%v,dryrun=%v) executing",
 		h.runtime, info.Pwd, info.Info, len(info.Args), info.Project, info.Stack, len(info.Config), info.DryRun)
 	config := make(map[string]string, len(info.Config))
@@ -384,7 +381,7 @@ func (h *langhost) Run(info RunInfo) (string, bool, error) {
 		return "", false, err
 	}
 
-	resp, err := h.client.Run(h.ctx.Request(), &pulumirpc.RunRequest{
+	resp, err := h.client.Run(ctx, &pulumirpc.RunRequest{
 		MonitorAddress:   info.MonitorAddress,
 		Pwd:              info.Pwd,
 		Program:          info.Info.EntryPoint(),
@@ -416,10 +413,10 @@ func (h *langhost) Run(info RunInfo) (string, bool, error) {
 }
 
 // GetPluginInfo returns this plugin's information.
-func (h *langhost) GetPluginInfo() (PluginInfo, error) {
+func (h *langhost) GetPluginInfo(ctx context.Context) (PluginInfo, error) {
 	logging.V(7).Infof("langhost[%v].GetPluginInfo() executing", h.runtime)
 
-	resp, err := h.client.GetPluginInfo(h.ctx.Request(), &emptypb.Empty{})
+	resp, err := h.client.GetPluginInfo(ctx, &emptypb.Empty{})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
 		logging.V(7).Infof("langhost[%v].GetPluginInfo() failed: err=%v", h.runtime, rpcError)
@@ -448,7 +445,7 @@ func (h *langhost) Close() error {
 	return nil
 }
 
-func (h *langhost) InstallDependencies(request InstallDependenciesRequest) (
+func (h *langhost) InstallDependencies(ctx context.Context, request InstallDependenciesRequest) (
 	io.Reader,
 	io.Reader,
 	<-chan error,
@@ -462,7 +459,7 @@ func (h *langhost) InstallDependencies(request InstallDependenciesRequest) (
 		return nil, nil, nil, err
 	}
 
-	resp, err := h.client.InstallDependencies(h.ctx.Request(), &pulumirpc.InstallDependenciesRequest{
+	resp, err := h.client.InstallDependencies(ctx, &pulumirpc.InstallDependenciesRequest{
 		Directory:               request.Info.ProgramDirectory(),
 		IsTerminal:              cmdutil.GetGlobalColorization() != colors.Never,
 		Info:                    minfo,
@@ -543,7 +540,7 @@ func (h *langhost) InstallDependencies(request InstallDependenciesRequest) (
 	return outr, errr, done, nil
 }
 
-func (h *langhost) RuntimeOptionsPrompts(info ProgramInfo) ([]RuntimeOptionPrompt, error) {
+func (h *langhost) RuntimeOptionsPrompts(ctx context.Context, info ProgramInfo) ([]RuntimeOptionPrompt, error) {
 	logging.V(7).Infof("langhost[%v].RuntimeOptionsPrompts() executing", h.runtime)
 
 	minfo, err := info.Marshal()
@@ -551,7 +548,7 @@ func (h *langhost) RuntimeOptionsPrompts(info ProgramInfo) ([]RuntimeOptionPromp
 		return []RuntimeOptionPrompt{}, err
 	}
 
-	resp, err := h.client.RuntimeOptionsPrompts(h.ctx.Request(), &pulumirpc.RuntimeOptionsRequest{
+	resp, err := h.client.RuntimeOptionsPrompts(ctx, &pulumirpc.RuntimeOptionsRequest{
 		Info: minfo,
 	})
 	if err != nil {
@@ -577,7 +574,7 @@ func (h *langhost) RuntimeOptionsPrompts(info ProgramInfo) ([]RuntimeOptionPromp
 	return prompts, nil
 }
 
-func (h *langhost) Template(info ProgramInfo, projectName tokens.PackageName) error {
+func (h *langhost) Template(ctx context.Context, info ProgramInfo, projectName tokens.PackageName) error {
 	logging.V(7).Infof("langhost[%v].Template() executing", h.runtime)
 
 	minfo, err := info.Marshal()
@@ -585,7 +582,7 @@ func (h *langhost) Template(info ProgramInfo, projectName tokens.PackageName) er
 		return err
 	}
 
-	_, err = h.client.Template(h.ctx.Request(), &pulumirpc.TemplateRequest{
+	_, err = h.client.Template(ctx, &pulumirpc.TemplateRequest{
 		Info:        minfo,
 		ProjectName: string(projectName),
 	})
@@ -603,13 +600,13 @@ func (h *langhost) Template(info ProgramInfo, projectName tokens.PackageName) er
 	return nil
 }
 
-func (h *langhost) About(info ProgramInfo) (AboutInfo, error) {
+func (h *langhost) About(ctx context.Context, info ProgramInfo) (AboutInfo, error) {
 	logging.V(7).Infof("langhost[%v].About() executing", h.runtime)
 	minfo, err := info.Marshal()
 	if err != nil {
 		return AboutInfo{}, err
 	}
-	resp, err := h.client.About(h.ctx.Request(), &pulumirpc.AboutRequest{
+	resp, err := h.client.About(ctx, &pulumirpc.AboutRequest{
 		Info: minfo,
 	})
 	if err != nil {
@@ -629,7 +626,9 @@ func (h *langhost) About(info ProgramInfo) (AboutInfo, error) {
 	return result, nil
 }
 
-func (h *langhost) GetProgramDependencies(info ProgramInfo, transitiveDependencies bool) ([]DependencyInfo, error) {
+func (h *langhost) GetProgramDependencies(
+	ctx context.Context, info ProgramInfo, transitiveDependencies bool,
+) ([]DependencyInfo, error) {
 	prefix := fmt.Sprintf("langhost[%v].GetProgramDependencies(%s)", h.runtime, info.String())
 	minfo, err := info.Marshal()
 	if err != nil {
@@ -637,7 +636,7 @@ func (h *langhost) GetProgramDependencies(info ProgramInfo, transitiveDependenci
 	}
 
 	logging.V(7).Infof("%s executing", prefix)
-	resp, err := h.client.GetProgramDependencies(h.ctx.Request(), &pulumirpc.GetProgramDependenciesRequest{
+	resp, err := h.client.GetProgramDependencies(ctx, &pulumirpc.GetProgramDependenciesRequest{
 		TransitiveDependencies: transitiveDependencies,
 		Info:                   minfo,
 	})
@@ -749,11 +748,11 @@ func (h *langhost) RunPlugin(ctx context.Context, info RunPluginInfo) (
 }
 
 func (h *langhost) GenerateProject(
-	sourceDirectory, targetDirectory, project string, strict bool,
+	ctx context.Context, sourceDirectory, targetDirectory, project string, strict bool,
 	loaderTarget string, localDependencies map[string]string,
 ) (hcl.Diagnostics, error) {
 	logging.V(7).Infof("langhost[%v].GenerateProject() executing", h.runtime)
-	resp, err := h.client.GenerateProject(h.ctx.Request(), &pulumirpc.GenerateProjectRequest{
+	resp, err := h.client.GenerateProject(ctx, &pulumirpc.GenerateProjectRequest{
 		SourceDirectory:   sourceDirectory,
 		TargetDirectory:   targetDirectory,
 		Project:           project,
@@ -778,12 +777,13 @@ func (h *langhost) GenerateProject(
 }
 
 func (h *langhost) GeneratePackage(
+	ctx context.Context,
 	directory string, schema string, extraFiles map[string][]byte,
 	loaderTarget string, localDependencies map[string]string,
 	local bool,
 ) (hcl.Diagnostics, error) {
 	logging.V(7).Infof("langhost[%v].GeneratePackage() executing", h.runtime)
-	resp, err := h.client.GeneratePackage(h.ctx.Request(), &pulumirpc.GeneratePackageRequest{
+	resp, err := h.client.GeneratePackage(ctx, &pulumirpc.GeneratePackageRequest{
 		Directory:         directory,
 		Schema:            schema,
 		ExtraFiles:        extraFiles,
@@ -808,10 +808,10 @@ func (h *langhost) GeneratePackage(
 	return diags, nil
 }
 
-func (h *langhost) GenerateProgram(program map[string]string, loaderTarget string, strict bool,
+func (h *langhost) GenerateProgram(ctx context.Context, program map[string]string, loaderTarget string, strict bool,
 ) (map[string][]byte, hcl.Diagnostics, error) {
 	logging.V(7).Infof("langhost[%v].GenerateProgram() executing", h.runtime)
-	resp, err := h.client.GenerateProgram(h.ctx.Request(), &pulumirpc.GenerateProgramRequest{
+	resp, err := h.client.GenerateProgram(ctx, &pulumirpc.GenerateProgramRequest{
 		Source:       program,
 		LoaderTarget: loaderTarget,
 		Strict:       strict,
@@ -833,6 +833,7 @@ func (h *langhost) GenerateProgram(program map[string]string, loaderTarget strin
 }
 
 func (h *langhost) Pack(
+	ctx context.Context,
 	packageDirectory string, destinationDirectory string,
 ) (string, error) {
 	label := fmt.Sprintf("langhost[%v].Pack(%s, %s)", h.runtime, packageDirectory, destinationDirectory)
@@ -848,7 +849,7 @@ func (h *langhost) Pack(
 		return "", err
 	}
 
-	req, err := h.client.Pack(h.ctx.Request(), &pulumirpc.PackRequest{
+	req, err := h.client.Pack(ctx, &pulumirpc.PackRequest{
 		PackageDirectory:     packageDirectory,
 		DestinationDirectory: destinationDirectory,
 	})
@@ -891,7 +892,7 @@ func languageHandshake(
 }
 
 func (h *langhost) Link(
-	info ProgramInfo, deps []workspace.LinkablePackageDescriptor, loaderTarget string,
+	ctx context.Context, info ProgramInfo, deps []workspace.LinkablePackageDescriptor, loaderTarget string,
 ) (string, error) {
 	label := fmt.Sprintf("langhost[%v].Link(%v, %v)", h.runtime, info, deps)
 	logging.V(7).Infof("%s executing", label)
@@ -929,7 +930,7 @@ func (h *langhost) Link(
 		})
 	}
 
-	res, err := h.client.Link(h.ctx.Request(), &pulumirpc.LinkRequest{
+	res, err := h.client.Link(ctx, &pulumirpc.LinkRequest{
 		Info:         minfo,
 		Packages:     packages,
 		LoaderTarget: loaderTarget,
@@ -944,11 +945,11 @@ func (h *langhost) Link(
 	return res.ImportInstructions, nil
 }
 
-func (h *langhost) Cancel() error {
+func (h *langhost) Cancel(ctx context.Context) error {
 	label := fmt.Sprintf("langhost[%v].Cancel()", h.runtime)
 	logging.V(7).Infof("%s executing", label)
 
-	_, err := h.client.Cancel(h.ctx.Request(), &emptypb.Empty{})
+	_, err := h.client.Cancel(ctx, &emptypb.Empty{})
 	if err != nil {
 		status, ok := status.FromError(err)
 		if ok && status.Code() == codes.Unimplemented {

--- a/sdk/go/common/resource/plugin/langruntime_test.go
+++ b/sdk/go/common/resource/plugin/langruntime_test.go
@@ -171,17 +171,14 @@ func TestRunPluginPassesCorrectPwd(t *testing.T) {
 		},
 	}
 
-	pCtx, err := NewContext(t.Context(), nil, nil, nil, nil, "", nil, false, nil, nil)
-	require.NoError(t, err)
 	host := &langhost{
-		ctx:     pCtx,
 		runtime: "go",
 		plug:    nil,
 		client:  mockLanguageRuntime,
 	}
 
 	// Test that the plugin is run with the correct working directory.
-	_, _, _, err = host.RunPlugin(pCtx.Request(), RunPluginInfo{
+	_, _, _, err := host.RunPlugin(t.Context(), RunPluginInfo{
 		WorkingDirectory: "/tmp",
 	})
 	require.Equal(t, returnErr, err)
@@ -201,23 +198,13 @@ func TestRunPluginPassesLoaderAddress(t *testing.T) {
 		},
 	}
 
-	mockHost := &MockHost{
-		LoaderAddrF: func() string {
-			return expectedLoaderAddr
-		},
-	}
-
-	pCtx, err := NewContext(t.Context(), nil, nil, mockHost, nil, "", nil, false, nil, nil)
-	require.NoError(t, err)
-
 	host := &langhost{
-		ctx:     pCtx,
 		runtime: "test",
 		plug:    nil,
 		client:  mockLanguageRuntime,
 	}
 
-	_, _, _, err = host.RunPlugin(pCtx.Request(), RunPluginInfo{
+	_, _, _, err := host.RunPlugin(t.Context(), RunPluginInfo{
 		WorkingDirectory: "/tmp",
 		LoaderAddress:    expectedLoaderAddr,
 	})


### PR DESCRIPTION
Rather than relying on the plugin context to make up a fresh context on each request, this makes use the actual contextual operation context. For some of the call sites that is just `pluginContext.Request()` still, but a lot of the others have actual contexts.

This brings RuntimeLanguage in line with the Converter plugin where we already pass a context to each method.