### PR TITLE
Support `...` in PCL

### DIFF
--- a/changelog/pending/20260521--pcl--dont-silently-ignore-in-function-arguments.yaml
+++ b/changelog/pending/20260521--pcl--dont-silently-ignore-in-function-arguments.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: pcl
+  description: Don't silently ignore `...` in function arguments

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -203,6 +203,45 @@ func getOperationSignature(op *hclsyntax.Operation) StaticFunctionSignature {
 	return sig
 }
 
+// expandFinalArg returns args with the final argument expanded into one synthetic Expression per
+// element type when expandFinal is true and the final argument's type is a tuple, list, or set.
+// The synthetic expressions only carry the element type and the source range of the expanding
+// argument; they are intended for use during signature resolution and typechecking. If the final
+// argument's type cannot be expanded (e.g. dynamic), the original args are returned unchanged.
+func expandFinalArg(args []Expression, expandFinal bool) []Expression {
+	if !expandFinal || len(args) == 0 {
+		return args
+	}
+
+	last := args[len(args)-1]
+	rng := last.SyntaxNode().Range()
+	expanded := make([]Expression, 0, len(args))
+	expanded = append(expanded, args[:len(args)-1]...)
+
+	switch t := ResolveOutputs(last.Type()).(type) {
+	case *TupleType:
+		for _, et := range t.ElementTypes {
+			expanded = append(expanded, &LiteralValueExpression{
+				Syntax:   &hclsyntax.LiteralValueExpr{SrcRange: rng},
+				exprType: et,
+			})
+		}
+	case *ListType:
+		expanded = append(expanded, &LiteralValueExpression{
+			Syntax:   &hclsyntax.LiteralValueExpr{SrcRange: rng},
+			exprType: t.ElementType,
+		})
+	case *SetType:
+		expanded = append(expanded, &LiteralValueExpression{
+			Syntax:   &hclsyntax.LiteralValueExpr{SrcRange: rng},
+			exprType: t.ElementType,
+		})
+	default:
+		return args
+	}
+	return expanded
+}
+
 // typecheckArgs typechecks the arguments against a given function signature.
 func typecheckArgs(srcRange hcl.Range, signature StaticFunctionSignature, args ...Expression) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
@@ -430,20 +469,24 @@ func (b *expressionBinder) bindFunctionCallExpression(
 				VarargsParameter: &Parameter{Name: "args", Type: DynamicType},
 				ReturnType:       DynamicType,
 			},
-			Args: args,
+			Args:        args,
+			ExpandFinal: syntax.ExpandFinal,
 		}, diagnostics
 	}
 
-	// Compute the function's signature.
-	signature, sigDiags := function.GetSignature(args)
+	// Compute the function's signature. If the call uses `...` to expand its final argument, resolve
+	// the signature against the per-element types of the expanded collection so that signatures
+	// derived from argument types match the call's effective arity.
+	signature, sigDiags := function.GetSignature(expandFinalArg(args, syntax.ExpandFinal))
 	diagnostics = append(diagnostics, sigDiags...)
 
 	expr := &FunctionCallExpression{
-		Syntax:    syntax,
-		Tokens:    tokens,
-		Name:      syntax.Name,
-		Signature: signature,
-		Args:      args,
+		Syntax:      syntax,
+		Tokens:      tokens,
+		Name:        syntax.Name,
+		Signature:   signature,
+		Args:        args,
+		ExpandFinal: syntax.ExpandFinal,
 	}
 	typecheckDiags := expr.Typecheck(false)
 	diagnostics = append(diagnostics, typecheckDiags...)

--- a/pkg/codegen/hcl2/model/binder_expression_test.go
+++ b/pkg/codegen/hcl2/model/binder_expression_test.go
@@ -307,6 +307,118 @@ func TestBindFunctionCall(t *testing.T) {
 	}
 }
 
