### PR TITLE
Add preserveEnvironmentOnDelete to apitype.StackConfig

### DIFF
--- a/changelog/pending/sdk-feat-preserve-environment-on-delete.yaml
+++ b/changelog/pending/sdk-feat-preserve-environment-on-delete.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: chore
+body: Add a preserveEnvironmentOnDelete field to the apitype stack config struct for future use by the Pulumi Cloud backend
+time: 2026-05-28T10:00:00.000000+01:00
+custom:
+    PR: ""

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -624,6 +624,13 @@ type StackConfig struct {
 	// EncryptionSalt is this stack's base64 encoded encryption salt. Only used for
 	// passphrase-based secrets providers.
 	EncryptionSalt string `json:"encryptionSalt,omitempty"`
+	// PreserveEnvironmentOnDelete, when true, leaves the linked ESC environment in
+	// place when the stack is deleted. Defaults to false (best-effort cleanup).
+	//
+	// No omitempty: the server stores this as a policy, so false must serialize
+	// explicitly instead of collapsing to "unset" — that keeps a true->false flip
+	// expressible over the wire.
+	PreserveEnvironmentOnDelete bool `json:"preserveEnvironmentOnDelete"`
 }
 
 // OperationStatus describes the state of an operation being performed on a Pulumi stack.

--- a/sdk/go/common/apitype/core_test.go
+++ b/sdk/go/common/apitype/core_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PreserveEnvironmentOnDelete intentionally omits the omitempty JSON tag so that a
+// false value serializes explicitly; an absent key must stay distinguishable from
+// an explicit false on the wire. Guard that here so a future edit can't silently
+// reintroduce omitempty.
+func TestStackConfig_PreserveEnvironmentOnDeleteSerializesFalse(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(StackConfig{Environment: "acme/prod"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"environment":"acme/prod","preserveEnvironmentOnDelete":false}`, string(b))
+
+	var rt StackConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"preserveEnvironmentOnDelete":true}`), &rt))
+	assert.True(t, rt.PreserveEnvironmentOnDelete)
+}


### PR DESCRIPTION
Groundwork for a per-stack policy controlling whether the linked ESC environment is removed when a stack is deleted. The field is wire-only for now: the Pulumi Cloud backend persistence, delete-handler wiring, and any CLI surface to set it land separately.

The JSON tag omits omitempty so false serializes explicitly, keeping an explicit false distinguishable from unset on the wire - required for a future true->false flip. A serialization test guards that decision.

Towards pulumi/pulumi-service#43936
