### PR TITLE
fix: remove config when logging out of backend

### DIFF
--- a/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
+++ b/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
@@ -1,3 +1,5 @@
 kind: fix
 body: "BREAKING: Delete all backend config when logging out"
 component: cli/auth
+custom:
+  PR: "23358"

--- a/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
+++ b/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
@@ -1,3 +1,3 @@
 kind: fix
-body: Delete all backend config when logging out
+body: "BREAKING: Delete all backend config when logging out"
 component: cli/auth

--- a/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
+++ b/changelog/pending/.changie-20260527--cli-auth--delete-all-backend-config-when-logging-out.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Delete all backend config when logging out
+component: cli/auth

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -849,17 +849,27 @@ func deleteBackendConfigFromFile(configFile, key string) error {
 	return writePulumiConfigFile(configFile, config)
 }
 
-// deleteAllBackendConfig removes the default config file when it only contains
-// backend configuration.
+// deleteAllBackendConfig removes all backend configuration from the default
+// config file.
 func deleteAllBackendConfig() error {
 	configFile, err := getConfigFilePath()
 	if err != nil {
 		return err
 	}
-	if err = os.Remove(configFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing '%s': %w", configFile, err)
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading '%s': %w", configFile, err)
 	}
-	return nil
+
+	var config PulumiConfig
+	if err = json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("failed to read Pulumi config file '%s': %w", configFile, err)
+	}
+	config.BackendConfig = nil
+	return writePulumiConfigFile(configFile, config)
 }
 
 type BackendConfig struct {

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -105,7 +105,10 @@ func DeleteAccount(key string) error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	return StoreCredentials(deleteAccountFromCredentials(creds, key))
+	if err = StoreCredentials(deleteAccountFromCredentials(creds, key)); err != nil {
+		return err
+	}
+	return deleteBackendConfig(key)
 }
 
 // deleteAccountFromCredentials removes a cloud URL from a credentials object
@@ -129,10 +132,14 @@ func DeleteAllAccounts() error {
 		return err
 	}
 
+	var result error
 	if err = os.Remove(credsFile); err != nil && !os.IsNotExist(err) {
-		return err
+		result = errors.Join(result, err)
 	}
-	return nil
+	if err = deleteAllBackendConfig(); err != nil {
+		result = errors.Join(result, err)
+	}
+	return result
 }
 
 // StoreAccount saves the given account underneath the given key.
