### PR TITLE
fix usage string for `pulumi do`

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -237,6 +237,12 @@ func NewDoCmd(
 			dryrun:            dryrun,
 			showSecrets:       showSecrets,
 		}).newCommand()
+		// Replace the short name in Use with the full token so the usage
+		// string shows e.g. "pulumi do aws:s3:Bucket" instead of "pulumi do Bucket".
+		if len(pargs) > 0 {
+			subcmd.Use = pargs[0] + strings.TrimPrefix(subcmd.Use, subcmd.Name())
+		}
+
 		subcmd.SetContext(cmd.Context())
 		subcmd.SetOut(cmd.OutOrStdout())
 		subcmd.SetErr(cmd.ErrOrStderr())
@@ -271,8 +277,19 @@ func NewDoCmd(
 				subcmd.PersistentFlags().AddFlag(f)
 			}
 		})
+		// Insert a fake "do" node so the command path reads "pulumi do <token>"
+		// instead of "pulumi <token>". Don't copy flags here — they're already
+		// on subcmd from the copy above.
+		fakeDo := &cobra.Command{Use: cmd.Use}
+		fakeDo.SetContext(cmd.Context())
+		fakeDo.SetOut(cmd.OutOrStdout())
+		fakeDo.SetErr(cmd.ErrOrStderr())
+		fakeDo.SetIn(cmd.InOrStdin())
+		fakeDo.AddCommand(subcmd)
+		fullArgs = append([]string{subcmd.Name()}, fullArgs...)
+
 		parent := cmd.Parent()
-		current := subcmd
+		current := fakeDo
 		for parent != nil {
 			nextParent := &cobra.Command{
 				Use: parent.Use,

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -126,7 +126,7 @@ Outputs:
   output3 (boolean, required) - Whether it worked.
 
 Usage:
-  myOtherFunction [flags]
+  do azure:myModule:myOtherFunction [flags]
 
 Flags:
       --dry-run                  Run the operation in preview mode

--- a/pkg/cmd/pulumi/do/do_resource_test.go
+++ b/pkg/cmd/pulumi/do/do_resource_test.go
@@ -118,14 +118,12 @@ List Inputs:
   prefix (string, optional)
 
 Usage:
-  myResource [flags]
-  myResource [command]
+  do azure:index:myResource [flags]
+  do azure:index:myResource [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
   create      Create a resource
   delete      Delete a resource
-  help        Help about any command
   list        List resources
   patch       Patch a resource
   read        Read a resource
@@ -138,7 +136,7 @@ Flags:
       --provider-format string   Format of the provider configuration file (default "pcl")
       --show-secrets             Show secret values in output
 
-Use "myResource [command] --help" for more information about a command.
+Use "do azure:index:myResource [command] --help" for more information about a command.
 `
 	assert.Equal(t, expected, stdout.String())
 }
@@ -168,14 +166,12 @@ Outputs:
   size (integer)
 
 Usage:
-  myResource [flags]
-  myResource [command]
+  do azure:index:myResource [flags]
+  do azure:index:myResource [command]
 
 Available Commands:
-  completion  Generate the autocompletion script for the specified shell
   create      Create a resource
   delete      Delete a resource
-  help        Help about any command
   patch       Patch a resource
   read        Read a resource
 
@@ -187,7 +183,7 @@ Flags:
       --provider-format string   Format of the provider configuration file (default "pcl")
       --show-secrets             Show secret values in output
 
-Use "myResource [command] --help" for more information about a command.
+Use "do azure:index:myResource [command] --help" for more information about a command.
 `
 	assert.Equal(t, expected, stdout.String())
 }


### PR DESCRIPTION
Currently when I run e.g. `pulumi do aws:lambda:Function`, the usage string ends up being `pulumi Function`. This isn't correct, and can be confusing.

Fix this to show the full usage string as the command was typed, so it can be copy-pasted.

As an additional (good) side effect, this also removes the `help` and `completion` commands from the "Available Commands" output, which is correct as they aren't actually available at this level.
