### PR TITLE
Suggest similar tokens when an unknown token is passed to `pulumi do`

### DIFF
--- a/changelog/pending/cli-do-improvement-20260528-125138.yaml
+++ b/changelog/pending/cli-do-improvement-20260528-125138.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Suggest similar tokens when an unknown token is passed to `pulumi do`
 time: 2026-05-28T12:51:38.035196+02:00
 custom:
-    PR: https://github.com/pulumi/pulumi/pull/23341
+    PR: 23341

--- a/changelog/pending/cli-do-improvement-20260528-125138.yaml
+++ b/changelog/pending/cli-do-improvement-20260528-125138.yaml
@@ -1,0 +1,6 @@
+component: cli/do
+kind: improvement
+body: Suggest similar tokens when an unknown token is passed to `pulumi do`
+time: 2026-05-28T12:51:38.035196+02:00
+custom:
+    PR: https://github.com/pulumi/pulumi/pull/23341

--- a/pkg/cmd/pulumi/cmd/exit_codes.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes.go
@@ -46,6 +46,17 @@ type CustomExitCodeError interface {
 	CustomExitCode() int
 }
 
+// ConfigurationError signals that a command was called with malformed input: an unknown
+// token, bad flag combination, unparsable argument, and so on. ExitCodeFor maps it to
+// ExitConfigurationError.
+type ConfigurationError struct {
+	Message string
+}
+
+func (e ConfigurationError) Error() string {
+	return e.Message
+}
+
 // ExitCodeFor maps an error to a process exit code, based on its concrete or
 // wrapped type. This function is the single choke point for mapping errors
 // into the public exit code contract.
