### PR TITLE
fix: support anonymous agent logout when backend unspecified

### DIFF
--- a/changelog/pending/.changie-20260529--cli-auth--logout-agent-credentials.yaml
+++ b/changelog/pending/.changie-20260529--cli-auth--logout-agent-credentials.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Delete shared temporary agent credentials when logging out
+component: cli/auth

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -112,7 +112,7 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 // deleteAllAccounts removes user credentials and, in agent mode, any shared
 // temporary agent credentials.
 func deleteAllAccounts() error {
-	if !agentLogoutFallbackEnabled() {
+	if !workspace.AgentCredentialsFallbackEnabled() {
 		return workspace.DeleteAllAccounts()
 	}
 	if err := workspace.DeleteAllAccounts(); err != nil {
@@ -124,7 +124,7 @@ func deleteAllAccounts() error {
 // deleteAccount removes credentials for a cloud URL, falling back to shared
 // temporary agent credentials when default credentials are unavailable.
 func deleteAccount(cloudURL string) error {
-	if !agentLogoutFallbackEnabled() {
+	if !workspace.AgentCredentialsFallbackEnabled() {
 		return workspace.DeleteAccount(cloudURL)
 	}
 	account, err := workspace.GetAccount(cloudURL)
@@ -132,10 +132,4 @@ func deleteAccount(cloudURL string) error {
 		return workspace.DeleteAccount(cloudURL)
 	}
 	return workspace.DeleteAgentAccount(cloudURL)
-}
-
-// agentLogoutFallbackEnabled reports whether logout may use the shared agent
-// credential store as an implicit fallback.
-func agentLogoutFallbackEnabled() bool {
-	return workspace.AgentCredentialsFallbackEnabled()
 }

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -17,7 +17,6 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -76,7 +74,7 @@ func NewLogoutCmd(ws pkgWorkspace.Context) *cobra.Command {
 						return err
 					}
 
-					cloudURL, err = pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
+					cloudURL, err = pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
 					if err != nil {
 						return fmt.Errorf("could not determine current cloud: %w", err)
 					}
@@ -139,7 +137,5 @@ func deleteAccount(cloudURL string) error {
 // agentLogoutFallbackEnabled reports whether logout may use the shared agent
 // credential store as an implicit fallback.
 func agentLogoutFallbackEnabled() bool {
-	return agentdetect.Detect(os.Getenv) != "" &&
-		os.Getenv(workspace.PulumiCredentialsPathEnvVar) == "" &&
-		os.Getenv(env.Home.Var().Name()) == ""
+	return workspace.AgentCredentialsFallbackEnabled()
 }

--- a/pkg/cmd/pulumi/auth/logout_test.go
+++ b/pkg/cmd/pulumi/auth/logout_test.go
@@ -147,3 +147,31 @@ func TestLogoutCommandCloudURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, output.String(), "Logged out of "+cloudURL)
 }
+
+//nolint:paralleltest // mutates env vars and shared temporary agent credentials
+func TestLogoutCommandFallsBackToAgentCurrentCloud(t *testing.T) {
+	t.Setenv("CODEX_SANDBOX", "1")
+	t.Setenv(workspace.PulumiCredentialsPathEnvVar, "")
+	t.Setenv(env.Home.Var().Name(), "")
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+
+	cloudURL := "https://api.logout-agent-current.example.com"
+	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{AccessToken: "agent-token"}, true)
+	require.NoError(t, err)
+
+	cmd := NewLogoutCmd(&pkgWorkspace.MockContext{
+		GetStoredCredentialsF: func() (workspace.Credentials, error) {
+			return workspace.Credentials{}, assert.AnError
+		},
+	})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, output.String(), "Logged out of "+cloudURL)
+
+	account, err := workspace.GetAgentAccount(cloudURL)
+	require.NoError(t, err)
+	assert.Empty(t, account.AccessToken)
+}

--- a/pkg/cmd/pulumi/auth/logout_test.go
+++ b/pkg/cmd/pulumi/auth/logout_test.go
@@ -148,12 +148,12 @@ func TestLogoutCommandCloudURL(t *testing.T) {
 	assert.Contains(t, output.String(), "Logged out of "+cloudURL)
 }
 
-//nolint:paralleltest // mutates env vars and shared temporary agent credentials
 func TestLogoutCommandFallsBackToAgentCurrentCloud(t *testing.T) {
+	agentDir := t.TempDir()
 	t.Setenv("CODEX_SANDBOX", "1")
 	t.Setenv(workspace.PulumiCredentialsPathEnvVar, "")
 	t.Setenv(env.Home.Var().Name(), "")
-	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", agentDir)
 
 	cloudURL := "https://api.logout-agent-current.example.com"
 	err := workspace.StoreAgentAccount(cloudURL, workspace.Account{AccessToken: "agent-token"}, true)
@@ -174,4 +174,12 @@ func TestLogoutCommandFallsBackToAgentCurrentCloud(t *testing.T) {
 	account, err := workspace.GetAgentAccount(cloudURL)
 	require.NoError(t, err)
 	assert.Empty(t, account.AccessToken)
+
+	agentCredsFile := filepath.Join(agentDir, "credentials.json")
+	contents, err := os.ReadFile(agentCredsFile)
+	if !os.IsNotExist(err) {
+		require.NoError(t, err)
+		assert.NotContains(t, string(contents), cloudURL)
+		assert.NotContains(t, string(contents), "agent-token")
+	}
 }

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -58,9 +58,9 @@ func NonInteractiveCurrentBackend(
 		return BackendInstance, nil
 	}
 
-	url, err := getCurrentCloudURL(ws, project)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
 	logging.V(7).Infof("Current cloud URL: %q", url)
 
@@ -76,23 +76,13 @@ func CurrentBackend(
 		return BackendInstance, nil
 	}
 
-	url, err := getCurrentCloudURL(ws, project)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
 	logging.V(7).Infof("Current cloud URL: %q", url)
 	insecure := pkgWorkspace.GetCloudInsecure(ws, url)
 
 	// Only set current if we don't currently have a cloud URL set.
 	return lm.Login(ctx, ws, cmdutil.Diag(), url, project, url == "", insecure, opts.Color)
-}
-
-// getCurrentCloudURL returns the active cloud URL, using the shared agent
-// credentials as a fallback when an agent cannot read the default credentials.
-func getCurrentCloudURL(ws pkgWorkspace.Context, project *workspace.Project) (string, error) {
-	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
-	if err != nil {
-		return "", fmt.Errorf("could not get cloud url: %w", err)
-	}
-	return url, nil
 }

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -92,35 +90,9 @@ func CurrentBackend(
 // getCurrentCloudURL returns the active cloud URL, using the shared agent
 // credentials as a fallback when an agent cannot read the default credentials.
 func getCurrentCloudURL(ws pkgWorkspace.Context, project *workspace.Project) (string, error) {
-	url, err := pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
-	if err == nil {
-		return url, nil
-	}
-
-	agent := agentdetect.Detect(os.Getenv)
-	if agent == "" || hasExplicitPulumiPathEnv() {
-		logging.V(7).Infof("Could not get cloud URL from default credentials without agent fallback: %v", err)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), project)
+	if err != nil {
 		return "", fmt.Errorf("could not get cloud url: %w", err)
 	}
-
-	logging.V(7).Infof(
-		"Could not get cloud URL from default credentials in agent mode (%s); checking shared agent credentials: %v",
-		agent, err)
-	agentCreds, agentErr := workspace.GetAgentStoredCredentials()
-	if agentErr != nil {
-		return "", fmt.Errorf("could not get cloud url from agent credentials: %w", errors.Join(err, agentErr))
-	}
-	if agentCreds.Current != "" {
-		logging.V(7).Infof("Using current cloud URL %q from shared agent credentials", agentCreds.Current)
-	} else {
-		logging.V(7).Infof("No current cloud URL found in shared agent credentials")
-	}
-
-	return agentCreds.Current, nil
-}
-
-// hasExplicitPulumiPathEnv reports whether the user explicitly selected a
-// Pulumi credential or home path, disabling implicit agent fallback paths.
-func hasExplicitPulumiPathEnv() bool {
-	return os.Getenv(workspace.PulumiCredentialsPathEnvVar) != "" || os.Getenv(env.Home.Var().Name()) != ""
+	return url, nil
 }

--- a/pkg/cmd/pulumi/backend/backend_test.go
+++ b/pkg/cmd/pulumi/backend/backend_test.go
@@ -57,7 +57,7 @@ func TestGetCurrentCloudURLFallsBackToAgentCredentials(t *testing.T) {
 		},
 	}
 
-	url, err := getCurrentCloudURL(ws, nil)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.agent.example", url)
 }
