### PR TITLE
Make core pulumi config commands work for remote-config stacks

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -314,6 +314,29 @@ type EnvironmentsBackend interface {
 		yaml []byte,
 		duration time.Duration,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
+
+	// GetEnvironment reads a named environment at the given version (empty for latest). If decrypt is
+	// true, fn::secret ciphertext in the definition is decrypted in place. etag enables read-modify-write
+	// against the same revision; revision is returned for later pin/restore use.
+	GetEnvironment(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+		version string,
+		decrypt bool,
+	) (yaml []byte, etag string, revision int, err error)
+
+	// UpdateEnvironmentWithProject replaces a named environment's definition YAML. A non-empty etag is
+	// checked against the current revision and the update fails with a conflict if they differ.
+	UpdateEnvironmentWithProject(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+		yaml []byte,
+		etag string,
+	) (apitype.EnvironmentDiagnostics, error)
 }
 
 // SpecificDeploymentExporter is an interface defining an additional capability of a Backend, specifically the
@@ -460,6 +483,9 @@ var (
 	// which do not support the teams feature.
 	ErrTeamsNotSupported  = errors.New("teams are not supported")
 	ErrConfigNotSupported = errors.New("remote config is not supported")
+	// ErrConfigConflict is returned by UpdateEnvironmentWithProject when the environment was modified
+	// since the etag was read.
+	ErrConfigConflict = errors.New("remote config was modified concurrently")
 )
 
 // CreateStackOptions provides options for stack creation.

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -16,6 +16,9 @@ package httpstate
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/pulumi/esc"
@@ -33,9 +36,10 @@ func convertESCDiags(diags []client.EnvironmentDiagnostic) apitype.EnvironmentDi
 	apiDiags := make(apitype.EnvironmentDiagnostics, len(diags))
 	for i, d := range diags {
 		apiDiags[i] = apitype.EnvironmentDiagnostic{
-			Range:   d.Range,
-			Summary: d.Summary,
-			Detail:  d.Detail,
+			Range:    d.Range,
+			Summary:  d.Summary,
+			Detail:   d.Detail,
+			Severity: apitype.EnvironmentDiagnosticSeverity(d.Severity),
 		}
 	}
 	return apiDiags
@@ -76,4 +80,53 @@ func (b *cloudBackend) OpenYAMLEnvironment(
 	}
 	env, err := b.escClient.GetAnonymousOpenEnvironment(ctx, org, id)
 	return env, nil, err
+}
+
+func (b *cloudBackend) GetEnvironment(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+	version string,
+	decrypt bool,
+) (yaml []byte, etag string, revision int, err error) {
+	return b.escClient.GetEnvironment(ctx, org, projectName, envName, version, decrypt)
+}
+
+func (b *cloudBackend) UpdateEnvironmentWithProject(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+	yaml []byte,
+	etag string,
+) (apitype.EnvironmentDiagnostics, error) {
+	diags, err := b.escClient.UpdateEnvironmentWithProject(ctx, org, projectName, envName, yaml, etag)
+	return convertESCDiags(diags), translateConfigConflict(err)
+}
+
+// translateConfigConflict maps the esc client's 409 environment-update rejection to
+// backend.ErrConfigConflict so callers needn't import the esc client or match on HTTP status.
+func translateConfigConflict(err error) error {
+	if isConfigConflict(err) {
+		return fmt.Errorf("%w: %w", backend.ErrConfigConflict, err)
+	}
+	return err
+}
+
+// isConfigConflict reports whether err is a 409 from an esc environment update. The esc client
+// surfaces the status two ways depending on the response body: a structured body decodes into
+// *EnvironmentErrorResponse whose Code carries the echoed `code`, while an empty or non-JSON body
+// falls back to *apitype.ErrorResponse whose Code is set from the HTTP status. Matching only the
+// former would miss a 409 whose body omits `code`.
+func isConfigConflict(err error) bool {
+	var escErr *client.EnvironmentErrorResponse
+	if errors.As(err, &escErr) && escErr.Code == http.StatusConflict {
+		return true
+	}
+	var apiErr *apitype.ErrorResponse
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusConflict {
+		return true
+	}
+	return false
 }

--- a/pkg/backend/httpstate/environments_test.go
+++ b/pkg/backend/httpstate/environments_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpstate
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/pulumi/esc/cmd/esc/cli/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestTranslateConfigConflict(t *testing.T) {
+	t.Parallel()
+
+	conflict := &client.EnvironmentErrorResponse{Code: http.StatusConflict, Message: "modified"}
+	translated := translateConfigConflict(conflict)
+	require.ErrorIs(t, translated, backend.ErrConfigConflict)
+	require.ErrorIs(t, translated, conflict, "the original esc error stays in the chain for context")
+
+	// A 409 with an empty or non-JSON body surfaces as *apitype.ErrorResponse with the HTTP status,
+	// not *EnvironmentErrorResponse, so it must still be recognized as a conflict.
+	apiConflict := &apitype.ErrorResponse{Code: http.StatusConflict, Message: "conflict"}
+	require.ErrorIs(t, translateConfigConflict(apiConflict), backend.ErrConfigConflict)
+
+	other := &client.EnvironmentErrorResponse{Code: http.StatusBadRequest, Message: "bad request"}
+	require.NotErrorIs(t, translateConfigConflict(other), backend.ErrConfigConflict)
+
+	apiOther := &apitype.ErrorResponse{Code: http.StatusBadRequest, Message: "bad request"}
+	require.NotErrorIs(t, translateConfigConflict(apiOther), backend.ErrConfigConflict)
+
+	require.NoError(t, translateConfigConflict(nil))
+
+	plain := errors.New("network down")
+	require.Equal(t, plain, translateConfigConflict(plain))
+}

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -157,6 +157,18 @@ func (m *mockEnvironmentsBackend) OpenYAMLEnvironment(
 	return m.openYAMLEnvironmentF(ctx, org, yaml, duration)
 }
 
+func (m *mockEnvironmentsBackend) GetEnvironment(
+	context.Context, string, string, string, string, bool,
+) ([]byte, string, int, error) {
+	return nil, "", 0, nil
+}
+
+func (m *mockEnvironmentsBackend) UpdateEnvironmentWithProject(
+	context.Context, string, string, string, []byte, string,
+) (apitype.EnvironmentDiagnostics, error) {
+	return nil, nil
+}
+
 func TestResolveEnvironments(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -543,6 +543,24 @@ type MockEnvironmentsBackend struct {
 		yaml []byte,
 		duration time.Duration,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
+
+	GetEnvironmentF func(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+		version string,
+		decrypt bool,
+	) (yaml []byte, etag string, revision int, err error)
+
+	UpdateEnvironmentWithProjectF func(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+		yaml []byte,
+		etag string,
+	) (apitype.EnvironmentDiagnostics, error)
 }
 
 func (be *MockEnvironmentsBackend) CreateEnvironment(
@@ -577,6 +595,34 @@ func (be *MockEnvironmentsBackend) OpenYAMLEnvironment(
 ) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 	if be.OpenYAMLEnvironmentF != nil {
 		return be.OpenYAMLEnvironmentF(ctx, org, yaml, duration)
+	}
+	panic("not implemented")
+}
+
+func (be *MockEnvironmentsBackend) GetEnvironment(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+	version string,
+	decrypt bool,
+) (yaml []byte, etag string, revision int, err error) {
+	if be.GetEnvironmentF != nil {
+		return be.GetEnvironmentF(ctx, org, projectName, envName, version, decrypt)
+	}
+	panic("not implemented")
+}
+
+func (be *MockEnvironmentsBackend) UpdateEnvironmentWithProject(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+	yaml []byte,
+	etag string,
+) (apitype.EnvironmentDiagnostics, error) {
+	if be.UpdateEnvironmentWithProjectF != nil {
+		return be.UpdateEnvironmentWithProjectF(ctx, org, projectName, envName, yaml, etag)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -401,6 +401,10 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string, configFile *string) 
 				return fmt.Errorf("invalid configuration key: %w", err)
 			}
 
+			if err := rejectIfPinned(stack, *configFile); err != nil {
+				return err
+			}
+
 			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
 				return err
@@ -467,6 +471,10 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string, configFile *strin
 				*configFile,
 			)
 			if err != nil {
+				return err
+			}
+
+			if err := rejectIfPinned(stack, *configFile); err != nil {
 				return err
 			}
 
@@ -775,6 +783,10 @@ func (c *configSetCmd) Run(
 		}
 	}
 
+	if err := rejectIfPinned(s, configFile); err != nil {
+		return err
+	}
+
 	ps, err := c.LoadProjectStack(ctx, cmdutil.Diag(), project, s, configFile)
 	if err != nil {
 		return err
@@ -889,6 +901,10 @@ func newConfigSetAllCmd(
 				*configFile,
 			)
 			if err != nil {
+				return err
+			}
+
+			if err := rejectIfPinned(stack, *configFile); err != nil {
 				return err
 			}
 

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -100,6 +100,11 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// A remote stack with no service-side config yields a nil ProjectStack; listing should
+			// still surface environment-derived values, so treat it as empty rather than panicking.
+			if ps == nil {
+				ps = &workspace.ProjectStack{}
+			}
 
 			// If --open is explicitly set, use that value. Otherwise, default to true if --show-secrets is set.
 			openSetByUser := cmd.Flags().Changed("open")
@@ -400,13 +405,7 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string, configFile *string) 
 			if err != nil {
 				return err
 			}
