### PR TITLE
Remove EnsurePlugins from Host

### DIFF
--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -518,10 +519,42 @@ func ensurePluginsAreInstalled(ctx context.Context, opts *deploymentOptions, d d
 	return nil
 }
 
-// ensurePluginsAreLoaded ensures that all of the plugins in the given plugin set that match the given plugin flags are
-// loaded.
+// ensurePluginsAreLoaded ensures all plugins in the given array are loaded and ready to use. If any plugins are
+// missing, and/or there are errors loading one or more plugins, a non-nil error is returned.
 func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins PluginSet, kinds plugin.Flags) error {
-	return plugctx.Host.EnsurePlugins(plugins.Values(), kinds)
+	host := plugctx.Host
+
+	// Use a multieerror to track failures so we can return one big list of all failures at the end.
+	var result error
+	for _, p := range plugins {
+		switch p.Kind {
+		case apitype.AnalyzerPlugin:
+			if kinds&plugin.AnalyzerPlugins != 0 {
+				if _, err := host.Analyzer(tokens.QName(p.Name)); err != nil {
+					result = multierror.Append(result,
+						fmt.Errorf("failed to load analyzer plugin %s: %w", p.Name, err))
+				}
+			}
+		case apitype.LanguagePlugin:
+			if kinds&plugin.LanguagePlugins != 0 {
+				if _, err := host.LanguageRuntime(p.Name); err != nil {
+					result = multierror.Append(result,
+						fmt.Errorf("failed to load language plugin %s: %w", p.Name, err))
+				}
+			}
+		case apitype.ResourcePlugin:
+			if kinds&plugin.ResourcePlugins != 0 {
+				if _, err := host.Provider(p, env.Global()); err != nil {
+					result = multierror.Append(result,
+						fmt.Errorf("failed to load resource plugin %s: %w", p.Name, err))
+				}
+			}
+		case apitype.ConverterPlugin, apitype.ToolPlugin:
+			contract.Failf("unexpected plugin kind: %s", p.Kind)
+		}
+	}
+
+	return result
 }
 
 // installPlugin installs a plugin from the given backend client.

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -544,13 +544,6 @@ func (host *pluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
 	return host.PolicyAnalyzer(nm, "", nil)
 }
 
