### PR TITLE
make sure TestDebuggerAttachBun doesn't panic

### DIFF
--- a/tests/integration/integration_bun_test.go
+++ b/tests/integration/integration_bun_test.go
@@ -47,9 +47,10 @@ func TestDebuggerAttachBun(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+	var previewErr error
 	go func() {
 		defer wg.Done()
-		e.RunCommand("pulumi", "preview", "--attach-debugger",
+		_, _, previewErr = e.GetCommandResults("pulumi", "preview", "--attach-debugger",
 			"--event-log", filepath.Join(e.RootPath, "debugger.log"))
 	}()
 
@@ -103,6 +104,7 @@ outer:
 	}()
 	select {
 	case <-waitDone:
+		require.NoError(t, previewErr, "pulumi preview failed")
 	case <-time.After(60 * time.Second):
 		t.Fatal("timed out waiting for program to complete")
 	}


### PR DESCRIPTION
Currently TestDebuggerAttachBun sometimes panics in CI, because `t.Fatal` is called in a goroutine that hasn't finished.  Presumably this is because the test times out for some reason, but then the command still fails with an error after all.

This is hard to debug because of the panic, so let's make sure it doesn't panic first, and then we can investigate the test failure further, when we hopefully have a clearer picture of what's happening.