-
-			if configLocation := stack.ConfigLocation(); configLocation.IsRemote {
-				err := errors.New("config rm not supported for remote stack config")
-				if configLocation.EscEnv != nil {
-					return fmt.Errorf("%w: use `pulumi env rm %s pulumiConfig.%s` to update config environment",
-						err, *configLocation.EscEnv, key.String())
-				}
+			if err := checkRemoteProjectStack(stack, ps); err != nil {
 				return err
 			}
 
@@ -475,13 +474,7 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string, configFile *strin
 			if err != nil {
 				return err
 			}
-
-			if configLocation := stack.ConfigLocation(); configLocation.IsRemote {
-				err := errors.New("config rm-all not supported for remote stack config")
-				if configLocation.EscEnv != nil {
-					return fmt.Errorf("%w: use `pulumi env rm %s pulumiConfig.<key>` to update config environment",
-						err, *configLocation.EscEnv)
-				}
+			if err := checkRemoteProjectStack(stack, ps); err != nil {
 				return err
 			}
 
@@ -786,12 +779,15 @@ func (c *configSetCmd) Run(
 	if err != nil {
 		return err
 	}
+	if err := checkRemoteProjectStack(s, ps); err != nil {
+		return err
+	}
 
 	// The editor encrypts secrets, so pass plaintext as a secure value plus the encrypter to use.
 	encrypter := config.NopEncrypter
 	var v config.Value
 	if c.Secret {
-		if !s.ConfigLocation().IsRemote {
+		if !configStoreIsRemote(s, configFile) {
 			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 			// GetEncrypter may update ps (e.g. set up a new encryption salt); Save persists ps
 			// unconditionally, so the changed-state bool can be ignored.
@@ -826,19 +822,6 @@ func (c *configSetCmd) Run(
 				"rerun with --secret to encrypt it, or --plaintext if you meant to store in plaintext",
 				key)
 		}
-	}
-
-	if configLocation := s.ConfigLocation(); configLocation.IsRemote {
-		err := errors.New("config set not supported for remote stack config")
-		if configLocation.EscEnv != nil {
-			exampleValue := "--secret <value>"
-			if !c.Secret {
-				exampleValue = value
-			}
-			return fmt.Errorf("%w: use `pulumi env set %s pulumiConfig.%s %s`",
-				err, *configLocation.EscEnv, key.String(), exampleValue)
-		}
-		return err
 	}
 
 	editor, err := newConfigEditor(ctx, s, ps, encrypter, configFile)
@@ -909,18 +892,11 @@ func newConfigSetAllCmd(
 				return err
 			}
 
-			if configStoreIsRemote(stack, *configFile) {
-				configLocation := stack.ConfigLocation()
-				err := errors.New("config set-all not supported for remote stack config")
-				if configLocation.EscEnv != nil {
-					return fmt.Errorf("%w: use `pulumi env set %s pulumiConfig.<key> <value>`",
-						err, *configLocation.EscEnv)
-				}
-				return err
-			}
-
 			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
 			if err != nil {
+				return err
+			}
+			if err := checkRemoteProjectStack(stack, ps); err != nil {
 				return err
 			}
 
@@ -948,6 +924,12 @@ func newConfigSetAllCmd(
 			// loaded it.
 			var c config.Encrypter
 			encrypt := func(plaintext string) (string, error) {
+				// Remote (ESC-backed) stacks store secrets as fn::secret and are encrypted
+				// server-side, so the editor wraps the plaintext directly. An explicit
+				// --config-file writes locally even for a remote stack, so encrypt in that case.
+				if configStoreIsRemote(stack, *configFile) {
+					return plaintext, nil
+				}
 				var err error
 				if c == nil {
 					// We're always going to save, so can ignore the bool for if GetEncrypter changed the config data.
@@ -1262,6 +1244,11 @@ func getConfig(
 	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
 	if err != nil {
 		return err
+	}
+	// A remote stack with no service-side config yields a nil ProjectStack; reading should still
+	// surface environment-derived values, so treat it as empty rather than panicking.
+	if ps == nil {
+		ps = &workspace.ProjectStack{}
 	}
 
 	var env *esc.Environment

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -410,12 +410,14 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string, configFile *string) 
 				return err
 			}
 
-			err = ps.Config.Remove(key, path)
+			editor, err := newConfigEditor(ctx, stack, ps, config.NopEncrypter, *configFile)
 			if err != nil {
 				return err
 			}
-
-			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
+			if err = editor.Remove(ctx, key, path); err != nil {
+				return err
+			}
+			return editor.Save(ctx)
 		},
 	}
 	constrictor.AttachArguments(rmCmd, &constrictor.Arguments{
@@ -483,19 +485,22 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string, configFile *strin
 				return err
 			}
 
+			editor, err := newConfigEditor(ctx, stack, ps, config.NopEncrypter, *configFile)
+			if err != nil {
+				return err
+			}
 			for _, arg := range args {
 				key, err := ParseConfigKey(ws, arg, path)
 				if err != nil {
 					return fmt.Errorf("invalid configuration key: %w", err)
 				}
 
-				err = ps.Config.Remove(key, path)
-				if err != nil {
+				if err = editor.Remove(ctx, key, path); err != nil {
 					return err
 				}
 			}
 
-			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
+			return editor.Save(ctx)
 		},
 	}
 	constrictor.AttachArguments(rmAllCmd, &constrictor.Arguments{
@@ -782,22 +787,21 @@ func (c *configSetCmd) Run(
 		return err
 	}
 
-	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-
-	// Encrypt the config value if needed.
+	// The editor encrypts secrets, so pass plaintext as a secure value plus the encrypter to use.
+	encrypter := config.NopEncrypter
 	var v config.Value
 	if c.Secret {
-		// We're always going to save, so can ignore the bool for if getStackEncrypter changed the
-		// config data.
-		c, _, cerr := ssml.GetEncrypter(ctx, s, ps)
-		if cerr != nil {
-			return cerr
+		if !s.ConfigLocation().IsRemote {
+			ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
+			// GetEncrypter may update ps (e.g. set up a new encryption salt); Save persists ps
+			// unconditionally, so the changed-state bool can be ignored.
+			enc, _, cerr := ssml.GetEncrypter(ctx, s, ps)
+			if cerr != nil {
+				return cerr
+			}
+			encrypter = enc
 		}
-		enc, eerr := c.EncryptValue(ctx, value)
-		if eerr != nil {
-			return eerr
-		}
-		v = config.NewSecureValue(enc)
+		v = config.NewSecureValue(value)
 	} else {
 		var t config.Type
 		switch c.Type {
@@ -837,12 +841,14 @@ func (c *configSetCmd) Run(
 		return err
 	}
 
-	err = ps.Config.Set(key, v, c.Path)
+	editor, err := newConfigEditor(ctx, s, ps, encrypter, configFile)
 	if err != nil {
+		return err
+	}
+	if err = editor.Set(ctx, key, v, c.Path); err != nil {
 		return fmt.Errorf("could not set config: %w", err)
 	}
-
-	return cmdStack.SaveProjectStack(ctx, s, ps, configFile)
+	return editor.Save(ctx)
 }
 
 func newConfigSetAllCmd(
@@ -903,7 +909,24 @@ func newConfigSetAllCmd(
 				return err
 			}
 
+			if configStoreIsRemote(stack, *configFile) {
+				configLocation := stack.ConfigLocation()
+				err := errors.New("config set-all not supported for remote stack config")
+				if configLocation.EscEnv != nil {
+					return fmt.Errorf("%w: use `pulumi env set %s pulumiConfig.<key> <value>`",
+						err, *configLocation.EscEnv)
+				}
+				return err
+			}
+
 			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, *configFile)
+			if err != nil {
+				return err
+			}
+
+			// set-all pre-encrypts secrets via the encrypt closure below, so the editor is given a
+			// NopEncrypter to avoid re-encrypting already-encrypted values.
+			editor, err := newConfigEditor(ctx, stack, ps, config.NopEncrypter, *configFile)
 			if err != nil {
 				return err
 			}
@@ -915,8 +938,7 @@ func newConfigSetAllCmd(
 				}
 				v := config.NewValue(value)
 
-				err = ps.Config.Set(key, v, path)
-				if err != nil {
+				if err = editor.Set(ctx, key, v, path); err != nil {
 					return err
 				}
 			}
@@ -955,8 +977,7 @@ func newConfigSetAllCmd(
 				}
 				v := config.NewSecureValue(enc)
 
-				err = ps.Config.Set(key, v, path)
-				if err != nil {
+				if err = editor.Set(ctx, key, v, path); err != nil {
 					return err
 				}
 			}
@@ -1008,14 +1029,13 @@ func newConfigSetAllCmd(
 						value = config.NewValue(*jsonValue.Value)
 					}
 
-					err = ps.Config.Set(key, value, path)
-					if err != nil {
+					if err = editor.Set(ctx, key, value, path); err != nil {
 						return fmt.Errorf("could not set --json config for %q: %w", jsonKey, err)
 					}
 				}
 			}
 
-			return cmdStack.SaveProjectStack(ctx, stack, ps, *configFile)
+			return editor.Save(ctx)
 		},
 	}
 

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -159,13 +159,15 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
 	cmd.AddCommand(newConfigSetAllCmd(ws, &stack, cmdBackend.DefaultLoginManager, &ssml, &configFile))
 	cmd.AddCommand(newConfigRefreshCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
-	cmd.AddCommand(newConfigCopyCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigCopyCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
 	cmd.AddCommand(newConfigEnvCmd(ws, &stack, &configFile))
 
 	return cmd
 }
 
-func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string) *cobra.Command {
+func newConfigCopyCmd(
+	ws pkgWorkspace.Context, stack *string, lm cmdBackend.LoginManager, configFile *string,
+) *cobra.Command {
 	var path bool
 	var destinationStackName string
 
@@ -190,7 +192,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				cmdBackend.DefaultLoginManager,
+				lm,
 				*stack,
 				cmdStack.SetCurrent,
 				opts,
@@ -202,6 +204,17 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 			if currentStack.Ref().Name().String() == destinationStackName {
 				return errors.New("current stack and destination stack are the same")
 			}
+
+			if configStoreIsRemote(currentStack, *configFile) {
+				configLocation := currentStack.ConfigLocation()
+				err := errors.New("config copy source not supported for remote stack config")
+				if configLocation.EscEnv != nil {
+					return fmt.Errorf("%w: its config is managed in environment `%s`",
+						err, *configLocation.EscEnv)
+				}
+				return err
+			}
+
 			currentProjectStack, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, currentStack, *configFile)
 			if err != nil {
 				return err
@@ -212,7 +225,7 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				ctx,
 				cmdutil.Diag(),
 				ws,
-				cmdBackend.DefaultLoginManager,
+				lm,
 				destinationStackName,
 				cmdStack.LoadOnly,
 				opts,
@@ -227,7 +240,8 @@ func newConfigCopyCmd(ws pkgWorkspace.Context, stack *string, configFile *string
 				return err
 			}
 
-			if configLocation := destinationStack.ConfigLocation(); configLocation.IsRemote {
+			if configStoreIsRemote(destinationStack, *configFile) {
+				configLocation := destinationStack.ConfigLocation()
 				err := errors.New("config copy destination not supported for remote stack config")
 				if configLocation.EscEnv != nil {
 					return fmt.Errorf("%w: use `pulumi env set %s pulumiConfig.<key>`",

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -232,37 +232,6 @@ func (cmd *configEnvInitCmd) getStackConfig(
 	return ps, m, nil
 }
 
-func (cmd *configEnvInitCmd) render(v property.Value) any {
-	switch {
-	case v.Secret():
-		return map[string]any{
-			"fn::secret": cmd.render(v.WithSecret(false)),
-		}
-	case v.IsBool():
-		return v.AsBool()
-	case v.IsNumber():
-		return v.AsNumber()
-	case v.IsString():
-		return v.AsString()
-	case v.IsArray():
-		arrV := v.AsArray()
-		rendered := make([]any, arrV.Len())
-		for i, v := range arrV.All {
-			rendered[i] = cmd.render(v)
-		}
-		return rendered
-	case v.IsMap():
-		objV := v.AsMap()
-		rendered := make(map[string]any, objV.Len())
-		for k, v := range objV.All {
-			rendered[k] = cmd.render(v)
-		}
-		return rendered
-	default:
-		return nil
-	}
-}
-
 func (cmd *configEnvInitCmd) renderEnvironmentDefinition(
 	ctx context.Context,
 	envName string,
@@ -275,7 +244,7 @@ func (cmd *configEnvInitCmd) renderEnvironmentDefinition(
 	enc.SetIndent(2)
 	err := enc.Encode(map[string]any{
 		"values": map[string]any{
-			"pulumiConfig": cmd.render(property.New(config)),
+			"pulumiConfig": renderConfigValueForESC(property.New(config)),
 		},
 	})
 	if err != nil {

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -1178,6 +1178,88 @@ config:
 	})
 }
 
+func TestConfigCopyRemoteSource(t *testing.T) {
+	t.Parallel()
+
+	env := "org/my-env"
+	// The backend reports every stack as remote-config so the effective-store predicate, not the
+	// stack identity, decides whether the source guard fires.
+	setup := func() (cmdBackend.LoginManager, pkgWorkspace.Context) {
+		mockBackend := &backend.MockBackend{
+			GetStackF: func(_ context.Context, ref backend.StackReference) (backend.Stack, error) {
+				return &backend.MockStack{
+					RefF: func() backend.StackReference { return ref },
+					ConfigLocationF: func() backend.StackConfigLocation {
+						return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+					},
+					DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
+						return &secrets.MockSecretsManager{
+							TypeF:      func() string { return "mock" },
+							EncrypterF: func() config.Encrypter { return config.NewPanicCrypter() },
+							DecrypterF: func() config.Decrypter { return config.NewPanicCrypter() },
+						}, nil
+					},
+				}, nil
+			},
+			ParseStackReferenceF: func(s string) (backend.StackReference, error) {
+				return &backend.MockStackReference{
+					NameV:               tokens.MustParseStackName(s),
+					FullyQualifiedNameV: tokens.QName("org/testProject/" + s),
+				}, nil
+			},
+		}
+		lm := &cmdBackend.MockLoginManager{
+			LoginF: func(
+				_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
+				_ string, _ *workspace.Project, _ bool, _ bool, _ colors.Colorization,
+			) (backend.Backend, error) {
+				return mockBackend, nil
+			},
+		}
+		ws := &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				return &workspace.Project{Name: "testProject"}, "", nil
+			},
+			GetStoredCredentialsF: func() (workspace.Credentials, error) {
+				return workspace.Credentials{Current: "https://api.pulumi.com"}, nil
+			},
+		}
+		return lm, ws
+	}
+
+	t.Run("rejected when config is stored remotely", func(t *testing.T) {
+		t.Parallel()
+		lm, ws := setup()
+
+		stackName := "sourceStack"
+		configFile := ""
+		cmd := newConfigCopyCmd(ws, &stackName, lm, &configFile)
+		cmd.SetContext(t.Context())
+		require.NoError(t, cmd.PersistentFlags().Set("dest", "destStack"))
+
+		err := cmd.RunE(cmd, []string{})
+		require.ErrorContains(t, err, "config copy source not supported for remote stack config")
+		require.ErrorContains(t, err, env)
+	})
+
+	t.Run("--config-file overrides the remote link and is copied", func(t *testing.T) {
+		t.Parallel()
+		lm, ws := setup()
+
+		// Both stacks resolve to the same local file, so the copy reads and writes that file
+		// rather than the remote config; an empty source map makes it a clean no-op.
+		configFile := filepath.Join(t.TempDir(), "Pulumi.local.yaml")
+		require.NoError(t, os.WriteFile(configFile, []byte("config: {}\n"), 0o600))
+
+		stackName := "sourceStack"
+		cmd := newConfigCopyCmd(ws, &stackName, lm, &configFile)
+		cmd.SetContext(t.Context())
+		require.NoError(t, cmd.PersistentFlags().Set("dest", "destStack"))
+
+		require.NoError(t, cmd.RunE(cmd, []string{}))
+	})
+}
+
 func TestConfigPathOperations(t *testing.T) {
 	t.Parallel()
 	type testArgs struct {

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -974,6 +974,81 @@ func TestConfigSetAllConfigFileOverridesRemote(t *testing.T) {
 	require.Equal(t, "config:\n  testProject:key1: value1\n", string(data))
 }
 
+// An explicit --config-file writes to the local file even for a remote-config stack. A --secret
+// value on that path must be encrypted with the local encrypter, not stored as plaintext under a
+// secure: node (which would happen if the secret gate keyed off ConfigLocation().IsRemote alone
+// instead of the --config-file-aware configStoreIsRemote).
+func TestConfigSetAllSecretConfigFileEncryptsLocally(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	escEnv := "testProject/testStack"
+	s := backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &escEnv}
+		},
+	}
+
+	tmpdir := t.TempDir()
+	configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, "", nil
+		},
+	}
+
+	stackName := "testStack"
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return &backend.MockBackend{
+				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+					return &s, nil
+				},
+			}, nil
+		},
+		LoginF: func(
+			ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return &backend.MockBackend{
+				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+					return &s, nil
+				},
+			}, nil
+		},
+	}
+
+	mockEncrypterFactory := &mockEncrypterFactory{
+		encrypter: &secrets.MockEncrypter{
+			EncryptValueF: func(plaintext string) string {
+				return base64.StdEncoding.EncodeToString([]byte(plaintext))
+			},
+		},
+	}
+
+	cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory, &configFile)
+	cmd.SetContext(ctx)
+	require.NoError(t, cmd.PersistentFlags().Set("secret", "testProject:key1=supersecret"))
+
+	require.NoError(t, cmd.RunE(cmd, []string{}))
+
+	data, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	ciphertext := base64.StdEncoding.EncodeToString([]byte("supersecret"))
+	require.Contains(t, string(data), "secure: "+ciphertext)
+	require.NotContains(t, string(data), "supersecret")
+}
+
 func TestConfigRefresh(t *testing.T) {
 	t.Parallel()
 	minimalDeployment := &apitype.UntypedDeployment{

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -903,6 +903,77 @@ func (m *mockEncrypterFactory) GetEncrypter(
 	return m.encrypter, cmdStack.SecretsManagerUnchanged, nil
 }
 
+// An explicit --config-file selects a local file even when the stack is linked to remote config, so
+// set-all must write that file rather than reject the stack as remote.
+func TestConfigSetAllConfigFileOverridesRemote(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	escEnv := "testProject/testStack"
+	s := backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &escEnv}
+		},
+	}
+
+	tmpdir := t.TempDir()
+	configFile := filepath.Join(tmpdir, "Pulumi.stack.yaml")
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, "", nil
+		},
+	}
+
+	stackName := "testStack"
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool,
+		) (backend.Backend, error) {
+			return &backend.MockBackend{
+				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+					return &s, nil
+				},
+			}, nil
+		},
+		LoginF: func(
+			ctx context.Context, ws pkgWorkspace.Context, sink diag.Sink,
+			url string, project *workspace.Project, setCurrent bool, insecure bool, color colors.Colorization,
+		) (backend.Backend, error) {
+			return &backend.MockBackend{
+				GetStackF: func(ctx context.Context, ref backend.StackReference) (backend.Stack, error) {
+					return &s, nil
+				},
+			}, nil
+		},
+	}
+
+	mockEncrypterFactory := &mockEncrypterFactory{
+		encrypter: &secrets.MockEncrypter{
+			EncryptValueF: func(plaintext string) string {
+				return base64.StdEncoding.EncodeToString([]byte(plaintext))
+			},
+		},
+	}
+
+	cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory, &configFile)
+	cmd.SetContext(ctx)
+	require.NoError(t, cmd.PersistentFlags().Set("plaintext", "testProject:key1=value1"))
+
+	require.NoError(t, cmd.RunE(cmd, []string{}))
+
+	data, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	require.Equal(t, "config:\n  testProject:key1: value1\n", string(data))
+}
+
 func TestConfigRefresh(t *testing.T) {
 	t.Parallel()
 	minimalDeployment := &apitype.UntypedDeployment{

--- a/pkg/cmd/pulumi/config/coverage_sbc00_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc00_test.go
@@ -1,0 +1,237 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// remoteStackWithBackend builds a remote (ESC-backed) MockStack whose EscEnv ref and backing
+// EnvironmentsBackend are supplied by the caller, so constructor error paths can be exercised.
+func remoteStackWithBackend(env *string, be backend.Backend) *backend.MockStack {
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+func TestNewESCConfigEditorErrors(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	env := "proj/env"
+
+	t.Run("backend without environments support", func(t *testing.T) {
+		t.Parallel()
+		s := remoteStackWithBackend(&env, &backend.MockBackend{NameF: func() string { return "plain" }})
+		_, err := newESCConfigEditor(ctx, s)
+		require.ErrorContains(t, err, "does not support environments")
+	})
+
+	t.Run("missing linked environment", func(t *testing.T) {
+		t.Parallel()
+		s := remoteStackWithBackend(nil, &backend.MockEnvironmentsBackend{})
+		_, err := newESCConfigEditor(ctx, s)
+		require.ErrorContains(t, err, "no linked environment")
+	})
+
+	t.Run("malformed environment reference", func(t *testing.T) {
+		t.Parallel()
+		bad := "noslash"
+		s := remoteStackWithBackend(&bad, &backend.MockEnvironmentsBackend{})
+		_, err := newESCConfigEditor(ctx, s)
+		require.ErrorContains(t, err, "environment reference")
+	})
+
+	t.Run("GetEnvironment failure", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+				return nil, "", 0, errors.New("boom")
+			},
+		}
+		s := remoteStackWithBackend(&env, be)
+		_, err := newESCConfigEditor(ctx, s)
+		require.ErrorContains(t, err, "getting environment definition")
+	})
+
+	t.Run("unparseable environment definition", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+				return []byte("\tnot: [valid"), "etag", 0, nil
+			},
+		}
+		s := remoteStackWithBackend(&env, be)
+		_, err := newESCConfigEditor(ctx, s)
+		require.ErrorContains(t, err, "unmarshaling environment definition")
+	})
+}
+
+// newESCEditor builds an escConfigEditor over the given definition YAML, asserting the remote path
+// is taken. onUpdate (if non-nil) observes/overrides the upload performed by Save.
+func newESCEditor(
+	t *testing.T,
+	initialYAML string,
+	onUpdate func(yaml []byte, etag string) (apitype.EnvironmentDiagnostics, error),
+) *escConfigEditor {
+	t.Helper()
+	s := remoteStackForEditor(t, []byte(initialYAML), "etag", onUpdate)
+	editor, err := newConfigEditor(t.Context(), s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	esc, ok := editor.(*escConfigEditor)
+	require.True(t, ok)
+	return esc
+}
+
+func TestESCConfigEditorRemoveNoOps(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("no values node", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "{}\n", nil)
+		require.NoError(t, e.Remove(ctx, config.MustMakeKey("testProject", "missing"), false))
+	})
+
+	t.Run("absent key", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "values:\n  pulumiConfig:\n    testProject:other: v\n", nil)
+		require.NoError(t, e.Remove(ctx, config.MustMakeKey("testProject", "missing"), false))
+	})
+
+	t.Run("absent array index path", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "values:\n  pulumiConfig: {}\n", nil)
+		require.NoError(t, e.Remove(ctx, config.MustMakeKey("testProject", "names[0]"), true))
+	})
+}
+
+func TestESCConfigEditorSetInvalidPath(t *testing.T) {
+	t.Parallel()
+	e := newESCEditor(t, "values:\n  pulumiConfig: {}\n", nil)
+	err := e.Set(t.Context(), config.MustMakeKey("testProject", "root["), config.NewValue("v"), true)
+	require.ErrorContains(t, err, "invalid configuration key path")
+}
+
+// TestESCConfigEditorSaveReturnsDiags verifies that Save fails only when the update returns error
+// diagnostics. A successful update can carry non-error diagnostics (warnings), which must not turn
+// a write into a failure; an empty severity is treated as an error for backward compatibility.
+func TestESCConfigEditorSaveReturnsDiags(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	save := func(t *testing.T, diags apitype.EnvironmentDiagnostics) error {
+		t.Helper()
+		e := newESCEditor(t, "values:\n  pulumiConfig: {}\n",
+			func(_ []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+				return diags, nil
+			})
+		require.NoError(t, e.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+		return e.Save(ctx)
+	}
+
+	t.Run("error diagnostic fails", func(t *testing.T) {
+		t.Parallel()
+		err := save(t, apitype.EnvironmentDiagnostics{{Summary: "bad value", Severity: apitype.DiagError}})
+		require.ErrorContains(t, err, "updating environment")
+	})
+
+	t.Run("empty severity is treated as error", func(t *testing.T) {
+		t.Parallel()
+		err := save(t, apitype.EnvironmentDiagnostics{{Summary: "bad value"}})
+		require.ErrorContains(t, err, "updating environment")
+	})
+
+	t.Run("warning does not fail", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, save(t, apitype.EnvironmentDiagnostics{{Summary: "heads up", Severity: apitype.DiagWarning}}))
+	})
+}
+
+// TestConfigSetRemoteNilProjectStack covers the guard that rejects a config mutation against a
+// remote stack with no service-side configuration (a nil ProjectStack), which would otherwise panic.
+func TestConfigSetRemoteNilProjectStack(t *testing.T) {
+	t.Parallel()
+	env := "testProject/testStack"
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+	cmd := &configSetCmd{
+		LoadProjectStack: func(
+			_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			return nil, nil
+		},
+	}
+	project := &workspace.Project{Name: "testProject"}
+	ws := &pkgWorkspace.MockContext{}
+	err := cmd.Run(t.Context(), ws, []string{"testProject:k", "v"}, project, s, "")
+	require.ErrorContains(t, err, "config env init")
+}
+
+// TestConfigSetRemotePlaintext covers the non-secret remote write path of configSetCmd.Run: the
+// value is routed through the ESC editor and uploaded as a native scalar.
+//
+//nolint:paralleltest // exercises the command with shared mock state
+func TestConfigSetRemotePlaintext(t *testing.T) {
+	ctx := t.Context()
+
+	var uploaded []byte
+	s := remoteStackForEditor(t, []byte("values:\n  pulumiConfig: {}\n"), "etag",
+		func(y []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = y
+			return nil, nil
+		})
+
+	cmd := &configSetCmd{
+		LoadProjectStack: func(
+			_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			return &workspace.ProjectStack{Config: config.Map{}}, nil
+		},
+	}
+	project := &workspace.Project{Name: "testProject"}
+	ws := &pkgWorkspace.MockContext{}
+	require.NoError(t, cmd.Run(ctx, ws, []string{"testProject:key", "value"}, project, s, ""))
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "value", pc["testProject:key"])
+}

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	escEncoding "github.com/pulumi/esc/syntax/encoding"
 	"gopkg.in/yaml.v3"
