### PR TITLE
Avoid `os.Exit` within cobra commands

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,5 +1,5 @@
-# Builds a custom golangci-lint binary that includes the requiredfield
-# linter as a module plugin. The version below must match
+# Builds a custom golangci-lint binary that includes the requiredfield and
+# noosexit linters as module plugins. The version below must match
 # GOLANGCI_LINT_VERSION in .github/workflows/ci-lint.yml.
 #
 # Build with: golangci-lint custom
@@ -10,3 +10,5 @@ destination: ./bin
 plugins:
   - module: github.com/pulumi/pulumi/.golangci/plugins/requiredfield
     path: ./.golangci/plugins/requiredfield
+  - module: github.com/pulumi/pulumi/.golangci/plugins/noosexit
+    path: ./.golangci/plugins/noosexit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,11 +27,15 @@ linters:
     - copyloopvar
     - gocritic
     - requiredfield
+    - noosexit
   settings:
     custom:
       requiredfield:
         type: module
         description: Checks that required fields are set in struct literals (see go.abhg.dev/requiredfield)
+      noosexit:
+        type: module
+        description: Forbids process-terminating calls (os.Exit, cmdutil.Exit, cmdutil.ExitError) outside of main and TestMain
     usetesting:
       os-temp-dir: true
       context-background: true

--- a/.golangci/plugins/noosexit/go.mod
+++ b/.golangci/plugins/noosexit/go.mod
@@ -1,0 +1,13 @@
+module github.com/pulumi/pulumi/.golangci/plugins/noosexit
+
+go 1.23.0
+
+require (
+	github.com/golangci/plugin-module-register v0.1.1
+	golang.org/x/tools v0.31.0
+)
+
+require (
+	golang.org/x/mod v0.24.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
+)

--- a/.golangci/plugins/noosexit/go.sum
+++ b/.golangci/plugins/noosexit/go.sum
@@ -1,0 +1,10 @@
+github.com/golangci/plugin-module-register v0.1.1 h1:TCmesur25LnyJkpsVrupv1Cdzo+2f7zX0H6Jkw1Ol6c=
+github.com/golangci/plugin-module-register v0.1.1/go.mod h1:TTpqoB6KkwOJMV8u7+NyXMrkwwESJLOkfl9TxR1DGFc=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=

--- a/.golangci/plugins/noosexit/plugin.go
+++ b/.golangci/plugins/noosexit/plugin.go
@@ -1,0 +1,116 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noosexit provides a golangci-lint module plugin that reports
+// process-terminating calls (os.Exit and the cmdutil.Exit/cmdutil.ExitError
+// helpers) outside of the main and TestMain functions. Exiting elsewhere skips
+// deferred cleanup and makes code untestable; functions should return an error
+// and let main decide the process exit code. See .custom-gcl.yml for how the
+// plugin is wired into the custom golangci-lint binary.
+package noosexit
+
+import (
+	"go/ast"
+	"go/types"
+
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+)
+
+func init() {
+	register.Plugin("noosexit", New)
+}
+
+func New(any) (register.LinterPlugin, error) {
+	return &plugin{}, nil
+}
+
+type plugin struct{}
+
+func (p *plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return []*analysis.Analyzer{Analyzer}, nil
+}
+
+func (p *plugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}
+
+// cmdutilPath is the import path of the package that owns the Exit helpers.
+const cmdutilPath = "github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+
+// forbiddenExits maps an import path to the set of function names within that
+// package whose calls terminate the process and so are permitted only in main
+// and TestMain.
+var forbiddenExits = map[string]map[string]bool{
+	"os":        {"Exit": true},
+	cmdutilPath: {"Exit": true, "ExitError": true},
+}
+
+// Analyzer reports calls to os.Exit, cmdutil.Exit, and cmdutil.ExitError that
+// appear outside of the main and TestMain functions.
+var Analyzer = &analysis.Analyzer{
+	Name: "noosexit",
+	Doc:  "reports process-terminating calls outside of the main and TestMain functions",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || isEntrypoint(fn) {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				if exit := forbiddenExit(pass, call); exit != nil {
+					pass.Reportf(call.Pos(),
+						"do not call %s.%s outside of main or TestMain; return an error instead",
+						exit.Pkg().Name(), exit.Name())
+				}
+				return true
+			})
+		}
+	}
+	return nil, nil
+}
+
+// isEntrypoint reports whether fn is a function in which a process-terminating
+// call is permitted: a package's main entrypoint or a test binary's TestMain.
+func isEntrypoint(fn *ast.FuncDecl) bool {
+	return fn.Recv == nil && (fn.Name.Name == "main" || fn.Name.Name == "TestMain")
+}
+
+// forbiddenExit returns the function call invokes if it is a process-terminating
+// call listed in forbiddenExits, or nil otherwise. The callee is resolved
+// through type information so that import aliases are handled correctly. Calls
+// written as bare identifiers (i.e. from within the defining package) are
+// intentionally not matched, so the helpers may compose with one another.
+func forbiddenExit(pass *analysis.Pass, call *ast.CallExpr) *types.Func {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+	fn, ok := pass.TypesInfo.Uses[sel.Sel].(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return nil
+	}
+	if forbiddenExits[fn.Pkg().Path()][fn.Name()] {
+		return fn
+	}
+	return nil
+}

