### PR TITLE
Fix Cancel/Shutdown methods to have the right tracing spans

### DIFF
--- a/changelog/pending/20260528--engine--plugin-shutdown-cancel-rpcs-no-longer-emit-extra-root-spans.yaml
+++ b/changelog/pending/20260528--engine--plugin-shutdown-cancel-rpcs-no-longer-emit-extra-root-spans.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: engine
+  description: Cancel RPCs sent to plugins during shutdown are now traced as children of the active operation instead of emitting separate root spans

--- a/changelog/pending/20260528--engine--plugin-shutdown-cancel-rpcs-no-longer-emit-extra-root-spans.yaml
+++ b/changelog/pending/20260528--engine--plugin-shutdown-cancel-rpcs-no-longer-emit-extra-root-spans.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: fix
-  scope: engine
-  description: Cancel RPCs sent to plugins during shutdown are now traced as children of the active operation instead of emitting separate root spans

--- a/changelog/pending/engine-fix-20260528-094925.yaml
+++ b/changelog/pending/engine-fix-20260528-094925.yaml
@@ -1,0 +1,6 @@
+component: engine
+kind: fix
+body: Cancel RPCs sent to plugins during shutdown are now traced as children of the active operation instead of emitting separate root spans
+time: 2026-05-28T09:49:25.618848+01:00
+custom:
+    PR: "23362"

--- a/changelog/pending/engine-fix-20260528-094925.yaml
+++ b/changelog/pending/engine-fix-20260528-094925.yaml
@@ -1,6 +1,6 @@
 component: engine
 kind: fix
-body: Cancel RPCs sent to plugins during shutdown are now traced as children of the active operation instead of emitting separate root spans
+body: Trace cancel RPCs sent to plugins during shutdown as children of the active operation instead of emitting separate root spans
 time: 2026-05-28T09:49:25.618848+01:00
 custom:
     PR: "23362"

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -559,6 +559,17 @@ type hostManagedProvider struct {
 	host *defaultHost
 }
 
+// shutdownParentContext returns the context to use as the parent for plugin shutdown RPCs
+// (Cancel, SignalCancellation). It preserves the active OTel / OpenTracing span from the plugin
+// Context so those RPCs appear as children of the current operation rather than emitting fresh
+// root spans, but strips cancellation — shutdown still gets its timeout budget even if the caller
+// context has already been cancelled. Falls back to context.Background() when the plugin Context
+// has no base, which happens in tests that construct Context literals directly.
+func shutdownParentContext(ctx *Context) context.Context {
+	base := ctx.Request()
+	return context.WithoutCancel(base)
+}
+
 // Overrides the wrapped provider's implementation of Provider.Close to ask the managing plugin host to close the
 // provider.
 func (pc hostManagedProvider) Close() error {
@@ -566,7 +577,7 @@ func (pc hostManagedProvider) Close() error {
 	// Plugin.Close does not treat the subsequent exit as a premature crash. defaultHost.Close does the same for
 	// providers still in resourcePlugins at shutdown, but callers that Close individual providers (e.g. the
 	// convert mapper) bypass that path.
-	cancelCtx, cancelCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(pc.host.ctx), 5*time.Second)
 	defer cancelCancel()
 	contract.IgnoreError(pc.SignalCancellation(cancelCtx))
 
@@ -622,7 +633,7 @@ func (host *defaultHost) GetProjectPlugins() []workspace.ProjectPlugin {
 func (host *defaultHost) SignalCancellation() error {
 	// NOTE: we're abusing loadPlugin in order to ensure proper synchronization.
 	_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-		cancelCtx, cancelCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(host.ctx), 30*time.Second)
 		defer cancelCancel()
 
 		// Cancel in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based providers
@@ -681,7 +692,7 @@ func (host *defaultHost) Close() (err error) {
 		host.pluginLock.Lock()
 		// N.B We purposefully do not unlock this.
 
-		cancelCtx, cancelCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(host.ctx), 5*time.Second)
 		defer cancelCancel()
 
 		// Close plugins in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -214,7 +214,8 @@ func TestNewDefaultHost_PackagesResolution(t *testing.T) {
 
 	// Create a context for testing
 	ctx := &Context{
-		Root: tempDir,
+		baseContext: t.Context(),
+		Root:        tempDir,
 		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 			Color: colors.Never,
 		}),
@@ -276,7 +277,8 @@ func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
 
 	// Create a context for testing
 	ctx := &Context{
-		Root: tempDir,
+		baseContext: t.Context(),
+		Root:        tempDir,
 		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 			Color: colors.Never,
 		}),