@@ -113,6 +112,8 @@ type escConfigEditor struct {
 	envName    string
 	doc        yaml.Node
 	etag       string
+	// version is the pinned revision/tag read at (empty for latest); non-empty makes Save refuse to write.
+	version string
 }
 
 func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEditor, error) {
@@ -131,14 +132,15 @@ func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEdi
 	if ref == nil {
 		return nil, errors.New("stack is configured for remote config but has no linked environment")
 	}
-	// The linked env ref has the form "<project>/<name>" and may carry an "@version" suffix.
-	envRef, _, _ := strings.Cut(*ref, "@")
-	envProject, envName, found := strings.Cut(envRef, "/")
-	if !found {
-		return nil, fmt.Errorf("invalid environment reference %q: expected <project>/<name>", *ref)
+	envProject, envName, err := splitEnvRef(*ref)
+	if err != nil {
+		return nil, err
 	}
+	// Read at the pinned revision/tag when the ref carries one, else latest. Save still guards against
+	// writing to a pinned version regardless.
+	version := envRefVersion(*ref)
 
-	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
+	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, version, false)
 	if err != nil {
 		return nil, fmt.Errorf("getting environment definition: %w", err)
 	}
@@ -160,6 +162,7 @@ func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEdi
 		envName:    envName,
 		doc:        doc,
 		etag:       etag,
+		version:    version,
 	}, nil
 }
 