+func TestBindFunctionCallExpandFinal(t *testing.T) {
+	t.Parallel()
+
+	// `fSL` takes a string and a list(int): list is intentionally not implicitly convertible from
+	// a primitive (and vice versa), so element-type mismatches on `...` produce diagnostics.
+	// `fSV` is the varargs variant.
+	env := environment(map[string]any{
+		"fSL": NewFunction(StaticFunctionSignature{
+			Parameters: []Parameter{
+				{Name: "foo", Type: StringType},
+				{Name: "bar", Type: NewListType(IntType)},
+			},
+			ReturnType: BoolType,
+		}),
+		"fSV": NewFunction(StaticFunctionSignature{
+			Parameters: []Parameter{
+				{Name: "foo", Type: StringType},
+			},
+			VarargsParameter: &Parameter{
+				Name: "bar", Type: NewListType(IntType),
+			},
+			ReturnType: BoolType,
+		}),
+		"listOfListOfInt":   NewListType(NewListType(IntType)),
+		"setOfListOfInt":    NewSetType(NewListType(IntType)),
+		"stringAndListInt":  NewTupleType(StringType, NewListType(IntType)),
+		"stringAndListInts": NewTupleType(StringType, NewListType(IntType), NewListType(IntType)),
+		"listOfStrings":     NewListType(StringType),
+		"stringAndString":   NewTupleType(StringType, StringType),
+		"emptyTuple":        NewTupleType(),
+	})
+	scope := env.scope()
+
+	t.Run("valid expansions", func(t *testing.T) {
+		t.Parallel()
+		cases := []exprTestCase{
+			// Expand a list(list(int)) into the varargs parameter of fSV.
+			{x: `fSV("foo", listOfListOfInt...)`, t: BoolType},
+			// Expand a set(list(int)) into the varargs parameter of fSV.
+			{x: `fSV("foo", setOfListOfInt...)`, t: BoolType},
+			// Expand a tuple whose element types line up with fSL's positional parameters.
+			{x: `fSL(stringAndListInt...)`, t: BoolType},
+			// Expand a tuple whose element types line up with fSV's positional + varargs.
+			{x: `fSV(stringAndListInts...)`, t: BoolType},
+		}
+		for _, c := range cases {
+			t.Run(c.x, func(t *testing.T) {
+				t.Parallel()
+				expr, diags := BindExpressionText(c.x, scope, hcl.Pos{})
+				require.Len(t, diags, 0)
+				assertConvertibleFrom(t, c.t, expr.Type())
+				call, ok := expr.(*FunctionCallExpression)
+				require.True(t, ok)
+				assert.True(t, call.ExpandFinal, "expected ExpandFinal to be set on the bound expression")
+			})
+		}
+	})
+
+	t.Run("type mismatches", func(t *testing.T) {
+		t.Parallel()
+		// The summary "cannot assign expression of type %s to location of type %s: " uses the
+		// InputType wrapper for the destination, which lifts list(int) into the verbose union form.
+		elementMismatch := "cannot assign expression of type string to location of type " +
+			"list(int | output(int)) | output(list(int)): "
+		cases := []struct {
+			x         string
+			summaries []string
+		}{
+			// Expanding a list(string) into fSL's list(int) parameter should report that the
+			// element type string is not convertible to list(int).
+			{
+				x:         `fSL("foo", listOfStrings...)`,
+				summaries: []string{elementMismatch},
+			},
+			// Expanding a list(string) where fSV's varargs parameter expects list(int).
+			{
+				x:         `fSV("foo", listOfStrings...)`,
+				summaries: []string{elementMismatch},
+			},
+			// Expanding a tuple(string, string) into fSL(string, list(int)): second element wrong.
+			{
+				x:         `fSL(stringAndString...)`,
+				summaries: []string{elementMismatch},
+			},
+			// Expanding an empty tuple omits both required positional parameters.
+			{
+				x: `fSL(emptyTuple...)`,
+				summaries: []string{
+					"missing required parameter 'foo'",
+					"missing required parameter 'bar'",
+				},
+			},
+			// Expanding a tuple with more elements than fSL accepts (and no varargs).
+			{
+				x:         `fSL(stringAndListInts...)`,
+				summaries: []string{"too many arguments to call: expected 2, got 3"},
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.x, func(t *testing.T) {
+				t.Parallel()
+				_, diags := BindExpressionText(c.x, scope, hcl.Pos{})
+				summaries := make([]string, len(diags))
+				for i, d := range diags {
+					summaries[i] = d.Summary
+				}
+				assert.Equal(t, c.summaries, summaries)
+			})
+		}
+	})
+}
+
 func TestBindIndex(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1057,14 +1057,18 @@ func (x *FunctionCallExpression) Typecheck(typecheckOperands bool) hcl.Diagnosti
 		rng = x.Syntax.Range()
 	}
 
+	// When the call uses `...` to expand its final argument, typecheck and lift detection operate on
+	// the per-element types of the expanded collection rather than the collection itself.
+	effectiveArgs := expandFinalArg(x.Args, x.ExpandFinal)
+
 	// Typecheck the function's arguments.
