### PR TITLE
Show download and unpack progress when installing provider plugins

### DIFF
--- a/changelog/pending/cli-improvement-20260602-140738.yaml
+++ b/changelog/pending/cli-improvement-20260602-140738.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Show download and unpack progress when installing provider plugins
+time: 2026-06-02T14:07:38.04998+02:00
+custom:
+    PR: https://github.com/pulumi/pulumi/issues/23408

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -174,9 +174,9 @@ func (w Workspace) DownloadPlugin(
 	}
 
 	wrapper := func(stream io.ReadCloser, size int64) io.ReadCloser {
-		// Log at info but to stderr so we don't pollute stdout for commands like `package get-schema`
-		fmt.Fprintf(w.stderr, "Downloading provider: %s\n", pluginSpec.Name)
-		return stream
+		// Renders a progress bar to stderr in interactive terminals and prints a plain message otherwise.
+		return workspace.ReadCloserProgressBar(
+			stream, w.stderr, size, "Downloading provider "+pluginSpec.Name, diagutils.GetGlobalColorization())
 	}
 
 	retry := func(err error, attempt int, limit int, delay time.Duration) {
@@ -191,8 +191,17 @@ func (w Workspace) DownloadPlugin(
 	}
 
 	logging.V(1).Infof("unpacking provider %s", pluginSpec.Name)
+	// Wrap the downloaded tarball with a progress bar sized by the downloaded tarball, so extraction shows progress
+	// during unpacking. [pluginstorage.UnpackContents] closes the content (and thus this stream) when it returns, which
+	// is what finishes the bar.
+	var unpackStream io.ReadCloser = downloadedFile
+	if fi, statErr := downloadedFile.Stat(); statErr == nil {
+		unpackStream = workspace.ReadCloserProgressBar(
+			downloadedFile, w.stderr, fi.Size(),
+			"Unpacking provider "+pluginSpec.Name, diagutils.GetGlobalColorization())
+	}
 	cleanup, err := pluginstorage.UnpackContents(
-		ctx, pluginSpec, pluginstorage.TarPlugin(downloadedFile), true, /* reinstall */
+		ctx, pluginSpec, pluginstorage.TarPlugin(unpackStream), true, /* reinstall */
 	)
 	if err != nil {
 		return "", nil, err

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -64,6 +64,7 @@ func newPluginInstallCmd() *cobra.Command {
 			"the plugin, though the result is not guaranteed.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			picmd.stderr = cmd.ErrOrStderr()
 			return picmd.Run(ctx, args)
 		},
 	}
@@ -106,6 +107,7 @@ type pluginInstallCmd struct {
 	env      env.Env
 	color    colors.Colorization
 	registry registry.Registry
+	stderr   io.Writer
 
 	pluginGetLatestVersion func(
 		workspace.PluginDescriptor, context.Context,
@@ -114,7 +116,7 @@ type pluginInstallCmd struct {
 	installPluginSpec func(
 		ctx context.Context, label string,
 		install workspace.PluginDescriptor, file string,
-		sink diag.Sink, color colors.Colorization, reinstall bool,
+		sink diag.Sink, stderr io.Writer, color colors.Colorization, reinstall bool,
 	) error // == installPluginSpec
 }
 
@@ -133,6 +135,9 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 	}
 	if cmd.installPluginSpec == nil {
 		cmd.installPluginSpec = installPluginSpec
+	}
+	if cmd.stderr == nil {
+		cmd.stderr = io.Discard
 	}
 	if cmd.registry == nil {
 		cmd.registry = cmdCmd.NewDefaultRegistry(
@@ -284,7 +289,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 		}
 
 		cmd.diag.Infoerrf(diag.Message("", "%s installing"), label)
-		err := cmd.installPluginSpec(ctx, label, install, cmd.file, cmd.diag, cmd.color, cmd.reinstall)
+		err := cmd.installPluginSpec(ctx, label, install, cmd.file, cmd.diag, cmd.stderr, cmd.color, cmd.reinstall)
 		if err != nil {
 			return err
 		}
@@ -296,7 +301,7 @@ func (cmd *pluginInstallCmd) Run(ctx context.Context, args []string) error {
 func installPluginSpec(
 	ctx context.Context, label string,
 	install workspace.PluginDescriptor, file string,
-	sink diag.Sink, color colors.Colorization, reinstall bool,
+	sink diag.Sink, stderr io.Writer, color colors.Colorization, reinstall bool,
 ) error {
 	// If we got here, actually try to do the download.
 	var source string
@@ -304,7 +309,7 @@ func installPluginSpec(
 	var err error
 	if file == "" {
 		withProgress := func(stream io.ReadCloser, size int64) io.ReadCloser {
-			return workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", color)
+			return workspace.ReadCloserProgressBar(stream, stderr, size, "Downloading plugin", color)
 		}
 		retry := func(err error, attempt int, limit int, delay time.Duration) {
 			sink.Warningf(
@@ -317,7 +322,15 @@ func installPluginSpec(
 		}
 		defer func() { contract.IgnoreError(os.Remove(r.Name())) }()
 
-		payload = pluginstorage.TarPlugin(r)
+		// Wrap the downloaded tarball with a progress bar sized by the downloaded tarball, so extraction shows progress
+		// during unpacking. [pluginstorage.UnpackContents], called via [pkgWorkspace.InstallPluginContent] closes the
+		// content (and thus this stream) when it returns, which is what finishes the bar.
+		var unpackStream io.ReadCloser = r
+		if fi, statErr := r.Stat(); statErr == nil {
+			unpackStream = workspace.ReadCloserProgressBar(r, stderr, fi.Size(), "Unpacking plugin", color)
+		}
+
+		payload = pluginstorage.TarPlugin(unpackStream)
 	} else {
 		source = file
 		logging.V(1).Infof("%s opening tarball from %s", label, file)

--- a/pkg/cmd/pulumi/plugin/plugin_install_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"iter"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func TestGetLatestPluginIncludedVersion(t *testing.T) {
 		installPluginSpec: func(
 			_ context.Context, _ string,
 			install workspace.PluginDescriptor, file string,
-			_ diag.Sink, _ colors.Colorization, _ bool,
+			_ diag.Sink, _ io.Writer, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
 			assert.Empty(t, file)
@@ -156,7 +157,7 @@ func TestGetPluginDownloadURLFromRegistry(t *testing.T) {
 		installPluginSpec: func(
 			_ context.Context, _ string,
 			install workspace.PluginDescriptor, _ string,
-			_ diag.Sink, _ colors.Colorization, _ bool,
+			_ diag.Sink, _ io.Writer, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
 			assert.Equal(t, workspace.PluginDescriptor{
@@ -220,7 +221,7 @@ func TestGetPluginDownloadFromKnownUnpublishedPackage(t *testing.T) {
 		installPluginSpec: func(
 			_ context.Context, _ string,
 			install workspace.PluginDescriptor, _ string,
-			_ diag.Sink, _ colors.Colorization, _ bool,
+			_ diag.Sink, _ io.Writer, _ colors.Colorization, _ bool,
 		) error {
 			pluginWasInstalled = true
 			assert.Equal(t, workspace.PluginDescriptor{
@@ -315,7 +316,7 @@ func TestRegistryIsNotUsedWhenAFileIsSpecified(t *testing.T) {
 		installPluginSpec: func(
 			_ context.Context, _ string,
 			install workspace.PluginDescriptor, file string,
-			sink diag.Sink, color colors.Colorization, reinstall bool,
+			sink diag.Sink, _ io.Writer, color colors.Colorization, reinstall bool,
 		) error {
 			wasInstalled = true
 			assert.Equal(t, "./pulumi-resource-some-file.tar.gz", file)
@@ -363,7 +364,7 @@ packages:
 		},
 		installPluginSpec: func(
 			_ context.Context, _ string, install workspace.PluginDescriptor, _ string,
-			_ diag.Sink, _ colors.Colorization, _ bool,
+			_ diag.Sink, _ io.Writer, _ colors.Colorization, _ bool,
 		) error {
 			require.Equal(t, "./my-provider", install.Name)
 			require.NotContains(t, install.PluginDownloadURL, "github.com/pulumi/pulumi-my-local-provider")
@@ -415,7 +416,7 @@ func TestSuggestedPackagesDisplay(t *testing.T) {
 		},
 		installPluginSpec: func(
 			_ context.Context, _ string, install workspace.PluginDescriptor, _ string,
-			_ diag.Sink, _ colors.Colorization, _ bool,
+			_ diag.Sink, _ io.Writer, _ colors.Colorization, _ bool,
 		) error {
 			assert.Fail(t, "installPluginSpec should not have been called")
 			return nil

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -607,6 +607,7 @@ func installPlugin(
 		withDownloadProgress = func(stream io.ReadCloser, size int64) io.ReadCloser {
 			return workspace.ReadCloserProgressBar(
 				stream,
+				os.Stderr,
 				size,
 				downloadMessage,
 				cmdutil.GetGlobalColorization(),

--- a/pkg/engine/policypacks.go
+++ b/pkg/engine/policypacks.go
@@ -60,6 +60,7 @@ func installPolicyPack(
 		withDownloadProgress = func(stream io.ReadCloser, size int64) io.ReadCloser {
 			return workspace.ReadCloserProgressBar(
 				stream,
+				os.Stderr,
 				size,
 				downloadMessage,
 				cmdutil.GetGlobalColorization(),

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -2390,19 +2390,18 @@ func SelectCompatiblePlugin(
 
 // ReadCloserProgressBar displays a progress bar for the given closer and returns a wrapper closer to manipulate it.
 func ReadCloserProgressBar(
-	closer io.ReadCloser, size int64, message string, colorization colors.Colorization,
+	closer io.ReadCloser, w io.Writer, size int64, message string, colorization colors.Colorization,
 ) io.ReadCloser {
-	if size == -1 {
-		return closer
-	}
-
-	if !cmdutil.Interactive() {
+	if size == -1 || !cmdutil.Interactive() {
+		// We can't render a progress bar (unknown size, or non-interactive output), but still tell the
+		// user what's happening.
+		fmt.Fprintln(w, colorization.Colorize(colors.SpecUnimportant+message+colors.Reset))
 		return closer
 	}
 
 	// If we know the length of the download, show a progress bar.
 	bar := pb.New(int(size))
-	bar.Output = os.Stderr
+	bar.Output = w
 	bar.Prefix(colorization.Colorize(colors.SpecUnimportant + message + ":"))
 	bar.Postfix(colorization.Colorize(colors.Reset))
 	bar.SetMaxWidth(80)
@@ -2542,6 +2541,6 @@ func (bc *barCloser) Read(dest []byte) (int, error) {
 }
 
 func (bc *barCloser) Close() error {
-	bc.bar.FinishPrint("\r")
+	bc.bar.Finish()
 	return bc.readCloser.Close()
 }


### PR DESCRIPTION
Make commands that load a provider (`pulumi package {get-schema,add,info,...}`, `pulumi do`) show a progress bar for the downloading and unpacking.

https://asciinema.org/a/czayEeqmknpyz4ag

Fixes https://github.com/pulumi/pulumi/issues/23408
