### PR TITLE
Isolate Neo CLI child-process stderr from the progress UI

### DIFF
--- a/changelog/pending/cli-neo-fix-20260603-163340.yaml
+++ b/changelog/pending/cli-neo-fix-20260603-163340.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: fix
+body: Fix Neo CLI progress UI corruption caused by child-process stderr leaking onto the terminal
+time: 2026-06-03T16:33:40+03:00
+custom:
+    PR: ""

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -341,16 +341,15 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		Scopes:             ctxOnlyCancellationSource{},
 	}
 
-	// The engine and backend print a handful of headers/messages directly to
-	// os.Stdout/os.Stderr (e.g. the "Previewing update (stack)" banner in
-	// pkg/backend/httpstate/backend.go) that bypass Display.Stdout. Under the
-	// Neo TUI this corrupts bubbletea's alt-screen, so redirect both streams to
-	// /dev/null for the duration of the backend call. bubbletea holds a
-	// captured reference to the original stdout from tea.NewProgram, so this
-	// swap doesn't disturb rendering. Deferred so a panic in the engine
-	// can't leave the CLI permanently muted.
-	restoreStd := silenceStd()
-	defer restoreStd()
+	// The engine and backend print headers/messages directly to os.Stdout/os.Stderr
+	// (e.g. the "Previewing update (stack)" banner in pkg/backend/httpstate/backend.go),
+	// and the child processes the engine spawns (plugins, language hosts) inherit the
+	// real stderr file descriptor. Both would corrupt the Neo TUI, so silence the Go
+	// stdout/stderr variables and redirect the real fd 2 into a capture buffer for the
+	// duration of the backend call. fd 1 is left alone so bubbletea keeps rendering.
+	// Deferred so a panic in the engine can't leave the CLI permanently muted.
+	silencer := silenceStd()
+	defer silencer.Restore()
 
 	var runErr error
 	var changes display.ResourceChanges
@@ -363,6 +362,11 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	// the channel for us; once the backend call returns, no more events will arrive.
 	close(eventsCh)
 	<-drainDone
+
+	// Restore stdio and recover any child-process stderr the engine's subprocesses
+	// emitted (surfaced below only when the operation failed). The deferred Restore
+	// is idempotent, so this explicit call is safe.
+	capturedStderr := silencer.Restore()
 
 	res := newPulumiResult(proj, s.Ref(), eventsPath)
 
@@ -396,6 +400,9 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		// returned without emitting any DiagEvents (host crash, plugin
 		// discovery, marshalling).
 		res.Logs = fmt.Sprintf("error: pulumi %s: %s\n", label, runErr) + res.Logs
+		if stderr := strings.TrimSpace(capturedStderr); stderr != "" {
+			res.Logs += "\nchild process output:\n" + stderr + "\n"
+		}
 		return res, errToolFailed
 	}
 	return res, nil
@@ -614,27 +621,6 @@ type ctxOnlyCancellationScope struct {
 
 func (c *ctxOnlyCancellationScope) Context() *cancel.Context { return c.ctx }
 func (c *ctxOnlyCancellationScope) Close()                   { c.src.Cancel() }
-
-// silenceStd redirects os.Stdout and os.Stderr to /dev/null and returns a
-// restore func. Calls to fmt.Printf / fmt.Println / fmt.Print during the
-// redirection go nowhere. Safe even if opening /dev/null fails — in that case
-// the originals remain in place. bubbletea's tea.NewProgram captures a stable
-// reference to the terminal at construction, so this swap does not affect the
-// TUI's rendering; it only catches writes that look up os.Stdout dynamically.
-//
-//nolint:forbidigo
-func silenceStd() func() {
-	null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		return func() {}
-	}
-	origStdout, origStderr := os.Stdout, os.Stderr
-	os.Stdout, os.Stderr = null, null
-	return func() {
-		os.Stdout, os.Stderr = origStdout, origStderr
-		_ = null.Close()
-	}
-}
 
 // newPulumiResult returns a pulumiResult populated with the canonical project
 // name and bare stack name from the parsed StackReference. ParseStackReference

