### PR TITLE
Add snapshot serialization for PCL snippets

### DIFF
--- a/pkg/backend/diy/backend_legacy_test.go
+++ b/pkg/backend/diy/backend_legacy_test.go
@@ -305,7 +305,7 @@ func TestHtmlEscaping_legacy(t *testing.T) {
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil)
 	ctx := t.Context()
 
 	udep, err := stack.SerializeUntypedDeployment(ctx, snap, &stack.SerializeOptions{

--- a/pkg/backend/diy/backend_test.go
+++ b/pkg/backend/diy/backend_test.go
@@ -251,7 +251,7 @@ func makeUntypedDeploymentTimestamp(
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil)
 
 	udep, err := stack.SerializeUntypedDeployment(t.Context(), snap, nil /*opts*/)
 	if err != nil {
@@ -665,7 +665,7 @@ func TestRenamePreservesIntegrity(t *testing.T) {
 		rParent,
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, resources, nil, deploy.SnapshotMetadata{})
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, resources, nil, deploy.SnapshotMetadata{}, nil)
 	ctx = t.Context()
 
 	udep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)
@@ -786,7 +786,7 @@ func TestHtmlEscaping(t *testing.T) {
 		},
 	}
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil)
 	ctx := t.Context()
 
 	udep, err := stack.SerializeUntypedDeployment(ctx, snap, &stack.SerializeOptions{

--- a/pkg/backend/journaler_snapshot_test.go
+++ b/pkg/backend/journaler_snapshot_test.go
@@ -1180,7 +1180,7 @@ func TestJournalEncryptionFailureNotSilent(t *testing.T) {
 	baseSnap := deploy.NewSnapshot(deploy.Manifest{
 		Time:    time.Now(),
 		Version: version.Version,
-	}, sm, nil, nil, deploy.SnapshotMetadata{})
+	}, sm, nil, nil, deploy.SnapshotMetadata{}, nil)
 
 	sp := &MockStackPersister{}
 	j, err := NewSnapshotJournaler(t.Context(), sp, sm, stack.Base64SecretsProvider{}, baseSnap)

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -747,12 +747,14 @@ func (sm *SnapshotManager) Snap() *deploy.Snapshot {
 	}
 
 	var metadata deploy.SnapshotMetadata
+	var snippets []resource.Snippet
 	if sm.baseSnapshot != nil {
 		metadata = sm.baseSnapshot.Metadata
+		snippets = sm.baseSnapshot.Snippets
 	}
 
 	manifest.Magic = manifest.NewMagic()
-	return deploy.NewSnapshot(manifest, secretsManager, resources, operations, metadata)
+	return deploy.NewSnapshot(manifest, secretsManager, resources, operations, metadata, snippets)
 }
 
 func (sm *SnapshotManager) Deployment() (apitype.TypedDeployment, error) {

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -94,7 +94,7 @@ func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{})
+	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{}, nil)
 }
 
 var (

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -41,7 +41,7 @@ func createStackWithResources(
 ) backend.Stack {
 	sm := b64.NewBase64SecretsManager()
 
-	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{})
+	snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil)
 	ctx := t.Context()
 
 	udep, err := stack.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)

