### PR TITLE
Reserve 'input' as a package name

### DIFF
--- a/changelog/pending/20260522--sdkgen--reserve-the-package-names-pulumi-and-input-for-internal-use.yaml
+++ b/changelog/pending/20260522--sdkgen--reserve-the-package-names-pulumi-and-input-for-internal-use.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: sdkgen
+  description: Reserve the package names 'pulumi' and 'input' for internal use

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -170,6 +170,13 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 
 	diags = diags.Extend(spec.validateTypeTokens())
 
+	// Disallow the package names "pulumi" and "input". "pulumi" is reserved for the builtin package and provider
+	// resources, and "input" is reserved for `pulumi do` to use as a discriminator for input flags.
+	if (!options.AllowPulumiPackage && spec.Name == "pulumi") || spec.Name == "input" {
+		diags = diags.Append(errorf("#/name",
+			"invalid package name '%s' (package names 'pulumi' and 'input' are reserved)", spec.Name))
+	}
+
 	config, configDiags, err := bindConfig(spec.Config, types, options)
 	diags = diags.Extend(configDiags)
 	if err != nil {
@@ -336,6 +343,8 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 
 // Options that affect the validation of the packgae schema.
 type ValidationOptions struct {
+	// Internal flag set to allow the builtin pulumi package to bind.
+	AllowPulumiPackage      bool
 	AllowDanglingReferences bool
 }
 

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -105,6 +105,7 @@ func newPulumiPackage() *Package {
 	}
 
 	pkg, diags, err := bindSpec(spec, nil, nullLoader{}, false, ValidationOptions{
+		AllowPulumiPackage:      true,
 		AllowDanglingReferences: true,
 	})
 	if err == nil && diags.HasErrors() {

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1412,8 +1412,11 @@ func TestMethods(t *testing.T) {
 
 			pkgSpec := readSchemaFile(filepath.Join("schema", tt.filename))
 
+			// provider-methods-3.json declares the builtin "pulumi" package to exercise method binding on
+			// pulumi:providers:pulumi; allow the reserved name for these fixtures.
 			pkg, err := ImportSpec(pkgSpec, nil, ValidationOptions{
 				AllowDanglingReferences: true,
+				AllowPulumiPackage:      true,
 			})
 			if tt.expectedError != "" {
 				assert.ErrorContains(t, err, tt.expectedError)
@@ -3377,5 +3380,39 @@ func TestRequiredObjectCycles(t *testing.T) {
 					"test:index:B -> test:index:B",
 			},
 		}, diags)
+	})
+}
+
+// TestBindSpecReservedPackageNames asserts that the package names "pulumi" and "input" are rejected at bind time.
+// "pulumi" is reserved for the builtin package/provider resources; "input" is reserved for `pulumi do` to use as
+// a flag-vs-token discriminator.
+func TestBindSpecReservedPackageNames(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"pulumi", "input"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, diags, err := BindSpec(PackageSpec{Name: name}, nil, ValidationOptions{})
+			require.NoError(t, err)
+			require.True(t, diags.HasErrors(), "expected errors for reserved name %q, got %v", name, diags)
+			found := false
+			for _, d := range diags {
+				if d.Severity == hcl.DiagError &&
+					strings.Contains(d.Summary, "invalid package name '"+name+"'") {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected a reserved-name diagnostic for %q, got %v", name, diags)
+		})
+	}
+
+	// Sanity-check: any other name binds without that specific diagnostic.
+	t.Run("non-reserved", func(t *testing.T) {
+		t.Parallel()
+		_, diags, _ := BindSpec(PackageSpec{Name: "aws"}, nil, ValidationOptions{})
+		for _, d := range diags {
+			assert.NotContains(t, d.Summary, "package names 'pulumi' and 'input' are reserved")
+		}
 	})
 }


### PR DESCRIPTION
`pulumi do` makes use of `--input:X Y` as a fallback for when X would clash with other flags. It also uses this form for provider config, as such we can't support a provider package also called 'input'. 

This adds validation to schema binding to disallow that, so no one should ever make a package called 'input' and hit this corner case. While at it, also don't allow anyone to make a 'pulumi' package.