--- a/.golangci/plugins/noosexit/plugin_test.go
+++ b/.golangci/plugins/noosexit/plugin_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noosexit
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	t.Parallel()
+	analysistest.Run(t, analysistest.TestData(), Analyzer, "a")
+}

--- a/.golangci/plugins/noosexit/testdata/src/a/a.go
+++ b/.golangci/plugins/noosexit/testdata/src/a/a.go
@@ -1,0 +1,51 @@
+package a
+
+import (
+	"os"
+	osalias "os"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// main is an exempt entrypoint: os.Exit is permitted, including inside nested
+// closures within its body.
+func main() {
+	os.Exit(0)
+	cmdutil.Exit(nil)
+	defer func() { os.Exit(1) }()
+}
+
+// TestMain is an exempt entrypoint.
+func TestMain() {
+	os.Exit(0)
+}
+
+func helper() {
+	os.Exit(1) // want `do not call os\.Exit outside of main or TestMain`
+}
+
+func nested() {
+	if true {
+		os.Exit(1) // want `do not call os\.Exit outside of main or TestMain`
+	}
+}
+
+func aliased() {
+	osalias.Exit(1) // want `do not call os\.Exit outside of main or TestMain`
+}
+
+func cmdutilExits() {
+	cmdutil.Exit(nil)      // want `do not call cmdutil\.Exit outside of main or TestMain`
+	cmdutil.ExitError("x") // want `do not call cmdutil\.ExitError outside of main or TestMain`
+}
+
+func init() {
+	os.Exit(1) // want `do not call os\.Exit outside of main or TestMain`
+}
+
+type t struct{}
+
+// A method named main is not the package entrypoint and is not exempt.
+func (t) main() {
+	os.Exit(1) // want `do not call os\.Exit outside of main or TestMain`
+}

--- a/.golangci/plugins/noosexit/testdata/src/github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil/cmdutil.go
+++ b/.golangci/plugins/noosexit/testdata/src/github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil/cmdutil.go
@@ -1,0 +1,8 @@
+package cmdutil
+
+// Stub of the real cmdutil exit helpers, used only so the analyzer test can
+// resolve calls to them by import path.
+
+func Exit(err error) {}
+
+func ExitError(msg string) {}

--- a/Makefile
+++ b/Makefile
@@ -170,14 +170,17 @@ lint_pulumi_json_fix::
 
 lint_fix:: lint_golang_fix lint_pulumi_json_fix
 
-# bin/custom-gcl is a golangci-lint binary with the requiredfield linter
-# baked in as a module plugin. Built from .custom-gcl.yml and the wrapper
-# under .golangci/plugins/requiredfield/.
+# bin/custom-gcl is a golangci-lint binary with the requiredfield and noosexit
+# linters baked in as module plugins. Built from .custom-gcl.yml and the
+# wrappers under .golangci/plugins/.
 CUSTOM_GCL := bin/custom-gcl
 CUSTOM_GCL_DEPS := .custom-gcl.yml \
 		   .golangci/plugins/requiredfield/go.mod \
 		   .golangci/plugins/requiredfield/go.sum \
-		   .golangci/plugins/requiredfield/plugin.go
+		   .golangci/plugins/requiredfield/plugin.go \
+		   .golangci/plugins/noosexit/go.mod \
+		   .golangci/plugins/noosexit/go.sum \
+		   .golangci/plugins/noosexit/plugin.go
 
 $(CUSTOM_GCL): $(CUSTOM_GCL_DEPS) .make/ensure/golangci-lint
 	golangci-lint custom

--- a/pkg/cmd/pulumi/cmd/exit_codes.go
+++ b/pkg/cmd/pulumi/cmd/exit_codes.go
@@ -39,12 +39,23 @@ const (
 	ExitInternalError       = 255
 )
 
+// An error that specifies it's own error code.
+type CustomExitCodeError interface {
+	error
+
+	CustomExitCode() int
+}
+
 // ExitCodeFor maps an error to a process exit code, based on its concrete or
 // wrapped type. This function is the single choke point for mapping errors
 // into the public exit code contract.
 func ExitCodeFor(err error) int {
 	if err == nil {
 		return ExitSuccess
+	}
+
+	if c, ok := err.(CustomExitCodeError); ok {
+		return c.CustomExitCode()
 	}
 
 	// `pulumi api` carries its own semantic exit code on the error so

--- a/pkg/cmd/pulumi/main.go
+++ b/pkg/cmd/pulumi/main.go
@@ -52,7 +52,7 @@ func panicHandler(finished *bool) {
 		fmt.Fprintf(os.Stderr, "Operating System: %s\n", runtime.GOOS)
 		fmt.Fprintf(os.Stderr, "Panic:            %s\n\n", panicPayload)
 		fmt.Fprintln(os.Stderr, stack)
-		os.Exit(1)
+		os.Exit(1) //nolint:noosexit // panicHandler is the last-resort crash reporter; it must terminate.
 	}
 }
 

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -34,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -198,7 +200,7 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 				return fmt.Errorf("plugin %s exited with error: %w", source, err)
 			}
 			if code != 0 {
-				os.Exit(code)
+				return pluginErrorCode{source, code}
 			}
 			return nil
 		},
