### PR TITLE
Fix changelog lint failing when there are no pending entries

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -177,7 +177,13 @@ jobs:
       - uses: miniscruff/changie-action@v2
         with:
           version: v1.21.0
-      - run: changie batch auto --dry-run
+      - name: Validate changelog entries
+        run: |
+          if [ -z "$(find changelog/pending -maxdepth 1 -name '*.yaml' -print -quit)" ]; then
+            echo "No pending changelog entries; skipping changie batch."
+            exit 0
+          fi
+          changie batch auto --dry-run
 
   pulumi-json:
     name: Lint pulumi.json

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -174,16 +174,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ fromJson(inputs.version-set).go }}
+          check-latest: true
       - uses: miniscruff/changie-action@v2
         with:
           version: v1.21.0
-      - name: Validate changelog entries
-        run: |
-          if [ -z "$(find changelog/pending -maxdepth 1 -name '*.yaml' -print -quit)" ]; then
-            echo "No pending changelog entries; skipping changie batch."
-            exit 0
-          fi
-          changie batch auto --dry-run
+      - run: make lint_changelog
 
   pulumi-json:
     name: Lint pulumi.json

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,11 @@ brew::
 lint:: .make/ensure/golangci-lint lint_golang lint_pulumi_json lint_changelog
 
 lint_changelog::
-	changie batch auto --dry-run
+	@if [ -n "$$(find changelog/pending -maxdepth 1 -name '*.yaml' -print -quit)" ]; then \
+		changie batch auto --dry-run; \
+	else \
+		echo "No pending changelog entries; skipping changie batch."; \
+	fi
 
 lint_pulumi_json::
 	# NOTE: github.com/santhosh-tekuri/jsonschema uses Go's regexp engine, but


### PR DESCRIPTION
We can't lint changelog entries unless there are changelog entries