### PR TITLE
Manage remote config env imports and status

### DIFF
--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -48,6 +48,8 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 		configFile:       configFile,
 	}
 
+	var jsonOut bool
+
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Manage ESC environments for a stack",
@@ -56,7 +58,13 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			impl.stdout = cmd.OutOrStdout()
 		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			impl.initArgs()
+			return impl.runStatus(cmd, jsonOut)
+		},
 	}
+
+	cmd.Flags().BoolVarP(&jsonOut, "json", "j", false, "Emit output as JSON")
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
@@ -111,6 +119,24 @@ func (cmd *configEnvCmd) initArgs() {
 	cmd.ssml = cmdStack.NewStackSecretsManagerLoaderFromEnv()
 }
 
+func (cmd *configEnvCmd) resolveStack(ctx context.Context) (*workspace.Project, backend.Stack, error) {
+	project, _, err := cmd.ws.ReadProject()
+	if err != nil {
+		return nil, nil, err
+	}
+	stack, err := cmd.requireStack(
+		ctx,
+		cmd.diags,
+		cmd.ws,
+		cmdBackend.DefaultLoginManager,
+		*cmd.stackRef,
+		cmdStack.LoadOnly,
+		display.Options{Color: cmd.color},
+		*cmd.configFile,
+	)
+	return project, stack, err
+}
+
 func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 ) (*workspace.ProjectStack, *workspace.Project, *backend.Stack, error) {
 	opts := display.Options{Color: cmd.color}
@@ -148,11 +174,21 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 }
 
 func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool) error {
-	projectStack, _, _, err := cmd.loadEnvPreamble(ctx)
+	projectStack, _, stack, err := cmd.loadEnvPreamble(ctx)
 	if err != nil {
 		return err
 	}
-	imports := projectStack.Environment.Imports()
+
+	var imports []string
+	if (*stack).ConfigLocation().IsRemote {
+		editor, err := newESCConfigEditor(ctx, *stack)
+		if err != nil {
+			return err
+		}
+		imports = editor.Imports()
+	} else {
+		imports = projectStack.Environment.Imports()
+	}
 
 	if jsonOut {
 		if len(imports) == 0 {
@@ -183,11 +219,32 @@ func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool
 	return nil
 }
 
+// importOp is one import mutation: exactly one of addEnvs or removeEnv is set.
+type importOp struct {
+	addEnvs   []string
+	removeEnv string
+}
+
+func (op importOp) applyLocal(stack *workspace.ProjectStack) {
+	if len(op.addEnvs) > 0 {
+		stack.Environment = stack.Environment.Append(op.addEnvs...)
+		return
+	}
+	stack.Environment = stack.Environment.Remove(op.removeEnv)
+}
+
+func (op importOp) applyRemote(editor *escConfigEditor) error {
+	if len(op.addEnvs) > 0 {
+		return editor.AddImports(op.addEnvs...)
+	}
+	return editor.RemoveImport(op.removeEnv)
+}
+
 func (cmd *configEnvCmd) editStackEnvironment(
 	ctx context.Context,
 	showSecrets bool,
 	yes bool,
-	edit func(stack *workspace.ProjectStack) error,
+	op importOp,
 ) error {
 	if !yes && !cmd.interactive {
 		return backenderr.ErrNonInteractiveRequiresYes
@@ -198,9 +255,11 @@ func (cmd *configEnvCmd) editStackEnvironment(
 		return err
 	}
 
-	if err := edit(projectStack); err != nil {
-		return err
+	if configStoreIsRemote(*stack, *cmd.configFile) {
+		return cmd.editRemoteStackEnvironment(ctx, yes, *stack, op)
 	}
+
+	op.applyLocal(projectStack)
 
 	if err := listConfig(
 		ctx,
@@ -230,6 +289,144 @@ func (cmd *configEnvCmd) editStackEnvironment(
 
 	if err = cmd.saveProjectStack(ctx, *stack, projectStack, *cmd.configFile); err != nil {
 		return fmt.Errorf("saving stack config: %w", err)
+	}
+	return nil
+}
+
+// editRemoteStackEnvironment edits the backing ESC environment's imports, skipping the full
+// merged-config display the local path shows since that would require re-resolving the environment.
+func (cmd *configEnvCmd) editRemoteStackEnvironment(
+	ctx context.Context,
+	yes bool,
+	stack backend.Stack,
+	op importOp,
+) error {
+	if err := rejectIfPinned(stack, *cmd.configFile); err != nil {
+		return err
+	}
+
+	editor, err := newESCConfigEditor(ctx, stack)
+	if err != nil {
+		return err
+	}
+
+	if err := op.applyRemote(editor); err != nil {
+		return err
+	}
+
+	imports := editor.Imports()
+	if len(imports) == 0 {
+		ui.Fprintf(cmd.stdout, "This stack configuration has no environments listed.\n")
+	} else {
+		printImportsTable(cmd.stdout, imports)
+	}
+
+	if !yes {
+		fmt.Fprintln(cmd.stdout)
+
+		response := ui.PromptUser("Save?", []string{"yes", "no"}, "yes", cmdutil.GetGlobalColorization())
+		switch response {
+		case "no":
+			return errors.New("canceled")
+		case "yes":
+		}
+	}
+
+	if err := editor.Save(ctx); err != nil {
+		return fmt.Errorf("saving stack config: %w", err)
+	}
+	return nil
+}
+
+func printImportsTable(w io.Writer, imports []string) {
+	rows := make([]cmdutil.TableRow, 0, len(imports))
+	for _, imp := range imports {
+		rows = append(rows, cmdutil.TableRow{Columns: []string{imp}})
+	}
+	ui.FprintTable(w, cmdutil.Table{
+		Headers: []string{"ENVIRONMENTS"},
+		Rows:    rows,
+	}, nil)
+}
+
+// runStatus implements bare `pulumi config env`, reporting where the stack's config lives (linked
+// ESC environment or local file).
+func (cmd *configEnvCmd) runStatus(cobraCmd *cobra.Command, jsonOut bool) error {
+	ctx := cobraCmd.Context()
+
+	project, stack, err := cmd.resolveStack(ctx)
+	if err != nil {
+		// Bare `config env` historically printed help offline; preserve that when no stack resolves.
+		return cobraCmd.Help()
+	}
+
+	if stack.ConfigLocation().IsRemote {
+		return cmd.runRemoteStatus(ctx, stack, jsonOut)
+	}
+	return cmd.runLocalStatus(ctx, project, stack, jsonOut)
+}
+
+func (cmd *configEnvCmd) runRemoteStatus(ctx context.Context, stack backend.Stack, jsonOut bool) error {
+	loc := stack.ConfigLocation()
+	envRef := ""
+	if loc.EscEnv != nil {
+		envRef = *loc.EscEnv
+	}
+
+	editor, err := newESCConfigEditor(ctx, stack)
+	if err != nil {
+		return err
+	}
+	imports := editor.Imports()
+
+	if jsonOut {
+		return ui.FprintJSON(cmd.stdout, struct {
+			Source      string   `json:"source"`
+			Environment string   `json:"environment"`
+			Imports     []string `json:"imports"`
+		}{Source: "remote", Environment: envRef, Imports: imports})
+	}
+
+	ui.Fprintf(cmd.stdout, "This stack's configuration is stored remotely in environment %q.\n", envRef)
+	if len(imports) == 0 {
+		ui.Fprintf(cmd.stdout, "It imports no environments.\n")
+	} else {
+		printImportsTable(cmd.stdout, imports)
+	}
+	return nil
+}
+
+func (cmd *configEnvCmd) runLocalStatus(
+	ctx context.Context, project *workspace.Project, stack backend.Stack, jsonOut bool,
+) error {
+	configPath := *cmd.configFile
+	if configPath == "" {
+		_, path, err := workspace.DetectProjectStackPath(stack.Ref().Name().Q())
+		if err != nil {
+			return fmt.Errorf("getting configuration file: %w", err)
+		}
+		configPath = path
+	}
+
+	projectStack, err := cmd.loadProjectStack(ctx, cmd.diags, project, stack, *cmd.configFile)
+	if err != nil {
+		return err
+	}
+	imports := projectStack.Environment.Imports()
+
+	if jsonOut {
+		return ui.FprintJSON(cmd.stdout, struct {
+			Source     string   `json:"source"`
+			ConfigFile string   `json:"configFile"`
+			Imports    []string `json:"imports"`
+		}{Source: "local", ConfigFile: configPath, Imports: imports})
+	}
+
+	ui.Fprintf(cmd.stdout, "This stack's configuration is stored locally in %q.\n", configPath)
+	if len(imports) == 0 {
+		ui.Fprintf(cmd.stdout, "It imports no environments.\n")
+	} else {
+		printImportsTable(cmd.stdout, imports)
 	}
 	return nil
 }

--- a/pkg/cmd/pulumi/config/config_env_add.go
+++ b/pkg/cmd/pulumi/config/config_env_add.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -63,9 +62,5 @@ type configEnvAddCmd struct {
 }
 
 func (cmd *configEnvAddCmd) run(ctx context.Context, args []string) error {
-	return cmd.parent.editStackEnvironment(
-		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
-			stack.Environment = stack.Environment.Append(args...)
-			return nil
-		})
+	return cmd.parent.editStackEnvironment(ctx, cmd.showSecrets, cmd.yes, importOp{addEnvs: args})
 }

--- a/pkg/cmd/pulumi/config/config_env_remote_test.go
+++ b/pkg/cmd/pulumi/config/config_env_remote_test.go
@@ -1,0 +1,468 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// newRemoteConfigEnvCmdForTest builds a configEnvCmd whose stack is remote (ESC-backed). The backing
+// environment definition is initialDefYAML; UpdateEnvironmentWithProject records the uploaded YAML
+// into *uploaded.
+func newRemoteConfigEnvCmdForTest(
+	stdin io.Reader,
+	stdout io.Writer,
+	initialDefYAML string,
+	uploaded *[]byte,
+	updateErr error,
+) *configEnvCmd {
+	stackRef := "stack"
+	configFile := ""
+	env := "testProject/testEnv"
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte(initialDefYAML), "etag", 0, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, y []byte, _ string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			if uploaded != nil {
+				*uploaded = y
+			}
+			return nil, updateErr
+		},
+	}
+
+	return &configEnvCmd{
+		stdin:       stdin,
+		stdout:      stdout,
+		interactive: true,
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes(
+					[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return &backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						StringV:             "org/stack",
+						NameV:               tokens.MustParseStackName("stack"),
+						ProjectV:            "testProject",
+						FullyQualifiedNameV: "org/testProject/stack",
+					}
+				},
+				OrgNameF: func() string { return "org" },
+				BackendF: func() backend.Backend { return be },
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+				},
+			}, nil
+		},
+		loadProjectStack: func(
+			_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			return &workspace.ProjectStack{}, nil
+		},
+		saveProjectStack: func(_ context.Context, _ backend.Stack, _ *workspace.ProjectStack, _ string) error {
+			return nil
+		},
+		stackRef:   &stackRef,
+		configFile: &configFile,
+	}
+}
+
+func TestConfigEnvLsRemote(t *testing.T) {
+	t.Parallel()
+
+	const def = `imports:
+  - a
+  - b
+values:
+  pulumiConfig:
+    testProject:k: v
+`
+	var stdout bytes.Buffer
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader(""), &stdout, def, nil, nil)
+	ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
+	require.NoError(t, ls.run(t.Context(), nil))
+
+	const expected = `ENVIRONMENTS
+a
+b
+`
+	assert.Equal(t, expected, cleanStdoutIncludingPrompt(stdout.String()))
+}
+
+//nolint:paralleltest // exercises the prompt path with shared survey state
+func TestConfigEnvAddRemote(t *testing.T) {
+	const def = `imports:
+  - a
+values:
+  pulumiConfig:
+    testProject:k: v
+`
+	var uploaded []byte
+	var stdout bytes.Buffer
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, &uploaded, nil)
+	parent.initArgs()
+	add := &configEnvAddCmd{parent: parent, yes: true}
+	require.NoError(t, add.run(t.Context(), []string{"c"}))
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	require.Equal(t, []any{"a", "c"}, doc["imports"])
+	// Unrelated config section is preserved.
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "v", pc["testProject:k"])
+}
+
+//nolint:paralleltest // exercises the prompt path with shared survey state
+func TestConfigEnvRmConfigFileWritesLocal(t *testing.T) {
+	var uploaded []byte
+	// The stack is linked to remote config, but an explicit --config-file must route the import edit to
+	// the local stack file rather than mutating the backing ESC environment.
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader(""), &bytes.Buffer{}, "imports: []\n", &uploaded, nil)
+	parent.ssml = cmdStack.NewStackSecretsManagerLoaderFromEnv()
+	configFile := "Pulumi.local.yaml"
+	parent.configFile = &configFile
+	parent.loadProjectStack = func(
+		_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+	) (*workspace.ProjectStack, error) {
+		return &workspace.ProjectStack{Environment: workspace.NewEnvironment([]string{"c"})}, nil
+	}
+	var savedFile string
+	parent.saveProjectStack = func(_ context.Context, _ backend.Stack, _ *workspace.ProjectStack, file string) error {
+		savedFile = file
+		return nil
+	}
+	parent.initArgs()
+
+	rm := &configEnvRmCmd{parent: parent, yes: true}
+	require.NoError(t, rm.run(t.Context(), []string{"c"}))
+	require.Equal(t, "Pulumi.local.yaml", savedFile, "--config-file must route the import edit to the local file")
+	require.Nil(t, uploaded, "--config-file must not mutate the remote environment")
+}
+
+func TestEditRemoteStackEnvironmentRejectsPinned(t *testing.T) {
+	t.Parallel()
+
+	configFile := ""
+	parent := &configEnvCmd{configFile: &configFile}
+	pinned := func(env string) backend.Stack {
+		return &backend.MockStack{
+			ConfigLocationF: func() backend.StackConfigLocation {
+				return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+			},
+		}
+	}
+	// The guard is the first statement of editRemoteStackEnvironment, so it rejects before any backend
+	// access; a pinned ref via either separator must be refused.
+	for _, env := range []string{"testProject/testEnv@5", "testProject/testEnv:5"} {
+		err := parent.editRemoteStackEnvironment(t.Context(), true, pinned(env), importOp{})
+		require.ErrorContains(t, err, "unpin", env)
+	}
+}
+
+//nolint:paralleltest // exercises the prompt path with shared survey state
+func TestConfigEnvRmRemote(t *testing.T) {
+	const def = `imports:
+  - a
+  - b
+values:
+  pulumiConfig:
+    testProject:k: v
+`
+	var uploaded []byte
+	var stdout bytes.Buffer
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, &uploaded, nil)
+	parent.initArgs()
+	rm := &configEnvRmCmd{parent: parent, yes: true}
+	require.NoError(t, rm.run(t.Context(), []string{"a"}))
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	require.Equal(t, []any{"b"}, doc["imports"])
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "v", pc["testProject:k"])
+}
+
+//nolint:paralleltest // exercises the prompt path with shared survey state
+func TestConfigEnvRemotePreservesUnrelatedSections(t *testing.T) {
+	const def = `# top comment
+imports:
+  - a
+values:
+  environmentVariables:
+    FOO: bar # keep me
+  pulumiConfig:
+    testProject:k: v
+`
+	t.Run("add", func(t *testing.T) {
+		var uploaded []byte
+		var stdout bytes.Buffer
+		parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, &uploaded, nil)
+		parent.initArgs()
+		add := &configEnvAddCmd{parent: parent, yes: true}
+		require.NoError(t, add.run(t.Context(), []string{"b"}))
+		out := string(uploaded)
+		require.Contains(t, out, "# top comment")
+		require.Contains(t, out, "FOO: bar # keep me")
+		require.Contains(t, out, "testProject:k: v")
+		require.Contains(t, out, "- b")
+	})
+
+	t.Run("rm", func(t *testing.T) {
+		var uploaded []byte
+		var stdout bytes.Buffer
+		parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, &uploaded, nil)
+		parent.initArgs()
+		rm := &configEnvRmCmd{parent: parent, yes: true}
+		require.NoError(t, rm.run(t.Context(), []string{"a"}))
+		out := string(uploaded)
+		require.Contains(t, out, "# top comment")
+		require.Contains(t, out, "FOO: bar # keep me")
+		require.Contains(t, out, "testProject:k: v")
+	})
+}
+
+//nolint:paralleltest // exercises the prompt path with shared survey state
+func TestConfigEnvAddRemoteEtagConflictSurfaces(t *testing.T) {
+	const def = "imports:\n  - a\n"
+	var stdout bytes.Buffer
+	// The cloud backend translates esc's 409 into ErrConfigConflict; the editor keys on that sentinel.
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, nil,
+		fmt.Errorf("updating environment: %w", backend.ErrConfigConflict))
+	parent.initArgs()
+	add := &configEnvAddCmd{parent: parent, yes: true}
+	err := add.run(t.Context(), []string{"b"})
+	require.ErrorContains(t, err, "modified concurrently")
+}
+
+func TestConfigEnvStatusRemote(t *testing.T) {
+	t.Parallel()
+
+	const def = `imports:
+  - a
+  - b
+`
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+		var stdout bytes.Buffer
+		parent := newRemoteConfigEnvCmdForTest(strings.NewReader(""), &stdout, def, nil, nil)
+		parent.initArgs()
+		cobraCmd := newConfigEnvCmd(parent.ws, parent.stackRef, parent.configFile)
+		cobraCmd.SetContext(t.Context())
+		require.NoError(t, parent.runStatus(cobraCmd, false))
+		out := cleanStdoutIncludingPrompt(stdout.String())
+		require.Contains(t, out, "testProject/testEnv")
+		require.Contains(t, out, "a")
+		require.Contains(t, out, "b")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+		var stdout bytes.Buffer
+		parent := newRemoteConfigEnvCmdForTest(strings.NewReader(""), &stdout, def, nil, nil)
+		parent.initArgs()
+		cobraCmd := newConfigEnvCmd(parent.ws, parent.stackRef, parent.configFile)
+		cobraCmd.SetContext(t.Context())
+		require.NoError(t, parent.runStatus(cobraCmd, true))
+
+		var got struct {
+			Source      string   `json:"source"`
+			Environment string   `json:"environment"`
+			Imports     []string `json:"imports"`
+		}
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+		assert.Equal(t, "remote", got.Source)
+		assert.Equal(t, "testProject/testEnv", got.Environment)
+		assert.Equal(t, []string{"a", "b"}, got.Imports)
+	})
+}
+
+// TestConfigEnvStatusLocal verifies bare `config env` reports the local config file for a local stack
+// rather than printing help. The --config-file path is honored so the reported file matches the one
+// the command resolved against.
+func TestConfigEnvStatusLocal(t *testing.T) {
+	t.Parallel()
+
+	newLocal := func(stdout io.Writer) *configEnvCmd {
+		stackRef := "stack"
+		configFile := "Pulumi.dev.yaml"
+		return &configEnvCmd{
+			stdout: stdout,
+			ws: &pkgWorkspace.MockContext{
+				ReadProjectF: func() (*workspace.Project, string, error) {
+					return &workspace.Project{Name: "test"}, "", nil
+				},
+			},
+			requireStack: func(
+				_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+				_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+			) (backend.Stack, error) {
+				return &backend.MockStack{
+					ConfigLocationF: func() backend.StackConfigLocation {
+						return backend.StackConfigLocation{IsRemote: false}
+					},
+				}, nil
+			},
+			loadProjectStack: func(
+				_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+			) (*workspace.ProjectStack, error) {
+				return &workspace.ProjectStack{Environment: workspace.NewEnvironment([]string{"review-stacks"})}, nil
+			},
+			stackRef:   &stackRef,
+			configFile: &configFile,
+		}
+	}
+
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+		var stdout bytes.Buffer
+		parent := newLocal(&stdout)
+		parent.initArgs()
+		cobraCmd := newConfigEnvCmd(parent.ws, parent.stackRef, parent.configFile)
+		cobraCmd.SetContext(t.Context())
+		require.NoError(t, parent.runStatus(cobraCmd, false))
+		out := cleanStdoutIncludingPrompt(stdout.String())
+		require.Contains(t, out, "stored locally")
+		require.Contains(t, out, "Pulumi.dev.yaml")
+		require.Contains(t, out, "review-stacks")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+		var stdout bytes.Buffer
+		parent := newLocal(&stdout)
+		parent.initArgs()
+		cobraCmd := newConfigEnvCmd(parent.ws, parent.stackRef, parent.configFile)
+		cobraCmd.SetContext(t.Context())
+		require.NoError(t, parent.runStatus(cobraCmd, true))
+
+		var got struct {
+			Source     string   `json:"source"`
+			ConfigFile string   `json:"configFile"`
+			Imports    []string `json:"imports"`
+		}
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+		assert.Equal(t, "local", got.Source)
+		assert.Equal(t, "Pulumi.dev.yaml", got.ConfigFile)
+		assert.Equal(t, []string{"review-stacks"}, got.Imports)
+	})
+}
+
+// TestConfigEnvLsRemoteStructuredImport verifies structured imports (e.g. {env: {merge: false}}) are
+// listed by name, matching workspace.Environment.Imports.
+func TestConfigEnvLsRemoteStructuredImport(t *testing.T) {
+	t.Parallel()
+
+	const def = `imports:
+  - a
+  - b:
+      merge: false
+values:
+  pulumiConfig: {}
+`
+	var stdout bytes.Buffer
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader(""), &stdout, def, nil, nil)
+	ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
+	require.NoError(t, ls.run(t.Context(), nil))
+
+	out := cleanStdoutIncludingPrompt(stdout.String())
+	require.Contains(t, out, "a")
+	require.Contains(t, out, "b")
+}
+
+// TestConfigEnvRmRemoteDuplicate verifies removing a duplicated import drops the last occurrence,
+// matching workspace.Environment.Remove.
+//
+//nolint:paralleltest // exercises the edit/save path
+func TestConfigEnvRmRemoteDuplicate(t *testing.T) {
+	const def = "imports:\n  - a\n  - a\n"
+	var uploaded []byte
+	var stdout bytes.Buffer
+	parent := newRemoteConfigEnvCmdForTest(strings.NewReader("y"), &stdout, def, &uploaded, nil)
+	parent.initArgs()
+	rm := &configEnvRmCmd{parent: parent, yes: true}
+	require.NoError(t, rm.run(t.Context(), []string{"a"}))
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	require.Equal(t, []any{"a"}, doc["imports"])
+}
+
+// TestConfigEnvStatusFallsThroughToHelpOnResolveError verifies bare `config env` preserves its prior
+// offline/local contract: when no stack can be resolved (logged out, none selected, non-interactive) it
+// prints help and returns no error, rather than surfacing the resolution error to every backend.
+func TestConfigEnvStatusFallsThroughToHelpOnResolveError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("backend unavailable")
+	stackRef := "stack"
+	configFile := ""
+	parent := &configEnvCmd{
+		stdout: io.Discard,
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				return &workspace.Project{Name: "test"}, "", nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return nil, sentinel
+		},
+		stackRef:   &stackRef,
+		configFile: &configFile,
+	}
+	parent.initArgs()
+	cobraCmd := newConfigEnvCmd(parent.ws, parent.stackRef, parent.configFile)
+	cobraCmd.SetContext(t.Context())
+	cobraCmd.SetOut(io.Discard)
+
+	require.NoError(t, parent.runStatus(cobraCmd, false))
+}