@@ -218,3 +220,20 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	return cmd
 }
+
+var _ cmd.CustomExitCodeError = pluginErrorCode{}
+
+type pluginErrorCode struct {
+	plugin string
+	code   int
+}
+
+func (pec pluginErrorCode) CustomExitCode() int {
+	return pec.code
+}
+
+func (pec pluginErrorCode) Error() string {
+	return fmt.Sprintf("plugin %s exited with non-zero error code %d", pec.plugin, pec.code)
+}
+
+func (pec pluginErrorCode) Unwrap() error { return result.BailError(pec) }

--- a/pkg/cmd/pulumi/plugin/plugin_run_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run_test.go
@@ -22,9 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -269,8 +271,9 @@ func TestNewInstallPluginFunc_PluginInstallError(t *testing.T) {
 	assert.Nil(t, version, "should return nil when plugin installation fails")
 }
 
-//nolint:paralleltest // Cannot use t.Parallel() because this test executes a subprocess
 func TestPluginRunCommand(t *testing.T) {
+	t.Parallel()
+
 	// Skip on Windows - test uses bash script which is not cross-platform
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping on Windows - test requires bash")
@@ -320,4 +323,44 @@ exit 0
 	assert.Contains(t, outputStr, "PULUMI_RPC_TARGET=", "Plugin should receive PULUMI_RPC_TARGET")
 	assert.Contains(t, outputStr, "PULUMI_API="+cloudURL, "Plugin should receive PULUMI_API")
 	assert.Contains(t, outputStr, "PULUMI_ACCESS_TOKEN="+token, "Plugin should receive PULUMI_ACCESS_TOKEN")
+}
+
+func TestPluginRunCommandError(t *testing.T) {
+	t.Parallel()
+
+	// Skip on Windows - test uses bash script which is not cross-platform
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - test requires bash")
+	}
+
+	// Create a temporary directory for our test plugin
+	tmpDir := t.TempDir()
+
+	// Create a simple test plugin that writes its environment variables to a file
+	pluginPath := filepath.Join(tmpDir, "pulumi-tool-testplugin")
+	pluginScript := `#!/bin/bash
+exit 42
+`
+	//nolint:gosec // G306: File needs to be executable (0755)
+	err := os.WriteFile(pluginPath, []byte(pluginScript), 0o755)
+	require.NoError(t, err)
+
+	// Create mock workspace with credentials
+	cloudURL := "https://api.test-pulumi.com"
+	token := "test-token-123"
+	mockWs := mockWorkspaceWithProject(cloudURL, token)
+
+	// Create the command
+	runCmd := newPluginRunCmd(mockWs)
+	runCmd.SetArgs([]string{pluginPath})
+
+	// Execute the command
+	ctx := t.Context()
+	runCmd.SetContext(ctx)
+	err = runCmd.Execute()
+	require.True(t, result.IsBail(err))
+
+	var cec cmd.CustomExitCodeError
+	require.ErrorAs(t, err, &cec)
+	assert.Equal(t, 42, cec.CustomExitCode())
 }

