### PR TITLE
Support up/down arrows for prompt history in `pulumi neo`

### DIFF
--- a/changelog/pending/cli-neo-improvement-20260603-000000.yaml
+++ b/changelog/pending/cli-neo-improvement-20260603-000000.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: improvement
+body: Support up/down arrows to scroll through prompt history in `pulumi neo`
+time: 2026-06-03T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/cli-neo-improvement-20260603-000000.yaml
+++ b/changelog/pending/cli-neo-improvement-20260603-000000.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Support up/down arrows to scroll through prompt history in `pulumi neo`
 time: 2026-06-03T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23425"

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -311,6 +311,19 @@ type Model struct {
 	toolHistory   []toolCallRecord
 	overlayActive bool
 	overlay       overlayModel
+	// history holds the prompts the user has submitted this session, oldest
+	// first, recalled with the up/down arrows. There is intentionally no
+	// footer hint for it — the affordance mirrors shell history and is
+	// meant to be discovered by muscle memory.
+	history []string
+	// historyIdx is the cursor into history during up/down navigation. It
+	// equals len(history) when not navigating, i.e. the user is editing the
+	// live draft; stepping back with Up walks it down toward the oldest entry.
+	historyIdx int
+	// historyDraft stashes the in-progress draft when history navigation
+	// begins, so pressing Down past the newest entry restores what the user
+	// had typed rather than leaving a recalled prompt behind.
+	historyDraft string
 }
 
 var (
@@ -381,6 +394,42 @@ func nextPermissionMode(m client.NeoPermissionMode) client.NeoPermissionMode {
 		return client.NeoPermissionModeDefault
 	}
 	return client.NeoPermissionModeReadOnly
+}
+
+// historyPrev steps to an older prompt. It returns true when it handled the
+// key (so the caller swallows it). The first step out of the live draft
+// stashes that draft in historyDraft so a later Down can restore it.
+func (m *Model) historyPrev() bool {
+	if len(m.history) == 0 {
+		return false
+	}
+	if m.historyIdx == 0 {
+		return true // already at the oldest entry; pin here
+	}
+	if m.historyIdx == len(m.history) {
+		m.historyDraft = m.textInput.Value()
+	}
+	m.historyIdx--
+	m.textInput.SetValue(m.history[m.historyIdx])
+	m.textInput.MoveToEnd()
+	return true
+}
+
+// historyNext steps toward newer prompts; past the newest it restores the
+// saved draft. It returns false when not currently navigating so Down falls
+// through to the textarea's own cursor movement.
+func (m *Model) historyNext() bool {
+	if m.historyIdx >= len(m.history) {
+		return false
+	}
+	m.historyIdx++
+	if m.historyIdx == len(m.history) {
+		m.textInput.SetValue(m.historyDraft)
+	} else {
+		m.textInput.SetValue(m.history[m.historyIdx])
+	}
+	m.textInput.MoveToEnd()
+	return true
 }
 
 // renderIndented word-wraps content (ANSI-safe) to termWidth minus the
@@ -804,6 +853,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					// UIUserMessage handler to avoid duplicates.
 					userCmd := m.appendUserMessageBlock(text)
 					m.pendingUserEchoes = append(m.pendingUserEchoes, text)
+					// Record the prompt for up/down history recall. Skip a
+					// consecutive duplicate so mashing the same message
+					// doesn't bloat the history.
+					if n := len(m.history); n == 0 || m.history[n-1] != text {
+						m.history = append(m.history, text)
+					}
+					m.historyIdx = len(m.history)
+					m.historyDraft = ""
 					// Freeze the plan-mode affordance: planMode has now been
 					// committed to the dispatcher and any later Shift+Tab
 					// would be a no-op on the server.