-	typecheckDiags := typecheckArgs(rng, x.Signature, x.Args...)
+	typecheckDiags := typecheckArgs(rng, x.Signature, effectiveArgs...)
 	diagnostics = append(diagnostics, typecheckDiags...)
 
 	// If any of the inputs are Output<T> but the function only expects T then we need to lift the function into output
 	// space.
 	lift := false
-	for i, arg := range x.Args {
+	for i, arg := range effectiveArgs {
 		var param Parameter
 		if i >= len(x.Signature.Parameters) {
 			if x.Signature.VarargsParameter == nil {
@@ -1084,7 +1088,7 @@ func (x *FunctionCallExpression) Typecheck(typecheckOperands bool) hcl.Diagnosti
 	}
 
 	if lift {
-		x.Signature.ReturnType = liftOperationType(x.Signature.ReturnType, x.Args...)
+		x.Signature.ReturnType = liftOperationType(x.Signature.ReturnType, effectiveArgs...)
 	}
 
 	return diagnostics

--- a/pkg/testing/pulumi-test-language/tests/l1_expand_final.go
+++ b/pkg/testing/pulumi-test-language/tests/l1_expand_final.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	LanguageTests["l1-expand-final"] = LanguageTest{
+		Runs: []TestRun{
+			{
+				Assert: func(l *L, res AssertArgs) {
+					require.NoError(l, res.Err)
+					stack := RequireSingleResource(l, res.Snap.Resources, "pulumi:pulumi:Stack")
+					assert.Equal(l, resource.PropertyMap{
+						"expandedMax": resource.NewProperty(3.0),
+					}, stack.Outputs)
+				},
+			},
+		},
+	}
+}

--- a/pkg/testing/pulumi-test-language/tests/testdata/l1-expand-final/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l1-expand-final/main.pp
@@ -1,0 +1,3 @@
+output "expandedMax" {
+  value = max([1, 2, 3]...)
+}

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -102,6 +102,7 @@ var expectedFailures = map[string]string{
 	"l1-config-types-object":        "fails to compile",
 	"l1-config-types-optional":      "fails to compile: cfg.GetObject signature mismatch (same as l1-config-types-object)", //nolint:lll
 	"l1-builtin-try":                "pulumi#18506 Support try in Go program generation",
+	"l1-expand-final":               "Go program generation does not support `...` argument expansion",
 	"l1-builtin-can":                "pulumi#18570 Support can in Go program generation",
 	"l1-builtin-list":               "list(string) config decoded as string; element/split emit TODO stubs",
 	"l1-builtin-object":             "entries/lookup emit TODO stubs",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -98,6 +98,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
+	"l1-expand-final":                    "Node.js program generation does not support `...` argument expansion",
 	"l3-deferred-outputs":                "Cannot find name '_arg0_'.",
 	"l3-range-ref":                       "Property 'k1' does not exist on type 'Target[]'",
 	"l3-component-primitive-conversions": "primitive conversions accepted by PCL bind, but not lowered correctly by SDK generators", //nolint:lll

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-expand-final/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-expand-final
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-expand-final/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l1-expand-final/main.pp
@@ -1,0 +1,3 @@
+output "expandedMax" {
+  value = max([1, 2, 3]...)
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-expand-final/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-expand-final
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-expand-final/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l1-expand-final/main.pp
@@ -1,0 +1,3 @@
+output "expandedMax" {
+  value = max([1, 2, 3]...)
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-expand-final/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-expand-final/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l1-expand-final
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-expand-final/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l1-expand-final/main.pp
@@ -1,0 +1,3 @@
+output "expandedMax" {
+  value = max([1, 2, 3]...)
+}

--- a/sdk/python/cmd/pulumi-language-python/language_test.go
+++ b/sdk/python/cmd/pulumi-language-python/language_test.go
@@ -102,6 +102,7 @@ func runTestingHost(t *testing.T) (string, testingrpc.LanguageTestClient) {
 // Add test names here that are expected to fail and the reason why they are failing
 var expectedFailures = map[string]string{
 	"l1-builtin-try":                     "Temporarily disabled until pr #18915 is submitted",
+	"l1-expand-final":                    "Python program generation does not support `...` argument expansion",
 	"l1-builtin-can":                     "Temporarily disabled until pr #18916 is submitted",
 	"l3-deferred-outputs":                "does not type-check",
 	"l3-range-ref":                       `Item "None" of "Target | None" has no attribute "name"  [union-attr]`,


### PR DESCRIPTION
This feature is supported in Terraform and many of our target languages. Target languages that don't support variadic arguments will need to figure out how to implement `...`.