### PR TITLE
Make binding stricter around nested index modules

### DIFF
--- a/changelog/pending/sdkgen-chore-20260604-091515.yaml
+++ b/changelog/pending/sdkgen-chore-20260604-091515.yaml
@@ -1,0 +1,6 @@
+component: sdkgen
+kind: chore
+body: Modules can no longer be nested under the index module, this was never well supported and is now a strict bind error
+time: 2026-06-04T09:15:15.406712+01:00
+custom:
+    PR: "23436"

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -597,9 +597,7 @@ func (spec *PackageSpec) validateTypeToken(
 	}
 
 	if strings.HasPrefix(moduleName, "index/") {
-		// TODO: We want this to be an error really, but for now warn about it to see if any users comment about it. We
-		// know at least aws-native needs to be updated to handle it.
-		err := warningf(path, "invalid token '%s' (nested modules under index are not allowed)", token)
+		err := errorf(path, "invalid token '%s' (nested modules under index are not allowed)", token)
 		diags = diags.Append(err)
 	}
 	if modules != nil && !slices.Contains(modules, parts[1]) {


### PR DESCRIPTION
Bump the warning about nested index modules up to an error. The only instance we'd seen of this was in aws-native, which is going to be fixed by https://github.com/pulumi/pulumi-aws-native/pull/2902.

We'll probably want to let that release and wait a little while before merging this error change, but raising it now so it doesn't get forgotten about.