-func (host *pluginHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
-	if host.isClosed() {
-		return ErrHostIsClosed
-	}
-	return nil
-}
-
 func (host *pluginHost) ResolvePlugin(
 	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -157,11 +157,6 @@ func TestPluginHostProvider(t *testing.T) {
 			_, err := host.Analyzer("")
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
-		t.Run("EnsurePlugins", func(t *testing.T) {
-			t.Parallel()
-			host := &pluginHost{closed: true}
-			assert.ErrorIs(t, host.EnsurePlugins(nil, 0), ErrHostIsClosed)
-		})
 		t.Run("PolicyAnalyzer", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -89,10 +89,6 @@ func (host *testPluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime
 	return nil, errors.New("unsupported")
 }
 
-func (host *testPluginHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
-	return nil
-}
-
 func (host *testPluginHost) ResolvePlugin(
 	spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -726,14 +726,13 @@ func (eng *languageTestServer) RunLanguageTest(
 
 	// And now replace the context host with our own test host
 	host := &testHost{
-		engine:                      eng,
-		ctx:                         pctx,
-		host:                        pctx.Host,
-		runtime:                     languageClient,
-		runtimeName:                 token.LanguagePluginName,
-		providers:                   make(map[string]func() (plugin.Provider, error)),
-		connections:                 make(map[plugin.Provider]io.Closer),
-		skipEnsurePluginsValidation: test.SkipEnsurePluginsValidation,
+		engine:      eng,
+		ctx:         pctx,
+		host:        pctx.Host,
+		runtime:     languageClient,
+		runtimeName: token.LanguagePluginName,
+		providers:   make(map[string]func() (plugin.Provider, error)),
+		connections: make(map[plugin.Provider]io.Closer),
 	}
 
 	pctx.Host = host
@@ -1391,96 +1390,101 @@ func runLanguageTests(
 		}
 
 		// Query the language plugin for what it thinks the project packages are, we expect to see the SDKs.
-		packages, err := languageClient.GetRequiredPackages(ctx, programInfo)
-		if err != nil {
-			return makeTestResponse(fmt.Sprintf("get required packages: %v", err)), nil
-		}
-		expectedPackages := []workspace.PackageDescriptor{}
-		for _, pkg := range programPackages {
-			if pkg.Name() == "pulumi" {
-				// Skip the pulumi package, the version for that is handled above.
-				continue
-			}
-
-			pkgDef, err := pkg.Definition()
+		// This is the conformance hook that used to live behind Host.EnsurePlugins: now that the engine ensures
+		// plugins inline, the runner checks GetRequiredPackages directly here. Tests opt out of the check with
+		// SkipEnsurePluginsValidation when the program intentionally diverges (e.g. version-pinning tests).
+		if !test.SkipEnsurePluginsValidation {
+			packages, err := languageClient.GetRequiredPackages(ctx, programInfo)
 			if err != nil {
-				return makeTestResponse(fmt.Sprintf("get package definition: %v", err)), nil
+				return makeTestResponse(fmt.Sprintf("get required packages: %v", err)), nil
 			}
-
-			var desc workspace.PackageDescriptor
-			if pkgDef.Parameterization == nil {
-				desc = workspace.PackageDescriptor{
-					PluginDescriptor: workspace.PluginDescriptor{
-						Name:    pkgDef.Name,
-						Version: pkgDef.Version,
-					},
+			expectedPackages := []workspace.PackageDescriptor{}
+			for _, pkg := range programPackages {
+				if pkg.Name() == "pulumi" {
+					// Skip the pulumi package, the version for that is handled above.
+					continue
 				}
-			} else {
-				desc = workspace.PackageDescriptor{
-					PluginDescriptor: workspace.PluginDescriptor{
-						Name:    pkgDef.Parameterization.BaseProvider.Name,
-						Version: &pkgDef.Parameterization.BaseProvider.Version,
-					},
-					Parameterization: &workspace.Parameterization{
-						Name:    pkgDef.Name,
-						Version: *pkgDef.Version,
-						Value:   pkgDef.Parameterization.Parameter,
-					},
+
+				pkgDef, err := pkg.Definition()
+				if err != nil {
+					return makeTestResponse(fmt.Sprintf("get package definition: %v", err)), nil
 				}
-			}
 
-			expectedPackages = append(expectedPackages, desc)
-		}
-
-		versionsMatch := func(expected, actual *semver.Version) bool {
-			if expected == nil && actual == nil {
-				return true
-			}
-			if expected == nil || actual == nil {
-				return false
-			}
-			return expected.EQ(*actual)
-		}
-		parameterizationsMatch := func(expected, actual *workspace.Parameterization) bool {
-			if expected == nil && actual == nil {
-				return true
-			}
-			if expected == nil || actual == nil {
-				return false
-			}
-			return expected.Name == actual.Name &&
-				versionsMatch(&expected.Version, &actual.Version) &&
-				slices.Equal(expected.Value, actual.Value)
-		}
-		for _, expectedPackage := range expectedPackages {
-			var found bool
-			for _, actual := range packages {
-				if actual.Name == expectedPackage.Name &&
-					versionsMatch(expectedPackage.Version, actual.Version) &&
-					parameterizationsMatch(expectedPackage.Parameterization, actual.Parameterization) {
-					found = true
-					break
+				var desc workspace.PackageDescriptor
+				if pkgDef.Parameterization == nil {
+					desc = workspace.PackageDescriptor{
+						PluginDescriptor: workspace.PluginDescriptor{
+							Name:    pkgDef.Name,
+							Version: pkgDef.Version,
+						},
+					}
+				} else {
+					desc = workspace.PackageDescriptor{
+						PluginDescriptor: workspace.PluginDescriptor{
+							Name:    pkgDef.Parameterization.BaseProvider.Name,
+							Version: &pkgDef.Parameterization.BaseProvider.Version,
+						},
+						Parameterization: &workspace.Parameterization{
+							Name:    pkgDef.Name,
+							Version: *pkgDef.Version,
+							Value:   pkgDef.Parameterization.Parameter,
+						},
+					}
 				}
+
+				expectedPackages = append(expectedPackages, desc)
 			}
 
-			if !found {
-				return makeTestResponse(fmt.Sprintf("missing expected package %v", expectedPackage)), nil
+			versionsMatch := func(expected, actual *semver.Version) bool {
+				if expected == nil && actual == nil {
+					return true
+				}
+				if expected == nil || actual == nil {
+					return false
+				}
+				return expected.EQ(*actual)
 			}
-		}
-		// For packages we need a symmetric check, we shouldn't have any packages that _aren't_ expected.
-		for _, actual := range packages {
-			var found bool
+			parameterizationsMatch := func(expected, actual *workspace.Parameterization) bool {
+				if expected == nil && actual == nil {
+					return true
+				}
+				if expected == nil || actual == nil {
+					return false
+				}
+				return expected.Name == actual.Name &&
+					versionsMatch(&expected.Version, &actual.Version) &&
+					slices.Equal(expected.Value, actual.Value)
+			}
 			for _, expectedPackage := range expectedPackages {
-				if actual.Name == expectedPackage.Name &&
-					versionsMatch(expectedPackage.Version, actual.Version) &&
-					parameterizationsMatch(expectedPackage.Parameterization, actual.Parameterization) {
-					found = true
-					break
+				var found bool
+				for _, actual := range packages {
+					if actual.Name == expectedPackage.Name &&
+						versionsMatch(expectedPackage.Version, actual.Version) &&
+						parameterizationsMatch(expectedPackage.Parameterization, actual.Parameterization) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					return makeTestResponse(fmt.Sprintf("missing expected package %v", expectedPackage)), nil
 				}
 			}
+			// For packages we need a symmetric check, we shouldn't have any packages that _aren't_ expected.
+			for _, actual := range packages {
+				var found bool
+				for _, expectedPackage := range expectedPackages {
+					if actual.Name == expectedPackage.Name &&
+						versionsMatch(expectedPackage.Version, actual.Version) &&
+						parameterizationsMatch(expectedPackage.Parameterization, actual.Parameterization) {
+						found = true
+						break
+					}
+				}
 
-			if !found {
-				return makeTestResponse(fmt.Sprintf("unexpected extra package %v", actual)), nil
+				if !found {
+					return makeTestResponse(fmt.Sprintf("unexpected extra package %v", actual)), nil
+				}
 			}
 		}
 

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -19,11 +19,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 	"sync"
 
-	mapset "github.com/deckarep/golang-set/v2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -55,8 +53,6 @@ type testHost struct {
 	policies []plugin.Analyzer
 
 	closeMutex sync.Mutex
-
-	skipEnsurePluginsValidation bool
 
 	loaderAddress string
 }
@@ -184,56 +180,6 @@ func (h *testHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, erro
 		return nil, fmt.Errorf("unexpected runtime %s", runtime)
 	}
 	return h.runtime, nil
-}
-
-func (h *testHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds plugin.Flags) error {
-	// Remove the builtin "pulumi" provider, as that's always available.
-	filtered := make([]workspace.PluginDescriptor, 0, len(plugins))
-	for _, plugin := range plugins {
-		if plugin.Kind == apitype.ResourcePlugin && plugin.Name == "pulumi" {
-			continue
-		}
-		filtered = append(filtered, plugin)
-	}
-	plugins = filtered
-
-	// Skip validation if requested (e.g., for tests using version resource option)
-	if h.skipEnsurePluginsValidation {
-		return nil
-	}
-
-	// EnsurePlugins will be called with the result of GetRequiredPlugins, so we can use this to check
-	// that that returned the expected plugins (with expected versions).
-	expected := mapset.NewSet[string]()
-	for name, provider := range h.providers {
-		p, err := provider()
-		if err != nil {
-			return fmt.Errorf("initializing provider %s for ensure plugins: %w", name, err)
-		}
-		pkg := p.Pkg()
-		version, err := GetProviderVersion(p)
-		if err != nil {
-			return fmt.Errorf("get provider version %s: %w", pkg, err)
-		}
-		expected.Add(fmt.Sprintf("resource-%s@%s", pkg, version))
-	}
-
-	actual := mapset.NewSetWithSize[string](len(plugins))
-	for _, plugin := range plugins {
-		actual.Add(fmt.Sprintf("%s-%s@%s", plugin.Kind, plugin.Name, plugin.Version))
-	}
-
-	// Symmetric difference, we want to know if there are any unexpected plugins, or any missing plugins.
-	diff := expected.SymmetricDifference(actual)
-	if !diff.IsEmpty() {
-		expectedSlice := expected.ToSlice()
-		slices.Sort(expectedSlice)
-		actualSlice := actual.ToSlice()
-		slices.Sort(actualSlice)
-		return fmt.Errorf("unexpected required plugins: actual %v, expected %v", actualSlice, expectedSlice)
-	}
-
-	return nil
 }
 
 func (h *testHost) ResolvePlugin(

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -74,10 +73,6 @@ type Host interface {
 	// LanguageRuntime fetches the language runtime plugin for a given language, lazily allocating if necessary.  If
 	// an implementation of this language runtime wasn't found, on an error occurs, a non-nil error is returned.
 	LanguageRuntime(runtime string) (LanguageRuntime, error)
-
-	// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
-	// and/or there are errors loading one or more plugins, a non-nil error is returned.
-	EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error
 
 	// ResolvePlugin resolves a pluginspec to a candidate plugin to load.
 	ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
@@ -614,42 +609,6 @@ func (host *defaultHost) LanguageRuntime(runtime string,
 		return nil, err
 	}
 	return plugin.(LanguageRuntime), nil
-}
-
-// EnsurePlugins ensures all plugins in the given array are loaded and ready to use.  If any plugins are missing,
-// and/or there are errors loading one or more plugins, a non-nil error is returned.
-func (host *defaultHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error {
-	// Use a multieerror to track failures so we can return one big list of all failures at the end.
-	var result error
-	for _, plugin := range plugins {
-		switch plugin.Kind {
-		case apitype.AnalyzerPlugin:
-			if kinds&AnalyzerPlugins != 0 {
-				if _, err := host.Analyzer(tokens.QName(plugin.Name)); err != nil {
-					result = multierror.Append(result,
-						fmt.Errorf("failed to load analyzer plugin %s: %w", plugin.Name, err))
-				}
-			}
-		case apitype.LanguagePlugin:
-			if kinds&LanguagePlugins != 0 {
-				if _, err := host.LanguageRuntime(plugin.Name); err != nil {
-					result = multierror.Append(result,
-						fmt.Errorf("failed to load language plugin %s: %w", plugin.Name, err))
-				}
-			}
-		case apitype.ResourcePlugin:
-			if kinds&ResourcePlugins != 0 {
-				if _, err := host.Provider(plugin, env.Global()); err != nil {
-					result = multierror.Append(result,
-						fmt.Errorf("failed to load resource plugin %s: %w", plugin.Name, err))
-				}
-			}
-		case apitype.ConverterPlugin, apitype.ToolPlugin:
-			contract.Failf("unexpected plugin kind: %s", plugin.Kind)
-		}
-	}
-
-	return result
 }
 
 func (host *defaultHost) ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -37,7 +37,6 @@ type MockHost struct {
 	PolicyAnalyzerF     func(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
 	ProviderF           func(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
 	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
-	EnsurePluginsF      func(plugins []workspace.PluginDescriptor, kinds Flags) error
 	ResolvePluginF      func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 	GetProjectPluginsF  func() []workspace.ProjectPlugin
 	SignalCancellationF func() error
@@ -100,13 +99,6 @@ func (m *MockHost) LanguageRuntime(runtime string) (LanguageRuntime, error) {
 		return m.LanguageRuntimeF(runtime)
 	}
 	return nil, errors.New("LanguageRuntime not implemented")
-}
-
-func (m *MockHost) EnsurePlugins(plugins []workspace.PluginDescriptor, kinds Flags) error {
-	if m.EnsurePluginsF != nil {
-		return m.EnsurePluginsF(plugins, kinds)
-	}
-	return nil
 }
 
 func (m *MockHost) ResolvePlugin(


### PR DESCRIPTION
Continuing my crusade to make Host more focused. There's no need for an `EnsurePlugins` call on the host, all it does is loop the plugin list given and call into the top-level host methods to start up those plugins. We can just do that via a simple method in the engine at the one point it's called.

The only other thing we used `EnsurePlugins` for was some trickiness in the conformance tests to see what `GetRequiredPackages` was returning, but we can _just call it_ as part of test setup and do a simpler check.