### PR TITLE
Tweak command help

### DIFF
--- a/changelog/pending/20260520--cli-do--add-resource-support-to-pulumi-do.yaml
+++ b/changelog/pending/20260520--cli-do--add-resource-support-to-pulumi-do.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli/do
+  description: Add resource support to `pulumi do`

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -302,7 +302,7 @@ configuration flags, all discoverable via --help on the provider subcommand.
 
 packages can be a package name or the path to a plugin binary or folder.
 Further parameters can be passed after the package name which will be used to
-parameterize the plugin loaded. 
+parameterize the plugin loaded.
 e.g. pulumi do "name@version param1 \"multi word param\""
 
 Resource operations: list, create, read, patch, delete
@@ -395,8 +395,15 @@ func (pc *packageCommand) newCommand() *cobra.Command {
 		Use:   pc.args[0],
 		Short: shorthelp,
 		Long:  longhelp,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	cmd.Args = unknownSubcommandArgs
+	cmd.SetUsageTemplate(doUsageTemplate)
+	// Tolerate unknown flags so that we don't error on a flag that belongs to the child command.
+	cmd.FParseErrWhitelist.UnknownFlags = true
 
 	cmd.PersistentFlags().StringVar(
 		&pc.providerFile, "provider-file", "", "Path to a file containing provider configuration")
@@ -522,8 +529,14 @@ func newModuleCommand(args []string, use, shortDisplayName, longDisplayName, hel
 		GroupID: "Modules",
 		Short:   shorthelp,
 		Long:    longhelp,
-		Args:    cobra.NoArgs,
+		Args:    unknownSubcommandArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
+	cmd.SetUsageTemplate(doUsageTemplate)
+	// Tolerate unknown flags so that we don't error on a flag that belongs to the child command.
+	cmd.FParseErrWhitelist.UnknownFlags = true
 	return cmd
 }
 
@@ -537,4 +550,68 @@ func ensureCommandGroup(cmd *cobra.Command, id, title string) {
 		ID:    id,
 		Title: title,
 	})