@@ -75,7 +75,7 @@ func TestGetCurrentCloudURLReturnsEmptyAgentCurrent(t *testing.T) {
 		},
 	}
 
-	url, err := getCurrentCloudURL(ws, nil)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), nil)
 	require.NoError(t, err)
 	assert.Empty(t, url)
 }
@@ -95,7 +95,7 @@ func TestGetCurrentCloudURLReturnsAgentCredentialReadError(t *testing.T) {
 		},
 	}
 
-	_, err := getCurrentCloudURL(ws, nil)
+	_, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), nil)
 	require.ErrorContains(t, err, "could not get cloud url from agent credentials")
 }
 
@@ -112,7 +112,7 @@ func TestGetCurrentCloudURLDoesNotFallbackWithExplicitPath(t *testing.T) {
 		},
 	}
 
-	_, err := getCurrentCloudURL(ws, nil)
+	_, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), nil)
 	require.ErrorIs(t, err, assert.AnError)
 }
 
@@ -127,7 +127,7 @@ func TestGetCurrentCloudURLReturnsDefaultCredentialErrorsOutsideAgents(t *testin
 		},
 	}
 
-	_, err := getCurrentCloudURL(ws, nil)
+	_, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(ws, env.Global(), nil)
 	require.ErrorIs(t, err, assert.AnError)
 }
 
