### PR TITLE
Avoid double-wrapping input-typed values in Go programgen

### DIFF
--- a/changelog/pending/programgen-go-fix-20260602-160037.yaml
+++ b/changelog/pending/programgen-go-fix-20260602-160037.yaml
@@ -1,0 +1,6 @@
+component: programgen/go
+kind: fix
+body: double-wrapping of plain values passed to input types when generating Go programs
+time: 2026-06-02T16:00:37.164204131-05:00
+custom:
+    PR: "23418"

--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -385,6 +386,29 @@ func TestIntrinsicConvertScopeTraversalToOutputScalar(t *testing.T) {
 
 	g.Fgenf(&index, "%v", expr)
 	assert.Equal(t, "pulumi.String(notSecret)", index.String())
+}
+
+// Regression test for pulumi/pulumi#22256.
+func TestIntrinsicConvertScopeTraversalToInputScalarNoDoubleWrap(t *testing.T) {
+	t.Parallel()
+
+	g := newTestGenerator(t, filepath.Join("aws-s3-logging-pp", "aws-s3-logging.pp"))
+	var index bytes.Buffer
+
+	// Resource argument Input<T> binds as union(T, Output<T>) annotated with
+	// schema.InputType.
+	inputType := model.NewUnionTypeAnnotated(
+		[]model.Type{model.StringType, model.NewOutputType(model.StringType)},
+		&schema.InputType{ElementType: schema.StringType},
+	)
+
+	expr := pcl.NewConvertCall(
+		model.VariableReference(&model.Variable{Name: "bucketName", VariableType: model.StringType}),
+		inputType,
+	)
+
+	g.Fgenf(&index, "%v", expr)
+	assert.Equal(t, "pulumi.String(bucketName)", index.String())
 }
 
 func TestTupleConsExpression(t *testing.T) {

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -295,20 +295,19 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				if cns, ok := scalarType.(*model.ConstType); ok {
 					scalarType = cns.Type
 				}
-				switch scalarType {
-				case model.StringType, model.IntType, model.NumberType, model.BoolType, model.DynamicType:
-					if typeName := g.argumentTypeName(to, isOutput); typeName != "" {
-						g.Fgenf(w, "%s(", typeName)
-						g.genScopeTraversalExpression(w, arg, expr.Type())
-						g.Fgenf(w, ")")
-						return
-					}
-				default:
-					// For collection types (maps, objects, lists), wrap with pulumi.ToMap/ToArray.
-					// Only do this when genScopeTraversalExpression won't already handle the
-					// conversion via its isInput/array-helper logic, which it does when the
-					// expression type has an associated schema type.
-					if _, hasSchema := pcl.GetSchemaForType(expr.Type()); !hasSchema {
+				// Schema-backed destinations are cast by genScopeTraversalExpression;
+				// casting here too would double-wrap values like pulumi.String(pulumi.String(x)).
+				if _, hasSchema := pcl.GetSchemaForType(expr.Type()); !hasSchema {
+					switch scalarType {
+					case model.StringType, model.IntType, model.NumberType, model.BoolType, model.DynamicType:
+						if typeName := g.argumentTypeName(to, isOutput); typeName != "" {
+							g.Fgenf(w, "%s(", typeName)
+							g.genScopeTraversalExpression(w, arg, expr.Type())
+							g.Fgenf(w, ")")
+							return
+						}
+					default:
+						// For collection types (maps, objects, lists), wrap with pulumi.ToMap/ToArray.
 						switch scalarType.(type) {
 						case *model.ObjectType, *model.MapType:
 							g.Fgenf(w, "pulumi.ToMap(")

--- a/tests/testdata/codegen/aws-eks-pp/go/aws-eks.go
+++ b/tests/testdata/codegen/aws-eks-pp/go/aws-eks.go
@@ -61,7 +61,7 @@ func main() {
 				VpcId:                       eksVpc.ID(),
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
 				CidrBlock:                   pulumi.Sprintf("10.100.%v.0/24", key0),
-				AvailabilityZone:            pulumi.String(pulumi.String(val0)),
+				AvailabilityZone:            pulumi.String(val0),
 				Tags: pulumi.StringMap{
 					"Name": pulumi.Sprintf("pulumi-sn-%v", val0),
 				},
@@ -135,7 +135,7 @@ func main() {
 		}
 		json0 := string(tmpJSON0)
 		eksRole, err := iam.NewRole(ctx, "eksRole", &iam.RoleArgs{
-			AssumeRolePolicy: pulumi.String(pulumi.String(json0)),
+			AssumeRolePolicy: pulumi.String(json0),
 		})
 		if err != nil {
 			return err
@@ -172,7 +172,7 @@ func main() {
 		}
 		json1 := string(tmpJSON1)
 		ec2Role, err := iam.NewRole(ctx, "ec2Role", &iam.RoleArgs{
-			AssumeRolePolicy: pulumi.String(pulumi.String(json1)),
+			AssumeRolePolicy: pulumi.String(json1),
 		})
 		if err != nil {
 			return err

--- a/tests/testdata/codegen/aws-fargate-pp/go/aws-fargate.go
+++ b/tests/testdata/codegen/aws-fargate-pp/go/aws-fargate.go
@@ -27,7 +27,7 @@ func main() {
 		}
 		// Create a security group that permits HTTP ingress and unrestricted egress.
 		webSecurityGroup, err := ec2.NewSecurityGroup(ctx, "webSecurityGroup", &ec2.SecurityGroupArgs{
-			VpcId: pulumi.String(pulumi.String(vpc.Id)),
+			VpcId: pulumi.String(vpc.Id),
 			Egress: ec2.SecurityGroupEgressArray{
 				&ec2.SecurityGroupEgressArgs{
 					Protocol: pulumi.String("-1"),
@@ -76,7 +76,7 @@ func main() {
 		json0 := string(tmpJSON0)
 		// Create an IAM role that can be used by our service's task.
 		taskExecRole, err := iam.NewRole(ctx, "taskExecRole", &iam.RoleArgs{
-			AssumeRolePolicy: pulumi.String(pulumi.String(json0)),
+			AssumeRolePolicy: pulumi.String(json0),
 		})
 		if err != nil {
 			return err
@@ -102,7 +102,7 @@ func main() {
 			Port:       pulumi.Int(80),
 			Protocol:   pulumi.String("HTTP"),
 			TargetType: pulumi.String("ip"),
-			VpcId:      pulumi.String(pulumi.String(vpc.Id)),
+			VpcId:      pulumi.String(vpc.Id),
 		})
 		if err != nil {
 			return err
@@ -147,7 +147,7 @@ func main() {
 				pulumi.String("FARGATE"),
 			},
 			ExecutionRoleArn:     taskExecRole.Arn,
-			ContainerDefinitions: pulumi.String(pulumi.String(json1)),
+			ContainerDefinitions: pulumi.String(json1),
 		})
 		if err != nil {
 			return err

--- a/tests/testdata/codegen/aws-iam-policy-pp/go/aws-iam-policy.go
+++ b/tests/testdata/codegen/aws-iam-policy-pp/go/aws-iam-policy.go
@@ -40,7 +40,7 @@ func main() {
 		policy, err := iam.NewPolicy(ctx, "policy", &iam.PolicyArgs{
 			Path:        pulumi.String("/"),
 			Description: pulumi.String("My test policy"),
-			Policy:      pulumi.String(pulumi.String(json0)),
+			Policy:      pulumi.String(json0),
 		})
 		if err != nil {
 			return err

--- a/tests/testdata/codegen/aws-optionals-pp/go/aws-optionals.go
+++ b/tests/testdata/codegen/aws-optionals-pp/go/aws-optionals.go
@@ -27,7 +27,7 @@ func main() {
 		_, err = iam.NewPolicy(ctx, "example", &iam.PolicyArgs{
 			Name:   pulumi.String("example_policy"),
 			Path:   pulumi.String("/"),
-			Policy: pulumi.String(pulumi.String(policyDocument.Json)),
+			Policy: pulumi.String(policyDocument.Json),
 		})
 		if err != nil {
 			return err

--- a/tests/testdata/codegen/aws-webserver-pp/go/aws-webserver.go
+++ b/tests/testdata/codegen/aws-webserver-pp/go/aws-webserver.go
@@ -51,7 +51,7 @@ func main() {
 			SecurityGroups: pulumi.StringArray{
 				securityGroup.Name,
 			},
-			Ami:      pulumi.String(pulumi.String(ami.Id)),
+			Ami:      pulumi.String(ami.Id),
 			UserData: pulumi.String("#!/bin/bash\necho \"Hello, World!\" > index.html\nnohup python -m SimpleHTTPServer 80 &\n"),
 		})
 		if err != nil {

--- a/tests/testdata/codegen/azure-sa-pp/go/azure-sa.go
+++ b/tests/testdata/codegen/azure-sa-pp/go/azure-sa.go
@@ -33,12 +33,12 @@ func main() {
 			storageAccountTypeReplicationParam = param
 		}
 		storageAccountResource, err := storage.NewAccount(ctx, "storageAccountResource", &storage.AccountArgs{
-			Name:                   pulumi.String(pulumi.String(storageAccountNameParam)),
+			Name:                   pulumi.String(storageAccountNameParam),
 			AccountKind:            pulumi.String("StorageV2"),
-			Location:               pulumi.String(pulumi.String(locationParam)),
-			ResourceGroupName:      pulumi.String(pulumi.String(resourceGroupNameParam)),
-			AccountTier:            pulumi.String(pulumi.String(storageAccountTierParam)),
-			AccountReplicationType: pulumi.String(pulumi.String(storageAccountTypeReplicationParam)),
+			Location:               pulumi.String(locationParam),
+			ResourceGroupName:      pulumi.String(resourceGroupNameParam),
+			AccountTier:            pulumi.String(storageAccountTierParam),
+			AccountReplicationType: pulumi.String(storageAccountTypeReplicationParam),
 		})
 		if err != nil {
 			return err

--- a/tests/testdata/codegen/components-pp/go/exampleComponent.go
+++ b/tests/testdata/codegen/components-pp/go/exampleComponent.go
@@ -49,7 +49,7 @@ func NewExampleComponent(
 	password, err := random.NewRandomPassword(ctx, fmt.Sprintf("%s-password", name), &random.RandomPasswordArgs{
 		Length:          pulumi.Int(16),
 		Special:         pulumi.Bool(true),
-		OverrideSpecial: pulumi.String(args.Input),
+		OverrideSpecial: args.Input,
 	}, pulumi.Parent(&componentResource))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fixes https://github.com/pulumi/pulumi/issues/22256

When Go program generation converted a plain value into an input-typed destination, such as a resource argument, it could emit an extra Pulumi wrapper:

```go
pulumi.String(pulumi.String(bucketName))
```

`genScopeTraversalExpression` already knows how to emit the input cast when the destination type carries a schema input type. The `IntrinsicConvert` handler was adding another cast for the same conversion. This changes that handler to only add its own cast when there is no associated schema type, leaving the schema-aware path to produce the single expected wrapper.

The generated output is now:

```go
pulumi.String(bucketName)
```

## Test plan

- [x] Added a regression test for converting a scope traversal into an input-typed scalar destination
- [x] Regenerated affected Go programgen golden files with `PULUMI_ACCEPT=1`

## Validation

- [x] `mise exec -- make lint` - clean
- [x] `mise exec -- make test_fast` - all pass
- [ ] make tidy_fix — clean
- [ ] make format — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] make check_proto — clean (if proto changes)

## Changelog

- [x] Changelog entry added (`changelog/pending/programgen-go-fix-20260602-160037.yaml`)

## Risk

Low. This is limited to Go program generation for conversions into input-typed destinations. The main risk is changing generated Go for cases that previously relied on the redundant wrapper, but the updated golden files show the intended output stays type-correct while removing the duplicate cast.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.
-->