@@ -204,6 +207,11 @@ func (e *escConfigEditor) Remove(_ context.Context, key config.Key, path bool) e
 }
 
 func (e *escConfigEditor) Save(ctx context.Context) error {
+	if e.version != "" {
+		return fmt.Errorf("the stack's configuration is pinned to %s/%s@%s; "+
+			"run `pulumi config env pin latest` to unpin before making changes",
+			e.envProject, e.envName, e.version)
+	}
 	newYAML, err := yaml.Marshal(e.doc.Content[0])
 	if err != nil {
 		return fmt.Errorf("marshaling definition: %w", err)

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -17,11 +17,18 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+
+	escEncoding "github.com/pulumi/esc/syntax/encoding"
+	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // configEditor is a write-focused abstraction over a stack's configuration store. Mutations are
@@ -36,14 +43,13 @@ type configEditor interface {
 	Save(ctx context.Context) error
 }
 
-// newConfigEditor returns a configEditor for the stack's configuration store. encrypter is used by
-// the local editor to encrypt secret values before they are written to the stack file; it is unused
-// for stores that protect secrets themselves.
+// newConfigEditor returns a configEditor for the stack's configuration store. encrypter is used only
+// by the local editor; ESC-backed stores wrap secrets as fn::secret and encrypt them server-side.
 func newConfigEditor(
-	_ context.Context, stack backend.Stack, ps *workspace.ProjectStack, encrypter config.Encrypter, configFile string,
+	ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, encrypter config.Encrypter, configFile string,
 ) (configEditor, error) {
 	if configStoreIsRemote(stack, configFile) {
-		return nil, errors.New("editing remote stack configuration is not supported")
+		return newESCConfigEditor(ctx, stack)
 	}
 	return &localConfigEditor{stack: stack, ps: ps, encrypter: encrypter, configFile: configFile}, nil
 }
@@ -53,6 +59,16 @@ func newConfigEditor(
 // the precedence in cmdStack.LoadProjectStack/SaveProjectStack.
 func configStoreIsRemote(stack backend.Stack, configFile string) bool {
 	return configFile == "" && stack.ConfigLocation().IsRemote
+}
+
+// checkRemoteProjectStack guards mutation commands against a nil ProjectStack for remote stacks.
+// cloudStack.LoadRemoteConfig returns (nil, nil) when the service-side stack config is absent, and
+// LoadProjectStack passes that through; dereferencing it would panic.
+func checkRemoteProjectStack(stack backend.Stack, ps *workspace.ProjectStack) error {
+	if ps == nil && stack.ConfigLocation().IsRemote {
+		return errors.New("the stack has no remote configuration; run `pulumi config env init` to create one")
+	}
+	return nil
 }
 
 type localConfigEditor struct {
@@ -85,4 +101,234 @@ func (e *localConfigEditor) Remove(_ context.Context, key config.Key, path bool)
 
 func (e *localConfigEditor) Save(ctx context.Context) error {
 	return cmdStack.SaveProjectStack(ctx, e.stack, e.ps, e.configFile)
+}
+
+// escConfigEditor edits config in the ESC environment backing the stack, buffering edits against an
+// in-memory YAML doc and uploading on Save with etag-keyed read-modify-write. Secrets are wrapped as
+// fn::secret and encrypted server-side; this editor never encrypts or logs them.
+type escConfigEditor struct {
+	envBackend backend.EnvironmentsBackend
+	orgName    string
+	envProject string
+	envName    string
+	doc        yaml.Node
+	etag       string
+}
+
+func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEditor, error) {
+	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return nil, errors.New("internal error: stack does not provide an organization name")
+	}
+	orgName := orgNamer.OrgName()
+
+	ref := stack.ConfigLocation().EscEnv
+	if ref == nil {
+		return nil, errors.New("stack is configured for remote config but has no linked environment")
+	}
+	// The linked env ref has the form "<project>/<name>" and may carry an "@version" suffix.
+	envRef, _, _ := strings.Cut(*ref, "@")
+	envProject, envName, found := strings.Cut(envRef, "/")
+	if !found {
+		return nil, fmt.Errorf("invalid environment reference %q: expected <project>/<name>", *ref)
+	}
+
+	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
+	if err != nil {
+		return nil, fmt.Errorf("getting environment definition: %w", err)
+	}
+
+	var doc yaml.Node
+	if len(def) != 0 {
+		if err := yaml.Unmarshal(def, &doc); err != nil {
+			return nil, fmt.Errorf("unmarshaling environment definition: %w", err)
+		}
+	}
+	if doc.Kind != yaml.DocumentNode {
+		doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{}}}
+	}
+
+	return &escConfigEditor{
+		envBackend: envBackend,
+		orgName:    orgName,
+		envProject: envProject,
+		envName:    envName,
+		doc:        doc,
+		etag:       etag,
+	}, nil
+}
+
+func (e *escConfigEditor) Set(ctx context.Context, key config.Key, value config.Value, path bool) error {
+	valueNode, err := configValueToYAMLNode(ctx, key, value)
+	if err != nil {
+		return err
+	}
+
+	configPath, err := pulumiConfigPath(key, path)
+	if err != nil {
+		return err
+	}
+
+	valuesNode, err := e.ensureValuesNode()
+	if err != nil {
+		return err
+	}
+
+	if _, err := (escEncoding.YAMLSyntax{Node: valuesNode}).Set(nil, configPath, valueNode); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *escConfigEditor) Remove(_ context.Context, key config.Key, path bool) error {
+	configPath, err := pulumiConfigPath(key, path)
+	if err != nil {
+		return err
+	}
+
+	valuesNode, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"values"})
+	if !ok {
+		return nil
+	}
+	// Delete assumes every intermediate node on the path exists; if the full path is absent, treat
+	// the removal as a no-op rather than traversing a missing parent.
+	if _, ok := (escEncoding.YAMLSyntax{Node: valuesNode}).Get(configPath); !ok {
+		return nil
+	}
+	return escEncoding.YAMLSyntax{Node: valuesNode}.Delete(nil, configPath)
+}
+
+func (e *escConfigEditor) Save(ctx context.Context) error {
+	newYAML, err := yaml.Marshal(e.doc.Content[0])
+	if err != nil {
+		return fmt.Errorf("marshaling definition: %w", err)
+	}
+
+	diags, err := e.envBackend.UpdateEnvironmentWithProject(ctx, e.orgName, e.envProject, e.envName, newYAML, e.etag)
+	if err != nil {
+		if errors.Is(err, backend.ErrConfigConflict) {
+			return fmt.Errorf("the stack's configuration was modified concurrently; please retry: %w", err)
+		}
+		return err
+	}
+	if diags.HasErrors() {
+		return fmt.Errorf("updating environment: %w", diags)
+	}
+	return nil
+}
+
+func (e *escConfigEditor) ensureValuesNode() (*yaml.Node, error) {
+	valuesNode, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"values"})
+	if ok {
+		return valuesNode, nil
+	}
+	valuesNode, err := escEncoding.YAMLSyntax{Node: &e.doc}.Set(
+		nil, resource.PropertyPath{"values"}, yaml.Node{Kind: yaml.MappingNode})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %w", err)
+	}
+	return valuesNode, nil
+}
+
+// pulumiConfigPath builds the property path to a config key within an environment's `values` node,
+// rooted at `pulumiConfig`. For path keys the top-level segment is namespaced ("<ns>:<segment>") and
+// the remainder of the key's property path follows.
+func pulumiConfigPath(key config.Key, path bool) (resource.PropertyPath, error) {
+	if !path {
+		return resource.PropertyPath{"pulumiConfig", key.String()}, nil
+	}
+
+	nameSegments, err := resource.ParsePropertyPath(key.Name())
+	if err != nil {
+		return nil, fmt.Errorf("invalid configuration key path: %w", err)
+	}
+	if len(nameSegments) == 0 {
+		return nil, errors.New("configuration key path is empty")
+	}
+
+	// The first segment is the config key's name, which keys the namespaced top-level value; a leading
+	// array index has no value to index into.
+	first, ok := nameSegments[0].(string)
+	if !ok {
+		return nil, errors.New("configuration key path must begin with a name, not an array index")
+	}
+
+	result := make(resource.PropertyPath, 0, len(nameSegments)+1)
+	result = append(result, "pulumiConfig", key.Namespace()+":"+first)
+	result = append(result, nameSegments[1:]...)
+	return result, nil
+}
+
+// configValueToYAMLNode converts a config.Value (carrying plaintext for secrets) into a YAML node
+// with native types preserved and secrets wrapped as {fn::secret: <plaintext>}.
+func configValueToYAMLNode(ctx context.Context, key config.Key, value config.Value) (yaml.Node, error) {
+	pm, err := config.Map{key: value}.AsDecryptedPropertyMap(ctx, config.NopDecrypter)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	pv, ok := pm.GetOk(key.String())
+	if !ok {
+		return yaml.Node{}, fmt.Errorf("internal error: config value for %q not found after conversion", key.String())
+	}
+
+	rendered := renderConfigValueForESC(pv)
+
+	// A whole-object secret (e.g. `config set-all --json` with objectValue and secret:true) loses its
+	// top-level secret flag in AsDecryptedPropertyMap: object secrets are carried as nested markers,
+	// not a top-level flag, so the rendered object is plain. Wrap it as fn::secret here so the service
+	// encrypts the whole object.
+	if value.Secure() && value.Object() {
+		rendered = map[string]any{"fn::secret": rendered}
+	}
+
+	b, err := yaml.Marshal(rendered)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(b, &node); err != nil {
+		return yaml.Node{}, err
+	}
+	if len(node.Content) == 0 {
+		return yaml.Node{}, errors.New("internal error: empty value node")
+	}
+	return *node.Content[0], nil
+}
+
+// renderConfigValueForESC recursively converts a property.Value into native Go values for an ESC
+// definition, preserving scalar types and wrapping secrets as {fn::secret: <inner>}.
+func renderConfigValueForESC(v property.Value) any {
+	switch {
+	case v.Secret():
+		return map[string]any{
+			"fn::secret": renderConfigValueForESC(v.WithSecret(false)),
+		}
+	case v.IsBool():
+		return v.AsBool()
+	case v.IsNumber():
+		return v.AsNumber()
+	case v.IsString():
+		return v.AsString()
+	case v.IsArray():
+		arrV := v.AsArray()
+		rendered := make([]any, arrV.Len())
+		for i, v := range arrV.All {
+			rendered[i] = renderConfigValueForESC(v)
+		}
+		return rendered
+	case v.IsMap():
+		objV := v.AsMap()
+		rendered := make(map[string]any, objV.Len())
+		for k, v := range objV.All {
+			rendered[k] = renderConfigValueForESC(v)
+		}
+		return rendered
+	default:
+		return nil
+	}
 }

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -1,0 +1,88 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// configEditor is a write-focused abstraction over a stack's configuration store. Mutations are
+// buffered and persisted on Save. Callers pass plaintext for secrets (a config.Value with
+// Secure()=true whose raw value is the plaintext); the editor is responsible for encrypting or
+// otherwise protecting the secret according to where the config lives.
+type configEditor interface {
+	// If path is true, key's name is a property path within a map or list.
+	Set(ctx context.Context, key config.Key, value config.Value, path bool) error
+	// If path is true, key's name is a property path. Removing an absent key is a no-op.
+	Remove(ctx context.Context, key config.Key, path bool) error
+	Save(ctx context.Context) error
+}
+
+// newConfigEditor returns a configEditor for the stack's configuration store. encrypter is used by
+// the local editor to encrypt secret values before they are written to the stack file; it is unused
+// for stores that protect secrets themselves.
+func newConfigEditor(
+	_ context.Context, stack backend.Stack, ps *workspace.ProjectStack, encrypter config.Encrypter, configFile string,
+) (configEditor, error) {
+	if configStoreIsRemote(stack, configFile) {
+		return nil, errors.New("editing remote stack configuration is not supported")
+	}
+	return &localConfigEditor{stack: stack, ps: ps, encrypter: encrypter, configFile: configFile}, nil
+}
+
+// configStoreIsRemote reports whether the stack's configuration is effectively stored remotely. An
+// explicit --config-file selects a local file regardless of the stack's linked location, mirroring
+// the precedence in cmdStack.LoadProjectStack/SaveProjectStack.
+func configStoreIsRemote(stack backend.Stack, configFile string) bool {
+	return configFile == "" && stack.ConfigLocation().IsRemote
+}
+
+type localConfigEditor struct {
+	stack      backend.Stack
+	ps         *workspace.ProjectStack
+	encrypter  config.Encrypter
+	configFile string
+}
+
+func (e *localConfigEditor) Set(ctx context.Context, key config.Key, value config.Value, path bool) error {
+	// Secure object values already carry per-leaf ciphertext the caller produced; encrypting the
+	// whole serialized object as one blob would corrupt it, so only scalar secrets are encrypted here.
+	if value.Secure() && !value.Object() {
+		plaintext, err := value.Value(config.NopDecrypter)
+		if err != nil {
+			return err
+		}
+		encrypted, err := e.encrypter.EncryptValue(ctx, plaintext)
+		if err != nil {
+			return err
+		}
+		value = config.NewSecureValue(encrypted)
+	}
+	return e.ps.Config.Set(key, value, path)
+}
+
+func (e *localConfigEditor) Remove(_ context.Context, key config.Key, path bool) error {
+	return e.ps.Config.Remove(key, path)
+}
+
+func (e *localConfigEditor) Save(ctx context.Context) error {
+	return cmdStack.SaveProjectStack(ctx, e.stack, e.ps, e.configFile)
+}