--- a/pkg/cmd/pulumi/config/config_env_rm.go
+++ b/pkg/cmd/pulumi/config/config_env_rm.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -60,9 +59,5 @@ type configEnvRmCmd struct {
 }
 
 func (cmd *configEnvRmCmd) run(ctx context.Context, args []string) error {
-	return cmd.parent.editStackEnvironment(
-		ctx, cmd.showSecrets, cmd.yes, func(stack *workspace.ProjectStack) error {
-			stack.Environment = stack.Environment.Remove(args[0])
-			return nil
-		})
+	return cmd.parent.editStackEnvironment(ctx, cmd.showSecrets, cmd.yes, importOp{removeEnv: args[0]})
 }

--- a/pkg/cmd/pulumi/config/coverage_sbc04_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc04_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestESCConfigEditorImports(t *testing.T) {
+	t.Parallel()
+
+	t.Run("absent imports", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "values:\n  pulumiConfig: {}\n", nil)
+		require.Empty(t, e.Imports())
+	})
+
+	t.Run("plain and structured entries", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports:\n  - shared\n  - other:\n      merge: false\nvalues: {}\n", nil)
+		require.Equal(t, []string{"shared", "other"}, e.Imports())
+	})
+
+	t.Run("non-name entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		// A multi-key mapping and a nested sequence are not valid single-name import entries, so they
+		// are reported as no entries rather than guessed at.
+		e := newESCEditor(t, "imports:\n  - a: 1\n    b: 2\n  - - nested\n", nil)
+		require.Empty(t, e.Imports())
+	})
+
+	t.Run("imports key present but not a sequence", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports: scalar\n", nil)
+		require.Empty(t, e.Imports())
+	})
+}
+
+func TestESCConfigEditorAddImports(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates the sequence when absent", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "values:\n  pulumiConfig: {}\n", nil)
+		require.NoError(t, e.AddImports("env1", "env2"))
+		require.Equal(t, []string{"env1", "env2"}, e.Imports())
+	})
+
+	t.Run("appends to an existing sequence in order, no dedup", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports:\n  - existing\n", nil)
+		require.NoError(t, e.AddImports("existing", "new"))
+		require.Equal(t, []string{"existing", "existing", "new"}, e.Imports())
+	})
+
+	t.Run("refuses a malformed non-sequence imports", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports: notasequence\n", nil)
+		require.ErrorContains(t, e.AddImports("env1"), "not a sequence")
+	})
+}
+
+func TestESCConfigEditorRemoveImport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes the last matching entry", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports:\n  - a\n  - b\n  - a\n", nil)
+		require.NoError(t, e.RemoveImport("a"))
+		require.Equal(t, []string{"a", "b"}, e.Imports())
+	})
+
+	t.Run("absent entry is a no-op", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "imports:\n  - a\n", nil)
+		require.NoError(t, e.RemoveImport("missing"))
+		require.Equal(t, []string{"a"}, e.Imports())
+	})
+
+	t.Run("no imports sequence is a no-op", func(t *testing.T) {
+		t.Parallel()
+		e := newESCEditor(t, "values: {}\n", nil)
+		require.NoError(t, e.RemoveImport("a"))
+	})
+}

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -258,6 +258,91 @@ func (e *escConfigEditor) Save(ctx context.Context) error {
 	return nil
 }
 
