### PR TITLE
block merge queue while release is in progress

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -86,17 +86,56 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Check release marker
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
         run: |
           set -euo pipefail
           git fetch --depth=1 origin master
-          # The marker is dropped by scripts/set-version.py in the freeze PR and
-          # removed by the post-release changelog/go.mod PR. Any merge_group ref
-          # that still carries the marker after master has it is something other
-          # than that post-release PR, so block it.
-          if git cat-file -e origin/master:.release-pending 2>/dev/null \
-              && [ -f .release-pending ]; then
+
+          # No release in progress - nothing to enforce.
+          if ! git cat-file -e origin/master:.release-pending 2>/dev/null; then
+            exit 0
+          fi
+
+          # Release in progress. The marker must be gone after this PR.
+          if [ -f .release-pending ]; then
             echo "::error::A release is in progress (.release-pending exists)."
             echo "Only the post-release changelog/go.mod PR can merge until the marker is removed."
+            exit 1
+          fi
+
+          # The marker is gone in this PR's tree. The merge queue merges all PRs
+          # when the last one in the queue is green. So we need to specifically check
+          # that the changelog/go.mod update PR is merged right after the freeze PR.
+          # We do this by checking that the merge base is the freeze commit and otherwise
+          # fail, by checking that it added the .release-pending file, and checking that
+          # its sdk/.version matches the sdk/v3 version this PR now depends on in its pkg/go.mod
+          #
+          # The merge queue will kick out PRs in order, from the earliest failing one, so it'll
+          # kick out all of the PRs before the changelog/go.mod update PR.
+          git fetch --depth=2 origin "$BASE_SHA"
+
+          if ! git cat-file -e "$BASE_SHA":.release-pending 2>/dev/null; then
+            echo "::error::The merge base ($BASE_SHA) does not contain .release-pending."
+            echo "This PR is not stacked directly on the freeze commit."
+            exit 1
+          fi
+          if git cat-file -e "$BASE_SHA^":.release-pending 2>/dev/null; then
+            echo "::error::The merge base ($BASE_SHA) did not introduce .release-pending - it was already present in its parent."
+            echo "Another commit slipped between the freeze and this PR."
+            exit 1
+          fi
+
+          EXPECTED_VERSION=$(git show "$BASE_SHA":sdk/.version | tr -d '[:space:]')
+          DEPENDED_VERSION=$(awk '$1 == "github.com/pulumi/pulumi/sdk/v3" && $2 ~ /^v[0-9]/ {print $2; exit}' pkg/go.mod | sed 's/^v//')
+          if [ -z "$DEPENDED_VERSION" ]; then
+            echo "::error::Could not read the github.com/pulumi/pulumi/sdk/v3 dependency from pkg/go.mod."
+            exit 1
+          fi
+          if [ "$EXPECTED_VERSION" != "$DEPENDED_VERSION" ]; then
+            echo "::error::Version mismatch between the freeze commit's sdk/.version and this PR's pkg/go.mod dependency:"
+            echo "  sdk/.version at merge base: $EXPECTED_VERSION"
+            echo "  pkg/go.mod sdk/v3:          $DEPENDED_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -80,9 +80,29 @@ jobs:
       project: ${{ github.repository }}
     secrets: inherit
 
+  block-during-release:
+    name: block during release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check release marker
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin master
+          # The marker is dropped by scripts/set-version.py in the freeze PR and
+          # removed by the post-release changelog/go.mod PR. Any merge_group ref
+          # that still carries the marker after master has it is something other
+          # than that post-release PR, so block it.
+          if git cat-file -e origin/master:.release-pending 2>/dev/null \
+              && [ -f .release-pending ]; then
+            echo "::error::A release is in progress (.release-pending exists)."
+            echo "Only the post-release changelog/go.mod PR can merge until the marker is removed."
+            exit 1
+          fi
+
   ci-ok:
     name: ci-ok
-    needs: [ci, performance-gate, prepare-release]
+    needs: [ci, performance-gate, prepare-release, block-during-release]
     if: always() # always report a status
     runs-on: ubuntu-latest
     steps:
@@ -91,6 +111,9 @@ jobs:
         run: exit 1
       - name: Release failed
         if: ${{ needs.prepare-release.result != 'success' }}
+        run: exit 1
+      - name: Release in progress
+        if: ${{ needs.block-during-release.result != 'success' }}
         run: exit 1
       - name: CI succeeded
         run: exit 0

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -68,6 +68,9 @@ jobs:
             go get -u "github.com/pulumi/pulumi/sdk/v3@v${PULUMI_VERSION}"
           )
           make tidy_fix
+          # Clear the release-in-progress marker dropped by set-version.py.
+          # Merging this PR re-opens the queue to other PRs.
+          rm -f .release-pending
           git add -A
           git commit -m "chore: post-release go.mod updates"
 

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -26,6 +26,14 @@ def main():
     with open("sdk/.version", "w+") as f:
         f.write(version + "\n")
 
+    # Drop a marker so the on-merge gate can block any other PR from merging
+    # between the freeze PR and the post-release changelog/go.mod PR (which
+    # removes this file). Stage it eagerly so it can't be left out of the
+    # freeze commit by accident.
+    with open(".release-pending", "w") as f:
+        f.write(f"v{version}\n")
+    subprocess.run(["git", "add", ".release-pending"], check=True)
+
     node = open("sdk/nodejs/package.json").readlines()
     replace_line(node, "    \"version\":", f'    "version": "{version}",\n')
     with open("sdk/nodejs/package.json", "w") as f:


### PR DESCRIPTION
This implements @iwahbe's suggestion for blocking the merge queue while a release is in progress.  We simply touch a file when the `set-version.py` script is run.  We automatically `git add` it there as well, so it's not forgotten.

Then the merge queue blocks commits until that file is removed.  The CI job that updates the changelog, and updates the SDK reference then removes the file again, thus unblocking the merge queue.

This may not be the ideal solution for this, but it's simple and will definitely avoid us creating bad releases.