### PR TITLE
add assumeRoles options to s3 backend and kms secrets provider

### DIFF
--- a/changelog/pending/20260526--backend-diy--add-ability-to-assume-aws-iam-role-for-diy-aws-s3-backend.yaml
+++ b/changelog/pending/20260526--backend-diy--add-ability-to-assume-aws-iam-role-for-diy-aws-s3-backend.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: feat
+  scope: backend/diy
+  description: Add ability to assume AWS IAM Role for DIY AWS S3 backend

--- a/pkg/authhelpers/awsauth.go
+++ b/pkg/authhelpers/awsauth.go
@@ -1,0 +1,275 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authhelpers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/s3blob"
+)
+
+// Represents a role to assume.
+// Mirrors the structure used by pulumi-aws provider's assumeRoles option.
+type AssumeRoleConfig struct {
+	// RoleArn is the ARN of the role to assume (required).
+	RoleArn string `json:"roleArn"`
+	// ExternalID is an external ID to use when assuming the role (optional).
+	ExternalID *string `json:"externalId,omitempty"`
+	// SessionName is the session name to use when assuming the role (optional).
+	SessionName string `json:"sessionName,omitempty"`
+}
+
+// Credentials provider that chains through a list of AWS credentials
+// providers, returning the first successful result.
+type assumeRolesChainedProvider struct {
+	providers []awsv2.CredentialsProvider
+}
+
+// Retrieve attempts to retrieve credentials from each provider in
+// order, returning the first successful result.
+func (p *assumeRolesChainedProvider) Retrieve(ctx context.Context) (awsv2.Credentials, error) {
+	var lastErr error
+	for _, provider := range p.providers {
+		creds, err := provider.Retrieve(ctx)
+		if err == nil {
+			return creds, nil
+		}
+		lastErr = err
+	}
+	return awsv2.Credentials{}, fmt.Errorf("all credentials providers failed: %w", lastErr)
+}
+
+// Credentials provider that uses stscreds.AssumeRoleProvider.
+type assumeRoleProviderWithSTS struct {
+	roleArn     string
+	externalID  *string
+	sessionName string
+	baseCreds   awsv2.CredentialsProvider
+	region      string
+}
+
+// Retrieve retrieves temporary credentials by assuming the role via STS.
+func (p *assumeRoleProviderWithSTS) Retrieve(ctx context.Context) (awsv2.Credentials, error) {
+	// STS is a global service, default to us-east-1 if no region specified.
+	region := p.region
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	// Create STS client with base credentials
+	stsCfg := awsv2.Config{
+		Credentials: p.baseCreds,
+		Region:      region,
+	}
+	stsClient := sts.NewFromConfig(stsCfg)
+
+	// Create assume role provider
+	provider := stscreds.NewAssumeRoleProvider(stsClient, p.roleArn, func(o *stscreds.AssumeRoleOptions) {
+		if p.externalID != nil {
+			o.ExternalID = p.externalID
+		}
+		if p.sessionName != "" {
+			o.RoleSessionName = p.sessionName
+		}
+	})
+
+	creds, err := provider.Retrieve(ctx)
+	return creds, err
+}
+
+// Create a credentials provider that attempts to assume the specified roles in
+// order. If assumeRoles is empty, it returns a provider that uses the default
+// AWS credentials chain.
+// When assumeRoles is specified, assume role providers are tried first (in order),
+// and the default credentials chain is used as a fallback if all assume roles fail.
+func NewAssumeRoleChainedCredentials(
+	ctx context.Context,
+	assumeRoles []AssumeRoleConfig,
+	region string,
+) (awsv2.CredentialsProvider, error) {
+	// Base provider: always start with the default credentials chain
+	base, err := newDefaultCredChain(ctx, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default credentials provider: %w", err)
+	}
+
+	providers := make([]awsv2.CredentialsProvider, 0, len(assumeRoles)+1)
+
+	// Add assume role providers for each role (tried first, in order)
+	for _, role := range assumeRoles {
+		provider := &assumeRoleProviderWithSTS{
+			roleArn:     role.RoleArn,
+			externalID:  role.ExternalID,
+			sessionName: role.SessionName,
+			baseCreds:   base,
+			region:      region,
+		}
+		providers = append(providers, provider)
+	}
+
+	// Default credentials chain is the fallback (tried last)
+	providers = append(providers, base)
+
+	return &assumeRolesChainedProvider{providers: providers}, nil
+}
+
+// Create a credentials provider that uses the default AWS credentials
+// chain (env vars, shared credentials file, EC2/ECS instance roles,
+// etc.).
+func newDefaultCredChain(ctx context.Context, region string) (awsv2.CredentialsProvider, error) {
+	var opts []func(*config.LoadOptions) error
+	if region != "" {
+		opts = append(opts, config.WithRegion(region))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load default AWS config: %w", err)
+	}
+
+	return cfg.Credentials, nil
+}
+
+// Parse the assumeRoles query parameter from a URL and return
+// the list of role configs, or nil if not specified.
+// The assumeRoles parameter is expected to be a JSON array of objects,
+// URL-encoded. For example:
+//
+//	s3://mybucket?assumeRoles=[{"roleArn":"arn:aws:iam::123456789012:role/Role1","externalId":"ext1"}]
+func AssumeRoleFromURLParams(q url.Values) ([]AssumeRoleConfig, error) {
+	rolesParam := q.Get("assumeRoles")
+	if rolesParam == "" {
+		return nil, nil
+	}
+
+	// URL decode the parameter (it may be URL-encoded by the URL parser)
+	decoded, err := url.QueryUnescape(rolesParam)
+	if err != nil {
+		return nil, fmt.Errorf("failed to URL-decode assumeRoles parameter: %w", err)
+	}
+
+	// Parse JSON
+	var roles []AssumeRoleConfig
+	if err := json.Unmarshal([]byte(decoded), &roles); err != nil {
+		return nil, fmt.Errorf("failed to parse assumeRoles as JSON array: %w (value: %q)", err, decoded)
+	}
+
+	// Validate that each role has a roleArn
+	for i, role := range roles {
+		if role.RoleArn == "" {
+			return nil, fmt.Errorf("assumeRoles[%d]: roleArn is required", i)
+		}
+		if !strings.HasPrefix(role.RoleArn, "arn:") {
+			return nil, fmt.Errorf("assumeRoles[%d]: roleArn must be a valid ARN (starts with 'arn:'): %s", i, role.RoleArn)
+		}
+	}
+
+	return roles, nil
+}
+
+// Create a blob.URLMux configured for S3 with optional assume role
+// support. If assumeRoles is specified, credentials will be obtained
+// by assuming roles in order (starting with the default chain).
+// If assumeRoles is empty, the default AWS credentials chain is used.
+func AWSCredentialsMux(ctx context.Context, assumeRoles []AssumeRoleConfig, region string) (*blob.URLMux, error) {
+	credsProvider, err := NewAssumeRoleChainedCredentials(ctx, assumeRoles, region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create credentials provider: %w", err)
+	}
+
+	// Create an S3 client with the credentials provider
+	s3Config := awsv2.Config{
+		Credentials: credsProvider,
+		Region:      region,
+	}
+
+	s3Client := s3.NewFromConfig(s3Config)
+
+	// Create the URL mux
+	bm := &blob.URLMux{}
+	bm.RegisterBucket(s3blob.Scheme, &s3blobURLOpener{
+		Client:      s3Client,
+		AssumeRoles: assumeRoles,
+	})
+
+	return bm, nil
+}
+
+// Custom opener for S3 URLs that supports assume role credentials via
+// the assumeRoles parameter.
+type s3blobURLOpener struct {
+	Client      *s3.Client
+	AssumeRoles []AssumeRoleConfig
+}
+
+// Open an S3 bucket URL, using assume role credentials if assumeRoles
+// is specified.
+func (o *s3blobURLOpener) OpenBucketURL(ctx context.Context, u *url.URL) (*blob.Bucket, error) {
+	q := u.Query()
+
+	// Parse server-side encryption parameters
+	sseTypeParam := q.Get("ssetype")
+	if sseTypeParam != "" {
+		q.Del("ssetype")
+	}
+	kmsKeyID := q.Get("kmskeyid")
+	if kmsKeyID != "" {
+		q.Del("kmskeyid")
+	}
+
+	// Check if we need to use a different SDK version
+	useV2 := true
+	if val := q.Get("awssdk"); val == "v1" || val == "V1" {
+		useV2 = false
+	}
+
+	if !useV2 {
+		return nil, errors.New("AWS SDK v1 is not supported with assumeRoles")
+	}
+
+	// Create encryption options
+	var opts s3blob.Options
+	if sseTypeParam != "" {
+		for _, sseType := range types.ServerSideEncryptionAes256.Values() {
+			if strings.EqualFold(string(sseType), sseTypeParam) {
+				opts.EncryptionType = sseType
+				break
+			}
+		}
+		for _, sseType := range types.ServerSideEncryptionAwsKms.Values() {
+			if strings.EqualFold(string(sseType), sseTypeParam) {
+				opts.EncryptionType = sseType
+				break
+			}
+		}
+	}
+	if kmsKeyID != "" {
+		opts.KMSEncryptionID = kmsKeyID
+	}
+
+	return s3blob.OpenBucketV2(ctx, o.Client, u.Host, &opts)
+}