--- a/pkg/cmd/pulumi/neo/tools/silence.go
+++ b/pkg/cmd/pulumi/neo/tools/silence.go
@@ -1,0 +1,114 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+// stdSilencer isolates terminal output while an in-process engine operation runs
+// under the Neo TUI. bubbletea owns os.Stdout (fd 1); the engine and any child
+// processes it spawns (plugins, language hosts) would otherwise scribble on that
+// same terminal. stdSilencer (a) swaps the os.Stdout/os.Stderr package variables
+// to /dev/null so in-process fmt.Print* writes vanish, and (b) redirects the real
+// stderr file descriptor (fd 2) into a capture pipe so child-process stderr can't
+// reach the terminal. fd 1 is deliberately left alone so bubbletea keeps drawing.
+//
+// Swapping only the Go variables (the previous behavior) is not enough: child
+// processes inherit fd 2 at the OS level, so noise like macOS libmalloc's
+// "MallocStackLogging: can't turn off malloc stack logging" lands on the terminal
+// regardless. Only an fd-level redirect contains it.
+type stdSilencer struct {
+	once       sync.Once
+	null       *os.File
+	origStdout *os.File
+	origStderr *os.File
+
+	savedFD2  int      // dup of the original fd 2; -1 when the fd redirect is inactive
+	pipeW     *os.File // write end installed on fd 2
+	captured  *cappedBuffer
+	drainDone chan struct{}
+
+	capturedStderr string
+}
+
+// silenceStd installs the redirections and returns a silencer whose Restore method
+// reverts them. It is safe even if any individual step fails — whatever could not
+// be installed is simply left untouched.
+//
+//nolint:forbidigo // Intentionally manipulating os.Stdout/os.Stderr.
+func silenceStd() *stdSilencer {
+	s := &stdSilencer{savedFD2: -1}
+
+	// (a) Swap the Go stdout/stderr variables so in-process writes (e.g. the
+	// engine's "Previewing update (stack)" banner) don't corrupt the TUI. This
+	// only affects code that looks up os.Stdout/os.Stderr dynamically; it does
+	// not touch fd 1, so bubbletea's captured handle keeps rendering.
+	if null, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0); err == nil {
+		s.null = null
+		s.origStdout, s.origStderr = os.Stdout, os.Stderr
+		os.Stdout, os.Stderr = null, null
+	}
+
+	// (b) Redirect the process's real fd 2 into a pipe we drain. Child processes
+	// inherit fd 2 at the OS level, so the variable swap above cannot keep their
+	// stderr off the terminal — only an fd-level redirect does.
+	if pr, pw, err := os.Pipe(); err == nil {
+		saved, err := redirectFD2(pw)
+		if err == nil {
+			s.savedFD2 = saved
+			s.pipeW = pw
+			s.captured = &cappedBuffer{limit: maxOutputBytes}
+			s.drainDone = make(chan struct{})
+			go func() {
+				defer close(s.drainDone)
+				_, _ = io.Copy(s.captured, pr)
+				_ = pr.Close()
+			}()
+		} else {
+			// fd redirect unavailable (e.g. Windows); fall back to the variable
+			// swap alone and discard the unused pipe.
+			_ = pr.Close()
+			_ = pw.Close()
+		}
+	}
+
+	return s
+}
+
+// Restore reverts the redirections installed by silenceStd and returns any
+// child-process stderr captured while fd 2 was redirected. It is idempotent; only
+// the first call has an effect, and subsequent calls return the same captured text.
+//
+//nolint:forbidigo // Intentionally manipulating os.Stdout/os.Stderr.
+func (s *stdSilencer) Restore() string {
+	s.once.Do(func() {
+		if s.null != nil {
+			os.Stdout, os.Stderr = s.origStdout, s.origStderr
+			_ = s.null.Close()
+		}
+		if s.savedFD2 >= 0 {
+			// Put the real fd 2 back first so nothing else lands in the pipe,
+			// then close the write end so the drain goroutine sees EOF.
+			_ = restoreFD2(s.savedFD2)
+			_ = s.pipeW.Close()
+			<-s.drainDone
+			s.capturedStderr = s.captured.buf.String()
+		}
+	})
+	return s.capturedStderr
+}

--- a/pkg/cmd/pulumi/neo/tools/silence_fd_linux.go
+++ b/pkg/cmd/pulumi/neo/tools/silence_fd_linux.go
@@ -1,0 +1,46 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package tools
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// redirectFD2 saves the current stderr file descriptor and points fd 2 at target,
+// returning the saved descriptor for restoreFD2. Linux uses Dup3 because Dup2 is
+// not available on all architectures (e.g. arm64); the source and target fds here
+// always differ, so Dup3's EINVAL-on-equal constraint does not apply.
+func redirectFD2(target *os.File) (int, error) {
+	saved, err := unix.Dup(unix.Stderr)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.Dup3(int(target.Fd()), unix.Stderr, 0); err != nil {
+		_ = unix.Close(saved)
+		return -1, err
+	}
+	return saved, nil
+}
+
+// restoreFD2 points fd 2 back at the descriptor saved by redirectFD2 and closes it.
+func restoreFD2(saved int) error {
+	err := unix.Dup3(saved, unix.Stderr, 0)
+	_ = unix.Close(saved)
+	return err
+}

--- a/pkg/cmd/pulumi/neo/tools/silence_fd_unix.go
+++ b/pkg/cmd/pulumi/neo/tools/silence_fd_unix.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux && !windows
+
+package tools
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// redirectFD2 saves the current stderr file descriptor and points fd 2 at target,
+// returning the saved descriptor for restoreFD2.
+func redirectFD2(target *os.File) (int, error) {
+	saved, err := unix.Dup(unix.Stderr)
+	if err != nil {
+		return -1, err
+	}
+	if err := unix.Dup2(int(target.Fd()), unix.Stderr); err != nil {
+		_ = unix.Close(saved)
+		return -1, err
+	}
+	return saved, nil
+}
+
+// restoreFD2 points fd 2 back at the descriptor saved by redirectFD2 and closes it.
+func restoreFD2(saved int) error {
+	err := unix.Dup2(saved, unix.Stderr)
+	_ = unix.Close(saved)
+	return err
+}

