### PR TITLE
Write config to remote-config stacks from pulumi new; reject other writers

### DIFF
--- a/pkg/cmd/pulumi/config/coverage_sbc03_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc03_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+)
+
+// TestSaveRemoteConfigValuesEditorError covers the path where the ESC editor cannot be constructed
+// (the stack's backend does not support environments), so no values are written.
+func TestSaveRemoteConfigValuesEditorError(t *testing.T) {
+	t.Parallel()
+	env := "proj/env"
+	s := remoteStackWithBackend(&env, &backend.MockBackend{NameF: func() string { return "plain" }})
+	err := SaveRemoteConfigValues(t.Context(), s, config.Map{
+		config.MustMakeKey("proj", "k"): config.NewValue("v"),
+	})
+	require.ErrorContains(t, err, "does not support environments")
+}

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	escEncoding "github.com/pulumi/esc/syntax/encoding"
 	"gopkg.in/yaml.v3"
@@ -58,6 +59,33 @@ func newConfigEditor(
 // the precedence in cmdStack.LoadProjectStack/SaveProjectStack.
 func configStoreIsRemote(stack backend.Stack, configFile string) bool {
 	return configFile == "" && stack.ConfigLocation().IsRemote
+}
+
+// ConfigStoreIsRemote reports whether the stack's configuration is effectively stored remotely,
+// honoring an explicit --config-file.
+func ConfigStoreIsRemote(stack backend.Stack, configFile string) bool {
+	return configStoreIsRemote(stack, configFile)
+}
+
+// SaveRemoteConfigValues writes c to the ESC environment backing a remote-config stack, overwriting
+// matching keys while preserving unrelated keys, imports, and comments. Secure values are encrypted
+// server-side. The stack must already be linked to an environment.
+func SaveRemoteConfigValues(ctx context.Context, stack backend.Stack, c config.Map) error {
+	editor, err := newESCConfigEditor(ctx, stack)
+	if err != nil {
+		return err
+	}
+	keys := make(config.KeyArray, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+	for _, k := range keys {
+		if err := editor.Set(ctx, k, c[k], false /*path*/); err != nil {
+			return err
+		}
+	}
+	return editor.Save(ctx)
 }
 
 // checkRemoteProjectStack guards mutation commands against a nil ProjectStack for remote stacks.

--- a/pkg/cmd/pulumi/config/editor_test.go
+++ b/pkg/cmd/pulumi/config/editor_test.go
@@ -244,6 +244,30 @@ func editForRemote(
 	return uploaded
 }
 
+func TestSaveRemoteConfigValuesOverwrites(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// The env already has testProject:a; it is overwritten and the new key testProject:b is added.
+	existingYAML := "values:\n  pulumiConfig:\n    testProject:a: original\n"
+	var uploaded []byte
+	s := remoteStackForEditor(t, []byte(existingYAML), "etag",
+		func(yaml []byte, _ string) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = yaml
+			return nil, nil
+		})
+
+	c := config.Map{
+		config.MustMakeKey("testProject", "a"): config.NewValue("updated"),
+		config.MustMakeKey("testProject", "b"): config.NewValue("new"),
+	}
+	require.NoError(t, SaveRemoteConfigValues(ctx, s, c))
+
+	got := string(uploaded)
+	require.Contains(t, got, "testProject:a: updated", "an existing key is overwritten")
+	require.Contains(t, got, "testProject:b: new", "a new key is written")
+}
+
 func TestESCConfigEditorSet(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/pkg/cmd/pulumi/operations/io.go
+++ b/pkg/cmd/pulumi/operations/io.go
@@ -54,7 +54,8 @@ func parseAndSaveConfigArray(
 		return err
 	}
 
-	if err = newcmd.SaveConfig(ctx, sink, ws, s, commandLineConfig, configFile); err != nil {
+	// An operation command's -c must not persist to a remote-config stack's shared ESC environment.
+	if err = newcmd.SaveConfig(ctx, sink, ws, s, commandLineConfig, configFile, false); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
 	return nil

--- a/pkg/cmd/pulumi/operations/io_test.go
+++ b/pkg/cmd/pulumi/operations/io_test.go
@@ -17,10 +17,29 @@ package operations
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParseAndSaveConfigArrayRejectsRemote(t *testing.T) {
+	t.Parallel()
+	env := "proj/stack"
+	remote := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+
+	// -c on a remote-config stack must be rejected: persisting it would mutate the shared ESC
+	// environment, even from a read-only command like preview.
+	err := parseAndSaveConfigArray(t.Context(), nil, nil, remote, []string{"proj:k=v"}, false, "")
+	require.ErrorContains(t, err, "not supported for remote-config stacks")
+
+	// No -c values: a no-op, so the guard is not reached.
+	require.NoError(t, parseAndSaveConfigArray(t.Context(), nil, nil, remote, nil, false, ""))
+}
 
 func TestConfigureNeoTaskOption(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -430,6 +430,7 @@ func NewUpCmd() *cobra.Command {
 			path,
 			opts.Display,
 			configFile,
+			false, // operation commands must not persist -c to a remote stack's shared ESC env
 		); err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/project/newcmd/config.go
+++ b/pkg/cmd/pulumi/project/newcmd/config.go
@@ -16,6 +16,7 @@ package newcmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -52,6 +53,7 @@ func HandleConfig(
 	path bool,
 	opts display.Options,
 	configFile string,
+	allowRemoteConfigWrite bool,
 ) error {
 	// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
 	latest, err := backend.GetLatestConfiguration(ctx, s)
@@ -73,7 +75,11 @@ func HandleConfig(
 	// If the stack already existed and had previous config, those values will be used as the defaults.
 	var c config.Map
 	if isPreconfiguredEmptyStack(templateNameOrURL, template.Config, stackConfig, snap) {
-		c = stackConfig
+		// Re-saving a remote stack's recorded secure values (ciphertext here) would corrupt them; adopt
+		// stackConfig only for local stacks.
+		if !cmdConfig.ConfigStoreIsRemote(s, configFile) {
+			c = stackConfig
+		}
 		// TODO[pulumi/pulumi#1894] consider warning if templateNameOrURL is different from
 		// the stack's `pulumi:template` config value.
 	} else {
@@ -105,7 +111,7 @@ func HandleConfig(
 
 	// Save the config.
 	if len(c) > 0 {
-		if err = SaveConfig(ctx, sink, ws, s, c, configFile); err != nil {
+		if err = SaveConfig(ctx, sink, ws, s, c, configFile, allowRemoteConfigWrite); err != nil {
 			return fmt.Errorf("saving config: %w", err)
 		}
 
@@ -213,23 +219,30 @@ func promptForConfig(
 	}
 	sort.Sort(keys)
 
-	// We need to load the stack config here for the secret manager
-	ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
-	if err != nil {
-		return nil, fmt.Errorf("loading stack config: %w", err)
-	}
-
-	sm, state, err := ssml.GetSecretsManager(ctx, stack, ps)
-	if err != nil {
-		return nil, err
-	}
-	if state != cmdStack.SecretsManagerUnchanged {
-		if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
-			return nil, fmt.Errorf("saving stack config: %w", err)
+	// Remote-config stacks encrypt secrets server-side, so skip the local secrets manager and hand
+	// the editor plaintext secure values.
+	remote := cmdConfig.ConfigStoreIsRemote(stack, configFile)
+	encrypter := config.NopEncrypter
+	decrypter := config.NopDecrypter
+	if !remote {
+		// We need to load the stack config here for the secret manager
+		ps, err := cmdStack.LoadProjectStack(ctx, sink, project, stack, configFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading stack config: %w", err)
 		}
+
+		sm, state, err := ssml.GetSecretsManager(ctx, stack, ps)
+		if err != nil {
+			return nil, err
+		}
+		if state != cmdStack.SecretsManagerUnchanged {
+			if err = cmdStack.SaveProjectStack(ctx, stack, ps, configFile); err != nil {
+				return nil, fmt.Errorf("saving stack config: %w", err)
+			}
+		}
+		encrypter = sm.Encrypter()
+		decrypter = sm.Decrypter()
 	}
-	encrypter := sm.Encrypter()
-	decrypter := sm.Decrypter()
 
 	c := make(config.Map)
 
@@ -242,10 +255,11 @@ func promptForConfig(
 
 		templateConfigValue := parsedTemplateConfig[k]
 
-		// Prepare a default value.
+		// For a remote stack the only default is the template's; never seed from stackConfig (last
+		// deployment's config, possibly stale ciphertext).
 		var defaultValue string
 		var secret bool
-		if stackConfig != nil {
+		if !remote && stackConfig != nil {
 			// Use the stack's existing value as the default.
 			if val, ok := stackConfig[k]; ok {
 				// It's OK to pass a nil or non-nil crypter for non-secret values.
@@ -332,10 +346,23 @@ func ParseConfig(configArray []string, path bool) (config.Map, error) {
 	return configMap, nil
 }
 
-// SaveConfig saves the config for the stack.
+// SaveConfig saves the config for the stack. For a remote-config stack, allowRemoteConfigWrite must
+// be true to persist to the shared ESC environment; callers passing false are rejected and pointed at
+// `pulumi config set`.
 func SaveConfig(
-	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stack backend.Stack, c config.Map, configFile string,
+	ctx context.Context, sink diag.Sink, ws pkgWorkspace.Context, stack backend.Stack, c config.Map,
+	configFile string, allowRemoteConfigWrite bool,
 ) error {
+	if cmdConfig.ConfigStoreIsRemote(stack, configFile) {
+		if !allowRemoteConfigWrite {
+			return errors.New("setting configuration with --config is not supported for remote-config " +
+				"stacks; use `pulumi config set`")
+		}
+		// Write to the linked ESC environment via the editor; SaveProjectStack would route to the
+		// link-only SaveRemoteConfig, which rejects config.
+		return cmdConfig.SaveRemoteConfigValues(ctx, stack, c)
+	}
+
 	project, _, err := ws.ReadProject()
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -93,6 +93,7 @@ type newArgs struct {
 	templateMode          bool
 	runtimeOptions        []string
 	remoteStackConfig     bool
+	remoteConfig          bool
 	stdout                io.Writer
 	stderr                io.Writer
 }
@@ -101,6 +102,8 @@ func runNew(ctx context.Context, args newArgs) error {
 	if !args.interactive && !args.yes {
 		return backenderr.ErrNonInteractiveRequiresYes
 	}
+
+	useRemoteConfig := args.remoteStackConfig || args.remoteConfig
 
 	// Default to discarding output when callers (e.g. tests) don't provide writers.
 	if args.stdout == nil {
@@ -391,7 +394,7 @@ func runNew(ctx context.Context, args newArgs) error {
 	if !args.generateOnly && s == nil {
 		if s, err = PromptAndCreateStack(ctx, cmdutil.Diag(), ws, b, args.prompt,
 			args.stack, root, true /*setCurrent*/, args.yes, opts, args.secretsProvider,
-			args.remoteStackConfig, ""); err != nil {
+			useRemoteConfig, ""); err != nil {
 			return err
 		}
 		// The backend will print "Created stack '<stack>'" on success.
@@ -468,6 +471,7 @@ func runNew(ctx context.Context, args newArgs) error {
 			args.configPath,
 			opts,
 			"",
+			true, // pulumi new may write creation-time config to a remote-config stack
 		)
 		if err != nil {
 			return err
@@ -701,6 +705,13 @@ func NewNewCmd() *cobra.Command {
 		"Store stack configuration remotely",
 	)
 	_ = cmd.PersistentFlags().MarkHidden("remote-stack-config")
+
+	// Canonical name not yet finalized; keep both --remote-config and --remote-stack-config hidden.
+	cmd.PersistentFlags().BoolVar(
+		&args.remoteConfig, "remote-config", false,
+		"Store stack configuration remotely",
+	)
+	_ = cmd.PersistentFlags().MarkHidden("remote-config")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/project/newcmd/new_test.go
+++ b/pkg/cmd/pulumi/project/newcmd/new_test.go
@@ -1408,6 +1408,43 @@ func TestNewCmdYesWritesMinimalPulumiYAMLWithExplicitName(t *testing.T) {
 	assert.Equal(t, "name: my-project\n", string(contents))
 }
 
+// TestNewRemoteConfigFlagRouting verifies that non-interactive `new` defaults to local config, and
+// that both `--remote-config` and its `--remote-stack-config` alias feed the same remote-config
+// creation path — exercised here against the filestate backend, which rejects remote config, so both
+// flags fail identically while the no-flag case succeeds locally.
+//
+//nolint:paralleltest // mutates process env and working directory
+func TestNewRemoteConfigFlagRouting(t *testing.T) {
+	cases := []struct {
+		name      string
+		flag      string
+		wantError string // "" => succeeds with local config
+	}{
+		{"no flag defaults to local", "", ""},
+		{"--remote-config attempts remote", "--remote-config", "remote config is not supported"},
+		{"--remote-stack-config attempts remote", "--remote-stack-config", "remote config is not supported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempFilestateBackend(t)
+			dir := t.TempDir()
+			t.Chdir(dir)
+			args := []string{"-y", "--name", "p", "--stack", "dev"}
+			if tc.flag != "" {
+				args = append(args, tc.flag)
+			}
+			cmd := NewNewCmd()
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantError)
+			}
+		})
+	}
+}
+
 //nolint:paralleltest
 func TestNewCmdYesUsesCurrentDirectoryNameByDefault(t *testing.T) {
 	useTempFilestateBackend(t)
@@ -1473,4 +1510,129 @@ func TestNewCmdYesDoesNotOverwriteExistingPulumiYAML(t *testing.T) {
 	contents, readErr := os.ReadFile(existing)
 	require.NoError(t, readErr)
 	assert.Equal(t, "name: existing\n", string(contents))
+}
+
+// TestNewRemoteConfigFlags verifies the hidden remote-config creation flags are registered. Both
+// --remote-config (the canonical name) and the --remote-stack-config alias feed the same remote
+// stack-config creation path and stay hidden through Phase 1.
+func TestNewRemoteConfigFlags(t *testing.T) {
+	t.Parallel()
+	cmd := NewNewCmd()
+	for _, name := range []string{"remote-config", "remote-stack-config"} {
+		f := cmd.PersistentFlags().Lookup(name)
+		require.NotNil(t, f, "flag --%s should be registered", name)
+		require.True(t, f.Hidden, "flag --%s should be hidden", name)
+	}
+}
+
+// TestNewRemoteConfigWritesInitialConfigToEnv verifies that creation-time config for a remote-config
+// stack is written to the linked ESC environment via the editor (not the link-only SaveRemoteConfig),
+// and that secret values are handed over as plaintext fn::secret for server-side encryption rather
+// than being encrypted into a local secure: node.
+//
+//nolint:paralleltest // shares mock backend state
+func TestNewRemoteConfigWritesInitialConfigToEnv(t *testing.T) {
+	ctx := t.Context()
+
+	env := "testProject/testStack"
+	var uploaded []byte
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte("values:\n  pulumiConfig: {}\n"), "etag", 0, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, yaml []byte, _ string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = yaml
+			return nil, nil
+		},
+	}
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	c := config.Map{
+		config.MustMakeKey("testProject", "k"):      config.NewValue("v"),
+		config.MustMakeKey("testProject", "secret"): config.NewSecureValue("supersecret"),
+	}
+
+	err := SaveConfig(ctx, nil, &pkgWorkspace.MockContext{}, s, c, "", true /*allowRemoteConfigWrite*/)
+	require.NoError(t, err)
+
+	got := string(uploaded)
+	require.Contains(t, got, "testProject:k: v")
+	require.Contains(t, got, "fn::secret: supersecret")
+	require.NotContains(t, got, "secure:")
+}
+
+// TestNewRemoteConfigWritesThroughSaveConfig verifies that SaveConfig routes a remote stack's config
+// to the linked ESC environment, overwriting existing keys and adding new ones. SaveConfig is shared
+// by pulumi new and the operation commands' -c handling, so both apply remote config the same way.
+//
+//nolint:paralleltest // shares mock backend state
+func TestNewRemoteConfigWritesThroughSaveConfig(t *testing.T) {
+	ctx := t.Context()
+
+	env := "testProject/testStack"
+	var uploaded []byte
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte("values:\n  pulumiConfig:\n    testProject:existing: keep\n"), "etag", 0, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, yaml []byte, _ string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			uploaded = yaml
+			return nil, nil
+		},
+	}
+	s := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("testStack"),
+				FullyQualifiedNameV: "org/testProject/testStack",
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	c := config.Map{
+		config.MustMakeKey("testProject", "existing"): config.NewValue("updated"),
+		config.MustMakeKey("testProject", "new"):      config.NewValue("v"),
+	}
+	require.NoError(t, SaveConfig(ctx, nil, &pkgWorkspace.MockContext{}, s, c, "", true /*allowRemoteConfigWrite*/))
+
+	got := string(uploaded)
+	require.Contains(t, got, "testProject:new: v", "a new key is written")
+	require.Contains(t, got, "testProject:existing: updated", "an existing remote key is overwritten")
+}
+
+// TestSaveConfigRejectsRemoteWithoutAllow verifies the chokepoint: any caller that doesn't pass
+// allowRemoteConfigWrite (the operation commands' -c paths) is rejected on a remote-config stack, so
+// it can't mutate the shared ESC environment.
+func TestSaveConfigRejectsRemoteWithoutAllow(t *testing.T) {
+	t.Parallel()
+	env := "testProject/testStack"
+	s := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+	c := config.Map{config.MustMakeKey("testProject", "k"): config.NewValue("v")}
+	err := SaveConfig(t.Context(), nil, &pkgWorkspace.MockContext{}, s, c, "", false)
+	require.ErrorContains(t, err, "not supported for remote-config stacks")
 }

--- a/pkg/cmd/pulumi/stack/io_test.go
+++ b/pkg/cmd/pulumi/stack/io_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -115,4 +116,72 @@ func TestCreateStack_InitialisesStateWithSecretsManager(t *testing.T) {
 
 	// Assert.
 	assert.Equal(t, expectedSm.State(), actualDeployment.SecretsProviders.State)
+}
+
+// TestCreateStackRemoteConfig verifies that creating a stack with useRemoteConfig=true requests a
+// remote-config stack: it passes a StackConfig naming the "<project>/<stack>" environment to the
+// backend. This is the creation path both `new --remote-config` and `stack init --remote-config`
+// (and the `--remote-stack-config` alias) feed.
+//
+//nolint:paralleltest // shares mock backend state
+func TestCreateStackRemoteConfig(t *testing.T) {
+	var gotConfig *apitype.StackConfig
+	mockBackend := &backend.MockBackend{
+		NameF: func() string { return "mock" },
+		CreateStackF: func(
+			_ context.Context, _ backend.StackReference, _ string,
+			_ *apitype.UntypedDeployment, opts *backend.CreateStackOptions,
+		) (backend.Stack, error) {
+			if opts != nil {
+				gotConfig = opts.Config
+			}
+			return nil, nil
+		},
+		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
+			return nil, nil
+		},
+	}
+	stackRef := &backend.MockStackReference{
+		NameV:    tokens.MustParseStackName("dev"),
+		ProjectV: tokens.Name("proj"),
+	}
+
+	_, err := CreateStack(
+		t.Context(), cmdutil.Diag(), pkgWorkspace.Instance, mockBackend, stackRef,
+		"" /*root*/, nil /*teams*/, false /*setCurrent*/, "" /*secretsProvider*/, true /*useRemoteConfig*/, "" /*configFile*/)
+	require.NoError(t, err)
+	require.NotNil(t, gotConfig)
+	require.Equal(t, "proj/dev", gotConfig.Environment)
+}
+
+// TestCreateStackRemoteConfigUnsupported verifies that a backend which does not support remote
+// configuration rejects creation cleanly (the DIY backend returns ErrConfigNotSupported before any
+// state is written).
+//
+//nolint:paralleltest // shares mock backend state
+func TestCreateStackRemoteConfigUnsupported(t *testing.T) {
+	mockBackend := &backend.MockBackend{
+		NameF: func() string { return "mock" },
+		CreateStackF: func(
+			_ context.Context, _ backend.StackReference, _ string,
+			_ *apitype.UntypedDeployment, opts *backend.CreateStackOptions,
+		) (backend.Stack, error) {
+			if opts != nil && opts.Config != nil {
+				return nil, backend.ErrConfigNotSupported
+			}
+			return nil, nil
+		},
+		DefaultSecretManagerF: func(context.Context, *workspace.ProjectStack) (secrets.Manager, error) {
+			return nil, nil
+		},
+	}
+	stackRef := &backend.MockStackReference{
+		NameV:    tokens.MustParseStackName("dev"),
+		ProjectV: tokens.Name("proj"),
+	}
+
+	_, err := CreateStack(
+		t.Context(), cmdutil.Diag(), pkgWorkspace.Instance, mockBackend, stackRef,
+		"" /*root*/, nil /*teams*/, false /*setCurrent*/, "" /*secretsProvider*/, true /*useRemoteConfig*/, "" /*configFile*/)
+	require.ErrorContains(t, err, "remote config is not supported")
 }

--- a/pkg/cmd/pulumi/stack/stack_new.go
+++ b/pkg/cmd/pulumi/stack/stack_new.go
@@ -127,6 +127,14 @@ type stackNewCmd struct {
 }
 
 func (cmd *stackNewCmd) Run(ctx context.Context, args []string) error {
+	// Copying config into a remote-config stack is unsupported: the values would route to the linked
+	// ESC environment, which SaveRemoteConfig rejects. Reject before creating the stack.
+	if cmd.remoteConfig && cmd.stackToCopy != "" {
+		return errors.New("copying configuration with --copy-config-from is not supported when " +
+			"creating a remote-config stack; create the stack, then migrate config with " +
+			"`pulumi config env init --remote-config`")
+	}
+
 	if cmd.yes {
 		defer func(prev bool) { cmdutil.DisableInteractive = prev }(cmdutil.DisableInteractive)
 		cmdutil.DisableInteractive = true

--- a/pkg/cmd/pulumi/stack/stack_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_new_test.go
@@ -28,6 +28,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Copying config into a remote-config stack is out of scope for v1; it must be rejected up front,
+// before any stack is created, rather than hard-erroring at save time after CreateStack.
+func TestStackNewRejectsCopyConfigFromWithRemoteConfig(t *testing.T) {
+	t.Parallel()
+	cmd := &stackNewCmd{remoteConfig: true, stackToCopy: "dev"}
+	err := cmd.Run(t.Context(), nil)
+	assert.ErrorContains(t, err, "not supported when creating a remote-config stack")
+}
+
 // When a backend doesn't support the --teams flag,
 // stack creation should fail.
 func TestStackNew_teamsUnsupportedByBackend(t *testing.T) {


### PR DESCRIPTION
## Summary

Towards pulumi/pulumi-service#41541
Towards pulumi/pulumi#19557

Make `pulumi new` write creation-time config to a remote-config stack's linked ESC
environment instead of erroring, and reject every other path that would mutate that
shared config. Builds on the earlier PRs in this stacked series (the core `pulumi
config` write commands and the ESC-backed editor seam); internally this is
"service-backed config (SBC)", externally "remote config" for now.

This adds the hidden create flags for remote-config stacks and wires `pulumi new`'s
config application to the remote path.

- **Create flags** — `pulumi new` gains the hidden `--remote-config` flag as the
  canonical name, alongside the existing hidden `--remote-stack-config` alias; both
  feed the same remote stack-config creation path. Both stay hidden through Phase 1;
  canonical naming is finalized in Phase 2.
- **Remote config writes** — `SaveConfig` routes a remote stack through a new
  `config.SaveRemoteConfigValues`, which applies values via the ESC editor's
  read-modify-write: unrelated keys, imports, and comments are preserved, and a
  concurrent edit surfaces as a retryable etag conflict. Secrets are passed as
  plaintext and wrapped as `fn::secret` for server-side encryption, so
  `promptForConfig` skips the local secrets manager for remote stacks and never
  seeds defaults from the deployment config. `HandleConfig` skips the
  preconfigured-empty-stack adopt-and-save for remote, since the env is authoritative.
- **Chokepoint guard** — remote writes are gated behind a new `allowRemoteConfigWrite`
  parameter on `SaveConfig`; only `pulumi new` sets it. The operation commands' `-c`
  (`up`/`preview`/`refresh`/`destroy`/`watch`) is rejected and pointed at `pulumi
  config set`, so even read-only `preview` can't mutate the shared environment.
- **`stack init` guard** — `pulumi stack init --remote-config --copy-config-from
  <stack>` is rejected up front, before any stack is created (copying config into a
  remote-config stack is out of scope for v1; migrate with `pulumi config env init
  --remote-config` after creation), so it fails cleanly instead of leaving a
  half-configured stack.

No behavior change for local stacks.

## Changelog

None in this PR. Remote-config stacks are hidden/opt-in — gated by hidden CLI flags
and the LaunchDarkly flag `39623-service-backed-config` — so nothing here is
user-reachable yet. The user-facing changelog entry lands with the PR that un-hides
the feature. Applying `impact/no-changelog-required`.

## Risk

Low. No local-stack behavior change, and the remote path is unreachable without both
the hidden flags and the server flag. Writes to remote-config stacks are funneled
through a single `SaveConfig` chokepoint that rejects every caller except `pulumi
new`, so no operation command can mutate the shared ESC environment via `-c`.
