### PR TITLE
Update access token URL from /account/tokens to /user/settings/tokens

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -780,7 +780,7 @@ func (m defaultLoginManager) Login(
 
 	cloudURL = ValueOrDefaultURL(pkgWorkspace.Instance, cloudURL)
 	var accessToken string
-	accountLink := client.CloudConsoleURL(cloudURL, "account", "tokens")
+	accountLink := client.CloudConsoleURL(cloudURL, "user", "settings", "tokens")
 
 	if !cmdutil.Interactive() {
 		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.

--- a/pkg/backend/httpstate/client/console_test.go
+++ b/pkg/backend/httpstate/client/console_test.go
@@ -55,6 +55,20 @@ func TestConsoleURL(t *testing.T) {
 			CloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
 	})
 
+	t.Run("TokenSettingsURL", func(t *testing.T) {
+		assert.Equal(t,
+			"https://app.pulumi.com/user/settings/tokens",
+			CloudConsoleURL("https://api.pulumi.com", "user", "settings", "tokens"))
+
+		assert.Equal(t,
+			"http://localhost:3000/user/settings/tokens",
+			CloudConsoleURL("http://localhost:8080", "user", "settings", "tokens"))
+
+		assert.Equal(t,
+			"http://app.pulumi.example.com/user/settings/tokens",
+			CloudConsoleURL("http://api.pulumi.example.com", "user", "settings", "tokens"))
+	})
+
 	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
 		assert.Equal(t, "", CloudConsoleURL("https://pulumi.example.com", "pulumi-bot", "my-stack"))
 		assert.Equal(t, "", CloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))


### PR DESCRIPTION
## Summary

- Updates the CLI login prompt to direct users to `/user/settings/tokens` instead of the deprecated `/account/tokens` path
- Adds test coverage for the new multi-segment token settings URL across standard, localhost, and custom domain configurations

Fixes #23148

## Test plan

- [x] New `TokenSettingsURL` test case verifies correct URL construction for `api.pulumi.com`, `localhost:8080`, and custom self-hosted domains
- [x] All existing `TestConsoleURL` subtests continue to pass
- [x] Manual: run `pulumi login` and verify the printed URL uses `/user/settings/tokens`
```
lynnjung@Lynns-MacBook-Pro pulumi-service % /tmp/pulumi-test login --cloud-url="http://localhost:8080"
Manage your Pulumi stacks by logging in.
Run `pulumi login --help` for alternative login options.
Enter your access token from http://localhost:4200/user/settings/tokens
    or hit <ENTER> to log in using your browser                        :  
```