+// Imports returns the names of the top-level `imports` entries (empty if absent). Unlike
+// workspace.Environment.Imports it omits the synthetic "yaml" marker, a local-Environment artifact
+// meaningless for the backing env's real imports.
+func (e *escConfigEditor) Imports() []string {
+	seq, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"imports"})
+	if !ok || seq.Kind != yaml.SequenceNode {
+		return []string{}
+	}
+	imports := make([]string, 0, len(seq.Content))
+	for _, n := range seq.Content {
+		if name, ok := importEntryName(n); ok {
+			imports = append(imports, name)
+		}
+	}
+	return imports
+}
+
+// importEntryName returns the environment name of an `imports` entry: the scalar value for a plain
+// entry, or the single key for a structured entry like {env: {merge: false}}.
+func importEntryName(n *yaml.Node) (string, bool) {
+	switch n.Kind {
+	case yaml.ScalarNode:
+		return n.Value, true
+	case yaml.MappingNode:
+		// A structured import is a single-key mapping ({env: {merge: ...}}), so Content is [key, value];
+		// reject multi-key mappings rather than matching the first key.
+		if len(n.Content) == 2 && n.Content[0].Kind == yaml.ScalarNode {
+			return n.Content[0].Value, true
+		}
+		return "", false
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+// AddImports mirrors workspace.Environment.Append: entries are appended in order, not de-duplicated,
+// creating the sequence if absent.
+func (e *escConfigEditor) AddImports(envs ...string) error {
+	seq, err := e.ensureImportsNode()
+	if err != nil {
+		return err
+	}
+	for _, env := range envs {
+		seq.Content = append(seq.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: env})
+	}
+	return nil
+}
+
+// RemoveImport mirrors workspace.Environment.Remove: it removes the last entry matching env by name
+// (so structured entries match). The emptied sequence node is left in place rather than deleting the
+// `imports` key, so a head comment on that key survives.
+func (e *escConfigEditor) RemoveImport(env string) error {
+	seq, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"imports"})
+	if !ok || seq.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for i := len(seq.Content) - 1; i >= 0; i-- {
+		if name, ok := importEntryName(seq.Content[i]); ok && name == env {
+			seq.Content = append(seq.Content[:i], seq.Content[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (e *escConfigEditor) ensureImportsNode() (*yaml.Node, error) {
+	seq, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"imports"})
+	if ok {
+		// An existing `imports` that is not a sequence is a malformed env; overwriting it would
+		// silently discard it, so refuse rather than clobber.
+		if seq.Kind != yaml.SequenceNode {
+			return nil, errors.New("environment's `imports` is not a sequence")
+		}
+		return seq, nil
+	}
+	seq, err := escEncoding.YAMLSyntax{Node: &e.doc}.Set(
+		nil, resource.PropertyPath{"imports"}, yaml.Node{Kind: yaml.SequenceNode})
+	if err != nil {
+		return nil, fmt.Errorf("internal error: %w", err)
+	}
+	return seq, nil
+}
+
 func (e *escConfigEditor) ensureValuesNode() (*yaml.Node, error) {
 	valuesNode, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"values"})
 	if ok {


### PR DESCRIPTION
## Summary

Make `pulumi config env` manage imports and report status against the backing ESC environment for remote-config stacks, while leaving local stacks unchanged. Builds on the earlier PRs in this stacked series (core `pulumi config` writes and the ESC-backed editor seam); internally "service-backed config (SBC)", externally "remote config" for now.

Towards pulumi/pulumi-service#39624

## Changes

- **Import management** — `config env ls/add/rm` on a remote-config stack now read and write the `imports` of the linked ESC environment instead of the local stack file. Plain and structured imports (`{env: {merge: false}}`) are handled by name, matching `workspace.Environment` semantics.
- **Safe edits** — import edits are node-level on the parsed environment definition, so comments and unrelated sections survive; uploads use the environment's etag, surfacing a concurrent modification as a retryable error.
- **Status** — bare `pulumi config env` now reports where a stack's configuration lives instead of printing help: the linked ESC environment for a remote stack, or the local config file for a local stack (honoring `--config-file`), each listed with its imported environments. Both support `--json`.
- **Offline preserved** — when no stack can be resolved (logged out, none selected, non-interactive), it still prints help without contacting a backend, so the offline/CI path does not regress.

No behavior change for local-stack config mutation.

## Notes

- Stacked on #23431 — review/merge after it.
- Phase 1: behavior is reachable only for hidden-opt-in remote-config stacks (and the server flag); no public docs or changelog.
- Service-dependent paths are covered by mock tests only; end-to-end ESC behavior (etag concurrency, import preservation) needs a smoke run against a real service with the flag enabled.
