### PR TITLE
Remove `cmdStack.ConfigFile`

### DIFF
--- a/pkg/cmd/pulumi/cancel/cancel.go
+++ b/pkg/cmd/pulumi/cancel/cancel.go
@@ -68,6 +68,7 @@ func NewCancelCmd(ws pkgWorkspace.Context) *cobra.Command {
 				stack,
 				cmdStack.LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -60,6 +60,7 @@ type encrypterFactory interface {
 
 func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	var stack string
+	var configFile string
 	var showSecrets bool
 	var jsonOut bool
 	var open bool
@@ -89,12 +90,13 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 				stack,
 				cmdStack.OfferNew|cmdStack.SetCurrent,
 				opts,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack)
+			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, configFile)
 			if err != nil {
 				return err
 			}
@@ -121,6 +123,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 				showSecrets,
 				jsonOut,
 				openEnvironment,
+				configFile,
 			)
 		},
 	}
@@ -139,25 +142,25 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.AddCommand(newConfigGetCmd(ws, &stack))
-	cmd.AddCommand(newConfigRmCmd(ws, &stack))
-	cmd.AddCommand(newConfigRmAllCmd(ws, &stack))
-	cmd.AddCommand(newConfigSetCmd(ws, &stack))
+	cmd.AddCommand(newConfigGetCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigRmCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigRmAllCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigSetCmd(ws, &stack, &configFile))
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager, &ssml))
-	cmd.AddCommand(newConfigRefreshCmd(ws, &stack, cmdBackend.DefaultLoginManager))
-	cmd.AddCommand(newConfigCopyCmd(ws, &stack))
-	cmd.AddCommand(newConfigEnvCmd(ws, &stack))
+	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager, &ssml, &configFile))
+	cmd.AddCommand(newConfigRefreshCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
+	cmd.AddCommand(newConfigCopyCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigEnvCmd(ws, &stack, &configFile))
 
 	return cmd
 }
 
-func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
 	var path bool
 	var destinationStackName string
 
@@ -186,6 +189,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				*stack,
 				cmdStack.SetCurrent,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
@@ -193,7 +197,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 			if currentStack.Ref().Name().String() == destinationStackName {
 				return errors.New("current stack and destination stack are the same")
 			}
-			currentProjectStack, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, currentStack)
+			currentProjectStack, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, currentStack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -207,11 +211,13 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				destinationStackName,
 				cmdStack.LoadOnly,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
 			}
-			destinationProjectStack, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, destinationStack)
+			destinationProjectStack, err := cmdStack.LoadProjectStack(
+				ctx, cmdutil.Diag(), project, destinationStack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -239,6 +245,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 					currentProjectStack,
 					destinationStack,
 					destinationProjectStack,
+					*configFile,
 				)
 			}
 
@@ -257,7 +264,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 			// The use of `requiresSaving` here ensures that there was actually some config
 			// that needed saved, otherwise it's an unnecessary save call
 			if requiresSaving {
-				err := cmdStack.SaveProjectStack(ctx, destinationStack, destinationProjectStack)
+				err := cmdStack.SaveProjectStack(ctx, destinationStack, destinationProjectStack, *configFile)
 				if err != nil {
 					return err
 				}
@@ -284,7 +291,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	return cpCommand
 }
 
-func newConfigGetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
 	var jsonOut bool
 	var open bool
 	var path bool
@@ -312,6 +319,7 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				*stack,
 				cmdStack.OfferNew|cmdStack.SetCurrent,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
@@ -323,7 +331,7 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 			}
 
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-			return getConfig(ctx, cmd.OutOrStdout(), cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open)
+			return getConfig(ctx, cmd.OutOrStdout(), cmdutil.Diag(), ssml, ws, s, key, path, jsonOut, open, *configFile)
 		},
 	}
 	constrictor.AttachArguments(getCmd, &constrictor.Arguments{
@@ -346,7 +354,7 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	return getCmd
 }
 
-func newConfigRmCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigRmCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
 	var path bool
 
 	rmCmd := &cobra.Command{
@@ -377,6 +385,7 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				*stack,
 				cmdStack.OfferNew|cmdStack.SetCurrent,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
@@ -387,7 +396,7 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
 
-			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack)
+			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -406,7 +415,7 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				return err
 			}
 
-			return cmdStack.SaveProjectStack(ctx, stack, ps)
+			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
 		},
 	}
 	constrictor.AttachArguments(rmCmd, &constrictor.Arguments{
@@ -423,7 +432,7 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	return rmCmd
 }
 
-func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
 	var path bool
 
 	rmAllCmd := &cobra.Command{
@@ -454,12 +463,13 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				*stack,
 				cmdStack.OfferNew,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack)
+			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -485,7 +495,7 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				}
 			}
 
-			return cmdStack.SaveProjectStack(ctx, stack, ps)
+			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
 		},
 	}
 	constrictor.AttachArguments(rmAllCmd, &constrictor.Arguments{
@@ -503,7 +513,9 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 	return rmAllCmd
 }
 
-func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.LoginManager) *cobra.Command {
+func newConfigRefreshCmd(
+	ws pkgWorkspace.Context, stk *string, lm cmdBackend.LoginManager, configFile *string,
+) *cobra.Command {
 	var force bool
 	refreshCmd := &cobra.Command{
 		Use:   "refresh",
@@ -528,14 +540,15 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.Log
 				*stk,
 				cmdStack.LoadOnly,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
 			}
 
 			var configPath string
-			if cmdStack.ConfigFile != "" {
-				configPath = cmdStack.ConfigFile
+			if *configFile != "" {
+				configPath = *configFile
 			} else if s.ConfigLocation().IsRemote {
 				// TODO: This should be possible in the future to reset the remote config back to previous used config.
 				// See: https://github.com/pulumi/pulumi/issues/19557
@@ -553,7 +566,7 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.Log
 				return fmt.Errorf("getting latest configuration: %w", err)
 			}
 
-			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, s)
+			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, s, *configFile)
 			if err != nil {
 				return err
 			}
@@ -640,7 +653,9 @@ func newConfigRefreshCmd(ws pkgWorkspace.Context, stk *string, lm cmdBackend.Log
 
 type configSetCmd struct {
 	Stdin            *os.File
-	LoadProjectStack func(context.Context, diag.Sink, *workspace.Project, backend.Stack) (*workspace.ProjectStack, error)
+	LoadProjectStack func(
+		context.Context, diag.Sink, *workspace.Project, backend.Stack, string,
+	) (*workspace.ProjectStack, error)
 
 	Plaintext bool
 	Secret    bool
@@ -648,7 +663,7 @@ type configSetCmd struct {
 	Type      string
 }
 
-func newConfigSetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
+func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
 	configSetCmd := &configSetCmd{LoadProjectStack: cmdStack.LoadProjectStack}
 
 	setCmd := &cobra.Command{
@@ -687,12 +702,13 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 				*stack,
 				cmdStack.OfferNew|cmdStack.SetCurrent,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			return configSetCmd.Run(ctx, ws, args, project, s)
+			return configSetCmd.Run(ctx, ws, args, project, s, *configFile)
 		},
 	}
 
@@ -725,6 +741,7 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string) *cobra.Command {
 
 func (c *configSetCmd) Run(
 	ctx context.Context, ws pkgWorkspace.Context, args []string, project *workspace.Project, s backend.Stack,
+	configFile string,
 ) error {
 	stdin := c.Stdin
 	if stdin == nil {
@@ -760,7 +777,7 @@ func (c *configSetCmd) Run(
 		}
 	}
 
-	ps, err := c.LoadProjectStack(ctx, cmdutil.Diag(), project, s)
+	ps, err := c.LoadProjectStack(ctx, cmdutil.Diag(), project, s, configFile)
 	if err != nil {
 		return err
 	}
@@ -825,11 +842,11 @@ func (c *configSetCmd) Run(
 		return fmt.Errorf("could not set config: %w", err)
 	}
 
-	return cmdStack.SaveProjectStack(ctx, s, ps)
+	return cmdStack.SaveProjectStack(ctx, s, ps, configFile)
 }
 
 func newConfigSetAllCmd(
-	ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, ssml encrypterFactory,
+	ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, ssml encrypterFactory, configFile *string,
 ) *cobra.Command {
 	var plaintextArgs []string
 	var secretArgs []string
@@ -880,12 +897,13 @@ func newConfigSetAllCmd(
 				*stack,
 				cmdStack.OfferNew,
 				opts,
+				*configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack)
+			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -997,7 +1015,7 @@ func newConfigSetAllCmd(
 				}
 			}
 
-			return cmdStack.SaveProjectStack(ctx, stack, ps)
+			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
 		},
 	}
 
@@ -1040,6 +1058,7 @@ func listConfig(
 	showSecrets bool,
 	jsonOut bool,
 	openEnvironment bool,
+	configFile string,
 ) error {
 	var env *esc.Environment
 	var diags []apitype.EnvironmentDiagnostic
@@ -1066,7 +1085,7 @@ func listConfig(
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
 		if state != cmdStack.SecretsManagerUnchanged {
-			if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+			if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
 				return fmt.Errorf("save stack config: %w", err)
 			}
 		}
@@ -1099,7 +1118,7 @@ func listConfig(
 			}
 			// This may have setup the stack's secrets provider, so save the stack if needed.
 			if state != cmdStack.SecretsManagerUnchanged {
-				if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+				if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
 					return fmt.Errorf("save stack config: %w", err)
 				}
 			}