+}
+
+// doUsageTemplate is cobra's default usage template tweaked so that container commands (package,
+// module, resource) show only "<cmd> [command]" and not the redundant "<cmd> [flags]" UseLine.
+// They're technically Runnable so ValidateArgs fires for unknown subcommands, but you can't actually
+// invoke them standalone. Leaf commands underneath (functions, create/read/patch/delete/list) still
+// render their UseLine, since cobra propagates UsageTemplate down the subtree.
+//
+// From cobra's defaultUsageTemplate: https://github.com/spf13/cobra/blob/v1.10.1/command.go#L1942
+// Only the "Usage:" line is changed; the rest is verbatim.
+const doUsageTemplate = `Usage:{{if .Runnable}}{{if not .HasAvailableSubCommands}}
+  {{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+// unknownSubcommandArgs is a cobra positional-args validator for commands whose only valid positionals are subcommand
+// names. If extra args are supplied it returns "unknown command ..." and when available a hint for similarly named
+// subcommands.
+func unknownSubcommandArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	typed := args[0]
+	if cmd.SuggestionsMinimumDistance <= 0 {
+		cmd.SuggestionsMinimumDistance = 2
+	}
+	msg := fmt.Sprintf("unknown command %q for %q", typed, cmd.CommandPath())
+	suggestions := cmd.SuggestionsFor(typed)
+	if len(suggestions) == 0 {
+		return errors.New(msg)
+	}
+	var b strings.Builder
+	b.WriteString(msg)
+	b.WriteString("\n\nDid you mean this?\n")
+	for _, s := range suggestions {
+		fmt.Fprintf(&b, "\t%s\n", s)
+	}
+	return errors.New(b.String())
 }

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/google/shlex"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -33,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdConvert "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -446,7 +444,7 @@ func (pc *packageCommand) newCommand() *cobra.Command {
 	for _, fn := range pc.spec.Resources {
 		mod := ensureModuleCommand(pc.args, cmd, moduleCommands, pc.spec.TokenToModule(fn.Token))
 		ensureCommandGroup(mod, "Resources", "Resources")
-		mod.AddCommand(newResourceCommand(pc.args, pc.provider, &pc.providerFile, fn))
+		mod.AddCommand(pc.newResourceCommand(fn))
 	}
 
 	return cmd
@@ -539,28 +537,4 @@ func ensureCommandGroup(cmd *cobra.Command, id, title string) {
 		ID:    id,
 		Title: title,
 	})
-}
-
-func newResourceCommand(args []string, p plugin.Provider, providerFile *string, fn *schema.Resource) *cobra.Command {
-	_, _, name, diags := pcl.DecomposeToken(fn.Token, hcl.Range{})
-	contract.Assertf(!diags.HasErrors(), "token should decompose")
-
-	shorthelp := fmt.Sprintf("Operate on the %s resource", name)
-	longhelp := shorthelp + "."
-	if fn.Comment != "" {
-		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, fn.Comment)
-	}
-
-	cmd := &cobra.Command{
-		Use:     name,
-		GroupID: "Resources",
-		Short:   shorthelp,
-		Long:    longhelp,
-		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("resource operations not implemented yet")
-		},
-	}
-
-	return cmd
 }

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -15,352 +15,19 @@
 package do
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
-	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
-	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	pclruntime "github.com/pulumi/pulumi/pkg/v3/pcl/runtime"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
-
-type functionEvalContext struct {
-	WorkingDir    string
-	ProjectName   string
-	RootDirectory string
-}
-
-func jsonifyPropertyValue(v resource.PropertyValue, showSecrets bool) (any, error) {
-	if !showSecrets && (v.IsSecret() || (v.IsOutput() && v.OutputValue().Secret)) {
-		return "[secret]", nil
-	}
-
-	if v.IsComputed() || (v.IsOutput() && !v.OutputValue().Known) {
-		return "[unknown]", nil
-	}
-
-	if v.IsSecret() {
-		return jsonifyPropertyValue(v.SecretValue().Element, showSecrets)
-	}
-
-	if v.IsOutput() {
-		return jsonifyPropertyValue(v.OutputValue().Element, showSecrets)
-	}
-
-	if v.IsAsset() {
-		return v.AssetValue().Serialize(), nil
-	}
-
-	if v.IsArchive() {
-		return v.ArchiveValue().Serialize(), nil
-	}
-
-	if v.IsArray() {
-		arr := v.ArrayValue()
-		res := make([]any, len(arr))
-		for i := range arr {
-			ev, err := jsonifyPropertyValue(arr[i], showSecrets)
-			if err != nil {
-				return nil, err
-			}
-			res[i] = ev
-		}
-		return res, nil
-	}
-
-	if v.IsObject() {
-		obj := v.ObjectValue()
-		res := make(map[string]any, len(obj))
-		for k, v := range obj {
-			ev, err := jsonifyPropertyValue(v, showSecrets)
-			if err != nil {
-				return nil, err
-			}
-			res[string(k)] = ev
-		}
-		return res, nil
-	}
-
-	return v.V, nil
-}
-
-// jsonifyProperty converts a Property to a JSON string for display purposes. This strips things like secrets and
-// outputs down to their underlying values.
-func jsonifyProperty(prop resource.PropertyValue, showSecrets bool) (string, error) {
-	plain, err := jsonifyPropertyValue(prop, showSecrets)
-	if err != nil {
-		return "", err
-	}
-
-	json, err := ui.MakeJSONString(plain, true)
-	if err != nil {
-		return "", err
-	}
-	return json, nil
-}
-
-// filterOutputs recursively filters the given property map to only include properties present in the schema. This is
-// used to filter out any "internal" keys the provider might return that aren't part of the declared outputs, which
-// would otherwise cause the JSON output to be noisy and potentially break consumers expecting a specific shape.
-func filterOutputs(props resource.PropertyMap, properties []*schema.Property) resource.PropertyMap {
-	filtered := resource.PropertyMap{}
-	for _, property := range properties {
-		key := resource.PropertyKey(property.Name)
-		if value, ok := props[key]; ok {
-			filtered[key] = filterOutput(value, property.Type)
-		}
-	}
-	return filtered
-}
-
-func filterOutput(
-	prop resource.PropertyValue, typ schema.Type,
-) resource.PropertyValue {
-	if typ == nil {
-		return prop
-	}
-
-	if optTyp, ok := typ.(*schema.OptionalType); ok {
-		if prop.IsNull() {
-			return resource.NewNullProperty()
-		} else {
-			typ = optTyp.ElementType
-		}
-	}
-
-	isSecret := prop.IsSecret()
-	if isSecret {
-		return resource.MakeSecret(filterOutput(prop.SecretValue().Element, typ))
-	}
-
-	switch t := typ.(type) {
-	case *schema.ObjectType:
-		if prop.IsObject() {
-			return resource.NewProperty(filterOutputs(prop.ObjectValue(), t.Properties))
-		}
-	case *schema.ArrayType:
-		if prop.IsArray() {
-			arr := prop.ArrayValue()
-			filtered := make([]resource.PropertyValue, len(arr))
-			for i, el := range arr {
-				filtered[i] = filterOutput(el, t.ElementType)
-			}
-			return resource.NewProperty(filtered)
-		}
-	case *schema.MapType:
-		if prop.IsObject() {
-			obj := prop.ObjectValue()
-			filtered := make(resource.PropertyMap, len(obj))
-			for k, v := range obj {
-				filtered[k] = filterOutput(v, t.ElementType)
-			}
-			return resource.NewProperty(filtered)
-		}
-	case *schema.UnionType:
-		// Pick the first variant whose shape matches the runtime value. Discriminated unions would let us be more
-		// precise, but most cases here are simple kind-based dispatch.
-		for _, elt := range t.ElementTypes {
-			if unionVariantMatches(prop, elt) {
-				return filterOutput(prop, elt)
-			}
-		}
-	}
-
-	return prop
-}
-
-// unionVariantMatches reports whether the schema type is structurally compatible with the runtime kind of prop.
-// Used to pick a union variant for output filtering.
-func unionVariantMatches(prop resource.PropertyValue, typ schema.Type) bool {
-	// TODO https://github.com/pulumi/pulumi/issues/23234: This needs to be smarter and handle Discriminator
-	if opt, ok := typ.(*schema.OptionalType); ok {
-		typ = opt.ElementType
-	}
-	switch typ.(type) {
-	case *schema.ObjectType, *schema.MapType:
-		return prop.IsObject()
-	case *schema.ArrayType:
-		return prop.IsArray()
-	}
-	return false
-}
-
-// evaluatePCLFile reads, binds, and evaluates a PCL input file against a caller-supplied schema. The bind callback
-// decides how the parsed file is type-checked (function vs. resource) and returns the schema property list used to
-// coerce values during evaluation.
-func evaluatePCLFile(
-	path, fileType string,
-	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
-	evalContext functionEvalContext,
-) (resource.PropertyMap, error) {
-	// When no input file is supplied we still run the bind step against an empty file so that the schema's
-	// required-input check fires.
-	var input io.Reader
-	filename := path
-	if path == "" {
-		input = strings.NewReader("")
-		filename = fmt.Sprintf("<no %s file>", fileType)
-	} else {
-		f, err := os.Open(path)
-		if err != nil {
-			return nil, fmt.Errorf("open %s file: %w", fileType, err)
-		}
-		defer contract.IgnoreClose(f)
-		input = f
-	}
-
-	return evaluatePCL(input, filename, fileType, bind, evalContext)
-}
-
-func evaluatePCL(
-	input io.Reader,
-	filename, fileType string,
-	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
-	evalContext functionEvalContext,
-) (resource.PropertyMap, error) {
-	parser := hclsyntax.NewParser()
-	if err := parser.ParseFile(input, filename); err != nil {
-		return nil, fmt.Errorf("parse input: %w", err)
-	}
-	if parser.Diagnostics.HasErrors() {
-		return nil, parser.Diagnostics
-	}
-	contract.Assertf(len(parser.Files) == 1, "Should be one PCL file")
-	file := parser.Files[0]
-
-	attrs, inputType, properties, diagnostics := bind(file)
-	if diagnostics.HasErrors() {
-		return nil, diagnostics
-	}
-
-	notSupported := func(what string) error {
-		return fmt.Errorf("cannot %s in %s file", what, fileType)
-	}
-	ectx := pclruntime.NewEvalContext(
-		evalContext.WorkingDir,
-		evalContext.RootDirectory,
-		"",
-		evalContext.ProjectName,
-		"",
-		func(context.Context, string) (*schema.Resource, error) {
-			return nil, notSupported("reference resources")
-		},
-		func(context.Context, string) (*schema.Function, error) {
-			return nil, notSupported("reference functions")
-		},
-		func(context.Context, resource.ResourceReference) (resource.PropertyMap, error) {
-			return nil, notSupported("reference resources")
-		},
-		func(context.Context, *pulumirpc.ResourceInvokeRequest) (*pulumirpc.InvokeResponse, error) {
-			return nil, notSupported("invoke functions")
-		},
-		func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error) {
-			return nil, notSupported("call functions")
-		},
-	)
-
-	result, poison, diags := ectx.EvaluateObject(attrs, inputType, properties)
-	if poison != nil {
-		// `pulumi do` is one-shot — there's no upstream resource graph to propagate poison through, so surface it.
-		return nil, fmt.Errorf("%s file references unknown resource %s", fileType, *poison)
-	}
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	return result, nil
-}
-
-// evaluateFile reads an input file in the given format and evaluates it. For non-PCL formats the source is routed
-// through the named converter plugin's ConvertSnippet RPC and the resulting PCL is fed into the same bind pipeline.
-// An empty path is treated as "no input provided" and always goes through the PCL path so the bind step's
-// missing-required check still fires.
-func evaluateFile(
-	ctx context.Context,
-	path, fileType, inputFormat, token string,
-	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
-	loadConverter func(string) (plugin.Converter, error),
-	loaderTarget string,
-	packageDescriptor *codegenrpc.GetSchemaRequest,
-	evalContext functionEvalContext,
-) (resource.PropertyMap, error) {
-	if path == "" || inputFormat == "" || inputFormat == "pcl" {
-		return evaluatePCLFile(path, fileType, bind, evalContext)
-	}
-
-	converter, err := loadConverter(inputFormat)
-	if err != nil {
-		return nil, fmt.Errorf("load %s input converter: %w", inputFormat, err)
-	}
-	defer contract.IgnoreClose(converter)
-
-	source, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read %s file: %w", fileType, err)
-	}
-	resp, err := converter.ConvertSnippet(ctx, &plugin.ConvertSnippetRequest{
-		Filename:     path,
-		Source:       source,
-		TargetLoader: loaderTarget,
-		Package:      packageDescriptor,
-		Token:        token,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("generate PCL from %s file: %w", fileType, err)
-	}
-	if resp.Diagnostics.HasErrors() {
-		return nil, resp.Diagnostics
-	}
-	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext)
-}
-
-func evaluateFunctionFile(
-	ctx context.Context, path, fileType, inputFormat string, fn *schema.Function, evalContext functionEvalContext,
-	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
-	packageDescriptor *codegenrpc.GetSchemaRequest,
-) (resource.PropertyMap, error) {
-	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
-		attrs, inputType, diags := pcl.BindFunction(file, fn)
-		var properties []*schema.Property
-		if fn.Inputs != nil {
-			properties = fn.Inputs.Properties
-		}
-		return attrs, inputType, properties, diags
-	}
-	return evaluateFile(
-		ctx, path, fileType, inputFormat, fn.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
-	)
-}
-
-func evaluateResourceFile(
-	ctx context.Context, path, fileType, inputFormat string, res *schema.Resource, evalContext functionEvalContext,
-	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
-	packageDescriptor *codegenrpc.GetSchemaRequest,
-) (resource.PropertyMap, error) {
-	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
-		attrs, inputType, diags := pcl.BindResource(file, res)
-		return attrs, inputType, res.InputProperties, diags
-	}
-	return evaluateFile(
-		ctx, path, fileType, inputFormat, res.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
-	)
-}
 
 func functionSchemaHelp(fn *schema.Function) string {
 	var b strings.Builder
@@ -377,7 +44,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 		b.WriteString(title)
 		b.WriteString(":\n")
 		for _, property := range properties {
-			fmt.Fprintf(&b, "  %s (%s", property.Name, functionTypeString(property.Type))
+			fmt.Fprintf(&b, "  %s (%s", property.Name, schemaTypeString(property.Type))
 			if includeRequired {
 				if property.IsRequired() {
 					b.WriteString(", required")
@@ -402,20 +69,9 @@ func functionSchemaHelp(fn *schema.Function) string {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
-		fmt.Fprintf(&b, "Outputs:\n  result (%s)\n", functionTypeString(fn.ReturnType))
+		fmt.Fprintf(&b, "Outputs:\n  result (%s)\n", schemaTypeString(fn.ReturnType))
 	}
 	return strings.TrimSuffix(b.String(), "\n")
-}
-
-func functionTypeString(t schema.Type) string {
-	switch t := t.(type) {
-	case *schema.OptionalType:
-		return functionTypeString(t.ElementType)
-	case *schema.InputType:
-		return functionTypeString(t.ElementType)
-	default:
-		return t.String()
-	}
 }
 
 func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command {
@@ -443,37 +99,12 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			// We need to evaluate the provider configuration so we can call Configure on the provider before invoking
-			// the function.
-			config, err := evaluateResourceFile(
-				ctx, pc.providerFile, "provider", pc.providerFormat,
-				pc.spec.Provider, pc.evalContext, pc.converter, pc.loaderTarget, pc.packageDescriptor)
-			if err != nil {
-				return fmt.Errorf("parse provider file: %w", err)
-			}
-
-			urn := resource.NewURN("dev", "default", "", tokens.Type("pulumi:providers:"+pc.spec.Name), "")
-			name := urn.Name()
-			typ := urn.Type()
-			uuid, err := uuid.NewV4()
-			if err != nil {
-				return fmt.Errorf("generate UUID: %w", err)
-			}
-			id := resource.ID(uuid.String())
-
-			_, err = pc.provider.Configure(ctx, plugin.ConfigureRequest{
-				URN:    &urn,
-				Name:   &name,
-				Type:   &typ,
-				ID:     &id,
-				Inputs: config,
-			})
-			if err != nil {
-				return fmt.Errorf("configure provider: %w", err)
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
 			}
 
 			inputs, err := evaluateFunctionFile(
-				cmd.Context(), inputFile, "input", inputFormat, fn, pc.evalContext,
+				ctx, inputFile, "input", inputFormat, fn, pc.evalContext,
 				pc.converter, pc.loaderTarget, pc.packageDescriptor)
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -141,7 +141,8 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			if err != nil {
 				return err
 			}
-			if err := pc.confirm(cmd, summary, yes); err != nil {
+			// Create doesn't have an ID yet, so require the user to type "yes" — same pattern as `plugin rm`.
+			if err := pc.confirm(cmd, summary, "yes", yes); err != nil {
 				return err
 			}
 			response, err := pc.provider.Create(ctx, plugin.CreateRequest{
@@ -266,7 +267,8 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			}
 			summary := formatPatchSummary(
 				res, id, oldInputs, checked, diff, pc.showSecrets, cmdutil.GetGlobalColorization())
-			if err := pc.confirm(cmd, summary, yes); err != nil {
+			// Require the user to type the resource ID — same pattern as `stack rm` requiring the stack name.
+			if err := pc.confirm(cmd, summary, string(id), yes); err != nil {
 				return err
 			}
 
@@ -309,7 +311,8 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 			}
 			urn := resourceURN(res)
 			id := resource.ID(args[0])
-			if err := pc.confirm(cmd, formatDeleteSummary(res, id), yes); err != nil {
+			// Require the user to type the resource ID — same pattern as `stack rm` requiring the stack name.
+			if err := pc.confirm(cmd, formatDeleteSummary(res, id), string(id), yes); err != nil {
 				return err
 			}
 			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -1,0 +1,538 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+)
+
+func resourceSchemaHelp(res *schema.Resource) string {
+	var b strings.Builder
+	writeProperties := func(title string, properties []*schema.Property, includeRequired bool) {
+		if len(properties) == 0 {
+			return
+		}
+		if b.Len() > 0 {
+			trimmed := strings.TrimSuffix(b.String(), "\n")
+			b.Reset()
+			b.WriteString(trimmed)
+			b.WriteString("\n\n")
+		}
+		b.WriteString(title)
+		b.WriteString(":\n")
+		for _, property := range properties {
+			fmt.Fprintf(&b, "  %s (%s", property.Name, schemaTypeString(property.Type))
+			if includeRequired {
+				if property.IsRequired() {
+					b.WriteString(", required")
+				} else {
+					b.WriteString(", optional")
+				}
+			}
+			b.WriteString(")")
+			if property.Comment != "" {
+				fmt.Fprintf(&b, " - %s", strings.ReplaceAll(property.Comment, "\n", " "))
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	writeProperties("Inputs", res.InputProperties, true)
+	writeProperties("Outputs", res.Properties, false)
+	if res.ListInputs != nil {
+		writeProperties("List Inputs", res.ListInputs.Properties, true)
+	}
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Command {
+	_, _, name, diags := pcl.DecomposeToken(res.Token, hcl.Range{})
+	contract.Assertf(!diags.HasErrors(), "token should decompose")
+
+	shorthelp := fmt.Sprintf("Operate on the %s resource", name)
+	longhelp := shorthelp + "."
+	if res.Comment != "" {
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, res.Comment)
+	}
+	if schemaHelp := resourceSchemaHelp(res); schemaHelp != "" {
+		longhelp = fmt.Sprintf("%s\n\n%s", longhelp, schemaHelp)
+	}
+
+	cmd := &cobra.Command{
+		Use:     name,
+		GroupID: "Resources",
+		Short:   shorthelp,
+		Long:    longhelp,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(pc.newResourceCreateCommand(res))
+	cmd.AddCommand(pc.newResourceReadCommand(res))
+	cmd.AddCommand(pc.newResourcePatchCommand(res))
+	cmd.AddCommand(pc.newResourceDeleteCommand(res))
+	if res.ListInputs != nil {
+		cmd.AddCommand(pc.newResourceListCommand(res))
+	}
+	return cmd
+}
+
+func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a resource",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
+			}
+			urn := resourceURN(res)
+			inputs, err := evaluateResourceFile(
+				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
+				pc.converter, pc.loaderTarget, pc.packageDescriptor)
+			if err != nil {
+				return fmt.Errorf("parse input file: %w", err)
+			}
+			checked, err := pc.checkResourceInputs(ctx, urn, res, nil, inputs)
+			if err != nil {
+				return err
+			}
+			summary, err := formatCreateSummary(res, checked, pc.showSecrets)
+			if err != nil {
+				return err
+			}
+			if err := pc.confirm(cmd, summary, yes); err != nil {
+				return err
+			}
+			response, err := pc.provider.Create(ctx, plugin.CreateRequest{
+				URN:        urn,
+				Name:       urn.Name(),
+				Type:       urn.Type(),
+				Properties: checked,
+				Preview:    pc.dryrun,
+			})
+			if err != nil {
+				return err
+			}
+			if response.ID == "" {
+				response.ID = resource.ID("[unknown]")
+			}
+			return pc.printResourceResult(cmd, response.ID, response.Properties, res)
+		},
+	}
+	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
+	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	return cmd
+}
+
+func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Command {
+	return &cobra.Command{
+		Use:   "read <id>",
+		Short: "Read a resource",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
+			}
+			urn := resourceURN(res)
+			response, err := pc.provider.Read(ctx, plugin.ReadRequest{
+				URN:    urn,
+				Name:   urn.Name(),
+				Type:   urn.Type(),
+				ID:     resource.ID(args[0]),
+				Inputs: resource.PropertyMap{},
+				State:  resource.PropertyMap{},
+			})
+			if err != nil {
+				return err
+			}
+			if response.Outputs == nil {
+				return fmt.Errorf("resource %q was not found", args[0])
+			}
+			id := response.ID
+			if id == "" {
+				id = resource.ID(args[0])
+			}
+			return pc.printResourceResult(cmd, id, response.Outputs, res)
+		},
+	}
+}
+
+func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "patch <id>",
+		Short: "Patch a resource",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
+			}
+			urn := resourceURN(res)
+			id := resource.ID(args[0])
+			read, err := pc.provider.Read(ctx, plugin.ReadRequest{
+				URN:    urn,
+				Name:   urn.Name(),
+				Type:   urn.Type(),
+				ID:     id,
+				Inputs: resource.PropertyMap{},
+				State:  resource.PropertyMap{},
+			})
+			if err != nil {
+				return err
+			}
+			if read.Outputs == nil {
+				return fmt.Errorf("resource %q was not found", args[0])
+			}
+			// AllowMissingProperties because a patch typically only specifies the fields being changed; the binder
+			// would otherwise reject any partial patch that omits a required input.
+			patch, err := evaluateResourceFile(
+				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
+				pc.converter, pc.loaderTarget, pc.packageDescriptor, pcl.AllowMissingProperties)
+			if err != nil {
+				return fmt.Errorf("parse input file: %w", err)
+			}
+
+			oldInputs := read.Inputs
+			newInputs := oldInputs.Copy()
+			for key, value := range patch {
+				newInputs[key] = value
+			}
+			checked, err := pc.checkResourceInputs(ctx, urn, res, oldInputs, newInputs)
+			if err != nil {
+				return err
+			}
+
+			diff, err := pc.provider.Diff(ctx, plugin.DiffRequest{
+				URN:        urn,
+				Name:       urn.Name(),
+				Type:       urn.Type(),
+				ID:         id,
+				OldInputs:  oldInputs,
+				OldOutputs: read.Outputs,
+				NewInputs:  checked,
+			})
+			if err != nil {
+				return fmt.Errorf("diff: %w", err)
+			}
+			if err := pc.confirm(cmd, formatPatchSummary(res, id, diff), yes); err != nil {
+				return err
+			}
+
+			response, err := pc.provider.Update(ctx, plugin.UpdateRequest{
+				URN:        urn,
+				Name:       urn.Name(),
+				Type:       urn.Type(),
+				ID:         id,
+				OldInputs:  oldInputs,
+				OldOutputs: read.Outputs,
+				NewInputs:  checked,
+				Preview:    pc.dryrun,
+			})
+			if err != nil {
+				return err
+			}
+			return pc.printResourceResult(cmd, id, response.Properties, res)
+		},
+	}
+	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
+	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	return cmd
+}
+
+func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.Command {
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a resource",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := pc.requireYesIfNonInteractive(yes); err != nil {
+				return err
+			}
+			ctx := cmd.Context()
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
+			}
+			urn := resourceURN(res)
+			id := resource.ID(args[0])
+			if err := pc.confirm(cmd, formatDeleteSummary(res, id), yes); err != nil {
+				return err
+			}
+			_, err := pc.provider.Delete(ctx, plugin.DeleteRequest{
+				URN:     urn,
+				Name:    urn.Name(),
+				Type:    urn.Type(),
+				ID:      id,
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+			})
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"Automatically approve and perform the operation without a confirmation prompt")
+	return cmd
+}
+
+func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Command {
+	var inputFile string
+	var inputFormat string
+	var all bool
+	var count int64
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List resources",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && count > 0 {
+				return errors.New("--all and --count are mutually exclusive")
+			}
+			ctx := cmd.Context()
+			if err := pc.configureProvider(ctx); err != nil {
+				return err
+			}
+
+			query, err := evaluateResourceListFile(
+				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
+				pc.converter, pc.loaderTarget, pc.packageDescriptor)
+			if err != nil {
+				return fmt.Errorf("parse input file: %w", err)
+			}
+
+			var results []plugin.ListResult
+			var continuation string
+			for {
+				limit := int64(0)
+				if count > 0 {
+					limit = count - int64(len(results))
+				}
+				stream, err := pc.provider.List(ctx, plugin.ListRequest{
+					Token:             tokens.Type(res.Token),
+					Query:             query,
+					Limit:             limit,
+					ContinuationToken: continuation,
+				})
+				if err != nil {
+					return err
+				}
+				for item, err := range stream.Items {
+					if err != nil {
+						return err
+					}
+					results = append(results, item)
+				}
+				if stream.Computed {
+					output, err := jsonifyProperty(resource.NewProperty("<unknown>"), pc.showSecrets)
+					if err != nil {
+						return err
+					}
+					fmt.Fprint(cmd.OutOrStdout(), output)
+					return nil
+				}
+				continuation = stream.ContinuationToken
+				if count > 0 && int64(len(results)) >= count {
+					results = results[:int(count)]
+					break
+				}
+				if continuation == "" {
+					break
+				}
+				if count == 0 && !all {
+					break
+				}
+			}
+
+			return pc.printListResults(cmd, results)
+		},
+	}
+	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
+	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource list inputs")
+	cmd.Flags().BoolVar(&all, "all", false, "Enumerate all matching resources")
+	cmd.Flags().Int64Var(&count, "count", 0, "Enumerate up to count matching resources")
+	return cmd
+}
+
+func evaluateResourceListFile(
+	ctx context.Context, path, fileType, inputFormat string, res *schema.Resource, evalContext functionEvalContext,
+	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
+	packageDescriptor *codegenrpc.GetSchemaRequest,
+) (resource.PropertyMap, error) {
+	contract.Assertf(res.ListInputs != nil, "should not call evaluateResourceListFile for resources without list inputs")
+
+	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
+		attrs, inputType, diags := pcl.BindResourceList(file, res)
+		return attrs, inputType, res.ListInputs.Properties, diags
+	}
+	return evaluateFile(
+		ctx, path, fileType, inputFormat, res.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+	)
+}
+
+func (pc *packageCommand) checkResourceInputs(
+	ctx context.Context, urn resource.URN, res *schema.Resource, olds, news resource.PropertyMap,
+) (resource.PropertyMap, error) {
+	checked, err := pc.provider.Check(ctx, plugin.CheckRequest{
+		URN:  urn,
+		Type: tokens.Type(res.Token),
+		Olds: olds,
+		News: news,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(checked.Failures) > 0 {
+		var b strings.Builder
+		b.WriteString("resource inputs failed validation:")
+		for _, failure := range checked.Failures {
+			fmt.Fprintf(&b, "\n- %s: %s", failure.Property, failure.Reason)
+		}
+		return nil, fmt.Errorf("%s", b.String())
+	}
+	return checked.Properties, nil
+}
+
+func (pc *packageCommand) printResourceResult(
+	cmd *cobra.Command, id resource.ID, outputs resource.PropertyMap, res *schema.Resource,
+) error {
+	contract.Requiref(id != "", "id", "id should not be blank")
+
+	if res.Properties != nil {
+		outputs = filterOutputs(outputs, res.Properties)
+	}
+	result := resource.PropertyMap{
+		"id":         resource.NewProperty(string(id)),
+		"properties": resource.NewProperty(outputs),
+	}
+	output, err := jsonifyProperty(resource.NewProperty(result), pc.showSecrets)
+	if err != nil {
+		return fmt.Errorf("failed to convert outputs to JSON: %w", err)
+	}
+	fmt.Fprint(cmd.OutOrStdout(), output)
+	return nil
+}
+
+func (pc *packageCommand) printListResults(cmd *cobra.Command, results []plugin.ListResult) error {
+	values := make([]resource.PropertyValue, len(results))
+	for i, result := range results {
+		values[i] = resource.NewProperty(resource.PropertyMap{
+			"id":   resource.NewProperty(string(result.ID)),
+			"name": resource.NewProperty(result.Name),
+		})
+	}
+	output, err := jsonifyProperty(resource.NewProperty(values), pc.showSecrets)
+	if err != nil {
+		return fmt.Errorf("failed to convert outputs to JSON: %w", err)
+	}
+	fmt.Fprint(cmd.OutOrStdout(), output)
+	return nil
+}
+
+func formatCreateSummary(res *schema.Resource, inputs resource.PropertyMap, showSecrets bool) (string, error) {
+	body, err := jsonifyProperty(resource.NewProperty(inputs), showSecrets)
+	if err != nil {
+		return "", fmt.Errorf("format inputs: %w", err)
+	}
+	return fmt.Sprintf("This will create %s with the following inputs:\n%s", res.Token, body), nil
+}
+
+func formatDeleteSummary(res *schema.Resource, id resource.ID) string {
+	return fmt.Sprintf("This will delete %s %q.", res.Token, id)
+}
+
+// formatPatchSummary renders a human-readable summary of the changes a patch will apply, using the provider's
+// Diff response. If the provider returns no DetailedDiff we fall back to a short "no detailed diff available"
+// note — the operation can still proceed since Update is what actually applies the change.
+func formatPatchSummary(res *schema.Resource, id resource.ID, diff plugin.DiffResult) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "This will update %s %q.", res.Token, id)
+	if diff.Changes == plugin.DiffNone {
+		b.WriteString("\nNo changes.")
+		return b.String()
+	}
+	if len(diff.DetailedDiff) == 0 {
+		if len(diff.ChangedKeys) > 0 {
+			b.WriteString("\nChanged properties:")
+			for _, k := range diff.ChangedKeys {
+				fmt.Fprintf(&b, "\n  %s", k)
+			}
+		} else {
+			b.WriteString("\nProvider reported changes but no detailed diff is available.")
+		}
+		return b.String()
+	}
+	b.WriteString("\nChanges:")
+	// Stable order so the prompt is deterministic.
+	paths := make([]string, 0, len(diff.DetailedDiff))
+	for k := range diff.DetailedDiff {
+		paths = append(paths, k)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		d := diff.DetailedDiff[p]
+		marker := diffKindMarker(d.Kind)
+		fmt.Fprintf(&b, "\n  %s %s", marker, p)
+	}
+	return b.String()
+}
+
+func diffKindMarker(k plugin.DiffKind) string {
+	switch k {
+	case plugin.DiffAdd, plugin.DiffAddReplace:
+		return "+"
+	case plugin.DiffDelete, plugin.DiffDeleteReplace:
+		return "-"
+	case plugin.DiffUpdate, plugin.DiffUpdateReplace:
+		return "~"
+	default:
+		return "?"
+	}
+}

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -95,11 +95,14 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		GroupID: "Resources",
 		Short:   shorthelp,
 		Long:    longhelp,
-		Args:    cobra.NoArgs,
+		Args:    unknownSubcommandArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
 	}
+	cmd.SetUsageTemplate(doUsageTemplate)
+	// Tolerate unknown flags so that we don't error on a flag that belongs to the child command.
+	cmd.FParseErrWhitelist.UnknownFlags = true
 	cmd.AddCommand(pc.newResourceCreateCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -15,22 +15,25 @@
 package do
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
@@ -261,7 +264,9 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			if err != nil {
 				return fmt.Errorf("diff: %w", err)
 			}
-			if err := pc.confirm(cmd, formatPatchSummary(res, id, diff), yes); err != nil {
+			summary := formatPatchSummary(
+				res, id, oldInputs, checked, diff, pc.showSecrets, cmdutil.GetGlobalColorization())
+			if err := pc.confirm(cmd, summary, yes); err != nil {
 				return err
 			}
 
@@ -488,51 +493,40 @@ func formatDeleteSummary(res *schema.Resource, id resource.ID) string {
 	return fmt.Sprintf("This will delete %s %q.", res.Token, id)
 }
 
-// formatPatchSummary renders a human-readable summary of the changes a patch will apply, using the provider's
-// Diff response. If the provider returns no DetailedDiff we fall back to a short "no detailed diff available"
-// note — the operation can still proceed since Update is what actually applies the change.
-func formatPatchSummary(res *schema.Resource, id resource.ID, diff plugin.DiffResult) string {
+// formatPatchSummary renders a human-readable summary of the changes a patch will apply. The value-level diff is
+// produced by display.PrintObjectDiff — the same renderer the engine uses for `pulumi up` / `pulumi preview` —
+// so the output is shaped identically (e.g. "  ~ name: \"old\" => \"new\""). The provider's DiffResult informs
+// the "no changes" shortcut and the replacement notice.
+func formatPatchSummary(
+	res *schema.Resource, id resource.ID,
+	oldInputs, newInputs resource.PropertyMap,
+	providerDiff plugin.DiffResult,
+	showSecrets bool, color colors.Colorization,
+) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "This will update %s %q.", res.Token, id)
-	if diff.Changes == plugin.DiffNone {
-		b.WriteString("\nNo changes.")
+	fmt.Fprintf(&b, "This will update %s %q.\n", res.Token, id)
+
+	objDiff := oldInputs.Diff(newInputs)
+	if providerDiff.Changes == plugin.DiffNone || objDiff == nil {
+		b.WriteString("No changes.\n")
 		return b.String()
 	}
-	if len(diff.DetailedDiff) == 0 {
-		if len(diff.ChangedKeys) > 0 {
-			b.WriteString("\nChanged properties:")
-			for _, k := range diff.ChangedKeys {
-				fmt.Fprintf(&b, "\n  %s", k)
+
+	var diffBuf bytes.Buffer
+	display.PrintObjectDiff(&diffBuf, *objDiff, nil, /*include*/
+		true /*planning*/, 1 /*indent*/, false /*summary*/, false, /*truncateOutput*/
+		false /*debug*/, showSecrets, nil /*hidden*/)
+	b.WriteString(color.Colorize(diffBuf.String()))
+
+	if len(providerDiff.ReplaceKeys) > 0 {
+		b.WriteString("This change replaces the resource (")
+		for i, k := range providerDiff.ReplaceKeys {
+			if i > 0 {
+				b.WriteString(", ")
 			}
-		} else {
-			b.WriteString("\nProvider reported changes but no detailed diff is available.")
+			b.WriteString(string(k))
 		}
-		return b.String()
-	}
-	b.WriteString("\nChanges:")
-	// Stable order so the prompt is deterministic.
-	paths := make([]string, 0, len(diff.DetailedDiff))
-	for k := range diff.DetailedDiff {
-		paths = append(paths, k)
-	}
-	sort.Strings(paths)
-	for _, p := range paths {
-		d := diff.DetailedDiff[p]
-		marker := diffKindMarker(d.Kind)
-		fmt.Fprintf(&b, "\n  %s %s", marker, p)
+		b.WriteString(").\n")
 	}
 	return b.String()
-}
-
-func diffKindMarker(k plugin.DiffKind) string {
-	switch k {
-	case plugin.DiffAdd, plugin.DiffAddReplace:
-		return "+"
-	case plugin.DiffDelete, plugin.DiffDeleteReplace:
-		return "-"
-	case plugin.DiffUpdate, plugin.DiffUpdateReplace:
-		return "~"
-	default:
-		return "?"
-	}
 }

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -117,7 +117,6 @@ List Inputs:
   prefix (string, optional)
 
 Usage:
-  do azure myResource [flags]
   do azure myResource [command]
 
 Available Commands:
@@ -165,7 +164,6 @@ Outputs:
   size (integer)
 
 Usage:
-  do azure myResource [flags]
   do azure myResource [command]
 
 Available Commands:

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -1,0 +1,605 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func doResourceSpec(withList bool) schema.PackageSpec {
+	res := schema.ResourceSpec{
+		ObjectTypeSpec: schema.ObjectTypeSpec{
+			Description: "A test resource.",
+			Properties: map[string]schema.PropertySpec{
+				"name":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"size":    {TypeSpec: schema.TypeSpec{Type: "integer"}},
+				"enabled": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+				"extra":   {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+		},
+		InputProperties: map[string]schema.PropertySpec{
+			"name": {
+				TypeSpec:    schema.TypeSpec{Type: "string"},
+				Description: "The resource name.",
+			},
+			"size": {
+				TypeSpec: schema.TypeSpec{Type: "integer"},
+			},
+			"enabled": {
+				TypeSpec: schema.TypeSpec{Type: "boolean"},
+			},
+		},
+		RequiredInputs: []string{"name"},
+	}
+	if withList {
+		res.ListInputs = &schema.ObjectTypeSpec{
+			Properties: map[string]schema.PropertySpec{
+				"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+		}
+	}
+	return schema.PackageSpec{
+		Name: "azure",
+		Resources: map[string]schema.ResourceSpec{
+			"azure:index:myResource": res,
+		},
+	}
+}
+
+func newDoResourceCommand(
+	t *testing.T, provider *testProvider,
+) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		return provider, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	return cmd, &stdout, &stderr
+}
+
+func TestDoCmdResourceHelpListsOperations(t *testing.T) {
+	t.Parallel()
+
+	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(true)})
+	cmd.SetArgs([]string{"azure", "myResource", "--help"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	expected := `Operate on the myResource resource.
+
+A test resource.
+
+Inputs:
+  enabled (boolean, optional)
+  name (string, required) - The resource name.
+  size (integer, optional)
+
+Outputs:
+  enabled (boolean)
+  extra (string)
+  name (string)
+  size (integer)
+
+List Inputs:
+  prefix (string, optional)
+
+Usage:
+  do azure myResource [flags]
+  do azure myResource [command]
+
+Available Commands:
+  create      Create a resource
+  delete      Delete a resource
+  list        List resources
+  patch       Patch a resource
+  read        Read a resource
+
+Flags:
+  -h, --help   help for myResource
+
+Global Flags:
+      --dry-run                  Run the operation in preview mode
+      --provider-file string     Path to a file containing provider configuration
+      --provider-format string   Format of the provider configuration file (default "pcl")
+      --show-secrets             Show secret values in output
+
+Use "do azure myResource [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, stdout.String())
+}
+
+func TestDoCmdResourceHelpOmitsListWithoutListInputs(t *testing.T) {
+	t.Parallel()
+
+	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(false)})
+	cmd.SetArgs([]string{"azure", "myResource", "--help"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	expected := `Operate on the myResource resource.
+
+A test resource.
+
+Inputs:
+  enabled (boolean, optional)
+  name (string, required) - The resource name.
+  size (integer, optional)
+
+Outputs:
+  enabled (boolean)
+  extra (string)
+  name (string)
+  size (integer)
+
+Usage:
+  do azure myResource [flags]
+  do azure myResource [command]
+
+Available Commands:
+  create      Create a resource
+  delete      Delete a resource
+  patch       Patch a resource
+  read        Read a resource
+
+Flags:
+  -h, --help   help for myResource
+
+Global Flags:
+      --dry-run                  Run the operation in preview mode
+      --provider-file string     Path to a file containing provider configuration
+      --provider-format string   Format of the provider configuration file (default "pcl")
+      --show-secrets             Show secret values in output
+
+Use "do azure myResource [command] --help" for more information about a command.
+`
+	assert.Equal(t, expected, stdout.String())
+}
+
+func TestDoCmdResourceCreate(t *testing.T) {
+	t.Parallel()
+
+	var calls []string
+	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+		spec: doResourceSpec(false),
+		MockProvider: plugin.MockProvider{
+			CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+				calls = append(calls, "check")
+				assert.Equal(t, tokens.Type("azure:index:myResource"), req.Type)
+				assert.Equal(t, "example", req.News["name"].StringValue())
+				assert.Equal(t, 2.0, req.News["size"].NumberValue())
+				return plugin.CheckResponse{Properties: req.News}, nil
+			},
+			CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+				calls = append(calls, "create")
+				assert.Equal(t, "example", req.Properties["name"].StringValue())
+				return plugin.CreateResponse{
+					ID: "res-1",
+					Properties: resource.PropertyMap{
+						"name":  resource.NewProperty("example"),
+						"size":  resource.NewProperty(2.0),
+						"extra": resource.NewProperty("hidden"),
+					},
+				}, nil
+			},
+		},
+	})
+
+	inputFile := writeHCLFile(t, "inputs.pcl", `
+name = "example"
+size = 2
+`)
+	cmd.SetArgs([]string{"azure", "myResource", "create", "--yes", "--input-file", inputFile})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"check", "create"}, calls)
+	assert.JSONEq(t, `{
+  "id": "res-1",
+  "properties": {
+    "name": "example",
+    "size": 2,
+    "extra": "hidden"
+  }
+}`, stdout.String())
+}
+
+func TestDoCmdResourceReadDeletePatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					assert.Equal(t, resource.ID("res-1"), req.ID)
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID: "res-1",
+							Outputs: resource.PropertyMap{
+								"name": resource.NewProperty("read"),
+								"size": resource.NewProperty(3.0),
+							},
+						},
+					}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure", "myResource", "read", "res-1"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":"res-1","properties":{"name":"read","size":3}}`, stdout.String())
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+		var deleted bool
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					deleted = true
+					assert.Equal(t, resource.ID("res-1"), req.ID)
+					assert.Empty(t, req.Inputs)
+					assert.Empty(t, req.Outputs)
+					return plugin.DeleteResponse{}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure", "myResource", "delete", "res-1", "--yes"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.True(t, deleted)
+		assert.Empty(t, stdout.String())
+	})
+
+	t.Run("patch", func(t *testing.T) {
+		t.Parallel()
+		var calls []string
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					calls = append(calls, "read")
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID: "res-1",
+							Inputs: resource.PropertyMap{
+								"name":    resource.NewProperty("old"),
+								"size":    resource.NewProperty(1.0),
+								"enabled": resource.NewProperty(false),
+							},
+							Outputs: resource.PropertyMap{
+								"name":    resource.NewProperty("old"),
+								"size":    resource.NewProperty(1.0),
+								"enabled": resource.NewProperty(false),
+							},
+						},
+					}, nil
+				},
+				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					calls = append(calls, "check")
+					assert.Equal(t, "old", req.Olds["name"].StringValue())
+					assert.Equal(t, "new", req.News["name"].StringValue())
+					assert.Equal(t, 1.0, req.News["size"].NumberValue())
+					assert.Equal(t, true, req.News["enabled"].BoolValue())
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+					calls = append(calls, "diff")
+					return plugin.DiffResponse{
+						Changes:     plugin.DiffSome,
+						ChangedKeys: []resource.PropertyKey{"name", "enabled"},
+					}, nil
+				},
+				UpdateF: func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					calls = append(calls, "update")
+					assert.Equal(t, "new", req.NewInputs["name"].StringValue())
+					assert.Equal(t, 1.0, req.NewInputs["size"].NumberValue())
+					assert.Equal(t, true, req.NewInputs["enabled"].BoolValue())
+					return plugin.UpdateResponse{
+						Properties: resource.PropertyMap{
+							"name":    resource.NewProperty("new"),
+							"size":    resource.NewProperty(1.0),
+							"enabled": resource.NewProperty(true),
+						},
+					}, nil
+				},
+			},
+		})
+
+		inputFile := writeHCLFile(t, "patch.pcl", `
+name = "new"
+enabled = true
+`)
+		cmd.SetArgs([]string{"azure", "myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"read", "check", "diff", "update"}, calls)
+		assert.JSONEq(t, `{"id":"res-1","properties":{"name":"new","size":1,"enabled":true}}`, stdout.String())
+	})
+
+	// Partial patches should not require the user to restate required inputs that haven't changed; the existing
+	// inputs from Read fill those in, and the patch file is bound with AllowMissingProperties.
+	t.Run("patch omitting required input", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{
+						ReadResult: plugin.ReadResult{
+							ID: "res-1",
+							Inputs: resource.PropertyMap{
+								"name":    resource.NewProperty("existing"),
+								"enabled": resource.NewProperty(false),
+							},
+							Outputs: resource.PropertyMap{
+								"name":    resource.NewProperty("existing"),
+								"enabled": resource.NewProperty(false),
+							},
+						},
+					}, nil
+				},
+				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					assert.Equal(t, "existing", req.News["name"].StringValue())
+					assert.Equal(t, true, req.News["enabled"].BoolValue())
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+					return plugin.DiffResponse{Changes: plugin.DiffSome}, nil
+				},
+				UpdateF: func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					return plugin.UpdateResponse{
+						Properties: resource.PropertyMap{
+							"name":    resource.NewProperty("existing"),
+							"enabled": resource.NewProperty(true),
+						},
+					}, nil
+				},
+			},
+		})
+
+		inputFile := writeHCLFile(t, "patch.pcl", `enabled = true`)
+		cmd.SetArgs([]string{"azure", "myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":"res-1","properties":{"name":"existing","enabled":true}}`, stdout.String())
+	})
+}
+
+func TestDoCmdResourceList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single page by default", func(t *testing.T) {
+		t.Parallel()
+		var calls []plugin.ListRequest
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(true),
+			MockProvider: plugin.MockProvider{
+				ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+					calls = append(calls, req)
+					assert.Equal(t, "prod", req.Query["prefix"].StringValue())
+					return plugin.NewListStream([]plugin.ListResult{{ID: "1", Name: "one"}}, "next"), nil
+				},
+			},
+		})
+		inputFile := writeHCLFile(t, "list.pcl", `prefix = "prod"`)
+		cmd.SetArgs([]string{"azure", "myResource", "list", "--input-file", inputFile})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		require.Len(t, calls, 1)
+		assert.Empty(t, calls[0].ContinuationToken)
+		assert.JSONEq(t, `[{"id":"1","name":"one"}]`, stdout.String())
+	})
+
+	t.Run("count", func(t *testing.T) {
+		t.Parallel()
+		var calls []plugin.ListRequest
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(true),
+			MockProvider: plugin.MockProvider{
+				ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+					calls = append(calls, req)
+					if req.ContinuationToken == "" {
+						return plugin.NewListStream([]plugin.ListResult{{ID: "1", Name: "one"}}, "next"), nil
+					}
+					return plugin.NewListStream(
+						[]plugin.ListResult{{ID: "2", Name: "two"}, {ID: "3", Name: "three"}},
+						"",
+					), nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure", "myResource", "list", "--count", "2"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		require.Len(t, calls, 2)
+		assert.Equal(t, int64(2), calls[0].Limit)
+		assert.Equal(t, int64(1), calls[1].Limit)
+		assert.JSONEq(t, `[{"id":"1","name":"one"},{"id":"2","name":"two"}]`, stdout.String())
+	})
+
+	t.Run("all", func(t *testing.T) {
+		t.Parallel()
+		var calls []plugin.ListRequest
+		cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(true),
+			MockProvider: plugin.MockProvider{
+				ListF: func(ctx context.Context, req plugin.ListRequest) (*plugin.ListStream, error) {
+					calls = append(calls, req)
+					if req.ContinuationToken == "" {
+						return plugin.NewListStream([]plugin.ListResult{{ID: "1", Name: "one"}}, "next"), nil
+					}
+					return plugin.NewListStream([]plugin.ListResult{{ID: "2", Name: "two"}}, ""), nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure", "myResource", "list", "--all"})
+		err := cmd.Execute()
+		require.NoError(t, err)
+		require.Len(t, calls, 2)
+		assert.Equal(t, "next", calls[1].ContinuationToken)
+		assert.JSONEq(t, `[{"id":"1","name":"one"},{"id":"2","name":"two"}]`, stdout.String())
+	})
+
+	t.Run("mutually exclusive flags", func(t *testing.T) {
+		t.Parallel()
+		cmd, _, _ := newDoResourceCommand(t, &testProvider{spec: doResourceSpec(true)})
+		cmd.SetArgs([]string{"azure", "myResource", "list", "--all", "--count", "1"})
+		err := cmd.Execute()
+		require.ErrorContains(t, err, "--all and --count are mutually exclusive")
+	})
+}
+
+// TestDoCmdResourceNonInteractiveRequiresYes asserts that destructive subcommands refuse to run when the user is
+// not on a TTY and --yes was not supplied. Tests have no TTY, so omitting --yes triggers the early bail.
+func TestDoCmdResourceNonInteractiveRequiresYes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"create", []string{"azure", "myResource", "create"}},
+		{"patch", []string{"azure", "myResource", "patch", "res-1"}},
+		{"delete", []string{"azure", "myResource", "delete", "res-1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider := &testProvider{
+				spec: doResourceSpec(false),
+				MockProvider: plugin.MockProvider{
+					CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+						require.Fail(t, "Create should not be called without --yes in non-interactive mode")
+						return plugin.CreateResponse{}, nil
+					},
+					DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+						require.Fail(t, "Delete should not be called without --yes in non-interactive mode")
+						return plugin.DeleteResponse{}, nil
+					},
+					UpdateF: func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+						require.Fail(t, "Update should not be called without --yes in non-interactive mode")
+						return plugin.UpdateResponse{}, nil
+					},
+				},
+			}
+			cmd, _, _ := newDoResourceCommand(t, provider)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			require.ErrorIs(t, err, backenderr.ErrNonInteractiveRequiresYes)
+		})
+	}
+}
+
+// TestDoCmdResourceConfirmationSummary asserts the operation summary lands on stderr (so stdout stays a clean
+// JSON channel for piping) and that the patch summary surfaces the Diff response.
+func TestDoCmdResourceConfirmationSummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					return plugin.CreateResponse{ID: "res-1", Properties: req.Properties}, nil
+				},
+			},
+		})
+		inputFile := writeHCLFile(t, "inputs.pcl", `name = "example"`)
+		cmd.SetArgs([]string{"azure", "myResource", "create", "--yes", "--input-file", inputFile})
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, stderr.String(), "This will create azure:index:myResource")
+		assert.NotContains(t, stdout.String(), "This will create")
+	})
+
+	t.Run("patch surfaces diff", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				ReadF: func(ctx context.Context, req plugin.ReadRequest) (plugin.ReadResponse, error) {
+					return plugin.ReadResponse{ReadResult: plugin.ReadResult{
+						ID:      "res-1",
+						Inputs:  resource.PropertyMap{"name": resource.NewProperty("old")},
+						Outputs: resource.PropertyMap{"name": resource.NewProperty("old")},
+					}}, nil
+				},
+				CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+					return plugin.CheckResponse{Properties: req.News}, nil
+				},
+				DiffF: func(ctx context.Context, req plugin.DiffRequest) (plugin.DiffResponse, error) {
+					return plugin.DiffResponse{
+						Changes: plugin.DiffSome,
+						DetailedDiff: map[string]plugin.PropertyDiff{
+							"name": {Kind: plugin.DiffUpdate},
+						},
+					}, nil
+				},
+				UpdateF: func(ctx context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					return plugin.UpdateResponse{Properties: req.NewInputs}, nil
+				},
+			},
+		})
+		inputFile := writeHCLFile(t, "patch.pcl", `name = "new"`)
+		cmd.SetArgs([]string{"azure", "myResource", "patch", "res-1", "--yes", "--input-file", inputFile})
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, stderr.String(), "This will update azure:index:myResource")
+		assert.Contains(t, stderr.String(), "~ name")
+		assert.NotContains(t, stdout.String(), "This will update")
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+		cmd, stdout, stderr := newDoResourceCommand(t, &testProvider{
+			spec: doResourceSpec(false),
+			MockProvider: plugin.MockProvider{
+				DeleteF: func(ctx context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					return plugin.DeleteResponse{}, nil
+				},
+			},
+		})
+		cmd.SetArgs([]string{"azure", "myResource", "delete", "res-1", "--yes"})
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, stderr.String(), `This will delete azure:index:myResource "res-1"`)
+		assert.Empty(t, stdout.String())
+	})
+}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -1,0 +1,457 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package do
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pclruntime "github.com/pulumi/pulumi/pkg/v3/pcl/runtime"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+)
+
+type functionEvalContext struct {
+	WorkingDir    string
+	ProjectName   string
+	RootDirectory string
+}
+
+func jsonifyPropertyValue(v resource.PropertyValue, showSecrets bool) (any, error) {
+	if !showSecrets && (v.IsSecret() || (v.IsOutput() && v.OutputValue().Secret)) {
+		return "[secret]", nil
+	}
+
+	if v.IsComputed() || (v.IsOutput() && !v.OutputValue().Known) {
+		return "[unknown]", nil
+	}
+
+	if v.IsSecret() {
+		return jsonifyPropertyValue(v.SecretValue().Element, showSecrets)
+	}
+
+	if v.IsOutput() {
+		return jsonifyPropertyValue(v.OutputValue().Element, showSecrets)
+	}
+
+	if v.IsAsset() {
+		return v.AssetValue().Serialize(), nil
+	}
+
+	if v.IsArchive() {
+		return v.ArchiveValue().Serialize(), nil
+	}
+
+	if v.IsArray() {
+		arr := v.ArrayValue()
+		res := make([]any, len(arr))
+		for i := range arr {
+			ev, err := jsonifyPropertyValue(arr[i], showSecrets)
+			if err != nil {
+				return nil, err
+			}
+			res[i] = ev
+		}
+		return res, nil
+	}
+
+	if v.IsObject() {
+		obj := v.ObjectValue()
+		res := make(map[string]any, len(obj))
+		for k, v := range obj {
+			ev, err := jsonifyPropertyValue(v, showSecrets)
+			if err != nil {
+				return nil, err
+			}
+			res[string(k)] = ev
+		}
+		return res, nil
+	}
+
+	return v.V, nil
+}
+
+// jsonifyProperty converts a Property to a JSON string for display purposes. This strips things like secrets and
+// outputs down to their underlying values.
+func jsonifyProperty(prop resource.PropertyValue, showSecrets bool) (string, error) {
+	plain, err := jsonifyPropertyValue(prop, showSecrets)
+	if err != nil {
+		return "", err
+	}
+
+	json, err := ui.MakeJSONString(plain, true)
+	if err != nil {
+		return "", err
+	}
+	return json, nil
+}
+
+// filterOutputs recursively filters the given property map to only include properties present in the schema. This is
+// used to filter out any "internal" keys the provider might return that aren't part of the declared outputs, which
+// would otherwise cause the JSON output to be noisy and potentially break consumers expecting a specific shape.
+func filterOutputs(props resource.PropertyMap, properties []*schema.Property) resource.PropertyMap {
+	filtered := resource.PropertyMap{}
+	for _, property := range properties {
+		key := resource.PropertyKey(property.Name)
+		if value, ok := props[key]; ok {
+			filtered[key] = filterOutput(value, property.Type)
+		}
+	}
+	return filtered
+}
+
+func filterOutput(
+	prop resource.PropertyValue, typ schema.Type,
+) resource.PropertyValue {
+	if typ == nil {
+		return prop
+	}
+
+	if optTyp, ok := typ.(*schema.OptionalType); ok {
+		if prop.IsNull() {
+			return resource.NewNullProperty()
+		} else {
+			typ = optTyp.ElementType
+		}
+	}
+
+	isSecret := prop.IsSecret()
+	if isSecret {
+		return resource.MakeSecret(filterOutput(prop.SecretValue().Element, typ))
+	}
+
+	switch t := typ.(type) {
+	case *schema.ObjectType:
+		if prop.IsObject() {
+			return resource.NewProperty(filterOutputs(prop.ObjectValue(), t.Properties))
+		}
+	case *schema.ArrayType:
+		if prop.IsArray() {
+			arr := prop.ArrayValue()
+			filtered := make([]resource.PropertyValue, len(arr))
+			for i, el := range arr {
+				filtered[i] = filterOutput(el, t.ElementType)
+			}
+			return resource.NewProperty(filtered)
+		}
+	case *schema.MapType:
+		if prop.IsObject() {
+			obj := prop.ObjectValue()
+			filtered := make(resource.PropertyMap, len(obj))
+			for k, v := range obj {
+				filtered[k] = filterOutput(v, t.ElementType)
+			}
+			return resource.NewProperty(filtered)
+		}
+	case *schema.UnionType:
+		// Pick the first variant whose shape matches the runtime value. Discriminated unions would let us be more
+		// precise, but most cases here are simple kind-based dispatch.
+		for _, elt := range t.ElementTypes {
+			if unionVariantMatches(prop, elt) {
+				return filterOutput(prop, elt)
+			}
+		}
+	}
+
+	return prop
+}
+
+// unionVariantMatches reports whether the schema type is structurally compatible with the runtime kind of prop.
+// Used to pick a union variant for output filtering.
+func unionVariantMatches(prop resource.PropertyValue, typ schema.Type) bool {
+	// TODO https://github.com/pulumi/pulumi/issues/23234: This needs to be smarter and handle Discriminator
+	if opt, ok := typ.(*schema.OptionalType); ok {
+		typ = opt.ElementType
+	}
+	switch typ.(type) {
+	case *schema.ObjectType, *schema.MapType:
+		return prop.IsObject()
+	case *schema.ArrayType:
+		return prop.IsArray()
+	}
+	return false
+}
+
+// evaluatePCLFile reads, binds, and evaluates a PCL input file against a caller-supplied schema. The bind callback
+// decides how the parsed file is type-checked (function vs. resource) and returns the schema property list used to
+// coerce values during evaluation.
+func evaluatePCLFile(
+	path, fileType string,
+	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
+	evalContext functionEvalContext,
+) (resource.PropertyMap, error) {
+	// When no input file is supplied we still run the bind step against an empty file so that the schema's
+	// required-input check fires.
+	var input io.Reader
+	filename := path
+	if path == "" {
+		input = strings.NewReader("")
+		filename = fmt.Sprintf("<no %s file>", fileType)
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("open %s file: %w", fileType, err)
+		}
+		defer contract.IgnoreClose(f)
+		input = f
+	}
+
+	return evaluatePCL(input, filename, fileType, bind, evalContext)
+}
+
+func evaluatePCL(
+	input io.Reader,
+	filename, fileType string,
+	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
+	evalContext functionEvalContext,
+) (resource.PropertyMap, error) {
+	parser := hclsyntax.NewParser()
+	if err := parser.ParseFile(input, filename); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+	if parser.Diagnostics.HasErrors() {
+		return nil, parser.Diagnostics
+	}
+	contract.Assertf(len(parser.Files) == 1, "Should be one PCL file")
+	file := parser.Files[0]
+
+	attrs, inputType, properties, diagnostics := bind(file)
+	if diagnostics.HasErrors() {
+		return nil, diagnostics
+	}
+
+	notSupported := func(what string) error {
+		return fmt.Errorf("cannot %s in %s file", what, fileType)
+	}
+	ectx := pclruntime.NewEvalContext(
+		evalContext.WorkingDir,
+		evalContext.RootDirectory,
+		"",
+		evalContext.ProjectName,
+		"",
+		func(context.Context, string) (*schema.Resource, error) {
+			return nil, notSupported("reference resources")
+		},
+		func(context.Context, string) (*schema.Function, error) {
+			return nil, notSupported("reference functions")
+		},
+		func(context.Context, resource.ResourceReference) (resource.PropertyMap, error) {
+			return nil, notSupported("reference resources")
+		},
+		func(context.Context, *pulumirpc.ResourceInvokeRequest) (*pulumirpc.InvokeResponse, error) {
+			return nil, notSupported("invoke functions")
+		},
+		func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error) {
+			return nil, notSupported("call functions")
+		},
+	)
+
+	result, poison, diags := ectx.EvaluateObject(attrs, inputType, properties)
+	if poison != nil {
+		// `pulumi do` is one-shot — there's no upstream resource graph to propagate poison through, so surface it.
+		return nil, fmt.Errorf("%s file references unknown resource %s", fileType, *poison)
+	}
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	return result, nil
+}
+
+// evaluateFile reads an input file in the given format and evaluates it. For non-PCL formats the source is routed
+// through the named converter plugin's ConvertSnippet RPC and the resulting PCL is fed into the same bind pipeline.
+// An empty path is treated as "no input provided" and always goes through the PCL path so the bind step's
+// missing-required check still fires.
+func evaluateFile(
+	ctx context.Context,
+	path, fileType, inputFormat, token string,
+	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
+	loadConverter func(string) (plugin.Converter, error),
+	loaderTarget string,
+	packageDescriptor *codegenrpc.GetSchemaRequest,
+	evalContext functionEvalContext,
+) (resource.PropertyMap, error) {
+	if path == "" || inputFormat == "" || inputFormat == "pcl" {
+		return evaluatePCLFile(path, fileType, bind, evalContext)
+	}
+
+	converter, err := loadConverter(inputFormat)
+	if err != nil {
+		return nil, fmt.Errorf("load %s input converter: %w", inputFormat, err)
+	}
+	defer contract.IgnoreClose(converter)
+
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s file: %w", fileType, err)
+	}
+	resp, err := converter.ConvertSnippet(ctx, &plugin.ConvertSnippetRequest{
+		Filename:     path,
+		Source:       source,
+		TargetLoader: loaderTarget,
+		Package:      packageDescriptor,
+		Token:        token,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("generate PCL from %s file: %w", fileType, err)
+	}
+	if resp.Diagnostics.HasErrors() {
+		return nil, resp.Diagnostics
+	}
+	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext)
+}
+
+func evaluateFunctionFile(
+	ctx context.Context, path, fileType, inputFormat string, fn *schema.Function, evalContext functionEvalContext,
+	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
+	packageDescriptor *codegenrpc.GetSchemaRequest,
+) (resource.PropertyMap, error) {
+	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
+		attrs, inputType, diags := pcl.BindFunction(file, fn)
+		var properties []*schema.Property
+		if fn.Inputs != nil {
+			properties = fn.Inputs.Properties
+		}
+		return attrs, inputType, properties, diags
+	}
+	return evaluateFile(
+		ctx, path, fileType, inputFormat, fn.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+	)
+}
+
+func evaluateResourceFile(
+	ctx context.Context, path, fileType, inputFormat string, res *schema.Resource, evalContext functionEvalContext,
+	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
+	packageDescriptor *codegenrpc.GetSchemaRequest,
+	bindOpts ...pcl.BindOption,
+) (resource.PropertyMap, error) {
+	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
+		attrs, inputType, diags := pcl.BindResource(file, res, bindOpts...)
+		return attrs, inputType, res.InputProperties, diags
+	}
+	return evaluateFile(
+		ctx, path, fileType, inputFormat, res.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+	)
+}
+
+func schemaTypeString(t schema.Type) string {
+	switch t := t.(type) {
+	case *schema.OptionalType:
+		return schemaTypeString(t.ElementType)
+	case *schema.InputType:
+		return schemaTypeString(t.ElementType)
+	default:
+		return t.String()
+	}
+}
+
+func resourceURN(res *schema.Resource) resource.URN {
+	_, _, name, diags := pcl.DecomposeToken(res.Token, hcl.Range{})
+	contract.Assertf(!diags.HasErrors(), "token should decompose")
+	return resource.NewURN("dev", "default", "", tokens.Type(res.Token), name)
+}
+
+func (pc *packageCommand) configureProvider(ctx context.Context) error {
+	config, err := evaluateResourceFile(
+		ctx, pc.providerFile, "provider", pc.providerFormat,
+		pc.spec.Provider, pc.evalContext, pc.converter, pc.loaderTarget, pc.packageDescriptor)
+	if err != nil {
+		return fmt.Errorf("parse provider file: %w", err)
+	}
+
+	urn := resource.NewURN("dev", "default", "", tokens.Type("pulumi:providers:"+pc.spec.Name), "")
+	name := urn.Name()
+	typ := urn.Type()
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return fmt.Errorf("generate UUID: %w", err)
+	}
+	id := resource.ID(uuid.String())
+
+	_, err = pc.provider.Configure(ctx, plugin.ConfigureRequest{
+		URN:    &urn,
+		Name:   &name,
+		Type:   &typ,
+		ID:     &id,
+		Inputs: config,
+	})
+	if err != nil {
+		return fmt.Errorf("configure provider: %w", err)
+	}
+
+	return nil
+}
+
+// requireYesIfNonInteractive returns ErrNonInteractiveRequiresYes when the user is not on a TTY (so a y/n prompt
+// could never succeed) and --yes was not supplied. Dry-run is exempt since nothing destructive happens.
+func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
+	if yes || pc.dryrun {
+		return nil
+	}
+	if !cmdutil.Interactive() {
+		return backenderr.ErrNonInteractiveRequiresYes
+	}
+	return nil
+}
+
+// confirm prints summary to stderr (so it doesn't contaminate the JSON result on stdout) and, unless yes (or
+// --dry-run) was supplied, prompts the user for y/n. Returns nil to proceed, or an error when the user declines.
+// requireYesIfNonInteractive should have been called earlier; if somehow we reach here non-interactively without
+// --yes, we treat that as a decline.
+func (pc *packageCommand) confirm(cmd *cobra.Command, summary string, yes bool) error {
+	stderr := cmd.ErrOrStderr()
+	fmt.Fprint(stderr, summary)
+	if !strings.HasSuffix(summary, "\n") {
+		fmt.Fprintln(stderr)
+	}
+	if yes || pc.dryrun {
+		return nil
+	}
+	if !cmdutil.Interactive() {
+		return backenderr.ErrNonInteractiveRequiresYes
+	}
+	fmt.Fprint(stderr, "Proceed? [y/N]: ")
+	reader := bufio.NewReader(cmd.InOrStdin())
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("read confirmation: %w", err)
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return errors.New("confirmation declined")
+	}
+}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -15,10 +15,8 @@
 package do
 
 import (
-	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -29,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -40,6 +39,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
@@ -414,8 +414,9 @@ func (pc *packageCommand) configureProvider(ctx context.Context) error {
 	return nil
 }
 
-// requireYesIfNonInteractive returns ErrNonInteractiveRequiresYes when the user is not on a TTY (so a y/n prompt
-// could never succeed) and --yes was not supplied. Dry-run is exempt since nothing destructive happens.
+// requireYesIfNonInteractive returns ErrNonInteractiveRequiresYes when the user is not on a TTY (so a confirmation
+// prompt could never succeed) and --yes was not supplied. Dry-run is exempt since nothing destructive happens.
+// This is the same pattern stack rm / package delete / config env init use.
 func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
 	if yes || pc.dryrun {
 		return nil
@@ -426,11 +427,12 @@ func (pc *packageCommand) requireYesIfNonInteractive(yes bool) error {
 	return nil
 }
 
-// confirm prints summary to stderr (so it doesn't contaminate the JSON result on stdout) and, unless yes (or
-// --dry-run) was supplied, prompts the user for y/n. Returns nil to proceed, or an error when the user declines.
-// requireYesIfNonInteractive should have been called earlier; if somehow we reach here non-interactively without
-// --yes, we treat that as a decline.
-func (pc *packageCommand) confirm(cmd *cobra.Command, summary string, yes bool) error {
+// confirm prints summary and asks the user to type confirmName to proceed. The summary and prompt go to stderr so
+// that stdout stays a clean JSON channel for piping. Returns nil to proceed; a bail error (suppressed by the
+// outer CLI) when the user declines. requireYesIfNonInteractive should have been called earlier; if we somehow
+// reach here non-interactively without --yes we treat it as a decline. Uses ui.ConfirmPrompt for the prompt
+// itself so the look and feel matches stack rm and friends.
+func (pc *packageCommand) confirm(cmd *cobra.Command, summary, confirmName string, yes bool) error {
 	stderr := cmd.ErrOrStderr()
 	fmt.Fprint(stderr, summary)
 	if !strings.HasSuffix(summary, "\n") {
@@ -442,16 +444,13 @@ func (pc *packageCommand) confirm(cmd *cobra.Command, summary string, yes bool) 
 	if !cmdutil.Interactive() {
 		return backenderr.ErrNonInteractiveRequiresYes
 	}
-	fmt.Fprint(stderr, "Proceed? [y/N]: ")
-	reader := bufio.NewReader(cmd.InOrStdin())
-	line, err := reader.ReadString('\n')
-	if err != nil && err != io.EOF {
-		return fmt.Errorf("read confirmation: %w", err)
+	opts := display.Options{
+		Color:  cmdutil.GetGlobalColorization(),
+		Stdin:  cmd.InOrStdin(),
+		Stdout: stderr,
 	}
-	switch strings.ToLower(strings.TrimSpace(line)) {
-	case "y", "yes":
-		return nil
-	default:
-		return errors.New("confirmation declined")
+	if !ui.ConfirmPrompt("", confirmName, opts) {
+		return result.FprintBailf(stderr, "confirmation declined")
 	}
+	return nil
 }

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -456,3 +456,172 @@ Use "do pkg mod1/mod2 [command] --help" for more information about a command.
 	require.NoError(t, err)
 	assert.Equal(t, expectedNestedModuleHelp, stdout.String())
 }
+
+func TestDoCmdUnknownSubcommandSuggests(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "aws", source)
+		spec := schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:s3:Bucket":   {},
+				"aws:index:Stack": {},
+			},
+			Functions: map[string]schema.FunctionSpec{
+				"aws:s3:getBucket": {},
+			},
+		}
+		return &testProvider{spec: spec}, nil
+	}
+
+	table := []struct {
+		name           string
+		args           []string
+		wantMsg        string
+		wantSuggestion string
+		noSuggestion   bool
+	}{
+		{
+			name:           "module subcommand wrong case",
+			args:           []string{"aws", "s3", "bucket"},
+			wantMsg:        `unknown command "bucket" for "do aws s3"`,
+			wantSuggestion: "Bucket",
+		},
+		{
+			name:           "module subcommand typo",
+			args:           []string{"aws", "s3", "Buckt"},
+			wantMsg:        `unknown command "Buckt" for "do aws s3"`,
+			wantSuggestion: "Bucket",
+		},
+		{
+			name:         "module subcommand no close match",
+			args:         []string{"aws", "s3", "nothinglikethis"},
+			wantMsg:      `unknown command "nothinglikethis" for "do aws s3"`,
+			noSuggestion: true,
+		},
+		{
+			name:           "package subcommand wrong case",
+			args:           []string{"aws", "stack"},
+			wantMsg:        `unknown command "stack" for "do aws"`,
+			wantSuggestion: "Stack",
+		},
+		{
+			name:           "resource subcommand typo",
+			args:           []string{"aws", "s3", "Bucket", "creat"},
+			wantMsg:        `unknown command "creat" for "do aws s3 Bucket"`,
+			wantSuggestion: "create",
+		},
+		{
+			name:           "function name wrong case",
+			args:           []string{"aws", "s3", "getbucket"},
+			wantMsg:        `unknown command "getbucket" for "do aws s3"`,
+			wantSuggestion: "getBucket",
+		},
+		{
+			name:           "typo'd subcommand followed by leaf flag",
+			args:           []string{"aws", "s3", "getbucket", "--input-file", "./inputs.pcl"},
+			wantMsg:        `unknown command "getbucket" for "do aws s3"`,
+			wantSuggestion: "getBucket",
+		},
+	}
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+			if tc.noSuggestion {
+				assert.NotContains(t, err.Error(), "Did you mean")
+			} else {
+				assert.Contains(t, err.Error(), "Did you mean this?")
+				assert.Contains(t, err.Error(), tc.wantSuggestion)
+			}
+		})
+	}
+}
+
+// TestDoCmdLeafFlagValidationStrict validates that container commands (package, module, resource) tolerate unknown
+// flags so that typo'd subcommand names produce a "did you mean" hint instead of a confusing "unknown flag" error. Leaf
+// commands (functions, create/read/patch/delete/list) must still strictly reject unknown flags.
+func TestDoCmdLeafFlagValidationStrict(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "aws", source)
+		spec := schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:s3:Bucket": {},
+			},
+			Functions: map[string]schema.FunctionSpec{
+				"aws:s3:getBucket": {},
+			},
+		}
+		return &testProvider{spec: spec}, nil
+	}
+
+	table := []struct {
+		name        string
+		args        []string
+		wantUnknown bool
+	}{
+		{
+			name:        "function leaf unknown flag",
+			args:        []string{"aws", "s3", "getBucket", "--input-files", "/file"},
+			wantUnknown: true,
+		},
+		{
+			name:        "function leaf valid flag",
+			args:        []string{"aws", "s3", "getBucket", "--input-file", "/file"},
+			wantUnknown: false,
+		},
+		{
+			name:        "resource verb leaf unknown flag",
+			args:        []string{"aws", "s3", "Bucket", "read", "abc", "--no-such-flag"},
+			wantUnknown: true,
+		},
+		{
+			name:        "resource verb leaf valid args",
+			args:        []string{"aws", "s3", "Bucket", "read", "abc"},
+			wantUnknown: false,
+		},
+	}
+
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout, stderr bytes.Buffer
+			cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if tc.wantUnknown {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown flag")
+			} else {
+				// We don't care whether the command succeeds or fails downstream (the MockProvider
+				// returns "not implemented" for Read/Invoke); we just need to prove that the flag
+				// itself parsed cleanly and didn't trip the strict leaf parser.
+				if err != nil {
+					assert.NotContains(t, err.Error(), "unknown flag")
+				}
+			}
+		})
+	}
+}

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -286,6 +286,39 @@ func BindResource(
 	return args, inputType, diagnostics
 }
 