--- a/sdk/go/common/util/cmdutil/exit.go
+++ b/sdk/go/common/util/cmdutil/exit.go
@@ -73,14 +73,13 @@ func DetailedError(err error) string {
 //
 // If run returns a BailError, we will not print an error message.
 //
-// Deprecated: Instead of using [RunFunc], you should call [DisplayErrorMessage] and then
-// manually exit with `os.Exit(-1)`
+// Deprecated: Use the default cobra error handling logic.
 func RunFunc(run func(cmd *cobra.Command, args []string) error) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		err := run(cmd, args)
 		if err != nil {
 			DisplayErrorMessage(err)
-			os.Exit(-1)
+			os.Exit(-1) //nolint:noosexit // RunFunc is deprecated
 		}
 	}
 }
@@ -115,7 +114,7 @@ func Exit(err error) {
 // ExitError issues an error and exits with a standard error exit code.
 func ExitError(msg string) {
 	Diag().Errorf(diag.Message("", "%s"), msg)
-	os.Exit(ExitCodeError)
+	os.Exit(ExitCodeError) //nolint:noosexit // ExitError is also forbidden outside of main functions
 }
 
 // Exit code taxonomy for the Pulumi CLI. These values form part of the

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -59,7 +59,7 @@ func Run(body RunFunc, opts ...RunOption) {
 		printRequiredPlugins()
 	}
 
-	os.Exit(constant.ExitStatusLoggedError)
+	os.Exit(constant.ExitStatusLoggedError) //nolint:noosexit // Run's contract terminates the process on failure.
 }
 
 // RunErr executes the body of a Pulumi program, granting it access to a deployment context that it may use

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -1413,7 +1413,7 @@ func (host *nodeLanguageHost) Handshake(ctx context.Context,
 	}()
 	err := rpcutil.Healthcheck(ctx, host.engineAddress, 5*time.Minute, cancel)
 	if err != nil {
-		cmdutil.Exit(fmt.Errorf("could not start health check host RPC server: %w", err))
+		return nil, fmt.Errorf("could not start health check host RPC server: %w", err)
 	}
 
 	return &pulumirpc.LanguageHandshakeResponse{}, nil

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1891,7 +1891,7 @@ func (host *pythonLanguageHost) Handshake(ctx context.Context,
 	}()
 	err := rpcutil.Healthcheck(ctx, host.engineAddress, 5*time.Minute, cancel)
 	if err != nil {
-		cmdutil.Exit(fmt.Errorf("could not start health check host RPC server: %w", err))
+		return nil, fmt.Errorf("could not start health check host RPC server: %w", err)
 	}
 
 	return &pulumirpc.LanguageHandshakeResponse{}, nil

