### PR TITLE
Retry all errors

### DIFF
--- a/changelog/pending/20260526--engine--the-engine-now-forwards-all-provider-errors-to-error-hooks-for-retry.yaml
+++ b/changelog/pending/20260526--engine--the-engine-now-forwards-all-provider-errors-to-error-hooks-for-retry.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: The engine now forwards all provider errors to error hooks for retry

--- a/pkg/engine/lifecycletest/error_hooks_test.go
+++ b/pkg/engine/lifecycletest/error_hooks_test.go
@@ -2008,3 +2008,66 @@ func TestErrorHooks_IndependentPerResource_Delete(t *testing.T) {
 	require.GreaterOrEqual(t, resAHooks, 1)
 	require.GreaterOrEqual(t, resBHooks, 2)
 }
+
+// Regression test for https://github.com/pulumi/pulumi/issues/23344. A normal error from a provider should trigger an
+// error hook. Not just StatusPartialFailure responses.
+func TestErrorHooks_PlainCreateErrorRunsOnErrorHook(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(_ context.Context, req plugin.CreateRequest) (plugin.CreateResponse, error) {
+					if req.Preview {
+						return plugin.CreateResponse{Status: resource.StatusOK}, nil
+					}
+					return plugin.CreateResponse{Status: resource.StatusOK}, errors.New("create failed")
+				},
+			}, nil
+		}),
+	}
+
+	hookCalls := 0
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		callbacks, err := deploytest.NewCallbacksServer()
+		require.NoError(t, err)
+		defer func() { require.NoError(t, callbacks.Close()) }()
+
+		h, err := deploytest.NewErrorHook(monitor, callbacks, "hook",
+			func(_ context.Context, urn resource.URN, _ resource.ID, name string,
+				typ tokens.Type, _, _ *pulumirpc.ResourceOptions, _, _, _ resource.PropertyMap,
+				failedOperation string, errs []string,
+			) (bool, error) {
+				require.Equal(t, "resA", name)
+				require.Equal(t, tokens.Type("pkgA:m:typA"), typ)
+				require.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:m:typA::resA"), urn)
+				require.Equal(t, "create", failedOperation)
+				require.NotEmpty(t, errs)
+				hookCalls++
+				return false, nil
+			})
+		require.NoError(t, err)
+
+		_, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs: resource.NewPropertyMapFromMap(map[string]any{"v": "a"}),
+			ResourceHookBindings: deploytest.ResourceHookBindings{
+				OnError: []*deploytest.ResourceHook{h},
+			},
+		})
+		require.NoError(t, err)
+
+		err = monitor.SignalAndWaitForShutdown(context.Background()) //nolint:usetesting // the engine outlives t.Context
+		require.NoError(t, err)
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
+	}
+	project := p.GetProject()
+	_, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.Error(t, err)
+	require.Equal(t, 1, hookCalls)
+}

--- a/pkg/resource/deploy/retries.go
+++ b/pkg/resource/deploy/retries.go
@@ -34,11 +34,10 @@ func isMaxErrorHookRetriesReached(err error) bool {
 	return errors.Is(err, &maxErrorHookRetriesReachedError{})
 }
 
-// Retry an operation until it succeeds, encounters a non-retryable error, or hits the maximum number of retries.
+// Retry an operation until it succeeds or hits the maximum number of retries.
 func withRetries[T any](
 	maxRetries int,
 	operation func() (T, error),
-	isRetryable func(result T, err error) bool,
 	shouldRetry func(result T, failures []string) (bool, error),
 ) (T, error) {
 	failures := []string{}
@@ -47,10 +46,6 @@ func withRetries[T any](
 		result, err := operation()
 		if err == nil {
 			return result, nil
-		}
-
-		if !isRetryable(result, err) {
-			return result, err
 		}
 
 		failures = append([]string{err.Error()}, failures...)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -364,9 +364,6 @@ func (s *CreateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 				return resp, err
 			},
-			func(resp plugin.CreateResponse, err error) bool {
-				return resp.Status == resource.StatusPartialFailure
-			},
 			func(resp plugin.CreateResponse, failures []string) (bool, error) {
 				shouldRetry, err := s.Deployment().RunErrorHooks(
 					s.new.ResourceHooks[resource.OnError],
@@ -681,11 +678,6 @@ func (s *DeleteStep) Apply() (resource.Status, StepCompleteFunc, error) {
 
 				return resp, err
 			},
-
-			func(_ plugin.DeleteResponse, _ error) bool {
-				return true
-			},
-
 			func(_ plugin.DeleteResponse, failures []string) (bool, error) {
 				shouldRetry, err := s.Deployment().RunErrorHooks(
 					s.old.ResourceHooks[resource.OnError],
@@ -1011,9 +1003,6 @@ func (s *UpdateStep) Apply() (resource.Status, StepCompleteFunc, error) {
 				}
 
 				return resp, err
-			},
-			func(resp plugin.UpdateResponse, err error) bool {
-				return resp.Status == resource.StatusPartialFailure
 			},
 			func(resp plugin.UpdateResponse, failures []string) (bool, error) {
 				shouldRetry, err := s.Deployment().RunErrorHooks(


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/23344

We were limiting errors for retry to only those that were `StatusPartialFailure` errors. But there's no reason to limit users to just seeing those errors, we can forward every error to the user and let _them_ decide if they want to retry it or not.