### PR TITLE
fix(sdk/nodejs): fix mergeOptions dropping onError hooks

### DIFF
--- a/changelog/pending/sdk-nodejs-fix-merge-options-drops-on-error-hooks.yaml
+++ b/changelog/pending/sdk-nodejs-fix-merge-options-drops-on-error-hooks.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Fix mergeOptions dropping onError hooks from ResourceOptions in the Node.js SDK
+component: sdk/nodejs

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -1716,6 +1716,7 @@ export function mergeOptions(opts1: ResourceOptions | undefined, opts2: Resource
             "afterUpdate",
             "beforeDelete",
             "afterDelete",
+            "onError",
         ] as const;
         for (const hookType of hookTypes) {
             const destHooks = dest?.hooks?.[hookType];

--- a/sdk/nodejs/tests/options.spec.ts
+++ b/sdk/nodejs/tests/options.spec.ts
@@ -15,7 +15,13 @@
 /* eslint-disable */
 
 import * as assert from "assert";
-import { ComponentResourceOptions, ProviderResource, merge, mergeOptions } from "../resource";
+import {
+    ComponentResourceOptions,
+    ErrorHookFunction,
+    ProviderResource,
+    merge,
+    mergeOptions,
+} from "../resource";
 
 describe("options", () => {
     describe("merge", () => {
@@ -235,6 +241,32 @@ describe("options", () => {
             it("merges promise-array and promise-array into array", async () => {
                 const result = mergeDependsOn(Promise.resolve(["a"]), Promise.resolve(["b"]));
                 assert.deepStrictEqual(await result.promise(), ["a", "b"]);
+            });
+        });
+
+        describe("hooks.onError", () => {
+            const makeHook = (name: string) => ({
+                name,
+                callback: (() => false) as ErrorHookFunction,
+                __registered: Promise.resolve(),
+                __pulumiErrorHook: true as const,
+            });
+
+            it("keeps onError hooks from opts1 if not provided in opts2", async () => {
+                const hook = makeHook("h1");
+                const result = mergeOptions({ hooks: { onError: [hook] } }, {});
+                assert.deepStrictEqual(result.hooks?.onError, [hook]);
+            });
+            it("keeps onError hooks from opts2 if not provided in opts1", async () => {
+                const hook = makeHook("h1");
+                const result = mergeOptions({}, { hooks: { onError: [hook] } });
+                assert.deepStrictEqual(result.hooks?.onError, [hook]);
+            });
+            it("merges onError hooks from opts1 and opts2", async () => {
+                const hook1 = makeHook("h1");
+                const hook2 = makeHook("h2");
+                const result = mergeOptions({ hooks: { onError: [hook1] } }, { hooks: { onError: [hook2] } });
+                assert.deepStrictEqual(result.hooks?.onError, [hook1, hook2]);
             });
         });
 

--- a/sdk/nodejs/tests/options.spec.ts
+++ b/sdk/nodejs/tests/options.spec.ts
@@ -15,13 +15,7 @@
 /* eslint-disable */
 
 import * as assert from "assert";
-import {
-    ComponentResourceOptions,
-    ErrorHookFunction,
-    ProviderResource,
-    merge,
-    mergeOptions,
-} from "../resource";
+import { ComponentResourceOptions, ErrorHookFunction, ProviderResource, merge, mergeOptions } from "../resource";
 
 describe("options", () => {
     describe("merge", () => {


### PR DESCRIPTION
## Summary

- `mergeOptions` in the Node.js SDK handled the `hooks` field specially but only merged the six lifecycle hook types (`beforeCreate`, `afterCreate`, `beforeUpdate`, `afterUpdate`, `beforeDelete`, `afterDelete`) — `onError` was missing from the list
- Every generated provider SDK resource (e.g. `aws.s3.Bucket`) calls `pulumi.mergeOptions(resourceOptsDefaults(), opts)` in its constructor, so `onError` hooks passed by users were silently dropped before `RegisterResource` was sent to the engine
- The engine never received the `onError` hooks for the resource and therefore never invoked them on failure

Fixes #23344 (the engine-side fix in #23347 was correct but this Node.js SDK bug meant hooks never reached the engine).

## Test plan

- [ ] Added three unit tests to `sdk/nodejs/tests/options.spec.ts` covering: preserving `onError` hooks from opts1, preserving from opts2, and merging from both
- [ ] Run `npx mocha tests/options.spec.ts` in `sdk/nodejs` — all 45 tests pass