### PR TITLE
Add OAuth refresh-token support

### DIFF
--- a/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
+++ b/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
@@ -1,8 +1,6 @@
 component: cli/auth
 kind: feat
-body: Add CLI support for OAuth refresh tokens. `Account` now carries an optional
-    `refreshToken` field in `credentials.json`, and the API client exposes
-    `RefreshAccessToken` for exchanging it at `/api/oauth/token`
-    (`grant_type=refresh_token`). Wiring this into the HTTP layer's 401 handling
-    is a follow-up — this commit lays the storage and client foundation.
-time: 2026-06-01T20:30:00+00:00
+body: When `credentials.json` carries an OAuth refresh token, the CLI now auto-refreshes
+    the access token on 401 and retries the request once, instead of returning a
+    "login required" error
+time: 2026-06-05T14:30:00+00:00

--- a/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
+++ b/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
@@ -4,3 +4,5 @@ body: When `credentials.json` carries an OAuth refresh token, the CLI now auto-r
     the access token on 401 and retries the request once, instead of returning a
     "login required" error
 time: 2026-06-05T14:30:00+00:00
+custom:
+  PR: 23430

--- a/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
+++ b/changelog/pending/cli-feat-refresh-token-client-20260601.yaml
@@ -1,0 +1,8 @@
+component: cli/auth
+kind: feat
+body: Add CLI support for OAuth refresh tokens. `Account` now carries an optional
+    `refreshToken` field in `credentials.json`, and the API client exposes
+    `RefreshAccessToken` for exchanging it at `/api/oauth/token`
+    (`grant_type=refresh_token`). Wiring this into the HTTP layer's 401 handling
+    is a follow-up — this commit lays the storage and client foundation.
+time: 2026-06-01T20:30:00+00:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -547,6 +547,24 @@ func validateStoredAccount(
 		username, organizations, tokenInfo, err = getAccountDetails(
 			ctx, cloudURL, insecure, account.AccessToken,
 		)
+		if errors.Is(err, ErrUnauthorized) && account.RefreshToken != "" {
+			// The access token is no longer accepted but we still hold a refresh token. Exchange it
+			// for a fresh access token and re-validate so the caller persists the refreshed account
+			// rather than falling through to agent-signup or a re-login prompt.
+			refreshClient := client.NewClient(cloudURL, "", insecure, cmdutil.Diag())
+			resp, refreshErr := refreshClient.RefreshAccessToken(ctx, account.RefreshToken)
+			if refreshErr == nil {
+				account.AccessToken = resp.AccessToken
+				if resp.RefreshToken != "" {
+					account.RefreshToken = resp.RefreshToken
+				}
+				username, organizations, tokenInfo, err = getAccountDetails(
+					ctx, cloudURL, insecure, account.AccessToken,
+				)
+			} else {
+				logging.V(7).Infof("Refreshing access token for %q failed: %v", cloudURL, refreshErr)
+			}
+		}
 		if errors.Is(err, ErrUnauthorized) {
 			valid = false
 		} else if err != nil {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -751,6 +751,7 @@ func (m defaultLoginManager) currentOrSignupAgentAccount(
 
 	account := workspace.Account{
 		AccessToken:      signup.AccessToken,
+		RefreshToken:     signup.RefreshToken,
 		Username:         username,
 		Organizations:    organizations,
 		TokenInformation: tokenInfo,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -541,10 +541,11 @@ func validateStoredAccount(
 	organizations := account.Organizations
 	tokenInfo := account.TokenInformation
 	now := time.Now()
-	if tokenInfo != nil && tokenInfo.ExpiresAt != nil && tokenInfo.ExpiresAt.Before(now) {
+	expired := tokenInfo != nil && tokenInfo.ExpiresAt != nil && tokenInfo.ExpiresAt.Before(now)
+	if expired && account.RefreshToken == "" {
 		// TODO(https://github.com/pulumi/pulumi/issues/20986): Return expiresIn within TokenInformation.
 		valid = false
-	} else if username == "" || account.LastValidatedAt.Add(1*time.Hour).Before(now) {
+	} else if username == "" || account.LastValidatedAt.Add(1*time.Hour).Before(now) || expired {
 		// If the username has not yet been populated, fetch it now.
 		// Also, we do not store the expiration time of the backend access token if oidc token exchange is not used.
 		// So we need to check periodically if it is still valid.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -283,7 +283,7 @@ func New(ctx context.Context, d diag.Sink,
 	apiClient.WithRefresh(account.RefreshToken, func(at, rt string) error {
 		account.AccessToken = at
 		account.RefreshToken = rt
-		return workspace.StoreAccount(cloudURL, account, false)
+		return account.Save(cloudURL, false)
 	})
 	escClient := esc_client.New(client.UserAgent(), cloudURL, apiToken, insecure)
 
@@ -336,7 +336,7 @@ func getBackendAccount(ctx context.Context, cloudURL string) (workspace.Account,
 	if fromAgent {
 		logging.V(7).Infof("Using backend account for %q from shared agent credentials", cloudURL)
 		MarkAgentCredentialsUsed(ctx, cloudURL)
-	} else if account.AccessToken != "" {
+	} else if account.HasCredential() {
 		logging.V(7).Infof("Using backend account for %q from default credentials", cloudURL)
 	} else {
 		logging.V(7).Infof("No backend account for %q found", cloudURL)
@@ -451,7 +451,7 @@ func loginWithBrowser(
 
 	accessToken := <-c
 
-	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken)
+	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -522,14 +522,20 @@ var newLoginManager = func() LoginManager {
 
 type defaultLoginManager struct{}
 
-// validateStoredAccount checks whether a stored account can still
-// authenticate, refreshing cached user and token metadata when needed.
+// validateStoredAccount checks whether a stored account can still authenticate, refreshing cached
+// user and token metadata when needed. An account that carries a refresh token but a stale (or
+// missing) access token is renewed transparently via getAccountDetails's wrapper-equipped client —
+// the local account is updated to reflect any rotation, and the caller persists the result.
 func validateStoredAccount(
 	ctx context.Context,
 	cloudURL string,
 	insecure bool,
 	account workspace.Account,
 ) (workspace.Account, bool, error) {
+	if !account.HasCredential() {
+		return account, false, nil
+	}
+
 	valid := true
 	username := account.Username
 	organizations := account.Organizations
@@ -543,32 +549,20 @@ func validateStoredAccount(
 		// Also, we do not store the expiration time of the backend access token if oidc token exchange is not used.
 		// So we need to check periodically if it is still valid.
 		// We do this every hour by fetching the account details again using the backend access token.
-		var err error
-		username, organizations, tokenInfo, err = getAccountDetails(
-			ctx, cloudURL, insecure, account.AccessToken,
+		fetchedUser, fetchedOrgs, fetchedTokenInfo, err := getAccountDetails(
+			ctx, cloudURL, insecure, account.AccessToken, account.RefreshToken,
+			func(at, rt string) error {
+				account.AccessToken = at
+				account.RefreshToken = rt
+				return nil
+			},
 		)
-		if errors.Is(err, ErrUnauthorized) && account.RefreshToken != "" {
-			// The access token is no longer accepted but we still hold a refresh token. Exchange it
-			// for a fresh access token and re-validate so the caller persists the refreshed account
-			// rather than falling through to agent-signup or a re-login prompt.
-			refreshClient := client.NewClient(cloudURL, "", insecure, cmdutil.Diag())
-			resp, refreshErr := refreshClient.RefreshAccessToken(ctx, account.RefreshToken)
-			if refreshErr == nil {
-				account.AccessToken = resp.AccessToken
-				if resp.RefreshToken != "" {
-					account.RefreshToken = resp.RefreshToken
-				}
-				username, organizations, tokenInfo, err = getAccountDetails(
-					ctx, cloudURL, insecure, account.AccessToken,
-				)
-			} else {
-				logging.V(7).Infof("Refreshing access token for %q failed: %v", cloudURL, refreshErr)
-			}
-		}
 		if errors.Is(err, ErrUnauthorized) {
 			valid = false
 		} else if err != nil {
 			return workspace.Account{}, false, err
+		} else {
+			username, organizations, tokenInfo = fetchedUser, fetchedOrgs, fetchedTokenInfo
 		}
 		account.LastValidatedAt = now
 	}
@@ -601,12 +595,12 @@ func (m defaultLoginManager) Current(
 	// is not set use it.  If PULUMI_ACCESS_TOKEN does not match,
 	// we prefer that.
 	existingAccount, err := workspace.GetAccount(cloudURL)
-	if err == nil && existingAccount.AccessToken != "" {
+	if err == nil && existingAccount.HasCredential() {
 		logging.V(7).Infof("Found stored credentials for %q in default credentials", cloudURL)
 	} else if err != nil {
 		logging.V(7).Infof("Could not read default credentials for %q: %v", cloudURL, err)
 	}
-	if err == nil && existingAccount.AccessToken != "" &&
+	if err == nil && existingAccount.HasCredential() &&
 		(accessToken == "" || existingAccount.AccessToken == accessToken) {
 		var valid bool
 		logging.V(7).Infof("Validating stored credentials for %q", cloudURL)
@@ -648,7 +642,7 @@ func (m defaultLoginManager) Current(
 	_, err = fmt.Fprintf(os.Stderr, "Logging in using access token from %s\n", env.AccessToken.Var().Name())
 	contract.IgnoreError(err)
 
-	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken)
+	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -689,7 +683,7 @@ func (m defaultLoginManager) currentOrSignupAgentAccount(
 	if err != nil {
 		return nil, err
 	}
-	if agentAccount.AccessToken != "" {
+	if agentAccount.HasCredential() {
 		var valid bool
 		logging.V(7).Infof("Found shared agent credentials for %q; validating", cloudURL)
 		agentAccount, valid, err = validateStoredAccount(ctx, cloudURL, insecure, agentAccount)
@@ -698,7 +692,7 @@ func (m defaultLoginManager) currentOrSignupAgentAccount(
 		}
 		if valid {
 			logging.V(7).Infof("Using valid shared agent credentials for %q", cloudURL)
-			if err = workspace.StoreAgentAccount(cloudURL, agentAccount, setCurrent); err != nil {
+			if err = agentAccount.Save(cloudURL, setCurrent); err != nil {
 				return nil, err
 			}
 			MarkAgentCredentialsUsed(ctx, cloudURL)
@@ -746,7 +740,7 @@ func (m defaultLoginManager) currentOrSignupAgentAccount(
 		return nil, fmt.Errorf("creating agent Pulumi account: could not construct claim URL for cloud URL %q", cloudURL)
 	}
 
-	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, signup.AccessToken)
+	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, signup.AccessToken, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -862,7 +856,7 @@ func (m defaultLoginManager) Login(
 		}
 	}
 
-	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken)
+	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -899,7 +893,7 @@ func (m defaultLoginManager) LoginWithOIDCToken(
 		return nil, err
 	}
 
-	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken)
+	username, organizations, tokenInfo, err := getAccountDetails(ctx, cloudURL, insecure, accessToken, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2638,15 +2632,21 @@ func isExpectedTokenFormat(token string) bool {
 
 // getAccountDetails makes a request to get the authenticated user. If it returns a successful response,
 // we know the access token is valid and a managed or self-hosted cloud backend is used.
+//
+// When refreshToken is non-empty, the request goes through a wrapper-equipped client that
+// transparently exchanges it for a new access token on 401 and retries once. onRefresh, if set,
+// receives the refreshed (access, refresh) pair so the caller can persist them.
 func getAccountDetails(
 	ctx context.Context,
 	cloudURL string,
 	insecure bool,
-	accessToken string,
+	accessToken, refreshToken string,
+	onRefresh func(accessToken, refreshToken string) error,
 ) (string, []string, *workspace.TokenInformation, error) {
 	// TODO(https://github.com/pulumi/pulumi/issues/20986): Return expiresIn within TokenInformation.
-	username, organizations, tokenInfo, err := client.NewClient(cloudURL, accessToken, insecure, cmdutil.Diag()).
-		GetPulumiAccountDetails(ctx)
+	apiClient := client.NewClient(cloudURL, accessToken, insecure, cmdutil.Diag()).
+		WithRefresh(refreshToken, onRefresh)
+	username, organizations, tokenInfo, err := apiClient.GetPulumiAccountDetails(ctx)
 	if errors.Is(err, backenderr.LoginRequiredError{}) {
 		return "", nil, nil, ErrUnauthorized
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -280,9 +280,8 @@ func New(ctx context.Context, d diag.Sink,
 	apiToken := account.AccessToken
 
 	apiClient := client.NewClient(cloudURL, apiToken, insecure, d)
-	apiClient.WithRefresh(account.RefreshToken, func(at, rt string) error {
-		account.AccessToken = at
-		account.RefreshToken = rt
+	apiClient.WithRefresh(account.RefreshToken, func(at string, expiresAt time.Time, rt string) error {
+		account.SetCredentials(at, expiresAt, rt)
 		return account.Save(cloudURL, false)
 	})
 	escClient := esc_client.New(client.UserAgent(), cloudURL, apiToken, insecure)
@@ -552,9 +551,8 @@ func validateStoredAccount(
 		// We do this every hour by fetching the account details again using the backend access token.
 		fetchedUser, fetchedOrgs, fetchedTokenInfo, err := getAccountDetails(
 			ctx, cloudURL, insecure, account.AccessToken, account.RefreshToken,
-			func(at, rt string) error {
-				account.AccessToken = at
-				account.RefreshToken = rt
+			func(at string, expiresAt time.Time, rt string) error {
+				account.SetCredentials(at, expiresAt, rt)
 				return nil
 			},
 		)
@@ -563,7 +561,18 @@ func validateStoredAccount(
 		} else if err != nil {
 			return workspace.Account{}, false, err
 		} else {
-			username, organizations, tokenInfo = fetchedUser, fetchedOrgs, fetchedTokenInfo
+			username, organizations = fetchedUser, fetchedOrgs
+			// /api/user reports Name/Organization/Team only; preserve the locally
+			// cached ExpiresAt set by grant responses.
+			if fetchedTokenInfo != nil {
+				if account.TokenInformation == nil {
+					account.TokenInformation = &workspace.TokenInformation{}
+				}
+				account.TokenInformation.Name = fetchedTokenInfo.Name
+				account.TokenInformation.Organization = fetchedTokenInfo.Organization
+				account.TokenInformation.Team = fetchedTokenInfo.Team
+			}
+			tokenInfo = account.TokenInformation
 		}
 		account.LastValidatedAt = now
 	}
@@ -745,20 +754,14 @@ func (m defaultLoginManager) currentOrSignupAgentAccount(
 	if err != nil {
 		return nil, err
 	}
-	if tokenInfo == nil {
-		tokenInfo = &workspace.TokenInformation{}
-	}
-	tokenInfo.ExpiresAt = &signup.AccessTokenValidUntil
-
 	account := workspace.Account{
-		AccessToken:      signup.AccessToken,
-		RefreshToken:     signup.RefreshToken,
 		Username:         username,
 		Organizations:    organizations,
 		TokenInformation: tokenInfo,
 		LastValidatedAt:  time.Now(),
 		Insecure:         insecure,
 	}
+	account.SetCredentials(signup.AccessToken, signup.AccessTokenValidUntil, signup.RefreshToken)
 	if err = workspace.StoreAgentAccount(cloudURL, account, setCurrent); err != nil {
 		return nil, err
 	}
@@ -900,19 +903,14 @@ func (m defaultLoginManager) LoginWithOIDCToken(
 		return nil, err
 	}
 
-	if tokenInfo == nil {
-		tokenInfo = &workspace.TokenInformation{}
-	}
-	tokenInfo.ExpiresAt = &expiresAt
-
 	account := workspace.Account{
-		AccessToken:      accessToken,
 		Username:         username,
 		Organizations:    organizations,
 		TokenInformation: tokenInfo,
 		LastValidatedAt:  time.Now(),
 		Insecure:         insecure,
 	}
+	account.SetCredentials(accessToken, expiresAt, "")
 	if err = storeUserAccount(cloudURL, account, setCurrent); err != nil {
 		return nil, err
 	}
@@ -2643,9 +2641,8 @@ func getAccountDetails(
 	cloudURL string,
 	insecure bool,
 	accessToken, refreshToken string,
-	onRefresh func(accessToken, refreshToken string) error,
+	onRefresh func(accessToken string, accessTokenExpiresAt time.Time, refreshToken string) error,
 ) (string, []string, *workspace.TokenInformation, error) {
-	// TODO(https://github.com/pulumi/pulumi/issues/20986): Return expiresIn within TokenInformation.
 	apiClient := client.NewClient(cloudURL, accessToken, insecure, cmdutil.Diag()).
 		WithRefresh(refreshToken, onRefresh)
 	username, organizations, tokenInfo, err := apiClient.GetPulumiAccountDetails(ctx)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -280,6 +280,11 @@ func New(ctx context.Context, d diag.Sink,
 	apiToken := account.AccessToken
 
 	apiClient := client.NewClient(cloudURL, apiToken, insecure, d)
+	apiClient.WithRefresh(account.RefreshToken, func(at, rt string) error {
+		account.AccessToken = at
+		account.RefreshToken = rt
+		return workspace.StoreAccount(cloudURL, account, false)
+	})
 	escClient := esc_client.New(client.UserAgent(), cloudURL, apiToken, insecure)
 
 	config, err := workspace.GetPulumiConfig()

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -549,6 +549,63 @@ func TestCurrentRefreshesLocallyExpiredAccessTokenWhenRefreshTokenStored(t *test
 	assert.Equal(t, "fresh-access-token", saved.AccessToken,
 		"credentials.json should reflect the refreshed access token")
 	assert.Equal(t, "stored-refresh-token", saved.RefreshToken)
+	require.NotNil(t, saved.TokenInformation, "refresh must update TokenInformation with the new expiry")
+	require.NotNil(t, saved.TokenInformation.ExpiresAt,
+		"the grant's ExpiresIn must land as the new TokenInformation.ExpiresAt; "+
+			"without this the next cold-start can't take the local-expiry refresh path")
+	assert.True(t, saved.TokenInformation.ExpiresAt.After(time.Now()),
+		"the new ExpiresAt must be in the future (roughly now + ExpiresIn)")
+}
+
+//nolint:paralleltest // mutates env vars and shared temporary agent credentials
+func TestCurrentPreservesExpiresAtWhenServerAcceptsLocallyExpiredAccessToken(t *testing.T) {
+	// Cold-start with a locally-expired access token whose server-side TTL is actually still
+	// valid: validateStoredAccount enters the refresh-or-fetch branch and /api/user succeeds
+	// without firing a refresh. /api/user never returns ExpiresAt, so the merge must keep the
+	// existing (now-past) ExpiresAt instead of nullifying TokenInformation entirely — otherwise
+	// every subsequent run forfeits the cold-start refresh path and the agent-auth banner
+	// mis-reports the account as unable to authenticate.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/user":
+			assert.Equal(t, "token live-access-token", req.Header.Get("Authorization"),
+				"the existing access token must reach /api/user — refresh should not fire on 200")
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "alice",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		case "/api/oauth/token":
+			t.Errorf("refresh-token grant must not fire when /api/user returns 200")
+			rw.WriteHeader(http.StatusInternalServerError)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	expiredAt := time.Now().Add(-time.Hour)
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  "live-access-token",
+		RefreshToken: "stored-refresh-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiredAt,
+		},
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "live-access-token", account.AccessToken, "no refresh, no rotation")
+	assert.Equal(t, "alice", account.Username)
+	require.NotNil(t, account.TokenInformation,
+		"TokenInformation must survive a fetch that returns no token info of its own")
+	require.NotNil(t, account.TokenInformation.ExpiresAt,
+		"ExpiresAt must survive the merge so the banner and cold-start path keep working")
 }
 
 //nolint:paralleltest // mutates env vars and shared temporary agent credentials
@@ -626,10 +683,11 @@ func TestGetAccountDetailsInstallsRefreshWrapperWhenRefreshTokenSupplied(t *test
 	t.Cleanup(server.Close)
 
 	var gotAT, gotRT string
+	var gotExpiresAt time.Time
 	username, _, _, err := getAccountDetails(t.Context(), server.URL, false,
 		"stale-access", "the-refresh",
-		func(at, rt string) error {
-			gotAT, gotRT = at, rt
+		func(at string, expiresAt time.Time, rt string) error {
+			gotAT, gotRT, gotExpiresAt = at, rt, expiresAt
 			return nil
 		},
 	)
@@ -639,6 +697,10 @@ func TestGetAccountDetailsInstallsRefreshWrapperWhenRefreshTokenSupplied(t *test
 	assert.Equal(t, 2, userCalls, "the /api/user call should retry after refresh")
 	assert.Equal(t, "wrapper-minted-token", gotAT, "onRefresh receives the new access token")
 	assert.Equal(t, "the-refresh", gotRT, "onRefresh receives the (preserved) refresh token")
+	assert.False(t, gotExpiresAt.IsZero(),
+		"onRefresh receives the new access token's ExpiresAt derived from the grant's ExpiresIn")
+	assert.True(t, gotExpiresAt.After(time.Now().Add(50*time.Minute)),
+		"ExpiresAt is roughly now+ExpiresIn (3600s in this fixture)")
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -481,6 +481,116 @@ func TestValidateStoredAccountSkipsNetworkWhenNoCredential(t *testing.T) {
 	assert.Empty(t, account.AccessToken)
 }
 
+//nolint:paralleltest // mutates environment
+func TestCurrentRefreshesLocallyExpiredAccessTokenWhenRefreshTokenStored(t *testing.T) {
+	// Cold-start with a locally-expired access token: validateStoredAccount must take the refresh
+	// path instead of hard-failing, so the next call silently mints a fresh access token and
+	// credentials.json is updated in place.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			require.Equal(t, http.MethodPost, req.Method)
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "grant_type=refresh_token")
+			assert.Contains(t, string(body), "refresh_token=stored-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "fresh-access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "stored-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			switch req.Header.Get("Authorization") {
+			case "token stale-access-token":
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			case "token fresh-access-token":
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "alice",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected Authorization header: %q", req.Header.Get("Authorization"))
+				rw.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	expiredAt := time.Now().Add(-time.Hour)
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  "stale-access-token",
+		RefreshToken: "stored-refresh-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiredAt,
+		},
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "fresh-access-token", account.AccessToken,
+		"a locally-expired access token must trigger a refresh instead of failing the validate step")
+	assert.Equal(t, "stored-refresh-token", account.RefreshToken)
+	assert.Equal(t, "alice", account.Username)
+
+	saved, err := workspace.GetAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-access-token", saved.AccessToken,
+		"credentials.json should reflect the refreshed access token")
+	assert.Equal(t, "stored-refresh-token", saved.RefreshToken)
+}
+
+//nolint:paralleltest // mutates env vars and shared temporary agent credentials
+func TestCurrentReturnsNoAccountWhenAccessTokenLocallyExpiredAndNoRefreshToken(t *testing.T) {
+	// Cold-start with a locally-expired access token but no refresh token must short-circuit
+	// before hitting the network — preserves the pre-refresh-token behavior for accounts that
+	// were stored without one.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+	// Ensure agent-mode fallback doesn't trigger — we're verifying the no-login path.
+	t.Setenv("AI_AGENT", "")
+	t.Setenv("CODEX_SANDBOX", "")
+	t.Setenv("CODEX_CI", "")
+	t.Setenv("CODEX_THREAD_ID", "")
+	t.Setenv("CURSOR_TRACE_ID", "")
+	t.Setenv("CURSOR_AGENT", "")
+	t.Setenv("CLAUDECODE", "")
+	t.Setenv("CLAUDE_CODE", "")
+
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		hits++
+		t.Errorf("no network call should be made when the access token is locally expired and no refresh token is stored: %s", req.URL.Path)
+		rw.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	expiredAt := time.Now().Add(-time.Hour)
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken: "stale-access-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiredAt,
+		},
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	assert.Nil(t, account, "no refresh token + locally-expired access token must not produce a logged-in account")
+	assert.Equal(t, 0, hits, "validateStoredAccount must short-circuit without any network call")
+}
+
 //nolint:paralleltest // makes real HTTP calls to a test server
 func TestGetAccountDetailsInstallsRefreshWrapperWhenRefreshTokenSupplied(t *testing.T) {
 	var refreshCalls, userCalls int
@@ -900,9 +1010,9 @@ func TestCurrentSignupAgentAccountWithoutRefreshTokenLeavesAccountEmpty(t *testi
 
 //nolint:paralleltest // mutates shared temporary agent credentials
 func TestCurrentSignupAgentAccountReplacesExistingRefreshTokenOnResignup(t *testing.T) {
-	// When existing agent creds are no longer valid and the CLI re-signs up, the refresh token
-	// returned by the new signup replaces the stale one — the prior value must not survive into
-	// the rebuilt Account.
+	// When existing agent creds are no longer valid AND the stored refresh token is rejected by
+	// the server, the CLI falls through to re-signup. The refresh token returned by the new
+	// signup replaces the stale one — the prior value must not survive into the rebuilt Account.
 	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
 	t.Setenv(client.ConsoleDomainEnvVar, "app.example.com")
 
@@ -930,11 +1040,22 @@ func TestCurrentSignupAgentAccountReplacesExistingRefreshTokenOnResignup(t *test
 			default:
 				rw.WriteHeader(http.StatusMethodNotAllowed)
 			}
+		case "/api/oauth/token":
+			// Reject the stale refresh token so validateStoredAccount can't revive the account.
+			rw.WriteHeader(http.StatusBadRequest)
+			err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 400, Message: "invalid_grant"})
+			require.NoError(t, err)
 		case "/api/user":
-			err := json.NewEncoder(rw).Encode(map[string]any{
-				"githubLogin":   "agent-user",
-				"organizations": []map[string]string{},
-			})
+			if req.Header.Get("Authorization") == "token new-access-token" {
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "agent-user",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+				return
+			}
+			rw.WriteHeader(http.StatusUnauthorized)
+			err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
 			require.NoError(t, err)
 		default:
 			rw.WriteHeader(http.StatusNotFound)
@@ -942,9 +1063,9 @@ func TestCurrentSignupAgentAccountReplacesExistingRefreshTokenOnResignup(t *test
 	}))
 	t.Cleanup(server.Close)
 
-	// Stale agent creds: locally-expired access token (forces validateStoredAccount to mark them
-	// invalid before any network attempt) and an old refresh token. No claim is stored, so
-	// currentOrSignupAgentAccount falls through to re-signup.
+	// Stale agent creds: locally-expired access token and a stale refresh token that the server
+	// will reject. No claim is stored, so currentOrSignupAgentAccount falls through to re-signup
+	// once the refresh attempt fails.
 	expiredAt := time.Now().Add(-time.Hour)
 	require.NoError(t, workspace.StoreAgentAccount(server.URL, workspace.Account{
 		AccessToken:  "old-access-token",
@@ -965,6 +1086,83 @@ func TestCurrentSignupAgentAccountReplacesExistingRefreshTokenOnResignup(t *test
 	require.NoError(t, err)
 	assert.Equal(t, "new-refresh-token", stored.RefreshToken,
 		"re-signup must replace the stale refresh token, not preserve it")
+}
+
+//nolint:paralleltest // mutates shared temporary agent credentials
+func TestCurrentAgentAccountRefreshesLocallyExpiredAccessTokenInsteadOfResigning(t *testing.T) {
+	// Cold-start in agent mode with a locally-expired access token but a valid refresh token:
+	// validateStoredAccount must refresh through /api/oauth/token instead of falling through to
+	// re-signup. Re-signup would burn a fresh agent identity and lose the claim association.
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv(client.ConsoleDomainEnvVar, "app.example.com")
+
+	signupCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/agents/signup":
+			signupCalls++
+			t.Errorf("re-signup must NOT happen when the stored refresh token succeeds: %s %s", req.Method, req.URL.Path)
+			rw.WriteHeader(http.StatusInternalServerError)
+		case "/api/oauth/token":
+			require.Equal(t, http.MethodPost, req.Method)
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "grant_type=refresh_token")
+			assert.Contains(t, string(body), "refresh_token=stored-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "fresh-access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "stored-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			switch req.Header.Get("Authorization") {
+			case "token old-access-token":
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			case "token fresh-access-token":
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "agent-user",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected Authorization header: %q", req.Header.Get("Authorization"))
+				rw.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	expiredAt := time.Now().Add(-time.Hour)
+	require.NoError(t, workspace.StoreAgentAccount(server.URL, workspace.Account{
+		AccessToken:  "old-access-token",
+		RefreshToken: "stored-refresh-token",
+		Username:     "agent-user",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiredAt,
+		},
+	}, true))
+
+	ctx := ContextWithAgentCredentialUse(t.Context())
+	account, err := defaultLoginManager{}.currentOrSignupAgentAccount(ctx, server.URL, false, true, "codex")
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "fresh-access-token", account.AccessToken,
+		"locally-expired agent access token must be refreshed in place, not resigned")
+	assert.Equal(t, "stored-refresh-token", account.RefreshToken)
+	assert.Equal(t, "agent-user", account.Username, "username should survive the refresh path")
+	assert.Equal(t, 0, signupCalls, "signup must not be called when refresh succeeds")
+
+	stored, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-access-token", stored.AccessToken,
+		"agent credentials file should reflect the refreshed access token")
+	assert.Equal(t, "stored-refresh-token", stored.RefreshToken)
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -650,6 +650,73 @@ func TestCurrentSignupAgentAccountStoresClaimTokenURL(t *testing.T) {
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials
+func TestCurrentSignupAgentAccountStoresRefreshToken(t *testing.T) {
+	// The refresh token returned by agent signup must land in the stored Account so the
+	// auto-refresh wrapper can use it once the access token expires.
+	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
+	require.NoError(t, err)
+	oldAgentClaim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, workspace.DeleteAgentCredentials())
+		require.NoError(t, workspace.StoreAgentCredentials(oldAgentCreds))
+		if oldAgentClaim.ClaimURL != "" {
+			require.NoError(t, workspace.StoreAgentClaim(oldAgentClaim))
+		}
+	})
+	t.Setenv(client.ConsoleDomainEnvVar, "app.example.com")
+
+	accessTokenValidUntil := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	claimTokenValidUntil := accessTokenValidUntil.Add(24 * time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/agents/signup":
+			switch req.Method {
+			case http.MethodGet:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupChallenge{
+					ChallengeID:   "challenge-1",
+					ChallengeData: "v1:abcdef:8",
+				})
+				require.NoError(t, err)
+			case http.MethodPost:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupResponse{
+					AccessToken:           "agent-access-token",
+					AccessTokenValidUntil: accessTokenValidUntil,
+					RefreshToken:          "agent-refresh-token",
+					ClaimToken:            "claim-token",
+					ClaimTokenValidUntil:  claimTokenValidUntil,
+				})
+				require.NoError(t, err)
+			default:
+				rw.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/api/user":
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "agent-user",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := ContextWithAgentCredentialUse(t.Context())
+	account, err := defaultLoginManager{}.currentOrSignupAgentAccount(ctx, server.URL, false, true, "codex")
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "agent-access-token", account.AccessToken)
+	assert.Equal(t, "agent-refresh-token", account.RefreshToken,
+		"signup-returned refresh token must be plumbed into the returned Account")
+
+	stored, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-refresh-token", stored.RefreshToken,
+		"signup-returned refresh token must be persisted to the agent credentials file")
+}
+
+//nolint:paralleltest // mutates shared temporary agent credentials
 func TestCurrentSignupAgentAccountRequiresResponseFields(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -353,6 +353,124 @@ func TestCurrentRefreshesFromRefreshOnlyStoredAccount(t *testing.T) {
 	assert.Equal(t, "bob", account.Username)
 }
 
+//nolint:paralleltest // mutates environment
+func TestCurrentPersistsRotatedRefreshToken(t *testing.T) {
+	// True rotation: the refresh-token grant returns a refresh token DIFFERENT from the one we
+	// sent. The wrapper updates the in-memory account and the writeback persists the rotated
+	// value to credentials.json. Server-side rotation is a Phase 2 behavior — this test pins the
+	// CLI side so we don't need a change when it lands.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "refresh_token=stored-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "fresh-access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "rotated-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			if req.Header.Get("Authorization") == "token fresh-access-token" {
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "alice",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+				return
+			}
+			rw.WriteHeader(http.StatusUnauthorized)
+			err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+			require.NoError(t, err)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  "stale-access-token",
+		RefreshToken: "stored-refresh-token",
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "fresh-access-token", account.AccessToken)
+	assert.Equal(t, "rotated-refresh-token", account.RefreshToken)
+
+	saved, err := workspace.GetAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-access-token", saved.AccessToken)
+	assert.Equal(t, "rotated-refresh-token", saved.RefreshToken,
+		"credentials.json must reflect the rotated refresh token")
+}
+
+//nolint:paralleltest // mutates environment
+func TestCurrentPreservesRefreshTokenWhenGrantResponseOmitsIt(t *testing.T) {
+	// RFC 6749 §6: omitted (or empty) refresh_token in the grant response means "keep using
+	// yours" — the server is not signalling termination. credentials.json must hold onto the
+	// existing refresh token so the next 401 can refresh again.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "refresh_token=stored-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken: "fresh-access-token",
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+				// RefreshToken omitted — JSON encoder drops it.
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			if req.Header.Get("Authorization") == "token fresh-access-token" {
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "alice",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+				return
+			}
+			rw.WriteHeader(http.StatusUnauthorized)
+			err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+			require.NoError(t, err)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  "stale-access-token",
+		RefreshToken: "stored-refresh-token",
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "fresh-access-token", account.AccessToken)
+	assert.Equal(t, "stored-refresh-token", account.RefreshToken,
+		"omitted refresh_token in the response must not destroy the existing one")
+
+	saved, err := workspace.GetAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-access-token", saved.AccessToken)
+	assert.Equal(t, "stored-refresh-token", saved.RefreshToken,
+		"credentials.json must hold onto the existing refresh token")
+}
+
 func TestValidateStoredAccountSkipsNetworkWhenNoCredential(t *testing.T) {
 	t.Parallel()
 	// An account with neither an access nor a refresh token can't authenticate and must short-
@@ -714,6 +832,139 @@ func TestCurrentSignupAgentAccountStoresRefreshToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "agent-refresh-token", stored.RefreshToken,
 		"signup-returned refresh token must be persisted to the agent credentials file")
+}
+
+//nolint:paralleltest // mutates shared temporary agent credentials
+func TestCurrentSignupAgentAccountWithoutRefreshTokenLeavesAccountEmpty(t *testing.T) {
+	// Back-compat with a server that doesn't (yet) issue refresh tokens at signup: the response
+	// omits refreshToken and the CLI must not error or invent a value.
+	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
+	require.NoError(t, err)
+	oldAgentClaim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, workspace.DeleteAgentCredentials())
+		require.NoError(t, workspace.StoreAgentCredentials(oldAgentCreds))
+		if oldAgentClaim.ClaimURL != "" {
+			require.NoError(t, workspace.StoreAgentClaim(oldAgentClaim))
+		}
+	})
+	t.Setenv(client.ConsoleDomainEnvVar, "app.example.com")
+
+	accessTokenValidUntil := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	claimTokenValidUntil := accessTokenValidUntil.Add(24 * time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/agents/signup":
+			switch req.Method {
+			case http.MethodGet:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupChallenge{
+					ChallengeID:   "challenge-1",
+					ChallengeData: "v1:abcdef:8",
+				})
+				require.NoError(t, err)
+			case http.MethodPost:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupResponse{
+					AccessToken:           "agent-access-token",
+					AccessTokenValidUntil: accessTokenValidUntil,
+					ClaimToken:            "claim-token",
+					ClaimTokenValidUntil:  claimTokenValidUntil,
+				})
+				require.NoError(t, err)
+			default:
+				rw.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/api/user":
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "agent-user",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	ctx := ContextWithAgentCredentialUse(t.Context())
+	account, err := defaultLoginManager{}.currentOrSignupAgentAccount(ctx, server.URL, false, true, "codex")
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "agent-access-token", account.AccessToken)
+	assert.Empty(t, account.RefreshToken, "no refreshToken in response → none on the Account")
+
+	stored, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Empty(t, stored.RefreshToken, "no refreshToken in response → none persisted")
+}
+
+//nolint:paralleltest // mutates shared temporary agent credentials
+func TestCurrentSignupAgentAccountReplacesExistingRefreshTokenOnResignup(t *testing.T) {
+	// When existing agent creds are no longer valid and the CLI re-signs up, the refresh token
+	// returned by the new signup replaces the stale one — the prior value must not survive into
+	// the rebuilt Account.
+	t.Setenv("PULUMI_TEST_AGENT_PULUMI_DIR", t.TempDir())
+	t.Setenv(client.ConsoleDomainEnvVar, "app.example.com")
+
+	accessTokenValidUntil := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	claimTokenValidUntil := accessTokenValidUntil.Add(24 * time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/agents/signup":
+			switch req.Method {
+			case http.MethodGet:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupChallenge{
+					ChallengeID:   "challenge-1",
+					ChallengeData: "v1:abcdef:8",
+				})
+				require.NoError(t, err)
+			case http.MethodPost:
+				err := json.NewEncoder(rw).Encode(client.AgentSignupResponse{
+					AccessToken:           "new-access-token",
+					AccessTokenValidUntil: accessTokenValidUntil,
+					RefreshToken:          "new-refresh-token",
+					ClaimToken:            "new-claim-token",
+					ClaimTokenValidUntil:  claimTokenValidUntil,
+				})
+				require.NoError(t, err)
+			default:
+				rw.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case "/api/user":
+			err := json.NewEncoder(rw).Encode(map[string]any{
+				"githubLogin":   "agent-user",
+				"organizations": []map[string]string{},
+			})
+			require.NoError(t, err)
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	// Stale agent creds: locally-expired access token (forces validateStoredAccount to mark them
+	// invalid before any network attempt) and an old refresh token. No claim is stored, so
+	// currentOrSignupAgentAccount falls through to re-signup.
+	expiredAt := time.Now().Add(-time.Hour)
+	require.NoError(t, workspace.StoreAgentAccount(server.URL, workspace.Account{
+		AccessToken:  "old-access-token",
+		RefreshToken: "old-refresh-token",
+		TokenInformation: &workspace.TokenInformation{
+			ExpiresAt: &expiredAt,
+		},
+	}, true))
+
+	ctx := ContextWithAgentCredentialUse(t.Context())
+	account, err := defaultLoginManager{}.currentOrSignupAgentAccount(ctx, server.URL, false, true, "codex")
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "new-access-token", account.AccessToken)
+	assert.Equal(t, "new-refresh-token", account.RefreshToken)
+
+	stored, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "new-refresh-token", stored.RefreshToken,
+		"re-signup must replace the stale refresh token, not preserve it")
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -572,7 +572,8 @@ func TestCurrentReturnsNoAccountWhenAccessTokenLocallyExpiredAndNoRefreshToken(t
 	var hits int
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		hits++
-		t.Errorf("no network call should be made when the access token is locally expired and no refresh token is stored: %s", req.URL.Path)
+		t.Errorf("no network call should be made when the access token is locally expired "+
+			"and no refresh token is stored: %s", req.URL.Path)
 		rw.WriteHeader(http.StatusInternalServerError)
 	}))
 	t.Cleanup(server.Close)

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -299,6 +299,117 @@ func TestCurrentRefreshesAccessTokenOn401WhenRefreshTokenStored(t *testing.T) {
 	assert.Equal(t, "fresh-access-token", saved.AccessToken,
 		"credentials.json should reflect the refreshed access token")
 	assert.Equal(t, "stored-refresh-token", saved.RefreshToken)
+	assert.WithinDuration(t, time.Now(), saved.LastValidatedAt, time.Minute,
+		"validateStoredAccount must stamp LastValidatedAt when it actually validates")
+}
+
+//nolint:paralleltest // mutates environment
+func TestCurrentRefreshesFromRefreshOnlyStoredAccount(t *testing.T) {
+	// HasCredential opens the gate for accounts with a refresh token but no access token. The
+	// wrapper mints the first access token on the initial 401 from an empty bearer.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "refresh_token=only-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "minted-access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "only-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			if req.Header.Get("Authorization") == "token minted-access-token" {
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "bob",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			} else {
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		RefreshToken: "only-refresh-token",
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "minted-access-token", account.AccessToken)
+	assert.Equal(t, "bob", account.Username)
+}
+
+func TestValidateStoredAccountSkipsNetworkWhenNoCredential(t *testing.T) {
+	t.Parallel()
+	// An account with neither an access nor a refresh token can't authenticate and must short-
+	// circuit before any network attempt — the cloudURL here intentionally points nowhere.
+	account, valid, err := validateStoredAccount(t.Context(), "http://127.0.0.1:0", false, workspace.Account{})
+	require.NoError(t, err)
+	assert.False(t, valid)
+	assert.Empty(t, account.AccessToken)
+}
+
+//nolint:paralleltest // makes real HTTP calls to a test server
+func TestGetAccountDetailsInstallsRefreshWrapperWhenRefreshTokenSupplied(t *testing.T) {
+	var refreshCalls, userCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			refreshCalls++
+			err := json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "wrapper-minted-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "the-refresh",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			userCalls++
+			if req.Header.Get("Authorization") == "token wrapper-minted-token" {
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "carol",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			} else {
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var gotAT, gotRT string
+	username, _, _, err := getAccountDetails(t.Context(), server.URL, false,
+		"stale-access", "the-refresh",
+		func(at, rt string) error {
+			gotAT, gotRT = at, rt
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "carol", username)
+	assert.Equal(t, 1, refreshCalls, "refresh should fire exactly once after the initial 401")
+	assert.Equal(t, 2, userCalls, "the /api/user call should retry after refresh")
+	assert.Equal(t, "wrapper-minted-token", gotAT, "onRefresh receives the new access token")
+	assert.Equal(t, "the-refresh", gotRT, "onRefresh receives the (preserved) refresh token")
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials
@@ -444,6 +555,15 @@ func TestCurrentValidAgentCredentialsWithExpiredClaimDoesNotSignup(t *testing.T)
 	assert.Equal(t, "valid-agent-token", account.AccessToken)
 	assert.True(t, AgentCredentialsUsed(ctx, server.URL))
 	assert.Equal(t, 0, signupCalls)
+
+	// Post-validate persistence goes through agentAccount.Save, which writes to the agent file
+	// (the account's source) rather than leaking into default credentials.
+	fromAgent, err := workspace.GetAgentAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "valid-agent-token", fromAgent.AccessToken)
+	fromDefault, err := workspace.GetAccount(server.URL)
+	require.NoError(t, err)
+	assert.Empty(t, fromDefault.AccessToken, "agent-sourced account must not be copied into default credentials")
 }
 
 //nolint:paralleltest // mutates shared temporary agent credentials and console env

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -1962,7 +1962,7 @@ func TestGetAccountDetails(t *testing.T) {
 			}
 
 			username, orgs, tokenInfo, err := getAccountDetails(
-				t.Context(), cloudURL, false, tt.accessToken,
+				t.Context(), cloudURL, false, tt.accessToken, "", nil,
 			)
 
 			if tt.wantErr {

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -237,6 +237,70 @@ func TestCurrentEnvTokenStoresInDefaultPathWhenWritable(t *testing.T) {
 	assert.Empty(t, agentAccount.AccessToken)
 }
 
+//nolint:paralleltest // mutates env vars and credentials on disk
+func TestCurrentRefreshesAccessTokenOn401WhenRefreshTokenStored(t *testing.T) {
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			require.Equal(t, http.MethodPost, req.Method)
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			assert.Contains(t, string(body), "grant_type=refresh_token")
+			assert.Contains(t, string(body), "refresh_token=stored-refresh-token")
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  "fresh-access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "stored-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			switch req.Header.Get("Authorization") {
+			case "token stale-access-token":
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			case "token fresh-access-token":
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "alice",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected Authorization header: %q", req.Header.Get("Authorization"))
+				rw.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  "stale-access-token",
+		RefreshToken: "stored-refresh-token",
+	}, true))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, "fresh-access-token", account.AccessToken,
+		"the stored access token should be refreshed before reporting the account as valid")
+	assert.Equal(t, "stored-refresh-token", account.RefreshToken,
+		"the refresh token is preserved (Phase 1: server doesn't rotate)")
+	assert.Equal(t, "alice", account.Username)
+
+	saved, err := workspace.GetAccount(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh-access-token", saved.AccessToken,
+		"credentials.json should reflect the refreshed access token")
+	assert.Equal(t, "stored-refresh-token", saved.RefreshToken)
+}
+
 //nolint:paralleltest // mutates shared temporary agent credentials
 func TestCurrentInvalidAgentCredentialsWithActiveClaimDoesNotSignup(t *testing.T) {
 	oldAgentCreds, err := workspace.GetAgentStoredCredentials()

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -169,6 +170,14 @@ type accessToken interface {
 	Get(ctx context.Context) (string, error)
 }
 
+// refreshable is the opt-in interface for access tokens that can renew themselves when the server
+// rejects the current value with 401. defaultRESTClient.Call type-asserts on this after a 401 and,
+// if the assertion succeeds, calls Refresh once and retries the request before surfacing
+// LoginRequiredError.
+type refreshable interface {
+	Refresh(ctx context.Context) error
+}
+
 type httpCallOptions struct {
 	// RetryPolicy defines the policy for retrying requests by httpClient.Do.
 	//
@@ -202,6 +211,54 @@ func (apiAccessToken) Kind() accessTokenKind {
 
 func (t apiAccessToken) Get(_ context.Context) (string, error) {
 	return string(t), nil
+}
+
+// refreshableAPIAccessToken is an apiAccessToken that can renew itself via the OAuth refresh-token
+// grant (RFC 6749 §6) when the current access token expires. defaultRESTClient.Call type-asserts
+// on the refreshable interface after a 401 and calls Refresh once before falling through to
+// LoginRequiredError.
+//
+// The refresh and writeback callbacks are decoupled so the type stays free of dependencies on the
+// Pulumi service client and credential storage: callers wire the wrapper into client.NewClient by
+// closing over Client.RefreshAccessToken and workspace.StoreAccount respectively.
+type refreshableAPIAccessToken struct {
+	mu sync.Mutex
+	// accessToken is the current short-lived bearer; sent on every request.
+	accessToken string
+	// refreshToken is the long-lived credential exchanged at /api/oauth/token for a fresh
+	// access token. Held off the request path and only ever passed to the refresh callback.
+	refreshToken string
+	// refresh exchanges refreshToken for a new access token. Returns the new (access, refresh)
+	// pair; if the server doesn't rotate (Phase 1 behavior) it returns an empty newRefreshToken
+	// and the wrapper keeps the existing one.
+	refresh func(ctx context.Context, refreshToken string) (accessToken, newRefreshToken string, err error)
+	// writeback persists the refreshed credentials. Called with the wrapper's lock held so the
+	// in-memory and on-disk views can't diverge under concurrent refreshes.
+	writeback func(accessToken, refreshToken string) error
+}
+
+func (*refreshableAPIAccessToken) Kind() accessTokenKind {
+	return accessTokenKindAPIToken
+}
+
+func (t *refreshableAPIAccessToken) Get(_ context.Context) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.accessToken, nil
+}
+
+func (t *refreshableAPIAccessToken) Refresh(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	newAT, newRT, err := t.refresh(ctx, t.refreshToken)
+	if err != nil {
+		return err
+	}
+	t.accessToken = newAT
+	if newRT != "" {
+		t.refreshToken = newRT
+	}
+	return t.writeback(t.accessToken, t.refreshToken)
 }
 
 // UpdateTokenSource allows the API client to request tokens for an in-progress update as near as possible to the
@@ -624,9 +681,19 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 		}
 	}
 
-	// Make API call
+	// Make API call. If the access token can refresh itself and the server rejects it with
+	// LoginRequiredError, refresh once and retry — this lets agent CLIs survive routine access-token
+	// expiry without bouncing back through a human-driven login.
 	url, resp, err := pulumiAPICall(
 		ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
+	if err != nil && errors.Is(err, backenderr.LoginRequiredError{}) {
+		if r, ok := tok.(refreshable); ok {
+			if refreshErr := r.Refresh(ctx); refreshErr == nil {
+				url, resp, err = pulumiAPICall(
+					ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
+			}
+		}
+	}
 	if err != nil {
 		otelSpan.RecordError(err)
 		otelSpan.SetStatus(codes.Error, err.Error())

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -228,13 +228,14 @@ type refreshableAPIAccessToken struct {
 	// refreshToken is the long-lived credential exchanged at /api/oauth/token for a fresh
 	// access token. Held off the request path and only ever passed to the refresh callback.
 	refreshToken string
-	// refresh exchanges refreshToken for a new access token. Returns the new (access, refresh)
-	// pair; if the server doesn't rotate (Phase 1 behavior) it returns an empty newRefreshToken
-	// and the wrapper keeps the existing one.
-	refresh func(ctx context.Context, refreshToken string) (accessToken, newRefreshToken string, err error)
-	// writeback persists the refreshed credentials. Called with the wrapper's lock held so the
-	// in-memory and on-disk views can't diverge under concurrent refreshes.
-	writeback func(accessToken, refreshToken string) error
+	// refresh exchanges refreshToken for a new access token. Empty newRefreshToken /
+	// zero accessTokenExpiresAt means the server did not supply that field; the
+	// wrapper keeps the existing value.
+	refresh func(ctx context.Context, refreshToken string) (
+		accessToken string, accessTokenExpiresAt time.Time, newRefreshToken string, err error)
+	// writeback persists the refreshed credentials. Called with the wrapper's lock held
+	// so the in-memory and on-disk views can't diverge under concurrent refreshes.
+	writeback func(accessToken string, accessTokenExpiresAt time.Time, refreshToken string) error
 }
 
 func (*refreshableAPIAccessToken) Kind() accessTokenKind {
@@ -250,7 +251,7 @@ func (t *refreshableAPIAccessToken) Get(_ context.Context) (string, error) {
 func (t *refreshableAPIAccessToken) Refresh(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	newAT, newRT, err := t.refresh(ctx, t.refreshToken)
+	newAT, expiresAt, newRT, err := t.refresh(ctx, t.refreshToken)
 	if err != nil {
 		return err
 	}
@@ -258,7 +259,7 @@ func (t *refreshableAPIAccessToken) Refresh(ctx context.Context) error {
 	if newRT != "" {
 		t.refreshToken = newRT
 	}
-	return t.writeback(t.accessToken, t.refreshToken)
+	return t.writeback(t.accessToken, expiresAt, t.refreshToken)
 }
 
 // UpdateTokenSource allows the API client to request tokens for an in-progress update as near as possible to the

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -173,9 +173,11 @@ type accessToken interface {
 // refreshable is the opt-in interface for access tokens that can renew themselves when the server
 // rejects the current value with 401. defaultRESTClient.Call type-asserts on this after a 401 and,
 // if the assertion succeeds, calls Refresh once and retries the request before surfacing
-// LoginRequiredError.
+// LoginRequiredError. prevAccessToken is the access token the caller sent on the failed request;
+// if it no longer matches the wrapper's current token, another caller has already refreshed and
+// Refresh returns nil without contacting the server.
 type refreshable interface {
-	Refresh(ctx context.Context) error
+	Refresh(ctx context.Context, prevAccessToken string) error
 }
 
 type httpCallOptions struct {
@@ -248,9 +250,14 @@ func (t *refreshableAPIAccessToken) Get(_ context.Context) (string, error) {
 	return t.accessToken, nil
 }
 
-func (t *refreshableAPIAccessToken) Refresh(ctx context.Context) error {
+func (t *refreshableAPIAccessToken) Refresh(ctx context.Context, prevAccessToken string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	// If another caller already refreshed while we were queued for the lock, the in-memory
+	// access token has advanced past the one we sent — bail without burning another grant.
+	if t.accessToken != prevAccessToken {
+		return nil
+	}
 	newAT, expiresAt, newRT, err := t.refresh(ctx, t.refreshToken)
 	if err != nil {
 		return err
@@ -684,12 +691,15 @@ func (c *defaultRESTClient) Call(ctx context.Context, diag diag.Sink, cloudAPI, 
 
 	// Make API call. If the access token can refresh itself and the server rejects it with
 	// LoginRequiredError, refresh once and retry — this lets agent CLIs survive routine access-token
-	// expiry without bouncing back through a human-driven login.
+	// expiry without bouncing back through a human-driven login. Snapshot the access token before
+	// the send so we can tell Refresh which one we used; concurrent 401s thereby dedupe to one
+	// refresh instead of N.
+	sentAccessToken, _ := tok.Get(ctx)
 	url, resp, err := pulumiAPICall(
 		ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
 	if err != nil && errors.Is(err, backenderr.LoginRequiredError{}) {
 		if r, ok := tok.(refreshable); ok {
-			if refreshErr := r.Refresh(ctx); refreshErr == nil {
+			if refreshErr := r.Refresh(ctx, sentAccessToken); refreshErr == nil {
 				url, resp, err = pulumiAPICall(
 					ctx, requestSpan, diag, c.client, cloudAPI, method, path+querystring, reqBody, tok, opts)
 			}

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
@@ -350,12 +351,12 @@ func TestCall_RefreshOn401(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "stale",
 			refreshToken: "rt",
-			refresh: func(_ context.Context, rt string) (string, string, error) {
+			refresh: func(_ context.Context, rt string) (string, time.Time, string, error) {
 				refreshCalls.Add(1)
 				assert.Equal(t, "rt", rt, "the wrapper sends the current refresh token")
-				return "fresh", "rt", nil
+				return "fresh", time.Time{}, "rt", nil
 			},
-			writeback: func(at, rt string) error { return nil },
+			writeback: func(at string, _ time.Time, rt string) error { return nil },
 		}
 
 		err := rest.Call(t.Context(), sink,
@@ -383,10 +384,10 @@ func TestCall_RefreshOn401(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "stale",
 			refreshToken: "rt-revoked",
-			refresh: func(_ context.Context, _ string) (string, string, error) {
-				return "", "", errors.New("invalid_grant")
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
+				return "", time.Time{}, "", errors.New("invalid_grant")
 			},
-			writeback: func(at, rt string) error { return nil },
+			writeback: func(at string, _ time.Time, rt string) error { return nil },
 		}
 
 		err := rest.Call(t.Context(), sink,
@@ -434,11 +435,11 @@ func TestCall_RefreshOn401(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "stale",
 			refreshToken: "rt",
-			refresh: func(_ context.Context, _ string) (string, string, error) {
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
 				refreshCalls.Add(1)
-				return "still-stale", "rt", nil
+				return "still-stale", time.Time{}, "rt", nil
 			},
-			writeback: func(at, rt string) error { return nil },
+			writeback: func(at string, _ time.Time, rt string) error { return nil },
 		}
 
 		err := rest.Call(t.Context(), sink,

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -299,6 +300,154 @@ func TestPulumiAPICall_401_LoginRequired(t *testing.T) {
 		)
 
 		assert.True(t, errors.Is(err, backenderr.LoginRequiredError{}))
+	})
+}
+
+func TestCall_RefreshOn401(t *testing.T) {
+	t.Parallel()
+
+	// errBody401 is the on-wire shape the service returns for an expired access token.
+	errBody401, err := json.Marshal(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+	require.NoError(t, err)
+
+	// newRESTClient builds a defaultRESTClient whose underlying HTTP transport is the given func.
+	newRESTClient := func(rt func(req *http.Request) (*http.Response, error)) *defaultRESTClient {
+		return &defaultRESTClient{
+			client: &defaultHTTPClient{
+				&http.Client{Transport: &errorTransport{roundTripFunc: rt}},
+			},
+		}
+	}
+
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+
+	t.Run("refreshes once and retries the request when the access token is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		var auths []string
+		authsMu := make(chan struct{}, 1)
+		authsMu <- struct{}{}
+
+		rest := newRESTClient(func(req *http.Request) (*http.Response, error) {
+			<-authsMu
+			auths = append(auths, req.Header.Get("Authorization"))
+			authsMu <- struct{}{}
+			n := calls.Add(1)
+			if n == 1 {
+				return &http.Response{
+					StatusCode: 401, Status: "401 Unauthorized",
+					Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(errBody401)),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: 200, Status: "200 OK",
+				Header: http.Header{}, Body: io.NopCloser(bytes.NewReader([]byte(`{}`))),
+			}, nil
+		})
+
+		var refreshCalls atomic.Int32
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale",
+			refreshToken: "rt",
+			refresh: func(_ context.Context, rt string) (string, string, error) {
+				refreshCalls.Add(1)
+				assert.Equal(t, "rt", rt, "the wrapper sends the current refresh token")
+				return "fresh", "rt", nil
+			},
+			writeback: func(at, rt string) error { return nil },
+		}
+
+		err := rest.Call(t.Context(), sink,
+			"https://api.example.com", "GET", "/api/test", nil, nil, nil, tok, httpCallOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), calls.Load(), "the request should be tried twice")
+		assert.Equal(t, int32(1), refreshCalls.Load(), "refresh should fire exactly once")
+		require.Len(t, auths, 2)
+		assert.Equal(t, "token stale", auths[0], "first attempt uses the stale token")
+		assert.Equal(t, "token fresh", auths[1], "retry uses the refreshed token")
+	})
+
+	t.Run("surfaces LoginRequiredError when the refresh itself fails", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		rest := newRESTClient(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return &http.Response{
+				StatusCode: 401, Status: "401 Unauthorized",
+				Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(errBody401)),
+			}, nil
+		})
+
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale",
+			refreshToken: "rt-revoked",
+			refresh: func(_ context.Context, _ string) (string, string, error) {
+				return "", "", errors.New("invalid_grant")
+			},
+			writeback: func(at, rt string) error { return nil },
+		}
+
+		err := rest.Call(t.Context(), sink,
+			"https://api.example.com", "GET", "/api/test", nil, nil, nil, tok, httpCallOptions{})
+		require.Error(t, err)
+		var loginErr backenderr.LoginRequiredError
+		assert.ErrorAs(t, err, &loginErr)
+		assert.Equal(t, int32(1), calls.Load(), "no retry when the refresh attempt fails")
+	})
+
+	t.Run("plain (non-refreshable) tokens fall through to LoginRequiredError unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		rest := newRESTClient(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return &http.Response{
+				StatusCode: 401, Status: "401 Unauthorized",
+				Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(errBody401)),
+			}, nil
+		})
+
+		err := rest.Call(t.Context(), sink,
+			"https://api.example.com", "GET", "/api/test", nil, nil, nil,
+			apiAccessToken("plain"), httpCallOptions{})
+		require.Error(t, err)
+		var loginErr backenderr.LoginRequiredError
+		assert.ErrorAs(t, err, &loginErr)
+		assert.Equal(t, int32(1), calls.Load())
+	})
+
+	t.Run("retries at most once even if the refreshed token is also rejected", func(t *testing.T) {
+		t.Parallel()
+
+		var calls atomic.Int32
+		rest := newRESTClient(func(req *http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return &http.Response{
+				StatusCode: 401, Status: "401 Unauthorized",
+				Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(errBody401)),
+			}, nil
+		})
+
+		var refreshCalls atomic.Int32
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale",
+			refreshToken: "rt",
+			refresh: func(_ context.Context, _ string) (string, string, error) {
+				refreshCalls.Add(1)
+				return "still-stale", "rt", nil
+			},
+			writeback: func(at, rt string) error { return nil },
+		}
+
+		err := rest.Call(t.Context(), sink,
+			"https://api.example.com", "GET", "/api/test", nil, nil, nil, tok, httpCallOptions{})
+		require.Error(t, err)
+		var loginErr backenderr.LoginRequiredError
+		assert.ErrorAs(t, err, &loginErr)
+		assert.Equal(t, int32(2), calls.Load(), "retry once, then surface")
+		assert.Equal(t, int32(1), refreshCalls.Load(), "refresh fires only once even if retry still 401s")
 	})
 }
 

--- a/pkg/backend/httpstate/client/api_test.go
+++ b/pkg/backend/httpstate/client/api_test.go
@@ -450,6 +450,66 @@ func TestCall_RefreshOn401(t *testing.T) {
 		assert.Equal(t, int32(2), calls.Load(), "retry once, then surface")
 		assert.Equal(t, int32(1), refreshCalls.Load(), "refresh fires only once even if retry still 401s")
 	})
+
+	t.Run("concurrent 401s dedupe to a single refresh-grant exchange", func(t *testing.T) {
+		t.Parallel()
+
+		// A Pulumi operation can fan out parallel API calls, so an expired access token may
+		// come back as N concurrent 401s. The wrapper must dedupe into a single refresh
+		// exchange rather than N.
+		const N = 5
+
+		rest := newRESTClient(func(req *http.Request) (*http.Response, error) {
+			if req.Header.Get("Authorization") == "token fresh" {
+				return &http.Response{
+					StatusCode: 200, Status: "200 OK",
+					Header: http.Header{}, Body: io.NopCloser(bytes.NewReader([]byte(`{}`))),
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: 401, Status: "401 Unauthorized",
+				Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(errBody401)),
+			}, nil
+		})
+
+		var refreshCalls atomic.Int32
+		firstRefresh := make(chan struct{})
+		releaseRefresh := make(chan struct{})
+
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale",
+			refreshToken: "rt",
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
+				if refreshCalls.Add(1) == 1 {
+					close(firstRefresh)
+					<-releaseRefresh
+				}
+				return "fresh", time.Time{}, "rt", nil
+			},
+			writeback: func(_ string, _ time.Time, _ string) error { return nil },
+		}
+
+		results := make(chan error, N)
+		for range N {
+			go func() {
+				results <- rest.Call(t.Context(), sink,
+					"https://api.example.com", "GET", "/api/test", nil, nil, nil, tok, httpCallOptions{})
+			}()
+		}
+
+		// Once the first goroutine is in refresh, give the rest a moment to queue on the wrapper's
+		// mutex — no Go primitive surfaces "goroutine blocked on Mutex."
+		<-firstRefresh
+		time.Sleep(100 * time.Millisecond)
+		close(releaseRefresh)
+
+		for range N {
+			require.NoError(t, <-results,
+				"all concurrent callers should authenticate after the deduped refresh")
+		}
+		assert.Equal(t, int32(1), refreshCalls.Load(),
+			"concurrent 401s must dedupe to a single /api/oauth/token call")
+	})
 }
 
 //nolint:paralleltest //  subtests mutate the global otel tracer provider.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -219,7 +219,7 @@ type PublishTemplateVersionCompleteResponse struct{}
 // Client provides a slim wrapper around the Pulumi HTTP/REST API.
 type Client struct {
 	apiURL     string
-	apiToken   apiAccessToken
+	apiToken   accessToken
 	apiUser    string
 	apiOrgs    []string
 	tokenInfo  *workspace.TokenInformation // might be nil if running against old services
@@ -274,6 +274,34 @@ func (pc *Client) WithHTTPClient(httpClient *http.Client) *Client {
 		client: &defaultHTTPClient{
 			client: httpClient,
 		},
+	}
+	return pc
+}
+
+// WithRefresh wires an OAuth refresh token + a credentials-writeback callback into this client.
+// Once configured, the client transparently exchanges the refresh token at /api/oauth/token for a
+// fresh access token whenever the service rejects the current one with 401, retrying the original
+// request before falling through to LoginRequiredError. Passing an empty refresh token is a no-op
+// so callers can guard on workspace.Account.RefreshToken without a separate branch.
+func (pc *Client) WithRefresh(
+	refreshToken string,
+	writeback func(accessToken, refreshToken string) error,
+) *Client {
+	if refreshToken == "" {
+		return pc
+	}
+	initial, _ := pc.apiToken.Get(context.Background())
+	pc.apiToken = &refreshableAPIAccessToken{
+		accessToken:  initial,
+		refreshToken: refreshToken,
+		refresh: func(ctx context.Context, rt string) (string, string, error) {
+			resp, err := pc.RefreshAccessToken(ctx, rt)
+			if err != nil {
+				return "", "", err
+			}
+			return resp.AccessToken, resp.RefreshToken, nil
+		},
+		writeback: writeback,
 	}
 	return pc
 }
@@ -2818,7 +2846,11 @@ func (pc *Client) StreamNeoTaskEvents(
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("X-Pulumi-Source", "Pulumi CLI")
-	req.Header.Set("Authorization", "token "+string(pc.apiToken))
+	apiToken, err := pc.apiToken.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetching credentials: %w", err)
+	}
+	req.Header.Set("Authorization", "token "+apiToken)
 	if lastEventID != "" {
 		req.Header.Set("Last-Event-ID", lastEventID)
 	}
@@ -2925,7 +2957,10 @@ func (pc *Client) callCopilot(ctx context.Context, requestBody any) (string, err
 	defer cancel()
 
 	url := pc.apiURL + "/api/ai/chat/preview"
-	apiToken := string(pc.apiToken)
+	apiToken, err := pc.apiToken.Get(ctx)
+	if err != nil {
+		return "", fmt.Errorf("fetching credentials: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(jsonData))
 	if err != nil {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -610,6 +610,59 @@ func (pc *Client) ExchangeOidcToken(
 	return &unmarshalledResp, nil
 }
 
+// RefreshAccessToken exchanges a Pulumi-issued refresh token for a fresh access token via
+// /api/oauth/token (grant_type=refresh_token, RFC 6749 §6). The server resolves which user the
+// refresh token is currently bound to and mints a short-lived OBO access token scoped to that
+// user's organization. Returns the parsed token response, including the refresh_token to use on
+// subsequent calls (Phase 1: the same value the caller presented; rotation may come later).
+//
+// The caller is responsible for writing the response's AccessToken back into credentials.json
+// when the exchange succeeds.
+func (pc *Client) RefreshAccessToken(
+	ctx context.Context,
+	refreshToken string,
+) (*apitype.TokenExchangeGrantResponse, error) {
+	if refreshToken == "" {
+		return nil, errors.New("refresh token is required")
+	}
+	tokenURL := pc.apiURL + "/api/oauth/token"
+	data := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+	bodyReader := strings.NewReader(data.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := pc.restClient.HTTPClient().Do(req, retryAllMethods)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Forward the server's RFC 6749 §5.2 error payload as the error message so callers can
+		// distinguish invalid_grant (token gone / revoked / wrong type) from unsupported_grant_type
+		// (LD kill switch flipped) and react accordingly.
+		return nil, fmt.Errorf("refresh_token grant failed: %s: %s", resp.Status, string(body))
+	}
+	var unmarshalledResp apitype.TokenExchangeGrantResponse
+	if err := json.Unmarshal(body, &unmarshalledResp); err != nil {
+		return nil, err
+	}
+	if unmarshalledResp.AccessToken == "" {
+		return nil, errors.New("refresh_token grant returned empty access_token")
+	}
+	return &unmarshalledResp, nil
+}
+
 // GetPulumiAccountDetails returns the user implied by the API token associated with this client.
 func (pc *Client) GetPulumiAccountDetails(ctx context.Context) (string, []string, *workspace.TokenInformation, error) {
 	if pc.apiUser == "" {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -645,13 +645,10 @@ func (pc *Client) ExchangeOidcToken(
 }
 
 // RefreshAccessToken exchanges a Pulumi-issued refresh token for a fresh access token via
-// /api/oauth/token (grant_type=refresh_token, RFC 6749 §6). The server resolves which user the
-// refresh token is currently bound to and mints a short-lived OBO access token scoped to that
-// user's organization. Returns the parsed token response, including the refresh_token to use on
-// subsequent calls (Phase 1: the same value the caller presented; rotation may come later).
-//
-// The caller is responsible for writing the response's AccessToken back into credentials.json
-// when the exchange succeeds.
+// /api/oauth/token (grant_type=refresh_token, RFC 6749 §6). Returns the parsed token response;
+// the response's RefreshToken is the value to use on subsequent calls (the server may or may
+// not rotate it). The caller is responsible for writing the response's AccessToken back into
+// credentials.json when the exchange succeeds.
 func (pc *Client) RefreshAccessToken(
 	ctx context.Context,
 	refreshToken string,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -290,6 +290,7 @@ func (pc *Client) WithRefresh(
 	if refreshToken == "" {
 		return pc
 	}
+	contract.Requiref(writeback != nil, "writeback", "must not be nil when refreshToken is non-empty")
 	initial, _ := pc.apiToken.Get(context.Background())
 	pc.apiToken = &refreshableAPIAccessToken{
 		accessToken:  initial,

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -286,7 +286,7 @@ func (pc *Client) WithHTTPClient(httpClient *http.Client) *Client {
 // so callers can guard on workspace.Account.RefreshToken without a separate branch.
 func (pc *Client) WithRefresh(
 	refreshToken string,
-	writeback func(accessToken, refreshToken string) error,
+	writeback func(accessToken string, accessTokenExpiresAt time.Time, refreshToken string) error,
 ) *Client {
 	if refreshToken == "" {
 		return pc
@@ -296,12 +296,16 @@ func (pc *Client) WithRefresh(
 	pc.apiToken = &refreshableAPIAccessToken{
 		accessToken:  initial,
 		refreshToken: refreshToken,
-		refresh: func(ctx context.Context, rt string) (string, string, error) {
+		refresh: func(ctx context.Context, rt string) (string, time.Time, string, error) {
 			resp, err := pc.RefreshAccessToken(ctx, rt)
 			if err != nil {
-				return "", "", err
+				return "", time.Time{}, "", err
 			}
-			return resp.AccessToken, resp.RefreshToken, nil
+			var expiresAt time.Time
+			if resp.ExpiresIn > 0 {
+				expiresAt = time.Now().Add(time.Duration(resp.ExpiresIn) * time.Second)
+			}
+			return resp.AccessToken, expiresAt, resp.RefreshToken, nil
 		},
 		writeback: writeback,
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -150,6 +150,7 @@ type AgentSignupChallenge struct {
 type AgentSignupResponse struct {
 	AccessToken           string    `json:"accessToken"`
 	AccessTokenValidUntil time.Time `json:"accessTokenValidUntil"`
+	RefreshToken          string    `json:"refreshToken,omitempty"`
 	ClaimToken            string    `json:"claimToken"`
 	ClaimTokenValidUntil  time.Time `json:"claimTokenValidUntil"`
 }

--- a/pkg/backend/httpstate/client/client_package_test.go
+++ b/pkg/backend/httpstate/client/client_package_test.go
@@ -380,7 +380,7 @@ func TestPublishPackage(t *testing.T) {
 			// Create client pointing to our test server
 			client := &Client{
 				apiURL:   server.URL,
-				apiToken: "fake-token",
+				apiToken: apiAccessToken("fake-token"),
 				restClient: &defaultRESTClient{
 					client: &defaultHTTPClient{
 						client: httpClient,

--- a/pkg/backend/httpstate/client/client_template_test.go
+++ b/pkg/backend/httpstate/client/client_template_test.go
@@ -113,7 +113,7 @@ func TestStartTemplatePublish(t *testing.T) {
 
 			client := &Client{
 				apiURL:   server.URL,
-				apiToken: "fake-token",
+				apiToken: apiAccessToken("fake-token"),
 				restClient: &defaultRESTClient{
 					client: &defaultHTTPClient{
 						client: newHTTPClient(),
@@ -197,7 +197,7 @@ func TestCompleteTemplatePublish(t *testing.T) {
 
 			client := &Client{
 				apiURL:   server.URL,
-				apiToken: "fake-token",
+				apiToken: apiAccessToken("fake-token"),
 				restClient: &defaultRESTClient{
 					client: &defaultHTTPClient{
 						client: newHTTPClient(),
@@ -403,7 +403,7 @@ func TestPublishTemplate_Integration(t *testing.T) {
 			// Create a mock cloud registry that uses the HTTP client methods
 			client := &Client{
 				apiURL:   server.URL,
-				apiToken: "fake-token",
+				apiToken: apiAccessToken("fake-token"),
 				restClient: &defaultRESTClient{
 					client: &defaultHTTPClient{
 						client: httpClient,

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1807,3 +1807,93 @@ func TestStreamNeoTaskEvents(t *testing.T) {
 		}
 	})
 }
+
+func TestRefreshAccessToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the new access token on success", func(t *testing.T) {
+		t.Parallel()
+		var gotPath, gotMethod, gotContentType, gotBody string
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			gotPath = req.URL.Path
+			gotMethod = req.Method
+			gotContentType = req.Header.Get("Content-Type")
+			body, err := io.ReadAll(req.Body)
+			require.NoError(t, err)
+			gotBody = string(body)
+
+			err = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:     "new-obo-access-token",
+				IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+				TokenType:       "Bearer",
+				ExpiresIn:       3600,
+				RefreshToken:    "rt-value", // server echoes the same refresh token (no rotation)
+			})
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		resp, err := NewClient(server.URL, "", true, nil).RefreshAccessToken(t.Context(), "rt-value")
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, http.MethodPost, gotMethod)
+		assert.Equal(t, "/api/oauth/token", gotPath)
+		assert.Equal(t, "application/x-www-form-urlencoded", gotContentType)
+		assert.Contains(t, gotBody, "grant_type=refresh_token")
+		assert.Contains(t, gotBody, "refresh_token=rt-value")
+		assert.Equal(t, "new-obo-access-token", resp.AccessToken)
+		assert.Equal(t, "Bearer", resp.TokenType)
+		assert.Equal(t, int64(3600), resp.ExpiresIn)
+		assert.Equal(t, "rt-value", resp.RefreshToken)
+	})
+
+	t.Run("rejects an empty refresh token without hitting the server", func(t *testing.T) {
+		t.Parallel()
+		// Server fails the test if called — the empty-string check must short-circuit.
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			t.Errorf("server should not have been called for empty refresh token")
+		}))
+		defer server.Close()
+
+		_, err := NewClient(server.URL, "", true, nil).RefreshAccessToken(t.Context(), "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refresh token is required")
+	})
+
+	t.Run("surfaces server-side invalid_grant errors verbatim", func(t *testing.T) {
+		t.Parallel()
+		// Mirrors what the service returns when the row is gone / wrong-type / soft-deleted (see
+		// cmd/service/api/oauth2/grant_type_refresh_token.go in the pulumi-service repo).
+		const errBody = `{"error":"invalid_grant","error_description":"refresh token is not valid"}`
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusBadRequest)
+			_, err := rw.Write([]byte(errBody))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := NewClient(server.URL, "", true, nil).RefreshAccessToken(t.Context(), "rt-revoked")
+		require.Error(t, err)
+		// Caller must see both the status and the original error_description so they can branch
+		// on invalid_grant (give up, prompt for login) vs unsupported_grant_type (LD kill switch,
+		// retry later).
+		assert.Contains(t, err.Error(), "400")
+		assert.Contains(t, err.Error(), "invalid_grant")
+		assert.Contains(t, err.Error(), "refresh token is not valid")
+	})
+
+	t.Run("rejects an empty access_token in the response", func(t *testing.T) {
+		t.Parallel()
+		// Defensive: a malformed 200 with no access_token must not be silently treated as success.
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			_, err := rw.Write([]byte(`{"access_token":"","token_type":"Bearer"}`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := NewClient(server.URL, "", true, nil).RefreshAccessToken(t.Context(), "rt-value")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty access_token")
+	})
+}

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -2065,4 +2065,14 @@ func TestClient_WithRefresh(t *testing.T) {
 		_, isRefreshable := pc.apiToken.(refreshable)
 		assert.False(t, isRefreshable, "an empty refresh token must not swap in a refreshable wrapper")
 	})
+
+	t.Run("nil writeback with non-empty refresh token fails the precondition", func(t *testing.T) {
+		t.Parallel()
+
+		// A non-empty refresh token without a writeback is a programmer error — a refresh would
+		// crash at call time. Catch it at the wiring site, where the violated precondition can
+		// be named, rather than waiting for the first 401.
+		pc := NewClient("https://api.example.com", "tok", false, nil)
+		assert.Panics(t, func() { pc.WithRefresh("some-refresh", nil) })
+	})
 }

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1919,7 +1919,7 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, tok.Refresh(t.Context()))
+		require.NoError(t, tok.Refresh(t.Context(), "stale-access"))
 
 		got, err := tok.Get(t.Context())
 		require.NoError(t, err)
@@ -1940,14 +1940,14 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 			},
 			writeback: func(at string, _ time.Time, rt string) error { return nil },
 		}
-		require.NoError(t, tok.Refresh(t.Context()))
+		require.NoError(t, tok.Refresh(t.Context(), "stale-access"))
 
 		var seenSecondRefreshToken string
 		tok.refresh = func(_ context.Context, rt string) (string, time.Time, string, error) {
 			seenSecondRefreshToken = rt
 			return "newer-access", time.Time{}, "", nil
 		}
-		require.NoError(t, tok.Refresh(t.Context()))
+		require.NoError(t, tok.Refresh(t.Context(), "new-access"))
 		assert.Equal(t, "stable-refresh", seenSecondRefreshToken,
 			"the wrapper continues to send the original refresh token across calls")
 	})
@@ -1968,7 +1968,7 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 			},
 		}
 
-		err := tok.Refresh(t.Context())
+		err := tok.Refresh(t.Context(), "original-access")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid_grant")
 		assert.False(t, writebackCalled, "writeback must not fire when the refresh attempt fails")
@@ -1990,7 +1990,7 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 			writeback: func(_ string, _ time.Time, _ string) error { return errors.New("disk full") },
 		}
 
-		err := tok.Refresh(t.Context())
+		err := tok.Refresh(t.Context(), "original-access")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "disk full")
 	})

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -85,7 +86,7 @@ func newMockClient(server *httptest.Server) *Client {
 
 	return &Client{
 		apiURL:   server.URL,
-		apiToken: "",
+		apiToken: apiAccessToken(""),
 		apiUser:  "",
 		diag:     nil,
 		restClient: &defaultRESTClient{
@@ -1895,5 +1896,173 @@ func TestRefreshAccessToken(t *testing.T) {
 		_, err := NewClient(server.URL, "", true, nil).RefreshAccessToken(t.Context(), "rt-value")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "empty access_token")
+	})
+}
+
+func TestRefreshableAPIAccessToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Refresh replaces the access token and persists via writeback", func(t *testing.T) {
+		t.Parallel()
+
+		var seenRefreshToken, seenWriteAT, seenWriteRT string
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale-access",
+			refreshToken: "stale-refresh",
+			refresh: func(_ context.Context, rt string) (string, string, error) {
+				seenRefreshToken = rt
+				return "new-access", "new-refresh", nil
+			},
+			writeback: func(at, rt string) error {
+				seenWriteAT, seenWriteRT = at, rt
+				return nil
+			},
+		}
+
+		require.NoError(t, tok.Refresh(t.Context()))
+
+		got, err := tok.Get(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "new-access", got)
+		assert.Equal(t, "stale-refresh", seenRefreshToken)
+		assert.Equal(t, "new-access", seenWriteAT)
+		assert.Equal(t, "new-refresh", seenWriteRT)
+	})
+
+	t.Run("Refresh keeps the existing refresh token when the server returns empty (no rotation)", func(t *testing.T) {
+		t.Parallel()
+
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "stale-access",
+			refreshToken: "stable-refresh",
+			refresh: func(_ context.Context, _ string) (string, string, error) {
+				return "new-access", "", nil
+			},
+			writeback: func(at, rt string) error { return nil },
+		}
+		require.NoError(t, tok.Refresh(t.Context()))
+
+		var seenSecondRefreshToken string
+		tok.refresh = func(_ context.Context, rt string) (string, string, error) {
+			seenSecondRefreshToken = rt
+			return "newer-access", "", nil
+		}
+		require.NoError(t, tok.Refresh(t.Context()))
+		assert.Equal(t, "stable-refresh", seenSecondRefreshToken,
+			"the wrapper continues to send the original refresh token across calls")
+	})
+
+	t.Run("Refresh failure surfaces the underlying error and leaves state untouched", func(t *testing.T) {
+		t.Parallel()
+
+		var writebackCalled bool
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "original-access",
+			refreshToken: "original-refresh",
+			refresh: func(_ context.Context, _ string) (string, string, error) {
+				return "", "", errors.New("invalid_grant")
+			},
+			writeback: func(at, rt string) error {
+				writebackCalled = true
+				return nil
+			},
+		}
+
+		err := tok.Refresh(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid_grant")
+		assert.False(t, writebackCalled, "writeback must not fire when the refresh attempt fails")
+
+		got, gerr := tok.Get(t.Context())
+		require.NoError(t, gerr)
+		assert.Equal(t, "original-access", got, "Get returns the original token when the refresh failed")
+	})
+
+	t.Run("Refresh surfaces writeback failure", func(t *testing.T) {
+		t.Parallel()
+
+		tok := &refreshableAPIAccessToken{
+			accessToken:  "original-access",
+			refreshToken: "original-refresh",
+			refresh: func(_ context.Context, _ string) (string, string, error) {
+				return "new-access", "new-refresh", nil
+			},
+			writeback: func(_, _ string) error { return errors.New("disk full") },
+		}
+
+		err := tok.Refresh(t.Context())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disk full")
+	})
+}
+
+func TestClient_WithRefresh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("end-to-end: stale token triggers refresh and retry, writeback fires", func(t *testing.T) {
+		t.Parallel()
+
+		var apiCalls, refreshCalls atomic.Int32
+		var seenAuths []string
+		var mu sync.Mutex
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			switch req.URL.Path {
+			case "/api/oauth/token":
+				refreshCalls.Add(1)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.Contains(t, string(body), "grant_type=refresh_token")
+				assert.Contains(t, string(body), "refresh_token=stale-refresh")
+				_ = json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+					AccessToken:  "fresh-access",
+					TokenType:    "Bearer",
+					ExpiresIn:    3600,
+					RefreshToken: "stale-refresh",
+				})
+			case "/api/user":
+				mu.Lock()
+				seenAuths = append(seenAuths, req.Header.Get("Authorization"))
+				mu.Unlock()
+				n := apiCalls.Add(1)
+				if n == 1 {
+					rw.WriteHeader(http.StatusUnauthorized)
+					_ = json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+					return
+				}
+				_ = json.NewEncoder(rw).Encode(serviceUser{GitHubLogin: "alice"})
+			default:
+				rw.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		var writeAT, writeRT string
+		pc := NewClient(srv.URL, "stale-access", true, nil)
+		pc.WithRefresh("stale-refresh", func(at, rt string) error {
+			writeAT, writeRT = at, rt
+			return nil
+		})
+
+		name, _, _, err := pc.GetPulumiAccountDetails(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "alice", name)
+		assert.Equal(t, int32(2), apiCalls.Load(), "/api/user should be tried twice")
+		assert.Equal(t, int32(1), refreshCalls.Load())
+		require.Len(t, seenAuths, 2)
+		assert.Equal(t, "token stale-access", seenAuths[0])
+		assert.Equal(t, "token fresh-access", seenAuths[1])
+		assert.Equal(t, "fresh-access", writeAT, "writeback receives the refreshed access token")
+		assert.Equal(t, "stale-refresh", writeRT,
+			"writeback receives the still-current refresh token (no rotation in Phase 1)")
+	})
+
+	t.Run("empty refresh token leaves the plain access token in place", func(t *testing.T) {
+		t.Parallel()
+
+		pc := NewClient("https://api.example.com", "tok", false, nil)
+		pc.WithRefresh("", func(at, rt string) error { return nil })
+		_, isRefreshable := pc.apiToken.(refreshable)
+		assert.False(t, isRefreshable, "an empty refresh token must not swap in a refreshable wrapper")
 	})
 }

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1909,11 +1909,11 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "stale-access",
 			refreshToken: "stale-refresh",
-			refresh: func(_ context.Context, rt string) (string, string, error) {
+			refresh: func(_ context.Context, rt string) (string, time.Time, string, error) {
 				seenRefreshToken = rt
-				return "new-access", "new-refresh", nil
+				return "new-access", time.Time{}, "new-refresh", nil
 			},
-			writeback: func(at, rt string) error {
+			writeback: func(at string, _ time.Time, rt string) error {
 				seenWriteAT, seenWriteRT = at, rt
 				return nil
 			},
@@ -1935,17 +1935,17 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "stale-access",
 			refreshToken: "stable-refresh",
-			refresh: func(_ context.Context, _ string) (string, string, error) {
-				return "new-access", "", nil
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
+				return "new-access", time.Time{}, "", nil
 			},
-			writeback: func(at, rt string) error { return nil },
+			writeback: func(at string, _ time.Time, rt string) error { return nil },
 		}
 		require.NoError(t, tok.Refresh(t.Context()))
 
 		var seenSecondRefreshToken string
-		tok.refresh = func(_ context.Context, rt string) (string, string, error) {
+		tok.refresh = func(_ context.Context, rt string) (string, time.Time, string, error) {
 			seenSecondRefreshToken = rt
-			return "newer-access", "", nil
+			return "newer-access", time.Time{}, "", nil
 		}
 		require.NoError(t, tok.Refresh(t.Context()))
 		assert.Equal(t, "stable-refresh", seenSecondRefreshToken,
@@ -1959,10 +1959,10 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "original-access",
 			refreshToken: "original-refresh",
-			refresh: func(_ context.Context, _ string) (string, string, error) {
-				return "", "", errors.New("invalid_grant")
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
+				return "", time.Time{}, "", errors.New("invalid_grant")
 			},
-			writeback: func(at, rt string) error {
+			writeback: func(at string, _ time.Time, rt string) error {
 				writebackCalled = true
 				return nil
 			},
@@ -1984,10 +1984,10 @@ func TestRefreshableAPIAccessToken(t *testing.T) {
 		tok := &refreshableAPIAccessToken{
 			accessToken:  "original-access",
 			refreshToken: "original-refresh",
-			refresh: func(_ context.Context, _ string) (string, string, error) {
-				return "new-access", "new-refresh", nil
+			refresh: func(_ context.Context, _ string) (string, time.Time, string, error) {
+				return "new-access", time.Time{}, "new-refresh", nil
 			},
-			writeback: func(_, _ string) error { return errors.New("disk full") },
+			writeback: func(_ string, _ time.Time, _ string) error { return errors.New("disk full") },
 		}
 
 		err := tok.Refresh(t.Context())
@@ -2038,9 +2038,10 @@ func TestClient_WithRefresh(t *testing.T) {
 		defer srv.Close()
 
 		var writeAT, writeRT string
+		var writeExpiresAt time.Time
 		pc := NewClient(srv.URL, "stale-access", true, nil)
-		pc.WithRefresh("stale-refresh", func(at, rt string) error {
-			writeAT, writeRT = at, rt
+		pc.WithRefresh("stale-refresh", func(at string, expiresAt time.Time, rt string) error {
+			writeAT, writeRT, writeExpiresAt = at, rt, expiresAt
 			return nil
 		})
 
@@ -2055,13 +2056,17 @@ func TestClient_WithRefresh(t *testing.T) {
 		assert.Equal(t, "fresh-access", writeAT, "writeback receives the refreshed access token")
 		assert.Equal(t, "stale-refresh", writeRT,
 			"writeback receives the still-current refresh token (no rotation in Phase 1)")
+		assert.False(t, writeExpiresAt.IsZero(),
+			"writeback receives the new access token's ExpiresAt derived from the grant's ExpiresIn")
+		assert.True(t, writeExpiresAt.After(time.Now().Add(50*time.Minute)),
+			"the new ExpiresAt is roughly now+ExpiresIn (3600s in this fixture)")
 	})
 
 	t.Run("empty refresh token leaves the plain access token in place", func(t *testing.T) {
 		t.Parallel()
 
 		pc := NewClient("https://api.example.com", "tok", false, nil)
-		pc.WithRefresh("", func(at, rt string) error { return nil })
+		pc.WithRefresh("", func(at string, _ time.Time, rt string) error { return nil })
 		_, isRefreshable := pc.apiToken.(refreshable)
 		assert.False(t, isRefreshable, "an empty refresh token must not swap in a refreshable wrapper")
 	})

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -165,6 +165,10 @@ func StoreAccount(key string, account Account, current bool) error {
 type Account struct {
 	// The access token for this account.
 	AccessToken string `json:"accessToken,omitempty"`
+	// The OAuth refresh token, if the server issued one alongside the access token. When set, the
+	// CLI exchanges this token at /api/oauth/token for a fresh access token whenever the current
+	// one expires. Held off-the-wire — only sent to the token endpoint, not on every request.
+	RefreshToken string `json:"refreshToken,omitempty"`
 	// The username for this account.
 	Username string `json:"username,omitempty"`
 	// The organizations for this account.

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -213,6 +213,22 @@ func (a Account) HasCredential() bool {
 	return a.AccessToken != "" || a.RefreshToken != ""
 }
 
+// SetCredentials writes a credential-grant result to this account. A zero
+// accessTokenExpiresAt or empty refreshToken keeps the existing value — for grant
+// responses that omit the field (e.g. a refresh that didn't rotate the refresh token).
+func (a *Account) SetCredentials(accessToken string, accessTokenExpiresAt time.Time, refreshToken string) {
+	a.AccessToken = accessToken
+	if !accessTokenExpiresAt.IsZero() {
+		if a.TokenInformation == nil {
+			a.TokenInformation = &TokenInformation{}
+		}
+		a.TokenInformation.ExpiresAt = &accessTokenExpiresAt
+	}
+	if refreshToken != "" {
+		a.RefreshToken = refreshToken
+	}
+}
+
 // Save persists this account back to the credentials file it was loaded from. Returns an error if
 // the account has no known source (constructed in memory rather than loaded) — callers in that
 // case should use StoreAccount / StoreAgentAccount with an explicit destination.

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -62,14 +62,14 @@ func getAccountAt(path, key string) (Account, error) {
 	}
 
 	if account, ok := creds.Accounts[key]; ok {
-		account.source = path
+		account.sourcePath = path
 		return account, nil
 	}
 	token, ok := creds.AccessTokens[key]
 	if !ok {
 		return Account{}, nil
 	}
-	return Account{AccessToken: token, source: path}, nil
+	return Account{AccessToken: token, sourcePath: path}, nil
 }
 
 // GetAccountWithAgentFallback returns an account from default credentials, or
@@ -199,11 +199,11 @@ type Account struct {
 	// Information about the token used to authenticate.
 	TokenInformation *TokenInformation `json:"tokenInformation,omitempty"`
 
-	// source is the credentials file this account was loaded from. Set by the loaders
+	// sourcePath is the credentials file this account was loaded from. Set by the loaders
 	// (GetAccount, GetAgentAccount, GetAccountWithAgentFallback); empty for accounts constructed
 	// in memory (env-var tokens before persistence, test literals, fresh-login pre-persist).
 	// Used by Save to persist credential refreshes back to the file the account came from.
-	source string
+	sourcePath string
 }
 
 // HasCredential reports whether this account carries anything the CLI can use to authenticate —
@@ -233,10 +233,10 @@ func (a *Account) SetCredentials(accessToken string, accessTokenExpiresAt time.T
 // the account has no known source (constructed in memory rather than loaded) — callers in that
 // case should use StoreAccount / StoreAgentAccount with an explicit destination.
 func (a Account) Save(key string, current bool) error {
-	if a.source == "" {
+	if a.sourcePath == "" {
 		return errors.New("cannot Save an account that was not loaded from a credentials file")
 	}
-	return storeAccountAt(a.source, key, a, current)
+	return storeAccountAt(a.sourcePath, key, a, current)
 }
 
 // Information about the token that was used to authenticate the current user. One (or none) of Team or Organization
@@ -382,9 +382,14 @@ func readCredentialsFile(credsFile string) (Credentials, error) {
 			"or delete invalid credentials file: '%s': %w", credsFile, err)
 	}
 
-	secrets := slice.Prealloc[string](len(creds.AccessTokens))
+	secrets := slice.Prealloc[string](len(creds.AccessTokens) + len(creds.Accounts))
 	for _, v := range creds.AccessTokens {
 		secrets = append(secrets, v)
+	}
+	for _, account := range creds.Accounts {
+		if account.RefreshToken != "" {
+			secrets = append(secrets, account.RefreshToken)
+		}
 	}
 
 	logging.AddGlobalFilter(logging.CreateFilter(secrets, "[credential]"))

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -46,20 +46,30 @@ const PulumiCredentialsPathEnvVar = "PULUMI_CREDENTIALS_PATH"
 // Note that the account may not be fully populated: it may only have a valid AccessToken. In that case, it is up to
 // the caller to fill in the username and last validation time.
 func GetAccount(key string) (Account, error) {
-	creds, err := GetStoredCredentials()
+	path, err := getCredsFilePath()
+	if err != nil {
+		return Account{}, err
+	}
+	return getAccountAt(path, key)
+}
+
+// getAccountAt loads an account from the given credentials file, stamping the source path so
+// subsequent account.Save calls write back to the same file.
+func getAccountAt(path, key string) (Account, error) {
+	creds, err := readCredentialsFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return Account{}, err
 	}
 
-	// Try the account
 	if account, ok := creds.Accounts[key]; ok {
+		account.source = path
 		return account, nil
 	}
 	token, ok := creds.AccessTokens[key]
 	if !ok {
 		return Account{}, nil
 	}
-	return Account{AccessToken: token}, nil
+	return Account{AccessToken: token, source: path}, nil
 }
 
 // GetAccountWithAgentFallback returns an account from default credentials, or
@@ -68,7 +78,7 @@ func GetAccount(key string) (Account, error) {
 // true only when the returned account came from shared agent credentials.
 func GetAccountWithAgentFallback(key string) (Account, bool, error) {
 	account, err := GetAccount(key)
-	if err == nil && account.AccessToken != "" {
+	if err == nil && account.HasCredential() {
 		return account, false, nil
 	}
 
@@ -93,7 +103,7 @@ func GetAccountWithAgentFallback(key string) (Account, bool, error) {
 	if agentErr != nil {
 		return Account{}, false, errors.Join(err, agentErr)
 	}
-	if agentAccount.AccessToken == "" {
+	if !agentAccount.HasCredential() {
 		return Account{}, false, nil
 	}
 	return agentAccount, true, nil
@@ -142,9 +152,18 @@ func DeleteAllAccounts() error {
 	return result
 }
 
-// StoreAccount saves the given account underneath the given key.
+// StoreAccount saves the given account underneath the given key in the default credentials file.
 func StoreAccount(key string, account Account, current bool) error {
-	creds, err := GetStoredCredentials()
+	path, err := getCredsFilePath()
+	if err != nil {
+		return err
+	}
+	return storeAccountAt(path, key, account, current)
+}
+
+// storeAccountAt persists an account into the given credentials file (load-modify-write).
+func storeAccountAt(path, key string, account Account, current bool) error {
+	creds, err := readCredentialsFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -158,7 +177,7 @@ func StoreAccount(key string, account Account, current bool) error {
 	if current {
 		creds.Current = key
 	}
-	return StoreCredentials(creds)
+	return writeCredentialsFile(path, creds)
 }
 
 // Account holds the information associated with a Pulumi account.
@@ -179,6 +198,29 @@ type Account struct {
 	Insecure bool `json:"insecure,omitempty"`
 	// Information about the token used to authenticate.
 	TokenInformation *TokenInformation `json:"tokenInformation,omitempty"`
+
+	// source is the credentials file this account was loaded from. Set by the loaders
+	// (GetAccount, GetAgentAccount, GetAccountWithAgentFallback); empty for accounts constructed
+	// in memory (env-var tokens before persistence, test literals, fresh-login pre-persist).
+	// Used by Save to persist credential refreshes back to the file the account came from.
+	source string
+}
+
+// HasCredential reports whether this account carries anything the CLI can use to authenticate —
+// either a current access token or a refresh token to mint one with. Used at credential-selection
+// time so that an account with only a refresh token is treated as usable rather than skipped.
+func (a Account) HasCredential() bool {
+	return a.AccessToken != "" || a.RefreshToken != ""
+}
+
+// Save persists this account back to the credentials file it was loaded from. Returns an error if
+// the account has no known source (constructed in memory rather than loaded) — callers in that
+// case should use StoreAccount / StoreAgentAccount with an explicit destination.
+func (a Account) Save(key string, current bool) error {
+	if a.source == "" {
+		return errors.New("cannot Save an account that was not loaded from a credentials file")
+	}
+	return storeAccountAt(a.source, key, a, current)
 }
 
 // Information about the token that was used to authenticate the current user. One (or none) of Team or Organization
@@ -617,19 +659,12 @@ func getAgentConfigFilePathNoEnsure() string {
 // GetAgentAccount returns the account for the given cloud URL from the shared
 // agent credentials file.
 func GetAgentAccount(key string) (Account, error) {
-	creds, err := GetAgentStoredCredentials()
+	path, err := getAgentCredsFilePath()
 	if err != nil {
 		return Account{}, err
 	}
-
-	if account, ok := creds.Accounts[key]; ok {
-		return account, nil
-	}
-	token, ok := creds.AccessTokens[key]
-	if !ok {
-		return Account{}, nil
-	}
-	return Account{AccessToken: token}, nil
+	logging.V(7).Infof("Reading shared agent credentials from %q", path)
+	return getAccountAt(path, key)
 }
 
 // GetAgentStoredCredentials returns credentials stored in the shared temporary
@@ -646,21 +681,11 @@ func GetAgentStoredCredentials() (Credentials, error) {
 // StoreAgentAccount saves the account for the given cloud URL in the shared
 // temporary agent credentials file.
 func StoreAgentAccount(key string, account Account, current bool) error {
-	creds, err := GetAgentStoredCredentials()
+	path, err := getAgentCredsFilePath()
 	if err != nil {
 		return err
 	}
-	if creds.AccessTokens == nil {
-		creds.AccessTokens = make(map[string]string)
-	}
-	if creds.Accounts == nil {
-		creds.Accounts = make(map[string]Account)
-	}
-	creds.AccessTokens[key], creds.Accounts[key] = account.AccessToken, account
-	if current {
-		creds.Current = key
-	}
-	return StoreAgentCredentials(creds)
+	return storeAccountAt(path, key, account, current)
 }
 
 // DeleteAgentAccount deletes an account from the shared temporary agent

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -419,6 +419,40 @@ func TestGetAccountWithAgentFallbackUsesAgentCredentials(t *testing.T) {
 }
 
 //nolint:paralleltest // mutates environment and package global
+func TestGetAccountWithAgentFallbackDoesNotMergeFieldsAcrossFiles(t *testing.T) {
+	// File-as-a-unit invariant on the read side: a default account with an access token but no
+	// refresh token must not silently acquire a refresh token from the agent file. The loaded
+	// account is wholly from the source file, never a merge across the two.
+	oldCreds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	oldAgentPulumiDir := agentPulumiDir
+	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
+	t.Cleanup(func() {
+		require.NoError(t, StoreCredentials(oldCreds))
+		require.NoError(t, DeleteAgentCredentials())
+		agentPulumiDir = oldAgentPulumiDir
+	})
+
+	setAgentEnv(t)
+	t.Setenv(PulumiCredentialsPathEnvVar, "")
+	t.Setenv("PULUMI_HOME", "")
+
+	cloudURL := "https://api.no-cross-file-merge.example.com"
+	require.NoError(t, StoreAccount(cloudURL, Account{AccessToken: "default-access"}, true))
+	require.NoError(t, StoreAgentAccount(cloudURL, Account{
+		AccessToken:  "agent-access",
+		RefreshToken: "agent-refresh",
+	}, true))
+
+	account, fromAgent, err := GetAccountWithAgentFallback(cloudURL)
+	require.NoError(t, err)
+	assert.False(t, fromAgent, "default has a credential — must not fall through to agent")
+	assert.Equal(t, "default-access", account.AccessToken)
+	assert.Empty(t, account.RefreshToken,
+		"fields from the agent file must not leak into a default-sourced account")
+}
+
+//nolint:paralleltest // mutates environment and package global
 func TestGetAccountWithAgentFallbackDisabledOutsideAgentMode(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir
 	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -100,6 +100,123 @@ func TestExplicitCredentialsPathDoesNotFallbackToTemp(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAccountHasCredential(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		acct Account
+		want bool
+	}{
+		{"empty", Account{}, false},
+		{"access token only", Account{AccessToken: "a"}, true},
+		{"refresh token only", Account{RefreshToken: "r"}, true},
+		{"both tokens", Account{AccessToken: "a", RefreshToken: "r"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.acct.HasCredential())
+		})
+	}
+}
+
+func TestAccountSaveErrorsOnEmptySource(t *testing.T) {
+	t.Parallel()
+	// A literal Account has no source (it wasn't loaded from a file). Save must refuse rather
+	// than silently writing somewhere a caller didn't ask for.
+	err := Account{AccessToken: "x"}.Save("https://api.example.com", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not loaded")
+}
+
+//nolint:paralleltest // mutates environment and package global
+func TestAccountSaveWritesToSourceFile(t *testing.T) {
+	// File-as-a-unit invariant: an account loaded from a file must Save back to that same file.
+	// Loaded-from-default must not bleed into agent, and loaded-from-agent must not bleed into
+	// default (the bug the source field exists to prevent).
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+
+	oldAgentPulumiDir := agentPulumiDir
+	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
+	t.Cleanup(func() {
+		require.NoError(t, DeleteAgentCredentials())
+		agentPulumiDir = oldAgentPulumiDir
+	})
+
+	const cloudURL = "https://api.example.com"
+
+	t.Run("loaded from default writes back to default", func(t *testing.T) {
+		require.NoError(t, StoreAccount(cloudURL, Account{AccessToken: "orig-default"}, false))
+		require.NoError(t, StoreAgentAccount(cloudURL, Account{AccessToken: "orig-agent"}, false))
+
+		loaded, err := GetAccount(cloudURL)
+		require.NoError(t, err)
+		loaded.AccessToken = "updated-default"
+		require.NoError(t, loaded.Save(cloudURL, false))
+
+		fromDefault, err := GetAccount(cloudURL)
+		require.NoError(t, err)
+		assert.Equal(t, "updated-default", fromDefault.AccessToken)
+
+		fromAgent, err := GetAgentAccount(cloudURL)
+		require.NoError(t, err)
+		assert.Equal(t, "orig-agent", fromAgent.AccessToken,
+			"saving a default-sourced account must not touch the agent file")
+	})
+
+	t.Run("loaded from agent writes back to agent", func(t *testing.T) {
+		require.NoError(t, StoreAccount(cloudURL, Account{AccessToken: "orig-default"}, false))
+		require.NoError(t, StoreAgentAccount(cloudURL, Account{AccessToken: "orig-agent"}, false))
+
+		loaded, err := GetAgentAccount(cloudURL)
+		require.NoError(t, err)
+		loaded.AccessToken = "updated-agent"
+		require.NoError(t, loaded.Save(cloudURL, false))
+
+		fromAgent, err := GetAgentAccount(cloudURL)
+		require.NoError(t, err)
+		assert.Equal(t, "updated-agent", fromAgent.AccessToken)
+
+		fromDefault, err := GetAccount(cloudURL)
+		require.NoError(t, err)
+		assert.Equal(t, "orig-default", fromDefault.AccessToken,
+			"saving an agent-sourced account must not touch the default file")
+	})
+}
+
+//nolint:paralleltest // mutates environment and package global
+func TestGetAccountWithAgentFallbackUsesRefreshOnlyDefaultAccount(t *testing.T) {
+	// An account with only a refresh token (no access token) must be treated as usable rather
+	// than skipped in favour of the agent fallback — the wrapper will mint the first access
+	// token on the initial 401.
+	oldCreds, err := GetStoredCredentials()
+	require.NoError(t, err)
+	oldAgentPulumiDir := agentPulumiDir
+	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
+	t.Cleanup(func() {
+		require.NoError(t, StoreCredentials(oldCreds))
+		require.NoError(t, DeleteAgentCredentials())
+		agentPulumiDir = oldAgentPulumiDir
+	})
+
+	setAgentEnv(t)
+	t.Setenv(PulumiCredentialsPathEnvVar, "")
+	t.Setenv("PULUMI_HOME", "")
+
+	cloudURL := "https://api.refresh-only.example.com"
+	require.NoError(t, StoreAccount(cloudURL, Account{RefreshToken: "refresh-only"}, true))
+	require.NoError(t, StoreAgentAccount(cloudURL, Account{AccessToken: "agent-token"}, true))
+
+	account, fromAgent, err := GetAccountWithAgentFallback(cloudURL)
+	require.NoError(t, err)
+	assert.False(t, fromAgent, "refresh-only default account must not fall through to agent")
+	assert.Equal(t, "refresh-only", account.RefreshToken)
+	assert.Empty(t, account.AccessToken)
+}
+
 //nolint:paralleltest // mutates environment
 func TestAccountRefreshTokenRoundTrip(t *testing.T) {
 	// The refresh token is held off-the-wire and exchanged at /api/oauth/token for short-lived

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -100,6 +100,37 @@ func TestExplicitCredentialsPathDoesNotFallbackToTemp(t *testing.T) {
 	require.Error(t, err)
 }
 
+//nolint:paralleltest // mutates environment
+func TestAccountRefreshTokenRoundTrip(t *testing.T) {
+	// The refresh token is held off-the-wire and exchanged at /api/oauth/token for short-lived
+	// access tokens. It needs to survive credentials.json read/write so the CLI can use it across
+	// process invocations.
+	t.Setenv("PULUMI_CREDENTIALS_PATH", filepath.Join(t.TempDir(), "credentials.json"))
+
+	const cloudURL = "https://api.example.com"
+	original := Account{
+		AccessToken:  "current-access-token",
+		RefreshToken: "long-lived-refresh-token",
+		Username:     "jane",
+	}
+	require.NoError(t, StoreAccount(cloudURL, original, true))
+
+	loaded, err := GetAccount(cloudURL)
+	require.NoError(t, err)
+	assert.Equal(t, original.AccessToken, loaded.AccessToken)
+	assert.Equal(t, original.RefreshToken, loaded.RefreshToken)
+	assert.Equal(t, original.Username, loaded.Username)
+
+	// An Account with no refresh token must still round-trip cleanly — the field is optional and
+	// must serialize as omitted, not as an empty string anyone could mistake for "no refresh".
+	plain := Account{AccessToken: "another-token"}
+	require.NoError(t, StoreAccount(cloudURL, plain, true))
+	loadedPlain, err := GetAccount(cloudURL)
+	require.NoError(t, err)
+	assert.Equal(t, "another-token", loadedPlain.AccessToken)
+	assert.Empty(t, loadedPlain.RefreshToken)
+}
+
 //nolint:paralleltest // mutates package global
 func TestAgentCredentialsAndClaim(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir


### PR DESCRIPTION
## Summary

Refresh tokens are the standard OAuth2 mechanism for keeping long-lived credentials off the wire: a refresh token sits in storage, gets exchanged at a single endpoint for short-lived access tokens that travel with API requests, limiting any one credential's exposure. This PR adds the CLI side of [RFC 6749 §6](https://datatracker.ietf.org/doc/html/rfc6749#section-6): `credentials.json` gains a `refreshToken` field next to `accessToken`, the CLI captures the field from agent signup responses, and exchanges it for a fresh access token when the current one expires.

Preparatory — server-side support is in flight. Until it lands, no login issues a refresh token and existing CLI behavior is unchanged.

## Scenario

Once Pulumi Cloud starts issuing refresh tokens, `credentials.json` carries a `refreshToken` field alongside the access token, and the access token's lifetime drops to 1 hour. From there:

1. **Access token expires.** A long-running operation — an agent task, a slow preview — outlives the 1h access token; the next API call returns 401.
2. **CLI exchanges the refresh token.** A single `POST /api/oauth/token` request returns a fresh access token.
3. **CLI retries the original request once.** With the new access token. If the retry also returns 401, the CLI surfaces "login required" — the same error today's CLI shows.
4. **CLI persists the new access token.** Written back to the same `credentials.json` file the account was loaded from, so the next invocation skips the refresh.

The same flow fires at cold-start when the stored `tokenInformation.expiresAt` is already in the past — `validateStoredAccount` takes the refresh path instead of hard-failing, so an idle gap longer than the access-token lifetime also recovers silently rather than only mid-operation 401s.

## Notable choices

- **One retry.** No looping if the refreshed token is also rejected.
- **Refresh token off the wire.** Only ever sent to the token endpoint; held in storage otherwise.
- **Rotation-transparent.** Whatever refresh token the server returns from the exchange — same value, rotated value, or empty — the CLI persists what it should. Today the server doesn't rotate; when it does, no CLI change.

## Test plan

```bash
go test ./pkg/backend/httpstate/... ./sdk/go/common/workspace/...
```

### Refresh-on-401 behavior

- [x] Stale access token + stored refresh token → silent refresh, request retries with the new token
- [x] Stale access token + no refresh token → "login required" (unchanged)
- [x] Refresh-only stored account (refresh token but no access token) → wrapper mints the first access token and authenticates the request
- [x] Refresh exchange itself fails (revoked / invalid token) → "login required" without further retries
- [x] Refreshed access token also rejected → "login required" (at most one retry)
- [x] Token-exchange request body, error propagation, and empty-`access_token` defense are exercised
- [x] Cold-start with a locally-expired access token + stored refresh token → silent refresh and `credentials.json` updated, instead of hard-failing the validate step
- [x] Cold-start with a locally-expired access token + no refresh token → no network call and no logged-in account (preserves pre-refresh-token behavior)
- [x] Cold-start in agent mode with a locally-expired access token + stored refresh token → refresh path runs in place of re-signup; the agent identity and claim survive

### Credential persistence

- [x] Refreshed access token written back to `credentials.json` so subsequent invocations skip the refresh
- [x] Refresh token preserved when the server doesn't rotate it
- [x] `credentials.json` round-trips refresh tokens correctly: persisted when set, omitted from JSON when absent
- [x] If persistence to disk fails, the underlying error surfaces to the caller
- [x] Agent signup response: the `refreshToken` field is plumbed into the Account and persisted to the agent credentials file
- [x] Agent signup response without a `refreshToken` field → no token persisted (back-compat with a server that hasn't rolled out refresh-token issuance)
- [x] Re-signup with stale existing agent creds: the new refresh token replaces the old, the prior value does not survive
- [x] Refresh-token grant returns a rotated (different) refresh token → `credentials.json` updates to the new value
- [x] Refresh-token grant omits `refresh_token` from the success response (per RFC 6749 §6 = "keep using yours") → existing refresh token is preserved in `credentials.json`

### File-as-a-unit invariant

- [x] Account loaded from default credentials writes back to default credentials (does not leak into the agent file)
- [x] Account loaded from shared agent credentials writes back to the agent file (does not leak into default credentials)
- [x] When both files exist, a loaded account never merges fields from the other file (default access-token-only does not silently acquire the agent's refresh token)
- [x] `Account.Save()` on an in-memory literal (no source) returns a clean error
- [x] Post-validate persistence in `currentOrSignupAgentAccount` lands in the agent file

### Defensive preconditions

- [x] `validateStoredAccount` short-circuits without a network call when given an account with no credential
- [x] `validateStoredAccount` stamps `LastValidatedAt` after a successful validation
- [x] `WithRefresh` rejects a nil writeback paired with a non-empty refresh token at the injection site

### Live verification

- [x] Against a deployed Pulumi Service stack: refresh tokens mint access tokens with the expected JWT claims, three successive calls don't rotate the refresh token, and revoked / expired / wrong-type / unknown refresh tokens are rejected with `invalid_grant`
- [x] End-to-end on a review stack with the matching server-side PRs deployed: `pulumi` in agent mode signs up and persists the server-issued refresh token; a subsequent CLI operation whose stored access token has been invalidated silently exchanges the refresh token, retries the call, and writes the new access token back to `credentials.json`. Refresh token unchanged (server doesn't rotate today).

## Out of scope

- ESC operations and the Neo task event stream still surface "login required" on token expiry — those paths don't go through the changed code yet.
