### PR TITLE
Preserve explicit null entries in Go SDK input maps

### DIFF
--- a/changelog/pending/20260521--sdk-go--preserve-explicit-null-entries-in-go-sdk-input-maps.yaml
+++ b/changelog/pending/20260521--sdk-go--preserve-explicit-null-entries-in-go-sdk-input-maps.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/go
+  description: Preserve explicit null entries in Go SDK input maps

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -120,6 +120,20 @@ func marshalInputs(props Input) (resource.PropertyMap, map[string][]URN, []URN, 
 	return marshalInputsOptions(props, nil)
 }
 
+func isNilInput(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	//nolint:exhaustive // Only nil-able kinds can represent a typed nil input.
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
 // marshalInputs turns resource property inputs into a map suitable for marshaling.
 func marshalInputsOptions(props Input, opts *marshalOptions) (resource.PropertyMap, map[string][]URN, []URN, error) {
 	deps := map[URN]struct{}{}
@@ -129,7 +143,7 @@ func marshalInputsOptions(props Input, opts *marshalOptions) (resource.PropertyM
 		return pmap, pdeps, nil, nil
 	}
 
-	marshalProperty := func(pname string, pv any, pt reflect.Type) error {
+	marshalProperty := func(pname string, pv any, pt reflect.Type, keepNull bool) error {
 		// Get the underlying value, possibly waiting for an output to arrive.
 		v, resourceDeps, err := marshalInputOptions(pv, pt, opts)
 		if err != nil {
@@ -145,7 +159,7 @@ func marshalInputsOptions(props Input, opts *marshalOptions) (resource.PropertyM
 			deps[k] = struct{}{}
 		}
 
-		if !v.IsNull() || len(allDeps) > 0 {
+		if keepNull || !v.IsNull() || len(allDeps) > 0 {
 			urns := slice.Prealloc[URN](len(allDeps))
 			for v := range allDeps {
 				urns = append(urns, v)
@@ -189,7 +203,7 @@ func marshalInputsOptions(props Input, opts *marshalOptions) (resource.PropertyM
 			if tag == "" {
 				continue
 			}
-			err := marshalProperty(tag, pv.Field(i).Interface(), destField.Type)
+			err := marshalProperty(tag, pv.Field(i).Interface(), destField.Type, false /*keepNull*/)
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -201,7 +215,7 @@ func marshalInputsOptions(props Input, opts *marshalOptions) (resource.PropertyM
 		for _, key := range pv.MapKeys() {
 			keyname := key.Interface().(string)
 			val := pv.MapIndex(key).Interface()
-			err := marshalProperty(keyname, val, rt.Elem())
+			err := marshalProperty(keyname, val, rt.Elem(), isNilInput(val))
 			if err != nil {
 				return nil, nil, nil, err
 			}
@@ -474,11 +488,12 @@ func marshalInputOptionsImpl(v any,
 			obj := resource.PropertyMap{}
 			for _, key := range rv.MapKeys() {
 				value := rv.MapIndex(key)
+				keepNull := isNilInput(value.Interface())
 				mv, d, err := marshalInputOptions(value.Interface(), destElem, opts)
 				if err != nil {
 					return resource.PropertyValue{}, nil, err
 				}
-				if !mv.IsNull() {
+				if keepNull || !mv.IsNull() {
 					obj[resource.PropertyKey(key.String())] = mv
 				}
 				deps = append(deps, d...)

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -173,6 +173,61 @@ func (testInputs) ElementType() reflect.Type {
 	return reflect.TypeOf(test{})
 }
 
+type nullMapTest struct {
+	Values map[string]any    `pulumi:"values"`
+	Tags   map[string]string `pulumi:"tags"`
+}
+
+type nullMapTestInputs struct {
+	Values MapInput       `pulumi:"values"`
+	Tags   StringMapInput `pulumi:"tags"`
+}
+
+func (nullMapTestInputs) ElementType() reflect.Type {
+	return reflect.TypeOf(nullMapTest{})
+}
+
+func TestMarshalInputsPreservesExplicitNullMapEntries(t *testing.T) {
+	t.Parallel()
+
+	resolved, _, deps, err := marshalInputs(StringMap{
+		"keep":      String("value"),
+		"temporary": nil,
+	})
+	require.NoError(t, err)
+	require.Empty(t, deps)
+	assert.Equal(t, "value", resolved["keep"].StringValue())
+	require.Contains(t, resolved, resource.PropertyKey("temporary"))
+	assert.True(t, resolved["temporary"].IsNull())
+
+	resolved, _, deps, err = marshalInputs(nullMapTestInputs{
+		Values: Map{
+			"keep":      String("value"),
+			"nested":    Map{"inner": nil},
+			"temporary": nil,
+		},
+		Tags: StringMap{
+			"keep":      String("value"),
+			"temporary": nil,
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, deps)
+
+	values := resolved["values"].ObjectValue()
+	assert.Equal(t, "value", values["keep"].StringValue())
+	require.Contains(t, values, resource.PropertyKey("temporary"))
+	assert.True(t, values["temporary"].IsNull())
+	nested := values["nested"].ObjectValue()
+	require.Contains(t, nested, resource.PropertyKey("inner"))
+	assert.True(t, nested["inner"].IsNull())
+
+	tags := resolved["tags"].ObjectValue()
+	assert.Equal(t, "value", tags["keep"].StringValue())
+	require.Contains(t, tags, resource.PropertyKey("temporary"))
+	assert.True(t, tags["temporary"].IsNull())
+}
+
 // TestMarshalRoundtrip ensures that marshaling a complex structure to and from its on-the-wire gRPC format succeeds.
 func TestMarshalRoundtrip(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
Preserve explicit null entries in Go SDK input maps instead of dropping those keys during input marshaling.

This fixes #22713 for literal nil entries such as `pulumi.StringMap{"temporary": nil}` and nested `pulumi.Map` values, while keeping existing behavior for outputs that resolve to nil without dependencies.

AI assistance: OpenAI GPT-5 was used.

## Test plan
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
- [x] `make lint` — clean
- [ ] `make test_fast` — blocked locally because `proto/generate.sh` requires `mise`, which is not installed here
- [ ] `make tidy_fix` — not run; no module changes
- [x] `make format` — clean
- [x] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — not run; no proto changes

Actual command output:

```text
$ PATH=$PWD/.bin:$PATH GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make format
Checking for golangci-lint ....... ✓
FORMAT:
golangci-lint fmt
...
cd sdk/nodejs && yarn biome format --write ../../pkg/codegen/schema/pulumi.json
Formatted 1 file in 4ms. No fixes applied.
```

```text
$ PATH=$PWD/.bin:$PATH GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make lint
LINT:
Checking for golangci-lint ....... ✓
[golangci-lint] Linting sdk...
0 issues.
[golangci-lint] Linting pkg...
0 issues.
[golangci-lint] Linting tests...
0 issues.
[golangci-lint] Linting sdk/go/pulumi-language-go...
0 issues.
[golangci-lint] Linting sdk/nodejs/cmd/pulumi-language-nodejs...
0 issues.
[golangci-lint] Linting sdk/python/cmd/pulumi-language-python...
0 issues.
[golangci-lint] Linting sdk/pcl...
0 issues.
schema pkg/codegen/schema/pulumi.json: ok
Checked 1 file in 10ms. No fixes applied.
uv run scripts/check-changelog.py
```

```text
$ GOMODCACHE=$PWD/../.gomodcache GOCACHE=$PWD/../.gocache go test ./go/pulumi -run 'TestMarshalInputsPreservesExplicitNullMapEntries|TestOutputValueMarshalling|TestMarshalRoundtrip' -count=1
ok  	github.com/pulumi/pulumi/sdk/v3/go/pulumi	1.151s
```

```text
$ GOMODCACHE=$PWD/../.gomodcache GOCACHE=$PWD/../.gocache go test ./go/pulumi -count=1
ok  	github.com/pulumi/pulumi/sdk/v3/go/pulumi	1.860s
```

```text
$ PATH=$PWD/.bin:$PATH GOMODCACHE=$PWD/.gomodcache GOCACHE=$PWD/.gocache make test_fast
...
cd proto && ./generate.sh
./generate.sh: line 20: mise: command not found
make: *** [.make/proto] Error 127
```

```text
$ git diff --check
```

## Changelog
- [x] Changelog entry added.

## Risk
Low. The change is limited to input map marshaling and preserves existing omission behavior for nil struct fields and resolved nil outputs without dependencies.
