### PR TITLE
Support Ctrl+Z to suspend pulumi neo

### DIFF
--- a/changelog/pending/cli-neo-ctrl-z-suspend.yaml
+++ b/changelog/pending/cli-neo-ctrl-z-suspend.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Support Ctrl+Z to suspend a running `pulumi neo` session (resume with `fg`)
+time: 2026-06-03T00:00:00.000000+00:00
+custom:
+    PR: https://github.com/pulumi/pulumi/issues/23394

--- a/changelog/pending/cli-neo-ctrl-z-suspend.yaml
+++ b/changelog/pending/cli-neo-ctrl-z-suspend.yaml
@@ -1,6 +1,6 @@
 component: cli
 kind: improvement
-body: Support Ctrl+Z to suspend a running `pulumi neo` session (resume with `fg`)
+body: Support Ctrl+Z to suspend a running `pulumi neo` session and restore the transcript on resume with `fg`
 time: 2026-06-03T00:00:00.000000+00:00
 custom:
     PR: https://github.com/pulumi/pulumi/issues/23394

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -620,6 +620,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// will fire later but no-op because ctrlCArmed is already false.
 		m.ctrlCArmed = false
 
+		// Ctrl+Z suspends via standard Unix job control (SIGTSTP); resume with
+		// `fg`. Bubbletea restores the terminal around the stop, so raw mode is
+		// fine. Not gated on busy — suspending mid-turn is the point, since
+		// cancellation isn't instant.
+		if keyStr == "ctrl+z" {
+			return m, tea.Suspend
+		}
+
 		// Ctrl+O opens the overlay. Sits above the busy/approval gates so
 		// users can peek mid-turn. Closing is handled by the overlayActive
 		// branch above. Alt-screen toggling happens in View() via the

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -546,8 +546,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// blank line, matching the initial flush. Sequence keeps the clear ahead
 		// of the prints and the prints in transcript order.
 		m.hasEmittedScrollback = false
