### PR TITLE
Add flags for setting simple properties (string/bool/number)

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -484,23 +484,36 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 	var help strings.Builder
 	if len(modules) > 0 {
 		fmt.Fprintln(&help, "Modules:")
+		moduleNames := make([]string, 0, len(modules))
 		for mod := range modules {
+			moduleNames = append(moduleNames, mod)
+		}
+		slices.Sort(moduleNames)
+		for _, mod := range moduleNames {
 			fmt.Fprintf(&help, "  %s\n", mod)
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(functions) > 0 {
 		fmt.Fprintln(&help, "Functions:")
+		functionNames := make([]string, 0, len(functions))
 		for _, fn := range functions {
-			tok := pc.spec.CanonicalizeToken(fn.Token)
+			functionNames = append(functionNames, pc.spec.CanonicalizeToken(fn.Token))
+		}
+		slices.Sort(functionNames)
+		for _, tok := range functionNames {
 			fmt.Fprintf(&help, "  %s\n", tok)
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(resources) > 0 {
 		fmt.Fprintln(&help, "Resources:")
+		resourceNames := make([]string, 0, len(resources))
 		for _, res := range resources {
-			tok := pc.spec.CanonicalizeToken(res.Token)
+			resourceNames = append(resourceNames, pc.spec.CanonicalizeToken(res.Token))
+		}
+		slices.Sort(resourceNames)
+		for _, tok := range resourceNames {
 			fmt.Fprintf(&help, "  %s\n", tok)
 		}
 		fmt.Fprintln(&help, "")
@@ -573,23 +586,36 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 	var help strings.Builder
 	if len(modules) > 0 {
 		fmt.Fprintln(&help, "Modules:")
+		moduleNames := make([]string, 0, len(modules))
 		for mod := range modules {
+			moduleNames = append(moduleNames, mod)
+		}
+		slices.Sort(moduleNames)
+		for _, mod := range moduleNames {
 			fmt.Fprintf(&help, "  %s\n", mod)
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(functions) > 0 {
 		fmt.Fprintln(&help, "Functions:")
+		functionNames := make([]string, 0, len(functions))
 		for _, fn := range functions {
-			tok := pc.spec.CanonicalizeToken(fn.Token)
+			functionNames = append(functionNames, pc.spec.CanonicalizeToken(fn.Token))
+		}
+		slices.Sort(functionNames)
+		for _, tok := range functionNames {
 			fmt.Fprintf(&help, "  %s\n", tok)
 		}
 		fmt.Fprintln(&help, "")
 	}
 	if len(resources) > 0 {
 		fmt.Fprintln(&help, "Resources:")
+		resourceNames := make([]string, 0, len(resources))
 		for _, res := range resources {
-			tok := pc.spec.CanonicalizeToken(res.Token)
+			resourceNames = append(resourceNames, pc.spec.CanonicalizeToken(res.Token))
+		}
+		slices.Sort(resourceNames)
+		for _, tok := range resourceNames {
 			fmt.Fprintf(&help, "  %s\n", tok)
 		}
 		fmt.Fprintln(&help, "")

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -97,13 +97,18 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 
+			var inputProperties []*schema.Property
+			if fn.Inputs != nil {
+				inputProperties = fn.Inputs.Properties
+			}
 			inputs, err := evaluateFunctionFile(
 				ctx, inputFile, "input", pc.format, fn, pc.evalContext,
-				pc.converter, pc.loaderTarget, pc.packageDescriptor)
+				pc.converter, pc.loaderTarget, pc.packageDescriptor,
+				collectInputFlags(cmd, "input", inputProperties))
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}

--- a/pkg/cmd/pulumi/do/do_function.go
+++ b/pkg/cmd/pulumi/do/do_function.go
@@ -44,7 +44,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 		b.WriteString(title)
 		b.WriteString(":\n")
 		for _, property := range properties {
-			fmt.Fprintf(&b, "  %s (%s", property.Name, schemaTypeString(property.Type))
+			fmt.Fprintf(&b, "  %s (%s", property.Name, unwrapType(property.Type))
 			if includeRequired {
 				if property.IsRequired() {
 					b.WriteString(", required")
@@ -69,7 +69,7 @@ func functionSchemaHelp(fn *schema.Function) string {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
-		fmt.Fprintf(&b, "Outputs:\n  result (%s)\n", schemaTypeString(fn.ReturnType))
+		fmt.Fprintf(&b, "Outputs:\n  result (%s)\n", unwrapType(fn.ReturnType))
 	}
 	return strings.TrimSuffix(b.String(), "\n")
 }
@@ -147,6 +147,11 @@ func (pc *packageCommand) newFunctionCommand(fn *schema.Function) *cobra.Command
 		"Path to a file containing provider configuration")
 	cmd.Flags().StringVar(&pc.format, "input", "pcl",
 		"Format of the configuration files")
+
+	addInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties)
+	if fn.Inputs != nil {
+		addInputFlags(cmd, "input", fn.Inputs.Properties)
+	}
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2355,7 +2355,81 @@ func TestDoCmdFunctionInvokeWithConverterReturningInvalidPCL(t *testing.T) {
 	assert.ErrorContains(t, err, "not_an_input")
 }
 
-func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
+func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
+	t.Parallel()
+
+	configureCalled := false
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Provider: schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"opt1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"opt2": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"in1":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"in2":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"dry-run": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+						},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					configureCalled = true
+					// The converted PCL ("opt1 = \"val1\"") + opt2=val2 should be bound, evaluated, and reach Configure intact.
+					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
+					assert.Equal(t, "val2", req.Inputs["opt2"].StringValue())
+					return plugin.ConfigureResponse{}, nil
+				},
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					assert.Equal(t, "p1", req.Args["in1"].StringValue())
+					assert.Equal(t, "p2", req.Args["in2"].StringValue())
+					assert.Equal(t, true, req.Args["dry-run"].BoolValue())
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	providerFile := writeHCLFile(t, "provider.pcl", "opt1 = \"val1\"\n")
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"azure:index:myFunction",
+		"--provider-file", providerFile,
+		"--azure:opt2", "val2",
+		"--in1", "p1",
+		"--input:in2", "p2",
+		"--input:dry-run",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.True(t, configureCalled, "Configure should be called with the converted provider config")
+}
+
+func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	t.Parallel()
 
 	configureCalled := false
@@ -2387,7 +2461,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
 				assert.Equal(t, "azure", req.Package.Package)
 				return &plugin.ConvertSnippetResponse{
 					Filename: "provider.pp",
-					Source:   []byte(`opt1 = "val1"` + "\n"),
+					Source:   []byte(`opt1 = "val1"` + "\n" + `opt2 = "val2"` + "\n"),
 				}, nil
 			},
 		}, nil
@@ -2404,6 +2478,13 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
 			},
 			Functions: map[string]schema.FunctionSpec{
 				"azure:index:myFunction": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"in1":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"in2":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"dry-run": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+						},
+					},
 					Outputs: &schema.ObjectTypeSpec{
 						Properties: map[string]schema.PropertySpec{
 							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
@@ -2423,6 +2504,9 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					assert.Equal(t, "p1", req.Args["in1"].StringValue())
+					assert.Equal(t, "p2", req.Args["in2"].StringValue())
+					assert.Equal(t, true, req.Args["dry-run"].BoolValue())
 					return plugin.InvokeResponse{
 						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
 					}, nil
@@ -2441,6 +2525,9 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
 		"azure:index:myFunction",
 		"--provider-file", providerFile, "--provider-format", "yaml",
 		"--azure:opt2", "val2",
+		"--in1", "p1",
+		"--input:in2", "p2",
+		"--input:dry-run",
 	})
 	err := cmd.Execute()
 	require.NoError(t, err)

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2354,3 +2354,95 @@ func TestDoCmdFunctionInvokeWithConverterReturningInvalidPCL(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "not_an_input")
 }
+
+func TestDoCmdFunctionInvokeWithYAMLProviderFlags(t *testing.T) {
+	t.Parallel()
+
+	configureCalled := false
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	yamlHost := func() (plugin.Host, error) {
+		return &plugin.MockHost{
+			LoaderAddrF: func() string { return "loader-address" },
+		}, nil
+	}
+	loadConverter := func(
+		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
+	) (plugin.Converter, error) {
+		assert.Equal(t, "yaml", name)
+		return &plugin.MockConverter{
+			ConvertSnippetF: func(ctx context.Context, req *plugin.ConvertSnippetRequest) (
+				*plugin.ConvertSnippetResponse, error,
+			) {
+				assert.Equal(t, "provider.yaml", filepath.Base(req.Filename))
+				assert.Equal(t, "opt1: val1\n", string(req.Source))
+				assert.NotEmpty(t, req.TargetLoader)
+				assert.Equal(t, map[string]string{
+					"opt2": "val2",
+				}, req.Attributes)
+				// The converter should be told this is a provider-config snippet via the provider's resource token,
+				// not the function token.
+				assert.Equal(t, "pulumi:providers:azure", req.Token)
+				require.NotNil(t, req.Package)
+				assert.Equal(t, "azure", req.Package.Package)
+				return &plugin.ConvertSnippetResponse{
+					Filename: "provider.pp",
+					Source:   []byte(`opt1 = "val1"` + "\n"),
+				}, nil
+			},
+		}, nil
+	}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "azure", source)
+		spec := schema.PackageSpec{
+			Name: "azure",
+			Provider: schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"opt1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"opt2": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Functions: map[string]schema.FunctionSpec{
+				"azure:index:myFunction": {
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"output1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
+					configureCalled = true
+					// The converted PCL ("opt1 = \"val1\"") + opt2=val2 should be bound, evaluated, and reach Configure intact.
+					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
+					assert.Equal(t, "val2", req.Inputs["opt2"].StringValue())
+					return plugin.ConfigureResponse{}, nil
+				},
+				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
+					}, nil
+				},
+			},
+		}, nil
+	}
+
+	providerFile := writeHCLFile(t, "provider.yaml", "opt1: val1\n")
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{
+		"azure:index:myFunction",
+		"--provider-file", providerFile, "--provider-format", "yaml",
+		"--azure:opt2", "val2",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.True(t, configureCalled, "Configure should be called with the converted provider config")
+}

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -133,7 +133,9 @@ Flags:
   -h, --help                   help for do
       --input string           Format of the configuration files (default "pcl")
       --input-file string      Path to a file containing function inputs
