### PR TITLE
make sure all `{org,stack} webhook` commands correctly specify id args

### DIFF
--- a/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/org/org_webhook_delivery_list.go
@@ -74,9 +74,9 @@ func newOrgWebhookDeliveryListCmd() *cobra.Command {
 			"delivery includes the timestamp, event kind, HTTP response code,\n" +
 			"and request duration.",
 		Example: "  # List deliveries for a webhook\n" +
-			"  pulumi org webhook delivery list my-webhook\n\n" +
+			"  pulumi org webhook delivery list 1a2b3c4d\n\n" +
 			"  # List deliveries as JSON\n" +
-			"  pulumi org webhook delivery list my-webhook --output json",
+			"  pulumi org webhook delivery list 1a2b3c4d --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dlcmd.w = cmd.OutOrStdout()
 			return dlcmd.run(cmd.Context(), args[0])
@@ -84,7 +84,7 @@ func newOrgWebhookDeliveryListCmd() *cobra.Command {
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{{Name: "webhook"}},
+		Arguments: []constrictor.Argument{{Name: "id"}},
 		Required:  1,
 	})
 

--- a/pkg/cmd/pulumi/org/org_webhook_edit.go
+++ b/pkg/cmd/pulumi/org/org_webhook_edit.go
@@ -84,14 +84,14 @@ func newOrgWebhookEditCmd() *cobra.Command {
 			"modify event subscriptions incrementally. To clear the secret,\n" +
 			"pass --secret \"\".",
 		Example: "  # Disable a webhook\n" +
-			"  pulumi org webhook edit my-hook --active=false\n\n" +
+			"  pulumi org webhook edit 1a2b3c4d --active=false\n\n" +
 			"  # Change the payload URL\n" +
-			"  pulumi org webhook edit my-hook --url https://new-url.example.com\n\n" +
+			"  pulumi org webhook edit 1a2b3c4d --url https://new-url.example.com\n\n" +
 			"  # Add an event and remove another\n" +
-			"  pulumi org webhook edit my-hook \\\n" +
+			"  pulumi org webhook edit 1a2b3c4d \\\n" +
 			"    --add-event deployment_failed --remove-event deployment_started\n\n" +
 			"  # Add a group\n" +
-			"  pulumi org webhook edit my-hook --add-group environments",
+			"  pulumi org webhook edit 1a2b3c4d --add-group environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oecmd.w = cmd.OutOrStdout()
 			return oecmd.run(cmd.Context(), cmd, args[0])
@@ -99,7 +99,7 @@ func newOrgWebhookEditCmd() *cobra.Command {
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{{Name: "name"}},
+		Arguments: []constrictor.Argument{{Name: "id"}},
 		Required:  1,
 	})
 

--- a/pkg/cmd/pulumi/org/org_webhook_ping.go
+++ b/pkg/cmd/pulumi/org/org_webhook_ping.go
@@ -70,9 +70,9 @@ func newOrgWebhookPingCmd() *cobra.Command {
 			"properly configured and reachable. Returns the delivery result\n" +
 			"including the HTTP response code and duration.",
 		Example: "  # Ping a webhook\n" +
-			"  pulumi org webhook ping my-webhook\n\n" +
+			"  pulumi org webhook ping 1a2b3c4d\n\n" +
 			"  # Ping and get full delivery details as JSON\n" +
-			"  pulumi org webhook ping my-webhook --output json",
+			"  pulumi org webhook ping 1a2b3c4d --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opcmd.w = cmd.OutOrStdout()
 			return opcmd.run(cmd.Context(), args[0])
@@ -80,7 +80,7 @@ func newOrgWebhookPingCmd() *cobra.Command {
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{{Name: "name"}},
+		Arguments: []constrictor.Argument{{Name: "id"}},
 		Required:  1,
 	})
 

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -60,9 +60,9 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 			"\n" +
 			"Returns an error if the webhook does not exist.",
 		Example: "  # Remove a webhook (will prompt for confirmation)\n" +
-			"  pulumi org webhook remove my-webhook\n\n" +
+			"  pulumi org webhook remove 1a2b3c4d\n\n" +
 			"  # Remove without confirmation\n" +
-			"  pulumi org webhook remove my-webhook --yes",
+			"  pulumi org webhook remove 1a2b3c4d --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orcmd.w = cmd.OutOrStdout()
 			return orcmd.run(cmd.Context(), args[0])
@@ -70,7 +70,7 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 	}
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
-		Arguments: []constrictor.Argument{{Name: "name"}},
+		Arguments: []constrictor.Argument{{Name: "id"}},
 		Required:  1,
 	})
 