@@ -1214,12 +1233,13 @@ func getConfig(
 	key config.Key,
 	path, jsonOut,
 	openEnvironment bool,
+	configFile string,
 ) error {
 	project, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}
-	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack)
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
 	if err != nil {
 		return err
 	}
@@ -1247,7 +1267,7 @@ func getConfig(
 		}
 		// This may have setup the stack's secrets provider, so save the stack if needed.
 		if state != cmdStack.SecretsManagerUnchanged {
-			if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+			if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
 				return fmt.Errorf("save stack config: %w", err)
 			}
 		}
@@ -1283,7 +1303,7 @@ func getConfig(
 				}
 				// This may have setup the stack's secrets provider, so save the stack if needed.
 				if state != cmdStack.SecretsManagerUnchanged {
-					if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+					if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
 						return fmt.Errorf("save stack config: %w", err)
 					}
 				}

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -36,7 +36,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string) *cobra.Command {
+func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *string) *cobra.Command {
 	impl := configEnvCmd{
 		stdin:            os.Stdin,
 		diags:            cmdutil.Diag(),
@@ -45,6 +45,7 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string) *cobra.Command {
 		loadProjectStack: cmdStack.LoadProjectStack,
 		saveProjectStack: cmdStack.SaveProjectStack,
 		stackRef:         stackRef,
+		configFile:       configFile,
 	}
 
 	cmd := &cobra.Command{
@@ -86,6 +87,7 @@ type configEnvCmd struct {
 		stackName string,
 		lopt cmdStack.LoadOption,
 		opts display.Options,
+		configFile string,
 	) (backend.Stack, error)
 
 	loadProjectStack func(
@@ -93,11 +95,13 @@ type configEnvCmd struct {
 		diags diag.Sink,
 		project *workspace.Project,
 		stack backend.Stack,
+		configFile string,
 	) (*workspace.ProjectStack, error)
 
-	saveProjectStack func(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack) error
+	saveProjectStack func(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, configFile string) error
 
-	stackRef *string
+	stackRef   *string
+	configFile *string
 }
 
 func (cmd *configEnvCmd) initArgs() {
@@ -124,6 +128,7 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 		*cmd.stackRef,
 		cmdStack.OfferNew|cmdStack.SetCurrent,
 		opts,
+		*cmd.configFile,
 	)
 	if err != nil {
 		return nil, nil, nil, err
@@ -134,7 +139,7 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 		return nil, nil, nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
 	}
 
-	projectStack, err := cmd.loadProjectStack(ctx, cmd.diags, project, stack)
+	projectStack, err := cmd.loadProjectStack(ctx, cmd.diags, project, stack, *cmd.configFile)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -207,6 +212,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		showSecrets,
 		false, /*jsonOut*/
 		false, /*openEnvironment*/
+		*cmd.configFile,
 	); err != nil {
 		return err
 	}
@@ -222,7 +228,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		}
 	}
 
