### PR TITLE
Use --input for fun/res and provider format

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -334,7 +334,7 @@ installed locally.
 Provider configuration can be supplied via:
   - the provider's standard environment variables (e.g. AWS_REGION)
   - an input file passed with --provider-file (PCL by default;
-    set --provider-format to convert from another format)
+    set --input to convert from another format)
 
 Function inputs come from --input-file. PCL is the default; pass --input
 to convert from another format such as YAML. Non-PCL formats require a
@@ -399,7 +399,7 @@ type packageCommand struct {
 	packageDescriptor *codegenrpc.GetSchemaRequest
 	provider          plugin.Provider
 	providerFile      string
-	providerFormat    string
+	format            string
 	spec              *schema.Package
 	dryrun            bool
 	showSecrets       bool

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -88,7 +88,6 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 	}
 
 	var inputFile string
-	var inputFormat string
 
 	cmd := &cobra.Command{
 		Use:   name,
@@ -103,7 +102,7 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 			}
 
 			inputs, err := evaluateFunctionFile(
-				ctx, inputFile, "input", inputFormat, fn, pc.evalContext,
+				ctx, inputFile, "input", pc.format, fn, pc.evalContext,
 				pc.converter, pc.loaderTarget, pc.packageDescriptor)
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
@@ -143,12 +142,11 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 		},
 	}
 
-	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing function inputs")
 	cmd.Flags().StringVar(&pc.providerFile, "provider-file", "",
 		"Path to a file containing provider configuration")
-	cmd.Flags().StringVar(&pc.providerFormat, "provider-format", "pcl",
-		"Format of the provider configuration file")
+	cmd.Flags().StringVar(&pc.format, "input", "pcl",
+		"Format of the configuration files")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -129,14 +129,13 @@ Usage:
   myOtherFunction [flags]
 
 Flags:
-      --dry-run                  Run the operation in preview mode
-  -h, --help                     help for do
-      --input string             Input file format (default "pcl")
-      --input-file string        Path to a file containing function inputs
-      --package string           The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
-      --provider-file string     Path to a file containing provider configuration
-      --provider-format string   Format of the provider configuration file (default "pcl")
-      --show-secrets             Show secret values in output
+      --dry-run                Run the operation in preview mode
+  -h, --help                   help for do
+      --input string           Format of the configuration files (default "pcl")
+      --input-file string      Path to a file containing function inputs
+      --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
+      --provider-file string   Path to a file containing provider configuration
+      --show-secrets           Show secret values in output
 `
 	assert.Equal(t, expected, stdout.String())
 }
@@ -2075,7 +2074,7 @@ func TestDoCmdFunctionInvokeParameterizedSchemaWithoutArgs(t *testing.T) {
 	assert.ErrorContains(t, err, "provider returned parameterization but no parameterization args were sent")
 }
 
-// TestDoCmdFunctionInvokeWithYAMLProviderFile exercises the provider-config converter path: --provider-format yaml
+// TestDoCmdFunctionInvokeWithYAMLProviderFile exercises the provider-config converter path: --input yaml
 // + --provider-file p.yaml should run the YAML through the converter, hand the resulting PCL to Configure, and
 // pass the right token (the provider's pulumi:providers:<pkg> token) and the same package descriptor we use for
 // function inputs.
@@ -2158,7 +2157,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
-		"--provider-file", providerFile, "--provider-format", "yaml",
+		"--provider-file", providerFile, "--input", "yaml",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -102,7 +102,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 	// Provider configuration applies to all sub-operations, so register here as persistent flags.
 	cmd.PersistentFlags().StringVar(&pc.providerFile, "provider-file", "",
 		"Path to a file containing provider configuration")
-	cmd.PersistentFlags().StringVar(&pc.providerFormat, "provider-format", "pcl",
+	cmd.PersistentFlags().StringVar(&pc.format, "input", "pcl",
 		"Format of the provider configuration file")
 	cmd.AddCommand(pc.newResourceCreateCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
@@ -116,7 +116,6 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 
 func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.Command {
 	var inputFile string
-	var inputFormat string
 	var yes bool
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -132,7 +131,7 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			}
 			urn := resourceURN(res)
 			inputs, err := evaluateResourceFile(
-				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
+				ctx, inputFile, "input", pc.format, res, pc.evalContext,
 				pc.converter, pc.loaderTarget, pc.packageDescriptor)
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
@@ -165,7 +164,6 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 			return pc.printResourceResult(cmd, response.ID, response.Properties, res)
 		},
 	}
-	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
@@ -292,7 +290,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			return pc.printResourceResult(cmd, id, response.Properties, res)
 		},
 	}
-	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Input file format")
+	cmd.Flags().StringVar(&inputFormat, "input", "pcl", "Format of the configuration files")
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -131,12 +131,12 @@ Available Commands:
   read        Read a resource
 
 Flags:
-      --dry-run                  Run the operation in preview mode
-  -h, --help                     help for do
-      --package string           The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
-      --provider-file string     Path to a file containing provider configuration
-      --provider-format string   Format of the provider configuration file (default "pcl")
-      --show-secrets             Show secret values in output
+      --dry-run                Run the operation in preview mode
+  -h, --help                   help for do
+      --input string           Format of the provider configuration file (default "pcl")
+      --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
+      --provider-file string   Path to a file containing provider configuration
+      --show-secrets           Show secret values in output
 
 Use "myResource [command] --help" for more information about a command.
 `
@@ -180,12 +180,12 @@ Available Commands:
   read        Read a resource
 
 Flags:
-      --dry-run                  Run the operation in preview mode
-  -h, --help                     help for do
-      --package string           The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
-      --provider-file string     Path to a file containing provider configuration
-      --provider-format string   Format of the provider configuration file (default "pcl")
-      --show-secrets             Show secret values in output
+      --dry-run                Run the operation in preview mode
+  -h, --help                   help for do
+      --input string           Format of the provider configuration file (default "pcl")
+      --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
+      --provider-file string   Path to a file containing provider configuration
+      --show-secrets           Show secret values in output
 
 Use "myResource [command] --help" for more information about a command.
 `

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -385,7 +385,7 @@ func resourceURN(res *schema.Resource) resource.URN {
 
 func (pc *packageCommand) configureProvider(ctx context.Context) error {
 	config, err := evaluateResourceFile(
-		ctx, pc.providerFile, "provider", pc.providerFormat,
+		ctx, pc.providerFile, "provider", pc.format,
 		pc.spec.Provider, pc.evalContext, pc.converter, pc.loaderTarget, pc.packageDescriptor)
 	if err != nil {
 		return fmt.Errorf("parse provider file: %w", err)


### PR DESCRIPTION
There's no need to support separate formats for provider config and resource/function config. Users are going to use the same format for both, so simplify down to just one `--input` flag.