--- a/pkg/cmd/pulumi/neo/tools/silence_fd_windows.go
+++ b/pkg/cmd/pulumi/neo/tools/silence_fd_windows.go
@@ -1,0 +1,33 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package tools
+
+import (
+	"errors"
+	"os"
+)
+
+// errFDRedirectUnsupported signals that fd-level stderr redirection is not wired
+// up on this platform; silenceStd then falls back to swapping the os.Stdout/
+// os.Stderr variables alone. The child-process stderr noise this guards against
+// (macOS libmalloc warnings) does not occur on Windows, and Windows console
+// redirection (SetStdHandle/DuplicateHandle) is left as a follow-up.
+var errFDRedirectUnsupported = errors.New("fd-level stderr redirect not supported on this platform")
+
+func redirectFD2(*os.File) (int, error) { return -1, errFDRedirectUnsupported }
+
+func restoreFD2(int) error { return nil }

--- a/pkg/cmd/pulumi/neo/tools/silence_test.go
+++ b/pkg/cmd/pulumi/neo/tools/silence_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package tools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSilenceStdIsolatesChildStderr is a regression test for
+// https://github.com/pulumi/pulumi-service/issues/44157: while the Neo TUI is
+// rendering, stderr from child processes spawned by the in-process engine must not
+// reach the terminal. The previous silenceStd only swapped the os.Stdout/os.Stderr
+// Go variables, which child processes do not observe — they inherit fd 2 directly.
+//
+// The test stands a temp file in for the terminal by pointing the real fd 2 at it,
+// silences, then spawns a child that writes a marker to its inherited fd 2. With
+// only the variable swap the marker leaks into the "terminal"; with fd-level
+// redirection it is captured instead.
+//
+// It does not call t.Parallel: fd 2 is process-global, and Go runs non-parallel
+// tests sequentially with parallel ones paused, so the redirect can't race them.
+//
+//nolint:paralleltest // Redirects the process-global fd 2; must not run in parallel.
+func TestSilenceStdIsolatesChildStderr(t *testing.T) {
+	const marker = "NEO-CHILD-STDERR-LEAK-MARKER"
+
+	// A stand-in for the terminal: the file the real fd 2 points at for the test.
+	termPath := filepath.Join(t.TempDir(), "terminal.txt")
+	termFile, err := os.Create(termPath)
+	require.NoError(t, err)
+	defer termFile.Close()
+
+	// Point the process's real fd 2 at the temp file, restoring it afterwards.
+	savedReal, err := redirectFD2(termFile)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, restoreFD2(savedReal)) }()
+
+	silencer := silenceStd()
+
+	// Spawn a child that writes the marker to its inherited fd 2. os.NewFile wraps
+	// the process's current fd 2 (now the silencer's capture pipe), and os/exec
+	// dups it onto the child's stderr — exactly how an engine-spawned subprocess
+	// inherits the terminal's stderr.
+	childStderr := os.NewFile(uintptr(unix.Stderr), "stderr")
+	cmd := exec.Command("sh", "-c", "printf %s "+marker+" >&2")
+	cmd.Stderr = childStderr
+	runErr := cmd.Run()
+	runtime.KeepAlive(childStderr)
+
+	captured := silencer.Restore()
+	require.NoError(t, runErr)
+
+	termContents, err := os.ReadFile(termPath)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(termContents), marker,
+		"child-process stderr leaked onto the terminal (fd 2 was not isolated)")
+	assert.Contains(t, captured, marker,
+		"child-process stderr should have been captured by the silencer")
+}


### PR DESCRIPTION
In Neo CLI mode the local `pulumi` binary renders a live bubbletea progress UI on stdout while the in-process engine (`pulumi up`/`preview`) spawns child processes (plugins, language hosts). Those children inherit the real stderr file descriptor, so their stderr — e.g. macOS libmalloc's benign `MallocStackLogging: can't turn off malloc stack logging` — lands on the terminal and garbles the spinner.

The previous `silenceStd` only reassigned the `os.Stdout`/`os.Stderr` Go variables to `/dev/null`, which child processes don't observe. This replaces it with a silencer that also redirects the process's real fd 2 into a capture pipe for the duration of the engine run (fd 1 is left alone so bubbletea keeps rendering), then restores it. Captured child stderr is surfaced in the tool result logs only on failure.

Includes a regression test that points fd 2 at a temp file, silences, spawns a child writing to its inherited fd 2, and asserts nothing leaks to the terminal and the output is captured (verified failing before the fix).

Fixes pulumi/pulumi-service#44157

🤖 Generated with [Claude Code](https://claude.com/claude-code)