### PR TITLE
Add hidden config env init --remote-config migration

### DIFF
--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -75,6 +75,14 @@ func newConfigEnvInitCmd(parent *configEnvCmd) *cobra.Command {
 	cmd.Flags().BoolVarP(
 		&impl.yes, "yes", "y", false,
 		"True to save the created environment without prompting")
+	cmd.Flags().BoolVar(
+		&impl.remoteConfig, "remote-config", false,
+		"Migrate the stack to remote configuration backed by an environment instead of importing one")
+	_ = cmd.Flags().MarkHidden("remote-config")
+	cmd.Flags().BoolVar(
+		&impl.cleanupLocal, "cleanup-local", false,
+		"Delete the local stack configuration file after migrating to remote configuration")
+	_ = cmd.Flags().MarkHidden("cleanup-local")
 
 	return cmd
 }
@@ -93,13 +101,19 @@ type configEnvInitCmd struct {
 
 	newCrypter func() (evalCrypter, error)
 
-	envName     string
-	showSecrets bool
-	keepConfig  bool
-	yes         bool
+	envName      string
+	showSecrets  bool
+	keepConfig   bool
+	yes          bool
+	remoteConfig bool
+	cleanupLocal bool
 }
 
 func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
+	if cmd.remoteConfig {
+		return cmd.runMigrate(ctx)
+	}
+
 	if !cmd.yes && !cmd.parent.interactive {
 		return backenderr.ErrNonInteractiveRequiresYes
 	}

--- a/pkg/cmd/pulumi/config/config_env_init_migrate.go
+++ b/pkg/cmd/pulumi/config/config_env_init_migrate.go
@@ -110,11 +110,15 @@ func (cmd *configEnvInitCmd) runMigrate(ctx context.Context) error {
 		return err
 	}
 