--- a/pkg/cmd/pulumi/state/state_protect_test.go
+++ b/pkg/cmd/pulumi/state/state_protect_test.go
@@ -54,7 +54,7 @@ func TestProtectResourceWithDeleteTrue(t *testing.T) {
 			Delete:  false, // This is the replacement resource
 			Protect: false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to protect the resource
 	urns := []string{string(resourceURN)}
@@ -102,7 +102,7 @@ func TestProtectAllResourcesWithDeleteTrue(t *testing.T) {
 			Delete:  false,
 			Protect: false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to protect all resources
 	urns := []string{
@@ -144,7 +144,7 @@ func TestProtectOnlyDeletedResource(t *testing.T) {
 			Delete:  true, // Resource is marked for deletion
 			Protect: false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to protect the deleted resource
 	urns := []string{string(deletedURN)}
@@ -195,7 +195,7 @@ func TestProtectMultipleResourcesWithSameURNAndDelete(t *testing.T) {
 			Delete:  false, // The current active resource
 			Protect: false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to protect the resource
 	urns := []string{string(sharedURN)}

--- a/pkg/cmd/pulumi/state/state_repair_test.go
+++ b/pkg/cmd/pulumi/state/state_repair_test.go
@@ -304,7 +304,7 @@ func newStateRepairCmdFixture(
 		},
 		SnapshotF: func(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
 			sm := b64.NewBase64SecretsManager()
-			return deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}), nil
+			return deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil), nil
 		},
 	}
 

--- a/pkg/cmd/pulumi/state/state_taint_test.go
+++ b/pkg/cmd/pulumi/state/state_taint_test.go
@@ -393,7 +393,7 @@ func TestTaintMultipleResourcesWithErrors(t *testing.T) {
 			Type:  "a:b:c",
 			Taint: false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to taint multiple resources with some non-existent
 	urns := []string{
@@ -504,7 +504,7 @@ func TestTaintResourceWithDeleteTrue(t *testing.T) {
 			Delete: false, // This is the replacement resource
 			Taint:  false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to taint the resource
 	urns := []string{string(resourceURN)}
@@ -552,7 +552,7 @@ func TestTaintAllResourcesWithDeleteTrue(t *testing.T) {
 			Delete: false,
 			Taint:  false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to taint all resources
 	urns := []string{
@@ -594,7 +594,7 @@ func TestTaintOnlyDeletedResource(t *testing.T) {
 			Delete: true, // Resource is marked for deletion
 			Taint:  false,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to taint the deleted resource
 	urns := []string{string(deletedURN)}

--- a/pkg/cmd/pulumi/state/state_unprotect_test.go
+++ b/pkg/cmd/pulumi/state/state_unprotect_test.go
@@ -54,7 +54,7 @@ func TestUnprotectResourceWithDeleteTrue(t *testing.T) {
 			Delete:  false, // This is the replacement resource
 			Protect: true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to unprotect the resource
 	urns := []string{string(resourceURN)}
@@ -102,7 +102,7 @@ func TestUnprotectAllResourcesWithDeleteTrue(t *testing.T) {
 			Delete:  false,
 			Protect: true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to unprotect all resources
 	urns := []string{
@@ -144,7 +144,7 @@ func TestUnprotectOnlyDeletedResource(t *testing.T) {
 			Delete:  true, // Resource is marked for deletion
 			Protect: true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to unprotect the deleted resource
 	urns := []string{string(deletedURN)}
@@ -195,7 +195,7 @@ func TestUnprotectMultipleResourcesWithSameURNAndDelete(t *testing.T) {
 			Delete:  false, // The current active resource
 			Protect: true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to unprotect the resource
 	urns := []string{string(sharedURN)}

--- a/pkg/cmd/pulumi/state/state_untaint_test.go
+++ b/pkg/cmd/pulumi/state/state_untaint_test.go
@@ -396,7 +396,7 @@ func TestUntaintMultipleResourcesWithErrors(t *testing.T) {
 			Type:  "a:b:c",
 			Taint: true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to untaint multiple resources with some non-existent
 	urns := []string{
@@ -565,7 +565,7 @@ func TestUntaintResourceWithDeleteTrue(t *testing.T) {
 			Delete: false, // This is the replacement resource
 			Taint:  true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to untaint the resource
 	urns := []string{string(resourceURN)}
@@ -613,7 +613,7 @@ func TestUntaintAllResourcesWithDeleteTrue(t *testing.T) {
 			Delete: false,
 			Taint:  true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to untaint all resources
 	urns := []string{
@@ -655,7 +655,7 @@ func TestUntaintOnlyDeletedResource(t *testing.T) {
 			Delete: true, // Resource is marked for deletion
 			Taint:  true,
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Try to untaint the deleted resource
 	urns := []string{string(deletedURN)}

--- a/pkg/engine/test_journal.go
+++ b/pkg/engine/test_journal.go
@@ -170,18 +170,20 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		}
 	}
 
-	// If we have a base snapshot, copy over its secrets manager and metadata.
+	// If we have a base snapshot, copy over its secrets manager, metadata, and snippets.
 	var secretsManager secrets.Manager
 	var metadata deploy.SnapshotMetadata
+	var snippets []resource.Snippet
 	if base != nil {
 		secretsManager = base.SecretsManager
 		metadata = base.Metadata
+		snippets = base.Snippets
 	}
 
 	manifest := deploy.Manifest{}
 	manifest.Magic = manifest.NewMagic()
 
-	snap := deploy.NewSnapshot(manifest, secretsManager, filteredResources, operations, metadata)
+	snap := deploy.NewSnapshot(manifest, secretsManager, filteredResources, operations, metadata, snippets)
 	normSnap, err := snap.NormalizeURNReferences()
 	if err != nil {
 		return snap, err

--- a/pkg/resource/deploy/deployment_test.go
+++ b/pkg/resource/deploy/deployment_test.go
@@ -42,7 +42,7 @@ func newSnapshot(resources []*resource.State, ops []resource.Operation) *Snapsho
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, ops, SnapshotMetadata{})
+	}, b64.NewBase64SecretsManager(), resources, ops, SnapshotMetadata{}, nil)
 }
 
 func TestPendingOperationsDeployment(t *testing.T) {

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -17,6 +17,7 @@ package deploy
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/go-test/deep"
@@ -586,20 +587,11 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 		edited := false
 		for i, s := range newSnap.Snippets {
 			snippets[i] = s
-			if len(s.References) == 0 {
-				continue
-			}
-			var newRefs map[string]string
+			newRefs := maps.Clone(s.References)
 			for k, v := range s.References {
 				fixed := string(fixUrn(resource.URN(v)))
 				if fixed == v {
 					continue
-				}
-				if newRefs == nil {
-					newRefs = make(map[string]string, len(s.References))
-					for kk, vv := range s.References {
-						newRefs[kk] = vv
-					}
 				}
 				newRefs[k] = fixed
 			}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -790,6 +790,20 @@ func (snap *Snapshot) VerifyIntegrity() error {
 				return snapshot.SnapshotIntegrityErrorf("duplicate resource %s (not marked for deletion)", urn)
 			}
 		}
+
+		// Snippets may declare References to resources outside the snippet itself; each referenced
+		// URN must exist in the snapshot. We check this after the resource loop so all URNs
+		// (including ones referenced "forward" from a snippet) have been recorded.
+		for i, snippet := range snap.Snippets {
+			for ident, ref := range snippet.References {
+				if _, has := urns[resource.URN(ref)]; !has {
+					return snapshot.SnapshotIntegrityErrorf(
+						"snippet %d (type=%q, name=%q) refers to unknown URN %s via identifier %q",
+						i, snippet.Type, snippet.Name, ref, ident,
+					)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -38,6 +38,7 @@ type Snapshot struct {
 	Resources         []*resource.State    // fetches all resources and their associated states.
 	PendingOperations []resource.Operation // all currently pending resource operations.
 	Metadata          SnapshotMetadata     // metadata associated with the snapshot.
+	Snippets          []resource.Snippet   // any PCL snippets associated with the snapshot.
 }
 
 // SnapshotMetadata contains metadata about a snapshot.
@@ -61,7 +62,7 @@ type SnapshotIntegrityErrorMetadata struct {
 // This property is not checked; for verification, please refer to the VerifyIntegrity function below.
 func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 	resources []*resource.State, ops []resource.Operation,
-	metadata SnapshotMetadata,
+	metadata SnapshotMetadata, snippets []resource.Snippet,
 ) *Snapshot {
 	return &Snapshot{
 		Manifest:          manifest,
@@ -69,6 +70,7 @@ func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 		Resources:         resources,
 		PendingOperations: ops,
 		Metadata:          metadata,
+		Snippets:          snippets,
 	}
 }
 
@@ -574,7 +576,46 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 			build()
 	}
 
-	return snap.withUpdatedResources(fixResource), nil
+	newSnap := snap.withUpdatedResources(fixResource)
+
+	// Rewrite References on every snippet. Each value is a URN that may have been an alias for a resource that
+	// is now stored under its canonical URN; updating in place keeps future updates resolving cleanly through
+	// the broker.
+	if len(newSnap.Snippets) > 0 {
+		snippets := make([]resource.Snippet, len(newSnap.Snippets))
+		edited := false
+		for i, s := range newSnap.Snippets {
+			snippets[i] = s
+			if len(s.References) == 0 {
+				continue
+			}
+			var newRefs map[string]string
+			for k, v := range s.References {
+				fixed := string(fixUrn(resource.URN(v)))
+				if fixed == v {
+					continue
+				}
+				if newRefs == nil {
+					newRefs = make(map[string]string, len(s.References))
+					for kk, vv := range s.References {
+						newRefs[kk] = vv
+					}
+				}
+				newRefs[k] = fixed
+			}
+			if newRefs != nil {
+				snippets[i].References = newRefs
+				edited = true
+			}
+		}
+		if edited {
+			out := *newSnap // shallow copy
+			out.Snippets = snippets
+			newSnap = &out
+		}
+	}
+
+	return newSnap, nil
 }
 
 // VerifyIntegrity checks a snapshot to ensure it is well-formed.  Because of the cost of this operation,

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1248,4 +1249,59 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 			assert.ErrorContains(t, err, "snapshot has cyclic dependencies")
 		})
 	}
+}
+
+// TestSnapshotVerifyIntegrity_SnippetReferencesKnownURN is the positive case: a snippet whose
+// References map points at a URN that exists in snap.Resources passes integrity verification.
+func TestSnapshotVerifyIntegrity_SnippetReferencesKnownURN(t *testing.T) {
+	t.Parallel()
+
+	target := resource.NewURN("stack", "project", "", "pkgA:index:res", "target")
+	snap := &Snapshot{
+		Resources: []*resource.State{
+			{URN: target, Type: "pkgA:index:res"},
+		},
+		Snippets: []resource.Snippet{
+			{
+				Name: "consumer",
+				Type: "pkgA:index:res",
+				Code: `propA = target.id`,
+				References: map[string]string{
+					"target": string(target),
+				},
+			},
+		},
+	}
+
+	require.NoError(t, snap.VerifyIntegrity())
+}
+
+// TestSnapshotVerifyIntegrity_SnippetReferencesUnknownURN is the negative case: a snippet that
+// references a URN absent from snap.Resources produces a snapshot integrity error naming the
+// snippet, the bad URN, and the identifier through which it was referenced.
+func TestSnapshotVerifyIntegrity_SnippetReferencesUnknownURN(t *testing.T) {
+	t.Parallel()
+
+	missing := resource.NewURN("stack", "project", "", "pkgA:index:res", "missing")
+	snap := &Snapshot{
+		// No resources at all — the snippet's reference is therefore dangling.
+		Snippets: []resource.Snippet{
+			{
+				Name: "consumer",
+				Type: "pkgA:index:res",
+				Code: `propA = ghost.id`,
+				References: map[string]string{
+					"ghost": string(missing),
+				},
+			},
+		},
+	}
+
+	err := snap.VerifyIntegrity()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown URN")
+	require.ErrorContains(t, err, string(missing))
+	require.ErrorContains(t, err, `"ghost"`)
+	_, ok := snapshot.AsSnapshotIntegrityError(err)
+	require.True(t, ok, "should be a SnapshotIntegrityError")
 }

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -69,7 +69,7 @@ func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
 		Time:    time.Now(),
 		Version: version.Version,
 		Plugins: nil,
-	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{})
+	}, b64.NewBase64SecretsManager(), resources, nil, deploy.SnapshotMetadata{}, nil)
 }
 
 func TestDeletion(t *testing.T) {

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -69,6 +69,7 @@ const (
 	hooksFeature               = "hooks"
 	taintFeature               = "taint"
 	replaceWithFeature         = "replaceWith"
+	snippetsFeature            = "snippets-prototype"
 )
 
 var (
@@ -125,6 +126,7 @@ var supportedFeatures = map[string]bool{
 	hooksFeature:               true,
 	taintFeature:               true,
 	replaceWithFeature:         true,
+	snippetsFeature:            true,
 }
 
 // validateSupportedFeatures validates that the features used in a deployment are supported.
@@ -246,6 +248,15 @@ func SerializeDeploymentWithMetadata(
 		}
 	}
 
+	var snippets []apitype.SnippetV1
+	if len(snap.Snippets) > 0 {
+		snippets = make([]apitype.SnippetV1, len(snap.Snippets))
+		for i, s := range snap.Snippets {
+			snippets[i] = SerializeSnippet(s)
+		}
+		featureMap[snippetsFeature] = true
+	}
+
 	if completeBatch != nil { // If we started a batch operation, complete it.
 		if err := completeBatch(ctx); err != nil {
 			return nil, 0, nil, err
@@ -268,7 +279,76 @@ func SerializeDeploymentWithMetadata(
 		SecretsProviders:  secretsProvider,
 		PendingOperations: operations,
 		Metadata:          metadata,
+		Snippets:          snippets,
 	}, version, features, nil
+}
+
+// SerializeSnippet converts a resource.Snippet into its apitype representation.
+func SerializeSnippet(s resource.Snippet) apitype.SnippetV1 {
+	var refs map[string]string
+	if len(s.References) > 0 {
+		refs = make(map[string]string, len(s.References))
+		for k, v := range s.References {
+			refs[k] = v
+		}
+	}
+	return apitype.SnippetV1{
+		Name:       s.Name,
+		Type:       s.Type,
+		Code:       s.Code,
+		Descriptor: serializePackageDescriptor(s.Descriptor),
+		References: refs,
+	}
+}
+
+func serializePackageDescriptor(d resource.PackageDescriptor) apitype.PackageDescriptorV1 {
+	out := apitype.PackageDescriptorV1{
+		Name:        d.Name,
+		Version:     d.Version,
+		DownloadURL: d.DownloadURL,
+	}
+	if d.Parameterization != nil {
+		out.Parameterization = &apitype.ParameterizationDescriptorV1{
+			Name:    d.Parameterization.Name,
+			Version: d.Parameterization.Version,
+			Value:   d.Parameterization.Value,
+		}
+	}
+	return out
+}
+
+// DeserializeSnippet converts an apitype.SnippetV1 back into a resource.Snippet.
+func DeserializeSnippet(s apitype.SnippetV1) resource.Snippet {
+	var refs map[string]string
+	if len(s.References) > 0 {
+		refs = make(map[string]string, len(s.References))
+		for k, v := range s.References {
+			refs[k] = v
+		}
+	}
+	return resource.Snippet{
+		Name:       s.Name,
+		Type:       s.Type,
+		Code:       s.Code,
+		Descriptor: deserializePackageDescriptor(s.Descriptor),
+		References: refs,
+	}
+}
+
+func deserializePackageDescriptor(d apitype.PackageDescriptorV1) resource.PackageDescriptor {
+	out := resource.PackageDescriptor{
+		Name:        d.Name,
+		Version:     d.Version,
+		DownloadURL: d.DownloadURL,
+	}
+	if d.Parameterization != nil {
+		out.Parameterization = &resource.ParameterizationDescriptor{
+			Name:    d.Parameterization.Name,
+			Version: d.Parameterization.Version,
+			Value:   d.Parameterization.Value,
+		}
+	}
+	return out
 }
 
 // SerializeOptions controls how a deployment is serialized to JSON.
@@ -463,7 +543,14 @@ func DeserializeDeploymentV3(
 		}
 	}
 
-	return deploy.NewSnapshot(*manifest, secretsManager, data.resources, data.ops, metadata), nil
+	var snippets []resource.Snippet
+	if len(deployment.Snippets) > 0 {
+		snippets = make([]resource.Snippet, len(deployment.Snippets))
+		for i, s := range deployment.Snippets {
+			snippets[i] = DeserializeSnippet(s)
+		}
+	}
+	return deploy.NewSnapshot(*manifest, secretsManager, data.resources, data.ops, metadata, snippets), nil
 }
 
 // initializeSecretsManager initializes the secrets manager for a deployment.

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	combinations "github.com/mxschmitt/golang-combinations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -222,6 +223,7 @@ func TestSerializeDeploymentWithMetadata(t *testing.T) {
 	tests := []struct {
 		name             string
 		resources        []*resource.State
+		snippets         []resource.Snippet
 		expectedVersion  int
 		expectedFeatures []string
 	}{
@@ -234,6 +236,23 @@ func TestSerializeDeploymentWithMetadata(t *testing.T) {
 			},
 			expectedVersion:  3,
 			expectedFeatures: nil,
+		},
+		{
+			name: "v4 deployment with snippets",
+			resources: []*resource.State{
+				{
+					URN: "urn1",
+				},
+			},
+			snippets: []resource.Snippet{
+				{
+					Name: "r", Type: "pkgA:index:res",
+					Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+					Code:       `propA = true`,
+				},
+			},
+			expectedVersion:  4,
+			expectedFeatures: []string{snippetsFeature},
 		},
 		{
 			name: "v4 deployment with refreshBeforeUpdate",
@@ -292,6 +311,7 @@ func TestSerializeDeploymentWithMetadata(t *testing.T) {
 
 			snap := &deploy.Snapshot{
 				Resources: tt.resources,
+				Snippets:  tt.snippets,
 			}
 			deployment, version, features, err := SerializeDeploymentWithMetadata(ctx, snap, false)
 			require.NoError(t, err)
@@ -363,6 +383,51 @@ func TestUnsupportedFeature(t *testing.T) {
 	var expectedErr *ErrDeploymentUnsupportedFeatures
 	require.ErrorAs(t, err, &expectedErr)
 	require.Equal(t, []string{"unsupported-feature"}, expectedErr.Features)
+}
+
+// TestSnippetRoundTrip verifies that snippets attached to a snapshot survive an untyped-deployment
+// round trip and that the resulting deployment is gated by the "snippets" feature.
+func TestSnippetRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	version := semver.MustParse("1.2.3")
+	snap := &deploy.Snapshot{
+		Snippets: []resource.Snippet{
+			{
+				Name: "r1", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = true`,
+			},
+			{
+				Name: "r2", Type: "pkgB:index:res",
+				Descriptor: resource.PackageDescriptor{
+					Name:        "pkgB",
+					Version:     &version,
+					DownloadURL: "https://example/pkgB",
+					Parameterization: &resource.ParameterizationDescriptor{
+						Name:    "child",
+						Version: version,
+						Value:   []byte("hello"),
+					},
+				},
+				Code: `propB = "x"`,
+				References: map[string]string{
+					"comp": "urn:pulumi:dev::proj::pkgA:index:Comp::comp",
+				},
+			},
+		},
+	}
+
+	untyped, err := SerializeUntypedDeployment(ctx, snap, nil)
+	require.NoError(t, err)
+	require.Equal(t, DeploymentSchemaVersionLatest, untyped.Version)
+	require.Equal(t, []string{snippetsFeature}, untyped.Features)
+	require.NoError(t, ValidateUntypedDeployment(untyped))
+
+	roundTripped, err := DeserializeUntypedDeployment(ctx, untyped, b64.Base64SecretsProvider)
+	require.NoError(t, err)
+	require.Equal(t, snap.Snippets, roundTripped.Snippets)
 }
 
 // TestDeserializeUntypedDeploymentFeatures tests that the deserializer does not error for features that are supported.

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -163,6 +164,11 @@ type DeploymentV3 struct {
 	PendingOperations []OperationV2 `json:"pending_operations,omitempty" yaml:"pending_operations,omitempty"`
 	// Metadata associated with the snapshot.
 	Metadata SnapshotMetadataV1 `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	// Snippets are any PCL snippets associated with the snapshot. The engine reruns these on every update to
+	// produce additional resources alongside the program's. Deployments that include snippets must declare the
+	// "snippets" feature so older CLIs that cannot evaluate them refuse the snapshot rather than silently
+	// dropping the resources they would produce.
+	Snippets []SnippetV1 `json:"snippets,omitempty" yaml:"snippets,omitempty"`
 }
 
 func (snap *DeploymentV3) ToUntypedDeployment(version int, features []string) (*UntypedDeployment, error) {
@@ -258,6 +264,15 @@ func (snap *DeploymentV3) NormalizeURNReferences() (*DeploymentV3, error) {
 		}
 	}
 
+	// Rewrite References on every snippet. Each value is a URN that may have been an alias for a resource that
+	// is now stored under its canonical URN; updating in place keeps future updates resolving cleanly through
+	// the broker.
+	for i := range snap.Snippets {
+		for k, v := range snap.Snippets[i].References {
+			snap.Snippets[i].References[k] = string(fixURN(resource.URN(v)))
+		}
+	}
+
 	return snap, nil
 }
 
@@ -270,6 +285,45 @@ type SecretsProvidersV1 struct {
 type SnapshotMetadataV1 struct {
 	// Metadata associated with any integrity error affecting the snapshot.
 	IntegrityErrorMetadata *SnapshotIntegrityErrorMetadataV1 `json:"integrity_error,omitempty" yaml:"integrity_error,omitempty"`
+}
+
+// SnippetV1 is the serialized form of a PCL snippet stored alongside a snapshot. Snippets are evaluated by the
+// engine on every update to produce additional resource registrations.
+type SnippetV1 struct {
+	// Name is the logical name of the resource this snippet registers.
+	Name string `json:"name" yaml:"name"`
+	// Type is the type token of the resource this snippet registers.
+	Type string `json:"type" yaml:"type"`
+	// Code is the PCL source for the body of the resource.
+	Code string `json:"code" yaml:"code"`
+	// Descriptor identifies the package that owns the resource type.
+	Descriptor PackageDescriptorV1 `json:"descriptor" yaml:"descriptor"`
+	// References declares external resources that the snippet's Code may refer to by HCL identifier. The map
+	// key is the identifier used inside Code; the value is the URN of the target resource. Subject to URN
+	// normalisation (aliases) on each snapshot write.
+	References map[string]string `json:"references,omitempty" yaml:"references,omitempty"`
+}
+
+// PackageDescriptorV1 is the serialized form of a package descriptor for a snippet.
+type PackageDescriptorV1 struct {
+	// Name is the simple name of the plugin.
+	Name string `json:"name" yaml:"name"`
+	// Version is the optional version of the plugin.
+	Version *semver.Version `json:"version,omitempty" yaml:"version,omitempty"`
+	// DownloadURL is the optional URL to use when downloading the provider plugin binary.
+	DownloadURL string `json:"downloadURL,omitempty" yaml:"downloadURL,omitempty"`
+	// Parameterization is the optional parameterization of the package.
+	Parameterization *ParameterizationDescriptorV1 `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
+}
+
+// ParameterizationDescriptorV1 is the serialized form of a parameterization for a packaged plugin.
+type ParameterizationDescriptorV1 struct {
+	// Name is the name of the parameterized package.
+	Name string `json:"name" yaml:"name"`
+	// Version is the version of the parameterized package.
+	Version semver.Version `json:"version" yaml:"version"`
+	// Value is the parameter value of the package.
+	Value []byte `json:"value" yaml:"value"`
 }
 
 // SnapshotIntegrityErrorMetadataV1 contains metadata about a snapshot integrity error, such as the version

--- a/sdk/go/common/apitype/deployments.json
+++ b/sdk/go/common/apitype/deployments.json
@@ -79,6 +79,17 @@
                             "items": {
                                 "$ref": "#/$defs/operationV2"
                             }
+                        },
+                        "metadata": {
+                            "description": "Metadata associated with the snapshot.",
+                            "type": "object"
+                        },
+                        "snippets": {
+                            "description": "PCL snippets evaluated by the engine on every update.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/snippetV1"
+                            }
                         }
                     },
                     "required": ["manifest"],
@@ -174,6 +185,85 @@
                 }
             },
             "required": ["resource", "type"],
+            "additionalProperties": false
+        },
+        "snippetV1": {
+            "title": "PCL Snippet V1",
+            "description": "A PCL snippet stored alongside a snapshot. The engine evaluates these on every update.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The logical name of the resource this snippet registers.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The type token of the resource this snippet registers.",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "The PCL source for the body of the resource.",
+                    "type": "string"
+                },
+                "descriptor": {
+                    "description": "The package descriptor for the resource type.",
+                    "$ref": "#/$defs/packageDescriptorV1"
+                },
+                "references": {
+                    "description": "External resources the snippet code may refer to by HCL identifier. The map key is the identifier used inside the code; the value is the URN of the target resource.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": ["name", "type", "code", "descriptor"],
+            "additionalProperties": false
+        },
+        "packageDescriptorV1": {
+            "title": "Package Descriptor V1",
+            "description": "Identifies the package and optional parameterization for a snippet's resource type.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The simple name of the plugin.",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The optional semver version of the plugin.",
+                    "type": "string"
+                },
+                "downloadURL": {
+                    "description": "The optional URL to use when downloading the provider plugin binary.",
+                    "type": "string"
+                },
+                "parameterization": {
+                    "description": "The optional parameterization of the package.",
+                    "$ref": "#/$defs/parameterizationDescriptorV1"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        },
+        "parameterizationDescriptorV1": {
+            "title": "Parameterization Descriptor V1",
+            "description": "Parameterization data for a packaged plugin.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the parameterized package.",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The semver version of the parameterized package.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "The base64-encoded parameter value.",
+                    "type": "string",
+                    "contentEncoding": "base64"
+                }
+            },
+            "required": ["name", "version", "value"],
             "additionalProperties": false
         }
     }

--- a/sdk/go/common/resource/resource_snippet.go
+++ b/sdk/go/common/resource/resource_snippet.go
@@ -1,0 +1,57 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import "github.com/blang/semver"
+
+// ParameterizationDescriptor is the serializable description of a dependency's parameterization.
+type ParameterizationDescriptor struct {
+	// Name is the name of the package.
+	Name string `json:"name" yaml:"name"`
+	// Version is the version of the package.
+	Version semver.Version `json:"version" yaml:"version"`
+	// Value is the parameter value of the package.
+	Value []byte `json:"value" yaml:"value"`
+}
+
+// PackageDescriptor is a descriptor for a package, this is similar to a plugin spec but also contains parameterization
+// info.
+type PackageDescriptor struct {
+	// Name is the simple name of the plugin.
+	Name string `json:"name" yaml:"name"`
+	// Version is the optional version of the plugin.
+	Version *semver.Version `json:"version,omitempty" yaml:"version,omitempty"`
+	// DownloadURL is the optional URL to use when downloading the provider plugin binary.
+	DownloadURL string `json:"downloadURL,omitempty" yaml:"downloadURL,omitempty"`
+	// Parameterization is the optional parameterization of the package.
+	Parameterization *ParameterizationDescriptor `json:"parameterization,omitempty" yaml:"parameterization,omitempty"`
+}
+
+// Snippet represents a snippet of PCL that should be associated with a stack. The engine reruns these in deployments.
+//
+//nolint:lll
+type Snippet struct {
+	// The logical name of the resource this snippet is for.
+	Name string `json:"name" yaml:"name"`
+	// The type of the resource this snippet is for.
+	Type string `json:"type" yaml:"type"`
+	// The PCL code for an expression for the body of this resource.
+	Code string `json:"code" yaml:"code"`
+	// The package descriptor for the resource
+	Descriptor PackageDescriptor `json:"descriptor" yaml:"descriptor"`
+	// References declares the external resources that this snippet's Code may refer to by HCL identifier. The map key
+	// is the identifier used inside Code; the value identifies the target resource by its URN.
+	References map[string]string `json:"references,omitempty" yaml:"references,omitempty"`
+}

--- a/sdk/go/common/snapshot/integrity.go
+++ b/sdk/go/common/snapshot/integrity.go
@@ -162,6 +162,20 @@ func VerifyIntegrity(snap *apitype.DeploymentV3) error {
 		}
 	}
 
+	// Snippets may declare References to resources outside the snippet itself; each referenced URN
+	// must exist in the snapshot. We check this after the resource loop so all URNs (including ones
+	// referenced "forward" from a snippet) have been recorded.
+	for i, snippet := range snap.Snippets {
+		for ident, ref := range snippet.References {
+			if _, has := urns[resource.URN(ref)]; !has {
+				return SnapshotIntegrityErrorf(
+					"snippet %d (type=%q, name=%q) refers to unknown URN %s via identifier %q",
+					i, snippet.Type, snippet.Name, ref, ident,
+				)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/sdk/go/common/snapshot/integrity_test.go
+++ b/sdk/go/common/snapshot/integrity_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+// makeValidManifest returns a ManifestV1 whose magic cookie matches Version, so VerifyIntegrity
+// passes the magic check and can get to the snippet-reference validation.
+func makeValidManifest() apitype.ManifestV1 {
+	m := apitype.ManifestV1{Version: "test"}
+	m.Magic = m.NewMagic()
+	return m
+}
+
+// TestVerifyIntegrity_SnippetReferencesKnownURN is the positive case: a snippet whose References
+// map points at a URN that exists in snap.Resources should pass integrity verification.
+func TestVerifyIntegrity_SnippetReferencesKnownURN(t *testing.T) {
+	t.Parallel()
+
+	const knownURN = "urn:pulumi:stack::project::pkgA:index:res::target"
+	snap := &apitype.DeploymentV3{
+		Manifest: makeValidManifest(),
+		Resources: []apitype.ResourceV3{
+			{URN: knownURN, Type: "pkgA:index:res"},
+		},
+		Snippets: []apitype.SnippetV1{
+			{
+				Name: "consumer",
+				Type: "pkgA:index:res",
+				Code: `propA = target.id`,
+				References: map[string]string{
+					"target": knownURN,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, VerifyIntegrity(snap))
+}
+
+// TestVerifyIntegrity_SnippetReferencesUnknownURN is the negative case: a snippet that references
+// a URN that is not present in snap.Resources should produce a snapshot integrity error naming the
+// snippet, the bad URN, and the identifier through which it was referenced.
+func TestVerifyIntegrity_SnippetReferencesUnknownURN(t *testing.T) {
+	t.Parallel()
+
+	const missingURN = "urn:pulumi:stack::project::pkgA:index:res::missing"
+	snap := &apitype.DeploymentV3{
+		Manifest: makeValidManifest(),
+		// No resources at all — the snippet's reference is therefore dangling.
+		Snippets: []apitype.SnippetV1{
+			{
+				Name: "consumer",
+				Type: "pkgA:index:res",
+				Code: `propA = ghost.id`,
+				References: map[string]string{
+					"ghost": missingURN,
+				},
+			},
+		},
+	}
+
+	err := VerifyIntegrity(snap)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unknown URN")
+	require.ErrorContains(t, err, missingURN)
+	require.ErrorContains(t, err, `"ghost"`)
+	// Should be reported as a snapshot integrity error so callers using AsSnapshotIntegrityError
+	// can detect and react to it.
+	_, ok := AsSnapshotIntegrityError(err)
+	require.True(t, ok, "should be a SnapshotIntegrityError")
+}

--- a/tests/integration/backend/diy/backend_postgres_test.go
+++ b/tests/integration/backend/diy/backend_postgres_test.go
@@ -332,7 +332,7 @@ func TestPostgresBackend(t *testing.T) {
 				"arn":  resource.NewProperty("arn:test:resource"),
 			},
 		},
-	}, nil, deploy.SnapshotMetadata{})
+	}, nil, deploy.SnapshotMetadata{}, nil)
 
 	// Test deployment serialization - simulate what would happen during a real deployment
 	untypedDeployment, err := stackpkg.SerializeUntypedDeployment(ctx, snap, nil /*opts*/)


### PR DESCRIPTION
Adds the on-disk and in-memory data type for "snippets". Snippets are small blocks in state tagged with a name, type, pcl code body, and references to other resources. The references map URNs in the rest of the state file to hcl identifiers that can be referred to in the pcl code body. The code body is the same as what you would see inside a resource block in a normal pcl file. That is a list of resource attributes and optionally a resource options block.

This PR is scaffolding only. The engine doesn't write or read snippets anywhere yet; existing snapshots stay byte-identical.

This is currently tagged with the "snippets-prototype" feature flag in state while we work on this. As soon as we publicly expose this we'll switch that to a stable marker of just "snippets".