### PR TITLE
Simplify `l2-invoke-options-depends-on`

### DIFF
--- a/pkg/testing/pulumi-test-language/tests/l2_invoke_options.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_invoke_options.go
@@ -35,21 +35,8 @@ func init() {
 
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 2, "expected 2 resource")
-					// TODO https://github.com/pulumi/pulumi/issues/17816
-					// TODO: the root stack must be the first resource to be registered
-					// such that snap.Resources[0].Type == resource.RootStackType
-					// however with the python SDK, that is not the case, instead the default
-					// provider gets registered first. This is indicating that something might be wrong
-					// with the how python SDK registers resources
-					var stack *resource.State
-					for _, r := range snap.Resources {
-						if r.Type == resource.RootStackType {
-							stack = r
-							break
-						}
-					}
-
-					require.NotNil(l, stack, "expected a stack resource")
+					stack := snap.Resources[0]
+					require.Equal(l, resource.RootStackType, stack.Type)
 					outputs := stack.Outputs
 					AssertPropertyMapMember(l, outputs, "hello", resource.NewProperty("hello world"))
 				},

--- a/pkg/testing/pulumi-test-language/tests/l2_invoke_options_depends_on.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_invoke_options_depends_on.go
@@ -35,21 +35,10 @@ func init() {
 
 					RequireStackResource(l, err, changes)
 					require.Len(l, snap.Resources, 4, "expected 4 resources")
-					// TODO https://github.com/pulumi/pulumi/issues/17816
-					// TODO: the root stack must be the first resource to be registered
-					// such that snap.Resources[0].Type == resource.RootStackType
-					// however with the python SDK, that is not the case, instead the default
-					// provider gets registered first. This is indicating that something might be wrong
-					// with the how python SDK registers resources
-					var stack *resource.State
-					for _, r := range snap.Resources {
-						if r.Type == resource.RootStackType {
-							stack = r
-							break
-						}
-					}
 
-					require.NotNil(l, stack, "expected a stack resource")
+					stack := snap.Resources[0]
+					require.Equal(l, resource.RootStackType, stack.Type)
+
 					outputs := stack.Outputs
 					AssertPropertyMapMember(l, outputs, "hello", resource.NewProperty("hello world"))
 

--- a/pkg/testing/pulumi-test-language/tests/l2_invoke_options_depends_on.go
+++ b/pkg/testing/pulumi-test-language/tests/l2_invoke_options_depends_on.go
@@ -34,7 +34,7 @@ func init() {
 					changes := res.Changes
 
 					RequireStackResource(l, err, changes)
-					require.Len(l, snap.Resources, 5, "expected 5 resources")
+					require.Len(l, snap.Resources, 4, "expected 4 resources")
 					// TODO https://github.com/pulumi/pulumi/issues/17816
 					// TODO: the root stack must be the first resource to be registered
 					// such that snap.Resources[0].Type == resource.RootStackType

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-invoke-options-depends-on/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-invoke-options-depends-on/main.pp
@@ -1,5 +1,3 @@
-resource "explicitProvider" "pulumi:providers:simple-invoke" { }
-
 resource "first" "simple-invoke:index:StringResource" {
     text = "first hello"
 }

--- a/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/extra-types/projects/l2-invoke-options-depends-on/main.go
@@ -7,10 +7,6 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := simpleinvoke.NewProvider(ctx, "explicitProvider", nil)
-		if err != nil {
-			return err
-		}
 		first, err := simpleinvoke.NewStringResource(ctx, "first", &simpleinvoke.StringResourceArgs{
 			Text: pulumi.String("first hello"),
 		})

--- a/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/local/projects/l2-invoke-options-depends-on/main.go
@@ -7,10 +7,6 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := simpleinvoke.NewProvider(ctx, "explicitProvider", nil)
-		if err != nil {
-			return err
-		}
 		first, err := simpleinvoke.NewStringResource(ctx, "first", &simpleinvoke.StringResourceArgs{
 			Text: pulumi.String("first hello"),
 		})

--- a/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options-depends-on/main.go
+++ b/sdk/go/pulumi-language-go/testdata/published/projects/l2-invoke-options-depends-on/main.go
@@ -7,10 +7,6 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := simpleinvoke.NewProvider(ctx, "explicitProvider", nil)
-		if err != nil {
-			return err
-		}
 		first, err := simpleinvoke.NewStringResource(ctx, "first", &simpleinvoke.StringResourceArgs{
 			Text: pulumi.String("first hello"),
 		})

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-options-depends-on/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/bun/projects/l2-invoke-options-depends-on/index.ts
@@ -1,7 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple_invoke from "@pulumi/simple-invoke";
 
-const explicitProvider = new simple_invoke.Provider("explicitProvider", {});
 const first = new simple_invoke.StringResource("first", {text: "first hello"});
 const data = simple_invoke.myInvokeOutput({
     value: "hello",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-options-depends-on/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsc/projects/l2-invoke-options-depends-on/index.ts
@@ -1,7 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple_invoke from "@pulumi/simple-invoke";
 
-const explicitProvider = new simple_invoke.Provider("explicitProvider", {});
 const first = new simple_invoke.StringResource("first", {text: "first hello"});
 const data = simple_invoke.myInvokeOutput({
     value: "hello",

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-options-depends-on/index.ts
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/testdata/published/tsnode/projects/l2-invoke-options-depends-on/index.ts
@@ -1,7 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as simple_invoke from "@pulumi/simple-invoke";
 
-const explicitProvider = new simple_invoke.Provider("explicitProvider", {});
 const first = new simple_invoke.StringResource("first", {text: "first hello"});
 const data = simple_invoke.myInvokeOutput({
     value: "hello",

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-invoke-options-depends-on/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-invoke-options-depends-on/main.pp
@@ -1,5 +1,3 @@
-resource "explicitProvider" "pulumi:providers:simple-invoke" { }
-
 resource "first" "simple-invoke:index:StringResource" {
     text = "first hello"
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-invoke-options-depends-on/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-invoke-options-depends-on/main.pp
@@ -1,5 +1,3 @@
-resource "explicitProvider" "pulumi:providers:simple-invoke" { }
-
 resource "first" "simple-invoke:index:StringResource" {
     text = "first hello"
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-invoke-options-depends-on/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-invoke-options-depends-on/main.pp
@@ -1,5 +1,3 @@
-resource "explicitProvider" "pulumi:providers:simple-invoke" { }
-
 resource "first" "simple-invoke:index:StringResource" {
     text = "first hello"
 }

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-invoke-options-depends-on/__main__.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/projects/l2-invoke-options-depends-on/__main__.py
@@ -1,7 +1,6 @@
 import pulumi
 import pulumi_simple_invoke as simple_invoke
 
-explicit_provider = simple_invoke.Provider("explicitProvider")
 first = simple_invoke.StringResource("first", text="first hello")
 data = simple_invoke.my_invoke_output(value="hello", opts=pulumi.InvokeOutputOptions(depends_on=[first]))
 second = simple_invoke.StringResource("second", text=data.result)


### PR DESCRIPTION
We don't need to create an unused explicit provider, so we shouldn't.