@@ -136,7 +136,7 @@ func TestGetCurrentCloudURLReturnsDefaultCloudURL(t *testing.T) {
 	clearAIAgentEnv(t)
 	t.Setenv(env.BackendURL.Var().Name(), "https://api.default-current.example.com")
 
-	url, err := getCurrentCloudURL(&pkgWorkspace.MockContext{}, nil)
+	url, err := pkgWorkspace.GetCurrentCloudURLWithAgentFallback(&pkgWorkspace.MockContext{}, env.Global(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.default-current.example.com", url)
 }

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -15,7 +15,13 @@
 package workspace
 
 import (
+	"errors"
+	"fmt"
+	"os"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -44,6 +50,37 @@ func GetCurrentCloudURL(ws Context, e env.Env, project *workspace.Project) (stri
 	}
 
 	return url, nil
+}
+
+// GetCurrentCloudURLWithAgentFallback returns the active cloud URL, using
+// shared temporary agent credentials when an agent cannot read the default
+// credentials.
+func GetCurrentCloudURLWithAgentFallback(ws Context, e env.Env, project *workspace.Project) (string, error) {
+	url, err := GetCurrentCloudURL(ws, e, project)
+	if err == nil {
+		return url, nil
+	}
+
+	if !workspace.AgentCredentialsFallbackEnabled() {
+		logging.V(7).Infof("Could not get cloud URL from default credentials without agent fallback: %v", err)
+		return "", err
+	}
+
+	agent := agentdetect.Detect(os.Getenv)
+	logging.V(7).Infof(
+		"Could not get cloud URL from default credentials in agent mode (%s); checking shared agent credentials: %v",
+		agent, err)
+	agentCreds, agentErr := workspace.GetAgentStoredCredentials()
+	if agentErr != nil {
+		return "", fmt.Errorf("could not get cloud url from agent credentials: %w", errors.Join(err, agentErr))
+	}
+	if agentCreds.Current != "" {
+		logging.V(7).Infof("Using current cloud URL %q from shared agent credentials", agentCreds.Current)
+	} else {
+		logging.V(7).Infof("No current cloud URL found in shared agent credentials")
+	}
+
+	return agentCreds.Current, nil
 }
 
 // GetCloudInsecure returns if this cloud url is saved as one that should use insecure transport.

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -862,6 +862,12 @@ func hasExplicitPulumiPathEnv() bool {
 	return os.Getenv(PulumiCredentialsPathEnvVar) != "" || os.Getenv(env.Home.Var().Name()) != ""
 }
 
+// AgentCredentialsFallbackEnabled reports whether shared temporary agent
+// credentials may be used as an implicit fallback.
+func AgentCredentialsFallbackEnabled() bool {
+	return agentdetect.Detect(os.Getenv) != "" && !hasExplicitPulumiPathEnv()
+}
+
 func GetPulumiConfig() (PulumiConfig, error) {
 	configFile, err := getConfigFilePath()
 	if err != nil {


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->
Fixes pulumi logout in detected agent environments so it can fall back to shared temporary agent credentials when the default Pulumi home or credentials path is unavailable.

This centralizes the agent credential fallback predicate in the SDK, reuses the current-cloud fallback path for logout, and ensures logout can remove the active shared temporary agent account instead of failing while trying to read `~/.pulumi`.


## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->
Low to moderate. The change is scoped to credential resolution/logout behavior, primarily in detected agent environments without explicit `PULUMI_HOME` or `PULUMI_CREDENTIALS_PATH`.

The main risk is deleting shared temporary agent credentials in cases where a user expected only normal Pulumi credentials to be affected. That is consistent with logout semantics, but it changes behavior for agent sessions.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