-		seq := []tea.Cmd{tea.ClearScreen}
-		for _, r := range m.committedScrollback() {
+		scrollback := m.committedScrollback()
+		seq := make([]tea.Cmd, 0, 1+len(scrollback))
+		seq = append(seq, tea.ClearScreen)
+		for _, r := range scrollback {
 			seq = append(seq, m.printlnBlock(r))
 		}
 		return m, tea.Sequence(seq...)

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -524,12 +524,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.renderBlock(&m.blocks[i])
 		}
 		if firstSize {
-			rendered := []string{m.welcome.View()}
-			for _, b := range m.blocks {
-				if isCommittedKind(b) && b.rendered != "" {
-					rendered = append(rendered, b.rendered)
-				}
-			}
+			rendered := m.committedScrollback()
 			// 50ms covers ~3 ticks at bubbletea's 60Hz default — see
 			// firstFlushReadyMsg for why we defer at all.
 			cmds = append(cmds, tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg {
@@ -541,6 +536,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for _, r := range msg.rendered {
 			cmds = append(cmds, m.printlnBlock(r))
 		}
+
+	case tea.ResumeMsg:
+		// Resuming from a Ctrl+Z suspend (via `fg`): bubbletea repaints only the
+		// live frame, but the committed transcript was emitted to scrollback via
+		// tea.Println and isn't redrawn. Clear the viewport and re-emit the
+		// committed blocks so the session reads continuously after `fg`. Reset
+		// hasEmittedScrollback so the first re-emitted block skips its leading
+		// blank line, matching the initial flush. Sequence keeps the clear ahead
+		// of the prints and the prints in transcript order.
+		m.hasEmittedScrollback = false
+		seq := []tea.Cmd{tea.ClearScreen}
+		for _, r := range m.committedScrollback() {
+			seq = append(seq, m.printlnBlock(r))
+		}
+		return m, tea.Sequence(seq...)
 
 	case ctrlCDisarmMsg:
 		// Stale tick: the user already pressed another key (gen still
@@ -1216,6 +1226,20 @@ func (m *Model) commitBlock(b block) tea.Cmd {
 		return nil
 	}
 	return m.printlnBlock(b.rendered)
+}
+
+// committedScrollback returns the welcome banner followed by every committed
+// block's rendered text, in transcript order — i.e. everything that belongs in
+// terminal scrollback. Used for the initial flush and to re-emit the transcript
+// after a suspend/resume.
+func (m Model) committedScrollback() []string {
+	out := []string{m.welcome.View()}
+	for _, b := range m.blocks {
+		if isCommittedKind(b) && b.rendered != "" {
+			out = append(out, b.rendered)
+		}
+	}
+	return out
 }
 
 // printlnBlock emits rendered to scrollback, prepending a blank line so each

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -59,17 +59,17 @@ func collectPrintln(cmd tea.Cmd) []string {
 		}
 		return out
 	}
+	v := reflect.ValueOf(msg)
 	// tea.Sequence yields an unexported sequenceMsg ([]Cmd); walk it like a batch.
-	if sv := reflect.ValueOf(msg); sv.Kind() == reflect.Slice && sv.Type().Name() == "sequenceMsg" {
+	if v.Kind() == reflect.Slice && v.Type().Name() == "sequenceMsg" {
 		var out []string
-		for i := range sv.Len() {
-			if c, ok := sv.Index(i).Interface().(tea.Cmd); ok {
+		for i := 0; i < v.Len(); i++ {
+			if c, ok := v.Index(i).Interface().(tea.Cmd); ok {
 				out = append(out, collectPrintln(c)...)
 			}
 		}
 		return out
 	}
-	v := reflect.ValueOf(msg)
 	if v.Kind() == reflect.Struct && v.Type().Name() == "printLineMessage" {
 		if f := v.FieldByName("messageBody"); f.IsValid() && f.Kind() == reflect.String {
 			return []string{f.String()}
@@ -554,10 +554,9 @@ func TestModel_CommittedScrollback(t *testing.T) {
 	}
 
 	got := m.committedScrollback()
-	require.GreaterOrEqual(t, len(got), 3, "want welcome + two committed blocks")
-	assert.Equal(t, m.welcome.View(), got[0], "welcome banner must lead")
-	assert.Equal(t, []string{"user one", "assistant one"}, got[1:],
-		"committed blocks in order, live and empty blocks dropped")
+	want := []string{m.welcome.View(), "user one", "assistant one"}
+	assert.Equal(t, want, got,
+		"welcome leads, committed blocks follow in order, live and empty blocks dropped")
 }
 
 func TestModel_Update_Resume_ReprintsTranscript(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -503,6 +503,32 @@ func TestModel_Update_KeyCtrlC_StaleDisarmIgnored(t *testing.T) {
 	assert.True(t, um.ctrlCArmed, "stale-gen disarm tick must not clear a fresh arm")
 }
 
+func TestModel_Update_KeyCtrlZ_Suspends(t *testing.T) {
+	t.Parallel()
+
+	// Ctrl+Z must hand the shell back via standard job control (SIGTSTP).
+	// Bubbletea models this as the Suspend command, which resolves to a
+	// tea.SuspendMsg. It must work mid-turn, so assert it both idle and busy.
+	t.Run("idle", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{})
+		_, cmd := m.Update(tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl})
+		require.NotNil(t, cmd)
+		_, ok := cmd().(tea.SuspendMsg)
+		assert.True(t, ok, "Ctrl+Z must produce a tea.SuspendMsg")
+	})
+
+	t.Run("busy", func(t *testing.T) {
+		t.Parallel()
+		m := NewModel(ModelConfig{})
+		m.busy = true
+		_, cmd := m.Update(tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl})
+		require.NotNil(t, cmd)
+		_, ok := cmd().(tea.SuspendMsg)
+		assert.True(t, ok, "Ctrl+Z must suspend even while the agent is busy")
+	})
+}
+
 func TestModel_Update_KeyCtrlD_BehavesLikeCtrlC(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -59,6 +59,16 @@ func collectPrintln(cmd tea.Cmd) []string {
 		}
 		return out
 	}
+	// tea.Sequence yields an unexported sequenceMsg ([]Cmd); walk it like a batch.
+	if sv := reflect.ValueOf(msg); sv.Kind() == reflect.Slice && sv.Type().Name() == "sequenceMsg" {
+		var out []string
+		for i := range sv.Len() {
+			if c, ok := sv.Index(i).Interface().(tea.Cmd); ok {
+				out = append(out, collectPrintln(c)...)
+			}
+		}
+		return out
+	}
 	v := reflect.ValueOf(msg)
 	if v.Kind() == reflect.Struct && v.Type().Name() == "printLineMessage" {
 		if f := v.FieldByName("messageBody"); f.IsValid() && f.Kind() == reflect.String {
@@ -527,6 +537,50 @@ func TestModel_Update_KeyCtrlZ_Suspends(t *testing.T) {
 		_, ok := cmd().(tea.SuspendMsg)
 		assert.True(t, ok, "Ctrl+Z must suspend even while the agent is busy")
 	})
+}
+
+func TestModel_CommittedScrollback(t *testing.T) {
+	t.Parallel()
+
+	// committedScrollback feeds both the initial flush and the resume reprint:
+	// the welcome banner first, then committed blocks in order, skipping live
+	// blocks (e.g. the busy spinner) and empty renders.
+	m := NewModel(ModelConfig{})
+	m.blocks = []block{
+		{kind: blockUserMessage, rendered: "user one"},
+		{kind: blockBusy, rendered: "spinner"}, // live — excluded
+		{kind: blockAssistantFinal, rendered: "assistant one"},
+		{kind: blockError, rendered: ""}, // empty — excluded
+	}
+
+	got := m.committedScrollback()
+	require.GreaterOrEqual(t, len(got), 3, "want welcome + two committed blocks")
+	assert.Equal(t, m.welcome.View(), got[0], "welcome banner must lead")
+	assert.Equal(t, []string{"user one", "assistant one"}, got[1:],
+		"committed blocks in order, live and empty blocks dropped")
+}
+
+func TestModel_Update_Resume_ReprintsTranscript(t *testing.T) {
+	t.Parallel()
+
+	// On resume from a Ctrl+Z suspend, the committed transcript must be re-emitted
+	// to scrollback, since bubbletea only repaints the live frame. The first
+	// re-emitted block carries no leading blank line (hasEmittedScrollback reset),
+	// matching the initial flush.
+	m := NewModel(ModelConfig{})
+	m.hasEmittedScrollback = true // simulate a session that already printed
+	m.blocks = []block{
+		{kind: blockUserMessage, rendered: "user one"},
+		{kind: blockAssistantFinal, rendered: "assistant one"},
+	}
+
+	_, cmd := m.Update(tea.ResumeMsg{})
+	require.NotNil(t, cmd)
+
+	printed := collectPrintln(cmd)
+	want := []string{m.welcome.View(), "\nuser one", "\nassistant one"}
+	assert.Equal(t, want, printed,
+		"resume must reprint welcome + committed blocks, first without a leading blank")
 }
 
 func TestModel_Update_KeyCtrlD_BehavesLikeCtrlC(t *testing.T) {


### PR DESCRIPTION
Pressing Ctrl+Z in `pulumi neo` did nothing because Bubbletea runs the terminal in raw mode, so the byte is delivered as a keypress instead of triggering `SIGTSTP`. Handle that keypress by returning `tea.Suspend`, suspending the process via standard Unix job control (resume with `fg`). Bubbletea releases and restores the terminal around the stop, so this is safe in raw mode.

Neo renders inline and pushes completed transcript blocks into terminal scrollback via `tea.Println`, which Bubbletea treats as unmanaged output. On resume Bubbletea repaints only the live frame, so the transcript would otherwise be left blank. The resume path (`tea.ResumeMsg`) clears the viewport and re-emits the committed blocks so the session reads continuously after `fg`.

Fixes #23394

🤖 Generated with [Claude Code](https://claude.com/claude-code)