### PR TITLE
Suggest `pulumi neo` in preview/up diagnostics

### DIFF
--- a/changelog/pending/20260522--cli--suggest-pulumi-neo-in-preview-up-diagnostics.yaml
+++ b/changelog/pending/20260522--cli--suggest-pulumi-neo-in-preview-up-diagnostics.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: cli
+  description: Suggest `pulumi neo` in `pulumi preview` and `pulumi up` diagnostics output

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -84,6 +84,7 @@ func PrintNeoLink(out io.Writer, opts Options, permalink string) {
 	fmt.Fprintln(out, "  "+"Would you like additional help with this update?")
 	fmt.Fprintln(out, "  "+
 		opts.Color.Colorize(colors.Underline+colors.BrightBlue+ExplainFailureLink(permalink)+colors.Reset))
+	fmt.Fprintln(out, "  "+"Or run `pulumi neo` for an interactive agent in your terminal.")
 	fmt.Fprintln(out)
 }
 

--- a/pkg/backend/display/ai_test.go
+++ b/pkg/backend/display/ai_test.go
@@ -46,6 +46,7 @@ func TestRenderCopilotErrorSummary(t *testing.T) {
 
   Would you like additional help with this update?
   http://foo.bar/baz?explainFailure
+  Or run `+"`pulumi neo`"+` for an interactive agent in your terminal.
 
 `, neoDelimiterEmoji())
 	assert.Equal(t, expectedCopilotSummary, buf.String())

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -849,6 +849,7 @@ func (display *ProgressDisplay) printDiagnostics() {
 			colors.SpecCreateReplacement + "[Pulumi Neo]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + ExplainFailureLink(display.permalink) + colors.Reset)
+		display.println("    " + "Or run `pulumi neo` for an interactive agent in your terminal.")
 		display.println("")
 	}
 }

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -438,6 +438,10 @@ func NewPreviewCmd() *cobra.Command {
 				displayOpts.SuppressPermalink = true
 			}
 
+			// Link to Neo will be shown for orgs that have Neo enabled, unless the user explicitly suppressed it.
+			logging.V(7).Infof("PULUMI_SUPPRESS_NEO_LINK=%v", env.SuppressNeoLink.Value())
+			displayOpts.ShowLinkToNeo = !env.SuppressNeoLink.Value()
+
 			configureNeoOptions(neoEnabled, cmd, &displayOpts, isDIYBackend)
 			configureNeoTaskOption(neoTaskOnFailure, cmd, &displayOpts, isDIYBackend)
 

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -668,7 +668,6 @@ func NewUpCmd() *cobra.Command {
 			}
 
 			// Link to Neo will be shown for orgs that have Neo enabled, unless the user explicitly suppressed it.
-			// Currently only available for `pulumi up`.
 			logging.V(7).Infof("PULUMI_SUPPRESS_NEO_LINK=%v", env.SuppressNeoLink.Value())
 			opts.Display.ShowLinkToNeo = !env.SuppressNeoLink.Value()
 


### PR DESCRIPTION
## Summary
- Append a one-line hint suggesting the local `pulumi neo` CLI agent next to the existing cloud-console link printed under "Diagnostics:" on failure.
- Show the Neo hint block from `pulumi preview` too (previously only `pulumi up` set `ShowLinkToNeo`).
- Suppression via `PULUMI_SUPPRESS_NEO_LINK` covers both lines — no new env var.

## Test plan
- [ ] `pulumi up` against a stack with a failing resource shows the cloud link followed by the `pulumi neo` line.
- [ ] `pulumi preview` against the same stack now shows the same hint (previously absent).
- [ ] `PULUMI_SUPPRESS_NEO_LINK=true` suppresses both lines for `preview` and `up`.
- [ ] DIY backend (`pulumi login --local`) renders neither line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)