--- a/pkg/cmd/pulumi/config/editor_test.go
+++ b/pkg/cmd/pulumi/config/editor_test.go
@@ -17,18 +17,22 @@ package config
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"testing"
 
+	escEncoding "github.com/pulumi/esc/syntax/encoding"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
-	"github.com/stretchr/testify/require"
 )
 
 func base64Crypters() (config.Encrypter, config.Decrypter) {
@@ -77,11 +81,12 @@ func TestNewConfigEditor(t *testing.T) {
 		require.IsType(t, &localConfigEditor{}, editor)
 	})
 
-	t.Run("remote stack is rejected", func(t *testing.T) {
+	t.Run("remote stack returns ESC editor", func(t *testing.T) {
 		t.Parallel()
-		s := localStackForEditor(true)
-		_, err := newConfigEditor(ctx, &s, ps, config.NopEncrypter, "")
-		require.Error(t, err)
+		s := remoteStackForEditor(t, []byte("values:\n  pulumiConfig: {}\n"), "etag", nil)
+		editor, err := newConfigEditor(ctx, s, ps, config.NopEncrypter, "")
+		require.NoError(t, err)
+		require.IsType(t, &escConfigEditor{}, editor)
 	})
 }
 
@@ -174,14 +179,33 @@ func mustRawValue(t *testing.T, v config.Value) string {
 	return raw
 }
 
-// TestConfigSetAllRemoteRejected guards the IsRemote check added to set-all, which previously had
-// none and failed only downstream in SaveRemoteConfig.
-func TestConfigSetAllRemoteRejected(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
+// remoteStackForEditor builds a remote (ESC-backed) MockStack whose EnvironmentsBackend returns the
+// given definition YAML and etag from GetEnvironment, and whose UpdateEnvironmentWithProject calls
+// onUpdate (if non-nil) with the uploaded YAML, returning that callback's result.
+func remoteStackForEditor(
+	t *testing.T,
+	getYAML []byte,
+	getEtag string,
+	onUpdate func(yaml []byte, etag string) (apitype.EnvironmentDiagnostics, error),
+) *backend.MockStack {
+	t.Helper()
 	env := "testProject/testStack"
-	s := backend.MockStack{
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(
+			_ context.Context, _, _, _, _ string, _ bool,
+		) ([]byte, string, int, error) {
+			return getYAML, getEtag, 0, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, yaml []byte, etag string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			if onUpdate != nil {
+				return onUpdate(yaml, etag)
+			}
+			return nil, nil
+		},
+	}
+	return &backend.MockStack{
 		RefF: func() backend.StackReference {
 			return &backend.MockStackReference{
 				NameV:               tokens.MustParseStackName("testStack"),
@@ -191,44 +215,413 @@ func TestConfigSetAllRemoteRejected(t *testing.T) {
 		ConfigLocationF: func() backend.StackConfigLocation {
 			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
 		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+// editForRemote runs a single Set or Remove against an escConfigEditor backed by initialYAML and
+// returns the uploaded YAML.
+func editForRemote(
+	t *testing.T,
+	initialYAML string,
+	edit func(t *testing.T, editor *escConfigEditor),
+) []byte {
+	t.Helper()
+	ctx := t.Context()
+	var uploaded []byte
+	s := remoteStackForEditor(t, []byte(initialYAML), "etag",
+		func(yaml []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = yaml
+			return nil, nil
+		})
+	editor, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	esc, ok := editor.(*escConfigEditor)
+	require.True(t, ok)
+	edit(t, esc)
+	require.NoError(t, esc.Save(ctx))
+	return uploaded
+}
+
+func TestESCConfigEditorSet(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("plaintext scalar is a plain string", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n", func(t *testing.T, e *escConfigEditor) {
+			key := config.MustMakeKey("testProject", "key")
+			require.NoError(t, e.Set(ctx, key, config.NewValue("value"), false))
+		})
+		require.Equal(t, "string", scalarTag(t, uploaded, "testProject:key"))
+		require.Equal(t, "value", scalarValue(t, uploaded, "testProject:key"))
+	})
+
+	t.Run("typed values are native, not quoted strings", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name      string
+			value     config.Value
+			wantTag   string
+			wantValue string
+		}{
+			{"bool", config.NewTypedValue("true", config.TypeBool), "bool", "true"},
+			{"int", config.NewTypedValue("42", config.TypeInt), "int", "42"},
+			{"float", config.NewTypedValue("3.14", config.TypeFloat), "float", "3.14"},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				t.Parallel()
+				uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n",
+					func(t *testing.T, e *escConfigEditor) {
+						key := config.MustMakeKey("testProject", c.name)
+						require.NoError(t, e.Set(ctx, key, c.value, false))
+					})
+				require.Equal(t, c.wantTag, scalarTag(t, uploaded, "testProject:"+c.name))
+				require.Equal(t, c.wantValue, scalarValue(t, uploaded, "testProject:"+c.name))
+			})
+		}
+	})
+
+	t.Run("object value is a native mapping with array preserved", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n", func(t *testing.T, e *escConfigEditor) {
+			key := config.MustMakeKey("testProject", "obj")
+			require.NoError(t, e.Set(ctx, key, config.NewObjectValue(`{"a":1,"b":[2,3]}`), false))
+		})
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+		values := doc["values"].(map[string]any)
+		pc := values["pulumiConfig"].(map[string]any)
+		obj := pc["testProject:obj"].(map[string]any)
+		require.Equal(t, 1, obj["a"])
+		require.Equal(t, []any{2, 3}, obj["b"])
+	})
+
+	t.Run("secret scalar is wrapped as fn::secret in plaintext", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n", func(t *testing.T, e *escConfigEditor) {
+			key := config.MustMakeKey("testProject", "secret")
+			require.NoError(t, e.Set(ctx, key, config.NewSecureValue("plaintext"), false))
+		})
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+		values := doc["values"].(map[string]any)
+		pc := values["pulumiConfig"].(map[string]any)
+		secret := pc["testProject:secret"].(map[string]any)
+		require.Equal(t, "plaintext", secret["fn::secret"])
+	})
+}
+
+func TestESCConfigEditorPreservesUntouchedContent(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const initial = `# top comment
+imports:
+  - shared-env
+values:
+  environmentVariables:
+    FOO: bar # keep me
+  pulumiConfig:
+    testProject:existing: keep
+`
+	t.Run("set", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+			key := config.MustMakeKey("testProject", "added")
+			require.NoError(t, e.Set(ctx, key, config.NewValue("new"), false))
+		})
+		out := string(uploaded)
+		require.Contains(t, out, "# top comment")
+		require.Contains(t, out, "imports:")
+		require.Contains(t, out, "- shared-env")
+		require.Contains(t, out, "FOO: bar # keep me")
+		require.Contains(t, out, "testProject:existing: keep")
+		require.Contains(t, out, "testProject:added: new")
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+			key := config.MustMakeKey("testProject", "existing")
+			require.NoError(t, e.Remove(ctx, key, false))
+		})
+		out := string(uploaded)
+		require.Contains(t, out, "# top comment")
+		require.Contains(t, out, "imports:")
+		require.Contains(t, out, "- shared-env")
+		require.Contains(t, out, "FOO: bar # keep me")
+		require.NotContains(t, out, "testProject:existing")
+	})
+}
+
+func TestESCConfigEditorRemove(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const initial = `values:
+  pulumiConfig:
+    testProject:a: 1
+    testProject:b: 2
+`
+	uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+		require.NoError(t, e.Remove(ctx, config.MustMakeKey("testProject", "a"), false))
+	})
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	_, hasA := pc["testProject:a"]
+	require.False(t, hasA)
+	require.Equal(t, 2, pc["testProject:b"])
+}
+
+// TestESCConfigEditorArrayIndexPath verifies that path keys with array-index segments round-trip:
+// Set materializes a native YAML sequence under the namespaced config key, and Remove deletes an
+// element by index. This matches local `pulumi config set --path 'foo[0]'` and `esc env set`.
+func TestESCConfigEditorArrayIndexPath(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	pulumiConfigArray := func(t *testing.T, uploaded []byte) []any {
+		t.Helper()
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+		pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+		arr, ok := pc["testProject:foo"].([]any)
+		require.True(t, ok, "expected testProject:foo to be a sequence, got %#v", pc["testProject:foo"])
+		return arr
 	}
 
-	// No --config-file: the stack's remote location governs, so set-all must reject.
-	configFile := ""
+	t.Run("set creates and extends a sequence", func(t *testing.T) {
+		t.Parallel()
+		uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n", func(t *testing.T, e *escConfigEditor) {
+			require.NoError(t, e.Set(ctx, config.MustMakeKey("testProject", "foo[0]"), config.NewValue("a"), true))
+			require.NoError(t, e.Set(ctx, config.MustMakeKey("testProject", "foo[1]"), config.NewValue("b"), true))
+		})
+		require.Equal(t, []any{"a", "b"}, pulumiConfigArray(t, uploaded))
+	})
 
