### PR TITLE
Remove `DisableIntegrityChecking` global

### DIFF
--- a/changelog/pending/cli-chore-remove-disable-integrity-checking-global.yaml
+++ b/changelog/pending/cli-chore-remove-disable-integrity-checking-global.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: chore
+body: Thread the value of `--disable-integrity-checking` explicitly instead of through a package-level global
+time: 2026-05-31T00:00:00.000000+00:00
+custom:
+    PR: "23393"

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -369,6 +369,8 @@ type UpdateOptions struct {
 	SkipPreview bool
 	// PreviewOnly, when true, causes only the preview step to be run, without running the Update.
 	PreviewOnly bool
+	// DisableIntegrityChecking, when true, disables checkpoint state integrity verification for this operation.
+	DisableIntegrityChecking bool
 }
 
 // CancellationScope provides a scoped source of cancellation and termination requests.
@@ -436,7 +438,7 @@ func (c *backendClient) GetStackResourceOutputs(
 	if s == nil {
 		return property.Map{}, fmt.Errorf("unknown stack %q", name)
 	}
-	snap, err := s.Snapshot(ctx, c.secretsProvider)
+	snap, err := s.Snapshot(ctx, c.secretsProvider, false /* disableIntegrityChecking */)
 	if err != nil {
 		return property.Map{}, err
 	}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -56,7 +56,9 @@ func TestGetStackResourceOutputs(t *testing.T) {
 		},
 		GetStackF: func(ctx context.Context, stackRef StackReference) (Stack, error) {
 			return &MockStack{
-				SnapshotF: func(ctx context.Context, sp secrets.Provider) (*deploy.Snapshot, error) {
+				SnapshotF: func(
+					ctx context.Context, sp secrets.Provider, disableIntegrityChecking bool,
+				) (*deploy.Snapshot, error) {
 					return &deploy.Snapshot{Resources: []*resource.State{
 						resc1, resc2, deleted,
 					}}, nil

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -762,7 +762,7 @@ func (b *diyBackend) CreateStack(
 		return nil, &backenderr.StackAlreadyExistsError{StackName: string(stackName)}
 	}
 
-	_, err = b.saveStack(ctx, diyStackRef, apitype.TypedDeployment{})
+	_, err = b.saveStack(ctx, diyStackRef, apitype.TypedDeployment{}, false /* disableIntegrityChecking */)
 	if err != nil {
 		return nil, err
 	}
@@ -1249,8 +1249,9 @@ func (b *diyBackend) apply(
 	// We only need a snapshot manager if we're doing an update.
 	var manager *backend.SnapshotManager
 	if kind != apitype.PreviewUpdate && !opts.DryRun {
-		persister := b.newSnapshotPersister(ctx, diyStackRef)
-		manager = backend.NewSnapshotManager(persister, op.SecretsManager, update.Target.Snapshot, nil)
+		persister := b.newSnapshotPersister(ctx, diyStackRef, op.Opts.DisableIntegrityChecking)
+		manager = backend.NewSnapshotManager(
+			persister, op.SecretsManager, update.Target.Snapshot, nil, op.Opts.DisableIntegrityChecking)
 		engineCtx.SnapshotManager = manager
 	}
 
@@ -1409,7 +1410,8 @@ func (b *diyBackend) GetLogs(ctx context.Context,
 		return nil, err
 	}
 
-	target, err := b.getTarget(ctx, secretsProvider, diyStackRef, cfg.Config, cfg.Decrypter)
+	target, err := b.getTarget(
+		ctx, secretsProvider, diyStackRef, cfg.Config, cfg.Decrypter, false /* disableIntegrityChecking */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -686,7 +686,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, renamedStk)
 
-	renamedSnap, err := renamedStk.Snapshot(ctx, nil)
+	renamedSnap, err := renamedStk.Snapshot(ctx, nil, false /* disableIntegrityChecking */)
 	require.NoError(t, err)
 
 	err = renamedSnap.VerifyIntegrity()
@@ -1900,14 +1900,12 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	err = b.ImportDeployment(ctx, s, &deployment)
 	require.NoError(t, err)
 
-	backend.DisableIntegrityChecking = false
-	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider)
+	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider, false /* disableIntegrityChecking */)
 	require.ErrorContains(t, err,
 		"child resource urn:pulumi:stack::proj::type::name1's parent urn:pulumi:stack::proj::type::name2 comes after it")
 	assert.Nil(t, snap)
 
-	backend.DisableIntegrityChecking = true
-	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider)
+	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider, true /* disableIntegrityChecking */)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 }

--- a/pkg/backend/diy/snapshot.go
+++ b/pkg/backend/diy/snapshot.go
@@ -29,16 +29,19 @@ type diySnapshotPersister struct {
 
 	ref     *diyBackendReference
 	backend *diyBackend
+
+	disableIntegrityChecking bool
 }
 
 func (sp *diySnapshotPersister) Save(deployment apitype.TypedDeployment) error {
-	_, err := sp.backend.saveStack(sp.ctx, sp.ref, deployment)
+	_, err := sp.backend.saveStack(sp.ctx, sp.ref, deployment, sp.disableIntegrityChecking)
 	return err
 }
 
 func (b *diyBackend) newSnapshotPersister(
 	ctx context.Context,
 	ref *diyBackendReference,
+	disableIntegrityChecking bool,
 ) *diySnapshotPersister {
-	return &diySnapshotPersister{ctx: ctx, ref: ref, backend: b}
+	return &diySnapshotPersister{ctx: ctx, ref: ref, backend: b, disableIntegrityChecking: disableIntegrityChecking}
 }

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -70,12 +70,14 @@ func (s *diyStack) SaveRemoteConfig(ctx context.Context, projectStack *workspace
 	return fmt.Errorf("%w for the DIY backend", backend.ErrConfigNotSupported)
 }
 
-func (s *diyStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+func (s *diyStack) Snapshot(
+	ctx context.Context, secretsProvider secrets.Provider, disableIntegrityChecking bool,
+) (*deploy.Snapshot, error) {
 	if v := s.snapshot.Load(); v != nil {
 		return *v, nil
 	}
 
-	snap, err := s.b.getSnapshot(ctx, secretsProvider, s.ref)
+	snap, err := s.b.getSnapshot(ctx, secretsProvider, s.ref, disableIntegrityChecking)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/diy/stack_tags_test.go
+++ b/pkg/backend/diy/stack_tags_test.go
@@ -429,7 +429,7 @@ func (m *mockStackForTesting) SaveRemoteConfig(context.Context, *workspace.Proje
 	return nil
 }
 
-func (m *mockStackForTesting) Snapshot(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+func (m *mockStackForTesting) Snapshot(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 	return nil, nil
 }
 

--- a/pkg/backend/diy/state.go
+++ b/pkg/backend/diy/state.go
@@ -47,11 +47,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
-// DisableIntegrityChecking can be set to true to disable checkpoint state integrity verification.  This is not
-// recommended, because it could mean proceeding even in the face of a corrupted checkpoint state file, but can
-// be used as a last resort when a command absolutely must be run.
-var DisableIntegrityChecking bool
-
 func (b *diyBackend) newUpdate(
 	ctx context.Context,
 	secretsProvider secrets.Provider,
@@ -62,7 +57,7 @@ func (b *diyBackend) newUpdate(
 
 	// Construct the deployment target.
 	target, err := b.getTarget(ctx, secretsProvider, ref,
-		op.StackConfiguration.Config, op.StackConfiguration.Decrypter)
+		op.StackConfiguration.Config, op.StackConfiguration.Decrypter, op.Opts.DisableIntegrityChecking)
 	if err != nil {
 		return engine.UpdateInfo{}, err
 	}
@@ -81,13 +76,14 @@ func (b *diyBackend) getTarget(
 	ref *diyBackendReference,
 	cfg config.Map,
 	dec config.Decrypter,
+	disableIntegrityChecking bool,
 ) (*deploy.Target, error) {
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 	stack, err := b.GetStack(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
-	snapshot, err := stack.Snapshot(ctx, secretsProvider)
+	snapshot, err := stack.Snapshot(ctx, secretsProvider, disableIntegrityChecking)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +125,7 @@ func (b *diyBackend) stackExists(
 }
 
 func (b *diyBackend) getSnapshot(ctx context.Context,
-	secretsProvider secrets.Provider, ref *diyBackendReference,
+	secretsProvider secrets.Provider, ref *diyBackendReference, disableIntegrityChecking bool,
 ) (*deploy.Snapshot, error) {
 	contract.Requiref(ref != nil, "ref", "must not be nil")
 
@@ -145,7 +141,7 @@ func (b *diyBackend) getSnapshot(ctx context.Context,
 	}
 
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
-	if !backend.DisableIntegrityChecking {
+	if !disableIntegrityChecking {
 		if err := snap.VerifyIntegrity(); err != nil {
 			if sie, ok := snapshot.AsSnapshotIntegrityError(err); ok {
 				var metadata *apitype.SnapshotIntegrityErrorMetadataV1
@@ -351,6 +347,7 @@ func (b *diyBackend) saveStack(
 	ctx context.Context,
 	ref *diyBackendReference,
 	deployment apitype.TypedDeployment,
+	disableIntegrityChecking bool,
 ) (string, error) {
 	contract.Requiref(ref != nil, "ref", "ref was nil")
 	chk, err := stack.DeploymentV3ToCheckpointWithMarshaler(
@@ -369,7 +366,7 @@ func (b *diyBackend) saveStack(
 		return "", err
 	}
 
-	if !backend.DisableIntegrityChecking {
+	if !disableIntegrityChecking {
 		// Finally, *after* writing the checkpoint, check the integrity.  This is done afterwards so that we write
 		// out the checkpoint file since it may contain resource state updates.  But we will warn the user that the
 		// file is already written and might be bad.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2066,7 +2066,8 @@ func (b *cloudBackend) runEngineAction(
 		} else {
 			persister := b.newSnapshotPersister(ctx, update, tokenSource)
 			snapshotJournaler, err = backend.NewSnapshotJournaler(
-				ctx, journalPersister, op.SecretsManager, backend_secrets.DefaultProvider, u.Target.Snapshot)
+				ctx, journalPersister, op.SecretsManager, backend_secrets.DefaultProvider, u.Target.Snapshot,
+				op.Opts.DisableIntegrityChecking)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -2074,7 +2075,8 @@ func (b *cloudBackend) runEngineAction(
 			if err != nil {
 				return nil, nil, err
 			}
-			snapshotManager = backend.NewSnapshotManager(persister, op.SecretsManager, u.Target.Snapshot, engineEvents)
+			snapshotManager = backend.NewSnapshotManager(
+				persister, op.SecretsManager, u.Target.Snapshot, engineEvents, op.Opts.DisableIntegrityChecking)
 			combinedManager = &engine.CombinedManager{
 				Managers:          []engine.SnapshotManager{snapshotManager, journalManager},
 				CollectErrorsOnly: []bool{false, true},
@@ -2308,7 +2310,8 @@ func (b *cloudBackend) GetLogs(ctx context.Context,
 	secretsProvider secrets.Provider, stack backend.Stack, cfg backend.StackConfiguration,
 	logQuery operations.LogQuery,
 ) ([]operations.LogEntry, error) {
-	target, targetErr := b.getTarget(ctx, secretsProvider, stack.Ref(), cfg.Config, cfg.Decrypter)
+	target, targetErr := b.getTarget(
+		ctx, secretsProvider, stack.Ref(), cfg.Config, cfg.Decrypter, false /* disableIntegrityChecking */)
 	if targetErr != nil {
 		return nil, targetErr
 	}

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -891,14 +891,12 @@ func TestDisableIntegrityChecking(t *testing.T) {
 	err = b.ImportDeployment(ctx, s, &deployment)
 	require.NoError(t, err)
 
-	backend.DisableIntegrityChecking = false
-	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider)
+	snap, err := s.Snapshot(ctx, b64.Base64SecretsProvider, false /* disableIntegrityChecking */)
 	require.ErrorContains(t, err,
 		"child resource urn:pulumi:stack::proj::type::name1's parent urn:pulumi:stack::proj::type::name2 comes after it")
 	assert.Nil(t, snap)
 
-	backend.DisableIntegrityChecking = true
-	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider)
+	snap, err = s.Snapshot(ctx, b64.Base64SecretsProvider, true /* disableIntegrityChecking */)
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 }

--- a/pkg/backend/httpstate/snapshot_benchmark_test.go
+++ b/pkg/backend/httpstate/snapshot_benchmark_test.go
@@ -689,7 +689,7 @@ func BenchmarkSnapshot(b *testing.B) {
 
 	p := newServerPersister(b)
 	getManager := func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {
-		return backend.NewSnapshotManager(p, base.SecretsManager, base, nil)
+		return backend.NewSnapshotManager(p, base.SecretsManager, base, nil, false)
 	}
 	if useJournal {
 		getManager = func(t testing.TB, base *deploy.Snapshot) engine.SnapshotManager {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -220,12 +220,14 @@ func (s *cloudStack) StackIdentifier() client.StackIdentifier {
 	return si
 }
 
-func (s *cloudStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+func (s *cloudStack) Snapshot(
+	ctx context.Context, secretsProvider secrets.Provider, disableIntegrityChecking bool,
+) (*deploy.Snapshot, error) {
 	if v := s.snapshot.Load(); v != nil {
 		return *v, nil
 	}
 
-	snap, err := s.b.getSnapshot(ctx, secretsProvider, s.ref)
+	snap, err := s.b.getSnapshot(ctx, secretsProvider, s.ref, disableIntegrityChecking)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -162,7 +162,7 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 
 	// Construct the deployment target.
 	target, err := b.getTarget(ctx, op.SecretsProvider, stackRef,
-		op.StackConfiguration.Config, op.StackConfiguration.Decrypter)
+		op.StackConfiguration.Config, op.StackConfiguration.Decrypter, op.Opts.DisableIntegrityChecking)
 	if err != nil {
 		return engine.UpdateInfo{}, nil, err
 	}
@@ -188,7 +188,7 @@ func (b *cloudBackend) completeUpdate(
 }
 
 func (b *cloudBackend) getSnapshot(ctx context.Context,
-	secretsProvider secrets.Provider, stackRef backend.StackReference,
+	secretsProvider secrets.Provider, stackRef backend.StackReference, disableIntegrityChecking bool,
 ) (*deploy.Snapshot, error) {
 	untypedDeployment, err := b.exportDeployment(ctx, stackRef, nil /* get latest */)
 	if err != nil {
@@ -201,7 +201,7 @@ func (b *cloudBackend) getSnapshot(ctx context.Context,
 	}
 
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
-	if !backend.DisableIntegrityChecking {
+	if !disableIntegrityChecking {
 		if err := snap.VerifyIntegrity(); err != nil {
 			if sie, ok := snapshot.AsSnapshotIntegrityError(err); ok {
 				var metadata *apitype.SnapshotIntegrityErrorMetadataV1
@@ -244,14 +244,14 @@ func (b *cloudBackend) getSnapshotStackOutputs(ctx context.Context,
 }
 
 func (b *cloudBackend) getTarget(ctx context.Context, secretsProvider secrets.Provider, stackRef backend.StackReference,
-	cfg config.Map, dec config.Decrypter,
+	cfg config.Map, dec config.Decrypter, disableIntegrityChecking bool,
 ) (*deploy.Target, error) {
 	stackID, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshot, err := b.getSnapshot(ctx, secretsProvider, stackRef)
+	snapshot, err := b.getSnapshot(ctx, secretsProvider, stackRef, disableIntegrityChecking)
 	if err != nil {
 		return nil, stack.FormatDeploymentDeserializationError(err, stackRef.Name().String())
 	}

--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -494,7 +494,7 @@ func (sj *SnapshotJournaler) saveSnapshot() error {
 	if err := persister.Save(deployment); err != nil {
 		return fmt.Errorf("failed to save snapshot: %w", err)
 	}
-	if !DisableIntegrityChecking && integrityError != nil {
+	if !sj.disableIntegrityChecking && integrityError != nil {
 		return fmt.Errorf("failed to verify snapshot: %w", integrityError)
 	}
 	return nil
@@ -568,6 +568,9 @@ type SnapshotJournaler struct {
 	secretsManager  secrets.Manager
 	secretsProvider secrets.Provider
 	errors          []error
+
+	// disableIntegrityChecking, when true, disables checkpoint state integrity verification.
+	disableIntegrityChecking bool
 }
 
 // NewSnapshotJournaler creates a new Journal that uses a SnapshotPersister to persist the
@@ -595,6 +598,7 @@ func NewSnapshotJournaler(
 	secretsManager secrets.Manager,
 	secretsProvider secrets.Provider,
 	baseSnap *deploy.Snapshot,
+	disableIntegrityChecking bool,
 ) (*SnapshotJournaler, error) {
 	snapCopy := &deploy.Snapshot{}
 	if baseSnap != nil {
@@ -635,15 +639,16 @@ func NewSnapshotJournaler(
 	}
 
 	journaler := SnapshotJournaler{
-		ctx:             ctx,
-		persister:       persister,
-		snapshot:        deployment,
-		journalEvents:   journalEvents,
-		journalEntries:  make([]apitype.JournalEntry, 0),
-		secretsManager:  secretsManager,
-		secretsProvider: secretsProvider,
-		cancel:          cancel,
-		done:            done,
+		ctx:                      ctx,
+		persister:                persister,
+		snapshot:                 deployment,
+		journalEvents:            journalEvents,
+		journalEntries:           make([]apitype.JournalEntry, 0),
+		secretsManager:           secretsManager,
+		secretsProvider:          secretsProvider,
+		cancel:                   cancel,
+		done:                     done,
+		disableIntegrityChecking: disableIntegrityChecking,
 	}
 
 	serviceLoop := journaler.defaultServiceLoop

--- a/pkg/backend/journaler_snapshot_test.go
+++ b/pkg/backend/journaler_snapshot_test.go
@@ -46,7 +46,7 @@ func MockJournalSetup(t *testing.T, baseSnap *deploy.Snapshot) (engine.SnapshotM
 
 	secretsProvider := stack.Base64SecretsProvider{}
 	journal, err := NewSnapshotJournaler(
-		t.Context(), sp, baseSnap.SecretsManager, secretsProvider, baseSnap)
+		t.Context(), sp, baseSnap.SecretsManager, secretsProvider, baseSnap, false)
 	require.NoError(t, err)
 	snap, err := engine.NewJournalSnapshotManager(journal, baseSnap, baseSnap.SecretsManager)
 	require.NoError(t, err)
@@ -1039,7 +1039,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsJournaling(t 
 	sp := &MockStackPersister{}
 	secretsProvider := stack.Base64SecretsProvider{}
 	journal, err := NewSnapshotJournaler(
-		t.Context(), sp, snap.SecretsManager, secretsProvider, snap)
+		t.Context(), sp, snap.SecretsManager, secretsProvider, snap, false)
 	require.NoError(t, err)
 
 	sm, err := engine.NewJournalSnapshotManager(journal, snap, snap.SecretsManager)
@@ -1062,7 +1062,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsJournaling(t *t
 	sp := &MockStackPersister{}
 	secretsProvider := stack.Base64SecretsProvider{}
 	journal, err := NewSnapshotJournaler(
-		t.Context(), sp, snap.SecretsManager, secretsProvider, snap)
+		t.Context(), sp, snap.SecretsManager, secretsProvider, snap, false)
 	require.NoError(t, err)
 
 	sm, err := engine.NewJournalSnapshotManager(journal, snap, snap.SecretsManager)
@@ -1074,11 +1074,8 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsJournaling(t *t
 	assert.Nil(t, sp.LastSnap().Metadata.IntegrityErrorMetadata)
 }
 
-//nolint:paralleltest // mutates global state
 func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisabledJournaling(t *testing.T) {
-	old := DisableIntegrityChecking
-	DisableIntegrityChecking = true
-	defer func() { DisableIntegrityChecking = old }()
+	t.Parallel()
 
 	// The dependency "b" does not exist in the snapshot, so we'll get a missing
 	// dependency error when we try to save the snapshot.
@@ -1087,7 +1084,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisable
 	sp := &MockStackPersister{}
 	secretsProvider := stack.Base64SecretsProvider{}
 	journal, err := NewSnapshotJournaler(
-		t.Context(), sp, snap.SecretsManager, secretsProvider, snap)
+		t.Context(), sp, snap.SecretsManager, secretsProvider, snap, true /* disableIntegrityChecking */)
 	require.NoError(t, err)
 	sm, err := engine.NewJournalSnapshotManager(journal, snap, snap.SecretsManager)
 	require.NoError(t, err)
@@ -1098,11 +1095,8 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisable
 	require.NotNil(t, sp.LastSnap().Metadata.IntegrityErrorMetadata)
 }
 
-//nolint:paralleltest // mutates global state
 func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsChecksDisabledJournaling(t *testing.T) {
-	old := DisableIntegrityChecking
-	DisableIntegrityChecking = true
-	defer func() { DisableIntegrityChecking = old }()
+	t.Parallel()
 
 	// The dependency "b" does not exist in the snapshot, so we'll get a missing
 	// dependency error when we try to save the snapshot.
@@ -1111,7 +1105,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsChecksDisabledJ
 	sp := &MockStackPersister{}
 	secretsProvider := stack.Base64SecretsProvider{}
 	journal, err := NewSnapshotJournaler(
-		t.Context(), sp, snap.SecretsManager, secretsProvider, snap)
+		t.Context(), sp, snap.SecretsManager, secretsProvider, snap, true /* disableIntegrityChecking */)
 	require.NoError(t, err)
 	sm, err := engine.NewJournalSnapshotManager(journal, snap, snap.SecretsManager)
 	require.NoError(t, err)
@@ -1183,7 +1177,7 @@ func TestJournalEncryptionFailureNotSilent(t *testing.T) {
 	}, sm, nil, nil, deploy.SnapshotMetadata{})
 
 	sp := &MockStackPersister{}
-	j, err := NewSnapshotJournaler(t.Context(), sp, sm, stack.Base64SecretsProvider{}, baseSnap)
+	j, err := NewSnapshotJournaler(t.Context(), sp, sm, stack.Base64SecretsProvider{}, baseSnap, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = j.Close() })
 

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -586,13 +586,15 @@ func (be *MockEnvironmentsBackend) OpenYAMLEnvironment(
 //
 
 type MockStack struct {
-	RefF                  func() StackReference
-	ConfigLocationF       func() StackConfigLocation
-	LoadRemoteF           func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
-	SaveRemoteF           func(ctx context.Context, project *workspace.ProjectStack) error
-	OrgNameF              func() string
-	ConfigF               func() config.Map
-	SnapshotF             func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
+	RefF            func() StackReference
+	ConfigLocationF func() StackConfigLocation
+	LoadRemoteF     func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
+	SaveRemoteF     func(ctx context.Context, project *workspace.ProjectStack) error
+	OrgNameF        func() string
+	ConfigF         func() config.Map
+	SnapshotF       func(
+		ctx context.Context, secretsProvider secrets.Provider, disableIntegrityChecking bool,
+	) (*deploy.Snapshot, error)
 	TagsF                 func() map[apitype.StackTagName]string
 	BackendF              func() Backend
 	DefaultSecretManagerF func(ctx context.Context, info *workspace.ProjectStack) (secrets.Manager, error)
@@ -643,9 +645,11 @@ func (ms *MockStack) Config() config.Map {
 	panic("not implemented: MockStack.Config")
 }
 
-func (ms *MockStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+func (ms *MockStack) Snapshot(
+	ctx context.Context, secretsProvider secrets.Provider, disableIntegrityChecking bool,
+) (*deploy.Snapshot, error) {
 	if ms.SnapshotF != nil {
-		return ms.SnapshotF(ctx, secretsProvider)
+		return ms.SnapshotF(ctx, secretsProvider, disableIntegrityChecking)
 	}
 	panic("not implemented: MockStack.Snapshot")
 }
@@ -653,7 +657,7 @@ func (ms *MockStack) Snapshot(ctx context.Context, secretsProvider secrets.Provi
 func (ms *MockStack) SnapshotStackOutputs(
 	ctx context.Context, secretsProvider secrets.Provider,
 ) (property.Map, error) {
-	snapshot, err := ms.Snapshot(ctx, secretsProvider)
+	snapshot, err := ms.Snapshot(ctx, secretsProvider, false /* disableIntegrityChecking */)
 	if err != nil {
 		return property.Map{}, err
 	}

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -39,11 +39,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 )
 
-// DisableIntegrityChecking can be set to true to disable checkpoint state integrity verification.  This is not
-// recommended, because it could mean proceeding even in the face of a corrupted checkpoint state file, but can
-// be used as a last resort when a command absolutely must be run.
-var DisableIntegrityChecking bool
-
 // SnapshotPersister is an interface implemented by our backends that implements snapshot
 // persistence. In order to fit into our current model, snapshot persisters have two functions:
 // saving snapshots and invalidating already-persisted snapshots.
@@ -88,6 +83,11 @@ type SnapshotManager struct {
 	done             <-chan error             // A channel that sends a single result when the manager has shut down.
 
 	isRefresh bool // Whether or not the snapshot is part of a refresh
+
+	// disableIntegrityChecking, when true, disables checkpoint state integrity verification. This is not
+	// recommended, because it could mean proceeding even in the face of a corrupted checkpoint state file, but can
+	// be used as a last resort when a command absolutely must be run.
+	disableIntegrityChecking bool
 
 	// events is an optional channel for emitting engine events. When set, the snapshot manager will emit
 	// ErrorEvents to this channel when it detects and auto-repairs snapshot integrity errors.
@@ -803,7 +803,7 @@ func (sm *SnapshotManager) saveSnapshot() error {
 	// If we detected a snapshot integrity error, and we have an events channel
 	// i.e. in the httpstate backend, try to repair the snapshot.
 	var autoRepairErr error
-	if integrityError != nil && !DisableIntegrityChecking && sm.events != nil {
+	if integrityError != nil && !sm.disableIntegrityChecking && sm.events != nil {
 		sm.emitSnapshotIntegrityErrorEvent(integrityError)
 
 		repairedDeployment, repairErr := sm.repairAndSerialize()
@@ -837,7 +837,7 @@ func (sm *SnapshotManager) saveSnapshot() error {
 	if err := sm.persister.Save(deployment); err != nil {
 		return fmt.Errorf("failed to save snapshot: %w", err)
 	}
-	if !DisableIntegrityChecking && integrityError != nil {
+	if !sm.disableIntegrityChecking && integrityError != nil {
 		if autoRepairErr != nil {
 			var sie *snapshot.SnapshotIntegrityError
 			if errors.As(integrityError, &sie) {
@@ -943,19 +943,21 @@ func NewSnapshotManager(
 	secretsManager secrets.Manager,
 	baseSnap *deploy.Snapshot,
 	events chan<- engine.Event,
+	disableIntegrityChecking bool,
 ) *SnapshotManager {
 	mutationRequests, cancel, done := make(chan mutationRequest), make(chan bool), make(chan error)
 
 	manager := &SnapshotManager{
-		persister:        persister,
-		secretsManager:   secretsManager,
-		baseSnapshot:     baseSnap,
-		dones:            make(map[*resource.State]bool),
-		completeOps:      make(map[*resource.State]bool),
-		mutationRequests: mutationRequests,
-		cancel:           cancel,
-		done:             done,
-		events:           events,
+		persister:                persister,
+		secretsManager:           secretsManager,
+		baseSnapshot:             baseSnap,
+		dones:                    make(map[*resource.State]bool),
+		completeOps:              make(map[*resource.State]bool),
+		mutationRequests:         mutationRequests,
+		cancel:                   cancel,
+		done:                     done,
+		events:                   events,
+		disableIntegrityChecking: disableIntegrityChecking,
 	}
 
 	serviceLoop := manager.defaultServiceLoop

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -62,7 +62,7 @@ func MockSetup(t *testing.T, baseSnap *deploy.Snapshot) (*SnapshotManager, *Mock
 	require.NoError(t, err)
 
 	sp := &MockStackPersister{}
-	return NewSnapshotManager(sp, baseSnap.SecretsManager, baseSnap, nil), sp
+	return NewSnapshotManager(sp, baseSnap.SecretsManager, baseSnap, nil, false), sp
 }
 
 func NewResourceWithDeps(urn resource.URN, deps []resource.URN) *resource.State {
@@ -1081,7 +1081,7 @@ func TestSnapshotAutoRepairSucceedsForInvalidSnapshots(t *testing.T) {
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
 	events := make(chan engine.Event, 1)
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events, false)
 
 	err := sm.saveSnapshot()
 
@@ -1106,7 +1106,7 @@ func TestSnapshotAutoRepairErrorIsSurfacedWhenRepairFails(t *testing.T) {
 	snap := NewSnapshot([]*resource.State{rA, rB})
 	sp := &MockStackPersister{}
 	events := make(chan engine.Event, 1)
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, events, false)
 
 	err := sm.saveSnapshot()
 
@@ -1128,7 +1128,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshots(t *testing.T
 	r := NewResource("a", "b")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil, false)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1148,7 +1148,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshots(t *testing.T) 
 	snap.Metadata.IntegrityErrorMetadata = &deploy.SnapshotIntegrityErrorMetadata{}
 
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil, false)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1158,11 +1158,8 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshots(t *testing.T) 
 	assert.Nil(t, sp.LastSnap().Metadata.IntegrityErrorMetadata)
 }
 
-//nolint:paralleltest // mutates global state
 func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisabled(t *testing.T) {
-	old := DisableIntegrityChecking
-	DisableIntegrityChecking = true
-	defer func() { DisableIntegrityChecking = old }()
+	t.Parallel()
 
 	// Arrange.
 	//
@@ -1171,7 +1168,7 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisable
 	r := NewResource("a", "b")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil, true /* disableIntegrityChecking */)
 
 	// Act.
 	err := sm.saveSnapshot()
@@ -1181,11 +1178,8 @@ func TestSnapshotIntegrityErrorMetadataIsWrittenForInvalidSnapshotsChecksDisable
 	require.NotNil(t, sp.LastSnap().Metadata.IntegrityErrorMetadata)
 }
 
-//nolint:paralleltest // mutates global state
 func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsChecksDisabled(t *testing.T) {
-	old := DisableIntegrityChecking
-	DisableIntegrityChecking = true
-	defer func() { DisableIntegrityChecking = old }()
+	t.Parallel()
 
 	// Arrange.
 	//
@@ -1194,7 +1188,7 @@ func TestSnapshotIntegrityErrorMetadataIsClearedForValidSnapshotsChecksDisabled(
 	r := NewResource("a")
 	snap := NewSnapshot([]*resource.State{r})
 	sp := &MockStackPersister{}
-	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil)
+	sm := NewSnapshotManager(sp, snap.SecretsManager, snap, nil, true /* disableIntegrityChecking */)
 
 	// Act.
 	err := sm.saveSnapshot()

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -50,8 +50,12 @@ type Stack interface {
 	LoadRemoteConfig(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
 	// SaveRemoteConfig the stack's configuration remotely to the backend.
 	SaveRemoteConfig(ctx context.Context, projectStack *workspace.ProjectStack) error
-	// Snapshot returns the latest deployment snapshot.
-	Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
+	// Snapshot returns the latest deployment snapshot. When disableIntegrityChecking is true, the snapshot's
+	// integrity is not verified before it is returned; this is only safe for commands (such as `state repair`)
+	// that exist to operate on potentially-corrupt snapshots.
+	Snapshot(
+		ctx context.Context, secretsProvider secrets.Provider, disableIntegrityChecking bool,
+	) (*deploy.Snapshot, error)
 	// SnapshotStackOutputs returns the stack outputs of the latest deployment snapshot.
 	SnapshotStackOutputs(ctx context.Context, secretsProvider secrets.Provider) (property.Map, error)
 	// Backend returns the backend this stack belongs to.

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -69,7 +69,9 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 			" - the current backend\n",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			summary := getSummaryAbout(ctx, ws, cmdBackend.DefaultLoginManager, transitiveDependencies, stack)
+			summary := getSummaryAbout(
+				ctx, ws, cmdBackend.DefaultLoginManager, transitiveDependencies, stack,
+				cmdBackend.DisableIntegrityChecking(cmd))
 			if jsonOut {
 				return ui.FprintJSON(cmd.OutOrStdout(), summary)
 			}
@@ -111,7 +113,7 @@ type summaryAbout struct {
 
 func getSummaryAbout(
 	ctx context.Context, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
-	transitiveDependencies bool, selectedStack string,
+	transitiveDependencies bool, selectedStack string, disableIntegrityChecking bool,
 ) summaryAbout {
 	var err error
 	cli := getCLIAbout()
@@ -193,7 +195,7 @@ func getSummaryAbout(
 		addError(err, "Could not access the backend")
 	} else if backend != nil {
 		var stack currentStackAbout
-		if stack, err = getCurrentStackAbout(ctx, ws, backend, selectedStack); err != nil {
+		if stack, err = getCurrentStackAbout(ctx, ws, backend, selectedStack, disableIntegrityChecking); err != nil {
 			addError(err, "Failed to get information about the current stack")
 		} else {
 			result.CurrentStack = &stack
@@ -379,6 +381,7 @@ type aboutState struct {
 
 func getCurrentStackAbout(
 	ctx context.Context, ws pkgWorkspace.Context, b backend.Backend, selectedStack string,
+	disableIntegrityChecking bool,
 ) (currentStackAbout, error) {
 	var s backend.Stack
 	var err error
@@ -401,7 +404,7 @@ func getCurrentStackAbout(
 
 	name := s.Ref().String()
 	var snapshot *deploy.Snapshot
-	snapshot, err = s.Snapshot(ctx, secrets.DefaultProvider)
+	snapshot, err = s.Snapshot(ctx, secrets.DefaultProvider, disableIntegrityChecking)
 	if err != nil {
 		return currentStackAbout{}, err
 	} else if snapshot == nil {

--- a/pkg/cmd/pulumi/backend/backend.go
+++ b/pkg/cmd/pulumi/backend/backend.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/diy"
@@ -33,6 +35,23 @@ import (
 
 // BackendInstance is used to inject a backend mock from tests.
 var BackendInstance backend.Backend
+
+// DisableIntegrityCheckingFlag is the name of the persistent root flag that disables checkpoint state
+// integrity verification.
+const DisableIntegrityCheckingFlag = "disable-integrity-checking"
+
+// DisableIntegrityChecking returns the value of the --disable-integrity-checking persistent flag for the
+// given command. The flag is registered on the root command and inherited by all subcommands.
+func DisableIntegrityChecking(cmd *cobra.Command) bool {
+	v, err := cmd.Flags().GetBool(DisableIntegrityCheckingFlag)
+	if err != nil {
+		// The flag is registered on the root command as a persistent flag, so it is always present on
+		// subcommands. If it is somehow missing we default to enforcing integrity checking, which is the safe
+		// behavior.
+		return false
+	}
+	return v
+}
 
 func IsDIYBackend(ws pkgWorkspace.Context, opts display.Options) (bool, error) {
 	if BackendInstance != nil {

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -431,7 +431,7 @@ func prepareConfig(
 		OrgNameF: func() string {
 			return "testOrg"
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return snapshot, nil
 		},
 		BackendF: func() backend.Backend {

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -139,7 +139,8 @@ func NewDestroyCmd() *cobra.Command {
 				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
+			opts, err := updateFlagsToOptions(
+				interactive, skipPreview, yes, previewOnly, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}
@@ -293,7 +294,7 @@ func NewDestroyCmd() *cobra.Command {
 			excludeUrns := *excludes
 			protectedCount := 0
 			if excludeProtected {
-				snapshot, err := s.Snapshot(ctx, secrets.DefaultProvider)
+				snapshot, err := s.Snapshot(ctx, secrets.DefaultProvider, opts.DisableIntegrityChecking)
 				if err != nil {
 					return err
 				} else if snapshot == nil {

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -865,7 +865,8 @@ func NewImportCmd() *cobra.Command {
 				return backenderr.NoConfirmationInNonInteractiveError{}
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
+			opts, err := updateFlagsToOptions(
+				interactive, skipPreview, yes, previewOnly, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/io.go
+++ b/pkg/cmd/pulumi/operations/io.go
@@ -96,7 +96,9 @@ func readProjectForUpdate(ws pkgWorkspace.Context, clientAddress string) (*works
 
 // updateFlagsToOptions ensures that the given update flags represent a valid combination.  If so, an UpdateOptions
 // is returned with a nil-error; otherwise, the non-nil error contains information about why the combination is invalid.
-func updateFlagsToOptions(interactive, skipPreview, yes, previewOnly bool) (backend.UpdateOptions, error) {
+func updateFlagsToOptions(
+	interactive, skipPreview, yes, previewOnly, disableIntegrityChecking bool,
+) (backend.UpdateOptions, error) {
 	switch {
 	case !interactive && !yes && !skipPreview && !previewOnly:
 		return backend.UpdateOptions{}, backenderr.NoConfirmationInNonInteractiveError{}
@@ -108,9 +110,10 @@ func updateFlagsToOptions(interactive, skipPreview, yes, previewOnly bool) (back
 			errors.New("--yes and --preview-only cannot be used together")
 	default:
 		return backend.UpdateOptions{
-			AutoApprove: yes,
-			SkipPreview: skipPreview,
-			PreviewOnly: previewOnly,
+			AutoApprove:              yes,
+			SkipPreview:              skipPreview,
+			PreviewOnly:              previewOnly,
+			DisableIntegrityChecking: disableIntegrityChecking,
 		}, nil
 	}
 }

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -545,7 +545,8 @@ func NewPreviewCmd() *cobra.Command {
 					Autonamer:            autonamer,
 					SkipPluginPreInstall: skipPluginPreInstall,
 				},
-				Display: displayOpts,
+				Display:                  displayOpts,
+				DisableIntegrityChecking: cmdBackend.DisableIntegrityChecking(cmd),
 			}
 
 			// If we're building an import file we want to hook the event stream from the engine to transform

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -142,7 +142,8 @@ func NewRefreshCmd() *cobra.Command {
 				return fmt.Errorf("invalid --output value %q (expected %q or %q)", output, "default", "json")
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, previewOnly)
+			opts, err := updateFlagsToOptions(
+				interactive, skipPreview, yes, previewOnly, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}
@@ -264,7 +265,8 @@ func NewRefreshCmd() *cobra.Command {
 				if stderr == nil {
 					stderr = cmd.ErrOrStderr()
 				}
-				if unused, err := pendingCreatesToImports(ctx, s, yes, opts.Display, *importPendingCreates); err != nil {
+				if unused, err := pendingCreatesToImports(
+					ctx, s, yes, opts.Display, *importPendingCreates, opts.DisableIntegrityChecking); err != nil {
 					return err
 				} else if len(unused) > 1 {
 					fmt.Fprintf(stderr, "%s\n- \"%s\"\n", opts.Display.Color.Colorize(colors.Highlight(
@@ -278,7 +280,7 @@ func NewRefreshCmd() *cobra.Command {
 				}
 			}
 
-			snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+			snap, err := s.Snapshot(ctx, secrets.DefaultProvider, opts.DisableIntegrityChecking)
 			if err != nil {
 				return fmt.Errorf("getting snapshot: %w", err)
 			}
@@ -286,7 +288,7 @@ func NewRefreshCmd() *cobra.Command {
 			// We then allow the user to interactively handle remaining pending creates.
 			if interactive && hasPendingCreates(snap) && !skipPendingCreates {
 				if err := filterMapPendingCreates(ctx, s, opts.Display,
-					yes, interactiveFixPendingCreate); err != nil {
+					yes, opts.DisableIntegrityChecking, interactiveFixPendingCreate); err != nil {
 					return err
 				}
 			}
@@ -297,7 +299,8 @@ func NewRefreshCmd() *cobra.Command {
 				removePendingCreates := func(op resource.Operation) (*resource.Operation, error) {
 					return nil, nil
 				}
-				err := filterMapPendingCreates(ctx, s, opts.Display, yes, removePendingCreates)
+				err := filterMapPendingCreates(
+					ctx, s, opts.Display, yes, opts.DisableIntegrityChecking, removePendingCreates)
 				if err != nil {
 					return err
 				}
@@ -507,36 +510,38 @@ type editPendingOp = func(op resource.Operation) (*resource.Operation, error)
 // filterMapPendingCreates applies f to each pending create. If f returns nil, then the op
 // is deleted. Otherwise is replaced by the returned op.
 func filterMapPendingCreates(
-	ctx context.Context, s backend.Stack, opts display.Options, yes bool, f editPendingOp,
+	ctx context.Context, s backend.Stack, opts display.Options, yes bool, disableIntegrityChecking bool,
+	f editPendingOp,
 ) error {
-	return state.TotalStateEdit(ctx, s, yes, opts, func(opts display.Options, snap *deploy.Snapshot) error {
-		var pending []resource.Operation
-		for _, op := range snap.PendingOperations {
-			if op.Resource == nil {
-				return errors.New("found operation without resource")
+	return state.TotalStateEdit(
+		ctx, s, yes, disableIntegrityChecking, opts, func(opts display.Options, snap *deploy.Snapshot) error {
+			var pending []resource.Operation
+			for _, op := range snap.PendingOperations {
+				if op.Resource == nil {
+					return errors.New("found operation without resource")
+				}
+				if op.Type != resource.OperationTypeCreating {
+					pending = append(pending, op)
+					continue
+				}
+				op, err := f(op)
+				if err != nil {
+					return err
+				}
+				if op != nil {
+					pending = append(pending, *op)
+				}
 			}
-			if op.Type != resource.OperationTypeCreating {
-				pending = append(pending, op)
-				continue
-			}
-			op, err := f(op)
-			if err != nil {
-				return err
-			}
-			if op != nil {
-				pending = append(pending, *op)
-			}
-		}
-		snap.PendingOperations = pending
-		return nil
-	}, nil)
+			snap.PendingOperations = pending
+			return nil
+		}, nil)
 }
 
 // Apply the CLI args from --import-pending-creates [[URN ID]...]. If an error was found,
 // it is returned. The list of URNs that were not mapped to a pending create is also
 // returned.
 func pendingCreatesToImports(ctx context.Context, s backend.Stack, yes bool, opts display.Options,
-	importToCreates []string,
+	importToCreates []string, disableIntegrityChecking bool,
 ) ([]string, error) {
 	// A map from URN to ID
 	if len(importToCreates)%2 != 0 {
@@ -546,15 +551,16 @@ func pendingCreatesToImports(ctx context.Context, s backend.Stack, yes bool, opt
 	for i := 0; i < len(importToCreates); i += 2 {
 		alteredOps[importToCreates[i]] = importToCreates[i+1]
 	}
-	err := filterMapPendingCreates(ctx, s, opts, yes, func(op resource.Operation) (*resource.Operation, error) {
-		if id, ok := alteredOps[string(op.Resource.URN)]; ok {
-			op.Resource.ID = resource.ID(id)
-			op.Type = resource.OperationTypeImporting
-			delete(alteredOps, string(op.Resource.URN))
+	err := filterMapPendingCreates(
+		ctx, s, opts, yes, disableIntegrityChecking, func(op resource.Operation) (*resource.Operation, error) {
+			if id, ok := alteredOps[string(op.Resource.URN)]; ok {
+				op.Resource.ID = resource.ID(id)
+				op.Type = resource.OperationTypeImporting
+				delete(alteredOps, string(op.Resource.URN))
+				return &op, nil
+			}
 			return &op, nil
-		}
-		return &op, nil
-	})
+		})
 	unusedKeys := make([]string, len(alteredOps))
 	for k := range alteredOps {
 		unusedKeys = append(unusedKeys, k)

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -593,7 +593,8 @@ func NewUpCmd() *cobra.Command {
 				return err
 			}
 
-			opts, err := updateFlagsToOptions(interactive, skipPreview, yes, false /* previewOnly */)
+			opts, err := updateFlagsToOptions(
+				interactive, skipPreview, yes, false /* previewOnly */, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -75,7 +75,7 @@ func NewWatchCmd() *cobra.Command {
 			ws := pkgWorkspace.Instance
 
 			opts, err := updateFlagsToOptions(false /* interactive */, true /* skipPreview */, true, /* autoApprove */
-				false /* previewOnly */)
+				false /* previewOnly */, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -108,7 +108,7 @@ func newPolicyAnalyzeCmd(
 			}
 
 			// Load the current stack snapshot.
-			snap, err := s.Snapshot(ctx, secretsProvider)
+			snap, err := s.Snapshot(ctx, secretsProvider, cmdBackend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return fmt.Errorf("loading stack snapshot: %w", err)
 			}

--- a/pkg/cmd/pulumi/policy/policy_analyze_test.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze_test.go
@@ -154,7 +154,7 @@ func TestPolicyAnalyzeCmd_ErrorOnSnapshotFailure(t *testing.T) {
 
 	snapErr := errors.New("cannot load snapshot")
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return nil, snapErr
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -167,7 +167,7 @@ func TestPolicyAnalyzeCmd_EmptySnapshotPrintsMessage(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return &deploy.Snapshot{}, nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -180,7 +180,7 @@ func TestPolicyAnalyzeCmd_ErrorOnLoadAnalyzersFailure(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -197,7 +197,7 @@ func TestPolicyAnalyzeCmd_MandatoryViolationReturnsError(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -214,7 +214,7 @@ func TestPolicyAnalyzeCmd_NoViolationsSucceeds(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -227,7 +227,7 @@ func TestPolicyAnalyzeCmd_RemediationWritesToOutputStream(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -246,7 +246,7 @@ func TestPolicyAnalyzeCmd_ProgressDisplayGroupsPolicyOutput(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -269,7 +269,7 @@ func TestPolicyAnalyzeCmd_JSONDisplayWritesPolicyEvents(t *testing.T) {
 	t.Parallel()
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return makeAnalyzeSnapshot(), nil
 	}
 	ws, lm := newMockWsAndLm(be)
@@ -312,7 +312,7 @@ func TestPolicyAnalyzeCmd_AnalyzeStackCalled_PrintsAndUsesOutputs(t *testing.T) 
 	}
 
 	be, stk := newMockBackendForAnalyze()
-	stk.SnapshotF = func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+	stk.SnapshotF = func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 		return snap, nil
 	}
 	ws, lm := newMockWsAndLm(be)

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -60,7 +60,7 @@ func HandleConfig(
 	stackConfig := latest.Config
 
 	// Get the existing snapshot.
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, false /* disableIntegrityChecking */)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -44,7 +44,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/about"
@@ -193,6 +192,7 @@ func (loggingWriter) Write(bytes []byte) (int, error) {
 // NewPulumiCmd creates a new Pulumi Cmd instance.
 func NewPulumiCmd() (*cobra.Command, func()) {
 	var cwd string
+	var disableIntegrityChecking bool
 	var logFlow bool
 	var logToStderr bool
 	var tracingFlag string
@@ -442,7 +442,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		"Enable emojis in the output")
 	cmd.PersistentFlags().BoolVarP(&cmdutil.FullyQualifyStackNames, "fully-qualify-stack-names", "Q", false,
 		"Show fully-qualified stack names")
-	cmd.PersistentFlags().BoolVar(&backend.DisableIntegrityChecking, "disable-integrity-checking", false,
+	cmd.PersistentFlags().BoolVar(&disableIntegrityChecking, cmdBackend.DisableIntegrityCheckingFlag, false,
 		"Disable integrity checking of checkpoint files")
 	cmd.PersistentFlags().BoolVar(&logFlow, "logflow", false,
 		"Flow log settings to child processes (like plugins)")

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -486,7 +486,9 @@ func CopyEntireConfigMap(
 	return requiresSaving, nil
 }
 
-func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapshot, force bool) error {
+func SaveSnapshot(
+	ctx context.Context, s backend.Stack, snapshot *deploy.Snapshot, force bool, disableIntegrityChecking bool,
+) error {
 	stackName := s.Ref().Name()
 	var result error
 	for _, res := range snapshot.Resources {
@@ -506,7 +508,7 @@ func SaveSnapshot(ctx context.Context, s backend.Stack, snapshot *deploy.Snapsho
 		}
 	}
 	// Validate the stack. If --force was passed, issue an error if validation fails. Otherwise, issue a warning.
-	if !backend.DisableIntegrityChecking {
+	if !disableIntegrityChecking {
 		if err := snapshot.VerifyIntegrity(); err != nil {
 			msg := fmt.Sprintf("state file contains errors: %v", err)
 			if force {

--- a/pkg/cmd/pulumi/stack/secrets.go
+++ b/pkg/cmd/pulumi/stack/secrets.go
@@ -257,7 +257,7 @@ func (l *SecretsManagerLoader) GetSecretsManager(
 		// default secrets manager which differs from what the user has previously
 		// specified.
 		if l.FallbackToState {
-			snap, err := s.Snapshot(ctx, backend_secrets.DefaultProvider)
+			snap, err := s.Snapshot(ctx, backend_secrets.DefaultProvider, false /* disableIntegrityChecking */)
 			if err != nil {
 				return nil, SecretsManagerUnchanged, err
 			}

--- a/pkg/cmd/pulumi/stack/secrets_test.go
+++ b/pkg/cmd/pulumi/stack/secrets_test.go
@@ -72,7 +72,7 @@ func TestStackSecretsManagerLoaderDecrypterFallsBack(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{FullyQualifiedNameV: "org/project/stack"}
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return snap, nil
 		},
 	}
@@ -113,7 +113,7 @@ func TestStackSecretsManagerLoaderDecrypterUpdatesConfig(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{FullyQualifiedNameV: "org/project/stack"}
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return snap, nil
 		},
 	}
@@ -151,7 +151,7 @@ func TestStackSecretsManagerLoaderDecrypterUsesDefaultSecretsManager(t *testing.
 		DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return sm, nil
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{}, nil
 		},
 	}
@@ -189,7 +189,7 @@ func TestStackSecretsManagerLoaderEncrypterFallsBack(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{FullyQualifiedNameV: "org/project/stack"}
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return snap, nil
 		},
 	}
@@ -230,7 +230,7 @@ func TestStackSecretsManagerLoaderEncrypterUpdatesConfig(t *testing.T) {
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{FullyQualifiedNameV: "org/project/stack"}
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return snap, nil
 		},
 	}
@@ -268,7 +268,7 @@ func TestStackSecretsManagerLoaderEncrypterUsesDefaultSecretsManager(t *testing.
 		DefaultSecretManagerF: func(_ context.Context, info *workspace.ProjectStack) (secrets.Manager, error) {
 			return sm, nil
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{}, nil
 		},
 	}

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -42,13 +42,14 @@ import (
 )
 
 type stackArgs struct {
-	showIDs                bool
-	showURNs               bool
-	showSecrets            bool
-	startTime              string
-	showStackName          bool
-	fullyQualifyStackNames bool
-	output                 string
+	showIDs                  bool
+	showURNs                 bool
+	showSecrets              bool
+	startTime                string
+	showStackName            bool
+	fullyQualifyStackNames   bool
+	output                   string
+	disableIntegrityChecking bool
 }
 
 func NewStackCmd() *cobra.Command {
@@ -85,6 +86,7 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
+			args.disableIntegrityChecking = cmdBackend.DisableIntegrityChecking(cmd)
 			return runStack(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
@@ -147,7 +149,7 @@ func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArg
 		return fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", args.output)
 	}
 
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, args.disableIntegrityChecking)
 	if err != nil {
 		return err
 	}
@@ -435,7 +437,7 @@ func renderCloudStackText(out io.Writer, info *apitype.Stack) {
 // backends it also fetches the GetStack API for cloud-only metadata
 // (version, tags, activeUpdate, currentOperation, console URL).
 func runStackJSON(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
-	in, err := loadStackJSONInputs(ctx, s, args.showSecrets)
+	in, err := loadStackJSONInputs(ctx, s, args.showSecrets, args.disableIntegrityChecking)
 	if err != nil {
 		return fmt.Errorf("fetching stack: %w", err)
 	}

--- a/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
+++ b/pkg/cmd/pulumi/stack/stack_change_secrets_provider_test.go
@@ -123,7 +123,7 @@ func TestChangeSecretsProvider_NoSecrets(t *testing.T) {
 			}
 		},
 		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
-		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return snapshot, nil
 		},
 	}
@@ -223,7 +223,7 @@ func TestChangeSecretsProvider_WithSecrets(t *testing.T) {
 			}
 		},
 		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
-		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return snapshot, nil
 		},
 		DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -327,7 +327,7 @@ func newMockStack(snap *deploy.Snapshot, snapErr error) backend.Stack {
 			}
 		},
 		BackendF: func() backend.Backend { return mockBe },
-		SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return snap, snapErr
 		},
 	}
@@ -338,7 +338,7 @@ func newMockStack(snap *deploy.Snapshot, snapErr error) backend.Stack {
 func TestLoadStackJSONInputs_NonCloud_NilSnapshot(t *testing.T) {
 	t.Parallel()
 
-	in, err := loadStackJSONInputs(t.Context(), newMockStack(nil, nil), false)
+	in, err := loadStackJSONInputs(t.Context(), newMockStack(nil, nil), false, false)
 	require.NoError(t, err)
 	assert.Equal(t, "dev", in.StackName)
 	assert.Equal(t, "proj", in.Project)
@@ -354,7 +354,7 @@ func TestLoadStackJSONInputs_PropagatesSnapshotError(t *testing.T) {
 	t.Parallel()
 
 	want := assert.AnError
-	_, err := loadStackJSONInputs(t.Context(), newMockStack(nil, want), false)
+	_, err := loadStackJSONInputs(t.Context(), newMockStack(nil, want), false, false)
 	require.ErrorIs(t, err, want)
 }
 

--- a/pkg/cmd/pulumi/stack/stack_graph.go
+++ b/pkg/cmd/pulumi/stack/stack_graph.go
@@ -87,7 +87,7 @@ func newStackGraphCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+			snap, err := s.Snapshot(ctx, secrets.DefaultProvider, backend.DisableIntegrityChecking(cmd))
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack/stack_import.go
+++ b/pkg/cmd/pulumi/stack/stack_import.go
@@ -125,7 +125,7 @@ func newStackImportCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager, sp s
 				}
 			}
 
-			if err := SaveSnapshot(ctx, s, snapshot, force); err != nil {
+			if err := SaveSnapshot(ctx, s, snapshot, force, cmdBackend.DisableIntegrityChecking(cmd)); err != nil {
 				return err
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Import complete.")

--- a/pkg/cmd/pulumi/stack/stack_json.go
+++ b/pkg/cmd/pulumi/stack/stack_json.go
@@ -184,7 +184,7 @@ func snapshotResourceJSON(r *resource.State) stackResourceJSON {
 // resolved backend.Stack: it best-effort loads the local snapshot and, on
 // Pulumi Cloud backends, fetches the GetStack metadata.
 func loadStackJSONInputs(
-	ctx context.Context, s backend.Stack, showSecrets bool,
+	ctx context.Context, s backend.Stack, showSecrets bool, disableIntegrityChecking bool,
 ) (stackJSONInputs, error) {
 	ref := s.Ref()
 	project := ""
@@ -206,7 +206,7 @@ func loadStackJSONInputs(
 	in.CloudStack = cloudInfo
 	in.ConsoleURL = consoleURL
 
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, disableIntegrityChecking)
 	if err != nil {
 		return stackJSONInputs{}, err
 	}

--- a/pkg/cmd/pulumi/stack/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack/stack_output_test.go
@@ -114,7 +114,7 @@ func TestStackOutputCmd_plainText(t *testing.T) {
 				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil
@@ -225,7 +225,7 @@ func TestStackOutputCmd_json(t *testing.T) {
 				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil
@@ -346,7 +346,7 @@ func TestStackOutputCmd_shell(t *testing.T) {
 				string, LoadOption, display.Options,
 			) (backend.Stack, error) {
 				return &backend.MockStack{
-					SnapshotF: func(_ context.Context, _ secrets.Provider) (*deploy.Snapshot, error) {
+					SnapshotF: func(_ context.Context, _ secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 						return &snap, nil
 					},
 				}, nil

--- a/pkg/cmd/pulumi/state/io.go
+++ b/pkg/cmd/pulumi/state/io.go
@@ -53,6 +53,7 @@ func runTotalStateEdit(
 	lm cmdBackend.LoginManager,
 	stackName string,
 	showPrompt bool,
+	disableIntegrityChecking bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error,
 ) error {
 	opts := display.Options{
@@ -70,7 +71,7 @@ func runTotalStateEdit(
 	if err != nil {
 		return err
 	}
-	return TotalStateEdit(ctx, s, showPrompt, opts, operation, nil)
+	return TotalStateEdit(ctx, s, showPrompt, disableIntegrityChecking, opts, operation, nil)
 }
 
 // runTotalStateEditWithPrompt is the same as runTotalStateEdit, but allows the caller to
@@ -82,6 +83,7 @@ func runTotalStateEditWithPrompt(
 	lm cmdBackend.LoginManager,
 	stackName string,
 	showPrompt bool,
+	disableIntegrityChecking bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error,
 	overridePromptMessage string,
 ) error {
@@ -100,18 +102,19 @@ func runTotalStateEditWithPrompt(
 	if err != nil {
 		return err
 	}
-	return TotalStateEdit(ctx, s, showPrompt, opts, operation, &overridePromptMessage)
+	return TotalStateEdit(ctx, s, showPrompt, disableIntegrityChecking, opts, operation, &overridePromptMessage)
 }
 
 func TotalStateEdit(
 	ctx context.Context,
 	s backend.Stack,
 	showPrompt bool,
+	disableIntegrityChecking bool,
 	opts display.Options,
 	operation func(opts display.Options, snap *deploy.Snapshot) error,
 	overridePromptMessage *string,
 ) error {
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, disableIntegrityChecking)
 	if err != nil {
 		return err
 	} else if snap == nil {
@@ -144,7 +147,7 @@ func TotalStateEdit(
 	}
 
 	// If the stack is already broken, don't bother verifying the integrity here.
-	if !stackIsAlreadyHosed && !backend.DisableIntegrityChecking {
+	if !stackIsAlreadyHosed && !disableIntegrityChecking {
 		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
 	}
 
@@ -234,7 +237,7 @@ func resolveStateResourceArg(opts display.Options, snap *deploy.Snapshot, arg st
 // Prompt is displayed to the user when selecting the URN.
 func getURNFromState(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm cmdBackend.LoginManager,
-	stackName string, snap **deploy.Snapshot, prompt string,
+	stackName string, snap **deploy.Snapshot, prompt string, disableIntegrityChecking bool,
 ) (resource.URN, error) {
 	if snap == nil {
 		// This means we won't cache the value.
@@ -257,7 +260,7 @@ func getURNFromState(
 		if err != nil {
 			return "", err
 		}
-		*snap, err = s.Snapshot(ctx, secrets.DefaultProvider)
+		*snap, err = s.Snapshot(ctx, secrets.DefaultProvider, disableIntegrityChecking)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cmd/pulumi/state/state_delete.go
+++ b/pkg/cmd/pulumi/state/state_delete.go
@@ -70,6 +70,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			}
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 			nDeleted := 0
 
 			var handleProtected func(*resource.State) error
@@ -84,7 +85,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 
 			var err error
 			if all {
-				err = runTotalStateEdit(ctx, sink, ws, lm, stack, showPrompt,
+				err = runTotalStateEdit(ctx, sink, ws, lm, stack, showPrompt, disableIntegrityChecking,
 					func(opts display.Options, snap *deploy.Snapshot) error {
 						// Iterate the resources backwards (so we delete dependents first) and delete them.
 						for i := len(snap.Resources) - 1; i >= 0; i-- {
@@ -102,7 +103,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 						return missingNonInteractiveArg("resource URN")
 					}
 					urn, selErr := getURNFromState(ctx, sink, ws, backend.DefaultLoginManager, stack, nil,
-						"Select the resource to delete")
+						"Select the resource to delete", disableIntegrityChecking)
 					if selErr != nil {
 						return fmt.Errorf("failed to select resource: %w", selErr)
 					}
@@ -111,7 +112,8 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 					urnArgs = args
 				}
 				nDeleted, err = runStateDeleteResources(
-					ctx, sink, ws, lm, stack, showPrompt, urnArgs, handleProtected, targetDependents)
+					ctx, sink, ws, lm, stack, showPrompt, urnArgs, handleProtected, targetDependents,
+					disableIntegrityChecking)
 			}
 			if err != nil {
 				switch e := err.(type) {
@@ -166,9 +168,10 @@ func runStateDeleteResources(
 	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, lm backend.LoginManager,
 	stackName string, showPrompt bool, args []string,
 	handleProtected func(*resource.State) error, targetDependents bool,
+	disableIntegrityChecking bool,
 ) (int, error) {
 	var deleted int
-	err := runTotalStateEdit(ctx, sink, ws, lm, stackName, showPrompt,
+	err := runTotalStateEdit(ctx, sink, ws, lm, stackName, showPrompt, disableIntegrityChecking,
 		func(opts display.Options, snap *deploy.Snapshot) error {
 			targets := make(map[*resource.State]struct{})
 			for _, arg := range args {

--- a/pkg/cmd/pulumi/state/state_delete_test.go
+++ b/pkg/cmd/pulumi/state/state_delete_test.go
@@ -64,7 +64,7 @@ func TestStateDeleteMultipleURNs(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{URN: "urn:pulumi:proj::stk::pkg:index:typ::res-a"},
@@ -130,7 +130,7 @@ func TestStateDeleteMultipleURNsResolvesDependencyOrder(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{URN: depURN},
@@ -195,7 +195,7 @@ func TestStateDeleteParentAndChild(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{URN: parentURN},
@@ -252,7 +252,7 @@ func TestStateDeleteInvalidURN(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{URN: "urn:pulumi:proj::stk::pkg:index:typ::res"},
@@ -333,7 +333,7 @@ func TestStateDeleteURN(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{
@@ -375,7 +375,7 @@ func TestStateDeleteDependency(t *testing.T) {
 	t.Parallel()
 
 	mockStack := &backend.MockStack{
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{
@@ -445,7 +445,7 @@ func TestStateDeleteProtected(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return &deploy.Snapshot{
 				Resources: []*resource.State{
 					{
@@ -525,7 +525,7 @@ func TestStateDeleteAll(t *testing.T) {
 		BackendF: func() backend.Backend {
 			return mockBackend
 		},
-		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(ctx context.Context, secretsProvider secrets.Provider, _ bool) (*deploy.Snapshot, error) {
 			return snapshot, nil
 		},
 	}

--- a/pkg/cmd/pulumi/state/state_edit.go
+++ b/pkg/cmd/pulumi/state/state_edit.go
@@ -82,6 +82,7 @@ a preview showing a diff of the altered state.`,
 			if stateEdit.Stdout == nil {
 				stateEdit.Stdout = cmd.OutOrStdout()
 			}
+			stateEdit.DisableIntegrityChecking = cmdBackend.DisableIntegrityChecking(cmd)
 			if err := stateEdit.Run(ctx, s); err != nil {
 				return err
 			}
@@ -97,9 +98,10 @@ a preview showing a diff of the altered state.`,
 }
 
 type stateEditCmd struct {
-	Stdin     io.Reader
-	Stdout    io.Writer
-	Colorizer colors.Colorization
+	Stdin                    io.Reader
+	Stdout                   io.Writer
+	Colorizer                colors.Colorization
+	DisableIntegrityChecking bool
 }
 
 type snapshotBuffer struct {
@@ -154,7 +156,7 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 		cmd.Stdin = os.Stdin
 	}
 
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, cmd.DisableIntegrityChecking)
 	if err != nil {
 		return err
 	}
@@ -210,7 +212,7 @@ func (cmd *stateEditCmd) Run(ctx context.Context, s backend.Stack) error {
 
 		switch response := ui.PromptUser(msg, options, edit, cmd.Colorizer); response {
 		case accept:
-			return cmdStack.SaveSnapshot(ctx, s, news, false /* force */)
+			return cmdStack.SaveSnapshot(ctx, s, news, false /* force */, cmd.DisableIntegrityChecking)
 		case edit:
 			continue
 		case reset:
@@ -234,7 +236,7 @@ func (cmd *stateEditCmd) validateAndPrintState(ctx context.Context, f *snapshotB
 		return nil, err
 	}
 
-	if !backend.DisableIntegrityChecking {
+	if !cmd.DisableIntegrityChecking {
 		err = news.VerifyIntegrity()
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -47,11 +47,12 @@ import (
 const providerPrefix = "pulumi:providers:"
 
 type stateMoveCmd struct {
-	Stdin          io.Reader
-	Stdout         io.Writer
-	Colorizer      colors.Colorization
-	Yes            bool
-	IncludeParents bool
+	Stdin                    io.Reader
+	Stdout                   io.Writer
+	Colorizer                colors.Colorization
+	Yes                      bool
+	IncludeParents           bool
+	DisableIntegrityChecking bool
 
 	ws pkgWorkspace.Context
 }
@@ -113,6 +114,7 @@ splitting a stack into multiple stacks or when merging multiple stacks into one.
 
 			stateMove.Yes = yes
 			stateMove.IncludeParents = includeParents
+			stateMove.DisableIntegrityChecking = cmdBackend.DisableIntegrityChecking(cmd)
 
 			sourceSecretsProvider := backend_secrets.NamedStackProvider{
 				StackName: sourceStack.Ref().FullyQualifiedName().String(),
@@ -159,11 +161,11 @@ func (cmd *stateMoveCmd) Run(
 		cmd.ws = pkgWorkspace.Instance
 	}
 
-	sourceSnapshot, err := source.Snapshot(ctx, sourceSecretsProvider)
+	sourceSnapshot, err := source.Snapshot(ctx, sourceSecretsProvider, cmd.DisableIntegrityChecking)
 	if err != nil {
 		return err
 	}
-	destSnapshot, err := dest.Snapshot(ctx, destSecretsProvider)
+	destSnapshot, err := dest.Snapshot(ctx, destSecretsProvider, cmd.DisableIntegrityChecking)
 	if err != nil {
 		return err
 	}
@@ -482,18 +484,18 @@ This is a bug! We would appreciate a report: https://github.com/pulumi/pulumi/is
 	// We're saving the destination snapshot first, so that if saving a snapshot fails
 	// the resources will always still be tracked.  If the source snapshot fails the user
 	// will have to manually remove the resources from the source stack.
-	err = cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false)
+	err = cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false, cmd.DisableIntegrityChecking)
 	if err != nil {
 		return fmt.Errorf(`failed to save destination snapshot: %w
 
 None of the resources have been moved, it is safe to try again`, err)
 	}
 
-	err = cmdStack.SaveSnapshot(ctx, source, sourceSnapshot, false)
+	err = cmdStack.SaveSnapshot(ctx, source, sourceSnapshot, false, cmd.DisableIntegrityChecking)
 	if err != nil {
 		// Try to restore the destination snapshot to its original state
 		destSnapshot.Resources = originalDestResources
-		errDest := cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false)
+		errDest := cmdStack.SaveSnapshot(ctx, dest, destSnapshot, false, cmd.DisableIntegrityChecking)
 		if errDest != nil {
 			var deleteCommands strings.Builder
 			// Iterate over the resources in reverse order, so resources with no dependencies will be deleted first.

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -112,10 +112,10 @@ func runMoveWithOptionsAndDestResources(
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, args, mp, mp)
 	require.NoError(t, err)
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	return sourceSnapshot, destSnapshot, stdout
@@ -652,13 +652,13 @@ runtime: mock
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[1].URN)}, mp, mp)
 	require.NoError(t, err)
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destRef)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	require.Len(t, sourceSnapshot.Resources, 1) // Only the provider should remain in the source stack
@@ -734,10 +734,10 @@ func TestMovingProvidersWithSameID(t *testing.T) {
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	require.NoError(t, err)
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// The provider, rootstack and one resource remain
@@ -748,10 +748,10 @@ func TestMovingProvidersWithSameID(t *testing.T) {
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[3].URN)}, mp, mp)
 	require.NoError(t, err)
 
-	sourceSnapshot, err = sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err = sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
-	destSnapshot, err = destStack.Snapshot(ctx, mp)
+	destSnapshot, err = destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Only the provider and root stack remain
@@ -830,7 +830,7 @@ func TestMoveUnknownResource(t *testing.T) {
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{"not-a-urn"}, mp, mp)
 	assert.ErrorContains(t, err, "no resources found to move")
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	assert.Contains(t, stdout.String(), "warning: Resource not-a-urn not found in source stack")
@@ -937,7 +937,7 @@ func TestMoveProvider(t *testing.T) {
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(providerURN)}, mp, mp)
 	assert.ErrorContains(t, err, "cannot move provider")
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	require.Len(t, sourceSnapshot.Resources, 3) // No resources should be moved
@@ -1056,13 +1056,13 @@ runtime: mock
 	err = stateMoveCmd.Run(ctx, sourceStack, destStack, []string{string(sourceResources[2].URN)}, mp, mp)
 	require.NoError(t, err)
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destRef)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Expect the root stack and the provider to remain in the source stack
@@ -1147,13 +1147,13 @@ func TestMoveSecretOutsideOfProjectDir(t *testing.T) {
 	//nolint:lll
 	assert.ErrorContains(t, err, "destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory")
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destRef)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Expect no resources to be moved
@@ -1230,13 +1230,13 @@ runtime: mock
 	//nolint:lll
 	assert.ErrorContains(t, err, "destination stack has no secret manager. To move resources either initialize the stack with a secret manager, or run the pulumi state move command from the destination project directory")
 
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destRef)
 	require.NoError(t, err)
 
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Expect no resources to be moved
@@ -1374,12 +1374,12 @@ func TestMoveLockedBackendRevertsDestination(t *testing.T) {
 
 	sourceStack, err = b.GetStack(ctx, sourceStack.Ref())
 	require.NoError(t, err)
-	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp)
+	sourceSnapshot, err := sourceStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	destStack, err = b.GetStack(ctx, destStack.Ref())
 	require.NoError(t, err)
-	destSnapshot, err := destStack.Snapshot(ctx, mp)
+	destSnapshot, err := destStack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	require.Len(t, destSnapshot.Resources, 0)

--- a/pkg/cmd/pulumi/state/state_protect.go
+++ b/pkg/cmd/pulumi/state/state_protect.go
@@ -70,14 +70,16 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 			yes = yes || env.SkipConfirmations.Value()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 
 			if protectAll {
-				return protectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
+				return protectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt, disableIntegrityChecking)
 			}
 
 			// If URN arguments were provided, use those
 			if len(args) > 0 {
-				return protectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
+				return protectMultipleResources(
+					ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt, disableIntegrityChecking)
 			}
 
 			// Otherwise, use interactive selection
@@ -85,12 +87,15 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				return missingNonInteractiveArg("resource URN")
 			}
 
-			urn, err := getURNFromState(ctx, sink, ws, backend.DefaultLoginManager, stack, nil, "Select a resource to protect:")
+			urn, err := getURNFromState(
+				ctx, sink, ws, backend.DefaultLoginManager, stack, nil, "Select a resource to protect:",
+				disableIntegrityChecking)
 			if err != nil {
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return protectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, []string{string(urn)}, showPrompt)
+			return protectMultipleResources(
+				ctx, cmd.OutOrStdout(), sink, ws, stack, []string{string(urn)}, showPrompt, disableIntegrityChecking)
 		},
 	}
 
@@ -113,10 +118,10 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 func protectAllResources(
 	ctx context.Context, stdout io.Writer,
-	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool, disableIntegrityChecking bool,
 ) error {
 	err := runTotalStateEditWithPrompt(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			// Protects against Panic when a user tries to protect non-existing resources
 			if snap == nil {
@@ -175,9 +180,11 @@ func protectResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []er
 func protectMultipleResources(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
 	return runTotalStateEditWithPrompt(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, func(_ display.Options, snap *deploy.Snapshot,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
+		func(_ display.Options, snap *deploy.Snapshot,
 		) error {
 			resourceCount, errs := protectResourcesInSnapshot(snap, urns)
 

--- a/pkg/cmd/pulumi/state/state_rename.go
+++ b/pkg/cmd/pulumi/state/state_rename.go
@@ -184,6 +184,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			sink := cmdutil.Diag()
 			ws := pkgWorkspace.Instance
 			yes = yes || env.SkipConfirmations.Value()
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 
 			if len(args) < 2 && !cmdutil.Interactive() {
 				return missingNonInteractiveArg("resource URN", "new name")
@@ -196,7 +197,9 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 				var snap *deploy.Snapshot
 				err := ui.SurveyStack(
 					func() (err error) {
-						urn, err = getURNFromState(ctx, sink, ws, backend.DefaultLoginManager, stack, &snap, "Select a resource to rename:")
+						urn, err = getURNFromState(
+							ctx, sink, ws, backend.DefaultLoginManager, stack, &snap, "Select a resource to rename:",
+							disableIntegrityChecking)
 						if err != nil {
 							err = fmt.Errorf("failed to select resource: %w", err)
 						}
@@ -231,7 +234,7 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
 
-			err := runTotalStateEdit(ctx, sink, ws, backend.DefaultLoginManager, stack, showPrompt,
+			err := runTotalStateEdit(ctx, sink, ws, backend.DefaultLoginManager, stack, showPrompt, disableIntegrityChecking,
 				func(opts display.Options, snap *deploy.Snapshot) error {
 					return stateRenameOperation(urn, newResourceName, opts, snap)
 				})

--- a/pkg/cmd/pulumi/state/state_repair.go
+++ b/pkg/cmd/pulumi/state/state_repair.go
@@ -118,11 +118,9 @@ not write any changes.
 
 func (cmd *stateRepairCmd) run(ctx context.Context) error {
 	// We need to disable integrity checking since this command exists solely to repair invalid states and enabling
-	// integrity checking would prevent us from even loading them in the first place. Currently integrity checking is
-	// controlled by a hacky global variable, so this is the best we can do, but hopefully it and consequently this code
-	// can be refactored.
-	backend.DisableIntegrityChecking = true
-	defer func() { backend.DisableIntegrityChecking = false }()
+	// integrity checking would prevent us from even loading them in the first place. We therefore always read the
+	// snapshot with integrity checking disabled.
+	const disableIntegrityChecking = true
 
 	displayOpts := display.Options{
 		Color: cmd.Args.Colorizer,
@@ -140,7 +138,7 @@ func (cmd *stateRepairCmd) run(ctx context.Context) error {
 		return err
 	}
 
-	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
+	snap, err := s.Snapshot(ctx, secrets.DefaultProvider, disableIntegrityChecking)
 	if err != nil {
 		return err
 	} else if snap == nil {

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_ExitsIfTheStateIsAlreadyValid(t *testing.T) {
 	// Arrange.
 	cases := []struct {
@@ -80,7 +80,7 @@ func TestStateRepair_ExitsIfTheStateIsAlreadyValid(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_ConfirmationIncludesReorderSummary(t *testing.T) {
 	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
 	// Windows. Consequently we skip if the test is running on Windows.
@@ -105,7 +105,7 @@ func TestStateRepair_ConfirmationIncludesReorderSummary(t *testing.T) {
 	assert.NotContains(t, fx.stdout.String(), "will be modified")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_ConfirmationIncludesModificationSummary(t *testing.T) {
 	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
 	// Windows. Consequently we skip if the test is running on Windows.
@@ -129,7 +129,7 @@ func TestStateRepair_ConfirmationIncludesModificationSummary(t *testing.T) {
 	assert.Contains(t, fx.stdout.String(), "will be modified")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_ConfirmationIncludesCombinedSummaries(t *testing.T) {
 	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
 	// Windows. Consequently we skip if the test is running on Windows.
@@ -155,7 +155,7 @@ func TestStateRepair_ConfirmationIncludesCombinedSummaries(t *testing.T) {
 	assert.Contains(t, fx.stdout.String(), "will be modified")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_PromptsForConfirmationAndCancels(t *testing.T) {
 	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
 	// Windows. Consequently we skip if the test is running on Windows.
@@ -180,7 +180,7 @@ func TestStateRepair_PromptsForConfirmationAndCancels(t *testing.T) {
 	assert.Nil(t, fx.imported, "Import should not have proceeded")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_PromptsForConfirmationAndProceeds(t *testing.T) {
 	// Survey (the library we currently use for managing prompt input) does not currently pick up inputs when tested under
 	// Windows. Consequently we skip if the test is running on Windows.
@@ -205,7 +205,7 @@ func TestStateRepair_PromptsForConfirmationAndProceeds(t *testing.T) {
 	require.NotNil(t, fx.imported, "Import should have proceeded")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_SkipsConfirmationIfYesFlagIsSet(t *testing.T) {
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
@@ -223,7 +223,7 @@ func TestStateRepair_SkipsConfirmationIfYesFlagIsSet(t *testing.T) {
 	require.NotNil(t, fx.imported, "Import should have proceeded")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_DoesNotWriteIfRepairFails(t *testing.T) {
 	// Arrange.
 	//
@@ -246,7 +246,7 @@ func TestStateRepair_DoesNotWriteIfRepairFails(t *testing.T) {
 	assert.Nil(t, fx.imported, "Import should not have proceeded")
 }
 
-//nolint:paralleltest // State repairing modifies the DisableIntegrityChecking global variable
+//nolint:paralleltest // Uses shared survey/cmdutil terminal state
 func TestStateRepair_RepairsSnapshots(t *testing.T) {
 	// Arrange.
 	fx := newStateRepairCmdFixture(t, []*resource.State{
@@ -302,7 +302,7 @@ func newStateRepairCmdFixture(
 		BackendF: func() backend.Backend {
 			return b
 		},
-		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
+		SnapshotF: func(context.Context, secrets.Provider, bool) (*deploy.Snapshot, error) {
 			sm := b64.NewBase64SecretsManager()
 			return deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}), nil
 		},

--- a/pkg/cmd/pulumi/state/state_taint.go
+++ b/pkg/cmd/pulumi/state/state_taint.go
@@ -55,10 +55,12 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 
 			// If URN arguments were provided, use those:
 			if len(args) > 0 {
-				return taintMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
+				return taintMultipleResources(
+					ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt, disableIntegrityChecking)
 			}
 
 			// Otherwise, use interactive selection:
@@ -74,12 +76,13 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				stack,
 				nil,
 				"Select a resource to taint:",
+				disableIntegrityChecking,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return taintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
+			return taintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt, disableIntegrityChecking)
 		},
 	}
 
@@ -135,9 +138,10 @@ func taintResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []erro
 func taintMultipleResources(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
 	return runTotalStateEdit(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			resourceCount, errs := taintResourcesInSnapshot(snap, urns)
 
@@ -160,6 +164,8 @@ func taintMultipleResources(
 func taintResource(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
-	return taintMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return taintMultipleResources(
+		ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt, disableIntegrityChecking)
 }

--- a/pkg/cmd/pulumi/state/state_taint_test.go
+++ b/pkg/cmd/pulumi/state/state_taint_test.go
@@ -63,7 +63,7 @@ func TestTaintSingleResource(t *testing.T) {
 	})
 
 	// Get initial snapshot to verify taint state
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 	require.Len(t, initialSnap.Resources, 2)
 	assert.False(t, initialSnap.Resources[1].Taint)
@@ -124,7 +124,7 @@ func TestTaintMultipleResources(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Taint multiple resources
@@ -176,7 +176,7 @@ func TestTaintNonExistentResource(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Try to taint a non-existent resource
@@ -234,7 +234,7 @@ func TestTaintMixedExistingAndNonExistent(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Try to taint existing and non-existent resources
@@ -289,7 +289,7 @@ func TestTaintAlreadyTaintedResource(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 	require.Len(t, initialSnap.Resources, 2)
 	assert.True(t, initialSnap.Resources[1].Taint)
@@ -360,7 +360,7 @@ func TestTaintWithParentChildRelationship(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Taint the parent resource only
@@ -458,7 +458,7 @@ func TestTaintWithDependencies(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Taint the resource that has a dependency

--- a/pkg/cmd/pulumi/state/state_unprotect.go
+++ b/pkg/cmd/pulumi/state/state_unprotect.go
@@ -55,14 +55,16 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 			yes = yes || env.SkipConfirmations.Value()
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 
 			if unprotectAll {
-				return unprotectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
+				return unprotectAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt, disableIntegrityChecking)
 			}
 
 			// If URN arguments were provided, use those
 			if len(args) > 0 {
-				return unprotectMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
+				return unprotectMultipleResources(
+					ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt, disableIntegrityChecking)
 			}
 
 			// Otherwise, use interactive selection
@@ -78,12 +80,13 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				stack,
 				nil,
 				"Select a resource to unprotect:",
+				disableIntegrityChecking,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return unprotectResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
+			return unprotectResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt, disableIntegrityChecking)
 		},
 	}
 
@@ -106,10 +109,10 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 func unprotectAllResources(
 	ctx context.Context, stdout io.Writer,
-	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool, disableIntegrityChecking bool,
 ) error {
 	err := runTotalStateEdit(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			// Protects against Panic when a user tries to unprotect non-existing resources
 			if snap == nil {
@@ -168,9 +171,10 @@ func unprotectResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []
 func unprotectMultipleResources(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
 	return runTotalStateEdit(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			resourceCount, errs := unprotectResourcesInSnapshot(snap, urns)
 
@@ -193,6 +197,8 @@ func unprotectMultipleResources(
 func unprotectResource(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
-	return unprotectMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return unprotectMultipleResources(
+		ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt, disableIntegrityChecking)
 }

--- a/pkg/cmd/pulumi/state/state_untaint.go
+++ b/pkg/cmd/pulumi/state/state_untaint.go
@@ -56,14 +56,16 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
 			showPrompt := !yes
+			disableIntegrityChecking := backend.DisableIntegrityChecking(cmd)
 
 			if untaintAll {
-				return untaintAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt)
+				return untaintAllResources(ctx, cmd.OutOrStdout(), sink, ws, stack, showPrompt, disableIntegrityChecking)
 			}
 
 			// If URN arguments were provided, use those:
 			if len(args) > 0 {
-				return untaintMultipleResources(ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt)
+				return untaintMultipleResources(
+					ctx, cmd.OutOrStdout(), sink, ws, stack, args, showPrompt, disableIntegrityChecking)
 			}
 
 			// Otherwise, use interactive selection:
@@ -79,12 +81,13 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 				stack,
 				nil,
 				"Select a resource to untaint:",
+				disableIntegrityChecking,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to select resource: %w", err)
 			}
 
-			return untaintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt)
+			return untaintResource(ctx, cmd.OutOrStdout(), sink, ws, stack, urn, showPrompt, disableIntegrityChecking)
 		},
 	}
 
@@ -107,10 +110,10 @@ To see the list of URNs in a stack, use ` + "`pulumi stack --show-urns`" + `.`,
 
 func untaintAllResources(
 	ctx context.Context, stdout io.Writer,
-	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool,
+	sink diag.Sink, ws pkgWorkspace.Context, stackName string, showPrompt bool, disableIntegrityChecking bool,
 ) error {
 	err := runTotalStateEdit(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			// Protects against Panic when a user tries to untaint non-existing resources
 			if snap == nil {
@@ -169,9 +172,10 @@ func untaintResourcesInSnapshot(snap *deploy.Snapshot, urns []string) (int, []er
 func untaintMultipleResources(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urns []string, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
 	return runTotalStateEdit(
-		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt,
+		ctx, sink, ws, backend.DefaultLoginManager, stackName, showPrompt, disableIntegrityChecking,
 		func(_ display.Options, snap *deploy.Snapshot) error {
 			resourceCount, errs := untaintResourcesInSnapshot(snap, urns)
 
@@ -194,6 +198,8 @@ func untaintMultipleResources(
 func untaintResource(
 	ctx context.Context, stdout io.Writer,
 	sink diag.Sink, ws pkgWorkspace.Context, stackName string, urn resource.URN, showPrompt bool,
+	disableIntegrityChecking bool,
 ) error {
-	return untaintMultipleResources(ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt)
+	return untaintMultipleResources(
+		ctx, stdout, sink, ws, stackName, []string{string(urn)}, showPrompt, disableIntegrityChecking)
 }

--- a/pkg/cmd/pulumi/state/state_untaint_test.go
+++ b/pkg/cmd/pulumi/state/state_untaint_test.go
@@ -63,7 +63,7 @@ func TestUntaintSingleResource(t *testing.T) {
 	})
 
 	// Get initial snapshot to verify taint state
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 	require.Len(t, initialSnap.Resources, 2)
 	assert.True(t, initialSnap.Resources[1].Taint)
@@ -124,7 +124,7 @@ func TestUntaintMultipleResources(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Untaint multiple resources
@@ -176,7 +176,7 @@ func TestUntaintNonExistentResource(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Try to untaint a non-existent resource
@@ -235,7 +235,7 @@ func TestUntaintMixedExistingAndNonExistent(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Try to untaint existing and non-existent resources
@@ -291,7 +291,7 @@ func TestUntaintAlreadyUntaintedResource(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 	require.Len(t, initialSnap.Resources, 2)
 	assert.False(t, initialSnap.Resources[1].Taint)
@@ -362,7 +362,7 @@ func TestUntaintWithParentChildRelationship(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Untaint the parent resource only
@@ -462,7 +462,7 @@ func TestUntaintWithDependencies(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 
 	// Untaint the resource that has a dependency
@@ -514,7 +514,7 @@ func TestUntaintRoundTrip(t *testing.T) {
 	})
 
 	// Get initial snapshot
-	initialSnap, err := stack.Snapshot(ctx, mp)
+	initialSnap, err := stack.Snapshot(ctx, mp, false)
 	require.NoError(t, err)
 	require.Len(t, initialSnap.Resources, 2)
 	assert.False(t, initialSnap.Resources[1].Taint)

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -267,10 +267,10 @@ func (op TestOp) runWithContext(
 
 		var err error
 		journaler, err = backend.NewSnapshotJournaler(
-			context.Background(), journalPersister, secretsManager, secretsProvider, target.Snapshot)
+			context.Background(), journalPersister, secretsManager, secretsProvider, target.Snapshot, false)
 		require.NoErrorf(opts.T, err, "got error setting up journaler")
 
-		snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot, nil)
+		snapshotManager := backend.NewSnapshotManager(persister, secretsManager, target.Snapshot, nil, false)
 		journalSnapshotManager, err := engine.NewJournalSnapshotManager(journaler, target.Snapshot, secretsManager)
 		require.NoError(opts.T, err)
 

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -1701,7 +1701,7 @@ func runLanguageTests(
 				return nil, fmt.Errorf("get stack: %w", err)
 			}
 
-			snap, err = s.Snapshot(ctx, b64secrets.Base64SecretsProvider)
+			snap, err = s.Snapshot(ctx, b64secrets.Base64SecretsProvider, false /* disableIntegrityChecking */)
 			if err != nil {
 				return nil, fmt.Errorf("snapshot: %w", err)
 			}
@@ -1710,7 +1710,7 @@ func runLanguageTests(
 			// if we can't.
 			s, err = testBackend.GetStack(ctx, stackReference)
 			if err == nil {
-				snap, _ = s.Snapshot(ctx, b64secrets.Base64SecretsProvider)
+				snap, _ = s.Snapshot(ctx, b64secrets.Base64SecretsProvider, false /* disableIntegrityChecking */)
 			}
 		}
 


### PR DESCRIPTION
Part of #23391.

## What

Removes the two stateful package-level globals that stored the value of the
`--disable-integrity-checking` root flag (`backend.DisableIntegrityChecking` and
`diy.DisableIntegrityChecking`) and threads the value explicitly instead. These
globals were one of the obstacles to running the root cobra command in-process
for testing, and they forced `pulumi state repair` to flip the global and reset
it with a deferred call.

## How

- **Persistence layer:** `SnapshotManager`, `SnapshotJournaler`, and the diy
  snapshot persister now carry `disableIntegrityChecking` as a field set at
  construction. The diy and httpstate backends populate it from a new
  `UpdateOptions.DisableIntegrityChecking` field that flows from the CLI through
  the existing update-operation plumbing.
- **Backend read paths:** `Stack.Snapshot`, `diyBackend.getSnapshot`/`saveStack`,
  and `cloudBackend.getSnapshot`/`getTarget` take the boolean as a parameter.
- **Command layer:** `TotalStateEdit`, `SaveSnapshot`, `getURNFromState`, the
  `state` taint/protect/delete/rename helpers, `updateFlagsToOptions`, and the
  `about`/`stack`/`policy` read paths take the boolean as a parameter. The value
  is sourced from the cobra command via a new
  `backend.DisableIntegrityChecking(cmd)` helper that reads the inherited
  persistent flag, so nothing reads a hidden global anymore.
- `pulumi state repair` passes `true` directly to `Stack.Snapshot` instead of
  mutating a global.

The `--disable-integrity-checking` persistent flag is still registered on the
root command; it is now bound to a local variable in `NewPulumiCmd` and read by
subcommands through the helper.

## Behavior

Preserved exactly: the flag still disables integrity checks everywhere it did
before, and `state repair` still loads potentially-corrupt snapshots.

## Follow-ups

- A few low-traffic read helpers that are not wired to the flag today
  (`pulumi new`'s `HandleConfig`, the secrets-manager `FallbackToState` read,
  and the Neo automation path) pass `false` explicitly, matching the prior
  default. Threading the flag into those would require widening abstractions
  (the secrets-loader interface, etc.) for no behavior change and is left as a
  follow-up.
- The flag is still backed by a (now command-local) variable for cobra binding;
  fully eliminating the CLI-side variable belongs with the broader command-context
  refactor in #23391.

This is opened as a **draft** for review of the threading approach.
