### PR TITLE
Unbundle the HCL language runtime and download it on demand

### DIFF
--- a/changelog/pending/.changie-20260527--engine--download-the-hcl-language-runtime-on-demand-instead-of-bundling-it.yaml
+++ b/changelog/pending/.changie-20260527--engine--download-the-hcl-language-runtime-on-demand-instead-of-bundling-it.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Download the HCL language runtime on demand instead of bundling it
+component: engine

--- a/changelog/pending/.changie-20260527--engine--download-the-hcl-language-runtime-on-demand-instead-of-bundling-it.yaml
+++ b/changelog/pending/.changie-20260527--engine--download-the-hcl-language-runtime-on-demand-instead-of-bundling-it.yaml
@@ -1,3 +1,5 @@
 kind: fix
 body: Download the HCL language runtime on demand instead of bundling it
 component: engine
+custom:
+    PR: 23356

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -156,7 +156,7 @@ func NewDoCmd(
 
 		pctx, err := plugin.NewContext(
 			ctx, sink, sink, host, nil, wd, nil, false,
-			nil, schema.NewLoaderServerFromHost)
+			nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, fmt.Errorf("create plugin context: %w", err)
 		}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -729,7 +729,8 @@ func NewImportCmd() *cobra.Command {
 				return fmt.Errorf("get working directory: %w", err)
 			}
 			sink := cmdutil.Diag()
-			pCtx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost)
+			pCtx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil,
+				schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return fmt.Errorf("create plugin context: %w", err)
 			}
@@ -947,7 +948,8 @@ func NewImportCmd() *cobra.Command {
 				}
 				sink := cmdutil.Diag()
 