+	// Probe the target before prompting so the confirmation can distinguish creating a new environment
+	// from merging into one that already exists, letting the user decline before any remote write.
+	existingDef, etag, envExists, err := cmd.getMigrationTarget(ctx, envBackend, orgName, envProject, envName)
+	if err != nil {
+		return err
+	}
+
 	if !cmd.yes && cmd.parent.interactive {
-		if !ui.ConfirmPrompt(
-			fmt.Sprintf("Migrate the configuration of stack %v to environment %s and link the stack to it?",
-				stack.Ref().Name(), fullEnvName),
-			"yes", opts) {
+		if !ui.ConfirmPrompt(migrateConfirmPrompt(envExists, stack.Ref().Name().String(), fullEnvName), "yes", opts) {
 			return errors.New("migration canceled")
 		}
 	}
@@ -122,7 +126,12 @@ func (cmd *configEnvInitCmd) runMigrate(ctx context.Context) error {
 	// Write the environment before linking so a transient link failure reconciles on re-run (the env
 	// exists, so the retry merges into it). A persistent link failure leaves the env orphaned and the
 	// stack local; the env is not rolled back.
-	if err := cmd.writeMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, sourceDef); err != nil {
+	if envExists {
+		err = cmd.mergeMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, etag, existingDef, sourceDef)
+	} else {
+		err = cmd.createMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, sourceDef)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -223,23 +232,34 @@ func removeSelfImport(doc *yaml.Node, self string) error {
 	return nil
 }
 
-// writeMigratedEnvironment creates the target environment, or merges into it if it already exists.
-func (cmd *configEnvInitCmd) writeMigratedEnvironment(
+// migrateConfirmPrompt phrases the confirmation differently for a fresh environment versus a merge
+// into an existing one, since merging can overwrite keys already present in the target.
+func migrateConfirmPrompt(envExists bool, stackName, fullEnvName string) string {
+	if envExists {
+		return fmt.Sprintf(
+			"Environment %s already exists; merge the configuration of stack %s into it and link the stack to it?",
+			fullEnvName, stackName)
+	}
+	return fmt.Sprintf("Migrate the configuration of stack %s to new environment %s and link the stack to it?",
+		stackName, fullEnvName)
+}
+
+// getMigrationTarget fetches the target environment's current definition and etag, reporting whether
+// it exists. A 404 means it does not exist yet (the create path) and is not an error.
+func (cmd *configEnvInitCmd) getMigrationTarget(
 	ctx context.Context,
 	envBackend backend.EnvironmentsBackend,
 	orgName, envProject, envName string,
-	sourceDef *yaml.Node,
-) error {
-	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
+) (def []byte, etag string, exists bool, err error) {
+	def, etag, _, err = envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
 	if err != nil {
 		var errResp *apitype.ErrorResponse
 		if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
-			return cmd.createMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, sourceDef)
+			return nil, "", false, nil
 		}
-		return fmt.Errorf("getting environment %s/%s: %w", envProject, envName, err)
+		return nil, "", false, fmt.Errorf("getting environment %s/%s: %w", envProject, envName, err)
 	}
-	// The env exists; mergeMigratedEnvironment handles an empty existing definition.
-	return cmd.mergeMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, etag, def, sourceDef)
+	return def, etag, true, nil
 }
 
 func (cmd *configEnvInitCmd) createMigratedEnvironment(
@@ -313,6 +333,8 @@ func (cmd *configEnvInitCmd) mergeValues(target, sourceDef *yaml.Node) error {
 	if !ok || values.Kind != yaml.MappingNode {
 		return nil
 	}
+	// Outer loop walks the `values` sections (pulumiConfig, environmentVariables, files); inner loop
+	// their keys. Merging per key rather than per section is what keeps existing target keys alive.
 	for i := 0; i+1 < len(values.Content); i += 2 {
 		section := values.Content[i].Value
 		node := values.Content[i+1]

--- a/pkg/cmd/pulumi/config/config_env_init_migrate.go
+++ b/pkg/cmd/pulumi/config/config_env_init_migrate.go
@@ -1,0 +1,466 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	escEncoding "github.com/pulumi/esc/syntax/encoding"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// runMigrate writes a local-config stack's configuration into a backing ESC environment (secrets
+// wrapped as fn::secret) and links the stack to it. The decrypted plaintext is held only in memory;
+// it is never written to a file, log, preview, or diagnostic.
+func (cmd *configEnvInitCmd) runMigrate(ctx context.Context) error {
+	if !cmd.yes && !cmd.parent.interactive {
+		return backenderr.ErrNonInteractiveRequiresYes
+	}
+
+	opts := display.Options{Color: cmd.parent.color}
+
+	project, _, err := cmd.parent.ws.ReadProject()
+	if err != nil {
+		return err
+	}
+
+	stack, err := cmd.parent.requireStack(
+		ctx,
+		cmd.parent.diags,
+		cmd.parent.ws,
+		cmdBackend.DefaultLoginManager,
+		*cmd.parent.stackRef,
+		cmdStack.OfferNew|cmdStack.SetCurrent,
+		opts,
+		*cmd.parent.configFile,
+	)
+	if err != nil {
+		return err
+	}
+
+	if stack.ConfigLocation().IsRemote {
+		return errors.New("this stack already uses remote configuration; migration is not needed")
+	}
+
+	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+	orgName := orgNamer.OrgName()
+
+	envProject := project.Name.String()
+	envName := stack.Ref().Name().String()
+	first, second, found := strings.Cut(cmd.envName, "/")
+	if found {
+		envProject = first
+		envName = second
+	} else if first != "" {
+		envName = first
+	}
+	fullEnvName := envProject + "/" + envName
+
+	ps, decryptedConfig, err := cmd.getStackConfig(ctx, cmd.parent.diags, project, stack)
+	if err != nil {
+		return err
+	}
+
+	// The stack's `environment` block is itself an inline ESC definition. Seed the migrated definition
+	// from it so inline values survive, then overlay stack config on top (config wins), matching today's
+	// resolution order.
+	pulumiConfig, ok := renderConfigValueForESC(property.New(decryptedConfig)).(map[string]any)
+	if !ok {
+		return errors.New("internal error: rendered stack configuration is not a map")
+	}
+	sourceDef, err := buildMigratedDefinition(ps.Environment.Definition(), pulumiConfig, fullEnvName)
+	if err != nil {
+		return err
+	}
+
+	if !cmd.yes && cmd.parent.interactive {
+		if !ui.ConfirmPrompt(
+			fmt.Sprintf("Migrate the configuration of stack %v to environment %s and link the stack to it?",
+				stack.Ref().Name(), fullEnvName),
+			"yes", opts) {
+			return errors.New("migration canceled")
+		}
+	}
+
+	// Write the environment before linking so a transient link failure reconciles on re-run (the env
+	// exists, so the retry merges into it). A persistent link failure leaves the env orphaned and the
+	// stack local; the env is not rolled back.
+	if err := cmd.writeMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, sourceDef); err != nil {
+		return err
+	}
+
+	ps.Environment = workspace.NewEnvironment([]string{fullEnvName})
+	ps.Config = nil
+	// saveProjectStack dispatches on the stack's current config location, which is still local here,
+	// so it would write the local file. Link via SaveRemoteConfig directly instead.
+	if err := stack.SaveRemoteConfig(ctx, ps); err != nil {
+		return fmt.Errorf("linking stack to environment %s: %w", fullEnvName, err)
+	}
+
+	fmt.Fprintf(cmd.parent.stdout, "Migrated stack %v to remote configuration in environment %s\n",
+		stack.Ref().Name(), fullEnvName)
+
+	// The migration is durable once the stack is linked, so a local-file cleanup failure must not mask
+	// that success; report it as a warning rather than returning an error.
+	if err := cmd.cleanupLocalConfig(stack, opts); err != nil {
+		fmt.Fprintf(cmd.parent.stdout, "Warning: cleaning up the local configuration file failed: %v\n", err)
+	}
+	return nil
+}
+
+// buildMigratedDefinition renders the stack config as an ESC environment definition, seeded from the
+// inline `environment` block (config overlaid on top, config wins).
+func buildMigratedDefinition(inlineDef []byte, pulumiConfig map[string]any, self string) (*yaml.Node, error) {
+	var doc yaml.Node
+	if len(inlineDef) != 0 {
+		if err := yaml.Unmarshal(inlineDef, &doc); err != nil {
+			return nil, fmt.Errorf("unmarshaling stack environment definition: %w", err)
+		}
+	}
+	if doc.Kind != yaml.DocumentNode {
+		doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{}}}
+	}
+	syntax := escEncoding.YAMLSyntax{Node: &doc}
+
+	if _, ok := syntax.Get(resource.PropertyPath{"values", "pulumiConfig"}); !ok {
+		if _, err := syntax.Set(
+			nil, resource.PropertyPath{"values", "pulumiConfig"}, yaml.Node{Kind: yaml.MappingNode}); err != nil {
+			return nil, fmt.Errorf("internal error: %w", err)
+		}
+	}
+
+	// Sort for deterministic output.
+	keys := make([]string, 0, len(pulumiConfig))
+	for k := range pulumiConfig {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		valueNode, err := valueToYAMLNode(pulumiConfig[key])
+		if err != nil {
+			return nil, err
+		}
+		if _, err := syntax.Set(nil, resource.PropertyPath{"values", "pulumiConfig", key}, valueNode); err != nil {
+			return nil, fmt.Errorf("setting key %q: %w", key, err)
+		}
+	}
+
+	if err := removeSelfImport(&doc, self); err != nil {
+		return nil, err
+	}
+	forceBlockStyle(&doc)
+	return &doc, nil
+}
+
+// forceBlockStyle clears flow style across a node tree. ProjectStack.Environment.Definition() returns
+// JSON for an imports-list environment, and yaml.Unmarshal tags JSON nodes as flow style; without this
+// the seed's root would re-emit as inline JSON ({imports: [...], values: {...}}) instead of block YAML.
+func forceBlockStyle(n *yaml.Node) {
+	n.Style = 0
+	for _, c := range n.Content {
+		forceBlockStyle(c)
+	}
+}
+
+// removeSelfImport strips an import equal to the migrated stack's own environment (a prior non-remote
+// `config env init` may have added one), deleting the now-empty `imports` key entirely.
+func removeSelfImport(doc *yaml.Node, self string) error {
+	syntax := escEncoding.YAMLSyntax{Node: doc}
+	node, ok := syntax.Get(resource.PropertyPath{"imports"})
+	if !ok || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+	kept := node.Content[:0]
+	for _, n := range node.Content {
+		if name, ok := importEntryName(n); ok && name == self {
+			continue
+		}
+		kept = append(kept, n)
+	}
+	node.Content = kept
+	if len(node.Content) == 0 {
+		if err := syntax.Delete(nil, resource.PropertyPath{"imports"}); err != nil {
+			return fmt.Errorf("removing empty imports: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeMigratedEnvironment creates the target environment, or merges into it if it already exists.
+func (cmd *configEnvInitCmd) writeMigratedEnvironment(
+	ctx context.Context,
+	envBackend backend.EnvironmentsBackend,
+	orgName, envProject, envName string,
+	sourceDef *yaml.Node,
+) error {
+	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
+	if err != nil {
+		var errResp *apitype.ErrorResponse
+		if errors.As(err, &errResp) && errResp.Code == http.StatusNotFound {
+			return cmd.createMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, sourceDef)
+		}
+		return fmt.Errorf("getting environment %s/%s: %w", envProject, envName, err)
+	}
+	// The env exists; mergeMigratedEnvironment handles an empty existing definition.
+	return cmd.mergeMigratedEnvironment(ctx, envBackend, orgName, envProject, envName, etag, def, sourceDef)
+}
+
+func (cmd *configEnvInitCmd) createMigratedEnvironment(
+	ctx context.Context,
+	envBackend backend.EnvironmentsBackend,
+	orgName, envProject, envName string,
+	sourceDef *yaml.Node,
+) error {
+	newYAML, err := yaml.Marshal(sourceDef.Content[0])
+	if err != nil {
+		return fmt.Errorf("encoding environment definition: %w", err)
+	}
+
+	diags, err := envBackend.CreateEnvironment(ctx, orgName, envProject, envName, newYAML)
+	if err != nil {
+		return fmt.Errorf("creating environment %s/%s: %w", envProject, envName, err)
+	}
+	if diags.HasErrors() {
+		return fmt.Errorf("creating environment %s/%s: %w", envProject, envName, diags)
+	}
+	return nil
+}
+
+// mergeMigratedEnvironment merges the migrated definition into an existing environment at the
+// YAML-node level so existing comments and unrelated sections survive.
+func (cmd *configEnvInitCmd) mergeMigratedEnvironment(
+	ctx context.Context,
+	envBackend backend.EnvironmentsBackend,
+	orgName, envProject, envName string,
+	etag string,
+	existingDef []byte,
+	sourceDef *yaml.Node,
+) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(existingDef, &doc); err != nil {
+		return fmt.Errorf("unmarshaling environment definition: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode {
+		doc = yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{}}}
+	}
+
+	if err := cmd.mergeValues(&doc, sourceDef); err != nil {
+		return err
+	}
+	if err := mergeImportNodes(&doc, sourceDef); err != nil {
+		return err
+	}
+
+	newYAML, err := yaml.Marshal(doc.Content[0])
+	if err != nil {
+		return fmt.Errorf("marshaling definition: %w", err)
+	}
+
+	diags, err := envBackend.UpdateEnvironmentWithProject(ctx, orgName, envProject, envName, newYAML, etag)
+	if err != nil {
+		if errors.Is(err, backend.ErrConfigConflict) {
+			return fmt.Errorf("the environment was modified concurrently; please retry: %w", err)
+		}
+		return fmt.Errorf("updating environment %s/%s: %w", envProject, envName, err)
+	}
+	if diags.HasErrors() {
+		return fmt.Errorf("updating environment %s/%s: %w", envProject, envName, diags)
+	}
+	return nil
+}
+
+// mergeValues merges sourceDef's `values` subsections into target key by key, so unrelated keys in
+// the target survive.
+func (cmd *configEnvInitCmd) mergeValues(target, sourceDef *yaml.Node) error {
+	values, ok := (escEncoding.YAMLSyntax{Node: sourceDef}).Get(resource.PropertyPath{"values"})
+	if !ok || values.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(values.Content); i += 2 {
+		section := values.Content[i].Value
+		node := values.Content[i+1]
+		if node.Kind != yaml.MappingNode {
+			if err := cmd.setMergedValue(target, resource.PropertyPath{"values", section}, node); err != nil {
+				return err
+			}
+			continue
+		}
+		for j := 0; j+1 < len(node.Content); j += 2 {
+			key := node.Content[j].Value
+			if err := cmd.setMergedValue(target, resource.PropertyPath{"values", section, key}, node.Content[j+1]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// setMergedValue sets path in target, warning only when it overwrites an existing node whose value
+// differs. The reconcile path (re-run after a failed link) re-writes identical values, so warning on
+// an unchanged value would falsely imply a destructive overwrite.
+func (cmd *configEnvInitCmd) setMergedValue(target *yaml.Node, path resource.PropertyPath, value *yaml.Node) error {
+	syntax := escEncoding.YAMLSyntax{Node: target}
+	if existing, ok := syntax.Get(path); ok {
+		changed, err := yamlNodesDiffer(existing, value)
+		if err != nil {
+			return err
+		}
+		if changed {
+			fmt.Fprintf(cmd.parent.stdout, "Warning: overwriting existing key %q\n", path[len(path)-1])
+		}
+	}
+	if _, err := syntax.Set(nil, path, *value); err != nil {
+		return fmt.Errorf("merging %v: %w", path[len(path)-1], err)
+	}
+	return nil
+}
+
+// mergeImportNodes appends source's imports not already present (by name) to target's imports
+// sequence. Entries are cloned verbatim so a structured import (e.g. {env: {merge: false}}) keeps its
+// options rather than being flattened to a bare name.
+func mergeImportNodes(target, source *yaml.Node) error {
+	srcImports, ok := (escEncoding.YAMLSyntax{Node: source}).Get(resource.PropertyPath{"imports"})
+	if !ok || srcImports.Kind != yaml.SequenceNode || len(srcImports.Content) == 0 {
+		return nil
+	}
+
+	syntax := escEncoding.YAMLSyntax{Node: target}
+	var seq *yaml.Node
+	if node, ok := syntax.Get(resource.PropertyPath{"imports"}); ok {
+		// A non-sequence `imports` is a malformed env; refuse rather than silently discard it.
+		if node.Kind != yaml.SequenceNode {
+			return errors.New("environment's `imports` is not a sequence")
+		}
+		seq = node
+	} else {
+		var err error
+		seq, err = syntax.Set(nil, resource.PropertyPath{"imports"}, yaml.Node{Kind: yaml.SequenceNode})
+		if err != nil {
+			return fmt.Errorf("internal error: %w", err)
+		}
+	}
+
+	present := map[string]bool{}
+	for _, n := range seq.Content {
+		if name, ok := importEntryName(n); ok {
+			present[name] = true
+		}
+	}
+	for _, n := range srcImports.Content {
+		name, ok := importEntryName(n)
+		if !ok || present[name] {
+			continue
+		}
+		present[name] = true
+		seq.Content = append(seq.Content, cloneYAMLNode(n))
+	}
+	return nil
+}
+
+// cloneYAMLNode deep-copies a node so grafting it elsewhere doesn't share mutable state with the source.
+func cloneYAMLNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	c := *n
+	c.Content = make([]*yaml.Node, len(n.Content))
+	for i, child := range n.Content {
+		c.Content[i] = cloneYAMLNode(child)
+	}
+	return &c
+}
+
+// valueToYAMLNode marshals a native value (already rendered by renderConfigValueForESC) to a YAML node.
+func valueToYAMLNode(v any) (yaml.Node, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return yaml.Node{}, err
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(b, &node); err != nil {
+		return yaml.Node{}, err
+	}
+	if len(node.Content) == 0 {
+		return yaml.Node{}, errors.New("internal error: empty value node")
+	}
+	return *node.Content[0], nil
+}
+
+func yamlNodesDiffer(a, b *yaml.Node) (bool, error) {
+	ab, err := yaml.Marshal(a)
+	if err != nil {
+		return false, err
+	}
+	bb, err := yaml.Marshal(b)
+	if err != nil {
+		return false, err
+	}
+	return !bytes.Equal(ab, bb), nil
+}
+
+// cleanupLocalConfig deletes the local Pulumi.<stack>.yaml after a migration, but only if
+// --cleanup-local was passed or the user confirms; by default it is kept.
+func (cmd *configEnvInitCmd) cleanupLocalConfig(stack backend.Stack, opts display.Options) error {
+	remove := cmd.cleanupLocal
+	if !remove && cmd.parent.interactive && !cmd.yes {
+		remove = ui.ConfirmPrompt(
+			"Delete the local stack configuration file now that config is stored remotely?",
+			"yes", opts)
+	}
+	if !remove {
+		fmt.Fprintf(cmd.parent.stdout,
+			"Kept the local stack configuration file; it is no longer used and can be deleted\n")
+		return nil
+	}
+
+	path := *cmd.parent.configFile
+	if path == "" {
+		_, detected, err := workspace.DetectProjectStackPath(stack.Ref().Name().Q())
+		if err != nil {
+			return fmt.Errorf("locating local stack configuration file: %w", err)
+		}
+		path = detected
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing local stack configuration file: %w", err)
+	}
+	fmt.Fprintf(cmd.parent.stdout, "Deleted the local stack configuration file %s\n", path)
+	return nil
+}

--- a/pkg/cmd/pulumi/config/config_env_init_migrate_test.go
+++ b/pkg/cmd/pulumi/config/config_env_init_migrate_test.go
@@ -596,6 +596,18 @@ func setupLocalProject(t *testing.T) string {
 	return stackPath
 }
 
+// TestMigrateConfirmPrompt verifies the confirmation distinguishes creating a new environment from
+// merging into an existing one, so a user can decline before merging into a populated env.
+func TestMigrateConfirmPrompt(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, migrateConfirmPrompt(false, "stack", "test/stack"), "new environment")
+	assert.NotContains(t, migrateConfirmPrompt(false, "stack", "test/stack"), "already exists")
+
+	assert.Contains(t, migrateConfirmPrompt(true, "stack", "test/stack"), "already exists")
+	assert.Contains(t, migrateConfirmPrompt(true, "stack", "test/stack"), "merge")
+}
+
 // TestConfigEnvInitMigrateNoPlaintextLeak verifies the plaintext secret never appears in stdout.
 func TestConfigEnvInitMigrateNoPlaintextLeak(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/pulumi/config/config_env_init_migrate_test.go
+++ b/pkg/cmd/pulumi/config/config_env_init_migrate_test.go
@@ -1,0 +1,613 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// migrateCapture records what the migration produced.
+type migrateCapture struct {
+	createdYAML []byte
+	updatedYAML []byte
+	linkedPS    *workspace.ProjectStack
+	savedLocal  *workspace.ProjectStack
+}
+
+// newMigrateCmdForTest builds a configEnvInitCmd over a local (non-remote) stack. existingEnvYAML, if
+// non-empty, makes GetEnvironment report an existing environment (merge path); otherwise GetEnvironment
+// returns empty (create path). The returned capture records the created/updated env YAML and the link.
+func newMigrateCmdForTest(
+	stdin io.Reader,
+	stdout io.Writer,
+	projectStackYAML string,
+	existingEnvYAML string,
+	cap *migrateCapture,
+) *configEnvInitCmd {
+	stackRef := "stack"
+	configFile := ""
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			// An empty fixture means the environment does not exist yet (create path); model that as a
+			// 404 so the create-vs-merge decision is driven by the error, not by empty bytes.
+			if existingEnvYAML == "" {
+				return nil, "", 0, &apitype.ErrorResponse{Code: http.StatusNotFound, Message: "not found"}
+			}
+			return []byte(existingEnvYAML), "etag", 0, nil
+		},
+		CreateEnvironmentF: func(
+			_ context.Context, _, _, _ string, y []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			cap.createdYAML = y
+			return nil, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, y []byte, _ string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			cap.updatedYAML = y
+			return nil, nil
+		},
+	}
+
+	parent := &configEnvCmd{
+		stdin:       stdin,
+		stdout:      stdout,
+		interactive: true,
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes(
+					[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return &backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						StringV:             "org/stack",
+						NameV:               tokens.MustParseStackName("stack"),
+						ProjectV:            "test",
+						FullyQualifiedNameV: "org/test/stack",
+					}
+				},
+				OrgNameF: func() string { return "org" },
+				BackendF: func() backend.Backend { return be },
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{}
+				},
+				DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
+					return b64.NewBase64SecretsManager(), nil
+				},
+				SaveRemoteF: func(_ context.Context, ps *workspace.ProjectStack) error {
+					cap.linkedPS = ps
+					return nil
+				},
+			}, nil
+		},
+		loadProjectStack: func(
+			_ context.Context, d diag.Sink, p *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			return workspace.LoadProjectStackBytes(d, p, []byte(projectStackYAML), "Pulumi.stack.yaml", encoding.YAML)
+		},
+		saveProjectStack: func(_ context.Context, _ backend.Stack, ps *workspace.ProjectStack, _ string) error {
+			cap.savedLocal = ps
+			return nil
+		},
+		stackRef:   &stackRef,
+		configFile: &configFile,
+	}
+
+	return &configEnvInitCmd{parent: parent, remoteConfig: true, yes: true}
+}
+
+func pulumiConfigOf(t *testing.T, y []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(y, &doc))
+	values, ok := doc["values"].(map[string]any)
+	require.True(t, ok, "values section missing")
+	pc, ok := values["pulumiConfig"].(map[string]any)
+	require.True(t, ok, "pulumiConfig section missing")
+	return pc
+}
+
+// TestConfigEnvInitMigrateTypesAndSecrets verifies that plaintext, secret, typed, object, and array
+// config values migrate into the env's values.pulumiConfig with native types preserved and secrets
+// wrapped as fn::secret.
+func TestConfigEnvInitMigrateTypesAndSecrets(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `config:
+  test:plain: hello
+  test:flag: true
+  test:count: 7
+  test:ratio: 1.5
+  test:obj:
+    env: prod
+    nested:
+      deep: 1
+  test:list:
+    - a
+    - b
+  test:password:
+    secure: aHVudGVyMg==
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.createdYAML, "expected env created")
+	pc := pulumiConfigOf(t, cap.createdYAML)
+
+	assert.Equal(t, "hello", pc["test:plain"])
+	assert.Equal(t, true, pc["test:flag"])
+	assert.Equal(t, 7, pc["test:count"])
+	// Untyped float scalars are not coerced to numbers (config's coerce handles only bool/int), so
+	// they migrate as strings — matching the existing non-remote `config env init` behavior.
+	assert.Equal(t, "1.5", pc["test:ratio"])
+	assert.Equal(t, map[string]any{
+		"env":    "prod",
+		"nested": map[string]any{"deep": 1},
+	}, pc["test:obj"])
+	assert.Equal(t, []any{"a", "b"}, pc["test:list"])
+	assert.Equal(t, map[string]any{"fn::secret": "hunter2"}, pc["test:password"])
+}
+
+// TestConfigEnvInitMigratePreservesAndFiltersImports verifies existing imports are preserved and a
+// self-import equal to the target env name is filtered out.
+func TestConfigEnvInitMigratePreservesAndFiltersImports(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `environment:
+  - other-env
+  - test/stack
+config:
+  test:k: v
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(cap.createdYAML, &doc))
+	assert.Equal(t, []any{"other-env"}, doc["imports"])
+}
+
+// TestConfigEnvInitMigrateRendersBlockYAML verifies the migrated environment is emitted as block YAML,
+// not inline JSON. A local stack whose `environment` is an imports list makes Environment.Definition()
+// return JSON; yaml.Unmarshal tags those nodes flow-style, and without normalization the whole env
+// re-marshals as {imports: [...], values: {...}}.
+func TestConfigEnvInitMigrateRendersBlockYAML(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `environment:
+  - other-env
+config:
+  test:k: v
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.createdYAML, "expected env created")
+	assert.NotContains(t, string(cap.createdYAML), "{",
+		"migrated environment must be block YAML, not inline JSON")
+	assert.Contains(t, string(cap.createdYAML), "imports:\n",
+		"imports must render as a block sequence")
+}
+
+// TestConfigEnvInitMigratePreservesInlineEnvironmentValues verifies that a local stack whose inline
+// `environment` block carries its own imports and `values` (pulumiConfig + environmentVariables) keeps
+// all of them after migration, with the stack `config` block overriding a colliding inline key and the
+// self-import filtered out.
+func TestConfigEnvInitMigratePreservesInlineEnvironmentValues(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `environment:
+  imports:
+    - shared-env
+    - test/stack
+  values:
+    pulumiConfig:
+      test:fromenv: envvalue
+      test:override: inline
+    environmentVariables:
+      FOO: bar
+config:
+  test:override: stackwins
+  test:plain: hi
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.createdYAML, "expected env created")
+
+	pc := pulumiConfigOf(t, cap.createdYAML)
+	assert.Equal(t, "envvalue", pc["test:fromenv"], "inline env pulumiConfig value must survive")
+	assert.Equal(t, "stackwins", pc["test:override"], "stack config must override a colliding inline value")
+	assert.Equal(t, "hi", pc["test:plain"])
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(cap.createdYAML, &doc))
+	assert.Equal(t, []any{"shared-env"}, doc["imports"], "inline imports survive, self-import filtered")
+	values, ok := doc["values"].(map[string]any)
+	require.True(t, ok, "values section missing")
+	assert.Equal(t, map[string]any{"FOO": "bar"}, values["environmentVariables"],
+		"inline environmentVariables must survive migration")
+}
+
+// TestConfigEnvInitMigrateMergesInlineEnvironmentVariables verifies that when the target environment
+// already exists, the stack's inline environmentVariables are merged into it alongside pulumiConfig,
+// preserving unrelated keys already in the target.
+func TestConfigEnvInitMigrateMergesInlineEnvironmentVariables(t *testing.T) {
+	t.Parallel()
+
+	existingEnv := `values:
+  environmentVariables:
+    KEEP: keep
+  pulumiConfig:
+    test:keep: keep
+`
+	stackYAML := `environment:
+  values:
+    environmentVariables:
+      ADDED: added
+config:
+  test:new: new
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, existingEnv, &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.updatedYAML, "expected merge path")
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(cap.updatedYAML, &doc))
+	values, ok := doc["values"].(map[string]any)
+	require.True(t, ok, "values section missing")
+	assert.Equal(t, map[string]any{"KEEP": "keep", "ADDED": "added"}, values["environmentVariables"],
+		"inline env var merges in; target's unrelated env var survives")
+	pc, ok := values["pulumiConfig"].(map[string]any)
+	require.True(t, ok, "pulumiConfig section missing")
+	assert.Equal(t, "keep", pc["test:keep"], "target's existing pulumiConfig survives")
+	assert.Equal(t, "new", pc["test:new"], "stack config key is added")
+}
+
+// TestConfigEnvInitMigrateMergePreservesStructuredImports verifies that a structured inline import
+// ({env: {merge: false}}) keeps its options when merged into an existing target environment, rather
+// than being flattened to a bare import name.
+func TestConfigEnvInitMigrateMergePreservesStructuredImports(t *testing.T) {
+	t.Parallel()
+
+	existingEnv := `values:
+  pulumiConfig:
+    test:existing: x
+`
+	stackYAML := `environment:
+  imports:
+    - shared/env:
+        merge: false
+config:
+  test:k: v
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, existingEnv, &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.updatedYAML, "expected merge path")
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(cap.updatedYAML, &doc))
+	assert.Equal(t, []any{map[string]any{"shared/env": map[string]any{"merge": false}}}, doc["imports"],
+		"structured import must keep its options through the merge path")
+}
+
+// TestConfigEnvInitMigrateNestedSecrets verifies that secrets nested inside an object or an array are
+// wrapped as fn::secret, not migrated as plaintext — the highest-stakes invariant of the migration.
+func TestConfigEnvInitMigrateNestedSecrets(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `config:
+  test:obj:
+    apiKey:
+      secure: aHVudGVyMg==
+    plain: ok
+  test:list:
+    - secure: aHVudGVyMg==
+    - safe
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.createdYAML, "expected env created")
+	pc := pulumiConfigOf(t, cap.createdYAML)
+
+	obj, ok := pc["test:obj"].(map[string]any)
+	require.True(t, ok, "test:obj should be an object")
+	assert.Equal(t, map[string]any{"fn::secret": "hunter2"}, obj["apiKey"],
+		"a secret nested in an object must wrap as fn::secret, not migrate as plaintext")
+	assert.Equal(t, "ok", obj["plain"])
+
+	list, ok := pc["test:list"].([]any)
+	require.True(t, ok, "test:list should be an array")
+	assert.Equal(t, map[string]any{"fn::secret": "hunter2"}, list[0],
+		"a secret in an array must wrap as fn::secret, not migrate as plaintext")
+	assert.Equal(t, "safe", list[1])
+}
+
+// TestConfigEnvInitMigrateReconcileNoSpuriousWarnings covers the advertised reconcile path: after a
+// first run wrote the env but the link failed, re-running migrates identical values into the existing
+// env. The merge must not warn about overwriting values that did not change.
+//
+//nolint:paralleltest // captures stdout warnings deterministically
+func TestConfigEnvInitMigrateReconcileNoSpuriousWarnings(t *testing.T) {
+	existingEnv := `values:
+  pulumiConfig:
+    test:k: v
+    test:m: w
+`
+	stackYAML := `config:
+  test:k: v
+  test:m: w
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, existingEnv, &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.updatedYAML, "expected merge path")
+	assert.NotContains(t, stdout.String(), "overwriting",
+		"re-migrating identical values must not warn about overwriting")
+}
+
+// TestConfigEnvInitMigrateMerge verifies merging into an existing environment preserves unrelated
+// sections and warns on overwritten keys.
+//
+//nolint:paralleltest // captures stdout warnings deterministically
+func TestConfigEnvInitMigrateMerge(t *testing.T) {
+	existingEnv := `# top comment
+values:
+  environmentVariables:
+    FOO: bar # keep me
+  pulumiConfig:
+    test:existing: old
+`
+	stackYAML := `config:
+  test:existing: new
+  test:added: hi
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, existingEnv, &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.updatedYAML, "expected env updated (merge path)")
+	out := string(cap.updatedYAML)
+	require.Contains(t, out, "# top comment")
+	require.Contains(t, out, "FOO: bar # keep me")
+
+	pc := pulumiConfigOf(t, cap.updatedYAML)
+	assert.Equal(t, "new", pc["test:existing"])
+	assert.Equal(t, "hi", pc["test:added"])
+
+	assert.Contains(t, stdout.String(), `overwriting existing key "test:existing"`)
+}
+
+// TestConfigEnvInitMigrateEmptyExistingEnvMerges verifies that an environment which already exists
+// but has an empty definition (GetEnvironment returns empty bytes with no error) is merged into, not
+// created — creating it would fail because it already exists.
+//
+//nolint:paralleltest // shares capture state
+func TestConfigEnvInitMigrateEmptyExistingEnvMerges(t *testing.T) {
+	var cap migrateCapture
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return nil, "etag", 0, nil // exists, but empty definition
+		},
+		CreateEnvironmentF: func(
+			_ context.Context, _, _, _ string, y []byte,
+		) (apitype.EnvironmentDiagnostics, error) {
+			cap.createdYAML = y
+			return nil, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, y []byte, _ string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			cap.updatedYAML = y
+			return nil, nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, "config:\n  test:k: v\n", "x", &cap)
+	cmd.parent.requireStack = func(
+		_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+		_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+	) (backend.Stack, error) {
+		return &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{
+					StringV:             "org/stack",
+					NameV:               tokens.MustParseStackName("stack"),
+					ProjectV:            "test",
+					FullyQualifiedNameV: "org/test/stack",
+				}
+			},
+			OrgNameF:        func() string { return "org" },
+			BackendF:        func() backend.Backend { return be },
+			ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+			DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
+				return b64.NewBase64SecretsManager(), nil
+			},
+			SaveRemoteF: func(_ context.Context, _ *workspace.ProjectStack) error { return nil },
+		}, nil
+	}
+
+	require.NoError(t, cmd.runMigrate(t.Context()))
+	assert.Nil(t, cap.createdYAML, "must not create an environment that already exists")
+	require.NotNil(t, cap.updatedYAML, "must merge into the existing (empty) environment")
+}
+
+// TestConfigEnvInitMigrateLinks verifies the stack is linked: SaveRemoteConfig is invoked with
+// ps.Config == nil and a single import equal to the target env.
+func TestConfigEnvInitMigrateLinks(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `config:
+  test:k: v
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	require.NotNil(t, cap.linkedPS, "expected SaveRemoteConfig to be called")
+	assert.Nil(t, cap.linkedPS.Config)
+	assert.Equal(t, []string{"test/stack"}, cap.linkedPS.Environment.Imports())
+}
+
+// TestConfigEnvInitMigrateAlreadyRemote verifies an already-remote stack fails cleanly with no env
+// write and no link.
+func TestConfigEnvInitMigrateAlreadyRemote(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, "config:\n  test:k: v\n", "", &cap)
+	// Make the stack report remote config.
+	env := "test/stack"
+	cmd.parent.requireStack = func(
+		_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+		_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+	) (backend.Stack, error) {
+		return &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{NameV: tokens.MustParseStackName("stack")}
+			},
+			OrgNameF: func() string { return "org" },
+			BackendF: func() backend.Backend { return &backend.MockEnvironmentsBackend{} },
+			ConfigLocationF: func() backend.StackConfigLocation {
+				return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+			},
+		}, nil
+	}
+
+	err := cmd.runMigrate(t.Context())
+	require.ErrorContains(t, err, "already uses remote configuration")
+	assert.Nil(t, cap.createdYAML)
+	assert.Nil(t, cap.updatedYAML)
+	assert.Nil(t, cap.linkedPS)
+}
+
+// TestConfigEnvInitMigrateLocalKeepsFileByDefault verifies non-interactive without --cleanup-local
+// keeps the local config file. t.Chdir forbids t.Parallel.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvInitMigrateLocalKeepsFileByDefault(t *testing.T) {
+	stackYAML := "config:\n  test:k: v\n"
+	stackPath := setupLocalProject(t)
+
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	cmd.parent.interactive = false
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	assert.FileExists(t, stackPath)
+	assert.Contains(t, stdout.String(), "Kept the local stack configuration file")
+}
+
+// TestConfigEnvInitMigrateLocalDeletesWithFlag verifies --cleanup-local deletes the local config file.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvInitMigrateLocalDeletesWithFlag(t *testing.T) {
+	stackYAML := "config:\n  test:k: v\n"
+	stackPath := setupLocalProject(t)
+
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	cmd.parent.interactive = false
+	cmd.cleanupLocal = true
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	assert.NoFileExists(t, stackPath)
+	assert.Contains(t, stdout.String(), "Deleted the local stack configuration file")
+}
+
+// setupLocalProject chdirs into a temp dir holding Pulumi.yaml and Pulumi.stack.yaml so that
+// workspace.DetectProjectStackPath resolves to the latter, and returns its path.
+func setupLocalProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: test\nruntime: yaml\n"), 0o600))
+	stackPath := filepath.Join(dir, "Pulumi.stack.yaml")
+	require.NoError(t, os.WriteFile(stackPath, []byte("config:\n  test:k: v\n"), 0o600))
+	t.Chdir(dir)
+	return stackPath
+}
+
+// TestConfigEnvInitMigrateNoPlaintextLeak verifies the plaintext secret never appears in stdout.
+func TestConfigEnvInitMigrateNoPlaintextLeak(t *testing.T) {
+	t.Parallel()
+
+	stackYAML := `config:
+  test:password:
+    secure: aHVudGVyMg==
+`
+	var stdout bytes.Buffer
+	var cap migrateCapture
+	cmd := newMigrateCmdForTest(strings.NewReader(""), &stdout, stackYAML, "", &cap)
+	require.NoError(t, cmd.runMigrate(t.Context()))
+
+	assert.NotContains(t, stdout.String(), "hunter2")
+}