--- a/pkg/authhelpers/awsauth_test.go
+++ b/pkg/authhelpers/awsauth_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authhelpers
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestAssumeRoleFromURLParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		output  []AssumeRoleConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty param returns nil",
+			input:   "",
+			output:  nil,
+			wantErr: false,
+		},
+		{
+			name:  "single role with all fields",
+			input: `[{"roleArn":"arn:aws:iam::123456789012:role/Role1","externalId":"ext1","sessionName":"sess1"}]`,
+			output: []AssumeRoleConfig{
+				{
+					RoleArn:     "arn:aws:iam::123456789012:role/Role1",
+					ExternalID:  ptr("ext1"),
+					SessionName: "sess1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "single role with minimal fields",
+			input: `[{"roleArn":"arn:aws:iam::123456789012:role/Role1"}]`,
+			output: []AssumeRoleConfig{
+				{
+					RoleArn: "arn:aws:iam::123456789012:role/Role1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "multiple roles chained",
+			input: `[{"roleArn":"arn:aws:iam::111111111111:role/Role1"},{"roleArn":"arn:aws:iam::222222222222:role/Role2"}]`,
+			output: []AssumeRoleConfig{
+				{
+					RoleArn: "arn:aws:iam::111111111111:role/Role1",
+				},
+				{
+					RoleArn: "arn:aws:iam::222222222222:role/Role2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty roleArn returns error",
+			input:   `[{"roleArn":""}]`,
+			output:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid ARN returns error",
+			input:   `[{"roleArn":"invalid-arn"}]`,
+			output:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON returns error",
+			input:   `not json`,
+			output:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON array returns error",
+			input:   `{}`,
+			output:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			q := url.Values{}
+			if tt.input != "" {
+				q.Set("assumeRoles", tt.input)
+			}
+
+			output, err := AssumeRoleFromURLParams(q)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("AssumeRoleFromURLParams() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("AssumeRoleFromURLParams() unexpected error: %v", err)
+				return
+			}
+
+			if len(tt.output) != len(output) {
+				t.Errorf("AssumeRoleFromURLParams() expected %d roles, got %d", len(tt.output), len(output))
+				return
+			}
+
+			for i, role := range tt.output {
+				if role.RoleArn != output[i].RoleArn {
+					t.Errorf("AssumeRoleFromURLParams() role[%d].RoleArn expected %q, got %q", i, role.RoleArn, output[i].RoleArn)
+				}
+				if role.ExternalID != nil {
+					if output[i].ExternalID == nil || *role.ExternalID != *output[i].ExternalID {
+						t.Errorf("role[%d].ExternalID expected %q, got %v", i, *role.ExternalID, *output[i].ExternalID)
+					}
+				} else if output[i].ExternalID != nil {
+					t.Errorf("role[%d].ExternalID expected nil, got %v", i, *output[i].ExternalID)
+				}
+				if role.SessionName != output[i].SessionName {
+					t.Errorf("role[%d].SessionName expected %q, got %q", i, role.SessionName, output[i].SessionName)
+				}
+			}
+		})
+	}
+}
+
+func TestAssumeRoleFromURLParams_URLDecoded(t *testing.T) {
+	t.Parallel()
+
+	// Test URL-encoded JSON (as it would come from a URL)
+	input := url.QueryEscape(`[{"roleArn":"arn:aws:iam::123456789012:role/Role1","externalId":"ext1"}]`)
+
+	q := url.Values{}
+	q.Set("assumeRoles", input)
+
+	output, err := AssumeRoleFromURLParams(q)
+	if err != nil {
+		t.Errorf("AssumeRoleFromURLParams() unexpected error: %v", err)
+		return
+	}
+
+	if len(output) != 1 {
+		t.Errorf("AssumeRoleFromURLParams() expected 1 role, got %d", len(output))
+		return
+	}
+
+	if output[0].RoleArn != "arn:aws:iam::123456789012:role/Role1" {
+		want := "arn:aws:iam::123456789012:role/Role1"
+		t.Errorf("expected roleArn %q, got %q", want, output[0].RoleArn)
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -36,7 +36,7 @@ import (
 	_ "gocloud.dev/blob/azureblob" // driver for azblob://
 	_ "gocloud.dev/blob/fileblob"  // driver for file://
 	"gocloud.dev/blob/gcsblob"     // driver for gs://
-	_ "gocloud.dev/blob/s3blob"    // driver for s3://
+	"gocloud.dev/blob/s3blob"      // driver for s3://
 	"gocloud.dev/gcerrors"
 
 	"github.com/pulumi/pulumi/pkg/v3/authhelpers"
@@ -260,6 +260,21 @@ func newDIYBackend(
 		blobmux, err = authhelpers.GoogleCredentialsMux(ctx)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Check for AWS IAM Roles to assume for s3 bucket access
+	if p.Scheme == s3blob.Scheme {
+		assumeRoles, err := authhelpers.AssumeRoleFromURLParams(p.Query())
+		if err != nil {
+			return nil, err
+		}
+		if len(assumeRoles) > 0 {
+			region := p.Query().Get("region")
+			blobmux, err = authhelpers.AWSCredentialsMux(ctx, assumeRoles, region)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -23,10 +23,12 @@ import (
 	"fmt"
 	netUrl "net/url"
 	"os"
+	"path"
 	"strings"
 
+	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	gosecrets "gocloud.dev/secrets"
-	_ "gocloud.dev/secrets/awskms"        // support for awskms://
+	"gocloud.dev/secrets/awskms"          // support for awskms://
 	_ "gocloud.dev/secrets/azurekeyvault" // support for azurekeyvault://
 	"gocloud.dev/secrets/gcpkms"          // support for gcpkms://
 	_ "gocloud.dev/secrets/hashivault"    // support for hashivault://
@@ -54,6 +56,33 @@ func openKeeper(ctx context.Context, url string) (*gosecrets.Keeper, error) {
 	}
 
 	switch u.Scheme {
+	case awskms.Scheme:
+		assumeRoles, err := authhelpers.AssumeRoleFromURLParams(u.Query())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse assumeRoles for awskms://: %w", err)
+		}
+
+		if len(assumeRoles) > 0 {
+			credsProvider, err := authhelpers.NewAssumeRoleChainedCredentials(ctx, assumeRoles, u.Query().Get("region"))
+			if err != nil {
+				return nil, fmt.Errorf("failed to create assume role credentials for awskms://: %w", err)
+			}
+
+			kmsConfig := awsv2.Config{
+				Credentials: credsProvider,
+				Region:      u.Query().Get("region"),
+			}
+
+			kmsClient, err := awskms.DialV2(kmsConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create KMS client for awskms://: %w", err)
+			}
+
+			keyID := strings.TrimPrefix(path.Join(u.Host, u.Path), "/")
+			return awskms.OpenKeeperV2(kmsClient, keyID, nil), nil
+		}
+
+		return gosecrets.OpenKeeper(ctx, url)
 	case gcpkms.Scheme:
 		credentials, err := authhelpers.ResolveGoogleCredentials(ctx, cloudkms.CloudkmsScope)
 		if err != nil {

--- a/pkg/secrets/cloud/manager_test.go
+++ b/pkg/secrets/cloud/manager_test.go
@@ -134,3 +134,36 @@ func (k dummySecretsKeeper) Decrypt(ctx context.Context, ciphertext []byte) ([]b
 func (k dummySecretsKeeper) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
 	return plaintext, nil
 }
+
+func TestOpenKeeperAssumeRoles(t *testing.T) {
+	t.Parallel()
+
+	// openKeeper uses awskms.Scheme (which is "awskms"), but that scheme is already
+	// registered by gocloud.dev's awskms package in init(). We test the assumeRoles
+	// parsing logic directly by exercising openKeeper's error handling paths.
+
+	baseURL := "awskms://alias/test?region=us-west-2&awssdk=v2&assumeRoles="
+
+	t.Run("assumeRoles parsing - invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		_, err := openKeeper(t.Context(), baseURL+"not-valid-json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assumeRoles")
+	})
+
+	t.Run("assumeRoles parsing - empty roleArn", func(t *testing.T) {
+		t.Parallel()
+		url := baseURL + `[{"roleArn":""}]`
+		_, err := openKeeper(t.Context(), url)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assumeRoles")
+	})
+
+	t.Run("assumeRoles parsing - invalid ARN", func(t *testing.T) {
+		t.Parallel()
+		url := baseURL + `[{"roleArn":"not-an-arn"}]`
+		_, err := openKeeper(t.Context(), url)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assumeRoles")
+	})
+}


### PR DESCRIPTION
## Summary
This adds features akin to the [Terraform S3 backend role_arn](https://developer.hashicorp.com/terraform/language/backend/s3#role_arn)

That is, the ability to assume a role (i.e. in a different account) for state storage.

The config values follow the same syntax as [assumeRoles](https://www.pulumi.com/registry/packages/aws/installation-configuration/#configuration-options), allowing:

```bash
pulumi login 's3://pulumi-state-123456789012-us-west-2-an?region=us-west-2&awssdk=v2&assumeRoles=[{"roleArn":"arn:aws:iam::123456789012:role/foo"}]'
stack init test --secrets-provider="awskms://alias/mypulumikey?region=us-west-2&awssdk=v2&assumeRoles=[{\"roleArn\":\"arn:aws:iam::123456789012:role/foo\"}]"
```

(this might be better with a simple `assumeRole=rolearn` instead; I wasn't sure if consistency or terseness would be better and am open to changing it)

## Test plan
- [X] Added appropriate unit tests - For all changes
- ~Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes~
- ~Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes~
- ~Added a golden test in `pkg/backend/display` - For changes to the output renderers~

## Validation
- [X] `make lint` — clean
- ~`make test_fast` — all pass~
  - This has a pr-existing failure
- [X] `make tidy_fix` — clean
- [X] `make format` — clean
- ~Relevant SDK tests pass (if SDK changes)~
- ~`make check_proto` — clean (if proto changes)~

## Changelog
- [X] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
If the conditions added here weren't done correctly, it could break normal S3 DIY backend use. I've tested and believe that to not be the case.