-				ctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost)
+				ctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil,
+					schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -127,7 +127,8 @@ from the parameters, as in:
 
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(),
-				sink, sink, nil, nil, target.installRoot, nil, false, nil, schema.NewLoaderServerFromHost)
+				sink, sink, nil, nil, target.installRoot, nil, false, nil, schema.NewLoaderServerFromHost,
+				pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -59,7 +59,7 @@ empty string.`,
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost)
+				nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -51,7 +51,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost)
+				nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -61,7 +61,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost)
+				nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -58,7 +58,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost)
+				nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -163,7 +163,8 @@ func (cmd *packagePublishCmd) Run(
 		return err
 	}
 	sink := cmdutil.Diag()
-	pctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, wd, nil, false, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, wd, nil, false, nil,
+		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -334,7 +334,7 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, nil, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromHost)
+		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -173,7 +173,7 @@ func TestProviderFromSource(t *testing.T) {
 		installCtx.t = t
 
 		pctx, err := plugin.NewContext(
-			t.Context(), nil, nil, nil, nil, t.TempDir(), nil, false, nil, schema.NewLoaderServerFromHost)
+			t.Context(), nil, nil, nil, nil, t.TempDir(), nil, false, nil, schema.NewLoaderServerFromHost, nil)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pctx.Close()) }()
 

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -134,7 +134,8 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 			pluginArgs := args[1:]
 
-			pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil, schema.NewLoaderServerFromHost)
+			pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil,
+				schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return fmt.Errorf("could not create plugin context: %w", err)
 			}

--- a/pkg/cmd/pulumi/plugin/plugin_run_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run_test.go
@@ -37,7 +37,8 @@ func testSetup(t *testing.T) (context.Context, *plugin.Context, *plugin.GrpcServ
 	t.Helper()
 
 	ctx := t.Context()
-	pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil,
+		schema.NewLoaderServerFromHost, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { pctx.Close() })
 
@@ -243,7 +244,8 @@ func TestNewInstallPluginFunc_DisabledAcquisition(t *testing.T) {
 	// Set environment to disable automatic plugin acquisition
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
-	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil,
+		schema.NewLoaderServerFromHost, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 
@@ -259,7 +261,8 @@ func TestNewInstallPluginFunc_PluginInstallError(t *testing.T) {
 	// Clear the environment variable to enable automatic acquisition
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
-	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil,
+		schema.NewLoaderServerFromHost, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -87,7 +87,7 @@ func newPolicyAnalyzeCmd(
 						return nil, nil, fmt.Errorf("getting working directory: %w", err)
 					}
 					pctx, err := plugin.NewContext(ctx, cmdutil.Diag(), cmdutil.Diag(),
-						nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost)
+						nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 					if err != nil {
 						return nil, nil, fmt.Errorf("creating plugin context: %w", err)
 					}

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -124,7 +124,8 @@ func (cmd *policyInstallCmd) Run(
 		return fmt.Errorf("getting current working directory: %w", err)
 	}
 
-	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, nil, nil, cwd, nil, true, nil,
+		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return fmt.Errorf("creating plugin context: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -126,7 +126,8 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 	}
 
 	plugctx, err := plugin.NewContextWithRoot(ctx, cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
-		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil, schema.NewLoaderServerFromHost)
+		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil, schema.NewLoaderServerFromHost,
+		pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -71,7 +71,8 @@ func InstallPackagesFromProject(
 	d := diag.DefaultSink(stdout, stderr, diag.FormatOptions{
 		Color: utilCmdutil.GetGlobalColorization(),
 	})
-	pctx, err := plugin.NewContext(ctx, d, d, nil, nil, root, nil, false, nil, schema.NewLoaderServerFromHost)
+	pctx, err := plugin.NewContext(ctx, d, d, nil, nil, root, nil, false, nil,
+		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -109,7 +109,7 @@ func schemaFromSourceOrStdin(cmd *cobra.Command, source string, extraArgs []stri
 	}
 	sink := cmdutil.Diag()
 	pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-		nil, schema.NewLoaderServerFromHost)
+		nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/maputil"
@@ -387,7 +388,8 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, cwd, nil, false, nil, schema.NewLoaderServerFromHost)
+		ctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, cwd, nil, false, nil,
+			schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -310,7 +311,8 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil, NewLoaderServerFromHost)
+		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil,
+			NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -35,7 +35,7 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	require.NoError(b, err)
 	sink := diagtest.LogSink(b)
 	//nolint:usetesting // plugin.NewContext manages gRPC providers; b.Context cancels too early
-	ctx, err := plugin.NewContext(b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
+	ctx, err := plugin.NewContext(b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx.Host, options)
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2440,7 +2440,7 @@ func debugProvidersHelperHost(t *testing.T) plugin.Host {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	//nolint:usetesting // plugin.NewContext manages the lifecycle of gRPC providers; t.Context cancels before they shut down
-	pluginCtx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost)
+	pluginCtx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil)
 	require.NoError(t, err)
 	return pluginCtx.Host
 }

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
@@ -64,7 +65,8 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 
 	pctx, err := plugin.NewContextWithRoot(pluginCtx, diag, statusDiag, host, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
-		projinfo.Proj.GetPackageSpecs(), config, debugging, schema.NewLoaderServerFromHost)
+		projinfo.Proj.GetPackageSpecs(), config, debugging,
+		schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -128,7 +128,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -147,7 +147,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -167,7 +167,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -209,7 +209,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -240,7 +240,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -274,7 +274,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -231,7 +231,7 @@ func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
 	return plugin.NewContext(t.Context(), sink, statusSink, host, nil, "", nil, false,
-		nil, schema.NewLoaderServerFromHost)
+		nil, schema.NewLoaderServerFromHost, nil)
 }
 
 type testProviderSource struct {
@@ -2112,7 +2112,7 @@ func TestGetDeploymentInfo(t *testing.T) {
 	plugctx, err := plugin.NewContext(t.Context(),
 		&deploytest.NoopSink{}, &deploytest.NoopSink{},
 		deploytest.NewPluginHostF(nil, nil, nil)(),
-		nil, "", nil, false, nil, nil)
+		nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	plainKey := config.MustMakeKey("test", "region")
@@ -2336,7 +2336,7 @@ func TestInvoke(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2393,7 +2393,7 @@ func TestInvoke(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2471,7 +2471,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2542,7 +2542,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2644,7 +2644,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2709,7 +2709,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil)
+			nil, "", nil, false, nil, nil, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	b64secrets "github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/tests"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -534,7 +535,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 
 	// Start up a plugin context
 	pctx, err := plugin.NewContextWithRoot(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil,
-		nil, schema.NewLoaderServerFromHost)
+		nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -720,7 +721,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	// Start up a plugin context
 	pctx, err := plugin.NewContextWithRoot(
 		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
-		nil, schema.NewLoaderServerFromHost)
+		nil, schema.NewLoaderServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}

--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -18,12 +18,37 @@ package util
 import (
 	"slices"
 
+	"github.com/blang/semver"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// SetKnownPluginDownloadURL sets the PluginDownloadURL for the given PluginSpec if it's a known plugin.
-// Returns true if it filled in the URL.
+// knownLanguageRuntime describes a language runtime that is no longer bundled with the
+// `pulumi` binary and must be downloaded on demand. The URL points at the release source
+// (typically a GitHub repository) and Version pins the release the CLI is built against.
+type knownLanguageRuntime struct {
+	PluginDownloadURL string
+	Version           semver.Version
+}
+
+// knownLanguageRuntimes is the set of language runtimes that the CLI knows how to fetch
+// without being told a download URL by the user or a project file. As we migrate
+// previously-bundled language runtimes off the CLI release tarball, they are added here so
+// the CLI continues to know where to find them.
+var knownLanguageRuntimes = map[string]knownLanguageRuntime{
+	// The HCL language runtime lives in pulumi-labs/pulumi-hcl rather than pulumi/pulumi-hcl,
+	// so we have to point downloads at that repo explicitly.
+	"hcl": {
+		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
+		// renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl extractVersion=^v(?<version>.+)$
+		Version: semver.MustParse("0.4.0"),
+	},
+}
+
+// SetKnownPluginDownloadURL fills in metadata on the given PluginDescriptor that the CLI
+// knows about for well-known plugins: a PluginDownloadURL, and for unbundled language
+// runtimes, a pinned Version. Returns true if it filled in anything.
 func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 	// If the download url is already set don't touch it
 	if spec.PluginDownloadURL != "" {
@@ -44,6 +69,17 @@ func SetKnownPluginDownloadURL(spec *workspace.PluginDescriptor) bool {
 		// release artifact.
 		spec.PluginDownloadURL = "github://api.github.com/pulumi-labs/pulumi-hcl"
 		return true
+	}
+
+	if spec.Kind == apitype.LanguagePlugin {
+		if known, ok := knownLanguageRuntimes[spec.Name]; ok {
+			spec.PluginDownloadURL = known.PluginDownloadURL
+			if spec.Version == nil {
+				v := known.Version
+				spec.Version = &v
+			}
+			return true
+		}
 	}
 
 	return false

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -18,6 +18,7 @@ package util
 import (
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -46,4 +47,41 @@ func TestKnownProvider(t *testing.T) {
 	res := SetKnownPluginDownloadURL(&spec)
 	assert.True(t, res)
 	assert.Equal(t, "github://api.github.com/pulumiverse", spec.PluginDownloadURL)
+}
+
+func TestKnownLanguageRuntimeHCL(t *testing.T) {
+	t.Parallel()
+
+	spec := workspace.PluginDescriptor{
+		Name: "hcl",
+		Kind: apitype.LanguagePlugin,
+	}
+	res := SetKnownPluginDownloadURL(&spec)
+	assert.True(t, res)
+	pinned := semver.MustParse("0.4.0")
+	assert.Equal(t, workspace.PluginDescriptor{
+		Name:              "hcl",
+		Kind:              apitype.LanguagePlugin,
+		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
+		Version:           &pinned,
+	}, spec)
+}
+
+func TestKnownLanguageRuntimePreservesExplicitVersion(t *testing.T) {
+	t.Parallel()
+
+	explicit := semver.MustParse("0.3.0")
+	spec := workspace.PluginDescriptor{
+		Name:    "hcl",
+		Kind:    apitype.LanguagePlugin,
+		Version: &explicit,
+	}
+	res := SetKnownPluginDownloadURL(&spec)
+	assert.True(t, res)
+	assert.Equal(t, workspace.PluginDescriptor{
+		Name:              "hcl",
+		Kind:              apitype.LanguagePlugin,
+		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
+		Version:           &explicit,
+	}, spec)
 }

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
 	"github.com/pulumi/pulumi/pkg/v3/util"
 	"github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	diagutil "github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -110,6 +111,38 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 	return pluginSpec.Version, nil
 }
 
+// EnsureLanguageInstalled downloads and installs the named language runtime if it is not
+// bundled with the CLI and not already cached. This is the language-plugin analogue of
+// EnsurePluginsAreInstalled: it lets the CLI transparently fetch unbundled language runtimes
+// on first use, just like a resource provider.
+//
+// It satisfies plugin.LanguageInstaller and is wired into the plugin host at construction so
+// that every load of a language runtime through a default host triggers the install, rather
+// than each caller of Host.LanguageRuntime having to ensure the plugin is present.
+func EnsureLanguageInstalled(ctx context.Context, runtime string, newLoader plugin.NewLoaderFunc) error {
+	if runtime == "" {
+		return nil
+	}
+	if workspace.IsPluginBundled(apitype.LanguagePlugin, runtime) {
+		return nil
+	}
+	spec := workspace.PluginDescriptor{
+		Kind: apitype.LanguagePlugin,
+		Name: runtime,
+	}
+	if !util.SetKnownPluginDownloadURL(&spec) {
+		return nil
+	}
+	if pluginstorage.Instance.HasPlugin(ctx, spec) {
+		return nil
+	}
+	log := func(sev diag.Severity, msg string) {
+		logging.V(7).Infof("EnsureLanguageInstalled(%s): %s", runtime, msg)
+	}
+	_, err := InstallPlugin(ctx, spec, log, newLoader)
+	return err
+}
+
 // InstallPluginContent installs a plugin's tarball into the cache, then installs it's
 // dependencies.
 //
@@ -163,6 +196,7 @@ func installDependenciesForPluginSpec(
 		nil, // config
 		nil, // debugging
 		newLoader,
+		EnsureLanguageInstalled,
 	)
 	if err != nil {
 		return err

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,16 @@
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+\"\\S+ (?<currentValue>\\S+)\"",
       ],
     },
+    // Update the pinned versions of unbundled language runtimes in
+    // `pkg/util/plugin.go`. Each entry in `knownLanguageRuntimes` is preceded by a
+    // `// renovate:` annotation that tells this manager which release to track.
+    {
+      customType: "regex",
+      fileMatch: ["^pkg/util/plugin\\.go$"],
+      matchStrings: [
+        "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s+Version:\\s+semver\\.MustParse\\(\"(?<currentValue>[^\"]+)\"\\)",
+      ],
+    },
   ],
   // The preset's ignorePaths has `sdk/**` in it, we don't want that
   // https://github.com/pulumi/renovate-config/blob/main/default.json5#L55

