### PR TITLE
neo: adapt TUI to terminal background

### DIFF
--- a/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
+++ b/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
@@ -1,4 +1,4 @@
 changes:
 - type: fix
   scope: cli/neo
-  description: The `pulumi neo` TUI no longer hardcodes a dark color scheme; markdown, the assistant marker, and the busy-shimmer adapt to the terminal background, and echoed user messages drop the dark highlight
+  description: `pulumi neo` now adapts its TUI colors to the terminal background instead of hardcoding a dark scheme

--- a/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
+++ b/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
@@ -1,4 +1,6 @@
-changes:
-- type: fix
-  scope: cli/neo
-  description: `pulumi neo` now adapts its TUI colors to the terminal background instead of hardcoding a dark scheme
+component: cli/neo
+kind: fix
+body: The `pulumi neo` TUI now adapts its colors to the terminal background instead of hardcoding a dark scheme
+time: 2026-05-22T00:00:00.000000+00:00
+custom:
+    PR: "23333"

--- a/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
+++ b/changelog/pending/20260522--cli-neo--adapt-tui-to-terminal-background.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: cli/neo
+  description: The `pulumi neo` TUI no longer hardcodes a dark color scheme; markdown, the assistant marker, and the busy-shimmer adapt to the terminal background, and echoed user messages drop the dark highlight

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -324,6 +325,13 @@ func runNeo(
 
 	username, _, _, _ := pc.GetPulumiAccountDetails(ctx)
 
+	// Detect the terminal background once, before bubbletea takes over stdin.
+	// Querying in-band (via tea.RequestBackgroundColor or glamour's auto-style)
+	// races bubbletea's own input reader for the terminal's reply, which leaks
+	// the response into the textarea; lipgloss queries synchronously here and
+	// consumes its own response. Defaults to dark on any error.
+	hasDarkBackground := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+
 	model := NewModel(ModelConfig{
 		Org:                   orgName,
 		WorkDir:               cwdFlag,
@@ -335,6 +343,7 @@ func runNeo(
 		InitialPrompt:         prompt,
 		InitialApprovalMode:   approvalMode,
 		InitialPermissionMode: permissionMode,
+		HasDarkBackground:     hasDarkBackground,
 	})
 
 	// Inline (non-alt-screen) so the transcript stays in the user's terminal

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -330,6 +330,8 @@ func runNeo(
 	// races bubbletea's own input reader for the terminal's reply, which leaks
 	// the response into the textarea; lipgloss queries synchronously here and
 	// consumes its own response. Defaults to dark on any error.
+	//
+	//nolint:forbidigo // needs the real terminal fds to query the background; cmd.OutOrStdout() is an io.Writer
 	hasDarkBackground := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 
 	model := NewModel(ModelConfig{

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -230,6 +230,10 @@ type Model struct {
 	mdRenderer *glamour.TermRenderer
 	width      int
 	height     int
+	// hasDarkBackground is the terminal's background polarity, populated from
+	// tea.BackgroundColorMsg. Defaults to true so first paint matches the
+	// pre-detection behavior on terminals that never answer the OSC query.
+	hasDarkBackground bool
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
 	frame             int
@@ -334,8 +338,6 @@ var (
 	cancelledStyle = lipgloss.NewStyle().Faint(true)
 	toolOKMarker   = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Render("⏺")
 	toolErrMarker  = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("⏺")
-	finalMarker    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Render("⏺")
-	userMsgBubble  = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("8"))
 	// planAccentStyle is a distinct cyan+bold used for both the footer banner
 	// and the "Proposed plan" block header so they read as the same visual cue.
 	planAccentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
@@ -503,18 +505,21 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		textInput:      ti,
-		eventCh:        cfg.EventCh,
-		outCh:          cfg.OutCh,
-		busy:           cfg.Busy,
-		spinner:        sp,
-		width:          80,
-		height:         24,
-		messageSent:    cfg.MessageSent,
-		taskCreated:    cfg.TaskCreated,
-		approvalMode:   cfg.InitialApprovalMode,
-		permissionMode: cfg.InitialPermissionMode,
-		overlay:        newOverlayModel(80, 24),
+		textInput: ti,
+		eventCh:   cfg.EventCh,
+		outCh:     cfg.OutCh,
+		busy:      cfg.Busy,
+		spinner:   sp,
+		width:     80,
+		height:    24,
+		// Assume dark until tea.BackgroundColorMsg tells us otherwise; matches
+		// the pre-detection look on terminals that don't answer the OSC query.
+		hasDarkBackground: true,
+		messageSent:       cfg.MessageSent,
+		taskCreated:       cfg.TaskCreated,
+		approvalMode:      cfg.InitialApprovalMode,
+		permissionMode:    cfg.InitialPermissionMode,
+		overlay:           newOverlayModel(80, 24),
 	}
 	if cfg.InitialPrompt != "" {
 		// Render the initial-prompt block now so tests can find it via
@@ -535,7 +540,10 @@ func NewModel(cfg ModelConfig) Model {
 
 // Init returns the initial command that starts listening for events.
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{waitForEvent(m.eventCh), textarea.Blink}
+	// tea.RequestBackgroundColor triggers an OSC 11 query; the terminal's
+	// reply lands as tea.BackgroundColorMsg, which we use to pick light- or
+	// dark-friendly variants of the few styles that need it.
+	cmds := []tea.Cmd{waitForEvent(m.eventCh), textarea.Blink, tea.RequestBackgroundColor}
 	if m.busy {
 		cmds = append(cmds, m.spinner.Tick)
 	}
@@ -561,14 +569,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Glamour's wrap width is baked in at construction, so rebuild on resize.
-		// Wrap at liveWidth-4 so glamour-rendered output (assistant finals, plan
-		// markdown) stays inside the safe live-frame width.
-		if r, err := glamour.NewTermRenderer(
-			glamour.WithStylePath("dark"),
-			glamour.WithWordWrap(safeWidth-4),
-		); err == nil {
-			m.mdRenderer = r
-		}
+		// WithAutoStyle picks a light or dark palette from the terminal background,
+		// matching pkg/cmd/pulumi/config/config_env_init.go.
+		m.rebuildMarkdownRenderer(safeWidth - 4)
 		// Re-render every block at the new width. Live blocks (busy / streaming /
 		// open pulumi op) get reflected in View() on the next draw; committed
 		// blocks already in scrollback don't reflow — only the initial-prompt
@@ -595,6 +598,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for _, r := range msg.rendered {
 			cmds = append(cmds, m.printlnBlock(r))
 		}
+
+	case tea.BackgroundColorMsg:
+		// Terminal told us its background polarity (in reply to the
+		// tea.RequestBackgroundColor in Init, or because the user toggled
+		// the terminal theme mid-session). Rebuild any styles that depend on
+		// it; the next View() picks up the new look.
+		m.hasDarkBackground = msg.IsDark()
+		m.rebuildMarkdownRenderer(m.liveWidth() - 4)
 
 	case ctrlCDisarmMsg:
 		// Stale tick: the user already pressed another key (gen still
@@ -1207,6 +1218,19 @@ func (m Model) modeChips() string {
 	return strings.Join(chips, " ")
 }
 
+// rebuildMarkdownRenderer constructs a new glamour renderer at the given
+// wrap width. Glamour's wrap width is baked in at construction time and its
+// auto-style detection runs once at construction too, so we rebuild on every
+// WindowSizeMsg (width change) and BackgroundColorMsg (theme change).
+func (m *Model) rebuildMarkdownRenderer(wrap int) {
+	if r, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(wrap),
+	); err == nil {
+		m.mdRenderer = r
+	}
+}
+
 // liveWidth returns the width to use when rendering live-frame content:
 // the terminal width minus a small cushion that keeps glamour, lipgloss,
 // and the textarea off the wrap column.
@@ -1239,7 +1263,7 @@ func (m *Model) liveView() string {
 			continue
 		}
 		if b.kind == blockBusy {
-			parts = append(parts, "  "+m.spinner.View()+" "+shimmerLabel(b.label, b.shimmer, m.frame))
+			parts = append(parts, "  "+m.spinner.View()+" "+shimmerLabel(b.label, b.shimmer, m.frame, m.hasDarkBackground))
 		} else {
 			parts = append(parts, b.rendered)
 		}
@@ -1512,9 +1536,9 @@ func (m *Model) renderBlock(b *block) {
 	case blockCancelled:
 		b.rendered = renderIndented(cancelledStyle, m.width, b.raw)
 	case blockUserMessage:
-		b.rendered = m.renderUserBubble(b.raw)
+		b.rendered = m.renderUserMessage(b.raw)
 	case blockAssistantFinal:
-		b.rendered = renderAssistantFinal(m.renderMarkdown(b.raw))
+		b.rendered = m.renderAssistantFinal(m.renderMarkdown(b.raw))
 	case blockApprovalPlan:
 		header := planAccentStyle.Render("⏺ Proposed plan")
 		body := m.renderMarkdown(b.raw)
@@ -1598,18 +1622,27 @@ func (m *Model) renderApprovalChoice(b *block) {
 	b.rendered = renderIndented(lipgloss.NewStyle(), m.width, denied+" — "+b.raw)
 }
 
-// renderUserBubble renders a user-chat bubble. Short messages hug their
-// content; only overflow triggers Width, which both wraps and pads so the
-// background colour fills every wrapped line evenly.
-func (m *Model) renderUserBubble(content string) string {
+// renderUserMessage renders an echoed user message. The cyan-bold ❯ prefix
+// (promptStyle) marks the line as user input; the content itself is rendered
+// plain so it reads like ordinary terminal echo on any background. Long
+// messages wrap to liveWidth-2 and continuation lines indent two spaces so
+// they sit under the message body, not under the prompt glyph.
+func (m *Model) renderUserMessage(content string) string {
 	prefix := promptStyle.Render("❯") + " " // visible width 2
-	padded := " " + content + " "
-	bubbleWidth := max(m.liveWidth()-2, 8)
-	style := userMsgBubble
-	if m.width > 4 && lipgloss.Width(padded) > bubbleWidth {
-		style = style.Width(bubbleWidth)
+	wrap := m.liveWidth() - 2
+	if wrap < 4 {
+		return prefix + content
 	}
-	return prefix + style.Render(padded)
+	wrapped := wordwrap.String(content, wrap)
+	lines := strings.Split(wrapped, "\n")
+	var sb strings.Builder
+	sb.WriteString(prefix)
+	sb.WriteString(lines[0])
+	for _, line := range lines[1:] {
+		sb.WriteString("\n  ")
+		sb.WriteString(line)
+	}
+	return sb.String()
 }
 
 // wrapPlain word-wraps non-markdown text to the safe live width (m.liveWidth)
@@ -1653,14 +1686,23 @@ func renderHeaderedBlock(header, body string) string {
 	return lipgloss.JoinVertical(lipgloss.Left, first, indented)
 }
 
-// renderAssistantFinal renders a final assistant message with a white circle marker.
-func renderAssistantFinal(rendered string) string {
+// finalMarker returns the ⏺ glyph used to mark a final assistant message,
+// colored to contrast with the terminal background (white on dark, black on
+// light) per the polarity learned from tea.BackgroundColorMsg.
+func (m *Model) finalMarker() string {
+	pick := lipgloss.LightDark(m.hasDarkBackground)
+	return lipgloss.NewStyle().Foreground(pick(lipgloss.Color("0"), lipgloss.Color("15"))).Render("⏺")
+}
+
+// renderAssistantFinal renders a final assistant message with a circle marker
+// whose color adapts to the terminal background.
+func (m *Model) renderAssistantFinal(rendered string) string {
 	trimmed := strings.TrimLeft(rendered, "\n ")
 	if trimmed == "" {
 		return ""
 	}
 	firstLine, rest, _ := strings.Cut(trimmed, "\n")
-	return renderHeaderedBlock(finalMarker+" "+firstLine, rest)
+	return renderHeaderedBlock(m.finalMarker()+" "+firstLine, rest)
 }
 
 // waitForEvent returns a tea.Cmd that reads from the UIEvent channel.

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -230,9 +230,9 @@ type Model struct {
 	mdRenderer *glamour.TermRenderer
 	width      int
 	height     int
-	// hasDarkBackground is the terminal's background polarity, populated from
-	// tea.BackgroundColorMsg. Defaults to true so first paint matches the
-	// pre-detection behavior on terminals that never answer the OSC query.
+	// hasDarkBackground is populated from tea.BackgroundColorMsg. Defaults
+	// to true so first paint matches the dark-friendly look on terminals
+	// that never answer the OSC 11 query.
 	hasDarkBackground bool
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
@@ -505,15 +505,13 @@ func NewModel(cfg ModelConfig) Model {
 			termWidth: 80,
 			greeting:  pickGreeting(cfg.Username),
 		},
-		textInput: ti,
-		eventCh:   cfg.EventCh,
-		outCh:     cfg.OutCh,
-		busy:      cfg.Busy,
-		spinner:   sp,
-		width:     80,
-		height:    24,
-		// Assume dark until tea.BackgroundColorMsg tells us otherwise; matches
-		// the pre-detection look on terminals that don't answer the OSC query.
+		textInput:         ti,
+		eventCh:           cfg.EventCh,
+		outCh:             cfg.OutCh,
+		busy:              cfg.Busy,
+		spinner:           sp,
+		width:             80,
+		height:            24,
 		hasDarkBackground: true,
 		messageSent:       cfg.MessageSent,
 		taskCreated:       cfg.TaskCreated,
@@ -539,10 +537,10 @@ func NewModel(cfg ModelConfig) Model {
 }
 
 // Init returns the initial command that starts listening for events.
+// RequestBackgroundColor asks the terminal for its background polarity; the
+// reply arrives as a tea.BackgroundColorMsg that the Update handler uses to
+// pick light- or dark-friendly style variants.
 func (m Model) Init() tea.Cmd {
-	// tea.RequestBackgroundColor triggers an OSC 11 query; the terminal's
-	// reply lands as tea.BackgroundColorMsg, which we use to pick light- or
-	// dark-friendly variants of the few styles that need it.
 	cmds := []tea.Cmd{waitForEvent(m.eventCh), textarea.Blink, tea.RequestBackgroundColor}
 	if m.busy {
 		cmds = append(cmds, m.spinner.Tick)
@@ -568,9 +566,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overlay.Refresh(m.toolHistory)
 		}
 
-		// Glamour's wrap width is baked in at construction, so rebuild on resize.
-		// WithAutoStyle picks a light or dark palette from the terminal background,
-		// matching pkg/cmd/pulumi/config/config_env_init.go.
+		// Glamour bakes wrap width in at construction, so rebuild on resize.
 		m.rebuildMarkdownRenderer(safeWidth - 4)
 		// Re-render every block at the new width. Live blocks (busy / streaming /
 		// open pulumi op) get reflected in View() on the next draw; committed
@@ -600,10 +596,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.BackgroundColorMsg:
-		// Terminal told us its background polarity (in reply to the
-		// tea.RequestBackgroundColor in Init, or because the user toggled
-		// the terminal theme mid-session). Rebuild any styles that depend on
-		// it; the next View() picks up the new look.
+		// Bubble Tea emits this in reply to RequestBackgroundColor and again
+		// whenever the user changes the terminal theme. Rebuild glamour so
+		// its palette tracks; lipgloss-styled blocks re-read the flag on the
+		// next View().
 		m.hasDarkBackground = msg.IsDark()
 		m.rebuildMarkdownRenderer(m.liveWidth() - 4)
 
@@ -1218,10 +1214,10 @@ func (m Model) modeChips() string {
 	return strings.Join(chips, " ")
 }
 
-// rebuildMarkdownRenderer constructs a new glamour renderer at the given
-// wrap width. Glamour's wrap width is baked in at construction time and its
-// auto-style detection runs once at construction too, so we rebuild on every
-// WindowSizeMsg (width change) and BackgroundColorMsg (theme change).
+// rebuildMarkdownRenderer constructs a new glamour renderer with the current
+// wrap width and the terminal's auto-detected style. Glamour bakes both into
+// the renderer at construction, so callers rebuild on resize and on theme
+// change.
 func (m *Model) rebuildMarkdownRenderer(wrap int) {
 	if r, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
@@ -1622,19 +1618,17 @@ func (m *Model) renderApprovalChoice(b *block) {
 	b.rendered = renderIndented(lipgloss.NewStyle(), m.width, denied+" — "+b.raw)
 }
 
-// renderUserMessage renders an echoed user message. The cyan-bold ❯ prefix
-// (promptStyle) marks the line as user input; the content itself is rendered
-// plain so it reads like ordinary terminal echo on any background. Long
-// messages wrap to liveWidth-2 and continuation lines indent two spaces so
-// they sit under the message body, not under the prompt glyph.
+// renderUserMessage renders an echoed user message: the cyan-bold ❯ prefix
+// marks it as user input, the content renders plain so it reads on any
+// background. Continuation lines indent two spaces so they sit under the
+// message body, not under the prompt glyph.
 func (m *Model) renderUserMessage(content string) string {
 	prefix := promptStyle.Render("❯") + " " // visible width 2
 	wrap := m.liveWidth() - 2
 	if wrap < 4 {
 		return prefix + content
 	}
-	wrapped := wordwrap.String(content, wrap)
-	lines := strings.Split(wrapped, "\n")
+	lines := strings.Split(wordwrap.String(content, wrap), "\n")
 	var sb strings.Builder
 	sb.WriteString(prefix)
 	sb.WriteString(lines[0])
@@ -1686,16 +1680,14 @@ func renderHeaderedBlock(header, body string) string {
 	return lipgloss.JoinVertical(lipgloss.Left, first, indented)
 }
 
-// finalMarker returns the ⏺ glyph used to mark a final assistant message,
-// colored to contrast with the terminal background (white on dark, black on
-// light) per the polarity learned from tea.BackgroundColorMsg.
+// finalMarker returns the ⏺ glyph for a final assistant message, colored
+// to contrast with the terminal background (white on dark, black on light).
 func (m *Model) finalMarker() string {
-	pick := lipgloss.LightDark(m.hasDarkBackground)
-	return lipgloss.NewStyle().Foreground(pick(lipgloss.Color("0"), lipgloss.Color("15"))).Render("⏺")
+	fg := lipgloss.LightDark(m.hasDarkBackground)(lipgloss.Color("0"), lipgloss.Color("15"))
+	return lipgloss.NewStyle().Foreground(fg).Render("⏺")
 }
 
-// renderAssistantFinal renders a final assistant message with a circle marker
-// whose color adapts to the terminal background.
+// renderAssistantFinal renders a final assistant message with a circle marker.
 func (m *Model) renderAssistantFinal(rendered string) string {
 	trimmed := strings.TrimLeft(rendered, "\n ")
 	if trimmed == "" {

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -193,6 +193,11 @@ type ModelConfig struct {
 	// that want to exercise the post-task Ctrl+A / Ctrl+R path without driving
 	// a UISessionURL through the event channel.
 	TaskCreated bool
+	// HasDarkBackground selects light- or dark-friendly style variants for the
+	// whole TUI, including the textarea. runNeo detects it synchronously before
+	// the program starts (see the comment there) and defaults it to dark for
+	// terminals it can't probe.
+	HasDarkBackground bool
 }
 
 // Model is the top-level bubbletea model for the Neo TUI.
@@ -230,9 +235,9 @@ type Model struct {
 	mdRenderer *glamour.TermRenderer
 	width      int
 	height     int
-	// hasDarkBackground is populated from tea.BackgroundColorMsg. Defaults
-	// to true so first paint matches the dark-friendly look on terminals
-	// that never answer the OSC 11 query.
+	// hasDarkBackground selects light- or dark-friendly style variants. It is
+	// detected once before the program starts and seeded via
+	// ModelConfig.HasDarkBackground.
 	hasDarkBackground bool
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
@@ -478,7 +483,9 @@ func NewModel(cfg ModelConfig) Model {
 		}
 		return "  "
 	})
-	styles := ti.Styles()
+	// textarea.New defaults to dark styles; reselect for the detected background
+	// so the input box (cursor line, text) reads on a light terminal too.
+	styles := textarea.DefaultStyles(cfg.HasDarkBackground)
 	styles.Focused.Prompt = promptStyle
 	styles.Blurred.Prompt = promptStyle
 	ti.SetStyles(styles)
@@ -512,7 +519,7 @@ func NewModel(cfg ModelConfig) Model {
 		spinner:           sp,
 		width:             80,
 		height:            24,
-		hasDarkBackground: true,
+		hasDarkBackground: cfg.HasDarkBackground,
 		messageSent:       cfg.MessageSent,
 		taskCreated:       cfg.TaskCreated,
 		approvalMode:      cfg.InitialApprovalMode,
@@ -537,11 +544,8 @@ func NewModel(cfg ModelConfig) Model {
 }
 
 // Init returns the initial command that starts listening for events.
-// RequestBackgroundColor asks the terminal for its background polarity; the
-// reply arrives as a tea.BackgroundColorMsg that the Update handler uses to
-// pick light- or dark-friendly style variants.
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{waitForEvent(m.eventCh), textarea.Blink, tea.RequestBackgroundColor}
+	cmds := []tea.Cmd{waitForEvent(m.eventCh), textarea.Blink}
 	if m.busy {
 		cmds = append(cmds, m.spinner.Tick)
 	}
@@ -567,7 +571,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Glamour bakes wrap width in at construction, so rebuild on resize.
-		m.rebuildMarkdownRenderer(safeWidth - 4)
+		m.rebuildMarkdownRenderer()
 		// Re-render every block at the new width. Live blocks (busy / streaming /
 		// open pulumi op) get reflected in View() on the next draw; committed
 		// blocks already in scrollback don't reflow — only the initial-prompt
@@ -594,14 +598,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for _, r := range msg.rendered {
 			cmds = append(cmds, m.printlnBlock(r))
 		}
-
-	case tea.BackgroundColorMsg:
-		// Bubble Tea emits this in reply to RequestBackgroundColor and again
-		// whenever the user changes the terminal theme. Rebuild glamour so
-		// its palette tracks; lipgloss-styled blocks re-read the flag on the
-		// next View().
-		m.hasDarkBackground = msg.IsDark()
-		m.rebuildMarkdownRenderer(m.liveWidth() - 4)
 
 	case ctrlCDisarmMsg:
 		// Stale tick: the user already pressed another key (gen still
@@ -1214,14 +1210,19 @@ func (m Model) modeChips() string {
 	return strings.Join(chips, " ")
 }
 
-// rebuildMarkdownRenderer constructs a new glamour renderer with the current
-// wrap width and the terminal's auto-detected style. Glamour bakes both into
-// the renderer at construction, so callers rebuild on resize and on theme
-// change.
-func (m *Model) rebuildMarkdownRenderer(wrap int) {
+// rebuildMarkdownRenderer constructs a new glamour renderer at the current
+// live width and a style matching the terminal background. Glamour bakes both
+// in at construction, so callers rebuild on resize. We pick the style
+// explicitly rather than via glamour.WithAutoStyle, which queries the terminal
+// in-band and would race bubbletea's input reader (see hasDarkBackground).
+func (m *Model) rebuildMarkdownRenderer() {
+	style := "dark"
+	if !m.hasDarkBackground {
+		style = "light"
+	}
 	if r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(wrap),
+		glamour.WithStandardStyle(style),
+		glamour.WithWordWrap(m.liveWidth()-4),
 	); err == nil {
 		m.mdRenderer = r
 	}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -195,8 +195,7 @@ type ModelConfig struct {
 	TaskCreated bool
 	// HasDarkBackground selects light- or dark-friendly style variants for the
 	// whole TUI, including the textarea. runNeo detects it synchronously before
-	// the program starts (see the comment there) and defaults it to dark for
-	// terminals it can't probe.
+	// the program starts and defaults it to dark for terminals it can't probe.
 	HasDarkBackground bool
 }
 
@@ -235,9 +234,8 @@ type Model struct {
 	mdRenderer *glamour.TermRenderer
 	width      int
 	height     int
-	// hasDarkBackground selects light- or dark-friendly style variants. It is
-	// detected once before the program starts and seeded via
-	// ModelConfig.HasDarkBackground.
+	// hasDarkBackground selects light- or dark-friendly style variants;
+	// seeded from ModelConfig.HasDarkBackground.
 	hasDarkBackground bool
 	// frame advances on each spinner.TickMsg while busy and drives the
 	// shimmer animation on the busy block's label.
@@ -570,7 +568,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.overlay.Refresh(m.toolHistory)
 		}
 
-		// Glamour bakes wrap width in at construction, so rebuild on resize.
 		m.rebuildMarkdownRenderer()
 		// Re-render every block at the new width. Live blocks (busy / streaming /
 		// open pulumi op) get reflected in View() on the next draw; committed
@@ -1214,7 +1211,7 @@ func (m Model) modeChips() string {
 // live width and a style matching the terminal background. Glamour bakes both
 // in at construction, so callers rebuild on resize. We pick the style
 // explicitly rather than via glamour.WithAutoStyle, which queries the terminal
-// in-band and would race bubbletea's input reader (see hasDarkBackground).
+// in-band and would race bubbletea's input reader (see runNeo).
 func (m *Model) rebuildMarkdownRenderer() {
 	style := "dark"
 	if !m.hasDarkBackground {

--- a/pkg/cmd/pulumi/neo/tui_shimmer.go
+++ b/pkg/cmd/pulumi/neo/tui_shimmer.go
@@ -41,8 +41,8 @@ var (
 	verbNearStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 	verbDimStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Faint(true)
 
-	// waveStyles is a brightness ramp used by the traveling-wave shimmer.
-	// The wave reads bright→brightest→bright as it sweeps right.
+	// waveStyles is the wave palette for dark terminals: a bright→brightest→
+	// bright ramp that sweeps left-to-right and stays visible on a dark bg.
 	waveStyles = []lipgloss.Style{
 		lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
@@ -51,19 +51,32 @@ var (
 		lipgloss.NewStyle().Foreground(lipgloss.Color("250")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
 	}
+	// waveStylesLight is the same ramp inverted for light terminals: darker
+	// grays so the wave reads against a white background. Near-white grays
+	// (245-253) from the dark palette disappear on light bg.
+	waveStylesLight = []lipgloss.Style{
+		lipgloss.NewStyle().Foreground(lipgloss.Color("244")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("241")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("238")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("235")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("238")),
+		lipgloss.NewStyle().Foreground(lipgloss.Color("241")),
+	}
 	waveDimStyle = lipgloss.NewStyle().Faint(true)
 )
 
 // shimmerLabel renders text with the shimmer effect selected by kind. Frame
 // is the animation tick counter; callers should pass a value that advances
-// monotonically (modulo any safe bound) as the spinner ticks.
-func shimmerLabel(text string, kind shimmerKind, frame int) string {
+// monotonically (modulo any safe bound) as the spinner ticks. hasDarkBackground
+// picks the wave palette (the spotlight uses pure magenta and reads fine on
+// both backgrounds).
+func shimmerLabel(text string, kind shimmerKind, frame int, hasDarkBackground bool) string {
 	if text == "" {
 		return ""
 	}
 	switch kind {
 	case shimmerWave:
-		return buildWave(text, frame)
+		return buildWave(text, frame, hasDarkBackground)
 	case shimmerVerb:
 		fallthrough
 	default:
@@ -104,19 +117,25 @@ func buildSpotlight(text string, frame int) string {
 
 // buildWave renders text with a grayscale brightness ramp that sweeps
 // left-to-right across the string, then restarts after a brief lull where
-// every character renders dim.
-func buildWave(text string, frame int) string {
+// every character renders dim. hasDarkBackground selects between the bright-
+// gray palette (dark terms) and the dark-gray palette (light terms) so the
+// wave stays visible regardless of the terminal theme.
+func buildWave(text string, frame int, hasDarkBackground bool) string {
 	runes := []rune(text)
 	if len(runes) == 0 {
 		return ""
 	}
-	wavePos := frame % (len(runes) + len(waveStyles))
+	palette := waveStyles
+	if !hasDarkBackground {
+		palette = waveStylesLight
+	}
+	wavePos := frame % (len(runes) + len(palette))
 	var sb strings.Builder
 	for i, r := range runes {
 		ch := string(r)
 		dist := wavePos - i
-		if dist >= 0 && dist < len(waveStyles) {
-			sb.WriteString(waveStyles[dist].Render(ch))
+		if dist >= 0 && dist < len(palette) {
+			sb.WriteString(palette[dist].Render(ch))
 		} else {
 			sb.WriteString(waveDimStyle.Render(ch))
 		}

--- a/pkg/cmd/pulumi/neo/tui_shimmer.go
+++ b/pkg/cmd/pulumi/neo/tui_shimmer.go
@@ -41,8 +41,9 @@ var (
 	verbNearStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 	verbDimStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Faint(true)
 
-	// waveStyles is the wave palette for dark terminals: a bright→brightest→
-	// bright ramp that sweeps left-to-right and stays visible on a dark bg.
+	// Wave palettes: a brightness ramp the wave sweeps across the label.
+	// The dark-bg ramp uses near-white grays; the light-bg ramp inverts to
+	// near-black grays so the wave stays visible on either background.
 	waveStyles = []lipgloss.Style{
 		lipgloss.NewStyle().Foreground(lipgloss.Color("245")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
@@ -51,9 +52,6 @@ var (
 		lipgloss.NewStyle().Foreground(lipgloss.Color("250")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
 	}
-	// waveStylesLight is the same ramp inverted for light terminals: darker
-	// grays so the wave reads against a white background. Near-white grays
-	// (245-253) from the dark palette disappear on light bg.
 	waveStylesLight = []lipgloss.Style{
 		lipgloss.NewStyle().Foreground(lipgloss.Color("244")),
 		lipgloss.NewStyle().Foreground(lipgloss.Color("241")),
@@ -67,9 +65,9 @@ var (
 
 // shimmerLabel renders text with the shimmer effect selected by kind. Frame
 // is the animation tick counter; callers should pass a value that advances
-// monotonically (modulo any safe bound) as the spinner ticks. hasDarkBackground
-// picks the wave palette (the spotlight uses pure magenta and reads fine on
-// both backgrounds).
+// monotonically (modulo any safe bound) as the spinner ticks.
+// hasDarkBackground picks the wave palette; the spotlight is magenta and
+// reads on either background.
 func shimmerLabel(text string, kind shimmerKind, frame int, hasDarkBackground bool) string {
 	if text == "" {
 		return ""
@@ -117,9 +115,7 @@ func buildSpotlight(text string, frame int) string {
 
 // buildWave renders text with a grayscale brightness ramp that sweeps
 // left-to-right across the string, then restarts after a brief lull where
-// every character renders dim. hasDarkBackground selects between the bright-
-// gray palette (dark terms) and the dark-gray palette (light terms) so the
-// wave stays visible regardless of the terminal theme.
+// every character renders dim.
 func buildWave(text string, frame int, hasDarkBackground bool) string {
 	runes := []rune(text)
 	if len(runes) == 0 {

--- a/pkg/cmd/pulumi/neo/tui_shimmer_test.go
+++ b/pkg/cmd/pulumi/neo/tui_shimmer_test.go
@@ -36,8 +36,8 @@ func containsAllRunes(s, want string) bool {
 func TestShimmerLabel_EmptyText(t *testing.T) {
 	t.Parallel()
 
-	assert.Empty(t, shimmerLabel("", shimmerVerb, 0))
-	assert.Empty(t, shimmerLabel("", shimmerWave, 5))
+	assert.Empty(t, shimmerLabel("", shimmerVerb, 0, true))
+	assert.Empty(t, shimmerLabel("", shimmerWave, 5, true))
 }
 
 func TestShimmerLabel_Dispatch(t *testing.T) {
@@ -50,16 +50,16 @@ func TestShimmerLabel_Dispatch(t *testing.T) {
 	const text = "hello"
 	const frame = 3
 
-	wave := shimmerLabel(text, shimmerWave, frame)
-	spot := shimmerLabel(text, shimmerVerb, frame)
-	unknown := shimmerLabel(text, shimmerKind(999), frame)
+	wave := shimmerLabel(text, shimmerWave, frame, true)
+	spot := shimmerLabel(text, shimmerVerb, frame, true)
+	unknown := shimmerLabel(text, shimmerKind(999), frame, true)
 
 	// shimmerLabel is a thin dispatcher; each branch must return exactly what
 	// the underlying builder returns. Comparing against the raw builders both
 	// proves dispatch and pins the fall-through: an unknown kind must behave
 	// like the spotlight (the zero value / default arm), not crash or fall
 	// back to empty.
-	assert.Equal(t, buildWave(text, frame), wave)
+	assert.Equal(t, buildWave(text, frame, true), wave)
 	assert.Equal(t, buildSpotlight(text, frame), spot)
 	assert.Equal(t, spot, unknown, "unknown shimmerKind must fall back to spotlight")
 }
@@ -86,8 +86,8 @@ func TestBuildSpotlight_PositionWraps(t *testing.T) {
 
 func TestBuildWave_EmptyText(t *testing.T) {
 	t.Parallel()
-	assert.Empty(t, buildWave("", 0))
-	assert.Empty(t, buildWave("", 42))
+	assert.Empty(t, buildWave("", 0, true))
+	assert.Empty(t, buildWave("", 42, true))
 }
 
 func TestBuildWave_PreservesRunes(t *testing.T) {
@@ -95,8 +95,12 @@ func TestBuildWave_PreservesRunes(t *testing.T) {
 
 	const text = "read_file ..."
 	for frame := range 20 {
-		got := buildWave(text, frame)
-		assert.Truef(t, containsAllRunes(got, text), "frame %d: missing runes from %q", frame, got)
+		// Cover both palettes — runes must survive regardless of bg polarity.
+		for _, dark := range []bool{true, false} {
+			got := buildWave(text, frame, dark)
+			assert.Truef(t, containsAllRunes(got, text),
+				"frame %d (hasDarkBackground=%v): missing runes from %q", frame, dark, got)
+		}
 	}
 }
 
@@ -109,6 +113,6 @@ func TestBuildWave_CyclesWithPeriod(t *testing.T) {
 	// drift.
 	text := "abcdef"
 	period := len([]rune(text)) + len(waveStyles)
-	assert.Equal(t, buildWave(text, 0), buildWave(text, period))
-	assert.Equal(t, buildWave(text, 2), buildWave(text, 2+period))
+	assert.Equal(t, buildWave(text, 0, true), buildWave(text, period, true))
+	assert.Equal(t, buildWave(text, 2, true), buildWave(text, 2+period, true))
 }

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -142,20 +142,22 @@ func TestTruncate(t *testing.T) {
 func TestRenderAssistantFinal(t *testing.T) {
 	t.Parallel()
 
+	m := &Model{hasDarkBackground: true}
+
 	// Empty (or whitespace-only) input collapses to empty — otherwise we'd emit
 	// a lone marker with no content, which looks broken.
-	assert.Empty(t, renderAssistantFinal(""))
-	assert.Empty(t, renderAssistantFinal("\n  "))
+	assert.Empty(t, m.renderAssistantFinal(""))
+	assert.Empty(t, m.renderAssistantFinal("\n  "))
 
 	// Single-line: the marker sits on the same line as the text. No indented
 	// continuation block.
-	singleLine := renderAssistantFinal("hello")
+	singleLine := m.renderAssistantFinal("hello")
 	assert.Contains(t, singleLine, "hello")
 	assert.NotContains(t, singleLine, "\n    ", "single-line output must not add a 4-space continuation indent")
 
 	// Multi-line: first line gets the marker; remaining lines are indented under
 	// the marker so the paragraph visually belongs to the assistant reply.
-	multi := renderAssistantFinal("first\nsecond\nthird")
+	multi := m.renderAssistantFinal("first\nsecond\nthird")
 	assert.Contains(t, multi, "first")
 	assert.Contains(t, multi, "second")
 	assert.Contains(t, multi, "third")
@@ -1954,47 +1956,47 @@ func TestWarningWrapsToTerminalWidth(t *testing.T) {
 	assert.Contains(t, got, "warning", "wrapped output must still contain the message body")
 }
 
-func TestUserBubbleWrapsToTerminalWidth(t *testing.T) {
+func TestUserMessageWrapsToTerminalWidth(t *testing.T) {
 	t.Parallel()
 
 	m := &Model{width: 40}
 	long := strings.Repeat("word ", 25) // ~125 chars
-	got := m.renderUserBubble(long)
+	got := m.renderUserMessage(long)
 
-	require.Contains(t, got, "\n", "long bubble must contain a newline (wrapped): %q", got)
+	require.Contains(t, got, "\n", "long user message must contain a newline (wrapped): %q", got)
 	for i, w := range visibleLines(got) {
-		assert.LessOrEqual(t, w, 40, "bubble line %d exceeds terminal width: width=%d", i, w)
+		assert.LessOrEqual(t, w, 40, "user message line %d exceeds terminal width: width=%d", i, w)
 	}
 }
 
-func TestUserBubbleDoesNotPadShortMessages(t *testing.T) {
+func TestUserMessageDoesNotPadShortMessages(t *testing.T) {
 	t.Parallel()
 
-	// Short messages hug content so the bubble looks like a chat bubble,
-	// not a full-width card.
+	// Short messages render on a single line that hugs the content — no
+	// trailing whitespace, no full-width card.
 	m := &Model{width: 80}
-	got := m.renderUserBubble("hi")
+	got := m.renderUserMessage("hi")
 
 	widths := visibleLines(got)
-	require.Len(t, widths, 1, "short bubble should render on a single line: %q", got)
-	assert.Less(t, widths[0], 20, "short bubble line should hug content, not fill terminal; got width=%d", widths[0])
+	require.Len(t, widths, 1, "short user message should render on a single line: %q", got)
+	assert.Less(t, widths[0], 20, "short user message line should hug content, not fill terminal; got width=%d", widths[0])
 }
 
-func TestUserBubbleWrapsAtWideTerminal(t *testing.T) {
+func TestUserMessageWrapsAtWideTerminal(t *testing.T) {
 	t.Parallel()
 
-	// At a wide terminal the bubble must wrap against liveWidth (m.width-4),
+	// At a wide terminal the message must wrap against liveWidth (m.width-4),
 	// not raw m.width — otherwise wrapped lines sit on the terminal wrap
 	// column and desync the inline-renderer line accounting.
 	const termWidth = 200
 	m := &Model{width: termWidth}
 	long := strings.Repeat("word ", 60) // ~300 chars, forces wrap
-	got := m.renderUserBubble(long)
+	got := m.renderUserMessage(long)
 
 	widths := visibleLines(got)
-	require.Greater(t, len(widths), 1, "long bubble at wide terminal must wrap; got: %q", got)
+	require.Greater(t, len(widths), 1, "long user message at wide terminal must wrap; got: %q", got)
 	for i, w := range widths {
-		assert.LessOrEqual(t, w, m.liveWidth(), "bubble line %d sits past liveWidth: width=%d", i, w)
+		assert.LessOrEqual(t, w, m.liveWidth(), "user message line %d sits past liveWidth: width=%d", i, w)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Drop the dark-bg highlight on echoed user messages; the cyan-bold `❯` prefix already marks them as user input.
- Detect the terminal background **synchronously before the program starts** (`lipgloss.HasDarkBackground`) and thread the result through `ModelConfig`. Querying in-band (`tea.RequestBackgroundColor`, or glamour's `WithAutoStyle` which calls `termenv`) races bubbletea's own input reader for the reply — the response leaked into the textarea as raw escape sequences and termenv's blocking read stalled the deferred welcome banner.
- Build glamour with an explicit dark/light style and the textarea with `DefaultStyles(hasDark)` (it otherwise defaults to dark, leaving the input box's cursor-line/text dark on light terminals).
- Make the assistant `⏺` final marker adaptive via `lipgloss.LightDark`, and add a darker palette for the busy-shimmer wave so it stays visible on light terminals.

Fixes pulumi/pulumi-service#43646
<img width="1089" height="603" alt="Screenshot 2026-06-02 at 19 12 02" src="https://github.com/user-attachments/assets/6197cafa-1514-439a-9ddb-17a072d3d5a2" />


## Test plan
- [x] `go test -count=1 -tags all ./cmd/pulumi/neo/...`
- [x] `make format && make lint`
- [x] `go build ./cmd/pulumi`
- [x] Manual: open `pulumi neo` in a light-themed terminal (e.g. iTerm "Solarized Light") and confirm no dark slab on user messages, a light-friendly input box, visible `⏺` marker, light-friendly glamour palette, visible shimmer, and no stray escape sequences in the input
- [ ] Manual: open `pulumi neo` in a dark-themed terminal and confirm no visual regression vs. previous behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)