-	if err = cmd.saveProjectStack(ctx, *stack, projectStack); err != nil {
+	if err = cmd.saveProjectStack(ctx, *stack, projectStack, *cmd.configFile); err != nil {
 		return fmt.Errorf("saving stack config: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -119,6 +119,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 		*cmd.parent.stackRef,
 		cmdStack.OfferNew|cmdStack.SetCurrent,
 		opts,
+		*cmd.parent.configFile,
 	)
 	if err != nil {
 		return err
@@ -196,7 +197,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	if !cmd.keepConfig {
 		projectStack.Config = nil
 	}
-	if err = cmd.parent.saveProjectStack(ctx, stack, projectStack); err != nil {
+	if err = cmd.parent.saveProjectStack(ctx, stack, projectStack, *cmd.parent.configFile); err != nil {
 		return fmt.Errorf("saving stack config: %w", err)
 	}
 	return nil
@@ -208,7 +209,7 @@ func (cmd *configEnvInitCmd) getStackConfig(
 	project *workspace.Project,
 	stack backend.Stack,
 ) (*workspace.ProjectStack, property.Map, error) {
-	ps, err := cmd.parent.loadProjectStack(ctx, sink, project, stack)
+	ps, err := cmd.parent.loadProjectStack(ctx, sink, project, stack, *cmd.parent.configFile)
 	if err != nil {
 		return nil, property.Map{}, err
 	}
@@ -219,7 +220,7 @@ func (cmd *configEnvInitCmd) getStackConfig(
 	}
 	// This may have setup the stack's secrets provider, so save the stack if needed.
 	if state != cmdStack.SecretsManagerUnchanged {
-		if err = cmd.parent.saveProjectStack(ctx, stack, ps); err != nil {
+		if err = cmd.parent.saveProjectStack(ctx, stack, ps, *cmd.parent.configFile); err != nil {
 			return nil, property.Map{}, fmt.Errorf("saving stack config: %w", err)
 		}
 	}

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -84,6 +84,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 	newStackYAML *string,
 ) *configEnvCmd {
 	stackRef := "stack"
+	configFile := ""
 	return &configEnvCmd{
 		stdin:       stdin,
 		stdout:      stdout,
@@ -106,6 +107,7 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 			stackName string,
 			lopt cmdStack.LoadOption,
 			opts display.Options,
+			configFile string,
 		) (backend.Stack, error) {
 			return &backend.MockStack{
 				RefF: func() backend.StackReference {
@@ -133,11 +135,11 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		},
 
 		loadProjectStack: func(
-			_ context.Context, d diag.Sink, p *workspace.Project, _ backend.Stack,
+			_ context.Context, d diag.Sink, p *workspace.Project, _ backend.Stack, configFile string,
 		) (*workspace.ProjectStack, error) {
 			return workspace.LoadProjectStackBytes(d, p, []byte(projectStackYAML), "Pulumi.stack.yaml", encoding.YAML)
 		},
-		saveProjectStack: func(_ context.Context, _ backend.Stack, ps *workspace.ProjectStack) error {
+		saveProjectStack: func(_ context.Context, _ backend.Stack, ps *workspace.ProjectStack, configFile string) error {
 			b, err := encoding.YAML.Marshal(ps)
 			if err != nil {
 				return err
@@ -145,7 +147,8 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 			*newStackYAML = string(b)
 			return nil
 		},
-		stackRef: &stackRef,
+		stackRef:   &stackRef,
+		configFile: &configFile,
 	}
 }
 

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -118,7 +118,7 @@ func TestListConfig(t *testing.T) {
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, cfg, nil)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -143,7 +143,7 @@ common:obj  {"commonArray":["cfgVal3","cfgVal4"],"commonValue":"cfgVal2"}
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, config.Map{}, openEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -169,7 +169,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, cfg, openEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -197,7 +197,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, cfg, openEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, false, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, false, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -225,7 +225,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, cfg, checkEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, false)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, false, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -253,7 +253,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, cfg, checkEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, false, false, false)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, false, false, false, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -281,7 +281,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, plainCfg, plainEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -307,7 +307,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, plainCfg, openEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -334,7 +334,7 @@ env:value   envVal1
 		preparedStack, project, projectStack, secretsManagerLoader := prepareConfig(t, secretsManager, plainCfg, openEnv)
 
 		var stdout bytes.Buffer
-		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true)
+		err := listConfig(ctx, secretsManagerLoader, &stdout, &project, &preparedStack, projectStack, true, false, true, "")
 		require.NoError(t, err)
 
 		require.Equal(t, 0, *calledEncryptValue)
@@ -472,8 +472,8 @@ func prepareConfig(
 	return mockStack, project, projectStack, ssml
 }
 
-//nolint:paralleltest // changes global ConfigFile variable
 func TestConfigSet(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		args     []string
@@ -517,6 +517,7 @@ func TestConfigSet(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			project := workspace.Project{
 				Name: "testProject",
 			}
@@ -540,24 +541,22 @@ func TestConfigSet(t *testing.T) {
 					diags diag.Sink,
 					project *workspace.Project,
 					_ backend.Stack,
+					_ string,
 				) (*workspace.ProjectStack, error) {
 					return workspace.LoadProjectStackBytes(diags, project, []byte{}, "Pulumi.stack.yaml", encoding.YAML)
 				},
 			}
 
 			tmpdir := t.TempDir()
-			cmdStack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
-			defer func() {
-				cmdStack.ConfigFile = ""
-			}()
+			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{}
 
-			err := configSetCmd.Run(t.Context(), ws, c.args, &project, &s)
+			err := configSetCmd.Run(t.Context(), ws, c.args, &project, &s, configFile)
 			require.NoError(t, err)
 
 			// verify the config was set
-			data, err := os.ReadFile(cmdStack.ConfigFile)
+			data, err := os.ReadFile(configFile)
 			require.NoError(t, err)
 
 			require.Equal(t, c.expected, string(data))
@@ -565,9 +564,8 @@ func TestConfigSet(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // changes global ConfigFile variable
 func TestConfigSetTypes(t *testing.T) {
-	ctx := t.Context()
+	t.Parallel()
 
 	cases := []struct {
 		name     string
@@ -632,6 +630,7 @@ func TestConfigSetTypes(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			project := workspace.Project{
 				Name: "testProject",
 			}
@@ -652,24 +651,22 @@ func TestConfigSetTypes(t *testing.T) {
 				Path: c.path,
 				Type: c.typ,
 				LoadProjectStack: func(_ context.Context, d diag.Sink, project *workspace.Project, _ backend.Stack,
+					_ string,
 				) (*workspace.ProjectStack, error) {
 					return workspace.LoadProjectStackBytes(d, project, []byte{}, "Pulumi.stack.yaml", encoding.YAML)
 				},
 			}
 
 			tmpdir := t.TempDir()
-			cmdStack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
-			defer func() {
-				cmdStack.ConfigFile = ""
-			}()
+			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{}
 
-			err := configSetCmd.Run(ctx, ws, c.args, &project, &s)
+			err := configSetCmd.Run(t.Context(), ws, c.args, &project, &s, configFile)
 			require.NoError(t, err)
 
 			// verify the config was set
-			data, err := os.ReadFile(cmdStack.ConfigFile)
+			data, err := os.ReadFile(configFile)
 			require.NoError(t, err)
 
 			require.Equal(t, c.expected, string(data))
@@ -677,9 +674,8 @@ func TestConfigSetTypes(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // changes global ConfigFile variable
 func TestConfigSetAll(t *testing.T) {
-	ctx := t.Context()
+	t.Parallel()
 
 	cases := []struct {
 		name          string
@@ -784,6 +780,7 @@ func TestConfigSetAll(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			s := backend.MockStack{
 				RefF: func() backend.StackReference {
 					return &backend.MockStackReference{
@@ -797,10 +794,7 @@ func TestConfigSetAll(t *testing.T) {
 			}
 
 			tmpdir := t.TempDir()
-			cmdStack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
-			defer func() {
-				cmdStack.ConfigFile = ""
-			}()
+			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{
 				ReadProjectF: func() (*workspace.Project, string, error) {
@@ -854,8 +848,8 @@ func TestConfigSetAll(t *testing.T) {
 				},
 			}
 
-			cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory)
-			cmd.SetContext(ctx)
+			cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory, &configFile)
+			cmd.SetContext(t.Context())
 
 			// Set flags based on test case
 			if c.jsonArg != "" {
@@ -889,7 +883,7 @@ func TestConfigSetAll(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify the config was set correctly
-			data, err := os.ReadFile(cmdStack.ConfigFile)
+			data, err := os.ReadFile(configFile)
 			require.NoError(t, err)
 
 			require.Equal(t, c.expected, string(data))
@@ -909,8 +903,8 @@ func (m *mockEncrypterFactory) GetEncrypter(
 	return m.encrypter, cmdStack.SecretsManagerUnchanged, nil
 }
 
-//nolint:paralleltest // changes global ConfigFile variable
 func TestConfigRefresh(t *testing.T) {
+	t.Parallel()
 	minimalDeployment := &apitype.UntypedDeployment{
 		Version:    3,
 		Deployment: json.RawMessage(`{"manifest":{"time":"0001-01-01T00:00:00Z","magic":"","version":""}}`),
@@ -973,10 +967,9 @@ func TestConfigRefresh(t *testing.T) {
 	}
 
 	t.Run("environments from backend are written to config file", func(t *testing.T) {
+		t.Parallel()
 		tmpdir := t.TempDir()
 		configPath := filepath.Join(tmpdir, "Pulumi.testStack.yaml")
-		cmdStack.ConfigFile = configPath
-		defer func() { cmdStack.ConfigFile = "" }()
 
 		lm, ws := setupBackend(backend.LatestConfiguration{
 			Config: config.Map{
@@ -986,7 +979,7 @@ func TestConfigRefresh(t *testing.T) {
 		})
 
 		stackName := "testStack"
-		cmd := newConfigRefreshCmd(ws, &stackName, lm)
+		cmd := newConfigRefreshCmd(ws, &stackName, lm, &configPath)
 		cmd.SetContext(t.Context())
 		require.NoError(t, cmd.PersistentFlags().Set("force", "true"))
 
@@ -1007,10 +1000,9 @@ environment:
 	})
 
 	t.Run("nil environments do not overwrite existing environments", func(t *testing.T) {
+		t.Parallel()
 		tmpdir := t.TempDir()
 		configPath := filepath.Join(tmpdir, "Pulumi.testStack.yaml")
-		cmdStack.ConfigFile = configPath
-		defer func() { cmdStack.ConfigFile = "" }()
 
 		require.NoError(t, os.WriteFile(configPath,
 			[]byte("environment:\n  - existing-env\nconfig:\n  testProject:old: old-value\n"), 0o600))
@@ -1022,7 +1014,7 @@ environment:
 		})
 
 		stackName := "testStack"
-		cmd := newConfigRefreshCmd(ws, &stackName, lm)
+		cmd := newConfigRefreshCmd(ws, &stackName, lm, &configPath)
 		cmd.SetContext(t.Context())
 		require.NoError(t, cmd.PersistentFlags().Set("force", "true"))
 
@@ -1040,8 +1032,8 @@ config:
 	})
 }
 
-//nolint:paralleltest // changes global ConfigFile variable
 func TestConfigPathOperations(t *testing.T) {
+	t.Parallel()
 	type testArgs struct {
 		Key                   string
 		Value                 string
@@ -1390,6 +1382,7 @@ func TestConfigPathOperations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			project := workspace.Project{
 				Name: "testProject",
 			}
@@ -1427,10 +1420,7 @@ func TestConfigPathOperations(t *testing.T) {
 			}
 
 			tmpdir := t.TempDir()
-			cmdStack.ConfigFile = filepath.Join(tmpdir, "Pulumi.stack.yaml")
-			defer func() {
-				cmdStack.ConfigFile = ""
-			}()
+			configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
 
 			ws := &pkgWorkspace.MockContext{
 				ReadProjectF: func() (*workspace.Project, string, error) {
@@ -1447,8 +1437,9 @@ func TestConfigPathOperations(t *testing.T) {
 						diags diag.Sink,
 						project *workspace.Project,
 						_ backend.Stack,
+						configFile string,
 					) (*workspace.ProjectStack, error) {
-						data, err := os.ReadFile(cmdStack.ConfigFile)
+						data, err := os.ReadFile(configFile)
 						if os.IsNotExist(err) {
 							return &workspace.ProjectStack{
 								Config: config.Map{},
@@ -1459,7 +1450,7 @@ func TestConfigPathOperations(t *testing.T) {
 					},
 				}
 
-				err := configSetCmd.Run(t.Context(), ws, []string{operation.Key, operation.Value}, &project, &s)
+				err := configSetCmd.Run(t.Context(), ws, []string{operation.Key, operation.Value}, &project, &s, configFile)
 				if operation.ExpectFailure {
 					require.Error(t, err)
 					continue
@@ -1470,7 +1461,7 @@ func TestConfigPathOperations(t *testing.T) {
 				key, err := config.ParseKey(operation.TopLevelKey)
 				require.NoError(t, err)
 
-				ps, err := cmdStack.LoadProjectStack(t.Context(), cmdutil.Diag(), &project, &s)
+				ps, err := cmdStack.LoadProjectStack(t.Context(), cmdutil.Diag(), &project, &s, configFile)
 				require.NoError(t, err)
 
 				cfg, err := ps.Config.Copy(config.NopDecrypter, config.NopEncrypter)

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -44,8 +44,9 @@ func GetStackConfiguration(
 	ssml cmdStack.SecretsManagerLoader,
 	stack backend.Stack,
 	project *workspace.Project,
+	configFile string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	return getStackConfigurationWithFallback(ctx, sink, ssml, stack, project, nil)
+	return getStackConfigurationWithFallback(ctx, sink, ssml, stack, project, nil, configFile)
 }
 
 // GetStackConfigurationOrLatest attempts to load a current stack configuration
@@ -60,6 +61,7 @@ func GetStackConfigurationOrLatest(
 	ssml cmdStack.SecretsManagerLoader,
 	stack backend.Stack,
 	project *workspace.Project,
+	configFile string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
 	return getStackConfigurationWithFallback(
 		ctx, sink, ssml, stack, project,
@@ -71,7 +73,8 @@ func GetStackConfigurationOrLatest(
 				return latest.Config, err
 			}
 			return nil, err
-		})
+		},
+		configFile)
 }
 
 func getStackConfigurationWithFallback(
@@ -81,8 +84,9 @@ func getStackConfigurationWithFallback(
 	s backend.Stack,
 	project *workspace.Project,
 	fallbackGetConfig func(err error) (config.Map, error), // optional
+	configFile string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	workspaceStack, err := cmdStack.LoadProjectStack(ctx, sink, project, s)
+	workspaceStack, err := cmdStack.LoadProjectStack(ctx, sink, project, s, configFile)
 	if err != nil || workspaceStack == nil {
 		if fallbackGetConfig == nil {
 			return backend.StackConfiguration{}, nil, err
@@ -98,7 +102,7 @@ func getStackConfigurationWithFallback(
 		}
 	}
 
-	sm, err := getAndSaveSecretsManager(ctx, ssml, s, workspaceStack)
+	sm, err := getAndSaveSecretsManager(ctx, ssml, s, workspaceStack, configFile)
 	if err != nil {
 		return backend.StackConfiguration{}, nil, err
 	}
@@ -178,13 +182,14 @@ func getAndSaveSecretsManager(
 	ssml cmdStack.SecretsManagerLoader,
 	stack backend.Stack,
 	workspaceStack *workspace.ProjectStack,
+	configFile string,
 ) (secrets.Manager, error) {
 	sm, state, err := ssml.GetSecretsManager(ctx, stack, workspaceStack)
 	if err != nil {
 		return nil, fmt.Errorf("get stack secrets manager: %w", err)
 	}
 	if state != cmdStack.SecretsManagerUnchanged {
-		err = cmdStack.SaveProjectStack(ctx, stack, workspaceStack)
+		err = cmdStack.SaveProjectStack(ctx, stack, workspaceStack, configFile)
 		if err != nil && state == cmdStack.SecretsManagerMustSave {
 			return nil, fmt.Errorf("save stack config: %w", err)
 		}
@@ -250,6 +255,7 @@ func copySingleConfigKey(
 	currentProjectStack *workspace.ProjectStack,
 	destinationStack backend.Stack,
 	destinationProjectStack *workspace.ProjectStack,
+	configFile string,
 ) error {
 	var decrypter config.Decrypter
 	key, err := ParseConfigKey(pkgWorkspace.Instance, configKey, path)
@@ -293,7 +299,7 @@ func copySingleConfigKey(
 		return err
 	}
 
-	return cmdStack.SaveProjectStack(ctx, destinationStack, destinationProjectStack)
+	return cmdStack.SaveProjectStack(ctx, destinationStack, destinationProjectStack, configFile)
 }
 
 func parseKeyValuePair(pair string, path bool) (config.Key, string, error) {

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -91,6 +91,7 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 			},
 		},
 		nil,
+		"",
 	)
 }
 
@@ -127,6 +128,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 			},
 		},
 		nil,
+		"",
 	)
 	if !called {
 		t.Fatalf("GetLatestConfiguration should be called in getStackConfigurationOrLatest.")

--- a/pkg/cmd/pulumi/deployment/deployment.go
+++ b/pkg/cmd/pulumi/deployment/deployment.go
@@ -22,6 +22,7 @@ import (
 )
 
 func NewDeploymentCmd(ws pkgWorkspace.Context) *cobra.Command {
+	var stackDeploymentConfigFile string
 	cmd := &cobra.Command{
 		Use:   "deployment",
 		Short: "[EXPERIMENTAL] Manage stack deployments on Pulumi Cloud",
@@ -39,7 +40,7 @@ func NewDeploymentCmd(ws pkgWorkspace.Context) *cobra.Command {
 		&stackDeploymentConfigFile, "config-file", "",
 		"Override the file name where the deployment settings are specified. Default is Pulumi.[stack].deploy.yaml")
 
-	cmd.AddCommand(newDeploymentSettingsCmd())
+	cmd.AddCommand(newDeploymentSettingsCmd(&stackDeploymentConfigFile))
 	cmd.AddCommand(newDeploymentRunCmd(ws))
 	cmd.AddCommand(newDeploymentListCmd())
 	cmd.AddCommand(newDeploymentGetCmd())

--- a/pkg/cmd/pulumi/deployment/deployment_cancel.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cancel.go
@@ -147,7 +147,7 @@ func defaultDeploymentCancelClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, "", fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_get.go
@@ -126,7 +126,7 @@ func defaultDeploymentGetClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_list.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list.go
@@ -133,7 +133,7 @@ func defaultDeploymentListClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_log.go
+++ b/pkg/cmd/pulumi/deployment/deployment_log.go
@@ -146,7 +146,7 @@ func defaultDeploymentLogClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_run.go
+++ b/pkg/cmd/pulumi/deployment/deployment_run.go
@@ -86,6 +86,7 @@ func newDeploymentRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 				stack,
 				cmdStack.OfferNew|cmdStack.SetCurrent,
 				display,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -149,6 +149,7 @@ func initializeDeploymentSettingsCmd(
 		stack,
 		cmdStack.OfferNew|cmdStack.SetCurrent,
 		displayOpts,
+		"",
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/pulumi/deployment/deployment_settings_config.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_config.go
@@ -58,7 +58,7 @@ const (
 
 var errAbortCmd = errors.New("abort")
 
-func newDeploymentSettingsCmd() *cobra.Command {
+func newDeploymentSettingsCmd(configFile *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "settings",
 		Short: "Manage stack deployment settings",
@@ -75,12 +75,12 @@ func newDeploymentSettingsCmd() *cobra.Command {
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
 	// Commands to edit `Pulumi.<stack>.deployment.yaml`
-	cmd.AddCommand(newDeploymentSettingsInitCmd())
-	cmd.AddCommand(newDeploymentSettingsPullCmd())
-	cmd.AddCommand(newDeploymentSettingsUpdateCmd())
-	cmd.AddCommand(newDeploymentSettingsDestroyCmd())
-	cmd.AddCommand(newDeploymentSettingsEnvCmd())
-	cmd.AddCommand(newDeploymentSettingsConfigureCmd())
+	cmd.AddCommand(newDeploymentSettingsInitCmd(configFile))
+	cmd.AddCommand(newDeploymentSettingsPullCmd(configFile))
+	cmd.AddCommand(newDeploymentSettingsUpdateCmd(configFile))
+	cmd.AddCommand(newDeploymentSettingsDestroyCmd(configFile))
+	cmd.AddCommand(newDeploymentSettingsEnvCmd(configFile))
+	cmd.AddCommand(newDeploymentSettingsConfigureCmd(configFile))
 
 	// Edit the settings in cloud
 	cmd.AddCommand(newDeploymentSettingsGetCmd())
@@ -98,10 +98,11 @@ type deploymentSettingsCommandDependencies struct {
 	Ctx            context.Context
 	Prompts        prompts
 	WorkDir        string
+	ConfigFile     string
 }
 
 func initializeDeploymentSettingsCmd(
-	ctx context.Context, stdout io.Writer, ws pkgWorkspace.Context, stack string,
+	ctx context.Context, stdout io.Writer, ws pkgWorkspace.Context, stack string, configFile string,
 ) (*deploymentSettingsCommandDependencies, error) {
 	interactive := cmdutil.Interactive()
 
@@ -155,7 +156,7 @@ func initializeDeploymentSettingsCmd(
 		return nil, err
 	}
 
-	sd, err := loadProjectStackDeployment(s)
+	sd, err := loadProjectStackDeployment(s, configFile)
 	if err != nil {
 		return nil, err
 	}
@@ -174,10 +175,11 @@ func initializeDeploymentSettingsCmd(
 		Ctx:            ctx,
 		Prompts:        promptHandlers{},
 		WorkDir:        wd,
+		ConfigFile:     configFile,
 	}, nil
 }
 
-func newDeploymentSettingsInitCmd() *cobra.Command {
+func newDeploymentSettingsInitCmd(configFile *string) *cobra.Command {
 	var force bool
 	var stack string
 	var gitSSHPrivateKeyPath string
@@ -190,7 +192,8 @@ func newDeploymentSettingsInitCmd() *cobra.Command {
 		Short:      "Initialize the stack's deployment.yaml file",
 		Long:       "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -291,10 +294,10 @@ func initStackDeploymentCmd(
 		return err
 	}
 
-	return saveProjectStackDeployment(d.Deployment, d.Stack)
+	return saveProjectStackDeployment(d.Deployment, d.Stack, d.ConfigFile)
 }
 
-func newDeploymentSettingsConfigureCmd() *cobra.Command {
+func newDeploymentSettingsConfigureCmd(configFile *string) *cobra.Command {
 	var stack string
 	var gitSSHPrivateKeyPath string
 	var gitSSHPrivateKeyValue string
@@ -309,7 +312,8 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 				return errors.New("configure command is only supported in interactive mode")
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -354,7 +358,7 @@ func newDeploymentSettingsConfigureCmd() *cobra.Command {
 				return err
 			}
 
-			err = saveProjectStackDeployment(d.Deployment, d.Stack)
+			err = saveProjectStackDeployment(d.Deployment, d.Stack, d.ConfigFile)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_edit.go
@@ -287,7 +287,7 @@ func defaultDeploymentSettingsEditClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_get.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get.go
@@ -95,7 +95,7 @@ func defaultDeploymentSettingsGetClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, cmdStack.LoadOnly, opts)
+		stackFlag, cmdStack.LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_ops.go
@@ -37,7 +37,7 @@ func verifyInteractiveMode(yes bool) error {
 	return nil
 }
 
-func newDeploymentSettingsPullCmd() *cobra.Command {
+func newDeploymentSettingsPullCmd(configFile *string) *cobra.Command {
 	var stack string
 
 	cmd := &cobra.Command{
@@ -46,7 +46,8 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 		Short:  "Pull the stack's deployment settings from Pulumi Cloud into the deployment.yaml file",
 		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -60,7 +61,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 				DeploymentSettings: *ds,
 			}
 
-			err = saveProjectStackDeployment(newStackDeployment, d.Stack)
+			err = saveProjectStackDeployment(newStackDeployment, d.Stack, d.ConfigFile)
 			if err != nil {
 				return err
 			}
@@ -78,7 +79,7 @@ func newDeploymentSettingsPullCmd() *cobra.Command {
 	return cmd
 }
 
-func newDeploymentSettingsUpdateCmd() *cobra.Command {
+func newDeploymentSettingsUpdateCmd(configFile *string) *cobra.Command {
 	var stack string
 	var yes bool
 
@@ -96,7 +97,8 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -134,7 +136,7 @@ func newDeploymentSettingsUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func newDeploymentSettingsDestroyCmd() *cobra.Command {
+func newDeploymentSettingsDestroyCmd(configFile *string) *cobra.Command {
 	var stack string
 	var yes bool
 
@@ -152,7 +154,8 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 				return err
 			}
 
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -186,7 +189,7 @@ func newDeploymentSettingsDestroyCmd() *cobra.Command {
 	return cmd
 }
 
-func newDeploymentSettingsEnvCmd() *cobra.Command {
+func newDeploymentSettingsEnvCmd(configFile *string) *cobra.Command {
 	var stack string
 	var secret bool
 	var remove bool
@@ -198,7 +201,8 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 		Long:   "",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			d, err := initializeDeploymentSettingsCmd(cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack)
+			d, err := initializeDeploymentSettingsCmd(
+				cmd.Context(), cmd.OutOrStdout(), pkgWorkspace.Instance, stack, *configFile)
 			if err != nil {
 				return err
 			}
@@ -252,7 +256,7 @@ func newDeploymentSettingsEnvCmd() *cobra.Command {
 				d.Deployment.DeploymentSettings.Operation.EnvironmentVariables[key] = *secretValue
 			}
 
-			err = saveProjectStackDeployment(d.Deployment, d.Stack)
+			err = saveProjectStackDeployment(d.Deployment, d.Stack, d.ConfigFile)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_utils.go
@@ -30,20 +30,22 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-var stackDeploymentConfigFile string
-
-func loadProjectStackDeployment(stack backend.Stack) (*workspace.ProjectStackDeployment, error) {
-	if stackDeploymentConfigFile == "" {
+func loadProjectStackDeployment(
+	stack backend.Stack, configFile string,
+) (*workspace.ProjectStackDeployment, error) {
+	if configFile == "" {
 		return workspace.DetectProjectStackDeployment(stack.Ref().Name().Q())
 	}
-	return workspace.LoadProjectStackDeployment(stackDeploymentConfigFile)
+	return workspace.LoadProjectStackDeployment(configFile)
 }
 
-func saveProjectStackDeployment(psd *workspace.ProjectStackDeployment, stack backend.Stack) error {
-	if stackDeploymentConfigFile == "" {
+func saveProjectStackDeployment(
+	psd *workspace.ProjectStackDeployment, stack backend.Stack, configFile string,
+) error {
+	if configFile == "" {
 		return workspace.SaveProjectStackDeployment(stack.Ref().Name().Q(), psd)
 	}
-	return psd.Save(stackDeploymentConfigFile)
+	return psd.Save(configFile)
 }
 
 type prompts interface {

--- a/pkg/cmd/pulumi/logs/decrypt.go
+++ b/pkg/cmd/pulumi/logs/decrypt.go
@@ -134,7 +134,7 @@ func decryptPLOG(
 	s, err := cmdStack.RequireStack(
 		ctx, cmdutil.Diag(), ws,
 		cmdBackend.DefaultLoginManager,
-		stackName, cmdStack.LoadOnly, opts,
+		stackName, cmdStack.LoadOnly, opts, "",
 	)
 	if err != nil {
 		return fmt.Errorf("loading stack %q for decryption: %w", stackName, err)

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -40,6 +40,7 @@ import (
 
 func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 	var stackName string
+	var configFile string
 	var follow bool
 	var since string
 	var resource string
@@ -74,12 +75,13 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 				stackName,
 				cmdStack.LoadOnly,
 				opts,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -201,7 +203,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	logsCmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	logsCmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -255,7 +255,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, "")
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("getting stack configuration: %w", err))
 	}

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -59,6 +59,7 @@ func NewDestroyCmd() *cobra.Command {
 	var execKind string
 	var execAgent string
 	var configArray []string
+	var configFile string
 	var path bool
 	var client string
 
@@ -178,7 +179,7 @@ func NewDestroyCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(false, nil, false, client, jsonDisplay, nil,
 					nil, refresh, showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil, nil,
-					targetDependents, "", cmdStack.ConfigFile, runProgram)
+					targetDependents, "", configFile, runProgram)
 				if err != nil {
 					return err
 				}
@@ -216,12 +217,13 @@ func NewDestroyCmd() *cobra.Command {
 				stackName,
 				cmdStack.LoadOnly,
 				opts.Display,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path); err != nil {
+			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 				return err
 			}
 
@@ -253,7 +255,7 @@ func NewDestroyCmd() *cobra.Command {
 				// The config may be missing, fallback on the latest configuration in the backend.
 				getConfig = config.GetStackConfigurationOrLatest
 			}
-			cfg, sm, err := getConfig(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := getConfig(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -406,7 +408,7 @@ func NewDestroyCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -613,6 +613,7 @@ func NewImportCmd() *cobra.Command {
 	var debug bool
 	var message string
 	var stackName string
+	var configFile string
 	var execKind string
 	var execAgent string
 
@@ -917,12 +918,13 @@ func NewImportCmd() *cobra.Command {
 				stackName,
 				cmdStack.LoadOnly,
 				opts.Display,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -1110,7 +1112,7 @@ func NewImportCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 
 	// Flags for engine.UpdateOptions.

--- a/pkg/cmd/pulumi/operations/import_test.go
+++ b/pkg/cmd/pulumi/operations/import_test.go
@@ -618,9 +618,8 @@ func TestImportFileMarshal(t *testing.T) {
 // the `--output` flag with the expected default and hidden state. The
 // display-layer behaviour is covered by TestUp_OutputJSONSummary; here we
 // just check the flag is plumbed.
-//
-//nolint:paralleltest // NewImportCmd writes to global cmdStack.ConfigFile
 func TestImportCmd_OutputFlagRegistered(t *testing.T) {
+	t.Parallel()
 	cmd := NewImportCmd()
 	flag := cmd.Flags().Lookup("output")
 	require.NotNil(t, flag, "expected --output flag on `pulumi import`")
@@ -631,9 +630,8 @@ func TestImportCmd_OutputFlagRegistered(t *testing.T) {
 // TestImportCmd_OutputAndJSONMutuallyExclusive verifies that passing both
 // --json and --output is rejected by cobra's flag-group validation before
 // RunE is invoked, so the command never starts a real import.
-//
-//nolint:paralleltest // NewImportCmd writes to global cmdStack.ConfigFile
 func TestImportCmd_OutputAndJSONMutuallyExclusive(t *testing.T) {
+	t.Parallel()
 	cmd := NewImportCmd()
 	cmd.SetArgs([]string{"--json", "--output", "json"})
 	cmd.SetOut(io.Discard)

--- a/pkg/cmd/pulumi/operations/io.go
+++ b/pkg/cmd/pulumi/operations/io.go
@@ -44,6 +44,7 @@ func parseAndSaveConfigArray(
 	s backend.Stack,
 	configArray []string,
 	path bool,
+	configFile string,
 ) error {
 	if len(configArray) == 0 {
 		return nil
@@ -53,7 +54,7 @@ func parseAndSaveConfigArray(
 		return err
 	}
 
-	if err = newcmd.SaveConfig(ctx, sink, ws, s, commandLineConfig); err != nil {
+	if err = newcmd.SaveConfig(ctx, sink, ws, s, commandLineConfig, configFile); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -285,6 +285,7 @@ func NewPreviewCmd() *cobra.Command {
 	var execAgent string
 	var stackName string
 	var configArray []string
+	var configFile string
 	var configPath bool
 	var client string
 	var planFilePath string
@@ -410,7 +411,7 @@ func NewPreviewCmd() *cobra.Command {
 				err := deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, configPath, client, jsonDisplay,
 					policyPackPaths, policyPackConfigPaths, refresh, showConfig, showPolicyRemediations,
 					showReplacementSteps, showSames, showReads, suppressOutputs, "default", &targets, nil, replaces,
-					targetReplaces, targetDependents, planFilePath, cmdStack.ConfigFile, runProgram)
+					targetReplaces, targetDependents, planFilePath, configFile, runProgram)
 				if err != nil {
 					return err
 				}
@@ -457,17 +458,18 @@ func NewPreviewCmd() *cobra.Command {
 				stackName,
 				cmdStack.OfferNew,
 				displayOpts,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
 			// Save any config values passed via flags.
-			if err = parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath); err != nil {
+			if err = parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath, configFile); err != nil {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -646,7 +648,7 @@ func NewPreviewCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -58,6 +58,7 @@ func NewRefreshCmd() *cobra.Command {
 	var execAgent string
 	var stackName string
 	var configArray []string
+	var configFile string
 	var path bool
 	var client string
 
@@ -180,7 +181,7 @@ func NewRefreshCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, nil, false, client, jsonDisplay, nil,
 					nil, "", showConfig, false, showReplacementSteps, showSames, false,
 					suppressOutputs, "default", targets, nil, nil, nil,
-					false, "", cmdStack.ConfigFile, runProgram)
+					false, "", configFile, runProgram)
 				if err != nil {
 					return err
 				}
@@ -218,16 +219,17 @@ func NewRefreshCmd() *cobra.Command {
 				stackName,
 				cmdStack.OfferNew,
 				opts.Display,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
-			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path); err != nil {
+			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -375,7 +377,7 @@ func NewRefreshCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -91,6 +91,7 @@ func NewUpCmd() *cobra.Command {
 	var execAgent string
 	var stackName string
 	var configArray []string
+	var configFile string
 	var path bool
 	var client string
 
@@ -155,13 +156,14 @@ func NewUpCmd() *cobra.Command {
 			stackName,
 			cmdStack.OfferNew,
 			opts.Display,
+			configFile,
 		)
 		if err != nil {
 			return err
 		}
 
 		// Save any config values passed via flags.
-		if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path); err != nil {
+		if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 			return err
 		}
 
@@ -170,7 +172,7 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
-		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -406,7 +408,7 @@ func NewUpCmd() *cobra.Command {
 		// Create the stack, if needed.
 		if s == nil {
 			if s, err = newcmd.PromptAndCreateStack(ctx, cmdutil.Diag(), ws, b, ui.PromptForValue, stackName, root,
-				false /*setCurrent*/, yes, opts.Display, secretsProvider, false /*useRemoteConfig*/); err != nil {
+				false /*setCurrent*/, yes, opts.Display, secretsProvider, false /*useRemoteConfig*/, configFile); err != nil {
 				return err
 			}
 			// The backend will print "Created stack '<stack>'." on success.
@@ -427,6 +429,7 @@ func NewUpCmd() *cobra.Command {
 			yes,
 			path,
 			opts.Display,
+			configFile,
 		); err != nil {
 			return err
 		}
@@ -447,7 +450,7 @@ func NewUpCmd() *cobra.Command {
 			}
 		}
 
-		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, pctx.Diag, ssml, s, proj)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, pctx.Diag, ssml, s, proj, configFile)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -639,7 +642,7 @@ func NewUpCmd() *cobra.Command {
 				err = deployment.ValidateUnsupportedRemoteFlags(expectNop, configArray, path, client, jsonDisplay, policyPackPaths,
 					policyPackConfigPaths, refresh, showConfig, showPolicyRemediations, showReplacementSteps, showSames,
 					showReads, suppressOutputs, secretsProvider, &targets, &excludes, replaces, targetReplaces,
-					targetDependents, planFilePath, cmdStack.ConfigFile, runProgram)
+					targetDependents, planFilePath, configFile, runProgram)
 				if err != nil {
 					return err
 				}
@@ -714,7 +717,7 @@ func NewUpCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -42,6 +42,7 @@ func NewWatchCmd() *cobra.Command {
 	var execKind string
 	var stackName string
 	var configArray []string
+	var configFile string
 	var pathArray []string
 	var configPath bool
 
@@ -106,13 +107,14 @@ func NewWatchCmd() *cobra.Command {
 				stackName,
 				cmdStack.OfferNew,
 				opts.Display,
+				configFile,
 			)
 			if err != nil {
 				return err
 			}
 
 			// Save any config values passed via flags.
-			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath); err != nil {
+			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath, configFile); err != nil {
 				return err
 			}
 
@@ -121,7 +123,7 @@ func NewWatchCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -198,7 +200,7 @@ func NewWatchCmd() *cobra.Command {
 		&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVar(
-		&cmdStack.ConfigFile, "config-file", "",
+		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -102,7 +102,7 @@ func newPolicyAnalyzeCmd(
 
 			// Get the stack.
 			displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
-			s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, lm, stack, cmdStack.LoadOnly, displayOpts)
+			s, err := cmdStack.RequireStack(ctx, cmdutil.Diag(), ws, lm, stack, cmdStack.LoadOnly, displayOpts, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -94,7 +94,7 @@ func (cmd *policyInstallCmd) Run(
 				Color: cmdutil.GetGlobalColorization(),
 			}
 			return cmdStack.RequireStack(ctx, cmd.diag, pkgWorkspace.Instance,
-				cmdBackend.DefaultLoginManager, stackName, cmdStack.LoadOnly, displayOpts)
+				cmdBackend.DefaultLoginManager, stackName, cmdStack.LoadOnly, displayOpts, "")
 		}
 	}
 

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -51,6 +51,7 @@ func HandleConfig(
 	yes bool,
 	path bool,
 	opts display.Options,
+	configFile string,
 ) error {
 	// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
 	latest, err := backend.GetLatestConfiguration(ctx, s)
@@ -95,6 +96,7 @@ func HandleConfig(
 			stackConfig,
 			yes,
 			opts,
+			configFile,
 		)
 		if err != nil {
 			return err
@@ -103,7 +105,7 @@ func HandleConfig(
 
 	// Save the config.
 	if len(c) > 0 {
-		if err = SaveConfig(ctx, sink, ws, s, c); err != nil {
+		if err = SaveConfig(ctx, sink, ws, s, c, configFile); err != nil {
 			return fmt.Errorf("saving config: %w", err)
 		}
 
@@ -190,6 +192,7 @@ func promptForConfig(
 	stackConfig config.Map,
 	yes bool,
 	opts display.Options,
+	configFile string,
 ) (config.Map, error) {
 	// Convert `string` keys to `config.Key`. If a string key is missing a delimiter,
 	// the project name will be prepended.
@@ -211,7 +214,7 @@ func promptForConfig(
 	sort.Sort(keys)
 
 	// We need to load the stack config here for the secret manager
-	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack)
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading stack config: %w", err)
 	}
@@ -221,7 +224,7 @@ func promptForConfig(
 		return nil, err
 	}
 	if state != cmdStack.SecretsManagerUnchanged {
-		if err = cmdStack.SaveProjectStack(ctx, stack, ps); err != nil {
+		if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
 			return nil, fmt.Errorf("saving stack config: %w", err)
 		}
 	}
@@ -330,13 +333,15 @@ func ParseConfig(configArray []string, path bool) (config.Map, error) {
 }
 
 // SaveConfig saves the config for the stack.
-func SaveConfig(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stack backend.Stack, c config.Map) error {
+func SaveConfig(
+	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stack backend.Stack, c config.Map, configFile string,
+) error {
 	project, _, err := ws.ReadProject()
 	if err != nil {
 		return err
 	}
 
-	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack)
+	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
 	if err != nil {
 		return err
 	}
@@ -345,5 +350,5 @@ func SaveConfig(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, st
 		ps.Config[k] = v
 	}
 
-	return cmdStack.SaveProjectStack(ctx, stack, ps)
+	return cmdStack.SaveProjectStack(ctx, stack, ps, configFile)
 }

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -390,7 +390,8 @@ func runNew(ctx context.Context, args newArgs) error {
 	// Create the stack, if needed.
 	if !args.generateOnly && s == nil {
 		if s, err = PromptAndCreateStack(ctx, cmdutil.Diag(), ws, b, args.prompt,
-			args.stack, root, true /*setCurrent*/, args.yes, opts, args.secretsProvider, args.remoteStackConfig); err != nil {
+			args.stack, root, true /*setCurrent*/, args.yes, opts, args.secretsProvider,
+			args.remoteStackConfig, ""); err != nil {
 			return err
 		}
 		// The backend will print "Created stack '<stack>'" on success.
@@ -466,6 +467,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			args.yes,
 			args.configPath,
 			opts,
+			"",
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/pulumi/project/newcmd/stack.go
+++ b/pkg/cmd/pulumi/project/newcmd/stack.go
@@ -60,7 +60,7 @@ func GetStack(ctx context.Context, b backend.Backend,
 // PromptAndCreateStack creates and returns a new stack (prompting for the name as needed).
 func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	b backend.Backend, prompt promptForValueFunc, stack string, root string, setCurrent bool,
-	yes bool, opts display.Options, secretsProvider string, useRemoteConfig bool,
+	yes bool, opts display.Options, secretsProvider string, useRemoteConfig bool, configFile string,
 ) (backend.Stack, error) {
 	contract.Requiref(b != nil, "b", "must not be nil")
 	contract.Requiref(root != "", "root", "must not be empty")
@@ -70,7 +70,8 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		if err != nil {
 			return nil, err
 		}
-		s, err := cmdStack.InitStack(ctx, sink, ws, b, stackName, root, setCurrent, secretsProvider, useRemoteConfig)
+		s, err := cmdStack.InitStack(
+			ctx, sink, ws, b, stackName, root, setCurrent, secretsProvider, useRemoteConfig, configFile)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +94,8 @@ func PromptAndCreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.C
 		if err != nil {
 			return nil, err
 		}
-		s, err := cmdStack.InitStack(ctx, sink, ws, b, formattedStackName, root, setCurrent, secretsProvider, useRemoteConfig)
+		s, err := cmdStack.InitStack(
+			ctx, sink, ws, b, formattedStackName, root, setCurrent, secretsProvider, useRemoteConfig, configFile)
 		if err != nil {
 			if !yes {
 				// Let the user know about the error and loop around to try again.

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -49,16 +49,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-var ConfigFile string
-
 func LoadProjectStack(
 	ctx context.Context,
 	sink diag.Sink,
 	project *workspace.Project,
 	stack backend.Stack,
+	configFile string,
 ) (*workspace.ProjectStack, error) {
-	if ConfigFile != "" {
-		return workspace.LoadProjectStack(sink, project, ConfigFile)
+	if configFile != "" {
+		return workspace.LoadProjectStack(sink, project, configFile)
 	}
 	project, configFilePath, err := workspace.DetectProjectStackPath(stack.Ref().Name().Q())
 	if err != nil {
@@ -80,9 +79,11 @@ func LoadProjectStack(
 	return workspace.LoadProjectStack(sink, project, configFilePath)
 }
 
-func SaveProjectStack(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack) error {
-	if ConfigFile != "" {
-		return ps.Save(ConfigFile)
+func SaveProjectStack(
+	ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, configFile string,
+) error {
+	if configFile != "" {
+		return ps.Save(configFile)
 	}
 	if stack.ConfigLocation().IsRemote {
 		return stack.SaveRemoteConfig(ctx, ps)
@@ -119,10 +120,10 @@ func (o LoadOption) SetCurrent() bool {
 // the workspace is returned.  If no stack with either the given name, or a currently selected stack, exists,
 // and we are in an interactive terminal, the user will be prompted to create a new stack.
 func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
-	stackName string, lopt LoadOption, opts display.Options,
+	stackName string, lopt LoadOption, opts display.Options, configFile string,
 ) (backend.Stack, error) {
 	if stackName == "" {
-		return requireCurrentStack(ctx, sink, ws, lm, lopt, opts)
+		return requireCurrentStack(ctx, sink, ws, lm, lopt, opts, configFile)
 	}
 
 	// Try to read the current project
@@ -161,7 +162,7 @@ func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, 
 			return nil, err
 		}
 
-		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false)
+		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false, configFile)
 	}
 
 	return nil, backenderr.StackNotFoundError{StackName: stackName}
@@ -169,7 +170,7 @@ func RequireStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, 
 
 func requireCurrentStack(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
-	lm cmdBackend.LoginManager, lopt LoadOption, opts display.Options,
+	lm cmdBackend.LoginManager, lopt LoadOption, opts display.Options, configFile string,
 ) (backend.Stack, error) {
 	// Try to read the current project
 	project, _, err := ws.ReadProject()
@@ -190,13 +191,13 @@ func requireCurrentStack(
 	}
 
 	// If no current stack exists, and we are interactive, prompt to select or create one.
-	return ChooseStack(ctx, sink, ws, b, lopt, opts)
+	return ChooseStack(ctx, sink, ws, b, lopt, opts, configFile)
 }
 
 // ChooseStack will prompt the user to choose amongst the full set of stacks in the given backend.  If offerNew is
 // true, then the option to create an entirely new stack is provided and will create one as desired.
 func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
-	b backend.Backend, lopt LoadOption, opts display.Options,
+	b backend.Backend, lopt LoadOption, opts display.Options, configFile string,
 ) (backend.Stack, error) {
 	lopt ^= SetCurrent
 	// Prepare our error in case we need to issue it.  Bail early if we're not interactive.
@@ -304,7 +305,7 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 			return nil, parseErr
 		}
 
-		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false)
+		return CreateStack(ctx, sink, ws, b, stackRef, root, nil, lopt.SetCurrent(), "", false, configFile)
 	}
 
 	// With the stack name selected, look it up from the backend.
@@ -334,22 +335,22 @@ func ChooseStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 // InitStack creates the stack.
 func InitStack(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend, stackName string,
-	root string, setCurrent bool, secretsProvider string, useRemoteConfig bool,
+	root string, setCurrent bool, secretsProvider string, useRemoteConfig bool, configFile string,
 ) (backend.Stack, error) {
 	stackRef, err := b.ParseStackReference(stackName)
 	if err != nil {
 		return nil, err
 	}
-	return CreateStack(ctx, sink, ws, b, stackRef, root, nil, setCurrent, secretsProvider, useRemoteConfig)
+	return CreateStack(ctx, sink, ws, b, stackRef, root, nil, setCurrent, secretsProvider, useRemoteConfig, configFile)
 }
 
 // CreateStack creates a stack with the given name, and optionally selects it as the current.
 func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 	b backend.Backend, stackRef backend.StackReference,
 	root string, teams []string, setCurrent bool,
-	secretsProvider string, useRemoteConfig bool,
+	secretsProvider string, useRemoteConfig bool, configFile string,
 ) (backend.Stack, error) {
-	ps, needsSave, sm, err := createSecretsManagerForNewStack(ctx, sink, ws, b, stackRef, secretsProvider)
+	ps, needsSave, sm, err := createSecretsManagerForNewStack(ctx, sink, ws, b, stackRef, secretsProvider, configFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not create secrets manager for new stack: %w", err)
 	}
@@ -418,7 +419,7 @@ func CreateStack(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context,
 
 	// Now that we've created the stack, we'll write out any necessary configuration changes.
 	if needsSave {
-		err = SaveProjectStack(ctx, stack, ps)
+		err = SaveProjectStack(ctx, stack, ps, configFile)
 		if err != nil {
 			return nil, fmt.Errorf("saving stack config: %w", err)
 		}
@@ -553,7 +554,7 @@ func RequireCloudStack(
 ) (*client.Client, client.StackIdentifier, error) {
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	s, err := RequireStack(ctx, sink, ws, lm, stackName, LoadOnly, opts)
+	s, err := RequireStack(ctx, sink, ws, lm, stackName, LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/stack/io_test.go
+++ b/pkg/cmd/pulumi/stack/io_test.go
@@ -110,6 +110,7 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 		false, /*setCurrent*/
 		"",    /*secretsProvider*/
 		false, /* useRemoteConfig */
+		"",    /*configFile*/
 	)
 
 	// Assert.

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -63,7 +63,7 @@ func CreateSecretsManagerForExistingStack(
 	if err != nil {
 		return err
 	}
-	ps, err := LoadProjectStack(ctx, sink, project, stack)
+	ps, err := LoadProjectStack(ctx, sink, project, stack, "")
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func CreateSecretsManagerForExistingStack(
 
 	// Handle if the configuration changed any of EncryptedKey, etc
 	if needsSaveProjectStackAfterSecretManger(oldConfig, ps) {
-		if err = SaveProjectStack(ctx, stack, ps); err != nil {
+		if err = SaveProjectStack(ctx, stack, ps, ""); err != nil {
 			return fmt.Errorf("saving stack config: %w", err)
 		}
 	}
@@ -102,10 +102,11 @@ func createSecretsManagerForNewStack(
 	b backend.Backend,
 	stackRef backend.StackReference,
 	secretsProvider string,
+	configFile string,
 ) (*workspace.ProjectStack, bool, secrets.Manager, error) {
 	var sm secrets.Manager
 
-	ps, err := readStackConfiguration(ctx, sink, ws, b, stackRef)
+	ps, err := readStackConfiguration(ctx, sink, ws, b, stackRef, configFile)
 	if err != nil {
 		return nil, false, nil, err
 	}
@@ -129,7 +130,7 @@ func createSecretsManagerForNewStack(
 }
 
 func readStackConfiguration(ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, b backend.Backend,
-	stackRef backend.StackReference,
+	stackRef backend.StackReference, configFile string,
 ) (*workspace.ProjectStack, error) {
 	// Attempt to read a stack configuration, since it's possible that the user may have supplied one even though the
 	// stack has not actually been created yet. If we fail to read one, that's OK -- we'll just create a new one and
@@ -141,16 +142,13 @@ func readStackConfiguration(ctx context.Context, sink diag.Sink, ws pkgWorkspace
 	s, err := b.GetStack(ctx, stackRef)
 	if err != nil || s == nil {
 		// Attempt to load file directly as it might already exist even though not in the backend
-		if ConfigFile != "" {
-			return workspace.LoadProjectStack(sink, project, ConfigFile)
+		if configFile != "" {
+			return workspace.LoadProjectStack(sink, project, configFile)
 		}
 		return workspace.DetectProjectStack(sink, stackRef.Name().Q())
 	}
-	ps, err := LoadProjectStack(ctx, sink, project, s)
-	if err != nil || ps == nil {
-		if ConfigFile != "" {
-			return workspace.LoadProjectStack(sink, project, ConfigFile)
-		}
+	ps, err := LoadProjectStack(ctx, sink, project, s, configFile)
+	if configFile == "" && (err != nil || ps == nil) {
 		return workspace.DetectProjectStack(sink, stackRef.Name().Q())
 	}
 

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -79,6 +79,7 @@ func NewStackCmd() *cobra.Command {
 				stackName,
 				OfferNew,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider.go
@@ -122,12 +122,13 @@ func (cmd *stackChangeSecretsProviderCmd) Run(ctx context.Context, args []string
 		cmd.stack,
 		LoadOnly,
 		opts,
+		"",
 	)
 	if err != nil {
 		return err
 	}
 
-	currentProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), project, currentStack)
+	currentProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), project, currentStack, "")
 	if err != nil {
 		return err
 	}
@@ -185,7 +186,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 	decrypter config.Decrypter,
 ) error {
 	// Reload the project stack after the new secrets provider is in place
-	reloadedProjectStack, err := LoadProjectStack(ctx, sink, project, currentStack)
+	reloadedProjectStack, err := LoadProjectStack(ctx, sink, project, currentStack, "")
 	if err != nil {
 		return err
 	}
@@ -215,7 +216,7 @@ func migrateOldConfigAndCheckpointToNewSecretsProvider(
 		}
 	}
 
-	if err := SaveProjectStack(ctx, currentStack, reloadedProjectStack); err != nil {
+	if err := SaveProjectStack(ctx, currentStack, reloadedProjectStack, ""); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/pulumi/stack/stack_drift_list.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_list.go
@@ -127,7 +127,7 @@ func defaultDriftListClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, LoadOnly, opts)
+		stackFlag, LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/stack/stack_drift_status.go
+++ b/pkg/cmd/pulumi/stack/stack_drift_status.go
@@ -105,7 +105,7 @@ func defaultDriftStatusClientFactory(
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	s, err := RequireStack(ctx, cmdutil.Diag(), ws, cmdBackend.DefaultLoginManager,
-		stackFlag, LoadOnly, opts)
+		stackFlag, LoadOnly, opts, "")
 	if err != nil {
 		return nil, client.StackIdentifier{}, fmt.Errorf("resolving stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/stack/stack_export.go
+++ b/pkg/cmd/pulumi/stack/stack_export.go
@@ -65,6 +65,7 @@ func newStackExportCmd() *cobra.Command {
 				stackName,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -50,7 +50,7 @@ func newStackGetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			s, err := RequireStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager,
-				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()})
+				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()}, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_graph.go
+++ b/pkg/cmd/pulumi/stack/stack_graph.go
@@ -83,6 +83,7 @@ func newStackGraphCmd() *cobra.Command {
 				cmdOpts.stackName,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -71,6 +71,7 @@ This command displays data about previous updates for a stack.`,
 				stack,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err
@@ -86,7 +87,7 @@ This command displays data about previous updates for a stack.`,
 				if err != nil {
 					return fmt.Errorf("loading project: %w", err)
 				}
-				ps, err := LoadProjectStack(ctx, cmdutil.Diag(), project, s)
+				ps, err := LoadProjectStack(ctx, cmdutil.Diag(), project, s, "")
 				if err != nil {
 					return fmt.Errorf("getting stack config: %w", err)
 				}
@@ -95,7 +96,7 @@ This command displays data about previous updates for a stack.`,
 					return fmt.Errorf("decrypting secrets: %w", err)
 				}
 				if state != SecretsManagerUnchanged {
-					if err = SaveProjectStack(ctx, s, ps); err != nil {
+					if err = SaveProjectStack(ctx, s, ps, ""); err != nil {
 						return fmt.Errorf("saving stack config: %w", err)
 					}
 				}

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -63,6 +63,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 				stackName,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err
@@ -99,7 +100,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 				project, _, loadErr := ws.ReadProject()
 				var ps *workspace.ProjectStack
 				if loadErr == nil {
-					ps, loadErr = LoadProjectStack(ctx, diag, project, s)
+					ps, loadErr = LoadProjectStack(ctx, diag, project, s, "")
 				}
 				if loadErr != nil {
 					// Default to an empty ProjectStack if we fail to load the existing one
@@ -119,7 +120,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 					if loadErr != nil {
 						return fmt.Errorf("could not load existing project stack to update secrets manager configuration: %w", loadErr)
 					}
-					if err = SaveProjectStack(ctx, s, ps); err != nil {
+					if err = SaveProjectStack(ctx, s, ps, ""); err != nil {
 						return fmt.Errorf("saving stack config: %w", err)
 					}
 				}

--- a/pkg/cmd/pulumi/stack/stack_init.go
+++ b/pkg/cmd/pulumi/stack/stack_init.go
@@ -195,7 +195,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 
 	teams := sanitizeTeams(cmd.teams)
 	newStack, err := CreateStack(ctx, cmdutil.Diag(), ws, b, stackRef, root, teams,
-		!cmd.noSelect, cmd.secretsProvider, cmd.remoteConfig)
+		!cmd.noSelect, cmd.secretsProvider, cmd.remoteConfig, "")
 	if err != nil {
 		if errors.Is(err, backend.ErrTeamsNotSupported) {
 			return fmt.Errorf("stack %s uses the %s backend: "+
@@ -218,17 +218,18 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 			cmd.stackToCopy,
 			LoadOnly,
 			opts,
+			"",
 		)
 		if err != nil {
 			return err
 		}
-		copyProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), proj, copyStack)
+		copyProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), proj, copyStack, "")
 		if err != nil {
 			return err
 		}
 
 		// get the project for the newly created stack
-		newProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), proj, newStack)
+		newProjectStack, err := LoadProjectStack(ctx, cmdutil.Diag(), proj, newStack, "")
 		if err != nil {
 			return err
 		}
@@ -249,7 +250,7 @@ func (cmd *stackInitCmd) Run(ctx context.Context, args []string) error {
 		// The use of `requiresSaving` here ensures that there was actually some config
 		// that needed saved, otherwise it's an unnecessary save call
 		if requiresSaving {
-			err := SaveProjectStack(ctx, newStack, newProjectStack)
+			err := SaveProjectStack(ctx, newStack, newProjectStack, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_output.go
+++ b/pkg/cmd/pulumi/stack/stack_output.go
@@ -92,7 +92,7 @@ type stackOutputCmd struct {
 	// from tests.
 	requireStack func(
 		ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
-		name string, lopt LoadOption, opts display.Options,
+		name string, lopt LoadOption, opts display.Options, configFile string,
 	) (backend.Stack, error)
 
 	Stdout io.Writer // defaults to os.Stdout
@@ -139,6 +139,7 @@ func (cmd *stackOutputCmd) Run(ctx context.Context, args []string) error {
 		cmd.stackName,
 		LoadOnly,
 		opts,
+		"",
 	)
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/stack/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_test.go
@@ -111,7 +111,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, diag.Sink, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, LoadOption, display.Options,
+				string, LoadOption, display.Options, string,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -222,7 +222,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, diag.Sink, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, LoadOption, display.Options,
+				string, LoadOption, display.Options, string,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -343,7 +343,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 				},
 			}
 			requireStack := func(context.Context, diag.Sink, pkgWorkspace.Context, cmdBackend.LoginManager,
-				string, LoadOption, display.Options,
+				string, LoadOption, display.Options, string,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
 					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
@@ -382,6 +382,7 @@ func TestStackOutputCmd_jsonAndShellConflict(t *testing.T) {
 	cmd := stackOutputCmd{
 		requireStack: func(
 			context.Context, diag.Sink, pkgWorkspace.Context, cmdBackend.LoginManager, string, LoadOption, display.Options,
+			string,
 		) (backend.Stack, error) {
 			t.Fatal("This function should not be called")
 			return nil, errors.New("should not be called")

--- a/pkg/cmd/pulumi/stack/stack_rename.go
+++ b/pkg/cmd/pulumi/stack/stack_rename.go
@@ -63,6 +63,7 @@ func newStackRenameCmd() *cobra.Command {
 				stack,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -78,6 +78,7 @@ func newStackRmCmd() *cobra.Command {
 				stack,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_select.go
+++ b/pkg/cmd/pulumi/stack/stack_select.go
@@ -95,7 +95,7 @@ func newStackSelectCmd() *cobra.Command {
 				}
 				// If create flag was passed and stack was not found, create it and select it.
 				if create && stack != "" {
-					s, err := InitStack(ctx, sink, ws, b, stack, root, false, secretsProvider, false /*useRemoteConfig*/)
+					s, err := InitStack(ctx, sink, ws, b, stack, root, false, secretsProvider, false /*useRemoteConfig*/, "")
 					if err != nil {
 						return err
 					}
@@ -113,6 +113,7 @@ func newStackSelectCmd() *cobra.Command {
 				b,
 				OfferNew|SetCurrent,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -80,6 +80,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 				*stack,
 				LoadOnly,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err
@@ -126,6 +127,7 @@ func newStackTagLsCmd(stack *string) *cobra.Command {
 				*stack,
 				SetCurrent,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err
@@ -189,6 +191,7 @@ func newStackTagRmCmd(stack *string) *cobra.Command {
 				*stack,
 				SetCurrent,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err
@@ -233,6 +236,7 @@ func newStackTagSetCmd(stack *string) *cobra.Command {
 				*stack,
 				SetCurrent,
 				opts,
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/state/io.go
+++ b/pkg/cmd/pulumi/state/io.go
@@ -66,6 +66,7 @@ func runTotalStateEdit(
 		stackName,
 		cmdStack.OfferNew,
 		opts,
+		"",
 	)
 	if err != nil {
 		return err
@@ -96,6 +97,7 @@ func runTotalStateEditWithPrompt(
 		stackName,
 		cmdStack.OfferNew,
 		opts,
+		"",
 	)
 	if err != nil {
 		return err
@@ -253,6 +255,7 @@ func getURNFromState(
 			stackName,
 			cmdStack.LoadOnly,
 			opts,
+			"",
 		)
 		if err != nil {
 			return "", err

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -75,6 +75,7 @@ a preview showing a diff of the altered state.`,
 					Color:         cmdutil.GetGlobalColorization(),
 					IsInteractive: true,
 				},
+				"",
 			)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -91,6 +91,7 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 					Color:         cmdutil.GetGlobalColorization(),
 					IsInteractive: true,
 				},
+				"",
 			)
 			if err != nil {
 				return err
@@ -106,6 +107,7 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 					Color:         cmdutil.GetGlobalColorization(),
 					IsInteractive: true,
 				},
+				"",
 			)
 			if err != nil {
 				return err
@@ -211,7 +213,7 @@ func (cmd *stateMoveCmd) Run(
 		if err != nil {
 			return err
 		}
-		ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, dest)
+		ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, dest, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -135,6 +135,7 @@ func (cmd *stateRepairCmd) run(ctx context.Context) error {
 		cmd.Args.Stack,
 		cmdStack.OfferNew,
 		displayOpts,
+		"",
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
`cmdStack.ConfigFile` was a global variable. It has been replaced by splicing it into the call-stack where it's used.

This frees up 7 tests to be parallel and simplifies our code base.

Part of https://github.com/pulumi/pulumi/issues/23391