### PR TITLE
[cli] Inject TF_TOKEN_<host> for terraform-module addresses on the configured Pulumi cloud

### DIFF
--- a/changelog/pending/.changie-20260601--cli-packages--inject-tf-token-for-pulumi-cloud-terraform-modules.yaml
+++ b/changelog/pending/.changie-20260601--cli-packages--inject-tf-token-for-pulumi-cloud-terraform-modules.yaml
@@ -1,0 +1,5 @@
+kind: feat
+body: Inject TF_TOKEN_<host> when running `pulumi package add terraform-module` against a Pulumi Cloud address so the embedded `tofu init` authenticates without a separate `terraform login` step
+component: cli/packages
+custom:
+  PR: "23398"

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -16,12 +16,16 @@ package packagecmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
@@ -38,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/idna"
 )
 
 // Constructs the `pulumi package add` command.
@@ -136,6 +141,8 @@ from the parameters, as in:
 
 			pluginSource := args[0]
 			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+
+			defer injectPulumiCloudTFToken(cmd.Context(), pluginSource, parameters.Args)()
 
 			pkg, packageSpec, diags, err := packages.InstallPackage(
 				cmd.OutOrStdout(),
@@ -302,4 +309,83 @@ func loadEnclosingTarget(ctx context.Context, wd string) (addTarget, error) {
 		panic(fmt.Sprintf("workspace.LoadBaseProjectFrom promises that it will return "+
 			"either *workspace.Project or *workspace.PluginProject, found %T", baseProject))
 	}
+}
+
+func injectPulumiCloudTFToken(ctx context.Context, pluginSource string, params []string) func() {
+	noop := func() {}
+	if pluginSource != "terraform-module" || len(params) == 0 {
+		return noop
+	}
+	envKey, token, ok := tfTokenForPulumiCloudAddress(ctx, params[0])
+	if !ok || os.Getenv(envKey) != "" {
+		return noop
+	}
+	_ = os.Setenv(envKey, token)
+	return func() { _ = os.Unsetenv(envKey) }
+}
+
+// The registry is served on the cloud's TFE domain (tfe.pulumi.com), not the API
+// host the user logs in to (api.pulumi.com), so the trusted host comes from the
+// cloud's own service-discovery document rather than creds.Current.
+func tfTokenForPulumiCloudAddress(ctx context.Context, address string) (envKey, token string, ok bool) {
+	host, _, found := strings.Cut(address, "/")
+	if !found || host == "" {
+		return "", "", false
+	}
+	creds, err := workspace.GetStoredCredentials()
+	if err != nil || creds.Current == "" {
+		return "", "", false
+	}
+	tfeHost := discoverTFEHost(ctx, creds.Current)
+	if tfeHost == "" || !strings.EqualFold(tfeHost, host) {
+		return "", "", false
+	}
+	if envToken := os.Getenv("PULUMI_ACCESS_TOKEN"); envToken != "" {
+		token = envToken
+	} else {
+		token = creds.AccessTokens[creds.Current]
+	}
+	if token == "" {
+		return "", "", false
+	}
+	return "TF_TOKEN_" + tfTokenHostKey(host), token, true
+}
+
+func discoverTFEHost(ctx context.Context, cloudURL string) string {
+	endpoint := strings.TrimSuffix(cloudURL, "/") + "/.well-known/terraform.json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return ""
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer contract.IgnoreClose(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var doc struct {
+		TFEv2 string `json:"tfe.v2"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil || doc.TFEv2 == "" {
+		return ""
+	}
+	u, err := url.Parse(doc.TFEv2)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// tfTokenHostKey encodes a host per HashiCorp's TF_TOKEN_<host> convention:
+// https://developer.hashicorp.com/terraform/cli/config/config-file#environment-variable-credentials
+func tfTokenHostKey(host string) string {
+	if ascii, err := idna.Lookup.ToASCII(host); err == nil {
+		host = ascii
+	}
+	host = strings.ReplaceAll(host, "-", "__")
+	host = strings.ReplaceAll(host, ".", "_")
+	return host
 }

--- a/pkg/cmd/pulumi/packagecmd/package_add_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add_test.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -310,4 +312,83 @@ func TestPrintRegistryDocsHint(t *testing.T) {
 			assert.Equal(t, tt.want, buf.String())
 		})
 	}
+}
+
+func TestTFTokenHostKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"app.pulumi.com", "app_pulumi_com"},
+		{"pulumi.example.com", "pulumi_example_com"},
+		{"pulumi-internal.example.com", "pulumi__internal_example_com"},
+		{"my-host.my-domain.com", "my__host_my__domain_com"},
+		// Non-ASCII hosts are punycode-encoded first (HashiCorp convention).
+		{"café.fr", "xn____caf__dma_fr"},
+		{"xn--caf-dma.fr", "xn____caf__dma_fr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tfTokenHostKey(tt.host))
+		})
+	}
+}
+
+func TestDiscoverTFEHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"tfe.v2 present", http.StatusOK, `{"tfe.v2":"https://tfe.example.test/api/v2"}`, "tfe.example.test"},
+		{"no tfe.v2", http.StatusOK, `{"modules.v1":"/v1/modules/"}`, ""},
+		{"malformed json", http.StatusOK, `not json`, ""},
+		{"not found", http.StatusNotFound, ``, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/.well-known/terraform.json", r.URL.Path)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+			assert.Equal(t, tt.want, discoverTFEHost(context.Background(), srv.URL))
+		})
+	}
+}
+
+func TestTFTokenForPulumiCloudAddress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tfe.v2":"https://tfe.example.test/api/v2"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+	require.NoError(t, workspace.StoreCredentials(workspace.Credentials{
+		Current:      srv.URL,
+		AccessTokens: map[string]string{srv.URL: "tok"},
+	}))
+
+	t.Run("address host is the cloud's TFE domain", func(t *testing.T) {
+		envKey, token, ok := tfTokenForPulumiCloudAddress(context.Background(), "tfe.example.test/acme/vpc/aws")
+		require.True(t, ok)
+		assert.Equal(t, "TF_TOKEN_tfe_example_test", envKey)
+		assert.Equal(t, "tok", token)
+	})
+
+	t.Run("address host is not the TFE domain", func(t *testing.T) {
+		_, _, ok := tfTokenForPulumiCloudAddress(context.Background(), "registry.terraform.io/acme/vpc/aws")
+		assert.False(t, ok)
+	})
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -39,7 +39,7 @@ require (
 	gocloud.dev v0.46.0
 	gocloud.dev/secrets/hashivault v0.46.0
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/api v0.272.0


### PR DESCRIPTION
When a customer runs `pulumi package add terraform-module <host>/<ns>/<name>/<system>`, set `TF_TOKEN_<host>` in the environment passed to the `pulumi-terraform-module` provider so the embedded `tofu init` authenticates against Pulumi Cloud with no separate `terraform login` step.

The module registry is served on the cloud's TFE domain (for example `tfe.pulumi.com`), a different host from the API the user logs in to (`api.pulumi.com`). Resolve the TFE host from the configured cloud's Terraform service-discovery document (`/.well-known/terraform.json`, the `tfe.v2` entry) and inject only when the address host matches it. Comparing the address host against the login URL does not match, since they are different hosts.

Token resolution prefers `PULUMI_ACCESS_TOKEN` over stored credentials, matching the rest of the CLI's auth path. The env-var name encodes the host per HashiCorp's convention (dots to underscores, dashes to double underscores).

The injection does not fire when the address host is not the configured cloud's TFE domain (a public Terraform Registry host, or any other host).

Design doc: https://app.notion.com/p/Terraform-module-hosting-in-the-Pulumi-Cloud-registry-372fdbdf1cce801ea7a3f4946c1e4154

Fixes https://github.com/pulumi/pulumi-service/issues/44077

## Test plan

- `go test ./pkg/cmd/pulumi/packagecmd/ -run 'TFToken|DiscoverTFEHost|PulumiCloudAddress'`
  - `TestDiscoverTFEHost`: parses the `tfe.v2` host from a discovery document
  - `TestTFTokenForPulumiCloudAddress`: injects when the address host is the cloud's TFE domain, not otherwise
- Manual against a review stack: logged in to the API host, `pulumi package add terraform-module <tfe-host>/<ns>/<name>/<system> <ver> <local>` generated the SDK with no `terraform login`. The pre-rework build returned `401 Unauthorized` on the same inputs.