-	ws := &pkgWorkspace.MockContext{
-		ReadProjectF: func() (*workspace.Project, string, error) {
-			return &workspace.Project{Name: "testProject"}, "", nil
+	t.Run("remove deletes an element by index", func(t *testing.T) {
+		t.Parallel()
+		const initial = `values:
+  pulumiConfig:
+    testProject:foo:
+      - a
+      - b
+`
+		uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+			require.NoError(t, e.Remove(ctx, config.MustMakeKey("testProject", "foo[0]"), true))
+		})
+		require.Equal(t, []any{"b"}, pulumiConfigArray(t, uploaded))
+	})
+}
+
+func TestESCConfigEditorEtagConflict(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	s := remoteStackForEditor(t, []byte("values:\n  pulumiConfig: {}\n"), "etag",
+		func(_ []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+			// The cloud backend translates esc's 409 into ErrConfigConflict; the editor contracts
+			// on that sentinel, not on the esc client's error type.
+			return nil, fmt.Errorf("updating environment: %w", backend.ErrConfigConflict)
+		})
+	editor, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	require.NoError(t, editor.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+	err = editor.Save(ctx)
+	require.ErrorContains(t, err, "modified concurrently")
+}
+
+func TestESCConfigEditorPassesEtag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	var gotEtag string
+	s := remoteStackForEditor(t, []byte("values:\n  pulumiConfig: {}\n"), "the-etag",
+		func(_ []byte, etag string) (apitype.EnvironmentDiagnostics, error) {
+			gotEtag = etag
+			return nil, nil
+		})
+	editor, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	require.NoError(t, editor.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+	require.NoError(t, editor.Save(ctx))
+	require.Equal(t, "the-etag", gotEtag)
+}
+
+func TestCheckRemoteProjectStackNilGuard(t *testing.T) {
+	t.Parallel()
+	env := "testProject/testStack"
+	remote := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+	require.Error(t, checkRemoteProjectStack(remote, nil))
+	require.NoError(t, checkRemoteProjectStack(remote, &workspace.ProjectStack{}))
+
+	local := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+	}
+	require.NoError(t, checkRemoteProjectStack(local, nil))
+}
+
+// scalarTag returns the YAML scalar kind ("string"/"int"/"float"/"bool") of values.pulumiConfig.<key>.
+func scalarTag(t *testing.T, doc []byte, key string) string {
+	t.Helper()
+	n := pulumiConfigScalar(t, doc, key)
+	switch n.Tag {
+	case "!!str":
+		return "string"
+	case "!!int":
+		return "int"
+	case "!!float":
+		return "float"
+	case "!!bool":
+		return "bool"
+	default:
+		return n.Tag
+	}
+}
+
+func scalarValue(t *testing.T, doc []byte, key string) string {
+	t.Helper()
+	return pulumiConfigScalar(t, doc, key).Value
+}
+
+func pulumiConfigScalar(t *testing.T, doc []byte, key string) *yaml.Node {
+	t.Helper()
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal(doc, &root))
+	n, ok := escEncoding.YAMLSyntax{Node: &root}.Get(resource.PropertyPath{"values", "pulumiConfig", key})
+	require.True(t, ok, "key %q not found", key)
+	require.Equal(t, yaml.ScalarNode, n.Kind)
+	return n
+}
+
+// TestConfigSetSecretRemoteCommand exercises the full `config set --secret` command path against a
+// remote stack, verifying the plaintext is passed through to the editor (not encrypted locally) and
+// uploaded as fn::secret.
+//
+//nolint:paralleltest // exercises the command with shared mock state
+func TestConfigSetSecretRemoteCommand(t *testing.T) {
+	ctx := t.Context()
+
+	var uploaded []byte
+	s := remoteStackForEditor(t, []byte("values:\n  pulumiConfig: {}\n"), "etag",
+		func(y []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = y
+			return nil, nil
+		})
+
+	cmd := &configSetCmd{
+		Secret: true,
+		LoadProjectStack: func(
+			_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			return &workspace.ProjectStack{Config: config.Map{}}, nil
 		},
 	}
 
-	stackName := "testStack"
-	mockBackend := &backend.MockBackend{
-		GetStackF: func(_ context.Context, _ backend.StackReference) (backend.Stack, error) {
-			return &s, nil
+	project := &workspace.Project{Name: "testProject"}
+	ws := &pkgWorkspace.MockContext{}
+	err := cmd.Run(ctx, ws, []string{"testProject:tok", "shh"}, project, s, "")
+	require.NoError(t, err)
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "shh", pc["testProject:tok"].(map[string]any)["fn::secret"])
+}
+
+// TestESCConfigEditorStripsEnvVersion verifies an "@version" suffix on the linked env ref is stripped
+// before addressing the environment.
+func TestESCConfigEditorStripsEnvVersion(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	var gotProject, gotName string
+	env := "myproj/myenv@7"
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(
+			_ context.Context, _, project, name, _ string, _ bool,
+		) ([]byte, string, int, error) {
+			gotProject, gotName = project, name
+			return []byte("values:\n  pulumiConfig: {}\n"), "etag", 0, nil
 		},
 	}
-	lm := &cmdBackend.MockLoginManager{
-		CurrentF: func(
-			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			_ string, _ *workspace.Project, _ bool,
-		) (backend.Backend, error) {
-			return mockBackend, nil
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
 		},
-		LoginF: func(
-			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
-			_ string, _ *workspace.Project, _ bool, _ bool, _ colors.Colorization,
-		) (backend.Backend, error) {
-			return mockBackend, nil
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
 		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
 	}
 
-	mockEncrypterFactory := &mockEncrypterFactory{encrypter: config.NopEncrypter}
-	cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory, &configFile)
-	cmd.SetContext(ctx)
-	require.NoError(t, cmd.PersistentFlags().Set("plaintext", "testProject:key=value"))
+	_, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	require.Equal(t, "myproj", gotProject)
+	require.Equal(t, "myenv", gotName)
+}
 
