### PR TITLE
Give a better error message if snippet conversion isn't supported

### DIFF
--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2222,6 +2222,65 @@ func TestDoCmdFunctionInvokeWithUnknownInputFormat(t *testing.T) {
 	assert.ErrorContains(t, err, "converter not found")
 }
 
+// TestDoCmdFunctionInvokeWithConverterMissingConvertSnippet verifies that a converter plugin that exists but does not
+// implement ConvertSnippet produces a targeted error instead of leaking the raw RPC error.
+func TestDoCmdFunctionInvokeWithConverterMissingConvertSnippet(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	host := func() (plugin.Host, error) {
+		return &plugin.MockHost{LoaderAddrF: func() string { return "loader-address" }}, nil
+	}
+	loadConverter := func(
+		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
+	) (plugin.Converter, error) {
+		assert.Equal(t, "yaml", name)
+		return &plugin.MockConverter{}, nil
+	}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"x": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"y": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					require.Fail(t, "Invoke should not be called when the converter cannot convert snippets")
+					return plugin.InvokeResponse{}, nil
+				},
+			},
+		}, nil
+	}
+
+	inputFile := writeHCLFile(t, "inputs.yaml", "x: hello")
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, host, loadConverter)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"azure", "myFunction", "--input", "yaml", "--input-file", inputFile})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "yaml input converter does not support snippet conversion; "+
+		"use pcl format or try installing a newer yaml converter")
+	assert.NotContains(t, err.Error(), "ConvertSnippet not implemented")
+}
+
 // TestDoCmdFunctionInvokeWithConverterDiagnostics asserts that diagnostic-level errors from ConvertSnippet are
 // surfaced and that Invoke is never called.
 func TestDoCmdFunctionInvokeWithConverterDiagnostics(t *testing.T) {

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2273,7 +2273,7 @@ func TestDoCmdFunctionInvokeWithConverterMissingConvertSnippet(t *testing.T) {
 	cmd := NewDoCmd(mlm, mws, loader, host, loadConverter)
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stdout)
-	cmd.SetArgs([]string{"azure", "myFunction", "--input", "yaml", "--input-file", inputFile})
+	cmd.SetArgs([]string{"azure:myFunction", "--input", "yaml", "--input-file", inputFile})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "yaml input converter does not support snippet conversion; "+

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -325,6 +327,11 @@ func evaluateFile(
 		Token:        token,
 	})
 	if err != nil {
+		if status.Code(err) == codes.Unimplemented {
+			return nil, fmt.Errorf(
+				"%s %s converter does not support snippet conversion; use pcl format or try installing a newer %s converter",
+				inputFormat, fileType, inputFormat)
+		}
 		return nil, fmt.Errorf("generate PCL from %s file: %w", fileType, err)
 	}
 	if resp.Diagnostics.HasErrors() {

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -356,7 +358,7 @@ func (m *MockConverter) ConvertState(ctx context.Context, req *ConvertStateReque
 	if m.ConvertStateF != nil {
 		return m.ConvertStateF(ctx, req)
 	}
-	return nil, errors.New("ConvertState not implemented")
+	return nil, status.Error(codes.Unimplemented, "ConvertState not implemented")
 }
 
 func (m *MockConverter) ConvertProgram(
@@ -365,7 +367,7 @@ func (m *MockConverter) ConvertProgram(
 	if m.ConvertProgramF != nil {
 		return m.ConvertProgramF(ctx, req)
 	}
-	return nil, errors.New("ConvertProgram not implemented")
+	return nil, status.Error(codes.Unimplemented, "ConvertProgram not implemented")
 }
 
 func (m *MockConverter) ConvertSnippet(
@@ -374,5 +376,5 @@ func (m *MockConverter) ConvertSnippet(
 	if m.ConvertSnippetF != nil {
 		return m.ConvertSnippetF(ctx, req)
 	}
-	return nil, errors.New("ConvertSnippet not implemented")
+	return nil, status.Error(codes.Unimplemented, "ConvertSnippet not implemented")
 }


### PR DESCRIPTION
As it says on the tin. Detected `NotImplemented` and tell the user to try updating the converter or using pcl.