### PR TITLE
add more of the `pulumi do` command tree as metadata

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -690,7 +690,24 @@ func getCLIMetadata(cmd *cobra.Command, environ []string, args []string) map[str
 
 	if command == "pulumi plugin run" {
 		if len(args) > 0 {
-			command += " " + args[0]
+			positionals := positionalArgs(cmd, args)
+			if len(positionals) > 0 {
+				command += " " + positionals[0]
+			}
+		}
+	}
+
+	if command == "pulumi do" {
+		positionals := positionalArgs(cmd, args)
+		// Include the resource/function token
+		if len(positionals) > 0 {
+			command += " " + positionals[0]
+		}
+		if len(positionals) > 1 {
+			switch positionals[1] {
+			case "create", "read", "patch", "delete", "list":
+				command += " " + positionals[1]
+			}
 		}
 	}
 
@@ -710,6 +727,32 @@ func getCLIMetadata(cmd *cobra.Command, environ []string, args []string) map[str
 	}
 
 	return metadata
+}
+
+// positionalArgs extracts positional arguments from a raw argument list,
+// filtering out flags. This is used for commands with DisableFlagParsing
+// where args contains everything including flags. Known flags from the
+// command are registered so pflag can skip over their values correctly;
+// unknown flags are also tolerated.
+func positionalArgs(cmd *cobra.Command, args []string) []string {
+	fs := pflag.NewFlagSet("telemetry", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	// Register the command's own flags so pflag can correctly skip their
+	// values (e.g. --package "foo" should not treat "foo" as positional).
+	// Visit both Flags() and PersistentFlags() to cover all defined flags;
+	// cobra merges them during Execute(), but we may run before that merge.
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		fs.AddFlag(f)
+	})
+	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		if fs.Lookup(f.Name) == nil {
+			fs.AddFlag(f)
+		}
+	})
+	// Silence any output from parsing errors.
+	fs.SetOutput(io.Discard)
+	_ = fs.Parse(args)
+	return fs.Args()
 }
 
 // getCLIVersionInfo returns information about the latest version of the CLI and the oldest version that should be

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	cmdDo "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/do"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -427,6 +428,66 @@ func TestGetCLIMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "do with token and operation",
+			cmd:  newDoTestCmd(),
+			args: []string{"aws:s3:Bucket", "list"},
+			metadata: map[string]string{
+				"Command":     "pulumi do aws:s3:Bucket list",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
+			name: "do with flags mixed in",
+			cmd:  newDoTestCmd(),
+			args: []string{"--dry-run", "aws:s3:Bucket", "create", "--some-unknown-flag", "secret-value"},
+			metadata: map[string]string{
+				"Command":     "pulumi do aws:s3:Bucket create",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
+			name: "do with package flag",
+			cmd:  newDoTestCmd(),
+			args: []string{"--package", "aws", "aws:s3:Bucket", "list"},
+			metadata: map[string]string{
+				"Command":     "pulumi do aws:s3:Bucket list",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
+			name: "do drops extra positionals after verb",
+			cmd:  newDoTestCmd(),
+			args: []string{"aws:s3:Bucket", "read", "some-resource-id"},
+			metadata: map[string]string{
+				"Command":     "pulumi do aws:s3:Bucket read",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
+			name: "do drops unknown verb",
+			cmd:  newDoTestCmd(),
+			args: []string{"aws:lambda:Function", "someUnknownVerb"},
+			metadata: map[string]string{
+				"Command":     "pulumi do aws:lambda:Function",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
+			name: "do with no args",
+			cmd:  newDoTestCmd(),
+			args: []string{},
+			metadata: map[string]string{
+				"Command":     "pulumi do",
+				"Flags":       "",
+				"Environment": "",
+			},
+		},
+		{
 			name: "plugin run with argument",
 			cmd: (func() *cobra.Command {
 				cmd := &cobra.Command{Use: "pulumi"}
@@ -459,6 +520,13 @@ func TestGetCLIMetadata(t *testing.T) {
 			require.Equal(t, c.metadata, metadata)
 		})
 	}
+}
+
+func newDoTestCmd() *cobra.Command {
+	root := &cobra.Command{Use: "pulumi"}
+	doCmd := cmdDo.NewDoCmd(nil, nil, nil, nil, nil)
+	root.AddCommand(doCmd)
+	return doCmd
 }
 
 //nolint:paralleltest // changes environment variables and globals


### PR DESCRIPTION
Similar to `pulumi plugin run`, the interesting part of the command tree for `pulumi do` starts after the `do`.  However since the command tree is dynamically generated, we don't capture those.

Capture the identifier and the command, as those are safe to send as metadata.