-	err := cmd.RunE(cmd, []string{})
-	require.ErrorContains(t, err, "config set-all not supported for remote stack config")
-	require.ErrorContains(t, err, "pulumi env set testProject/testStack pulumiConfig.<key> <value>")
+// TestESCConfigEditorSecureObject covers the set-all --json objectValue+secret path: a secure object
+// value set with path=true must upload as fn::secret wrapping the native object (not a stringified
+// blob, not plaintext).
+func TestESCConfigEditorSecureObject(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	uploaded := editForRemote(t, "values:\n  pulumiConfig: {}\n", func(t *testing.T, e *escConfigEditor) {
+		key := config.MustMakeKey("testProject", "obj")
+		require.NoError(t, e.Set(ctx, key, config.NewSecureObjectValue(`{"inner":"v","n":1}`), true))
+	})
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	secret := pc["testProject:obj"].(map[string]any)
+	inner, ok := secret["fn::secret"].(map[string]any)
+	require.True(t, ok, "expected fn::secret to wrap a native object, got %#v", secret["fn::secret"])
+	require.Equal(t, "v", inner["inner"])
+	require.Equal(t, 1, inner["n"])
+}
+
+// TestESCConfigEditorEmptyDefinition covers a freshly linked env whose definition has no values node
+// yet: the first Set must create values.pulumiConfig rather than fail on the missing path.
+func TestESCConfigEditorEmptyDefinition(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	uploaded := editForRemote(t, "{}\n", func(t *testing.T, e *escConfigEditor) {
+		require.NoError(t, e.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+	})
+	require.Equal(t, "v", scalarValue(t, uploaded, "testProject:k"))
+}
+
+// TestESCConfigEditorPreservesExistingSecretCiphertext locks in the design's core claim: the editor
+// works at the node level with decrypt=false, so an existing fn::secret ciphertext on an untouched key
+// round-trips byte-for-byte when a different key is edited (it is never decrypted or re-wrapped).
+func TestESCConfigEditorPreservesExistingSecretCiphertext(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const initial = `values:
+  pulumiConfig:
+    testProject:existing:
+      fn::secret:
+        ciphertext: ZXhpc3Rpbmctc2VjcmV0
+    testProject:plain: old
+`
+	uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+		require.NoError(t, e.Set(ctx, config.MustMakeKey("testProject", "plain"), config.NewValue("new"), false))
+	})
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "new", pc["testProject:plain"])
+	secret := pc["testProject:existing"].(map[string]any)["fn::secret"].(map[string]any)
+	require.Equal(t, "ZXhpc3Rpbmctc2VjcmV0", secret["ciphertext"], "existing ciphertext must round-trip untouched")
 }

--- a/pkg/cmd/pulumi/config/editor_test.go
+++ b/pkg/cmd/pulumi/config/editor_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+func base64Crypters() (config.Encrypter, config.Decrypter) {
+	enc := &secrets.MockEncrypter{
+		EncryptValueF: func(plaintext string) string {
+			return base64.StdEncoding.EncodeToString([]byte(plaintext))
+		},
+	}
+	dec := &secrets.MockDecrypter{
+		DecryptValueF: func(ciphertext string) string {
+			decoded, _ := base64.StdEncoding.DecodeString(ciphertext)
+			return string(decoded)
+		},
+	}
+	return enc, dec
+}
+
+func localStackForEditor(remote bool) backend.MockStack {
+	return backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			if remote {
+				env := "testProject/testStack"
+				return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+			}
+			return backend.StackConfigLocation{}
+		},
+	}
+}
+
+func TestNewConfigEditor(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	ps := &workspace.ProjectStack{Config: config.Map{}}
+
+	t.Run("local stack", func(t *testing.T) {
+		t.Parallel()
+		s := localStackForEditor(false)
+		editor, err := newConfigEditor(ctx, &s, ps, config.NopEncrypter, "")
+		require.NoError(t, err)
+		require.IsType(t, &localConfigEditor{}, editor)
+	})
+
+	t.Run("remote stack is rejected", func(t *testing.T) {
+		t.Parallel()
+		s := localStackForEditor(true)
+		_, err := newConfigEditor(ctx, &s, ps, config.NopEncrypter, "")
+		require.Error(t, err)
+	})
+}
+
+func TestLocalConfigEditor(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	enc, dec := base64Crypters()
+
+	newEditor := func() (*localConfigEditor, *workspace.ProjectStack) {
+		s := localStackForEditor(false)
+		ps := &workspace.ProjectStack{Config: config.Map{}}
+		return &localConfigEditor{stack: &s, ps: ps, encrypter: enc}, ps
+	}
+
+	t.Run("plaintext value", func(t *testing.T) {
+		t.Parallel()
+		editor, ps := newEditor()
+		key := config.MustMakeKey("testProject", "key")
+		require.NoError(t, editor.Set(ctx, key, config.NewValue("value"), false))
+
+		got, ok, err := ps.Config.Get(key, false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.False(t, got.Secure())
+		v, err := got.Value(config.NopDecrypter)
+		require.NoError(t, err)
+		require.Equal(t, "value", v)
+	})
+
+	t.Run("secret value is encrypted by the editor", func(t *testing.T) {
+		t.Parallel()
+		editor, ps := newEditor()
+		key := config.MustMakeKey("testProject", "secret")
+		require.NoError(t, editor.Set(ctx, key, config.NewSecureValue("plaintext"), false))
+
+		got, ok, err := ps.Config.Get(key, false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, got.Secure())
+		require.False(t, got.Object())
+		// The editor encrypted the plaintext: the stored ciphertext is base64, and decrypting
+		// recovers the plaintext.
+		require.Equal(t, base64.StdEncoding.EncodeToString([]byte("plaintext")), mustRawValue(t, got))
+		v, err := got.Value(dec)
+		require.NoError(t, err)
+		require.Equal(t, "plaintext", v)
+	})
+
+	t.Run("secure object value passes through unencrypted", func(t *testing.T) {
+		t.Parallel()
+		// Secure object values carry per-leaf ciphertext the caller already produced. Even with a
+		// real (non-Nop) encrypter, the editor must not re-encrypt the serialized object as one blob;
+		// it must store it unchanged with its object and secure flags intact.
+		editor, ps := newEditor()
+		key := config.MustMakeKey("testProject", "obj")
+		objJSON := `{"inner":{"secure":"` + base64.StdEncoding.EncodeToString([]byte("leaf")) + `"}}`
+		require.NoError(t, editor.Set(ctx, key, config.NewSecureObjectValue(objJSON), false))
+
+		got, ok, err := ps.Config.Get(key, false)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, got.Secure())
+		require.True(t, got.Object())
+		require.Equal(t, objJSON, mustRawValue(t, got))
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
+		editor, ps := newEditor()
+		key := config.MustMakeKey("testProject", "key")
+		require.NoError(t, editor.Set(ctx, key, config.NewValue("value"), false))
+		require.NoError(t, editor.Remove(ctx, key, false))
+
+		_, ok, err := ps.Config.Get(key, false)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("remove absent key is a no-op", func(t *testing.T) {
+		t.Parallel()
+		editor, _ := newEditor()
+		require.NoError(t, editor.Remove(ctx, config.MustMakeKey("testProject", "missing"), false))
+	})
+}
+
+func mustRawValue(t *testing.T, v config.Value) string {
+	t.Helper()
+	raw, err := v.Value(config.NopDecrypter)
+	require.NoError(t, err)
+	return raw
+}
+
+// TestConfigSetAllRemoteRejected guards the IsRemote check added to set-all, which previously had
+// none and failed only downstream in SaveRemoteConfig.
+func TestConfigSetAllRemoteRejected(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	env := "testProject/testStack"
+	s := backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+
+	// No --config-file: the stack's remote location governs, so set-all must reject.
+	configFile := ""
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, "", nil
+		},
+	}
+
+	stackName := "testStack"
+	mockBackend := &backend.MockBackend{
+		GetStackF: func(_ context.Context, _ backend.StackReference) (backend.Stack, error) {
+			return &s, nil
+		},
+	}
+	lm := &cmdBackend.MockLoginManager{
+		CurrentF: func(
+			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
+			_ string, _ *workspace.Project, _ bool,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+		LoginF: func(
+			_ context.Context, _ pkgWorkspace.Context, _ diag.Sink,
+			_ string, _ *workspace.Project, _ bool, _ bool, _ colors.Colorization,
+		) (backend.Backend, error) {
+			return mockBackend, nil
+		},
+	}
+
+	mockEncrypterFactory := &mockEncrypterFactory{encrypter: config.NopEncrypter}
+	cmd := newConfigSetAllCmd(ws, &stackName, lm, mockEncrypterFactory, &configFile)
+	cmd.SetContext(ctx)
+	require.NoError(t, cmd.PersistentFlags().Set("plaintext", "testProject:key=value"))
+
+	err := cmd.RunE(cmd, []string{})
+	require.ErrorContains(t, err, "config set-all not supported for remote stack config")
+	require.ErrorContains(t, err, "pulumi env set testProject/testStack pulumiConfig.<key> <value>")
+}

--- a/pkg/cmd/pulumi/config/editor_test.go
+++ b/pkg/cmd/pulumi/config/editor_test.go
@@ -568,6 +568,39 @@ func TestESCConfigEditorStripsEnvVersion(t *testing.T) {
 	require.Equal(t, "myenv", gotName)
 }
 
+// TestESCConfigEditorPinnedVersion verifies the editor reads the pinned revision when the stack's
+// linked ref carries an @version, and that Save refuses to write to a pinned environment.
+func TestESCConfigEditorPinnedVersion(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	var gotVersion string
+	env := "testProject/testStack@5"
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, version string, _ bool) ([]byte, string, int, error) {
+			gotVersion = version
+			return []byte("values:\n  pulumiConfig: {}\n"), "etag", 0, nil
+		},
+	}
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	editor, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	require.Equal(t, "5", gotVersion, "the editor must read the pinned revision, not the latest")
+
+	require.NoError(t, editor.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+	require.ErrorContains(t, editor.Save(ctx), "pinned", "Save must refuse to write to a pinned environment")
+}
+
 // TestESCConfigEditorSecureObject covers the set-all --json objectValue+secret path: a secure object
 // value set with path=true must upload as fn::secret wrapping the native object (not a stringified
 // blob, not plaintext).