--- a/scripts/get-language-providers.sh
+++ b/scripts/get-language-providers.sh
@@ -48,6 +48,9 @@ download_release() {
 }
 
 # Each entry is "lang tag [owner]". The owner defaults to "pulumi" when omitted.
+#
+# Note: the HCL language runtime is no longer bundled. Its pinned version and download URL
+# live in pkg/util/plugin.go (knownLanguageRuntimes) and the CLI fetches it on demand.
 LANGUAGES=(
   # renovate: datasource=github-releases depName=pulumi/pulumi-dotnet
   "dotnet v3.106.2"
@@ -55,8 +58,6 @@ LANGUAGES=(
   "java v1.27.0"
   # renovate: datasource=github-releases depName=pulumi/pulumi-yaml
   "yaml v1.35.0"
-  # renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl
-  "hcl v0.4.0 pulumi-labs"
 )
 
 for i in "${LANGUAGES[@]}"; do

--- a/sdk/go/common/resource/plugin/analyzer_plugin_test.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAnalyzerSpawn(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Sanity test that from config.Map to envvars we see what we expect to see
@@ -71,7 +71,7 @@ func TestAnalyzerSpawn(t *testing.T) {
 
 func TestAnalyzerSpawnNoConfig(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/analyzer-no-config")
@@ -146,7 +146,7 @@ func TestConstructEnvWithoutAdditionalEnv(t *testing.T) {
 
 func TestAnalyzerSpawnViaLanguage(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	// Sanity test that from config.Map to property values we see what we expect to see

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -61,7 +61,7 @@ type Context struct {
 // host's.
 func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSource,
 	pwd string, runtimeOptions map[string]any, disableProviderPreview bool,
-	parentSpan opentracing.Span, newLoader NewLoaderFunc,
+	parentSpan opentracing.Span, newLoader NewLoaderFunc, installLang LanguageInstaller,
 ) (*Context, error) {
 	// TODO: really this ought to just take plugins *workspace.Plugins and packages map[string]workspace.PackageSpec
 	// as args, but yaml depends on this function so *sigh*. For now just see if there's a project we should be using,
@@ -78,7 +78,7 @@ func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSo
 	}
 
 	return NewContextWithRoot(ctx, d, statusD, host, pwd, pwd, runtimeOptions,
-		disableProviderPreview, parentSpan, plugins, packages, nil, nil, newLoader)
+		disableProviderPreview, parentSpan, plugins, packages, nil, nil, newLoader, installLang)
 }
 
 // NewContextWithRoot is a variation of NewContext that also sets known project Root. Additionally accepts Plugins
@@ -86,6 +86,7 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]any, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
 	config map[config.Key]string, debugging DebugContext, newLoader NewLoaderFunc,
+	installLang LanguageInstaller,
 ) (*Context, error) {
 	if d == nil {
 		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
@@ -119,7 +120,7 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	if host == nil {
 		h, err := NewDefaultHost(
 			pctx, runtimeOptions, disableProviderPreview, plugins, packages, config, debugging, projectName,
-			newLoader,
+			newLoader, installLang,
 		)
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -37,6 +37,7 @@ func TestContextRequest_race(t *testing.T) {
 		false,               // disableProviderPreview
 		mocktracer.New().StartSpan("root"),
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -176,11 +176,21 @@ func collectPluginsFromPackages(
 
 type NewLoaderFunc = func(h Host) codegenrpc.LoaderServer
 
+// LanguageInstaller downloads and installs an unbundled language runtime on demand, so that
+// loading it via Host.LanguageRuntime works even when the runtime is not bundled with the CLI
+// or already cached. It is the language-runtime analogue of the engine's plugin install path.
+//
+// The install machinery lives in the pkg module, which the SDK cannot import, so a host is
+// given its installer at construction. newLoader is the same loader the host was built with;
+// installing a plugin may need it to install the plugin's dependencies. A nil LanguageInstaller
+// disables on-demand install (the host then relies on the runtime already being present).
+type LanguageInstaller = func(ctx context.Context, runtime string, newLoader NewLoaderFunc) error
+
 // NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
 func NewDefaultHost(ctx *Context, runtimeOptions map[string]any,
 	disableProviderPreview bool, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
 	config map[config.Key]string, debugging DebugContext, projectName tokens.PackageName,
-	newLoader NewLoaderFunc,
+	newLoader NewLoaderFunc, installLang LanguageInstaller,
 ) (Host, error) {
 	// Create plugin info from providers
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
@@ -230,6 +240,8 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]any,
 		debugContext:            debugging,
 		projectName:             projectName,
 		hasLoaderServer:         newLoader != nil,
+		newLoader:               newLoader,
+		installLang:             installLang,
 	}
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
@@ -354,6 +366,8 @@ type defaultHost struct {
 	projectPlugins []workspace.ProjectPlugin
 
 	hasLoaderServer bool
+	newLoader       NewLoaderFunc     // the loader the host was built with, passed to installLang.
+	installLang     LanguageInstaller // installs unbundled language runtimes on demand; may be nil.
 }
 
 var _ Host = (*defaultHost)(nil)
@@ -600,6 +614,13 @@ func (host *defaultHost) LanguageRuntime(runtime string,
 		if plug, has := host.languagePlugins[runtime]; has {
 			contract.Assertf(plug != nil, "language plugin %v was loaded but is nil", runtime)
 			return plug.Plugin, nil
+		}
+
+		// Download and install the language runtime on demand if it is unbundled and missing.
+		if host.installLang != nil {
+			if err := host.installLang(host.ctx.Request(), runtime, host.newLoader); err != nil {
+				return nil, fmt.Errorf("failed to install language plugin %s: %w", runtime, err)
+			}
 		}
 
 		// If not, allocate a new one.

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -39,7 +40,7 @@ func TestHostManagedProviderCloseSignalsCancellation(t *testing.T) {
 	t.Parallel()
 
 	sink := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 	host, ok := ctx.Host.(*defaultHost)
 	require.True(t, ok)
@@ -70,7 +71,7 @@ func TestClosePanic(t *testing.T) {
 	t.Parallel()
 
 	sink := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 	host, ok := ctx.Host.(*defaultHost)
 	require.True(t, ok)
@@ -231,7 +232,7 @@ func TestNewDefaultHost_PackagesResolution(t *testing.T) {
 	}
 
 	// Create the host with our packages
-	host, err := NewDefaultHost(ctx, nil, false, nil, packages, nil, nil, "", nil)
+	host, err := NewDefaultHost(ctx, nil, false, nil, packages, nil, nil, "", nil, nil)
 	require.NoError(t, err)
 	defer host.Close()
 
@@ -297,7 +298,7 @@ func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
 		"azure":        {Source: "azure"}, // This should be skipped as it's not a local path
 	}
 
-	host, err := NewDefaultHost(ctx, nil, false, plugins, packages, nil, nil, "", nil)
+	host, err := NewDefaultHost(ctx, nil, false, plugins, packages, nil, nil, "", nil, nil)
 	require.NoError(t, err)
 	defer host.Close()
 
@@ -334,7 +335,7 @@ func TestNewDefaultHost_LoaderAddress(t *testing.T) {
 		return codegenrpc.UnimplementedLoaderServer{}
 	}
 
-	host, err := NewDefaultHost(ctx, nil, false, nil, nil, nil, nil, "", mockLoader)
+	host, err := NewDefaultHost(ctx, nil, false, nil, nil, nil, nil, "", mockLoader, nil)
 	require.NoError(t, err)
 	defer host.Close()
 
@@ -343,4 +344,53 @@ func TestNewDefaultHost_LoaderAddress(t *testing.T) {
 	loaderAddr := host.LoaderAddr()
 	assert.NotEmpty(t, loaderAddr)
 	assert.Equal(t, host.ServerAddr(), loaderAddr)
+}
+
+func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+
+	var loaderCalls int
+	mockLoader := func(Host) codegenrpc.LoaderServer {
+		loaderCalls++
+		return codegenrpc.UnimplementedLoaderServer{}
+	}
+
+	errInstall := errors.New("install boom")
+	var (
+		installCalls   int
+		gotRuntime     string
+		gotLoaderIsNil bool
+	)
+	installLang := func(_ context.Context, runtime string, newLoader NewLoaderFunc) error {
+		installCalls++
+		gotRuntime = runtime
+		gotLoaderIsNil = newLoader == nil
+		// Invoke the loader we were handed to prove it is the host's loader, not nil.
+		if newLoader != nil {
+			newLoader(nil)
+		}
+		return errInstall
+	}
+
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, mockLoader, installLang)
+	require.NoError(t, err)
+	host, ok := ctx.Host.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	loaderCallsBeforeLoad := loaderCalls
+	lang, err := host.LanguageRuntime("test-lang")
+
+	// The installer ran exactly once, for the requested runtime, and its error gated the load so we never
+	// got a runtime back.
+	require.ErrorIs(t, err, errInstall)
+	assert.Nil(t, lang)
+	assert.Equal(t, 1, installCalls)
+	assert.Equal(t, "test-lang", gotRuntime)
+
+	// The installer received the host's loader, not nil, and was able to invoke it.
+	assert.False(t, gotLoaderIsNil, "host should thread its loader to the installer")
+	assert.Greater(t, loaderCalls, loaderCallsBeforeLoad, "installer should have invoked the host's loader")
 }

--- a/sdk/go/common/resource/plugin/plugin_test.go
+++ b/sdk/go/common/resource/plugin/plugin_test.go
@@ -157,7 +157,7 @@ func TestPrematureExit(t *testing.T) {
 
 func TestStartupFailure(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
@@ -177,7 +177,7 @@ func TestStartupFailure(t *testing.T) {
 
 func TestNonZeroExitcode(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
@@ -229,7 +229,7 @@ func TestNonZeroExitcode(t *testing.T) {
 // Similar to TestNonZeroExitcode but with a zero exit code, but no port written so it's still an error.
 func TestZeroExitcode(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
@@ -376,7 +376,7 @@ func TestCheckVersionRange(t *testing.T) {
 //nolint:paralleltest // Modifying the global version.Version
 func TestPulumiVersionRangeYaml(t *testing.T) {
 	d := diagtest.LogSink(t)
-	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil)
+	ctx, err := NewContext(t.Context(), d, d, nil, nil, "", nil, false, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { ctx.Close() })
 

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -803,7 +803,7 @@ func newTestContext(t testing.TB) *Context {
 	ctx, err := NewContext(
 		t.Context(),
 		sink, sink,
-		nil /* host */, nil /* source */, cwd, nil /* options */, false, nil /* span */, nil)
+		nil /* host */, nil /* source */, cwd, nil /* options */, false, nil /* span */, nil, nil)
 	require.NoError(t, err, "build context")
 
 	return ctx

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2012,7 +2012,6 @@ func IsPluginBundled(kind apitype.PluginKind, name string) bool {
 		(kind == apitype.LanguagePlugin && name == "dotnet") ||
 		(kind == apitype.LanguagePlugin && name == "yaml") ||
 		(kind == apitype.LanguagePlugin && name == "java") ||
-		(kind == apitype.LanguagePlugin && name == "hcl") ||
 		(kind == apitype.LanguagePlugin && name == "pcl") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-nodejs") ||
 		(kind == apitype.ResourcePlugin && name == "pulumi-python")

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -61,11 +61,11 @@ func main() {
 		}
 
 		sink := cmdutil.Diag()
-		pCtx, err := plugin.NewContext(ctx.Context(), sink, sink, nil, nil, wd, nil, false, nil, nil)
+		pCtx, err := plugin.NewContext(ctx.Context(), sink, sink, nil, nil, wd, nil, false, nil, nil, nil)
 		if err != nil {
 			return err
 		}
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, nil, tokens.PackageName("test"), nil)
+		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, nil, tokens.PackageName("test"), nil, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Stop bundling `pulumi-language-hcl` in the CLI release tarball. The HCL language runtime is now fetched on demand the first time a stack with `runtime: hcl` runs, just like a resource plugin.
- Pin the HCL release the CLI targets in a new `knownLanguageRuntimes` table in `pkg/util/plugin.go`, with a Renovate annotation so version bumps continue to land via the same automation that used to update `scripts/get-language-providers.sh`.
- Wire the engine to install missing language plugins via `pkgWorkspace.InstallPlugin` before the language host is loaded.

Part of https://github.com/pulumi/pulumi/issues/23357

I'm using HCL as a test bed for this idea, since it's not yet officially released and is more OK to break then Nodejs.