@@ -99,6 +110,11 @@ func ExitCodeFor(err error) int {
 
 	// Non-interactive mode without confirmation flags.
 	if errors.As(err, &backenderr.NoConfirmationInNonInteractiveError{}) {
+		return ExitConfigurationError
+	}
+
+	// Command was invoked with malformed input
+	if errors.As(err, &ConfigurationError{}) {
 		return ExitConfigurationError
 	}
 

--- a/pkg/cmd/pulumi/cmd/exit_codes_test.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes_test.go
@@ -91,6 +91,11 @@ func TestExitCodeFor_KnownErrors(t *testing.T) {
 			want: ExitConfigurationError,
 		},
 		{
+			name: "invalid invocation",
+			err:  ConfigurationError{Message: "unknown function..."},
+			want: ExitConfigurationError,
+		},
+		{
 			name: "wrapped auth error",
 			err:  wrap(errors.New("outer"), backenderr.LoginRequiredError{}),
 			want: ExitAuthenticationError,

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -22,16 +22,20 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/google/shlex"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/pgavlin/fx/v2/maps"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/texttheater/golang-levenshtein/levenshtein"
 
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	cmdConvert "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/convert"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -226,7 +230,7 @@ func NewDoCmd(
 			return loadConverterPlugin(pctx, name, log)
 		}
 
-		subcmd := (&packageCommand{
+		subcmd, err := (&packageCommand{
 			pkg:               pkg,
 			args:              pargs,
 			evalContext:       evalContext,
@@ -238,6 +242,10 @@ func NewDoCmd(
 			dryrun:            dryrun,
 			showSecrets:       showSecrets,
 		}).newCommand()
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
 		// Replace the short name in Use with the full token so the usage
 		// string shows e.g. "pulumi do aws:s3:Bucket" instead of "pulumi do Bucket".
 		if len(pargs) > 0 {
@@ -340,7 +348,7 @@ package will be inferred from the token or passed via --package which can be a
 package name or the path to a plugin binary or folder. Further parameters can
 be passed after the package name which will be used to parameterize the plugin
 loaded.
-e.g. pulumi do --package "name@version param1 \"multi word param\"" 
+e.g. pulumi do --package "name@version param1 \"multi word param\""
 
 Resource operations: list, create, read, patch, delete
 Functions are invoked directly by name.
@@ -423,32 +431,164 @@ type packageCommand struct {
 	showSecrets       bool
 }
 
-func (pc *packageCommand) newCommand() *cobra.Command {
+func (pc *packageCommand) newCommand() (*cobra.Command, error) {
 	// Based on token (if present) we need to work out if this is a package, module, resource, or function command.
 
-	if len(pc.args) == 0 {
-		// No token, so this is just the package command.
-		return pc.newPackageCommand()
-	} else {
-		// Count the separators in the token.
-		count := strings.Count(pc.args[0], ":")
-		if count == 0 {
-			// No separators, this is a package
-			return pc.newPackageCommand()
-		}
-
-		// Try and look it up, it's either a module, resource, or function.
-		fun, ok := pc.spec.GetFunction(pc.args[0])
-		if ok {
-			return pc.newFunctionCommand(fun)
-		}
-		res, ok := pc.spec.GetResource(pc.args[0])
-		if ok {
-			return pc.newResourceCommand(res)
-		}
-
-		return pc.newModuleCommand()
+	if len(pc.args) == 0 || strings.Count(pc.args[0], ":") == 0 {
+		// No token (or just a package name), so this is just the package command.
+		return pc.newPackageCommand(), nil
 	}
+
+	// Try and look it up, it's either a module, resource, or function.
+	if fun, ok := pc.spec.GetFunction(pc.args[0]); ok {
+		return pc.newFunctionCommand(fun), nil
+	}
+	if res, ok := pc.spec.GetResource(pc.args[0]); ok {
+		return pc.newResourceCommand(res), nil
+	}
+	if pc.isKnownModule(pc.args[0]) {
+		return pc.newModuleCommand(), nil
+	}
+
+	return nil, pc.unknownTokenError(pc.args[0])
+}
+
+// isKnownModule checks whether `typed` (e.g. "aws:s3" or "pkg:mod1/mod2") matches a module in the schema.
+func (pc *packageCommand) isKnownModule(typed string) bool {
+	// inModule reports whether the token lives in module `typed` or a descendant of it. Modules nest
+	// on "/", so a parent like "pkg:mod1" matches a token in "pkg:mod1/mod2".
+	_, name, _ := strings.Cut(typed, ":")
+	if name == "" {
+		return false
+	}
+	inModule := func(token string) bool {
+		mod := pc.spec.TokenToModule(token)
+		return mod == name || strings.HasPrefix(mod, name+"/")
+	}
+	for _, fn := range pc.spec.Functions {
+		if !fn.IsMethod && inModule(fn.Token) {
+			return true
+		}
+	}
+	for _, res := range pc.spec.Resources {
+		if inModule(res.Token) {
+			return true
+		}
+	}
+	return false
+}
+
+func (pc *packageCommand) moduleToken(token string) string {
+	mod := pc.spec.TokenToModule(token)
+	if mod == "" {
+		return ""
+	}
+	return string(tokens.Token(token).Package()) + ":" + mod
+}
+
+func (pc *packageCommand) unknownTokenError(typed string) error {
+	msg := fmt.Sprintf("unknown function, resource, or module %q in package %q", typed, pc.spec.Name)
+	suggestions := pc.suggestTokens(typed)
+	if len(suggestions) == 0 {
+		return cmdCmd.ConfigurationError{Message: msg}
+	}
+	var b strings.Builder
+	b.WriteString(msg)
+	b.WriteString("\n\nDid you mean this?\n")
+	for _, s := range suggestions {
+		fmt.Fprintf(&b, "\t%s\n", s)
+	}
+	return cmdCmd.ConfigurationError{Message: b.String()}
+}
+
+// suggestTokens returns tokens whose module and name are individually close to the typed value's
+// components. The displayed form comes from spec.CanonicalizeToken.
+func (pc *packageCommand) suggestTokens(typed string) []string {
+	_, typedMod, typedName, diags := pcl.DecomposeToken(typed, hcl.Range{})
+	if diags.HasErrors() {
+		return nil
+	}
+
+	op := levenshtein.DefaultOptionsWithSub
+	op.Matches = func(r1, r2 rune) bool {
+		return unicode.ToLower(r1) == unicode.ToLower(r2)
+	}
+	// Scale the allowed edit distance with the longer string
+	closeEnough := func(a, b string) bool {
+		threshold := 2
+		if max(len(a), len(b)) < 6 {
+			threshold = 1
+		}
+		return levenshtein.DistanceForStrings([]rune(a), []rune(b), op) <= threshold
+	}
+
+	seen := map[string]struct{}{}
+	var suggestions []string
+	consider := func(token string) {
+		_, _, name, diags := pcl.DecomposeToken(token, hcl.Range{})
+		if diags.HasErrors() {
+			return
+		}
+		if !closeEnough(typedName, name) {
+			return
+		}
+		// Compare against the canonical module (the form the user types), not the raw module. Bridged providers nest
+		// submodules so the raw form looks nothing like what the user typed (e.g. "s3/bucket" vs "s3"). "index" stands
+		// in for a missing module so typing pkg:Type still ranks against tokens that live in that module.
+		canonicalMod := pc.spec.TokenToModule(token)
+		if canonicalMod == "" {
+			canonicalMod = "index"
+		}
+		modMatch := strings.EqualFold(typedMod, canonicalMod) ||
+			typedMod == "index" ||
+			closeEnough(typedMod, canonicalMod)
+		if !modMatch {
+			return
+		}
+		display := pc.spec.CanonicalizeToken(token)
+		if _, ok := seen[display]; ok {
+			return
+		}
+		seen[display] = struct{}{}
+		suggestions = append(suggestions, display)
+	}
+	for _, fn := range pc.spec.Functions {
+		if fn.IsMethod {
+			continue
+		}
+		consider(fn.Token)
+	}
+	for _, res := range pc.spec.Resources {
+		consider(res.Token)
+	}
+
+	// If the user typed a 2-segment value (pkg:something), the second segment may have been intended as a module name,
+	// e.g. "aws:s4" probably means "aws:s3". Search for modules so the suggestions aren't limited to leaf tokens.
+	if typedMod == "index" {
+		considerModule := func(token string) {
+			mod := pc.spec.TokenToModule(token)
+			if mod == "" || !closeEnough(typedName, mod) {
+				return
+			}
+			display := pc.moduleToken(token)
+			if _, ok := seen[display]; ok {
+				return
+			}
+			seen[display] = struct{}{}
+			suggestions = append(suggestions, display)
+		}
+		for _, fn := range pc.spec.Functions {
+			if !fn.IsMethod {
+				considerModule(fn.Token)
+			}
+		}
+		for _, res := range pc.spec.Resources {
+			considerModule(res.Token)
+		}
+	}
+
+	slices.Sort(suggestions)
+	return suggestions
 }
 
 func (pc *packageCommand) newPackageCommand() *cobra.Command {
@@ -481,21 +621,17 @@ func (pc *packageCommand) newPackageCommand() *cobra.Command {
 			continue
 		}
 
-		mod := pc.spec.TokenToModule(fn.Token)
-		if mod == "" {
+		if mod := pc.moduleToken(fn.Token); mod == "" {
 			functions[fn.Token] = fn
 		} else {
-			tok := string(tokens.Token(fn.Token).Package()) + ":" + mod
-			modules[tok] = struct{}{}
+			modules[mod] = struct{}{}
 		}
 	}
 	for _, res := range pc.spec.Resources {
-		mod := pc.spec.TokenToModule(res.Token)
-		if mod == "" {
+		if mod := pc.moduleToken(res.Token); mod == "" {
 			resources[res.Token] = res
 		} else {
-			tok := string(tokens.Token(res.Token).Package()) + ":" + mod
-			modules[tok] = struct{}{}
+			modules[mod] = struct{}{}
 		}
 	}
 
@@ -574,8 +710,7 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 		if mod == name {
 			functions[pc.spec.CanonicalizeToken(fn.Token)] = fn
 		} else if strings.HasPrefix(mod, name+"/") {
-			tok := string(tokens.Token(fn.Token).Package()) + ":" + mod
-			modules[tok] = struct{}{}
+			modules[pc.moduleToken(fn.Token)] = struct{}{}
 		}
 	}
 	for _, res := range pc.spec.Resources {
@@ -583,8 +718,7 @@ func (pc *packageCommand) newModuleCommand() *cobra.Command {
 		if mod == name {
 			resources[res.Token] = res
 		} else if strings.HasPrefix(mod, name+"/") {
-			tok := string(tokens.Token(res.Token).Package()) + ":" + mod
-			modules[tok] = struct{}{}
+			modules[pc.moduleToken(res.Token)] = struct{}{}
 		}
 	}
 

--- a/pkg/cmd/pulumi/do/do_test.go
+++ b/pkg/cmd/pulumi/do/do_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -591,4 +592,279 @@ Functions:
 	err = cmd.Execute()
 	require.NoError(t, err)
 	assert.Equal(t, expectedNestedModuleHelp, stdout.String())
+}
+
+func TestDoCmdUnknownTokenErrors(t *testing.T) {
+	t.Parallel()
+
+	formats := []struct {
+		name      string
+		meta      *schema.MetadataSpec
+		functions map[string]schema.FunctionSpec
+		resources map[string]schema.ResourceSpec
+		rawTokens []string
+	}{
+		{
+			name: "slash module format",
+			meta: &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			functions: map[string]schema.FunctionSpec{
+				"aws:s3/getObjects:getObjects": {},
+			},
+			resources: map[string]schema.ResourceSpec{
+				"aws:s3/bucket:Bucket":             {},
+				"aws:s3/bucketpolicy:BucketPolicy": {},
+			},
+			rawTokens: []string{
+				"aws:s3/getObjects:getObjects", "aws:s3/bucket:Bucket", "aws:s3/bucketpolicy:BucketPolicy",
+			},
+		},
+		{
+			name: "underscore module format",
+			meta: &schema.MetadataSpec{ModuleFormat: "(.*)(?:_[^_]*)"},
+			functions: map[string]schema.FunctionSpec{
+				"aws:s3_getObjects:getObjects": {},
+			},
+			resources: map[string]schema.ResourceSpec{
+				"aws:s3_bucket:Bucket":             {},
+				"aws:s3_bucketpolicy:BucketPolicy": {},
+			},
+			rawTokens: []string{
+				"aws:s3_getObjects:getObjects", "aws:s3_bucket:Bucket", "aws:s3_bucketpolicy:BucketPolicy",
+			},
+		},
+		{
+			name: "no module format",
+			meta: nil,
+			functions: map[string]schema.FunctionSpec{
+				"aws:s3:getObjects": {},
+			},
+			resources: map[string]schema.ResourceSpec{
+				"aws:s3:Bucket":       {},
+				"aws:s3:BucketPolicy": {},
+			},
+		},
+	}
+
+	table := []struct {
+		name           string
+		args           []string
+		wantContains   []string
+		wantNoContains []string
+	}{
+		{
+			name: "typo with downstream flag suggests function",
+			args: []string{"aws:s3:fgetObjects", "--input-file", "inputs.pcl"},
+			wantContains: []string{
+				`unknown function, resource, or module "aws:s3:fgetObjects"`, "Did you mean this?", "aws:s3:getObjects",
+			},
+			wantNoContains: []string{"unknown flag"},
+		},
+		{
+			name:         "wrong case suggests canonical token",
+			args:         []string{"aws:s3:bucket"},
+			wantContains: []string{`unknown function, resource, or module "aws:s3:bucket"`, "aws:s3:Bucket"},
+		},
+		{
+			name:         "small typo against nested-module schema",
+			args:         []string{"aws:s3:Buckt"},
+			wantContains: []string{`unknown function, resource, or module "aws:s3:Buckt"`, "aws:s3:Bucket"},
+		},
+		{
+			name:         "module typo suggests canonical sibling",
+			args:         []string{"aws:s4:Bucket"},
+			wantContains: []string{`unknown function, resource, or module "aws:s4:Bucket"`, "aws:s3:Bucket"},
+		},
+		{
+			name:           "two-segment typo suggests module",
+			args:           []string{"aws:s4"},
+			wantContains:   []string{`unknown function, resource, or module "aws:s4"`, "aws:s3"},
+			wantNoContains: []string{"aws:s3:Bucket"},
+		},
+		{
+			name:           "no near matches omits suggestion block",
+			args:           []string{"aws:s3:CompletelyDifferent"},
+			wantContains:   []string{`unknown function, resource, or module "aws:s3:CompletelyDifferent"`},
+			wantNoContains: []string{"Did you mean"},
+		},
+	}
+
+	for _, f := range formats {
+		t.Run(f.name, func(t *testing.T) {
+			t.Parallel()
+
+			loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+				return &testProvider{spec: schema.PackageSpec{
+					Name:      "aws",
+					Meta:      f.meta,
+					Functions: f.functions,
+					Resources: f.resources,
+				}}, nil
+			}
+
+			t.Run("known module resolves to help", func(t *testing.T) {
+				t.Parallel()
+
+				mlm := &cmdBackend.MockLoginManager{}
+				mws := &pkgWorkspace.MockContext{}
+
+				var stdout bytes.Buffer
+				cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+				cmd.SetOut(&stdout)
+				cmd.SetErr(&stdout)
+				cmd.SetArgs([]string{"aws:s3"})
+				require.NoError(t, cmd.Execute())
+
+				out := stdout.String()
+				assert.Contains(t, out, "Functions and resources for the s3 module")
+				assert.Contains(t, out, "aws:s3:getObjects")
+				assert.Contains(t, out, "aws:s3:Bucket")
+				assert.NotContains(t, out, "unknown function, resource, or module")
+			})
+
+			for _, tc := range table {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+
+					mlm := &cmdBackend.MockLoginManager{}
+					mws := &pkgWorkspace.MockContext{}
+
+					var stdout bytes.Buffer
+					cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+					cmd.SetOut(&stdout)
+					cmd.SetErr(&stdout)
+					cmd.SetArgs(tc.args)
+					err := cmd.Execute()
+					require.Error(t, err)
+					msg := err.Error()
+					for _, want := range tc.wantContains {
+						assert.Contains(t, msg, want)
+					}
+					for _, notWant := range tc.wantNoContains {
+						assert.NotContains(t, msg, notWant)
+					}
+					// Suggestions are always canonicalized; the raw (non-canonical) token forms must
+					// never appear, regardless of module format.
+					for _, raw := range f.rawTokens {
+						assert.NotContains(t, msg, raw)
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("parameterized package", func(t *testing.T) {
+		t.Parallel()
+
+		loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+			assert.Equal(t, "terraform-provider", source)
+			return &testProvider{
+				spec: schema.PackageSpec{
+					Name: "aws",
+					Meta: &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+					Functions: map[string]schema.FunctionSpec{
+						"aws:s3/getAccessPoint:getAccessPoint": {},
+					},
+					Resources: map[string]schema.ResourceSpec{
+						"aws:s3/bucket:Bucket": {},
+					},
+				},
+				MockProvider: plugin.MockProvider{
+					ParameterizeF: func(_ context.Context, req plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
+						args, ok := req.Parameters.(*plugin.ParameterizeArgs)
+						if assert.True(t, ok) {
+							assert.Equal(t, []string{"hashicorp/aws"}, args.Args)
+						}
+						return plugin.ParameterizeResponse{Name: "aws", Version: semver.MustParse("6.0.0")}, nil
+					},
+				},
+			}, nil
+		}
+
+		cases := []struct {
+			name           string
+			args           []string
+			wantContains   []string
+			wantNoContains []string
+		}{
+			{
+				name: "member typo suggests canonical subpackage token",
+				args: []string{"terraform-provider hashicorp/aws:s3:Buckt"},
+				wantContains: []string{
+					`unknown function, resource, or module "terraform-provider hashicorp/aws:s3:Buckt"`,
+					"Did you mean this?", "aws:s3:Bucket",
+				},
+			},
+			{
+				name:           "two-segment typo suggests canonical subpackage module",
+				args:           []string{"terraform-provider hashicorp/aws:s4"},
+				wantContains:   []string{`unknown function, resource, or module "terraform-provider hashicorp/aws:s4"`, "aws:s3"},
+				wantNoContains: []string{"aws:s3:Bucket", "terraform-provider hashicorp/aws:s3"},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				mlm := &cmdBackend.MockLoginManager{}
+				mws := &pkgWorkspace.MockContext{}
+
+				var stdout bytes.Buffer
+				cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+				cmd.SetOut(&stdout)
+				cmd.SetErr(&stdout)
+				cmd.SetArgs(tc.args)
+				err := cmd.Execute()
+				require.Error(t, err)
+				msg := err.Error()
+				for _, want := range tc.wantContains {
+					assert.Contains(t, msg, want)
+				}
+				for _, notWant := range tc.wantNoContains {
+					assert.NotContains(t, msg, notWant)
+				}
+			})
+		}
+	})
+}
+
+func TestDoCmdParameterizedModuleResolves(t *testing.T) {
+	t.Parallel()
+
+	mlm := &cmdBackend.MockLoginManager{}
+	mws := &pkgWorkspace.MockContext{}
+	loader := func(ctx context.Context, pctx *plugin.Context, wd, source string) (plugin.Provider, error) {
+		assert.Equal(t, "terraform-provider", source)
+		spec := schema.PackageSpec{
+			Name: "aws",
+			Meta: &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"aws:s3/bucket:Bucket": {},
+			},
+		}
+		return &testProvider{
+			spec: spec,
+			MockProvider: plugin.MockProvider{
+				ParameterizeF: func(_ context.Context, req plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
+					args, ok := req.Parameters.(*plugin.ParameterizeArgs)
+					if assert.True(t, ok) {
+						assert.Equal(t, []string{"hashicorp/aws"}, args.Args)
+					}
+					return plugin.ParameterizeResponse{Name: "aws", Version: semver.MustParse("6.0.0")}, nil
+				},
+			},
+		}, nil
+	}
+
+	var stdout bytes.Buffer
+	cmd := NewDoCmd(mlm, mws, loader, testHost, panicLoadConverterPlugin)
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"terraform-provider hashicorp/aws:s3"})
+	require.NoError(t, cmd.Execute())
+
+	out := stdout.String()
+	assert.Contains(t, out, "Functions and resources for the s3 module")
+	assert.Contains(t, out, "aws:s3:Bucket")
+	assert.NotContains(t, out, "unknown function, resource, or module")
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/segmentio/encoding v0.3.5
 	github.com/shirou/gopsutil/v3 v3.22.3
 	github.com/spf13/afero v1.9.5
+	github.com/texttheater/golang-levenshtein v1.0.1
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/bridge/opentracing v1.33.0
@@ -258,7 +259,6 @@ require (
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
-	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect


### PR DESCRIPTION
We were requiring an exact match for the token in `pulumi do`, but we can apply some fuzzy matching logic to suggest a token if there is no match.

```
$ pulumi do aws:s3:getObjet
error: unknown function, resource, or module "aws:s3:getObjet" for package "aws"

Did you mean this?
	aws:s3:getObject
	aws:s3:getObjects
```
```
$ pulumi do aws:s4
error: unknown function, resource, or module "aws:s4" for package "aws"

Did you mean this?
	aws:s3
```
```
$ pulumi do aws:s4:Bucket
error: unknown function, resource, or module "aws:s4:Bucket" for package "aws"

Did you mean this?
	aws:s3:Bucket
	aws:s3:BucketV2
```