--- a/pkg/cmd/pulumi/config/coverage_sbc05_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc05_test.go
@@ -1,0 +1,329 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func migrateCmd(stdout io.Writer) *configEnvInitCmd {
+	return &configEnvInitCmd{parent: &configEnvCmd{stdout: stdout}}
+}
+
+func mustYAMLNode(t *testing.T, s string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(s), &n))
+	return &n
+}
+
+func marshalYAMLNode(t *testing.T, n *yaml.Node) string {
+	t.Helper()
+	b, err := yaml.Marshal(n)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestBuildMigratedDefinition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("seeds values.pulumiConfig from an empty definition", func(t *testing.T) {
+		t.Parallel()
+		doc, err := buildMigratedDefinition(nil, map[string]any{"proj:key": "v", "proj:flag": true}, "")
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, yaml.Unmarshal([]byte(marshalYAMLNode(t, doc)), &got))
+		pc := got["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+		require.Equal(t, "v", pc["proj:key"])
+		require.Equal(t, true, pc["proj:flag"])
+	})
+
+	t.Run("rejects an unparseable definition", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildMigratedDefinition([]byte("\tnot: [valid"), nil, "")
+		require.ErrorContains(t, err, "unmarshaling stack environment definition")
+	})
+
+	t.Run("strips the stack's own import", func(t *testing.T) {
+		t.Parallel()
+		inline := []byte(`{"imports":["org/proj/stack","other"],"values":{"pulumiConfig":{}}}`)
+		doc, err := buildMigratedDefinition(inline, nil, "org/proj/stack")
+		require.NoError(t, err)
+		out := marshalYAMLNode(t, doc)
+		require.NotContains(t, out, "org/proj/stack")
+		require.Contains(t, out, "other")
+	})
+}
+
+func TestRemoveSelfImport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removing the sole self import deletes the imports key", func(t *testing.T) {
+		t.Parallel()
+		doc := mustYAMLNode(t, "imports:\n  - self\nvalues: {}\n")
+		require.NoError(t, removeSelfImport(doc, "self"))
+		require.NotContains(t, marshalYAMLNode(t, doc), "imports")
+	})
+
+	t.Run("non-sequence imports is a no-op", func(t *testing.T) {
+		t.Parallel()
+		doc := mustYAMLNode(t, "imports: scalar\n")
+		require.NoError(t, removeSelfImport(doc, "self"))
+		require.Contains(t, marshalYAMLNode(t, doc), "scalar")
+	})
+}
+
+func TestMergeImportNodes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges new entries and de-duplicates", func(t *testing.T) {
+		t.Parallel()
+		target := mustYAMLNode(t, "imports:\n  - a\nvalues: {}\n")
+		source := mustYAMLNode(t, "imports:\n  - a\n  - b\n")
+		require.NoError(t, mergeImportNodes(target, source))
+		var got map[string]any
+		require.NoError(t, yaml.Unmarshal([]byte(marshalYAMLNode(t, target)), &got))
+		require.Equal(t, []any{"a", "b"}, got["imports"])
+	})
+
+	t.Run("creates imports when the target lacks it", func(t *testing.T) {
+		t.Parallel()
+		target := mustYAMLNode(t, "values: {}\n")
+		source := mustYAMLNode(t, "imports:\n  - x\n")
+		require.NoError(t, mergeImportNodes(target, source))
+		require.Contains(t, marshalYAMLNode(t, target), "- x")
+	})
+
+	t.Run("empty source is a no-op", func(t *testing.T) {
+		t.Parallel()
+		target := mustYAMLNode(t, "values: {}\n")
+		require.NoError(t, mergeImportNodes(target, mustYAMLNode(t, "values: {}\n")))
+	})
+
+	t.Run("malformed non-sequence target imports errors", func(t *testing.T) {
+		t.Parallel()
+		target := mustYAMLNode(t, "imports: scalar\n")
+		source := mustYAMLNode(t, "imports:\n  - x\n")
+		require.ErrorContains(t, mergeImportNodes(target, source), "not a sequence")
+	})
+}
+
+func TestCloneYAMLNode(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, cloneYAMLNode(nil))
+
+	orig := mustYAMLNode(t, "a: 1\n")
+	clone := cloneYAMLNode(orig)
+	// Mutating the clone's tree must not affect the original.
+	clone.Content[0].Content[1].Value = "2"
+	require.Equal(t, "1", orig.Content[0].Content[1].Value)
+}
+
+func TestValueToYAMLNode(t *testing.T) {
+	t.Parallel()
+
+	scalar, err := valueToYAMLNode("hi")
+	require.NoError(t, err)
+	require.Equal(t, yaml.ScalarNode, scalar.Kind)
+	require.Equal(t, "hi", scalar.Value)
+
+	mapping, err := valueToYAMLNode(map[string]any{"k": "v"})
+	require.NoError(t, err)
+	require.Equal(t, yaml.MappingNode, mapping.Kind)
+}
+
+func TestYAMLNodesDiffer(t *testing.T) {
+	t.Parallel()
+
+	a := mustYAMLNode(t, "x: 1\n")
+	same := mustYAMLNode(t, "x: 1\n")
+	diff := mustYAMLNode(t, "x: 2\n")
+
+	d, err := yamlNodesDiffer(a, same)
+	require.NoError(t, err)
+	require.False(t, d)
+
+	d, err = yamlNodesDiffer(a, diff)
+	require.NoError(t, err)
+	require.True(t, d)
+}
+
+func TestCreateMigratedEnvironment(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	src := mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:key: v\n")
+
+	t.Run("uploads the definition", func(t *testing.T) {
+		t.Parallel()
+		var created []byte
+		be := &backend.MockEnvironmentsBackend{
+			CreateEnvironmentF: func(_ context.Context, _, _, _ string, y []byte) (apitype.EnvironmentDiagnostics, error) {
+				created = y
+				return nil, nil
+			},
+		}
+		require.NoError(t, migrateCmd(&bytes.Buffer{}).createMigratedEnvironment(ctx, be, "org", "proj", "env", src))
+		require.Contains(t, string(created), "proj:key: v")
+	})
+
+	t.Run("backend failure is wrapped", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			CreateEnvironmentF: func(_ context.Context, _, _, _ string, _ []byte) (apitype.EnvironmentDiagnostics, error) {
+				return nil, errors.New("boom")
+			},
+		}
+		err := migrateCmd(&bytes.Buffer{}).createMigratedEnvironment(ctx, be, "org", "proj", "env", src)
+		require.ErrorContains(t, err, "creating environment")
+	})
+
+	t.Run("diagnostics are an error", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			CreateEnvironmentF: func(_ context.Context, _, _, _ string, _ []byte) (apitype.EnvironmentDiagnostics, error) {
+				return apitype.EnvironmentDiagnostics{{Summary: "bad"}}, nil
+			},
+		}
+		err := migrateCmd(&bytes.Buffer{}).createMigratedEnvironment(ctx, be, "org", "proj", "env", src)
+		require.ErrorContains(t, err, "creating environment")
+	})
+}
+
+func TestMergeMigratedEnvironment(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("merges into the existing definition", func(t *testing.T) {
+		t.Parallel()
+		var uploaded []byte
+		be := &backend.MockEnvironmentsBackend{
+			UpdateEnvironmentWithProjectF: func(
+				_ context.Context, _, _, _ string, y []byte, _ string,
+			) (apitype.EnvironmentDiagnostics, error) {
+				uploaded = y
+				return nil, nil
+			},
+		}
+		def := []byte("values:\n  pulumiConfig:\n    proj:existing: keep\n")
+		src := mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:added: new\n")
+		require.NoError(t, migrateCmd(&bytes.Buffer{}).mergeMigratedEnvironment(
+			ctx, be, "org", "proj", "env", "etag", def, src))
+		require.Contains(t, string(uploaded), "proj:existing: keep")
+		require.Contains(t, string(uploaded), "proj:added: new")
+	})
+
+	t.Run("warns when overwriting a changed key", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		be := &backend.MockEnvironmentsBackend{
+			UpdateEnvironmentWithProjectF: func(
+				_ context.Context, _, _, _ string, _ []byte, _ string,
+			) (apitype.EnvironmentDiagnostics, error) {
+				return nil, nil
+			},
+		}
+		def := []byte("values:\n  pulumiConfig:\n    proj:k: old\n")
+		src := mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:k: new\n")
+		require.NoError(t, migrateCmd(&buf).mergeMigratedEnvironment(ctx, be, "org", "proj", "env", "etag", def, src))
+		require.Contains(t, buf.String(), "overwriting existing key")
+	})
+
+	t.Run("rejects an unparseable existing definition", func(t *testing.T) {
+		t.Parallel()
+		err := migrateCmd(&bytes.Buffer{}).mergeMigratedEnvironment(
+			ctx, &backend.MockEnvironmentsBackend{}, "org", "proj", "env",
+			"etag", []byte("\tnot: [valid"), mustYAMLNode(t, "values: {}\n"))
+		require.ErrorContains(t, err, "unmarshaling environment definition")
+	})
+
+	t.Run("surfaces an etag conflict as retryable", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			UpdateEnvironmentWithProjectF: func(
+				_ context.Context, _, _, _ string, _ []byte, _ string,
+			) (apitype.EnvironmentDiagnostics, error) {
+				return nil, fmt.Errorf("update: %w", backend.ErrConfigConflict)
+			},
+		}
+		err := migrateCmd(&bytes.Buffer{}).mergeMigratedEnvironment(
+			ctx, be, "org", "proj", "env", "etag", []byte("values: {}\n"),
+			mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:k: v\n"))
+		require.ErrorContains(t, err, "modified concurrently")
+	})
+}
+
+func TestWriteMigratedEnvironment(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	src := mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:k: v\n")
+
+	t.Run("creates when the environment does not exist", func(t *testing.T) {
+		t.Parallel()
+		var created bool
+		be := &backend.MockEnvironmentsBackend{
+			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+				return nil, "", 0, &apitype.ErrorResponse{Code: http.StatusNotFound}
+			},
+			CreateEnvironmentF: func(_ context.Context, _, _, _ string, _ []byte) (apitype.EnvironmentDiagnostics, error) {
+				created = true
+				return nil, nil
+			},
+		}
+		require.NoError(t, migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src))
+		require.True(t, created)
+	})
+
+	t.Run("merges when the environment exists", func(t *testing.T) {
+		t.Parallel()
+		var updated bool
+		be := &backend.MockEnvironmentsBackend{
+			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+				return []byte("values: {}\n"), "etag", 0, nil
+			},
+			UpdateEnvironmentWithProjectF: func(
+				_ context.Context, _, _, _ string, _ []byte, _ string,
+			) (apitype.EnvironmentDiagnostics, error) {
+				updated = true
+				return nil, nil
+			},
+		}
+		require.NoError(t, migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src))
+		require.True(t, updated)
+	})
+
+	t.Run("other GetEnvironment failures are wrapped", func(t *testing.T) {
+		t.Parallel()
+		be := &backend.MockEnvironmentsBackend{
+			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+				return nil, "", 0, errors.New("boom")
+			},
+		}
+		err := migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src)
+		require.ErrorContains(t, err, "getting environment")
+	})
+}

