### PR TITLE
Improve login prompt

### DIFF
--- a/changelog/pending/20260602--cli-cloud--clarify-interactive-login-prompt.yaml
+++ b/changelog/pending/20260602--cli-cloud--clarify-interactive-login-prompt.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: chore
+  scope: cli/cloud
+  description: Clarify the interactive `pulumi login` prompt to describe Pulumi Cloud and lead with the browser login option

--- a/changelog/pending/20260602--cli-cloud--clarify-interactive-login-prompt.yaml
+++ b/changelog/pending/20260602--cli-cloud--clarify-interactive-login-prompt.yaml
@@ -1,4 +1,0 @@
-changes:
-- type: chore
-  scope: cli/cloud
-  description: Clarify the interactive `pulumi login` prompt to describe Pulumi Cloud and lead with the browser login option

--- a/changelog/pending/cli-cloud-improvement-20260602-130111.yaml
+++ b/changelog/pending/cli-cloud-improvement-20260602-130111.yaml
@@ -1,0 +1,6 @@
+component: cli/cloud
+kind: improvement
+body: Improve the interactive `pulumi login` prompt wording and coloring
+time: 2026-06-02T13:01:11.249892-07:00
+custom:
+    PR: "23417"

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -790,18 +790,13 @@ func (m defaultLoginManager) Login(
 
 	// If no access token is available from the environment, and we are interactive, prompt and offer to
 	// open a browser to make it easy to generate and use a fresh token.
-	line1 := "Manage your " + message + " by logging in."
-	line1len := len(line1)
-	line1 = colors.Highlight(line1, message, colors.Underline+colors.Bold)
+	line1 := "Connect to Pulumi Cloud for state storage, config management, team collaboration, and more."
+	line1 = colors.Highlight(line1, "Pulumi Cloud", colors.Underline+colors.Bold)
 	fmt.Println(opts.Color.Colorize(line1))
-	maxlen := line1len
+	fmt.Println()
 
-	line2 := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
-	line2len := len(line2)
-	fmt.Println(opts.Color.Colorize(line2))
-	if line2len > maxlen {
-		maxlen = line2len
-	}
+	// Printed after the user responds to the prompt, regardless of which login path they choose.
+	helpLine := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
 
 	// In the case where we could not construct a link to the pulumi console based on the API server's hostname,
 	// don't offer magic log-in or text about where to find your access token.
@@ -814,26 +809,24 @@ func (m defaultLoginManager) Login(
 				break
 			}
 		}