+// BindResourceList binds a PCL file as a resource list input and returns the bound arguments. This is used for `do` to
+// type check and evaluate resource list inputs.
+func BindResourceList(
+	file *syntax.File, res *schema.Resource,
+	opts ...BindOption,
+) ([]*model.Attribute, model.Type, hcl.Diagnostics) {
+	b, args, inputRanges, diagnostics := bindInputFile(file, opts...)
+
+	if res.ListInputs == nil {
+		diagnostics = append(diagnostics, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("resource %s does not support list", res.Token),
+		})
+		return nil, nil, diagnostics
+	}
+
+	inputs := make(map[string]model.Expression, len(args))
+	for _, item := range args {
+		inputs[item.Name] = item.Value
+	}
+	inputProperties := b.resolveInputUnions(inputs, res.ListInputs.Properties)
+	inputType := b.schemaTypeToType(&schema.ObjectType{Properties: inputProperties})
+
+	diagnostics = append(diagnostics,
+		typecheckObjectArgs(inputType, file.Body.Range().Ptr(), args, inputRanges)...)
+
+	if diagnostics.HasErrors() {
+		return nil, nil, diagnostics
+	}
+
+	return args, inputType, diagnostics
+}
+
 func typecheckObjectArgs(
 	inputType model.Type,
 	rng *hcl.Range,

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1303,6 +1303,32 @@ Resources
 		"stdout did not start with expected help prefix.\nExpected:\n%s\nActual:\n%s", expectedPrefix, stdout)
 }
 