@@ -806,6 +813,20 @@ func StoreAgentClaim(claim AgentClaim) error {
 // config file, deleting that file if no backend config remains.
 func deleteAgentBackendConfig(key string) error {
 	configFile := getAgentConfigFilePathNoEnsure()
+	return deleteBackendConfigFromFile(configFile, key)
+}
+
+// deleteBackendConfig removes backend config for key from the default config
+// file, deleting that file if no backend config remains.
+func deleteBackendConfig(key string) error {
+	configFile, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+	return deleteBackendConfigFromFile(configFile, key)
+}
+
+func deleteBackendConfigFromFile(configFile, key string) error {
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -826,6 +847,19 @@ func deleteAgentBackendConfig(key string) error {
 		return nil
 	}
 	return writePulumiConfigFile(configFile, config)
+}
+
+// deleteAllBackendConfig removes the default config file when it only contains
+// backend configuration.
+func deleteAllBackendConfig() error {
+	configFile, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+	if err = os.Remove(configFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing '%s': %w", configFile, err)
+	}
+	return nil
 }
 
 type BackendConfig struct {

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -559,6 +559,103 @@ func TestDeleteAllAccountsDeletesBackendConfig(t *testing.T) {
 	assert.Empty(t, config.BackendConfig)
 }
 
+//nolint:paralleltest // mutates environment
+func TestDeleteAllAccountsReturnsCredentialsDeleteError(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	credentialsPath := filepath.Join(credsDir, "credentials.json")
+	require.NoError(t, os.Mkdir(credentialsPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(credentialsPath, "file"), []byte("token-value"), 0o600))
+
+	err := DeleteAllAccounts()
+	require.Error(t, err)
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAllAccountsReturnsBackendConfigDeleteError(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	require.NoError(t, StoreCredentials(Credentials{
+		AccessTokens: map[string]string{
+			"https://api.example.com": "token-value",
+		},
+	}))
+	require.NoError(t, os.Mkdir(filepath.Join(credsDir, "config.json"), 0o700))
+
+	err := DeleteAllAccounts()
+	require.ErrorContains(t, err, "reading")
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteBackendConfigMissingFile(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := deleteBackendConfig("https://api.example.com")
+	require.NoError(t, err)
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteBackendConfigInvalidJSON(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	require.NoError(t, os.WriteFile(filepath.Join(credsDir, "config.json"), []byte("{"), 0o600))
+
+	err := deleteBackendConfig("https://api.example.com")
+	require.ErrorContains(t, err, "failed to read Pulumi agent config file")
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteBackendConfigPathError(t *testing.T) {
+	credsPath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(credsPath, []byte("not a directory"), 0o600))
+	t.Setenv(PulumiCredentialsPathEnvVar, credsPath)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := deleteBackendConfig("https://api.example.com")
+	require.ErrorContains(t, err, "failed to create")
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAllBackendConfigMissingFile(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := deleteAllBackendConfig()
+	require.NoError(t, err)
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAllBackendConfigInvalidJSON(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	require.NoError(t, os.WriteFile(filepath.Join(credsDir, "config.json"), []byte("{"), 0o600))
+
+	err := deleteAllBackendConfig()
+	require.ErrorContains(t, err, "failed to read Pulumi config file")
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAllBackendConfigPathError(t *testing.T) {
+	credsPath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(credsPath, []byte("not a directory"), 0o600))
+	t.Setenv(PulumiCredentialsPathEnvVar, credsPath)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := deleteAllBackendConfig()
+	require.ErrorContains(t, err, "failed to create")
+}
+
 //nolint:paralleltest // mutates environment and package global
 func TestAgentPulumiConfigExplicitPathDoesNotFallbackToAgentPath(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -554,8 +554,9 @@ func TestDeleteAllAccountsDeletesBackendConfig(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(credsDir, "credentials.json"))
 	require.True(t, os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(credsDir, "config.json"))
-	require.True(t, os.IsNotExist(err))
+	config, err := GetPulumiConfig()
+	require.NoError(t, err)
+	assert.Empty(t, config.BackendConfig)
 }
 
 //nolint:paralleltest // mutates environment and package global

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -470,7 +470,6 @@ func TestAgentPulumiConfigUsesDefaultPathWhenWritable(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAccountDeletesBackendConfig(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -504,7 +503,6 @@ func TestDeleteAccountDeletesBackendConfig(t *testing.T) {
 	assert.Equal(t, "other-org", config.BackendConfig["https://api.other.example.com"].DefaultOrg)
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAccountDeletesBackendConfigFileWhenEmpty(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -530,7 +528,6 @@ func TestDeleteAccountDeletesBackendConfigFileWhenEmpty(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllAccountsDeletesBackendConfig(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -559,7 +556,6 @@ func TestDeleteAllAccountsDeletesBackendConfig(t *testing.T) {
 	assert.Empty(t, config.BackendConfig)
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllAccountsReturnsCredentialsDeleteError(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -573,7 +569,6 @@ func TestDeleteAllAccountsReturnsCredentialsDeleteError(t *testing.T) {
 	require.Error(t, err)
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllAccountsReturnsBackendConfigDeleteError(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -590,7 +585,6 @@ func TestDeleteAllAccountsReturnsBackendConfigDeleteError(t *testing.T) {
 	require.ErrorContains(t, err, "reading")
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteBackendConfigMissingFile(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -600,7 +594,6 @@ func TestDeleteBackendConfigMissingFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteBackendConfigInvalidJSON(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -612,7 +605,6 @@ func TestDeleteBackendConfigInvalidJSON(t *testing.T) {
 	require.ErrorContains(t, err, "failed to read Pulumi agent config file")
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteBackendConfigPathError(t *testing.T) {
 	credsPath := filepath.Join(t.TempDir(), "not-a-directory")
 	require.NoError(t, os.WriteFile(credsPath, []byte("not a directory"), 0o600))
@@ -623,7 +615,6 @@ func TestDeleteBackendConfigPathError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to create")
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllBackendConfigMissingFile(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -633,7 +624,6 @@ func TestDeleteAllBackendConfigMissingFile(t *testing.T) {
 	require.NoError(t, err)
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllBackendConfigInvalidJSON(t *testing.T) {
 	credsDir := t.TempDir()
 	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
@@ -645,7 +635,6 @@ func TestDeleteAllBackendConfigInvalidJSON(t *testing.T) {
 	require.ErrorContains(t, err, "failed to read Pulumi config file")
 }
 
-//nolint:paralleltest // mutates environment
 func TestDeleteAllBackendConfigPathError(t *testing.T) {
 	credsPath := filepath.Join(t.TempDir(), "not-a-directory")
 	require.NoError(t, os.WriteFile(credsPath, []byte("not a directory"), 0o600))

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -470,6 +470,94 @@ func TestAgentPulumiConfigUsesDefaultPathWhenWritable(t *testing.T) {
 	require.True(t, os.IsNotExist(err))
 }
 
+//nolint:paralleltest // mutates environment
+func TestDeleteAccountDeletesBackendConfig(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := StoreCredentials(Credentials{
+		AccessTokens: map[string]string{
+			"https://api.example.com":       "token-value",
+			"https://api.other.example.com": "other-token",
+		},
+	})
+	require.NoError(t, err)
+	err = StorePulumiConfig(PulumiConfig{
+		BackendConfig: map[string]BackendConfig{
+			"https://api.example.com":       {DefaultOrg: "agent-org"},
+			"https://api.other.example.com": {DefaultOrg: "other-org"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = DeleteAccount("https://api.example.com")
+	require.NoError(t, err)
+
+	creds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	assert.NotContains(t, creds.AccessTokens, "https://api.example.com")
+	assert.Equal(t, "other-token", creds.AccessTokens["https://api.other.example.com"])
+	config, err := GetPulumiConfig()
+	require.NoError(t, err)
+	assert.NotContains(t, config.BackendConfig, "https://api.example.com")
+	assert.Equal(t, "other-org", config.BackendConfig["https://api.other.example.com"].DefaultOrg)
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAccountDeletesBackendConfigFileWhenEmpty(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := StoreCredentials(Credentials{
+		AccessTokens: map[string]string{
+			"https://api.example.com": "token-value",
+		},
+	})
+	require.NoError(t, err)
+	err = StorePulumiConfig(PulumiConfig{
+		BackendConfig: map[string]BackendConfig{
+			"https://api.example.com": {DefaultOrg: "agent-org"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = DeleteAccount("https://api.example.com")
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(credsDir, "config.json"))
+	require.True(t, os.IsNotExist(err))
+}
+
+//nolint:paralleltest // mutates environment
+func TestDeleteAllAccountsDeletesBackendConfig(t *testing.T) {
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	err := StoreCredentials(Credentials{
+		AccessTokens: map[string]string{
+			"https://api.example.com": "token-value",
+		},
+	})
+	require.NoError(t, err)
+	err = StorePulumiConfig(PulumiConfig{
+		BackendConfig: map[string]BackendConfig{
+			"https://api.example.com": {DefaultOrg: "agent-org"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = DeleteAllAccounts()
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(credsDir, "credentials.json"))
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(credsDir, "config.json"))
+	require.True(t, os.IsNotExist(err))
+}
+
 //nolint:paralleltest // mutates environment and package global
 func TestAgentPulumiConfigExplicitPathDoesNotFallbackToAgentPath(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir


### PR DESCRIPTION
## Summary
`pulumi logout` now clears the local backend config (e.g. default org) alongside the access token, so config values don't persist across login/logout for the same backend.

### Before
- `pulumi logout <backend>` removed the access token from `credentials.json` but left `backendConfig[<backend>]` in `config.json` (including `defaultOrg`) in place. A subsequent login silently picked up the stale defaults.
- `pulumi logout --all` removed `credentials.json` but left `backendConfig` in `config.json` untouched.

### After
- `pulumi logout <backend>` also removes `backendConfig[<backend>]` from `config.json`. If that leaves `backendConfig` empty, `config.json` is deleted.
- `pulumi logout --all` also clears the `backendConfig` section of `config.json`. Other top-level fields in `config.json` are preserved.

BREAKING for anyone that relied on default-org-persists-across-logout.

## Test plan
- [x] Unit tests covering `DeleteAccount` and `DeleteAllAccounts` now also remove backend config (with the file-deletion-when-empty path).
- [x] Unit tests for `deleteBackendConfig` / `deleteAllBackendConfig` error paths.

## Changelog
- [x] Changelog entry added.

## Risk

### What could go wrong
- If `config.json` exists but contains malformed JSON, `pulumi logout --all` now returns an error *after* `credentials.json` has already been deleted (split state).
- If writing the updated `config.json` fails, credentials are removed but backend config remains.
- Single-backend logout deletes `config.json` outright when the removed backend was the only entry.

### Blast radius
- Local CLI state only: `credentials.json` and the `backendConfig` section of `config.json`.
- Affects `pulumi logout`, `pulumi logout --all`, and callers of `workspace.DeleteAccount` / `workspace.DeleteAllAccounts`.