--- a/pkg/cmd/pulumi/config/coverage_sbc05_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc05_test.go
@@ -277,43 +277,34 @@ func TestMergeMigratedEnvironment(t *testing.T) {
 	})
 }
 
-func TestWriteMigratedEnvironment(t *testing.T) {
+func TestGetMigrationTarget(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	src := mustYAMLNode(t, "values:\n  pulumiConfig:\n    proj:k: v\n")
 
-	t.Run("creates when the environment does not exist", func(t *testing.T) {
+	t.Run("reports not exists on 404", func(t *testing.T) {
 		t.Parallel()
-		var created bool
 		be := &backend.MockEnvironmentsBackend{
 			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
 				return nil, "", 0, &apitype.ErrorResponse{Code: http.StatusNotFound}
 			},
-			CreateEnvironmentF: func(_ context.Context, _, _, _ string, _ []byte) (apitype.EnvironmentDiagnostics, error) {
-				created = true
-				return nil, nil
-			},
 		}
-		require.NoError(t, migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src))
-		require.True(t, created)
+		_, _, exists, err := migrateCmd(&bytes.Buffer{}).getMigrationTarget(ctx, be, "org", "proj", "env")
+		require.NoError(t, err)
+		require.False(t, exists)
 	})
 
-	t.Run("merges when the environment exists", func(t *testing.T) {
+	t.Run("reports exists with def and etag", func(t *testing.T) {
 		t.Parallel()
-		var updated bool
 		be := &backend.MockEnvironmentsBackend{
 			GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
 				return []byte("values: {}\n"), "etag", 0, nil
 			},
-			UpdateEnvironmentWithProjectF: func(
-				_ context.Context, _, _, _ string, _ []byte, _ string,
-			) (apitype.EnvironmentDiagnostics, error) {
-				updated = true
-				return nil, nil
-			},
 		}
-		require.NoError(t, migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src))
-		require.True(t, updated)
+		def, etag, exists, err := migrateCmd(&bytes.Buffer{}).getMigrationTarget(ctx, be, "org", "proj", "env")
+		require.NoError(t, err)
+		require.True(t, exists)
+		require.Equal(t, "etag", etag)
+		require.Equal(t, "values: {}\n", string(def))
 	})
 
 	t.Run("other GetEnvironment failures are wrapped", func(t *testing.T) {
@@ -323,7 +314,7 @@ func TestWriteMigratedEnvironment(t *testing.T) {
 				return nil, "", 0, errors.New("boom")
 			},
 		}
-		err := migrateCmd(&bytes.Buffer{}).writeMigratedEnvironment(ctx, be, "org", "proj", "env", src)
+		_, _, _, err := migrateCmd(&bytes.Buffer{}).getMigrationTarget(ctx, be, "org", "proj", "env")
 		require.ErrorContains(t, err, "getting environment")
 	})
 }


