### PR TITLE
fix(nodejs/npm): use bracket notation for scoped packages in pkg set

### DIFF
--- a/changelog/pending/.changie-20260528--sdk-nodejs--fix-pnpm-scoped-package-link.yaml
+++ b/changelog/pending/.changie-20260528--sdk-nodejs--fix-pnpm-scoped-package-link.yaml
@@ -2,4 +2,4 @@ kind: fix
 body: Fix `pulumi package add` failing with pnpm when the generated SDK has a scoped package name (`@`-prefix), caused by pnpm's `pkg set` rejecting `@` in dot-notation property paths
 component: sdk/nodejs
 custom:
-  PR: ""
+  PR: 23365

--- a/changelog/pending/.changie-20260528--sdk-nodejs--fix-pnpm-scoped-package-link.yaml
+++ b/changelog/pending/.changie-20260528--sdk-nodejs--fix-pnpm-scoped-package-link.yaml
@@ -1,0 +1,5 @@
+kind: fix
+body: Fix `pulumi package add` failing with pnpm when the generated SDK has a scoped package name (`@`-prefix), caused by pnpm's `pkg set` rejecting `@` in dot-notation property paths
+component: sdk/nodejs
+custom:
+  PR: ""

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -277,6 +277,8 @@ func preferYarn() bool {
 }
 
 // getLinkPackageProperty returns a string to use in `npm pkg set` to add the package to package.json dependencies.
+// Bracket notation is used to support scoped package names (e.g. @pulumi/aap), as pnpm's pkg set tokenizer
+// rejects '@' in dot-notation property paths (ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH).
 func getLinkPackageProperty(packageName, path string) string {
-	return fmt.Sprintf("dependencies.%s=file:%s", packageName, path)
+	return fmt.Sprintf("dependencies[%q]=file:%s", packageName, path)
 }

--- a/sdk/nodejs/npm/manager.go
+++ b/sdk/nodejs/npm/manager.go
@@ -280,5 +280,5 @@ func preferYarn() bool {
 // Bracket notation is used to support scoped package names (e.g. @pulumi/aap), as pnpm's pkg set tokenizer
 // rejects '@' in dot-notation property paths (ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH).
 func getLinkPackageProperty(packageName, path string) string {
-	return fmt.Sprintf("dependencies[%q]=file:%s", packageName, path)
+	return fmt.Sprintf("dependencies[%s]=file:%s", packageName, path)
 }

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -50,13 +50,13 @@ func TestGetLinkPackageProperty(t *testing.T) {
 			name:        "scoped package",
 			packageName: "@pulumi/aap",
 			path:        "sdks/aap",
-			want:        `dependencies["@pulumi/aap"]=file:sdks/aap`,
+			want:        `dependencies[@pulumi/aap]=file:sdks/aap`,
 		},
 		{
 			name:        "unscoped package",
 			packageName: "pulumi-aap",
 			path:        "sdks/aap",
-			want:        `dependencies["pulumi-aap"]=file:sdks/aap`,
+			want:        `dependencies[pulumi-aap]=file:sdks/aap`,
 		},
 	}
 	for _, tt := range tests {

--- a/sdk/nodejs/npm/manager_test.go
+++ b/sdk/nodejs/npm/manager_test.go
@@ -38,6 +38,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetLinkPackageProperty(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		packageName string
+		path        string
+		want        string
+	}{
+		{
+			name:        "scoped package",
+			packageName: "@pulumi/aap",
+			path:        "sdks/aap",
+			want:        `dependencies["@pulumi/aap"]=file:sdks/aap`,
+		},
+		{
+			name:        "unscoped package",
+			packageName: "pulumi-aap",
+			path:        "sdks/aap",
+			want:        `dependencies["pulumi-aap"]=file:sdks/aap`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := getLinkPackageProperty(tt.packageName, tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 //nolint:paralleltest // changes working directory
 func TestNPMInstall(t *testing.T) {
 	t.Run("development", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes `pulumi package add` failing with pnpm when the generated SDK has a scoped package name (e.g. `@pulumi/aap`).

`sdk/nodejs/npm/manager.go` built the `pkg set` property path using dot notation (`dependencies.@pulumi/aap=file:...`). pnpm's `pkg set` tokenizer rejects `@` as an identifier start character, producing `ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH`.

Changed `getLinkPackageProperty` to use bracket notation (`dependencies["@pulumi/aap"]=file:...`), which is supported by pnpm, npm, and bun. `%q` is used for safe quoting of the package name.

Closes #23364

## Test plan

- [x] Added appropriate unit tests — `TestGetLinkPackageProperty` in `sdk/nodejs/npm/manager_test.go` covers scoped (`@pulumi/aap`) and unscoped (`pulumi-aap`) package names

## Validation

- [ ] `make lint` — clean
- [ ] `make test_fast` — all pass
- [ ] `make tidy_fix` — clean
- [ ] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog

- [ ] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk

Low. Single-line change to a format string in a package-internal helper. Bracket notation is equivalent to dot notation for unscoped packages and the only valid form for scoped packages. All three affected package managers (pnpm, npm, bun) accept bracket notation in `pkg set`.