+// Test that `pulumi do` can invoke a real provider resource end-to-end. We use the command provider's local:Command
+// resource because it's small, well-behaved, and exercises both an input file and a structured JSON output.
+func TestDoCommandLocalCommand(t *testing.T) {
+	t.Parallel()
+
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	// Allow auto-acquiring the command plugin.
+	e.Env = append(e.Env, "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=false")
+
+	e.WriteTestFile("inputs.pcl", "create = \"echo hello\"\n")
+
+	stdout, stderr := e.RunCommand(
+		"pulumi", "do", "command", "local", "Command", "create",
+		"--input-file", "inputs.pcl", "--yes")
+
+	// Guard against the dynamic-subcommand re-execute racing with the root command's update-check goroutine and
+	// producing a "send on closed channel" panic. The panic is intermittent so it doesn't always reproduce, but
+	// when it happens the test should fail loudly.
+	assert.NotContains(t, stderr, "panic:", "pulumi do should not panic; stderr:\n%s", stderr)
+
+	assert.Truef(t, strings.HasPrefix(stdout, "hello\n"),
+		"stdout did not start with hello\nActual:\n%s", stdout)
+}
+
 // Sanity test that we can `pulumi new -y` and then do some basic operations like stack selection and config.
 func TestPulumiNewEmptyOperations(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When running an unknown command, for example a misspelled resource, we were printing the command’s help.

We can do a little better and clearly flag the error and suggest a close match.

Before:
```
# should be captialized `Bucket`, not `bucket`
$ pulumi do aws s3 bucket read website-content-d6d1f5d
Functions and resources for the s3 module.

Run 'pulumi do aws s3 <resource/function> --help' for more details on usage.

Usage:
  pulumi do aws s3 [command]

...
```

After:
```
$ pulumi do aws s3 bucket read website-content-d6d1f5d
error: unknown command "bucket" for "pulumi do aws s3"

Did you mean this?
	Bucket
	BucketAbac
	BucketAccelerateConfiguration
	BucketAccelerateConfigurationV2
...
```

Also don’t show the `flags` usage bit  for container commands. They don’t do anything by themselves, but since the way we build our dynamic command tree they are technically runnable.