### PR DESCRIPTION
## Summary

Add a hidden `pulumi config env init --remote-config` flag that migrates an existing local-config stack to a remote-config (ESC-backed) stack. Builds on the earlier PRs in this stacked series; internally "service-backed config (SBC)", externally "remote config" for now.

Towards pulumi/pulumi-service#39624

## Changes

- **Migration** — `config env init --remote-config` writes the stack's decrypted config into the backing ESC environment (`values.pulumiConfig`), creating the environment or merging node-level into an existing one, then links the stack via `SaveRemoteConfig`. Secrets are written as `fn::secret` at any depth and re-encrypted by ESC on write; native types are preserved via the shared renderer.
- **Inline environment preserved** — the migrated definition is seeded from the stack's inline `environment` block, so its imports and `values` (pulumiConfig, environmentVariables, …) survive. The stack `config` block overlays on top, so stack config wins on a key collision, matching today's resolution order.
- **Imports** — existing imports carry over with their options (a structured `{env: {merge: false}}` keeps its setting through both the create and merge paths) and a self-import is filtered.
- **Secrets stay in memory** — decrypted values are never written to disk, a log, a diagnostic, or a preview.
- **Reconcile / cleanup** — the environment is written before the link, so a transient link failure reconciles on re-run (a persistent one leaves the env orphaned, documented). Merge warns only when an overwritten key's value actually changes. The local stack file is kept by default and deleted only with the hidden `--cleanup-local` flag or interactive confirmation, honoring an explicit `--config-file`.

## Notes

- Phase 1: reachable only via the hidden `--remote-config` flag on an opted-in remote-config-capable backend; no public docs or changelog. No interactive "use remote config" prompt yet (deferred with the Phase-1 no-prompt rule).
- Behavior is mock-tested only; end-to-end ESC behavior (etag concurrency, `fn::secret` round-trips, import/value preservation) needs a smoke run against a real service with the flag enabled.