+      --input:param1 string    To set param1 things
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
+      --param1 string          To set param1 things
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
 `
@@ -2448,21 +2450,43 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 			ConvertSnippetF: func(ctx context.Context, req *plugin.ConvertSnippetRequest) (
 				*plugin.ConvertSnippetResponse, error,
 			) {
-				assert.Equal(t, "provider.yaml", filepath.Base(req.Filename))
-				assert.Equal(t, "opt1: val1\n", string(req.Source))
 				assert.NotEmpty(t, req.TargetLoader)
-				assert.Equal(t, map[string]string{
-					"opt2": "val2",
-				}, req.Attributes)
-				// The converter should be told this is a provider-config snippet via the provider's resource token,
-				// not the function token.
-				assert.Equal(t, "pulumi:providers:azure", req.Token)
-				require.NotNil(t, req.Package)
-				assert.Equal(t, "azure", req.Package.Package)
-				return &plugin.ConvertSnippetResponse{
-					Filename: "provider.pp",
-					Source:   []byte(`opt1 = "val1"` + "\n" + `opt2 = "val2"` + "\n"),
-				}, nil
+				switch filepath.Base(req.Filename) {
+				case "provider.yaml":
+					assert.Equal(t, "opt1: val1\n", string(req.Source))
+					assert.Equal(t, map[string]string{
+						"opt2": "val2",
+					}, req.Attributes)
+					// The converter should be told this is a provider-config snippet via the provider's resource token,
+					// not the function token.
+					assert.Equal(t, "pulumi:providers:azure", req.Token)
+					require.NotNil(t, req.Package)
+					assert.Equal(t, "azure", req.Package.Package)
+					return &plugin.ConvertSnippetResponse{
+						Filename: "provider.pp",
+						Source:   []byte(`opt1 = "val1"` + "\n" + `opt2 = "val2"` + "\n"),
+					}, nil
+				case "inputs.yaml":
+					assert.Equal(t, "in1: file\n", string(req.Source))
+					assert.Equal(t, map[string]string{
+						"dry-run": "true",
+						"in1":     "p1",
+						"in2":     "p2",
+					}, req.Attributes)
+					assert.Equal(t, "azure:index:myFunction", req.Token)
+					require.NotNil(t, req.Package)
+					assert.Equal(t, "azure", req.Package.Package)
+					return &plugin.ConvertSnippetResponse{
+						Filename: "inputs.pp",
+						Source: []byte(
+							`in1 = "p1"` + "\n" +
+								`in2 = "p2"` + "\n" +
+								`dry-run = true` + "\n"),
+					}, nil
+				default:
+					require.Failf(t, "unexpected converter input", "filename: %s", req.Filename)
+					return nil, nil
+				}
 			},
 		}, nil
 	}
@@ -2516,6 +2540,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	}
 
 	providerFile := writeHCLFile(t, "provider.yaml", "opt1: val1\n")
+	inputFile := writeHCLFile(t, "inputs.yaml", "in1: file\n")
 
 	var stdout bytes.Buffer
 	cmd := NewDoCmd(mlm, mws, loader, yamlHost, loadConverter)
@@ -2523,7 +2548,8 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	cmd.SetErr(&stdout)
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
-		"--provider-file", providerFile, "--provider-format", "yaml",
+		"--provider-file", providerFile,
+		"--input-file", inputFile, "--input", "yaml",
 		"--azure:opt2", "val2",
 		"--in1", "p1",
 		"--input:in2", "p2",

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -133,9 +133,8 @@ Flags:
   -h, --help                   help for do
       --input string           Format of the configuration files (default "pcl")
       --input-file string      Path to a file containing function inputs
-      --input:param1 string    To set param1 things
       --package string         The package to load, in the form 'name@version' or a path to a plugin binary or folder. If the package supports parameterization, additional space-separated parameters can be included after the package name, e.g. --package "name@version param1 \"multi word param\""
-      --param1 string          To set param1 things
+      --param1 string          To set param1 things (alias for --input:param1)
       --provider-file string   Path to a file containing provider configuration
       --show-secrets           Show secret values in output
 `

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2464,7 +2464,10 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 					assert.Equal(t, "azure", req.Package.Package)
 					return &plugin.ConvertSnippetResponse{
 						Filename: "provider.pp",
-						Source:   []byte(`opt1 = "val1"` + "\n" + `opt2 = "val2"` + "\n"),
+						Source:   []byte(`opt1 = "val1"` + "\n"),
+						Attributes: map[string]string{
+							"opt2": "\"val2\"",
+						},
 					}, nil
 				case "inputs.yaml":
 					assert.Equal(t, "in1: file\n", string(req.Source))
@@ -2478,10 +2481,12 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 					assert.Equal(t, "azure", req.Package.Package)
 					return &plugin.ConvertSnippetResponse{
 						Filename: "inputs.pp",
-						Source: []byte(
-							`in1 = "p1"` + "\n" +
-								`in2 = "p2"` + "\n" +
-								`dry-run = true` + "\n"),
+						Source:   []byte(`in1 = "file"` + "\n"),
+						Attributes: map[string]string{
+							"in1":     "\"p1\"",
+							"in2":     "\"p2\"",
+							"dry-run": "true",
+						},
 					}, nil
 				default:
 					require.Failf(t, "unexpected converter input", "filename: %s", req.Filename)

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -2369,17 +2369,17 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 			Name: "azure",
 			Provider: schema.ResourceSpec{
 				InputProperties: map[string]schema.PropertySpec{
-					"opt1": {TypeSpec: schema.TypeSpec{Type: "string"}},
-					"opt2": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"opt1":   {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"optTwo": {TypeSpec: schema.TypeSpec{Type: "string"}},
 				},
 			},
 			Functions: map[string]schema.FunctionSpec{
 				"azure:index:myFunction": {
 					Inputs: &schema.ObjectTypeSpec{
 						Properties: map[string]schema.PropertySpec{
-							"in1":     {TypeSpec: schema.TypeSpec{Type: "string"}},
-							"in2":     {TypeSpec: schema.TypeSpec{Type: "string"}},
-							"dry-run": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+							"in1":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"inTwo":  {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"dryRun": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 						},
 					},
 					Outputs: &schema.ObjectTypeSpec{
@@ -2395,15 +2395,15 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
-					// The converted PCL ("opt1 = \"val1\"") + opt2=val2 should be bound, evaluated, and reach Configure intact.
+					// The converted PCL ("opt1 = \"val1\"") + optTwo=val2 should be bound, evaluated, and reach Configure intact.
 					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
-					assert.Equal(t, "val2", req.Inputs["opt2"].StringValue())
+					assert.Equal(t, "val2", req.Inputs["optTwo"].StringValue())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "p1", req.Args["in1"].StringValue())
-					assert.Equal(t, "p2", req.Args["in2"].StringValue())
-					assert.Equal(t, true, req.Args["dry-run"].BoolValue())
+					assert.Equal(t, "p2", req.Args["inTwo"].StringValue())
+					assert.Equal(t, true, req.Args["dryRun"].BoolValue())
 					return plugin.InvokeResponse{
 						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
 					}, nil
@@ -2421,9 +2421,9 @@ func TestDoCmdFunctionInvokeWithFlags(t *testing.T) {
 	cmd.SetArgs([]string{
 		"azure:index:myFunction",
 		"--provider-file", providerFile,
-		"--azure:opt2", "val2",
+		"--azure:opt-two", "val2",
 		"--in1", "p1",
-		"--input:in2", "p2",
+		"--input:in-two", "p2",
 		"--input:dry-run",
 	})
 	err := cmd.Execute()
@@ -2455,7 +2455,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 				case "provider.yaml":
 					assert.Equal(t, "opt1: val1\n", string(req.Source))
 					assert.Equal(t, map[string]string{
-						"opt2": "val2",
+						"optTwo": "val2",
 					}, req.Attributes)
 					// The converter should be told this is a provider-config snippet via the provider's resource token,
 					// not the function token.
@@ -2466,15 +2466,15 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 						Filename: "provider.pp",
 						Source:   []byte(`opt1 = "val1"` + "\n"),
 						Attributes: map[string]string{
-							"opt2": "\"val2\"",
+							"optTwo": "\"val2\"",
 						},
 					}, nil
 				case "inputs.yaml":
 					assert.Equal(t, "in1: file\n", string(req.Source))
 					assert.Equal(t, map[string]string{
-						"dry-run": "true",
-						"in1":     "p1",
-						"in2":     "p2",
+						"dryRun": "true",
+						"in1":    "p1",
+						"inTwo":  "p2",
 					}, req.Attributes)
 					assert.Equal(t, "azure:index:myFunction", req.Token)
 					require.NotNil(t, req.Package)
@@ -2483,9 +2483,9 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 						Filename: "inputs.pp",
 						Source:   []byte(`in1 = "file"` + "\n"),
 						Attributes: map[string]string{
-							"in1":     "\"p1\"",
-							"in2":     "\"p2\"",
-							"dry-run": "true",
+							"in1":    "\"p1\"",
+							"inTwo":  "\"p2\"",
+							"dryRun": "true",
 						},
 					}, nil
 				default:
@@ -2501,17 +2501,17 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 			Name: "azure",
 			Provider: schema.ResourceSpec{
 				InputProperties: map[string]schema.PropertySpec{
-					"opt1": {TypeSpec: schema.TypeSpec{Type: "string"}},
-					"opt2": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"opt1":   {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"optTwo": {TypeSpec: schema.TypeSpec{Type: "string"}},
 				},
 			},
 			Functions: map[string]schema.FunctionSpec{
 				"azure:index:myFunction": {
 					Inputs: &schema.ObjectTypeSpec{
 						Properties: map[string]schema.PropertySpec{
-							"in1":     {TypeSpec: schema.TypeSpec{Type: "string"}},
-							"in2":     {TypeSpec: schema.TypeSpec{Type: "string"}},
-							"dry-run": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+							"in1":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"inTwo":  {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"dryRun": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 						},
 					},
 					Outputs: &schema.ObjectTypeSpec{
@@ -2527,15 +2527,15 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 			MockProvider: plugin.MockProvider{
 				ConfigureF: func(ctx context.Context, req plugin.ConfigureRequest) (plugin.ConfigureResponse, error) {
 					configureCalled = true
-					// The converted PCL ("opt1 = \"val1\"") + opt2=val2 should be bound, evaluated, and reach Configure intact.
+					// The converted PCL ("opt1 = \"val1\"") + optTwo=val2 should be bound, evaluated, and reach Configure intact.
 					assert.Equal(t, "val1", req.Inputs["opt1"].StringValue())
-					assert.Equal(t, "val2", req.Inputs["opt2"].StringValue())
+					assert.Equal(t, "val2", req.Inputs["optTwo"].StringValue())
 					return plugin.ConfigureResponse{}, nil
 				},
 				InvokeF: func(ctx context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
 					assert.Equal(t, "p1", req.Args["in1"].StringValue())
-					assert.Equal(t, "p2", req.Args["in2"].StringValue())
-					assert.Equal(t, true, req.Args["dry-run"].BoolValue())
+					assert.Equal(t, "p2", req.Args["inTwo"].StringValue())
+					assert.Equal(t, true, req.Args["dryRun"].BoolValue())
 					return plugin.InvokeResponse{
 						Properties: resource.PropertyMap{"output1": resource.NewProperty("world")},
 					}, nil
@@ -2555,9 +2555,9 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 		"azure:index:myFunction",
 		"--provider-file", providerFile,
 		"--input-file", inputFile, "--input", "yaml",
-		"--azure:opt2", "val2",
+		"--azure:opt-two", "val2",
 		"--in1", "p1",
-		"--input:in2", "p2",
+		"--input:in-two", "p2",
 		"--input:dry-run",
 	})
 	err := cmd.Execute()

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -53,7 +53,7 @@ func resourceSchemaHelp(res *schema.Resource) string {
 		b.WriteString(title)
 		b.WriteString(":\n")
 		for _, property := range properties {
-			fmt.Fprintf(&b, "  %s (%s", property.Name, schemaTypeString(property.Type))
+			fmt.Fprintf(&b, "  %s (%s", property.Name, unwrapType(property.Type))
 			if includeRequired {
 				if property.IsRequired() {
 					b.WriteString(", required")

--- a/pkg/cmd/pulumi/do/do_resource.go
+++ b/pkg/cmd/pulumi/do/do_resource.go
@@ -104,6 +104,7 @@ func (pc *packageCommand) newResourceCommand(res *schema.Resource) *cobra.Comman
 		"Path to a file containing provider configuration")
 	cmd.PersistentFlags().StringVar(&pc.format, "input", "pcl",
 		"Format of the provider configuration file")
+	addPersistentInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties)
 	cmd.AddCommand(pc.newResourceCreateCommand(res))
 	cmd.AddCommand(pc.newResourceReadCommand(res))
 	cmd.AddCommand(pc.newResourcePatchCommand(res))
@@ -126,13 +127,14 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 				return err
 			}
 			ctx := cmd.Context()
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 			urn := resourceURN(res)
 			inputs, err := evaluateResourceFile(
 				ctx, inputFile, "input", pc.format, res, pc.evalContext,
-				pc.converter, pc.loaderTarget, pc.packageDescriptor)
+				pc.converter, pc.loaderTarget, pc.packageDescriptor,
+				collectInputFlags(cmd, "input", res.InputProperties))
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}
@@ -167,6 +169,7 @@ func (pc *packageCommand) newResourceCreateCommand(res *schema.Resource) *cobra.
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
+	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
 }
 
@@ -177,7 +180,7 @@ func (pc *packageCommand) newResourceReadCommand(res *schema.Resource) *cobra.Co
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 			urn := resourceURN(res)
@@ -217,7 +220,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 				return err
 			}
 			ctx := cmd.Context()
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 			urn := resourceURN(res)
@@ -240,7 +243,8 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 			// would otherwise reject any partial patch that omits a required input.
 			patch, err := evaluateResourceFile(
 				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
-				pc.converter, pc.loaderTarget, pc.packageDescriptor, pcl.AllowMissingProperties)
+				pc.converter, pc.loaderTarget, pc.packageDescriptor,
+				collectInputFlags(cmd, "input", res.InputProperties), pcl.AllowMissingProperties)
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}
@@ -294,6 +298,7 @@ func (pc *packageCommand) newResourcePatchCommand(res *schema.Resource) *cobra.C
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource inputs")
 	cmd.Flags().BoolVar(&yes, "yes", false,
 		"Automatically approve and perform the operation without a confirmation prompt")
+	addInputFlags(cmd, "input", res.InputProperties)
 	return cmd
 }
 
@@ -308,7 +313,7 @@ func (pc *packageCommand) newResourceDeleteCommand(res *schema.Resource) *cobra.
 				return err
 			}
 			ctx := cmd.Context()
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 			urn := resourceURN(res)
@@ -347,13 +352,14 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 				return errors.New("--all and --count are mutually exclusive")
 			}
 			ctx := cmd.Context()