--- a/pkg/cmd/pulumi/config/envref.go
+++ b/pkg/cmd/pulumi/config/envref.go
@@ -1,0 +1,69 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+)
+
+// A linked environment reference has the form "<project>/<name>" and may carry a version qualifier on
+// the tail as "@<version>" or ":<version>". ESC accepts both separators and treats "@" as primary with
+// ":" as the fallback (esc cmd/esc/cli/env.go), so the helpers below must too — detecting only "@"
+// silently misses a ":"-pinned ref.
+
+// envRefVersion returns the pinned revision or tag in an environment reference, or "" when unpinned.
+func envRefVersion(ref string) string {
+	if _, version, found := strings.Cut(ref, "@"); found {
+		return version
+	}
+	_, version, _ := strings.Cut(ref, ":")
+	return version
+}
+
+// stripEnvVersion returns the bare "<project>/<name>" form with any version qualifier removed.
+func stripEnvVersion(ref string) string {
+	if base, _, found := strings.Cut(ref, "@"); found {
+		return base
+	}
+	base, _, _ := strings.Cut(ref, ":")
+	return base
+}
+
+func splitEnvRef(ref string) (project, name string, err error) {
+	project, name, found := strings.Cut(stripEnvVersion(ref), "/")
+	if !found || project == "" || name == "" {
+		return "", "", fmt.Errorf("malformed environment reference %q; expected <project>/<name>", ref)
+	}
+	return project, name, nil
+}
+
+// rejectIfPinned refuses a mutation when the stack's remote configuration is pinned to a specific
+// environment revision or tag. Writing through a pinned ref would silently target the latest revision
+// the pinned stack never resolves, so callers must unpin first. An explicit --config-file routes the
+// write to a local file regardless of the stack's remote link, so the pin guard does not apply.
+func rejectIfPinned(stack backend.Stack, configFile string) error {
+	loc := stack.ConfigLocation()
+	if !configStoreIsRemote(stack, configFile) || loc.EscEnv == nil {
+		return nil
+	}
+	if envRefVersion(*loc.EscEnv) != "" {
+		return fmt.Errorf("the stack's configuration is pinned to %s; "+
+			"run `pulumi config env pin latest` to unpin before making changes", *loc.EscEnv)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/config/envref_test.go
+++ b/pkg/cmd/pulumi/config/envref_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+)
+
+func TestEnvRefVersion(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"proj/env":         "",
+		"proj/env@7":       "7",
+		"proj/env@stable":  "stable",
+		"proj/env:7":       "7",
+		"proj/env:stable":  "stable",
+		"proj/env@7:extra": "7:extra", // "@" wins; everything after it is the version
+	}
+	for ref, want := range cases {
+		require.Equal(t, want, envRefVersion(ref), ref)
+	}
+}
+
+func TestStripEnvVersion(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"proj/env":        "proj/env",
+		"proj/env@7":      "proj/env",
+		"proj/env:7":      "proj/env",
+		"proj/env:stable": "proj/env",
+	}
+	for ref, want := range cases {
+		require.Equal(t, want, stripEnvVersion(ref), ref)
+	}
+}
+
+func TestSplitEnvRef(t *testing.T) {
+	t.Parallel()
+
+	for _, ref := range []string{"proj/env", "proj/env@7", "proj/env:7"} {
+		project, name, err := splitEnvRef(ref)
+		require.NoError(t, err, ref)
+		require.Equal(t, "proj", project, ref)
+		require.Equal(t, "env", name, ref)
+	}
+
+	for _, ref := range []string{"env", "env@7", "/env", "proj/", ""} {
+		_, _, err := splitEnvRef(ref)
+		require.Error(t, err, ref)
+	}
+}
+
+func TestRejectIfPinned(t *testing.T) {
+	t.Parallel()
+
+	remote := func(ref string) backend.Stack {
+		return &backend.MockStack{
+			ConfigLocationF: func() backend.StackConfigLocation {
+				return backend.StackConfigLocation{IsRemote: true, EscEnv: &ref}
+			},
+		}
+	}
+
+	// A pinned ref (via either separator) is rejected with an actionable message.
+	require.ErrorContains(t, rejectIfPinned(remote("proj/env@5"), ""), "unpin")
+	require.ErrorContains(t, rejectIfPinned(remote("proj/env:5"), ""), "unpin")
+
+	// An unpinned ref is allowed.
+	require.NoError(t, rejectIfPinned(remote("proj/env"), ""))
+
+	// An explicit --config-file routes the write to a local file, so the pin guard must not fire even
+	// for a pinned remote stack.
+	require.NoError(t, rejectIfPinned(remote("proj/env@5"), "Pulumi.local.yaml"))
+
+	// A local stack is never pinned.
+	local := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: false}
+		},
+	}
+	require.NoError(t, rejectIfPinned(local, ""))
+}

--- a/sdk/go/common/apitype/environments.go
+++ b/sdk/go/common/apitype/environments.go
@@ -21,10 +21,25 @@ import (
 	"github.com/pulumi/esc"
 )
 
+// EnvironmentDiagnosticSeverity is the severity of an EnvironmentDiagnostic. An empty severity is
+// treated as an error for backward compatibility with services that predate the field.
+type EnvironmentDiagnosticSeverity string
+
+const (
+	DiagError   EnvironmentDiagnosticSeverity = "error"
+	DiagWarning EnvironmentDiagnosticSeverity = "warning"
+)
+
 type EnvironmentDiagnostic struct {
-	Range   *esc.Range `json:"range,omitempty"`
-	Summary string     `json:"summary,omitempty"`
-	Detail  string     `json:"detail,omitempty"`
+	Range    *esc.Range                    `json:"range,omitempty"`
+	Summary  string                        `json:"summary,omitempty"`
+	Detail   string                        `json:"detail,omitempty"`
+	Severity EnvironmentDiagnosticSeverity `json:"severity,omitempty"`
+}
+
+// IsError reports whether the diagnostic is an error. An empty severity is treated as an error.
+func (d EnvironmentDiagnostic) IsError() bool {
+	return d.Severity == DiagError || d.Severity == ""
 }
 
 type EnvironmentDiagnostics []EnvironmentDiagnostic
@@ -36,6 +51,17 @@ func (err EnvironmentDiagnostics) Error() string {
 		fmt.Fprintf(&diags, "%v\n", d.Summary)
 	}
 	return diags.String()
+}
+
+// HasErrors reports whether any diagnostic is an error (as opposed to a warning or other non-error
+// severity). A successful environment update can still return non-error diagnostics.
+func (err EnvironmentDiagnostics) HasErrors() bool {
+	for _, d := range err {
+		if d.IsError() {
+			return true
+		}
+	}
+	return false
 }
 
 type EnvironmentDiagnosticsResponse struct {


### PR DESCRIPTION
## Summary

Towards pulumi/pulumi-service#39624
Towards pulumi/pulumi#19557 

Make the core `pulumi config` write commands — `set`, `set-all`, `rm`, `rm-all` —
operate on remote-config stacks, whose configuration lives in a linked ESC
environment instead of a local `Pulumi.<stack>.yaml`. Reading already works
(`pulumi config get` resolves values from remote-config stacks today); this PR
adds the write side. Internally this is "service-backed config (SBC)"; externally
it's "remote config" for now.

This is the first in a series of stacked PRs delivering SBC; more functionality
(hidden create flags, edit/console, migration, eject, pin/restore) follows in
later PRs per the design doc linked from the tracking issues.

The change lands bottom-up:

- **Local `configEditor` seam** — routes config mutations through an editor
  abstraction; the local file-backed implementation preserves today's behavior.
  Routing is by *effective* storage location, so an explicit `--config-file`
  writes locally even for a remote-linked stack.
- **ESC-backed editor** — adds the two `EnvironmentsBackend` primitives the
  editor needs (`GetEnvironment` reads a definition at a version, returning etag
  and revision; `UpdateEnvironmentWithProject` replaces it under an optional etag
  guard — thin wrappers over the vendored esc client that preserve etags and
  diagnostics, wired for the cloud and mock backends), plus the ESC-backed editor
  implementation. The write commands mutate the linked environment: only the
  touched `values.pulumiConfig` node is edited (imports, comments, and unrelated
  sections are preserved), secrets — including whole-object secrets — are wrapped
  as `fn::secret` for server-side encryption, and `--path` keys with array-index
  segments round-trip as they do for local stacks (only a *leading* array index is
  rejected, since the first path segment must name the config key). Concurrent edits are detected via
  the environment etag: the cloud backend translates esc's 409 update rejection
  into `backend.ErrConfigConflict`, surfaced as a retryable conflict. A nil
  `ProjectStack` from a remote stack with no service-side config produces a clean
  error instead of panicking.
- **Pinned-stack guard** — `set`/`set-all`/`rm`/`rm-all` refuse when a
  remote-config stack is pinned to a specific environment revision or tag,
  pointing at `pin latest` to unpin. Honors `--config-file` (a local-file write is
  allowed regardless of the remote pin). The commands that create a pinned state
  land later in the stack, so this guard is inert until then.
- **`config cp` guard** — `config cp` copies through `ProjectStack.Config`, which
  is empty for a remote-config stack because its values live in the linked ESC
  environment. A remote-config destination is rejected (service-side config writes
  are unsupported) and a remote-config source is rejected (copying would otherwise
  silently copy nothing, or report "key not found" for a key that does exist in the
  environment). Both ends honor `--config-file`, so file-based copies still work.

No behavior change for local stacks.

## Test plan
- [x] Unit tests: local/ESC editor split, secret handling (scalar + whole-object),
  the `--config-file` override on a remote-linked stack, etag-conflict translation,
  the pinned-stack guard, and the `config cp` source/destination guards
- [x] Manually exercised `set`, `set-all`, `rm`, and `rm-all` against a
  remote-config stack locally

## Validation
- [x] `make lint` — clean
- [x] `make test_fast` — pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [x] `make check_proto` — N/A (no proto changes)

## Changelog

None in this PR. Remote-config stacks are hidden/opt-in — gated by hidden CLI
flags and the LaunchDarkly flag `39623-service-backed-config` — so nothing here is
user-reachable yet. The user-facing changelog entry lands with the PR that
un-hides the feature. Applying `impact/no-changelog-required`.

## Risk

Low. No local-stack behavior change, and the remote path is unreachable without
both the hidden flags and the server flag. The new `EnvironmentsBackend` methods
are an optional, type-asserted capability, so out-of-tree backends that don't
implement them degrade to "not supported" rather than failing to build. Blast
radius is the `config` command and the httpstate backend.