@@ -319,7 +321,8 @@ func TestNewDefaultHost_LoaderAddress(t *testing.T) {
 	t.Parallel()
 
 	ctx := &Context{
-		Root: t.TempDir(),
+		baseContext: t.Context(),
+		Root:        t.TempDir(),
 		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 			Color: colors.Never,
 		}),

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,12 +88,13 @@ func TestOtelTraces(t *testing.T) {
 				}
 			}
 			if len(unparented) != 1 {
-				msg := fmt.Sprintf("expected exactly 1 root span, got %d:", len(unparented))
+				var msg strings.Builder
+				fmt.Fprintf(&msg, "expected exactly 1 root span, got %d:", len(unparented))
 				for _, s := range unparented {
-					msg += fmt.Sprintf("\n  - name=%q service=%q span=%s trace=%s",
+					fmt.Fprintf(&msg, "\n  - name=%q service=%q span=%s trace=%s",
 						s.Name, s.ServiceName, s.SpanID, s.TraceID)
 				}
-				assert.Fail(t, msg)
+				assert.Fail(t, msg.String())
 			}
 
 			// Walk through the expected span hierarchy top-down:

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -21,25 +21,24 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
-type traceSpan struct {
-	Name        string
-	SpanID      pcommon.SpanID
-	ParentID    pcommon.SpanID
-	TraceID     pcommon.TraceID
-	ServiceName string
-	Attributes  map[string]string
-}
-
+// TestOtelTraces runs a basic `pulumi up` with --otel-traces and asserts that the captured trace
+// has exactly one root span. A well-formed trace should be a single tree rooted at the CLI's
+// "pulumi" span; multiple roots mean a span was emitted somewhere without inheriting the parent
+// context — typically a goroutine or RPC handler that wasn't wired into the trace context
+// propagation. We deliberately don't assert on the shape of the tree below the root, since the
+// names and arrangement of spans under "pulumi" are an internal detail that's expected to evolve.
+//
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestOtelTraces(t *testing.T) {
 	// Build the testprovider as a standalone binary so the engine launches it directly in ExecPlugin rather than
@@ -71,139 +70,41 @@ func TestOtelTraces(t *testing.T) {
 		Quick:      true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			upTracePath := filepath.Join(traceDir, "traces-pulumi-update-initial.json")
-			spans := readSpans(t, upTracePath)
+			traces := readTraces(t, upTracePath)
 
-			spanByID := make(map[pcommon.SpanID]traceSpan)
-			for _, s := range spans {
-				spanByID[s.SpanID] = s
+			var rootDescriptions []string
+			for i := range traces.ResourceSpans().Len() {
+				rs := traces.ResourceSpans().At(i)
+				serviceName := ""
+				if v, ok := rs.Resource().Attributes().Get("service.name"); ok {
+					serviceName = v.Str()
+				}
+				for j := range rs.ScopeSpans().Len() {
+					spans := rs.ScopeSpans().At(j).Spans()
+					for k := range spans.Len() {
+						s := spans.At(k)
+						if s.ParentSpanID().IsEmpty() {
+							rootDescriptions = append(rootDescriptions, fmt.Sprintf(
+								"  - name=%q service=%q span=%s trace=%s",
+								s.Name(), serviceName, s.SpanID(), s.TraceID()))
+						}
+					}
+				}
 			}
 
-			// Walk through the expected span hierarchy top-down:
-			//
-			//   pulumi                                    (pulumi-cli)
-			//   └── pulumi-plan                           (pulumi-cli)
-			//       ├── LanguageRuntime/Run               (pulumi-language-python)
-			//       │   └── RegisterResource              (pulumi-sdk-python, client)
-			//       │       └── RegisterResource          (pulumi-cli, server)
-			//       └── ResourceProvider/Create           (pulumi-cli, client)
-			//           └── ResourceProvider/Create       (testprovider, server)
-
-			// Root pulumi span: the CLI entry point, no parent.
-			rootSpans := findSpans(spans, "pulumi")
-			require.NotEmpty(t, rootSpans, "expected root 'pulumi' span")
-			assert.Equal(t, "pulumi-cli", rootSpans[0].ServiceName)
-			assert.True(t, rootSpans[0].ParentID.IsEmpty())
-			rootAttrs := rootSpans[0].Attributes
-			assert.Equal(t, rootAttrs["cli.command"], "pulumi up")
-			assert.NotEmpty(t, rootAttrs["pulumi.version"])
-			assert.NotEmpty(t, rootAttrs["pulumi.os"])
-			assert.NotEmpty(t, rootAttrs["pulumi.arch"])
-			assert.NotEmpty(t, rootAttrs["exec.kind"])
-
-			// pulumi-plan: the engine's deployment span, child of root.
-			planSpans := findSpans(spans, "pulumi-plan")
-			require.NotEmpty(t, planSpans)
-			assert.Equal(t, "pulumi-cli", planSpans[0].ServiceName)
-			assert.True(t, isDescendantOf(planSpans[0], rootSpans[0], spanByID))
-
-			// LanguageRuntime/Run: the language host handling the Run RPC from the engine.
-			pyRunSpans := filterByService(findSpans(spans, "pulumirpc.LanguageRuntime/Run"), "pulumi-language-python")
-			require.NotEmpty(t, pyRunSpans)
-
-			// RegisterResource (client side): the Python SDK calling the engine to register a resource, descendant of
-			// LanguageRuntime/Run.
-			// Python SDK client spans have a leading "/" in gRPC method names.
-			pyRegSpans := filterByService(findSpans(spans, "/pulumirpc.ResourceMonitor/RegisterResource"), "pulumi-sdk-python")
-			require.NotEmpty(t, pyRegSpans)
-			for _, s := range pyRegSpans {
-				assert.True(t, isDescendantOf(s, pyRunSpans[0], spanByID))
-			}
-
-			// RegisterResource (server side): the engine handling the RegisterResource call. Each engine-side span
-			// should be a child of a Python SDK client-side span.
-			engineRegSpans := filterByService(
-				findSpans(spans, "pulumirpc.ResourceMonitor/RegisterResource"), "pulumi-cli")
-			require.NotEmpty(t, engineRegSpans)
-			for _, s := range engineRegSpans {
-				assert.True(t, isDescendantOfAny(s, pyRegSpans, spanByID))
-			}
-
-			// ResourceProvider/Create: the engine calling the provider to create the resource, descendant of
-			// pulumi-plan.
-			createSpans := filterByService(findSpans(spans, "pulumirpc.ResourceProvider/Create"), "pulumi-cli")
-			require.NotEmpty(t, createSpans, "expected provider Create span")
-			for _, s := range createSpans {
-				assert.True(t, isDescendantOf(s, planSpans[0], spanByID))
-			}
-
-			// ResourceProvider/Create (server side): the provider handling the Create RPC. These spans come from the
-			// testprovider process itself.
-			providerCreateSpans := filterByService(findSpans(spans, "pulumirpc.ResourceProvider/Create"), "testprovider")
-			require.NotEmpty(t, providerCreateSpans)
-			for _, s := range providerCreateSpans {
-				assert.True(t, isDescendantOfAny(s, createSpans, spanByID))
+			if len(rootDescriptions) != 1 {
+				sort.Strings(rootDescriptions)
+				assert.Fail(t, fmt.Sprintf("expected exactly 1 root span, got %d:\n%s",
+					len(rootDescriptions), strings.Join(rootDescriptions, "\n")))
 			}
 		},
 	})
 }
 
-// findSpans returns all spans whose name exactly matches the given string.
-func findSpans(spans []traceSpan, name string) []traceSpan {
-	var result []traceSpan
-	for _, s := range spans {
-		if s.Name == name {
-			result = append(result, s)
-		}
-	}
-	return result
-}
-
-// filterByService returns spans with the given service name.
-func filterByService(spans []traceSpan, service string) []traceSpan {
-	var result []traceSpan
-	for _, s := range spans {
-		if s.ServiceName == service {
-			result = append(result, s)
-		}
-	}
-	return result
-}
-
-// isDescendantOfAny returns true if span is a descendant of any of the given ancestors.
-func isDescendantOfAny(span traceSpan, ancestors []traceSpan, index map[pcommon.SpanID]traceSpan) bool {
-	for _, a := range ancestors {
-		if isDescendantOf(span, a, index) {
-			return true
-		}
-	}
-	return false
-}
-
-// isDescendantOf walks the parent chain of span and returns true if it reaches ancestor.
-func isDescendantOf(span, ancestor traceSpan, index map[pcommon.SpanID]traceSpan) bool {
-	current := span
-	seen := make(map[pcommon.SpanID]bool)
-	for {
-		if current.SpanID == ancestor.SpanID {
-			return true
-		}
-		if current.ParentID.IsEmpty() {
-			return false
-		}
-		if seen[current.ParentID] {
-			return false
-		}
-		seen[current.ParentID] = true
-		parent, ok := index[current.ParentID]
-		if !ok {
-			return false
-		}
-		current = parent
-	}
-}
-
-// readSpans reads a newline-delimited OTLP JSON trace file and returns all spans with their metadata.
-func readSpans(t *testing.T, path string) []traceSpan {
+// readTraces reads a newline-delimited OTLP JSON trace file (the format written by the file://
+// exporter — each line is a separate ExportTraceServiceRequest) and merges every line into a
+// single ptrace.Traces value.
+func readTraces(t *testing.T, path string) ptrace.Traces {
 	t.Helper()
 
 	f, err := os.Open(path)
@@ -211,7 +112,7 @@ func readSpans(t *testing.T, path string) []traceSpan {
 	defer f.Close()
 
 	var unmarshaler ptrace.JSONUnmarshaler
-	var spans []traceSpan
+	out := ptrace.NewTraces()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -220,41 +121,12 @@ func readSpans(t *testing.T, path string) []traceSpan {
 		if len(line) == 0 {
 			continue
 		}
-
 		traces, err := unmarshaler.UnmarshalTraces(line)
 		require.NoError(t, err, "unmarshaling trace line")
-
-		for i := range traces.ResourceSpans().Len() {
-			rs := traces.ResourceSpans().At(i)
-
-			serviceName := ""
-			if val, ok := rs.Resource().Attributes().Get("service.name"); ok {
-				serviceName = val.Str()
-			}
-
-			for j := range rs.ScopeSpans().Len() {
-				ss := rs.ScopeSpans().At(j)
-				for k := range ss.Spans().Len() {
-					s := ss.Spans().At(k)
-					attrs := make(map[string]string)
-					s.Attributes().Range(func(k string, v pcommon.Value) bool {
-						attrs[k] = v.AsString()
-						return true
-					})
-					spans = append(spans, traceSpan{
-						Name:        s.Name(),
-						SpanID:      s.SpanID(),
-						ParentID:    s.ParentSpanID(),
-						TraceID:     s.TraceID(),
-						ServiceName: serviceName,
-						Attributes:  attrs,
-					})
-				}
-			}
-		}
+		traces.ResourceSpans().MoveAndAppendTo(out.ResourceSpans())
 	}
 	require.NoError(t, scanner.Err(), "scanning trace file")
-	require.NotEmpty(t, spans, "expected at least one span in trace file %s", path)
+	require.NotZero(t, out.SpanCount(), "expected at least one span in trace file %s", path)
 
-	return spans
+	return out
 }

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -78,6 +78,23 @@ func TestOtelTraces(t *testing.T) {
 				spanByID[s.SpanID] = s
 			}
 
+			// A well-formed trace is a single tree rooted at the CLI's "pulumi" span; multiple
+			// roots mean a span was emitted without inheriting the parent trace context.
+			var unparented []traceSpan
+			for _, s := range spans {
+				if s.ParentID.IsEmpty() {
+					unparented = append(unparented, s)
+				}
+			}
+			if len(unparented) != 1 {
+				msg := fmt.Sprintf("expected exactly 1 root span, got %d:", len(unparented))
+				for _, s := range unparented {
+					msg += fmt.Sprintf("\n  - name=%q service=%q span=%s trace=%s",
+						s.Name, s.ServiceName, s.SpanID, s.TraceID)
+				}
+				assert.Fail(t, msg)
+			}
+
 			// Walk through the expected span hierarchy top-down:
 			//
 			//   pulumi                                    (pulumi-cli)

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -21,24 +21,25 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
-// TestOtelTraces runs a basic `pulumi up` with --otel-traces and asserts that the captured trace
-// has exactly one root span. A well-formed trace should be a single tree rooted at the CLI's
-// "pulumi" span; multiple roots mean a span was emitted somewhere without inheriting the parent
-// context — typically a goroutine or RPC handler that wasn't wired into the trace context
-// propagation. We deliberately don't assert on the shape of the tree below the root, since the
-// names and arrangement of spans under "pulumi" are an internal detail that's expected to evolve.
-//
+type traceSpan struct {
+	Name        string
+	SpanID      pcommon.SpanID
+	ParentID    pcommon.SpanID
+	TraceID     pcommon.TraceID
+	ServiceName string
+	Attributes  map[string]string
+}
+
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestOtelTraces(t *testing.T) {
 	// Build the testprovider as a standalone binary so the engine launches it directly in ExecPlugin rather than
@@ -70,41 +71,139 @@ func TestOtelTraces(t *testing.T) {
 		Quick:      true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			upTracePath := filepath.Join(traceDir, "traces-pulumi-update-initial.json")
-			traces := readTraces(t, upTracePath)
+			spans := readSpans(t, upTracePath)
 
-			var rootDescriptions []string
-			for i := range traces.ResourceSpans().Len() {
-				rs := traces.ResourceSpans().At(i)
-				serviceName := ""
-				if v, ok := rs.Resource().Attributes().Get("service.name"); ok {
-					serviceName = v.Str()
-				}
-				for j := range rs.ScopeSpans().Len() {
-					spans := rs.ScopeSpans().At(j).Spans()
-					for k := range spans.Len() {
-						s := spans.At(k)
-						if s.ParentSpanID().IsEmpty() {
-							rootDescriptions = append(rootDescriptions, fmt.Sprintf(
-								"  - name=%q service=%q span=%s trace=%s",
-								s.Name(), serviceName, s.SpanID(), s.TraceID()))
-						}
-					}
-				}
+			spanByID := make(map[pcommon.SpanID]traceSpan)
+			for _, s := range spans {
+				spanByID[s.SpanID] = s
 			}
 
-			if len(rootDescriptions) != 1 {
-				sort.Strings(rootDescriptions)
-				assert.Fail(t, fmt.Sprintf("expected exactly 1 root span, got %d:\n%s",
-					len(rootDescriptions), strings.Join(rootDescriptions, "\n")))
+			// Walk through the expected span hierarchy top-down:
+			//
+			//   pulumi                                    (pulumi-cli)
+			//   └── pulumi-plan                           (pulumi-cli)
+			//       ├── LanguageRuntime/Run               (pulumi-language-python)
+			//       │   └── RegisterResource              (pulumi-sdk-python, client)
+			//       │       └── RegisterResource          (pulumi-cli, server)
+			//       └── ResourceProvider/Create           (pulumi-cli, client)
+			//           └── ResourceProvider/Create       (testprovider, server)
+
+			// Root pulumi span: the CLI entry point, no parent.
+			rootSpans := findSpans(spans, "pulumi")
+			require.NotEmpty(t, rootSpans, "expected root 'pulumi' span")
+			assert.Equal(t, "pulumi-cli", rootSpans[0].ServiceName)
+			assert.True(t, rootSpans[0].ParentID.IsEmpty())
+			rootAttrs := rootSpans[0].Attributes
+			assert.Equal(t, rootAttrs["cli.command"], "pulumi up")
+			assert.NotEmpty(t, rootAttrs["pulumi.version"])
+			assert.NotEmpty(t, rootAttrs["pulumi.os"])
+			assert.NotEmpty(t, rootAttrs["pulumi.arch"])
+			assert.NotEmpty(t, rootAttrs["exec.kind"])
+
+			// pulumi-plan: the engine's deployment span, child of root.
+			planSpans := findSpans(spans, "pulumi-plan")
+			require.NotEmpty(t, planSpans)
+			assert.Equal(t, "pulumi-cli", planSpans[0].ServiceName)
+			assert.True(t, isDescendantOf(planSpans[0], rootSpans[0], spanByID))
+
+			// LanguageRuntime/Run: the language host handling the Run RPC from the engine.
+			pyRunSpans := filterByService(findSpans(spans, "pulumirpc.LanguageRuntime/Run"), "pulumi-language-python")
+			require.NotEmpty(t, pyRunSpans)
+
+			// RegisterResource (client side): the Python SDK calling the engine to register a resource, descendant of
+			// LanguageRuntime/Run.
+			// Python SDK client spans have a leading "/" in gRPC method names.
+			pyRegSpans := filterByService(findSpans(spans, "/pulumirpc.ResourceMonitor/RegisterResource"), "pulumi-sdk-python")
+			require.NotEmpty(t, pyRegSpans)
+			for _, s := range pyRegSpans {
+				assert.True(t, isDescendantOf(s, pyRunSpans[0], spanByID))
+			}
+
+			// RegisterResource (server side): the engine handling the RegisterResource call. Each engine-side span
+			// should be a child of a Python SDK client-side span.
+			engineRegSpans := filterByService(
+				findSpans(spans, "pulumirpc.ResourceMonitor/RegisterResource"), "pulumi-cli")
+			require.NotEmpty(t, engineRegSpans)
+			for _, s := range engineRegSpans {
+				assert.True(t, isDescendantOfAny(s, pyRegSpans, spanByID))
+			}
+
+			// ResourceProvider/Create: the engine calling the provider to create the resource, descendant of
+			// pulumi-plan.
+			createSpans := filterByService(findSpans(spans, "pulumirpc.ResourceProvider/Create"), "pulumi-cli")
+			require.NotEmpty(t, createSpans, "expected provider Create span")
+			for _, s := range createSpans {
+				assert.True(t, isDescendantOf(s, planSpans[0], spanByID))
+			}
+
+			// ResourceProvider/Create (server side): the provider handling the Create RPC. These spans come from the
+			// testprovider process itself.
+			providerCreateSpans := filterByService(findSpans(spans, "pulumirpc.ResourceProvider/Create"), "testprovider")
+			require.NotEmpty(t, providerCreateSpans)
+			for _, s := range providerCreateSpans {
+				assert.True(t, isDescendantOfAny(s, createSpans, spanByID))
 			}
 		},
 	})
 }
 
-// readTraces reads a newline-delimited OTLP JSON trace file (the format written by the file://
-// exporter — each line is a separate ExportTraceServiceRequest) and merges every line into a
-// single ptrace.Traces value.
-func readTraces(t *testing.T, path string) ptrace.Traces {
+// findSpans returns all spans whose name exactly matches the given string.
+func findSpans(spans []traceSpan, name string) []traceSpan {
+	var result []traceSpan
+	for _, s := range spans {
+		if s.Name == name {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// filterByService returns spans with the given service name.
+func filterByService(spans []traceSpan, service string) []traceSpan {
+	var result []traceSpan
+	for _, s := range spans {
+		if s.ServiceName == service {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// isDescendantOfAny returns true if span is a descendant of any of the given ancestors.
+func isDescendantOfAny(span traceSpan, ancestors []traceSpan, index map[pcommon.SpanID]traceSpan) bool {
+	for _, a := range ancestors {
+		if isDescendantOf(span, a, index) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDescendantOf walks the parent chain of span and returns true if it reaches ancestor.
+func isDescendantOf(span, ancestor traceSpan, index map[pcommon.SpanID]traceSpan) bool {
+	current := span
+	seen := make(map[pcommon.SpanID]bool)
+	for {
+		if current.SpanID == ancestor.SpanID {
+			return true
+		}
+		if current.ParentID.IsEmpty() {
+			return false
+		}
+		if seen[current.ParentID] {
+			return false
+		}
+		seen[current.ParentID] = true
+		parent, ok := index[current.ParentID]
+		if !ok {
+			return false
+		}
+		current = parent
+	}
+}
+
+// readSpans reads a newline-delimited OTLP JSON trace file and returns all spans with their metadata.
+func readSpans(t *testing.T, path string) []traceSpan {
 	t.Helper()
 
 	f, err := os.Open(path)
@@ -112,7 +211,7 @@ func readTraces(t *testing.T, path string) ptrace.Traces {
 	defer f.Close()
 
 	var unmarshaler ptrace.JSONUnmarshaler
-	out := ptrace.NewTraces()
+	var spans []traceSpan
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
@@ -121,12 +220,41 @@ func readTraces(t *testing.T, path string) ptrace.Traces {
 		if len(line) == 0 {
 			continue
 		}
+
 		traces, err := unmarshaler.UnmarshalTraces(line)
 		require.NoError(t, err, "unmarshaling trace line")
-		traces.ResourceSpans().MoveAndAppendTo(out.ResourceSpans())
+
+		for i := range traces.ResourceSpans().Len() {
+			rs := traces.ResourceSpans().At(i)
+
+			serviceName := ""
+			if val, ok := rs.Resource().Attributes().Get("service.name"); ok {
+				serviceName = val.Str()
+			}
+
+			for j := range rs.ScopeSpans().Len() {
+				ss := rs.ScopeSpans().At(j)
+				for k := range ss.Spans().Len() {
+					s := ss.Spans().At(k)
+					attrs := make(map[string]string)
+					s.Attributes().Range(func(k string, v pcommon.Value) bool {
+						attrs[k] = v.AsString()
+						return true
+					})
+					spans = append(spans, traceSpan{
+						Name:        s.Name(),
+						SpanID:      s.SpanID(),
+						ParentID:    s.ParentSpanID(),
+						TraceID:     s.TraceID(),
+						ServiceName: serviceName,
+						Attributes:  attrs,
+					})
+				}
+			}
+		}
 	}
 	require.NoError(t, scanner.Err(), "scanning trace file")
-	require.NotZero(t, out.SpanCount(), "expected at least one span in trace file %s", path)
+	require.NotEmpty(t, spans, "expected at least one span in trace file %s", path)
 
-	return out
+	return spans
 }


### PR DESCRIPTION
This fixes the plugin host to thread through the active context so tracing spans get parented correctly. Also updates the otel traces test to assert there's only one root span.