-			if err := pc.configureProvider(ctx); err != nil {
+			if err := pc.configureProvider(cmd, ctx); err != nil {
 				return err
 			}
 
 			query, err := evaluateResourceListFile(
 				ctx, inputFile, "input", inputFormat, res, pc.evalContext,
-				pc.converter, pc.loaderTarget, pc.packageDescriptor)
+				pc.converter, pc.loaderTarget, pc.packageDescriptor,
+				collectInputFlags(cmd, "input", res.ListInputs.Properties))
 			if err != nil {
 				return fmt.Errorf("parse input file: %w", err)
 			}
@@ -408,6 +414,7 @@ func (pc *packageCommand) newResourceListCommand(res *schema.Resource) *cobra.Co
 	cmd.Flags().StringVar(&inputFile, "input-file", "", "Path to a file containing resource list inputs")
 	cmd.Flags().BoolVar(&all, "all", false, "Enumerate all matching resources")
 	cmd.Flags().Int64Var(&count, "count", 0, "Enumerate up to count matching resources")
+	addInputFlags(cmd, "input", res.ListInputs.Properties)
 	return cmd
 }
 
@@ -415,6 +422,7 @@ func evaluateResourceListFile(
 	ctx context.Context, path, fileType, inputFormat string, res *schema.Resource, evalContext functionEvalContext,
 	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
 	packageDescriptor *codegenrpc.GetSchemaRequest,
+	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
 	contract.Assertf(res.ListInputs != nil, "should not call evaluateResourceListFile for resources without list inputs")
 
@@ -424,6 +432,7 @@ func evaluateResourceListFile(
 	}
 	return evaluateFile(
 		ctx, path, fileType, inputFormat, res.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+		inputFlags,
 	)
 }
 

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -238,6 +238,72 @@ size = 2
 }`, stdout.String())
 }
 
+func TestDoCmdResourceCreateWithPCLInputFlags(t *testing.T) {
+	t.Parallel()
+
+	spec := schema.PackageSpec{
+		Name: "azure",
+		Resources: map[string]schema.ResourceSpec{
+			"azure:index:myResource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name":               {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"intValue":           {TypeSpec: schema.TypeSpec{Type: "integer"}},
+						"already-kebab-case": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"snake_case":         {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+					},
+				},
+				InputProperties: map[string]schema.PropertySpec{
+					"name":               {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"intValue":           {TypeSpec: schema.TypeSpec{Type: "integer"}},
+					"already-kebab-case": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"snake_case":         {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+				},
+				RequiredInputs: []string{"name"},
+			},
+		},
+	}
+
+	cmd, stdout, _ := newDoResourceCommand(t, &testProvider{
+		spec: spec,
+		MockProvider: plugin.MockProvider{
+			CheckF: func(ctx context.Context, req plugin.CheckRequest) (plugin.CheckResponse, error) {
+				assert.Equal(t, "example", req.News["name"].StringValue())
+				assert.Equal(t, 42.0, req.News["intValue"].NumberValue())
+				assert.Equal(t, "kebab", req.News["already-kebab-case"].StringValue())
+				assert.Equal(t, true, req.News["snake_case"].BoolValue())
+				return plugin.CheckResponse{Properties: req.News}, nil
+			},
+			CreateF: func(ctx context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+				return plugin.CreateResponse{
+					ID:         "res-1",
+					Properties: req.Properties,
+				}, nil
+			},
+		},
+	})
+
+	inputFile := writeHCLFile(t, "inputs.pcl", `name = "example"`)
+	cmd.SetArgs([]string{
+		"azure:index:myResource", "create",
+		"--yes",
+		"--input-file", inputFile,
+		"--int-value", "42",
+		"--already-kebab-case", "kebab",
+		"--snake-case",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+  "id": "res-1",
+  "name": "example",
+  "intValue": 42,
+  "already-kebab-case": "kebab",
+  "snake_case": true
+}`, stdout.String())
+}
+
 func TestDoCmdResourceReadDeletePatch(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -238,7 +238,11 @@ func evaluatePCLFile(
 		input = f
 	}
 
-	return evaluatePCL(input, filename, fileType, bind, evalContext, inputFlags)
+	attributeLiterals, err := inputFlagLiterals(inputFlags)
+	if err != nil {
+		return nil, err
+	}
+	return evaluatePCL(input, filename, fileType, bind, evalContext, attributeLiterals)
 }
 
 func evaluatePCL(
@@ -246,7 +250,7 @@ func evaluatePCL(
 	filename, fileType string,
 	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
 	evalContext functionEvalContext,
-	inputFlags map[string]inputFlagValue,
+	attributeLiterals map[string]string,
 ) (resource.PropertyMap, error) {
 	parser := hclsyntax.NewParser()
 	if err := parser.ParseFile(input, filename); err != nil {
@@ -257,7 +261,7 @@ func evaluatePCL(
 	}
 	contract.Assertf(len(parser.Files) == 1, "Should be one PCL file")
 	file := parser.Files[0]
-	if err := mergeInputFlags(file, filename, fileType, inputFlags); err != nil {
+	if err := mergeAttributeLiterals(file, filename, fileType, attributeLiterals); err != nil {
 		return nil, err
 	}
 
@@ -345,7 +349,7 @@ func evaluateFile(
 	if resp.Diagnostics.HasErrors() {
 		return nil, resp.Diagnostics
 	}
-	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext, nil)
+	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext, resp.Attributes)
 }
 
 func evaluateFunctionFile(
@@ -417,27 +421,37 @@ func inputFlagAttributes(inputFlags map[string]inputFlagValue) map[string]string
 	return attrs
 }
 
-func mergeInputFlags(
-	file *hclsyntax.File, filename, fileType string, inputFlags map[string]inputFlagValue,
-) error {
+func inputFlagLiterals(inputFlags map[string]inputFlagValue) (map[string]string, error) {
 	if len(inputFlags) == 0 {
+		return nil, nil
+	}
+	attrs := make(map[string]string, len(inputFlags))
+	for name, flag := range inputFlags {
+		literal, err := pclLiteral(flag)
+		if err != nil {
+			return nil, err
+		}
+		attrs[name] = literal
+	}
+	return attrs, nil
+}
+
+func mergeAttributeLiterals(
+	file *hclsyntax.File, filename, fileType string, attributes map[string]string,
+) error {
+	if len(attributes) == 0 {
 		return nil
 	}
 
-	names := make([]string, 0, len(inputFlags))
-	for name := range inputFlags {
+	names := make([]string, 0, len(attributes))
+	for name := range attributes {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	var overlay strings.Builder
 	for _, name := range names {
-		flag := inputFlags[name]
-		literal, err := pclLiteral(flag)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(&overlay, "%s = %s\n", name, literal)
+		fmt.Fprintf(&overlay, "%s = %s\n", name, attributes[name])
 	}
 
 	parser := hclsyntax.NewParser()

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -366,15 +366,48 @@ func evaluateResourceFile(
 	)
 }
 
-func schemaTypeString(t schema.Type) string {
-	switch t := t.(type) {
-	case *schema.OptionalType:
-		return schemaTypeString(t.ElementType)
-	case *schema.InputType:
-		return schemaTypeString(t.ElementType)
-	default:
-		return t.String()
+func addInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) {
+	for _, input := range inputs {
+		var flagFunc func(string)
+
+		typ := unwrapType(input.Type)
+
+		if typ == schema.StringType {
+			flagFunc = func(name string) {
+				cmd.Flags().String(name, "", input.Comment)
+			}
+		}
+		if typ == schema.BoolType {
+			flagFunc = func(name string) {
+				cmd.Flags().Bool(name, false, input.Comment)
+			}
+		}
+		if typ == schema.NumberType {
+			flagFunc = func(name string) {
+				cmd.Flags().Float64(name, 0, input.Comment)
+			}
+		}
+
+		if flagFunc != nil {
+			key := fmt.Sprintf("%s:%s", namespace, input.Name)
+			flagFunc(key)
+			if namespace == "input" && cmd.Flags().Lookup(input.Name) == nil {
+				flagFunc(input.Name)
+				cmd.MarkFlagsMutuallyExclusive(key, input.Name)
+			}
+		}
 	}
+}
+
+// unwrapType recursively unwraps Optional and Input types to get at the underlying element type.
+func unwrapType(typ schema.Type) schema.Type {
+	if opt, ok := typ.(*schema.OptionalType); ok {
+		return unwrapType(opt.ElementType)
+	}
+	if input, ok := typ.(*schema.InputType); ok {
+		return unwrapType(input.ElementType)
+	}
+	return typ
 }
 
 func resourceURN(res *schema.Resource) resource.URN {

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -499,38 +499,40 @@ func addPersistentInputFlags(cmd *cobra.Command, namespace string, inputs []*sch
 
 func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string, inputs []*schema.Property) {
 	for _, input := range inputs {
-		var flagFunc func(string)
+		var flagFunc func(string, string)
 
 		typ := unwrapType(input.Type)
 
 		if typ == schema.StringType {
-			flagFunc = func(name string) {
-				flags.String(name, "", input.Comment)
+			flagFunc = func(name, extraHelp string) {
+				flags.String(name, "", input.Comment+extraHelp)
 			}
 		}
 		if typ == schema.BoolType {
-			flagFunc = func(name string) {
-				flags.Bool(name, false, input.Comment)
+			flagFunc = func(name, extraHelp string) {
+				flags.Bool(name, false, input.Comment+extraHelp)
 			}
 		}
 		if typ == schema.IntType {
-			flagFunc = func(name string) {
-				flags.Int(name, 0, input.Comment)
+			flagFunc = func(name, extraHelp string) {
+				flags.Int(name, 0, input.Comment+extraHelp)
 			}
 		}
 		if typ == schema.NumberType {
-			flagFunc = func(name string) {
-				flags.Float64(name, 0, input.Comment)
+			flagFunc = func(name, extraHelp string) {
+				flags.Float64(name, 0, input.Comment+extraHelp)
 			}
 		}
 
 		if flagFunc != nil {
 			flagName := inputFlagName(input.Name)
 			key := fmt.Sprintf("%s:%s", namespace, flagName)
-			flagFunc(key)
+			flagFunc(key, "")
 			if namespace == "input" && flags.Lookup(flagName) == nil {
-				flagFunc(flagName)
+				flagFunc(flagName, " (alias for --"+key+")")
 				cmd.MarkFlagsMutuallyExclusive(key, flagName)
+				// Mark the namespaced flag as hidden
+				flags.Lookup(key).Hidden = true
 			}
 		}
 	}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -475,7 +475,7 @@ func pclLiteral(flag inputFlagValue) (string, error) {
 	switch flag.typ {
 	case schema.StringType:
 		return strconv.Quote(flag.value), nil
-	case schema.BoolType, schema.NumberType:
+	case schema.BoolType, schema.IntType, schema.NumberType:
 		return flag.value, nil
 	default:
 		return "", fmt.Errorf("unsupported flag type %s", flag.typ)
@@ -504,6 +504,11 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		if typ == schema.BoolType {
 			flagFunc = func(name string) {
 				flags.Bool(name, false, input.Comment)
+			}
+		}
+		if typ == schema.IntType {
+			flagFunc = func(name string) {
+				flags.Int(name, 0, input.Comment)
 			}
 		}
 		if typ == schema.NumberType {
@@ -555,7 +560,7 @@ func inputFlagName(name string) string {
 }
 
 func isInputFlagType(typ schema.Type) bool {
-	return typ == schema.StringType || typ == schema.BoolType || typ == schema.NumberType
+	return typ == schema.StringType || typ == schema.BoolType || typ == schema.IntType || typ == schema.NumberType
 }
 
 // unwrapType recursively unwraps Optional and Input types to get at the underlying element type.

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -20,11 +20,14 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -48,6 +51,11 @@ type functionEvalContext struct {
 	WorkingDir    string
 	ProjectName   string
 	RootDirectory string
+}
+
+type inputFlagValue struct {
+	value string
+	typ   schema.Type
 }
 
 func jsonifyPropertyValue(v resource.PropertyValue, showSecrets bool) (any, error) {
@@ -212,6 +220,7 @@ func evaluatePCLFile(
 	path, fileType string,
 	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
 	evalContext functionEvalContext,
+	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
 	// When no input file is supplied we still run the bind step against an empty file so that the schema's
 	// required-input check fires.
@@ -229,7 +238,7 @@ func evaluatePCLFile(
 		input = f
 	}
 
-	return evaluatePCL(input, filename, fileType, bind, evalContext)
+	return evaluatePCL(input, filename, fileType, bind, evalContext, inputFlags)
 }
 
 func evaluatePCL(
@@ -237,6 +246,7 @@ func evaluatePCL(
 	filename, fileType string,
 	bind func(*hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics),
 	evalContext functionEvalContext,
+	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
 	parser := hclsyntax.NewParser()
 	if err := parser.ParseFile(input, filename); err != nil {
@@ -247,6 +257,9 @@ func evaluatePCL(
 	}
 	contract.Assertf(len(parser.Files) == 1, "Should be one PCL file")
 	file := parser.Files[0]
+	if err := mergeInputFlags(file, filename, fileType, inputFlags); err != nil {
+		return nil, err
+	}
 
 	attrs, inputType, properties, diagnostics := bind(file)
 	if diagnostics.HasErrors() {
@@ -302,9 +315,10 @@ func evaluateFile(
 	loaderTarget string,
 	packageDescriptor *codegenrpc.GetSchemaRequest,
 	evalContext functionEvalContext,
+	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
 	if path == "" || inputFormat == "" || inputFormat == "pcl" {
-		return evaluatePCLFile(path, fileType, bind, evalContext)
+		return evaluatePCLFile(path, fileType, bind, evalContext, inputFlags)
 	}
 
 	converter, err := loadConverter(inputFormat)
@@ -323,6 +337,7 @@ func evaluateFile(
 		TargetLoader: loaderTarget,
 		Package:      packageDescriptor,
 		Token:        token,
+		Attributes:   inputFlagAttributes(inputFlags),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("generate PCL from %s file: %w", fileType, err)
@@ -330,13 +345,14 @@ func evaluateFile(
 	if resp.Diagnostics.HasErrors() {
 		return nil, resp.Diagnostics
 	}
-	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext)
+	return evaluatePCL(bytes.NewReader(resp.Source), resp.Filename, fileType, bind, evalContext, nil)
 }
 
 func evaluateFunctionFile(
 	ctx context.Context, path, fileType, inputFormat string, fn *schema.Function, evalContext functionEvalContext,
 	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
 	packageDescriptor *codegenrpc.GetSchemaRequest,
+	inputFlags map[string]inputFlagValue,
 ) (resource.PropertyMap, error) {
 	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
 		attrs, inputType, diags := pcl.BindFunction(file, fn)
@@ -348,6 +364,7 @@ func evaluateFunctionFile(
 	}
 	return evaluateFile(
 		ctx, path, fileType, inputFormat, fn.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+		inputFlags,
 	)
 }
 
@@ -355,6 +372,7 @@ func evaluateResourceFile(
 	ctx context.Context, path, fileType, inputFormat string, res *schema.Resource, evalContext functionEvalContext,
 	loadConverter func(string) (plugin.Converter, error), loaderTarget string,
 	packageDescriptor *codegenrpc.GetSchemaRequest,
+	inputFlags map[string]inputFlagValue,
 	bindOpts ...pcl.BindOption,
 ) (resource.PropertyMap, error) {
 	bind := func(file *hclsyntax.File) ([]*model.Attribute, model.Type, []*schema.Property, hcl.Diagnostics) {
@@ -363,10 +381,100 @@ func evaluateResourceFile(
 	}
 	return evaluateFile(
 		ctx, path, fileType, inputFormat, res.Token, bind, loadConverter, loaderTarget, packageDescriptor, evalContext,
+		inputFlags,
 	)
 }
 
+func collectInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) map[string]inputFlagValue {
+	values := map[string]inputFlagValue{}
+	for _, input := range inputs {
+		typ := unwrapType(input.Type)
+		if !isInputFlagType(typ) {
+			continue
+		}
+
+		if flag := cmd.Flag(fmt.Sprintf("%s:%s", namespace, input.Name)); flag != nil && flag.Changed {
+			values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
+			continue
+		}
+		if namespace == "input" {
+			if flag := cmd.Flag(input.Name); flag != nil && flag.Changed {
+				values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
+			}
+		}
+	}
+	return values
+}
+
+func inputFlagAttributes(inputFlags map[string]inputFlagValue) map[string]string {
+	if len(inputFlags) == 0 {
+		return nil
+	}
+	attrs := make(map[string]string, len(inputFlags))
+	for name, flag := range inputFlags {
+		attrs[name] = flag.value
+	}
+	return attrs
+}
+
+func mergeInputFlags(
+	file *hclsyntax.File, filename, fileType string, inputFlags map[string]inputFlagValue,
+) error {
+	if len(inputFlags) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(inputFlags))
+	for name := range inputFlags {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var overlay strings.Builder
+	for _, name := range names {
+		flag := inputFlags[name]
+		literal, err := pclLiteral(flag)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(&overlay, "%s = %s\n", name, literal)
+	}
+
+	parser := hclsyntax.NewParser()
+	overlayName := fmt.Sprintf("%s flags for %s", fileType, filename)
+	if err := parser.ParseFile(strings.NewReader(overlay.String()), overlayName); err != nil {
+		return fmt.Errorf("parse %s flags: %w", fileType, err)
+	}
+	if parser.Diagnostics.HasErrors() {
+		return parser.Diagnostics
+	}
+	contract.Assertf(len(parser.Files) == 1, "Should be one PCL flags file")
+	for name, attr := range parser.Files[0].Body.Attributes {
+		file.Body.Attributes[name] = attr
+	}
+	return nil
+}
+
+func pclLiteral(flag inputFlagValue) (string, error) {
+	switch flag.typ {
+	case schema.StringType:
+		return strconv.Quote(flag.value), nil
+	case schema.BoolType, schema.NumberType:
+		return flag.value, nil
+	default:
+		return "", fmt.Errorf("unsupported flag type %s", flag.typ)
+	}
+}
+
 func addInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) {
+	addInputFlagsTo(cmd, cmd.Flags(), namespace, inputs)
+}
+
+func addPersistentInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Property) {
+	addInputFlagsTo(cmd, cmd.PersistentFlags(), namespace, inputs)
+}
+
+func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string, inputs []*schema.Property) {
 	for _, input := range inputs {
 		var flagFunc func(string)
 
@@ -374,29 +482,33 @@ func addInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Proper
 
 		if typ == schema.StringType {
 			flagFunc = func(name string) {
-				cmd.Flags().String(name, "", input.Comment)
+				flags.String(name, "", input.Comment)
 			}
 		}
 		if typ == schema.BoolType {
 			flagFunc = func(name string) {
-				cmd.Flags().Bool(name, false, input.Comment)
+				flags.Bool(name, false, input.Comment)
 			}
 		}
 		if typ == schema.NumberType {
 			flagFunc = func(name string) {
-				cmd.Flags().Float64(name, 0, input.Comment)
+				flags.Float64(name, 0, input.Comment)
 			}
 		}
 
 		if flagFunc != nil {
 			key := fmt.Sprintf("%s:%s", namespace, input.Name)
 			flagFunc(key)
-			if namespace == "input" && cmd.Flags().Lookup(input.Name) == nil {
+			if namespace == "input" && flags.Lookup(input.Name) == nil {
 				flagFunc(input.Name)
 				cmd.MarkFlagsMutuallyExclusive(key, input.Name)
 			}
 		}
 	}
+}
+
+func isInputFlagType(typ schema.Type) bool {
+	return typ == schema.StringType || typ == schema.BoolType || typ == schema.NumberType
 }
 
 // unwrapType recursively unwraps Optional and Input types to get at the underlying element type.
@@ -416,10 +528,11 @@ func resourceURN(res *schema.Resource) resource.URN {
 	return resource.NewURN("dev", "default", "", tokens.Type(res.Token), name)
 }
 
-func (pc *packageCommand) configureProvider(ctx context.Context) error {
+func (pc *packageCommand) configureProvider(cmd *cobra.Command, ctx context.Context) error {
 	config, err := evaluateResourceFile(
 		ctx, pc.providerFile, "provider", pc.format,
-		pc.spec.Provider, pc.evalContext, pc.converter, pc.loaderTarget, pc.packageDescriptor)
+		pc.spec.Provider, pc.evalContext, pc.converter, pc.loaderTarget, pc.packageDescriptor,
+		collectInputFlags(cmd, pc.spec.Name, pc.spec.Provider.InputProperties))
 	if err != nil {
 		return fmt.Errorf("parse provider file: %w", err)
 	}

--- a/pkg/cmd/pulumi/do/do_shared.go
+++ b/pkg/cmd/pulumi/do/do_shared.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/hcl/v2"
@@ -397,12 +398,13 @@ func collectInputFlags(cmd *cobra.Command, namespace string, inputs []*schema.Pr
 			continue
 		}
 
-		if flag := cmd.Flag(fmt.Sprintf("%s:%s", namespace, input.Name)); flag != nil && flag.Changed {
+		flagName := inputFlagName(input.Name)
+		if flag := cmd.Flag(fmt.Sprintf("%s:%s", namespace, flagName)); flag != nil && flag.Changed {
 			values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
 			continue
 		}
 		if namespace == "input" {
-			if flag := cmd.Flag(input.Name); flag != nil && flag.Changed {
+			if flag := cmd.Flag(flagName); flag != nil && flag.Changed {
 				values[input.Name] = inputFlagValue{value: flag.Value.String(), typ: typ}
 			}
 		}
@@ -511,14 +513,45 @@ func addInputFlagsTo(cmd *cobra.Command, flags *pflag.FlagSet, namespace string,
 		}
 
 		if flagFunc != nil {
-			key := fmt.Sprintf("%s:%s", namespace, input.Name)
+			flagName := inputFlagName(input.Name)
+			key := fmt.Sprintf("%s:%s", namespace, flagName)
 			flagFunc(key)
-			if namespace == "input" && flags.Lookup(input.Name) == nil {
-				flagFunc(input.Name)
-				cmd.MarkFlagsMutuallyExclusive(key, input.Name)
+			if namespace == "input" && flags.Lookup(flagName) == nil {
+				flagFunc(flagName)
+				cmd.MarkFlagsMutuallyExclusive(key, flagName)
 			}
 		}
 	}
+}
+
+func inputFlagName(name string) string {
+	var builder strings.Builder
+	var previous rune
+	var previousIsWord bool
+	var previousIsSeparator bool
+	runes := []rune(name)
+	for i, r := range runes {
+		if r == '_' || r == '-' || unicode.IsSpace(r) {
+			if builder.Len() > 0 && !previousIsSeparator {
+				builder.WriteRune('-')
+			}
+			previous = '-'
+			previousIsWord = false
+			previousIsSeparator = true
+			continue
+		}
+
+		nextIsLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+		if unicode.IsUpper(r) && previousIsWord &&
+			(unicode.IsLower(previous) || unicode.IsDigit(previous) || nextIsLower) {
+			builder.WriteRune('-')
+		}
+		builder.WriteRune(unicode.ToLower(r))
+		previous = r
+		previousIsWord = true
+		previousIsSeparator = false
+	}
+	return strings.TrimSuffix(builder.String(), "-")
 }
 
 func isInputFlagType(typ schema.Type) bool {

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -115,7 +115,7 @@ message ConvertSnippetRequest {
     // a function token, or a resource token.
     string token = 5;
 
-    // any extra attributes to merge into the source file conversion.
+    // any extra attributes to convert.
     map<string, string> attributes = 6;
 }
 
@@ -128,4 +128,7 @@ message ConvertSnippetResponse {
 
     // The generated PCL source code.
     bytes source = 3;
+
+    // any extra attributes to merge into the final pcl result.
+    map<string, string> attributes = 4;
 }

--- a/proto/pulumi/converter.proto
+++ b/proto/pulumi/converter.proto
@@ -114,6 +114,9 @@ message ConvertSnippetRequest {
     // The token to use when converting the snippet. This may be a provider token, such as `pulumi:providers:pkg`,
     // a function token, or a resource token.
     string token = 5;
+
+    // any extra attributes to merge into the source file conversion.
+    map<string, string> attributes = 6;
 }
 
 message ConvertSnippetResponse {

--- a/sdk/go/common/resource/plugin/converter.go
+++ b/sdk/go/common/resource/plugin/converter.go
@@ -64,8 +64,9 @@ type ConvertSnippetRequest struct {
 	TargetLoader string
 	// Package identifies the package (and any parameterization) the snippet belongs to so the converter can load
 	// the same schema we did when invoking the provider.
-	Package *codegenrpc.GetSchemaRequest
-	Token   string
+	Package    *codegenrpc.GetSchemaRequest
+	Token      string
+	Attributes map[string]string
 }
 
 type ConvertSnippetResponse struct {

--- a/sdk/go/common/resource/plugin/converter.go
+++ b/sdk/go/common/resource/plugin/converter.go
@@ -73,6 +73,7 @@ type ConvertSnippetResponse struct {
 	Diagnostics hcl.Diagnostics
 	Filename    string
 	Source      []byte
+	Attributes  map[string]string
 }
 
 type Converter interface {

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -193,6 +193,7 @@ func (c *converter) ConvertSnippet(
 		TargetLoader: req.TargetLoader,
 		Package:      req.Package,
 		Token:        req.Token,
+		Attributes:   req.Attributes,
 	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -211,5 +211,6 @@ func (c *converter) ConvertSnippet(
 		Diagnostics: diags,
 		Filename:    resp.Filename,
 		Source:      resp.Source,
+		Attributes:  resp.Attributes,
 	}, nil
 }

--- a/sdk/go/common/resource/plugin/converter_server.go
+++ b/sdk/go/common/resource/plugin/converter_server.go
@@ -105,6 +105,7 @@ func (c *converterServer) ConvertSnippet(ctx context.Context,
 		TargetLoader: req.TargetLoader,
 		Package:      req.Package,
 		Token:        req.Token,
+		Attributes:   req.Attributes,
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/converter_server.go
+++ b/sdk/go/common/resource/plugin/converter_server.go
@@ -120,5 +120,6 @@ func (c *converterServer) ConvertSnippet(ctx context.Context,
 		Diagnostics: diags,
 		Filename:    resp.Filename,
 		Source:      resp.Source,
+		Attributes:  resp.Attributes,
 	}, nil
 }

--- a/sdk/nodejs/proto/converter_pb.d.ts
+++ b/sdk/nodejs/proto/converter_pb.d.ts
@@ -177,6 +177,9 @@ export class ConvertSnippetRequest extends jspb.Message {
     getToken(): string;
     setToken(value: string): ConvertSnippetRequest;
 
+    getAttributesMap(): jspb.Map<string, string>;
+    clearAttributesMap(): void;
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ConvertSnippetRequest.AsObject;
     static toObject(includeInstance: boolean, msg: ConvertSnippetRequest): ConvertSnippetRequest.AsObject;
@@ -194,6 +197,8 @@ export namespace ConvertSnippetRequest {
         targetLoader: string,
         pb_package?: pulumi_codegen_loader_pb.GetSchemaRequest.AsObject,
         token: string,
+
+        attributesMap: Array<[string, string]>,
     }
 }
 

--- a/sdk/nodejs/proto/converter_pb.d.ts
+++ b/sdk/nodejs/proto/converter_pb.d.ts
@@ -214,6 +214,9 @@ export class ConvertSnippetResponse extends jspb.Message {
     getSource_asB64(): string;
     setSource(value: Uint8Array | string): ConvertSnippetResponse;
 
+    getAttributesMap(): jspb.Map<string, string>;
+    clearAttributesMap(): void;
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): ConvertSnippetResponse.AsObject;
     static toObject(includeInstance: boolean, msg: ConvertSnippetResponse): ConvertSnippetResponse.AsObject;
@@ -229,5 +232,7 @@ export namespace ConvertSnippetResponse {
         diagnosticsList: Array<pulumi_codegen_hcl_pb.Diagnostic.AsObject>,
         filename: string,
         source: Uint8Array | string,
+
+        attributesMap: Array<[string, string]>,
     }
 }

--- a/sdk/nodejs/proto/converter_pb.js
+++ b/sdk/nodejs/proto/converter_pb.js
@@ -1749,7 +1749,8 @@ proto.pulumirpc.ConvertSnippetResponse.toObject = function(includeInstance, msg)
 diagnosticsList: jspb.Message.toObjectList(msg.getDiagnosticsList(),
     pulumi_codegen_hcl_pb.Diagnostic.toObject, includeInstance),
 filename: jspb.Message.getFieldWithDefault(msg, 2, ""),
-source: msg.getSource_asB64()
+source: msg.getSource_asB64(),
+attributesMap: (f = msg.getAttributesMap()) ? f.toObject(includeInstance, undefined) : []
   };
 
   if (includeInstance) {
@@ -1798,6 +1799,12 @@ proto.pulumirpc.ConvertSnippetResponse.deserializeBinaryFromReader = function(ms
     case 3:
       var value = /** @type {!Uint8Array} */ (reader.readBytes());
       msg.setSource(value);
+      break;
+    case 4:
+      var value = msg.getAttributesMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "", "");
+         });
       break;
     default:
       reader.skipField();
@@ -1849,6 +1856,10 @@ proto.pulumirpc.ConvertSnippetResponse.serializeBinaryToWriter = function(messag
       3,
       f
     );
+  }
+  f = message.getAttributesMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(4, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
   }
 };
 
@@ -1948,6 +1959,29 @@ proto.pulumirpc.ConvertSnippetResponse.prototype.getSource_asU8 = function() {
  */
 proto.pulumirpc.ConvertSnippetResponse.prototype.setSource = function(value) {
   return jspb.Message.setProto3BytesField(this, 3, value);
+};
+
+
+/**
+ * map<string, string> attributes = 4;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.pulumirpc.ConvertSnippetResponse.prototype.getAttributesMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 4, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.pulumirpc.ConvertSnippetResponse} returns this
+ */
+proto.pulumirpc.ConvertSnippetResponse.prototype.clearAttributesMap = function() {
+  this.getAttributesMap().clear();
+  return this;
 };
 
 

--- a/sdk/nodejs/proto/converter_pb.js
+++ b/sdk/nodejs/proto/converter_pb.js
@@ -1414,7 +1414,8 @@ filename: jspb.Message.getFieldWithDefault(msg, 1, ""),
 source: msg.getSource_asB64(),
 targetLoader: jspb.Message.getFieldWithDefault(msg, 3, ""),
 pb_package: (f = msg.getPackage()) && pulumi_codegen_loader_pb.GetSchemaRequest.toObject(includeInstance, f),
-token: jspb.Message.getFieldWithDefault(msg, 5, "")
+token: jspb.Message.getFieldWithDefault(msg, 5, ""),
+attributesMap: (f = msg.getAttributesMap()) ? f.toObject(includeInstance, undefined) : []
   };
 
   if (includeInstance) {
@@ -1471,6 +1472,12 @@ proto.pulumirpc.ConvertSnippetRequest.deserializeBinaryFromReader = function(msg
     case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setToken(value);
+      break;
+    case 6:
+      var value = msg.getAttributesMap();
+      reader.readMessage(value, function(message, reader) {
+        jspb.Map.deserializeBinary(message, reader, jspb.BinaryReader.prototype.readString, jspb.BinaryReader.prototype.readString, null, "", "");
+         });
       break;
     default:
       reader.skipField();
@@ -1536,6 +1543,10 @@ proto.pulumirpc.ConvertSnippetRequest.serializeBinaryToWriter = function(message
       5,
       f
     );
+  }
+  f = message.getAttributesMap(true);
+  if (f && f.getLength() > 0) {
+    f.serializeBinary(6, writer, jspb.BinaryWriter.prototype.writeString, jspb.BinaryWriter.prototype.writeString);
   }
 };
 
@@ -1670,6 +1681,29 @@ proto.pulumirpc.ConvertSnippetRequest.prototype.getToken = function() {
  */
 proto.pulumirpc.ConvertSnippetRequest.prototype.setToken = function(value) {
   return jspb.Message.setProto3StringField(this, 5, value);
+};
+
+
+/**
+ * map<string, string> attributes = 6;
+ * @param {boolean=} opt_noLazyCreate Do not create the map if
+ * empty, instead returning `undefined`
+ * @return {!jspb.Map<string,string>}
+ */
+proto.pulumirpc.ConvertSnippetRequest.prototype.getAttributesMap = function(opt_noLazyCreate) {
+  return /** @type {!jspb.Map<string,string>} */ (
+      jspb.Message.getMapField(this, 6, opt_noLazyCreate,
+      null));
+};
+
+
+/**
+ * Clears values from the map. The map will be non-null.
+ * @return {!proto.pulumirpc.ConvertSnippetRequest} returns this
+ */
+proto.pulumirpc.ConvertSnippetRequest.prototype.clearAttributesMap = function() {
+  this.getAttributesMap().clear();
+  return this;
 };
 
 

--- a/sdk/proto/go/converter.pb.go
+++ b/sdk/proto/go/converter.pb.go
@@ -405,7 +405,7 @@ type ConvertSnippetRequest struct {
 	// The token to use when converting the snippet. This may be a provider token, such as `pulumi:providers:pkg`,
 	// a function token, or a resource token.
 	Token string `protobuf:"bytes,5,opt,name=token,proto3" json:"token,omitempty"`
-	// any extra attributes to merge into the source file conversion.
+	// any extra attributes to convert.
 	Attributes    map[string]string `protobuf:"bytes,6,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -490,7 +490,9 @@ type ConvertSnippetResponse struct {
 	// The generated PCL filename.
 	Filename string `protobuf:"bytes,2,opt,name=filename,proto3" json:"filename,omitempty"`
 	// The generated PCL source code.
-	Source        []byte `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	Source []byte `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
+	// any extra attributes to merge into the final pcl result.
+	Attributes    map[string]string `protobuf:"bytes,4,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -546,6 +548,13 @@ func (x *ConvertSnippetResponse) GetSource() []byte {
 	return nil
 }
 
+func (x *ConvertSnippetResponse) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
 var File_pulumi_converter_proto protoreflect.FileDescriptor
 
 const file_pulumi_converter_proto_rawDesc = "" +
@@ -586,11 +595,17 @@ const file_pulumi_converter_proto_rawDesc = "" +
 	"attributes\x1a=\n" +
 	"\x0fAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8d\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9f\x02\n" +
 	"\x16ConvertSnippetResponse\x12?\n" +
 	"\vdiagnostics\x18\x01 \x03(\v2\x1d.pulumirpc.codegen.DiagnosticR\vdiagnostics\x12\x1a\n" +
 	"\bfilename\x18\x02 \x01(\tR\bfilename\x12\x16\n" +
-	"\x06source\x18\x03 \x01(\fR\x06source2\x90\x02\n" +
+	"\x06source\x18\x03 \x01(\fR\x06source\x12Q\n" +
+	"\n" +
+	"attributes\x18\x04 \x03(\v21.pulumirpc.ConvertSnippetResponse.AttributesEntryR\n" +
+	"attributes\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x012\x90\x02\n" +
 	"\tConverter\x12Q\n" +
 	"\fConvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n" +
 	"\x0eConvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n" +
@@ -608,7 +623,7 @@ func file_pulumi_converter_proto_rawDescGZIP() []byte {
 	return file_pulumi_converter_proto_rawDescData
 }
 
-var file_pulumi_converter_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_pulumi_converter_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_pulumi_converter_proto_goTypes = []any{
 	(*ConvertStateRequest)(nil),      // 0: pulumirpc.ConvertStateRequest
 	(*ResourceImport)(nil),           // 1: pulumirpc.ResourceImport
@@ -618,27 +633,29 @@ var file_pulumi_converter_proto_goTypes = []any{
 	(*ConvertSnippetRequest)(nil),    // 5: pulumirpc.ConvertSnippetRequest
 	(*ConvertSnippetResponse)(nil),   // 6: pulumirpc.ConvertSnippetResponse
 	nil,                              // 7: pulumirpc.ConvertSnippetRequest.AttributesEntry
-	(*codegen.Diagnostic)(nil),       // 8: pulumirpc.codegen.Diagnostic
-	(*codegen.GetSchemaRequest)(nil), // 9: codegen.GetSchemaRequest
+	nil,                              // 8: pulumirpc.ConvertSnippetResponse.AttributesEntry
+	(*codegen.Diagnostic)(nil),       // 9: pulumirpc.codegen.Diagnostic
+	(*codegen.GetSchemaRequest)(nil), // 10: codegen.GetSchemaRequest
 }
 var file_pulumi_converter_proto_depIdxs = []int32{
-	1, // 0: pulumirpc.ConvertStateResponse.resources:type_name -> pulumirpc.ResourceImport
-	8, // 1: pulumirpc.ConvertStateResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	8, // 2: pulumirpc.ConvertProgramResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	9, // 3: pulumirpc.ConvertSnippetRequest.package:type_name -> codegen.GetSchemaRequest
-	7, // 4: pulumirpc.ConvertSnippetRequest.attributes:type_name -> pulumirpc.ConvertSnippetRequest.AttributesEntry
-	8, // 5: pulumirpc.ConvertSnippetResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	0, // 6: pulumirpc.Converter.ConvertState:input_type -> pulumirpc.ConvertStateRequest
-	3, // 7: pulumirpc.Converter.ConvertProgram:input_type -> pulumirpc.ConvertProgramRequest
-	5, // 8: pulumirpc.Converter.ConvertSnippet:input_type -> pulumirpc.ConvertSnippetRequest
-	2, // 9: pulumirpc.Converter.ConvertState:output_type -> pulumirpc.ConvertStateResponse
-	4, // 10: pulumirpc.Converter.ConvertProgram:output_type -> pulumirpc.ConvertProgramResponse
-	6, // 11: pulumirpc.Converter.ConvertSnippet:output_type -> pulumirpc.ConvertSnippetResponse
-	9, // [9:12] is the sub-list for method output_type
-	6, // [6:9] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	1,  // 0: pulumirpc.ConvertStateResponse.resources:type_name -> pulumirpc.ResourceImport
+	9,  // 1: pulumirpc.ConvertStateResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	9,  // 2: pulumirpc.ConvertProgramResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	10, // 3: pulumirpc.ConvertSnippetRequest.package:type_name -> codegen.GetSchemaRequest
+	7,  // 4: pulumirpc.ConvertSnippetRequest.attributes:type_name -> pulumirpc.ConvertSnippetRequest.AttributesEntry
+	9,  // 5: pulumirpc.ConvertSnippetResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	8,  // 6: pulumirpc.ConvertSnippetResponse.attributes:type_name -> pulumirpc.ConvertSnippetResponse.AttributesEntry
+	0,  // 7: pulumirpc.Converter.ConvertState:input_type -> pulumirpc.ConvertStateRequest
+	3,  // 8: pulumirpc.Converter.ConvertProgram:input_type -> pulumirpc.ConvertProgramRequest
+	5,  // 9: pulumirpc.Converter.ConvertSnippet:input_type -> pulumirpc.ConvertSnippetRequest
+	2,  // 10: pulumirpc.Converter.ConvertState:output_type -> pulumirpc.ConvertStateResponse
+	4,  // 11: pulumirpc.Converter.ConvertProgram:output_type -> pulumirpc.ConvertProgramResponse
+	6,  // 12: pulumirpc.Converter.ConvertSnippet:output_type -> pulumirpc.ConvertSnippetResponse
+	10, // [10:13] is the sub-list for method output_type
+	7,  // [7:10] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_pulumi_converter_proto_init() }
@@ -652,7 +669,7 @@ func file_pulumi_converter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumi_converter_proto_rawDesc), len(file_pulumi_converter_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/proto/go/converter.pb.go
+++ b/sdk/proto/go/converter.pb.go
@@ -404,7 +404,9 @@ type ConvertSnippetRequest struct {
 	Package *codegen.GetSchemaRequest `protobuf:"bytes,4,opt,name=package,proto3" json:"package,omitempty"`
 	// The token to use when converting the snippet. This may be a provider token, such as `pulumi:providers:pkg`,
 	// a function token, or a resource token.
-	Token         string `protobuf:"bytes,5,opt,name=token,proto3" json:"token,omitempty"`
+	Token string `protobuf:"bytes,5,opt,name=token,proto3" json:"token,omitempty"`
+	// any extra attributes to merge into the source file conversion.
+	Attributes    map[string]string `protobuf:"bytes,6,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -472,6 +474,13 @@ func (x *ConvertSnippetRequest) GetToken() string {
 		return x.Token
 	}
 	return ""
+}
+
+func (x *ConvertSnippetRequest) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
 }
 
 type ConvertSnippetResponse struct {
@@ -565,13 +574,19 @@ const file_pulumi_converter_proto_rawDesc = "" +
 	"\x04args\x18\x05 \x03(\tR\x04args\x12>\n" +
 	"\x1bgenerated_project_directory\x18\x06 \x01(\tR\x19generatedProjectDirectory\"Y\n" +
 	"\x16ConvertProgramResponse\x12?\n" +
-	"\vdiagnostics\x18\x01 \x03(\v2\x1d.pulumirpc.codegen.DiagnosticR\vdiagnostics\"\xbb\x01\n" +
+	"\vdiagnostics\x18\x01 \x03(\v2\x1d.pulumirpc.codegen.DiagnosticR\vdiagnostics\"\xcc\x02\n" +
 	"\x15ConvertSnippetRequest\x12\x1a\n" +
 	"\bfilename\x18\x01 \x01(\tR\bfilename\x12\x16\n" +
 	"\x06source\x18\x02 \x01(\fR\x06source\x12#\n" +
 	"\rtarget_loader\x18\x03 \x01(\tR\ftargetLoader\x123\n" +
 	"\apackage\x18\x04 \x01(\v2\x19.codegen.GetSchemaRequestR\apackage\x12\x14\n" +
-	"\x05token\x18\x05 \x01(\tR\x05token\"\x8d\x01\n" +
+	"\x05token\x18\x05 \x01(\tR\x05token\x12P\n" +
+	"\n" +
+	"attributes\x18\x06 \x03(\v20.pulumirpc.ConvertSnippetRequest.AttributesEntryR\n" +
+	"attributes\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8d\x01\n" +
 	"\x16ConvertSnippetResponse\x12?\n" +
 	"\vdiagnostics\x18\x01 \x03(\v2\x1d.pulumirpc.codegen.DiagnosticR\vdiagnostics\x12\x1a\n" +
 	"\bfilename\x18\x02 \x01(\tR\bfilename\x12\x16\n" +
@@ -593,7 +608,7 @@ func file_pulumi_converter_proto_rawDescGZIP() []byte {
 	return file_pulumi_converter_proto_rawDescData
 }
 
-var file_pulumi_converter_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_pulumi_converter_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_pulumi_converter_proto_goTypes = []any{
 	(*ConvertStateRequest)(nil),      // 0: pulumirpc.ConvertStateRequest
 	(*ResourceImport)(nil),           // 1: pulumirpc.ResourceImport
@@ -602,26 +617,28 @@ var file_pulumi_converter_proto_goTypes = []any{
 	(*ConvertProgramResponse)(nil),   // 4: pulumirpc.ConvertProgramResponse
 	(*ConvertSnippetRequest)(nil),    // 5: pulumirpc.ConvertSnippetRequest
 	(*ConvertSnippetResponse)(nil),   // 6: pulumirpc.ConvertSnippetResponse
-	(*codegen.Diagnostic)(nil),       // 7: pulumirpc.codegen.Diagnostic
-	(*codegen.GetSchemaRequest)(nil), // 8: codegen.GetSchemaRequest
+	nil,                              // 7: pulumirpc.ConvertSnippetRequest.AttributesEntry
+	(*codegen.Diagnostic)(nil),       // 8: pulumirpc.codegen.Diagnostic
+	(*codegen.GetSchemaRequest)(nil), // 9: codegen.GetSchemaRequest
 }
 var file_pulumi_converter_proto_depIdxs = []int32{
 	1, // 0: pulumirpc.ConvertStateResponse.resources:type_name -> pulumirpc.ResourceImport
-	7, // 1: pulumirpc.ConvertStateResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	7, // 2: pulumirpc.ConvertProgramResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	8, // 3: pulumirpc.ConvertSnippetRequest.package:type_name -> codegen.GetSchemaRequest
-	7, // 4: pulumirpc.ConvertSnippetResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
-	0, // 5: pulumirpc.Converter.ConvertState:input_type -> pulumirpc.ConvertStateRequest
-	3, // 6: pulumirpc.Converter.ConvertProgram:input_type -> pulumirpc.ConvertProgramRequest
-	5, // 7: pulumirpc.Converter.ConvertSnippet:input_type -> pulumirpc.ConvertSnippetRequest
-	2, // 8: pulumirpc.Converter.ConvertState:output_type -> pulumirpc.ConvertStateResponse
-	4, // 9: pulumirpc.Converter.ConvertProgram:output_type -> pulumirpc.ConvertProgramResponse
-	6, // 10: pulumirpc.Converter.ConvertSnippet:output_type -> pulumirpc.ConvertSnippetResponse
-	8, // [8:11] is the sub-list for method output_type
-	5, // [5:8] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	8, // 1: pulumirpc.ConvertStateResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	8, // 2: pulumirpc.ConvertProgramResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	9, // 3: pulumirpc.ConvertSnippetRequest.package:type_name -> codegen.GetSchemaRequest
+	7, // 4: pulumirpc.ConvertSnippetRequest.attributes:type_name -> pulumirpc.ConvertSnippetRequest.AttributesEntry
+	8, // 5: pulumirpc.ConvertSnippetResponse.diagnostics:type_name -> pulumirpc.codegen.Diagnostic
+	0, // 6: pulumirpc.Converter.ConvertState:input_type -> pulumirpc.ConvertStateRequest
+	3, // 7: pulumirpc.Converter.ConvertProgram:input_type -> pulumirpc.ConvertProgramRequest
+	5, // 8: pulumirpc.Converter.ConvertSnippet:input_type -> pulumirpc.ConvertSnippetRequest
+	2, // 9: pulumirpc.Converter.ConvertState:output_type -> pulumirpc.ConvertStateResponse
+	4, // 10: pulumirpc.Converter.ConvertProgram:output_type -> pulumirpc.ConvertProgramResponse
+	6, // 11: pulumirpc.Converter.ConvertSnippet:output_type -> pulumirpc.ConvertSnippetResponse
+	9, // [9:12] is the sub-list for method output_type
+	6, // [6:9] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_pulumi_converter_proto_init() }
@@ -635,7 +652,7 @@ func file_pulumi_converter_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumi_converter_proto_rawDesc), len(file_pulumi_converter_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
@@ -15,7 +15,7 @@ from .codegen import hcl_pb2 as pulumi_dot_codegen_dot_hcl__pb2
 from .codegen import loader_pb2 as pulumi_dot_codegen_dot_loader__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\xa3\x01\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x8b\x01\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\"n\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\xa3\x01\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x84\x02\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"n\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -23,6 +23,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'pulumi.converter_pb2', _glo
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc'
+  _CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY._options = None
+  _CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY._serialized_options = b'8\001'
   _globals['_CONVERTSTATEREQUEST']._serialized_start=92
   _globals['_CONVERTSTATEREQUEST']._serialized_end=150
   _globals['_RESOURCEIMPORT']._serialized_start=153
@@ -34,9 +36,11 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_CONVERTPROGRAMRESPONSE']._serialized_start=615
   _globals['_CONVERTPROGRAMRESPONSE']._serialized_end=691
   _globals['_CONVERTSNIPPETREQUEST']._serialized_start=694
-  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=833
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=835
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=945
-  _globals['_CONVERTER']._serialized_start=948
-  _globals['_CONVERTER']._serialized_end=1220
+  _globals['_CONVERTSNIPPETREQUEST']._serialized_end=954
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=905
+  _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=954
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=956
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=1066
+  _globals['_CONVERTER']._serialized_start=1069
+  _globals['_CONVERTER']._serialized_end=1341
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.py
@@ -15,7 +15,7 @@ from .codegen import hcl_pb2 as pulumi_dot_codegen_dot_hcl__pb2
 from .codegen import loader_pb2 as pulumi_dot_codegen_dot_loader__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\xa3\x01\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x84\x02\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"n\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16pulumi/converter.proto\x12\tpulumirpc\x1a\x18pulumi/codegen/hcl.proto\x1a\x1bpulumi/codegen/loader.proto\":\n\x13\x43onvertStateRequest\x12\x15\n\rmapper_target\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\xa3\x01\n\x0eResourceImport\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\n\n\x02id\x18\x03 \x01(\t\x12\x0f\n\x07version\x18\x04 \x01(\t\x12\x19\n\x11pluginDownloadURL\x18\x05 \x01(\t\x12\x14\n\x0clogical_name\x18\x06 \x01(\t\x12\x14\n\x0cis_component\x18\x07 \x01(\x08\x12\x11\n\tis_remote\x18\x08 \x01(\x08\"x\n\x14\x43onvertStateResponse\x12,\n\tresources\x18\x01 \x03(\x0b\x32\x19.pulumirpc.ResourceImport\x12\x32\n\x0b\x64iagnostics\x18\x02 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\xac\x01\n\x15\x43onvertProgramRequest\x12\x18\n\x10source_directory\x18\x01 \x01(\t\x12\x18\n\x10target_directory\x18\x02 \x01(\t\x12\x15\n\rmapper_target\x18\x03 \x01(\t\x12\x15\n\rloader_target\x18\x04 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x05 \x03(\t\x12#\n\x1bgenerated_project_directory\x18\x06 \x01(\t\"L\n\x16\x43onvertProgramResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\"\x84\x02\n\x15\x43onvertSnippetRequest\x12\x10\n\x08\x66ilename\x18\x01 \x01(\t\x12\x0e\n\x06source\x18\x02 \x01(\x0c\x12\x15\n\rtarget_loader\x18\x03 \x01(\t\x12*\n\x07package\x18\x04 \x01(\x0b\x32\x19.codegen.GetSchemaRequest\x12\r\n\x05token\x18\x05 \x01(\t\x12\x44\n\nattributes\x18\x06 \x03(\x0b\x32\x30.pulumirpc.ConvertSnippetRequest.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xe8\x01\n\x16\x43onvertSnippetResponse\x12\x32\n\x0b\x64iagnostics\x18\x01 \x03(\x0b\x32\x1d.pulumirpc.codegen.Diagnostic\x12\x10\n\x08\x66ilename\x18\x02 \x01(\t\x12\x0e\n\x06source\x18\x03 \x01(\x0c\x12\x45\n\nattributes\x18\x04 \x03(\x0b\x32\x31.pulumirpc.ConvertSnippetResponse.AttributesEntry\x1a\x31\n\x0f\x41ttributesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\x90\x02\n\tConverter\x12Q\n\x0c\x43onvertState\x12\x1e.pulumirpc.ConvertStateRequest\x1a\x1f.pulumirpc.ConvertStateResponse\"\x00\x12W\n\x0e\x43onvertProgram\x12 .pulumirpc.ConvertProgramRequest\x1a!.pulumirpc.ConvertProgramResponse\"\x00\x12W\n\x0e\x43onvertSnippet\x12 .pulumirpc.ConvertSnippetRequest\x1a!.pulumirpc.ConvertSnippetResponse\"\x00\x42\x34Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpcb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -25,6 +25,8 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._serialized_options = b'Z2github.com/pulumi/pulumi/sdk/v3/proto/go;pulumirpc'
   _CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY._options = None
   _CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY._serialized_options = b'8\001'
+  _CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY._options = None
+  _CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY._serialized_options = b'8\001'
   _globals['_CONVERTSTATEREQUEST']._serialized_start=92
   _globals['_CONVERTSTATEREQUEST']._serialized_end=150
   _globals['_RESOURCEIMPORT']._serialized_start=153
@@ -39,8 +41,10 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_CONVERTSNIPPETREQUEST']._serialized_end=954
   _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_start=905
   _globals['_CONVERTSNIPPETREQUEST_ATTRIBUTESENTRY']._serialized_end=954
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=956
-  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=1066
-  _globals['_CONVERTER']._serialized_start=1069
-  _globals['_CONVERTER']._serialized_end=1341
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_start=957
+  _globals['_CONVERTSNIPPETRESPONSE']._serialized_end=1189
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_start=905
+  _globals['_CONVERTSNIPPETRESPONSE_ATTRIBUTESENTRY']._serialized_end=954
+  _globals['_CONVERTER']._serialized_start=1192
+  _globals['_CONVERTER']._serialized_end=1464
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
@@ -223,7 +223,7 @@ class ConvertSnippetRequest(google.protobuf.message.Message):
 
     @property
     def attributes(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
-        """any extra attributes to merge into the source file conversion."""
+        """any extra attributes to convert."""
 
     def __init__(
         self,
@@ -244,9 +244,26 @@ global___ConvertSnippetRequest = ConvertSnippetRequest
 class ConvertSnippetResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
+    @typing.final
+    class AttributesEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.str
+        value: builtins.str
+        def __init__(
+            self,
+            *,
+            key: builtins.str = ...,
+            value: builtins.str = ...,
+        ) -> None: ...
+        def ClearField(self, field_name: typing.Literal["key", b"key", "value", b"value"]) -> None: ...
+
     DIAGNOSTICS_FIELD_NUMBER: builtins.int
     FILENAME_FIELD_NUMBER: builtins.int
     SOURCE_FIELD_NUMBER: builtins.int
+    ATTRIBUTES_FIELD_NUMBER: builtins.int
     filename: builtins.str
     """The generated PCL filename."""
     source: builtins.bytes
@@ -255,13 +272,18 @@ class ConvertSnippetResponse(google.protobuf.message.Message):
     def diagnostics(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[pulumi.codegen.hcl_pb2.Diagnostic]:
         """Any diagnostics raised by code generation."""
 
+    @property
+    def attributes(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+        """any extra attributes to merge into the final pcl result."""
+
     def __init__(
         self,
         *,
         diagnostics: collections.abc.Iterable[pulumi.codegen.hcl_pb2.Diagnostic] | None = ...,
         filename: builtins.str = ...,
         source: builtins.bytes = ...,
+        attributes: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing.Literal["diagnostics", b"diagnostics", "filename", b"filename", "source", b"source"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["attributes", b"attributes", "diagnostics", b"diagnostics", "filename", b"filename", "source", b"source"]) -> None: ...
 
 global___ConvertSnippetResponse = ConvertSnippetResponse

--- a/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
+++ b/sdk/python/lib/pulumi/runtime/proto/converter_pb2.pyi
@@ -185,11 +185,28 @@ global___ConvertProgramResponse = ConvertProgramResponse
 class ConvertSnippetRequest(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
+    @typing.final
+    class AttributesEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.str
+        value: builtins.str
+        def __init__(
+            self,
+            *,
+            key: builtins.str = ...,
+            value: builtins.str = ...,
+        ) -> None: ...
+        def ClearField(self, field_name: typing.Literal["key", b"key", "value", b"value"]) -> None: ...
+
     FILENAME_FIELD_NUMBER: builtins.int
     SOURCE_FIELD_NUMBER: builtins.int
     TARGET_LOADER_FIELD_NUMBER: builtins.int
     PACKAGE_FIELD_NUMBER: builtins.int
     TOKEN_FIELD_NUMBER: builtins.int
+    ATTRIBUTES_FIELD_NUMBER: builtins.int
     filename: builtins.str
     """The name of the source file. This is used for diagnostics."""
     source: builtins.bytes
@@ -204,6 +221,10 @@ class ConvertSnippetRequest(google.protobuf.message.Message):
     def package(self) -> pulumi.codegen.loader_pb2.GetSchemaRequest:
         """The package description to load which contains the token."""
 
+    @property
+    def attributes(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
+        """any extra attributes to merge into the source file conversion."""
+
     def __init__(
         self,
         *,
@@ -212,9 +233,10 @@ class ConvertSnippetRequest(google.protobuf.message.Message):
         target_loader: builtins.str = ...,
         package: pulumi.codegen.loader_pb2.GetSchemaRequest | None = ...,
         token: builtins.str = ...,
+        attributes: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
     ) -> None: ...
     def HasField(self, field_name: typing.Literal["package", b"package"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing.Literal["filename", b"filename", "package", b"package", "source", b"source", "target_loader", b"target_loader", "token", b"token"]) -> None: ...
+    def ClearField(self, field_name: typing.Literal["attributes", b"attributes", "filename", b"filename", "package", b"package", "source", b"source", "target_loader", b"target_loader", "token", b"token"]) -> None: ...
 
 global___ConvertSnippetRequest = ConvertSnippetRequest
 


### PR DESCRIPTION
This adds flags for setting "simple" properties on resources/functions, rather than having to use the input files. 

Provider flags are always namespace'd with the provider name (e.g. `--aws:region`). Resource/function flags will use the plain name (e.g. `--bucket`) unless it conflicts with an existing builtin flag (like `input` or `dry-run`) in which case it gets namespace'd to `--input:dry-run`. We attempt to convert 'camelCase' to 'kebab-case' for the flag names.

You can _always_ specify the flag with `--input:X` so that's always safe to use. Trying to set `--input:X` and `--X` is an error.

If using pcl these simply get merged in as attributes to the input file. If using a converter we pass these as a separate attribute map to `ConvertSnippet` and the converter returns them back converted and they are then merged in.