--- a/tests/integration/aliases/go/retype_remote_component_and_child/provider/main.go
+++ b/tests/integration/aliases/go/retype_remote_component_and_child/provider/main.go
@@ -109,7 +109,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/call_component_failures/testcomponent-go/main.go
+++ b/tests/integration/call_component_failures/testcomponent-go/main.go
@@ -88,6 +88,6 @@ func main() {
 			return nil, perrors.NewInputPropertyError("foo", "the failure reason")
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/component_provider_schema/testcomponent-go/main.go
+++ b/tests/integration/component_provider_schema/testcomponent-go/main.go
@@ -35,6 +35,6 @@ func main() {
 		},
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component/testcomponent-go/main.go
+++ b/tests/integration/construct_component/testcomponent-go/main.go
@@ -115,7 +115,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/construct_component/testcomponent2-go/main.go
+++ b/tests/integration/construct_component/testcomponent2-go/main.go
@@ -133,7 +133,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/construct_component_failures/testcomponent-go/main.go
+++ b/tests/integration/construct_component_failures/testcomponent-go/main.go
@@ -49,6 +49,6 @@ func main() {
 			return nil, err
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_id_output/testcomponent-go/main.go
+++ b/tests/integration/construct_component_id_output/testcomponent-go/main.go
@@ -95,7 +95,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/construct_component_methods/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods/testcomponent-go/main.go
@@ -138,6 +138,6 @@ func main() {
 			return pulumiprovider.NewCallResult(result)
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_methods_errors/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_errors/testcomponent-go/main.go
@@ -69,6 +69,6 @@ func main() {
 			}, nil
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_methods_provider/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_provider/testcomponent-go/main.go
@@ -138,6 +138,6 @@ func main() {
 			return pulumiprovider.NewCallResult(result)
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_methods_resources/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_resources/testcomponent-go/main.go
@@ -117,6 +117,6 @@ func main() {
 			return pulumiprovider.NewCallResult(result)
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
@@ -117,6 +117,6 @@ func main() {
 			return pulumiprovider.NewCallResult(result)
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_output_values/testcomponent-go/main.go
+++ b/tests/integration/construct_component_output_values/testcomponent-go/main.go
@@ -139,6 +139,6 @@ func main() {
 			return pulumiprovider.NewConstructResult(component)
 		},
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_plain/testcomponent-go/main.go
+++ b/tests/integration/construct_component_plain/testcomponent-go/main.go
@@ -80,7 +80,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/construct_component_provider/testcomponent-go/main.go
+++ b/tests/integration/construct_component_provider/testcomponent-go/main.go
@@ -87,6 +87,6 @@ func main() {
 
 		return pulumiprovider.NewConstructResult(component)
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }

--- a/tests/integration/construct_component_provider_explicit/testcomponent-go/main.go
+++ b/tests/integration/construct_component_provider_explicit/testcomponent-go/main.go
@@ -51,7 +51,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/integration/construct_component_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_unknown/testcomponent-go/main.go
@@ -109,7 +109,7 @@ func main() {
 		return makeProvider(host, providerName, version)
 	})
 	if err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -102,7 +102,7 @@ func main() {
 	if err := provider.Main(providerName, func(host *provider.HostClient) (rpc.ResourceProviderServer, error) {
 		return makeProvider(host, providerName, version)
 	}); err != nil {
-		cmdutil.ExitError(err.Error())
+		cmdutil.Exit(err)
 	}
 }
 

--- a/tests/testutil/test_main_util.go
+++ b/tests/testutil/test_main_util.go
@@ -36,7 +36,7 @@ func SetupPulumiBinary() {
 	stdout, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		fmt.Printf("error finding repo root: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:noosexit // test setup helper invoked from TestMain.
 	}
 	repoRoot := strings.TrimSpace(string(stdout))
 	if os.Getenv("PULUMI_INTEGRATION_REBUILD_BINARIES") == "true" {
@@ -45,7 +45,7 @@ func SetupPulumiBinary() {
 		stdout, err = cmd.CombinedOutput()
 		if err != nil {
 			fmt.Printf("error building plugin: %v.  Output: %v\n", err, string(stdout))
-			os.Exit(1)
+			os.Exit(1) //nolint:noosexit // test setup helper invoked from TestMain.
 		}
 	}
 	repoBin := filepath.Join(repoRoot, "bin")
@@ -71,7 +71,7 @@ func InstallPythonProvider() {
 	stdout, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		fmt.Printf("error finding repo root: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:noosexit // test setup helper invoked from TestMain.
 	}
 	repoRoot := strings.TrimSpace(string(stdout))
 
@@ -81,7 +81,7 @@ func InstallPythonProvider() {
 	stdout, err = cmd.CombinedOutput()
 	if err != nil {
 		fmt.Printf("error install requirements for plugin: %v.  Output: %v\n", err, string(stdout))
-		os.Exit(1)
+		os.Exit(1) //nolint:noosexit // test setup helper invoked from TestMain.
 	}
 }
 


### PR DESCRIPTION
This PR removes the last usage of `os.Exit` in our cobra commands. As far as I can see, remaining usages are always in `main` packages or the `TestMain` function.

This PR also adds a test that `pulumi plugin run` still returns the error code of the underlying plugin.