+
+		fmt.Println()
+		fmt.Println(opts.Color.Colorize(helpLine))
 	} else {
-		line3 := "Enter your access token from " + accountLink
-		line3len := len(line3)
-		line3 = colors.Highlight(line3, "access token", colors.BrightCyan+colors.Bold)
-		line3 = colors.Highlight(line3, accountLink, colors.BrightBlue+colors.Underline+colors.Bold)
-		fmt.Println(opts.Color.Colorize(line3))
-		if line3len > maxlen {
-			maxlen = line3len
-		}
+		browserLine := "Press <ENTER> to log in with your browser, or"
+		browserLine = colors.Highlight(browserLine, "<ENTER>", colors.BrightCyan+colors.Bold)
+		fmt.Println(opts.Color.Colorize(browserLine))
 
-		line4 := "    or hit <ENTER> to log in using your browser"
-		var padding string
-		if pad := maxlen - len(line4); pad > 0 {
-			padding = strings.Repeat(" ", pad)
-		}
-		line4 = colors.Highlight(line4, "<ENTER>", colors.BrightCyan+colors.Bold)
+		prompt := "paste an access token from " + accountLink
+		prompt = colors.Highlight(prompt, "access token", colors.BrightCyan+colors.Bold)
+		prompt = colors.Highlight(prompt, accountLink, colors.BrightBlue+colors.Underline+colors.Bold)
 
-		if accessToken, err = cmdutil.ReadConsoleNoEcho(opts.Color.Colorize(line4) + padding); err != nil {
+		if accessToken, err = cmdutil.ReadConsoleNoEcho(opts.Color.Colorize(prompt)); err != nil {
 			return nil, err
 		}
+
+		fmt.Println()
+		fmt.Println(opts.Color.Colorize(helpLine))
 
 		if accessToken == "" {
 			return loginWithBrowser(ctx, cloudURL, insecure, command, welcome, setCurrent, opts)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -790,6 +790,10 @@ func (m defaultLoginManager) Login(
 
 	// If no access token is available from the environment, and we are interactive, prompt and offer to
 	// open a browser to make it easy to generate and use a fresh token.
+	//
+	// TODO: The `message` parameter is no longer used now that the prompt is the same regardless of
+	// caller. It used to differentiate between "Pulumi stacks" and "Pulumi ESC environments". Once the
+	// ESC CLI is merged into the Pulumi CLI, drop the parameter from the LoginManager.Login signature.
 	line1 := "Connect to Pulumi Cloud for state storage, config management, team collaboration, and more."
 	line1 = colors.Highlight(line1, "Pulumi Cloud", colors.SpecHeadline)
 	fmt.Println(opts.Color.Colorize(line1))

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -791,11 +791,13 @@ func (m defaultLoginManager) Login(
 	// If no access token is available from the environment, and we are interactive, prompt and offer to
 	// open a browser to make it easy to generate and use a fresh token.
 	line1 := "Connect to Pulumi Cloud for state storage, config management, team collaboration, and more."
-	line1 = colors.Highlight(line1, "Pulumi Cloud", colors.Underline+colors.Bold)
+	line1 = colors.Highlight(line1, "Pulumi Cloud", colors.SpecHeadline)
 	fmt.Println(opts.Color.Colorize(line1))
 	fmt.Println()
 
+	// Dim the help line so it reads as a secondary aside next to the headline and prompt.
 	line2 := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
+	line2 = colors.BrightBlack + line2 + colors.Reset
 	fmt.Println(opts.Color.Colorize(line2))
 	fmt.Println()
 
@@ -812,12 +814,12 @@ func (m defaultLoginManager) Login(
 		}
 	} else {
 		browserLine := "Press <ENTER> to log in with your browser, or"
-		browserLine = colors.Highlight(browserLine, "<ENTER>", colors.BrightCyan+colors.Bold)
+		browserLine = colors.Highlight(browserLine, "<ENTER>", colors.SpecPrompt)
 		fmt.Println(opts.Color.Colorize(browserLine))
 
 		prompt := "paste an access token from " + accountLink
-		prompt = colors.Highlight(prompt, "access token", colors.BrightCyan+colors.Bold)
-		prompt = colors.Highlight(prompt, accountLink, colors.BrightBlue+colors.Underline+colors.Bold)
+		prompt = colors.Highlight(prompt, "access token", colors.SpecPrompt)
+		prompt = colors.Highlight(prompt, accountLink, colors.BrightBlue+colors.Underline)
 
 		if accessToken, err = cmdutil.ReadConsoleNoEcho(opts.Color.Colorize(prompt)); err != nil {
 			return nil, err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -795,8 +795,9 @@ func (m defaultLoginManager) Login(
 	fmt.Println(opts.Color.Colorize(line1))
 	fmt.Println()
 
-	// Printed after the user responds to the prompt, regardless of which login path they choose.
-	helpLine := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
+	line2 := fmt.Sprintf("Run `%s login --help` for alternative login options.", command)
+	fmt.Println(opts.Color.Colorize(line2))
+	fmt.Println()
 
 	// In the case where we could not construct a link to the pulumi console based on the API server's hostname,
 	// don't offer magic log-in or text about where to find your access token.
@@ -809,9 +810,6 @@ func (m defaultLoginManager) Login(
 				break
 			}
 		}
-
-		fmt.Println()
-		fmt.Println(opts.Color.Colorize(helpLine))
 	} else {
 		browserLine := "Press <ENTER> to log in with your browser, or"
 		browserLine = colors.Highlight(browserLine, "<ENTER>", colors.BrightCyan+colors.Bold)
@@ -824,9 +822,6 @@ func (m defaultLoginManager) Login(
 		if accessToken, err = cmdutil.ReadConsoleNoEcho(opts.Color.Colorize(prompt)); err != nil {
 			return nil, err
 		}
-
-		fmt.Println()
-		fmt.Println(opts.Color.Colorize(helpLine))
 
 		if accessToken == "" {
 			return loginWithBrowser(ctx, cloudURL, insecure, command, welcome, setCurrent, opts)


### PR DESCRIPTION
### Description

Rewords the interactive `pulumi login` prompt to better explain what logging into Pulumi Cloud gives you and to lead with the browser login option.

**Before:**
```
Manage your Pulumi stacks by logging in.
Run `pulumi login --help` for alternative login options.
Enter your access token from https://app.pulumi.com/account/tokens
            or hit <ENTER> to log in using your browser                   :
```

**After:**
```
Connect to Pulumi Cloud for state storage, config management, team collaboration, and more.

Run `pulumi login --help` for alternative login options.

Press <ENTER> to log in with your browser, or
paste an access token from https://app.pulumi.com/user/settings/tokens:
```

Notes:
- Leads with the value proposition, then the `pulumi login --help` line, then the browser/paste-token prompt.
- The `/user/settings/tokens` token URL already landed in master via #23378; no change needed there.
- No change to the public `LoginManager.Login` interface.

### Checklist

- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)