@@ -812,6 +869,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
+		}
+
+		// Up/Down recall prompt history when the cursor sits on the edge line
+		// of the input — mirroring shell history. Mid-buffer they fall through
+		// to the textarea's line movement. No footer hint is shown, by design.
+		if keyStr == "up" && m.textInput.Line() == 0 {
+			if m.historyPrev() {
+				return m, nil
+			}
+		}
+		if keyStr == "down" && m.textInput.Line() == m.textInput.LineCount()-1 {
+			if m.historyNext() {
+				return m, nil
+			}
 		}
 
 		// Pass to text input for typing. The terminal's own scrollback is

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -396,6 +396,13 @@ func nextPermissionMode(m client.NeoPermissionMode) client.NeoPermissionMode {
 	return client.NeoPermissionModeReadOnly
 }
 
+// recallInput replaces the textarea contents with a recalled prompt and parks
+// the cursor at the end, ready to edit or resend.
+func (m *Model) recallInput(s string) {
+	m.textInput.SetValue(s)
+	m.textInput.MoveToEnd()
+}
+
 // historyPrev steps to an older prompt. It returns true when it handled the
 // key (so the caller swallows it). The first step out of the live draft
 // stashes that draft in historyDraft so a later Down can restore it.
@@ -410,8 +417,7 @@ func (m *Model) historyPrev() bool {
 		m.historyDraft = m.textInput.Value()
 	}
 	m.historyIdx--
-	m.textInput.SetValue(m.history[m.historyIdx])
-	m.textInput.MoveToEnd()
+	m.recallInput(m.history[m.historyIdx])
 	return true
 }
 
@@ -424,11 +430,10 @@ func (m *Model) historyNext() bool {
 	}
 	m.historyIdx++
 	if m.historyIdx == len(m.history) {
-		m.textInput.SetValue(m.historyDraft)
+		m.recallInput(m.historyDraft)
 	} else {
-		m.textInput.SetValue(m.history[m.historyIdx])
+		m.recallInput(m.history[m.historyIdx])
 	}
-	m.textInput.MoveToEnd()
 	return true
 }
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -3053,3 +3053,112 @@ func TestRenderApprovalAuto_VerbVariants(t *testing.T) {
 		})
 	}
 }