--- a/pkg/cmd/pulumi/stack/stack_webhook.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook.go
@@ -45,7 +45,7 @@ func newStackWebhookCmd() *cobra.Command {
 func stackWebhookHookArg() *constrictor.Arguments {
 	return &constrictor.Arguments{
 		Arguments: []constrictor.Argument{
-			{Name: "name"},
+			{Name: "id"},
 		},
 		Required: 1,
 	}

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_list.go
@@ -87,11 +87,11 @@ func newStackWebhookDeliveryListCmdWith(
 			"\n" +
 			"Returns an error if the webhook does not exist.",
 		Example: "  # List deliveries for a webhook\n" +
-			"  pulumi stack webhook delivery list my-webhook\n\n" +
+			"  pulumi stack webhook delivery list 1a2b3c4d\n\n" +
 			"  # List the last 5 deliveries\n" +
-			"  pulumi stack webhook delivery list my-webhook --count 5\n\n" +
+			"  pulumi stack webhook delivery list 1a2b3c4d --count 5\n\n" +
 			"  # List deliveries as JSON\n" +
-			"  pulumi stack webhook delivery list my-webhook --output json",
+			"  pulumi stack webhook delivery list 1a2b3c4d --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if dlcmd.factory == nil {
 				dlcmd.factory = defaultDeliveryListClientFactory

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
@@ -68,9 +68,9 @@ func newStackWebhookDeliveryRedeliverCmdWith(
 			"Returns the delivery result with HTTP status and response details.\n" +
 			"Returns an error if the webhook or event does not exist.",
 		Example: "  # Redeliver an event\n" +
-			"  pulumi stack webhook delivery redeliver my-webhook evt-abc123\n\n" +
+			"  pulumi stack webhook delivery redeliver 1a2b3c4d evt-abc123\n\n" +
 			"  # Redeliver and get the full result as JSON\n" +
-			"  pulumi stack webhook delivery redeliver my-webhook evt-abc123 --output json",
+			"  pulumi stack webhook delivery redeliver 1a2b3c4d evt-abc123 --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultRedeliverClientFactory
@@ -84,7 +84,7 @@ func newStackWebhookDeliveryRedeliverCmdWith(
 
 	constrictor.AttachArguments(cmd, &constrictor.Arguments{
 		Arguments: []constrictor.Argument{
-			{Name: "webhook"},
+			{Name: "id"},
 			{Name: "event-id"},
 		},
 		Required: 2,

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit.go
@@ -76,17 +76,17 @@ func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Co
 			"\n" +
 			"Returns an error if the webhook does not exist.",
 		Example: "  # Disable a webhook\n" +
-			"  pulumi stack webhook edit my-hook --active=false\n\n" +
+			"  pulumi stack webhook edit 1a2b3c4d --active=false\n\n" +
 			"  # Change the payload URL\n" +
-			"  pulumi stack webhook edit my-hook --url https://new-url.example.com\n\n" +
+			"  pulumi stack webhook edit 1a2b3c4d --url https://new-url.example.com\n\n" +
 			"  # Add event filters\n" +
-			"  pulumi stack webhook edit my-hook " +
+			"  pulumi stack webhook edit 1a2b3c4d " +
 			"--add-event update_succeeded --add-event update_failed\n\n" +
 			"  # Remove an event and add another\n" +
-			"  pulumi stack webhook edit my-hook " +
+			"  pulumi stack webhook edit 1a2b3c4d " +
 			"--remove-event update_failed --add-event destroy_failed\n\n" +
 			"  # Clear the secret\n" +
-			"  pulumi stack webhook edit my-hook --secret \"\"",
+			"  pulumi stack webhook edit 1a2b3c4d --secret \"\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultEditClientFactory

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping.go
@@ -69,9 +69,9 @@ func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Co
 			"\n" +
 			"Returns an error if the webhook does not exist.",
 		Example: "  # Ping a webhook to verify it works\n" +
-			"  pulumi stack webhook ping my-webhook\n\n" +
+			"  pulumi stack webhook ping 1a2b3c4d\n\n" +
 			"  # Ping a webhook and get the full delivery details as JSON\n" +
-			"  pulumi stack webhook ping my-webhook --output json",
+			"  pulumi stack webhook ping 1a2b3c4d --output json",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultStackWebhookPingClientFactory

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -64,9 +64,9 @@ func newStackWebhookRemoveCmdWith(factory stackWebhookRemoveClientFactory) *cobr
 			"\n" +
 			"Returns an error if the webhook does not exist.",
 		Example: "  # Remove a webhook (will prompt for confirmation)\n" +
-			"  pulumi stack webhook remove my-webhook\n\n" +
+			"  pulumi stack webhook remove 1a2b3c4d\n\n" +
 			"  # Remove without confirmation\n" +
-			"  pulumi stack webhook remove my-webhook --yes",
+			"  pulumi stack webhook remove 1a2b3c4d --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if factory == nil {
 				factory = defaultStackWebhookRemoveClientFactory


### PR DESCRIPTION
These commands all take IDs, because that's what the API takes, and it's the only unique identifier we have for them.  Update the docs and argument names to specify that consistently as well.  There's no functional changes here, only docs/argument names for display in the help text.

Fixes https://github.com/pulumi/pulumi/issues/23302