+
+// submitPrompt types text into the model and presses Enter, returning the
+// resulting model. The OutCh must be buffered enough for the test's sends.
+func submitPrompt(t *testing.T, m Model, text string) Model {
+	t.Helper()
+	m.textInput.SetValue(text)
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = updated.(Model)
+	// Submitting puts the model in the busy state; clear it as the agent does
+	// at the end of its turn so a follow-up submit isn't swallowed.
+	updated, _ = m.Update(UITaskIdle{})
+	return updated.(Model)
+}
+
+func TestModel_PromptHistory_RecallAfterSubmit(t *testing.T) {
+	t.Parallel()
+
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m = submitPrompt(t, m, "first")
+	m = submitPrompt(t, m, "second")
+	require.Empty(t, m.textInput.Value(), "input clears after submit")
+
+	// Up recalls the newest, then the older.
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(Model)
+	assert.Equal(t, "second", m.textInput.Value())
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(Model)
+	assert.Equal(t, "first", m.textInput.Value())
+
+	// Up at the oldest entry pins there.
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(Model)
+	assert.Equal(t, "first", m.textInput.Value())
+
+	// Down walks back toward newer prompts, then past the newest to the
+	// (empty) draft.
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(Model)
+	assert.Equal(t, "second", m.textInput.Value())
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(Model)
+	assert.Empty(t, m.textInput.Value(), "Down past newest restores the empty draft")
+}
+
+func TestModel_PromptHistory_PreservesDraft(t *testing.T) {
+	t.Parallel()
+
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m = submitPrompt(t, m, "sent")
+
+	// Type an unsent draft, recall history with Up, then Down past the newest
+	// must restore the draft rather than leave the recalled prompt behind.
+	m.textInput.SetValue("draft in progress")
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(Model)
+	assert.Equal(t, "sent", m.textInput.Value())
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = updated.(Model)
+	assert.Equal(t, "draft in progress", m.textInput.Value())
+}
+
+func TestModel_PromptHistory_DedupesConsecutive(t *testing.T) {
+	t.Parallel()
+
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m = submitPrompt(t, m, "same")
+	m = submitPrompt(t, m, "same")
+
+	assert.Equal(t, []string{"same"}, m.history,
+		"consecutive duplicate prompts collapse to one history entry")
+}
+
+func TestModel_PromptHistory_MidBufferUpDoesNotRecall(t *testing.T) {
+	t.Parallel()
+
+	// With the cursor on a middle line of a multi-line draft, Up must move the
+	// cursor (textarea default) rather than recall history.
+	outCh := make(chan outboundEvent, 4)
+	m := NewModel(ModelConfig{OutCh: outCh})
+	m = submitPrompt(t, m, "history entry")
+
+	m.textInput.SetValue("line1\nline2\nline3")
+	m.textInput.MoveToEnd()
+	m.textInput.CursorUp() // now on the middle line
+	require.NotEqual(t, 0, m.textInput.Line(), "cursor must not be on the first line")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	m = updated.(Model)
+	assert.Equal(t, "line1\nline2\nline3", m.textInput.Value(),
+		"Up mid-buffer must not recall history")
+}
+
+func TestModel_PromptHistory_NoFooterHint(t *testing.T) {
+	t.Parallel()
+
+	// Per the issue, the shortcut is intentionally undocumented in the footer.
+	m := NewModel(ModelConfig{})
+	view := m.viewString()
+	assert.NotContains(t, view, "history")
+	assert.NotContains(t, view, "↑")
+	assert.NotContains(t, view, "↓")
+}

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -3059,11 +3059,17 @@ func TestRenderApprovalAuto_VerbVariants(t *testing.T) {
 func submitPrompt(t *testing.T, m Model, text string) Model {
 	t.Helper()
 	m.textInput.SetValue(text)
-	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyEnter)
 	// Submitting puts the model in the busy state; clear it as the agent does
 	// at the end of its turn so a follow-up submit isn't swallowed.
-	updated, _ = m.Update(UITaskIdle{})
+	updated, _ := m.Update(UITaskIdle{})
+	return updated.(Model)
+}
+
+// pressKey feeds a single keypress to the model and returns the updated model.
+func pressKey(t *testing.T, m Model, code rune) Model {
+	t.Helper()
+	updated, _ := m.Update(tea.KeyPressMsg{Code: code})
 	return updated.(Model)
 }
 
@@ -3077,27 +3083,22 @@ func TestModel_PromptHistory_RecallAfterSubmit(t *testing.T) {
 	require.Empty(t, m.textInput.Value(), "input clears after submit")
 
 	// Up recalls the newest, then the older.
-	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyUp)
 	assert.Equal(t, "second", m.textInput.Value())
 
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyUp)
 	assert.Equal(t, "first", m.textInput.Value())
 
 	// Up at the oldest entry pins there.
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyUp)
 	assert.Equal(t, "first", m.textInput.Value())
 
 	// Down walks back toward newer prompts, then past the newest to the
 	// (empty) draft.
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyDown)
 	assert.Equal(t, "second", m.textInput.Value())
 
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyDown)
 	assert.Empty(t, m.textInput.Value(), "Down past newest restores the empty draft")
 }
 
@@ -3111,12 +3112,10 @@ func TestModel_PromptHistory_PreservesDraft(t *testing.T) {
 	// Type an unsent draft, recall history with Up, then Down past the newest
 	// must restore the draft rather than leave the recalled prompt behind.
 	m.textInput.SetValue("draft in progress")
-	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyUp)
 	assert.Equal(t, "sent", m.textInput.Value())
 
-	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	m = updated.(Model)
+	m = pressKey(t, m, tea.KeyDown)
 	assert.Equal(t, "draft in progress", m.textInput.Value())
 }
 


### PR DESCRIPTION
Up/down arrows now scroll through previously submitted prompts in `pulumi neo`, when the cursor is on the edge line of the input. Mid-buffer they still move the cursor between lines. No footer hint is added.

Fixes #23395

🤖 Generated with [Claude Code](https://claude.com/claude-code)