### PR TITLE
fix(codegen): handle v-prefixed version literals in NeedsVersionResourceOption

### DIFF
--- a/changelog/pending/codegen-fix-version-compare-20260606.yaml
+++ b/changelog/pending/codegen-fix-version-compare-20260606.yaml
@@ -1,3 +1,6 @@
-# `pkg/codegen/pcl`
-
-- fix(codegen): use strict semver.Parse and semver.Version.Equals for version comparison in NeedsVersionResourceOption and loadPackageSchema
+component: codegen/pcl
+kind: fix
+body: use strict semver.Parse and semver.Version.Equals for version comparison in NeedsVersionResourceOption and loadPackageSchema
+time: 2026-06-08T05:40:00.000000+00:00
+custom:
+    PR: "23441"

--- a/changelog/pending/codegen-fix-version-compare-20260606.yaml
+++ b/changelog/pending/codegen-fix-version-compare-20260606.yaml
@@ -1,6 +1,6 @@
 component: codegen/pcl
 kind: fix
-body: use strict semver.Parse and semver.Version.Equals for version comparison in NeedsVersionResourceOption and loadPackageSchema
+body: Fix version comparison in NeedsVersionResourceOption to use semver.Version.Equals and reject "v"-prefixed versions
 time: 2026-06-08T05:40:00.000000+00:00
 custom:
-    PR: "23441"
+    PR: https://github.com/pulumi/pulumi/pull/23441

--- a/changelog/pending/codegen-fix-version-compare-20260606.yaml
+++ b/changelog/pending/codegen-fix-version-compare-20260606.yaml
@@ -1,3 +1,3 @@
 # `pkg/codegen/pcl`
 
-- fix(codegen): use semver.Version.Equals for version comparison in NeedsVersionResourceOption
+- fix(codegen): use strict semver.Parse and semver.Version.Equals for version comparison in NeedsVersionResourceOption and loadPackageSchema

--- a/changelog/pending/codegen-fix-version-compare-20260606.yaml
+++ b/changelog/pending/codegen-fix-version-compare-20260606.yaml
@@ -1,0 +1,3 @@
+# `pkg/codegen/pcl`
+
+- fix(codegen): use semver.Version.Equals for version comparison in NeedsVersionResourceOption

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -160,7 +160,15 @@ func (c *PackageCache) loadPackageSchema(
 	}
 
 	var versionSemver *semver.Version
-	if v, err := semver.Make(version); err == nil {
+	if v, err := semver.ParseTolerant(version); err == nil {
+		// Validate the version string is proper semver. Reject values with a "v" prefix
+		// so users get a clear error instead of their version pin being silently ignored.
+		if strings.HasPrefix(version, "v") {
+			return nil, fmt.Errorf(
+				"package %q version %q has a \"v\" prefix; semver values must not include the \"v\" prefix (use %q instead of %q)",
+				name, version, version[1:], version,
+			)
+		}
 		versionSemver = &v
 	}
 

--- a/pkg/codegen/pcl/binder_schema.go
+++ b/pkg/codegen/pcl/binder_schema.go
@@ -160,13 +160,12 @@ func (c *PackageCache) loadPackageSchema(
 	}
 
 	var versionSemver *semver.Version
-	if v, err := semver.ParseTolerant(version); err == nil {
-		// Validate the version string is proper semver. Reject values with a "v" prefix
-		// so users get a clear error instead of their version pin being silently ignored.
-		if strings.HasPrefix(version, "v") {
+	if version != "" {
+		v, err := semver.Parse(version)
+		if err != nil {
 			return nil, fmt.Errorf(
-				"package %q version %q has a \"v\" prefix; semver values must not include the \"v\" prefix (use %q instead of %q)",
-				name, version, version[1:], version,
+				"package %q version %q is not valid semver: %w",
+				name, version, err,
 			)
 		}
 		versionSemver = &v

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -382,14 +382,9 @@ func NeedsVersionResourceOption(version model.Expression, schema *schema.Resourc
 	}
 
 	optVStr := optV.Value.AsString()
-	// PCL version literals must not include a "v" prefix.
-	// The engine does not understand "v"-prefixed versions and no language SDK normalizes them.
-	if len(optVStr) > 0 && optVStr[0] == 'v' {
-		return true
-	}
 	optVersion, err := semver.Parse(optVStr)
 	if err != nil {
-		// If the literal isn't valid semver, treat it as a mismatch.
+		// If the literal isn't valid semver (including "v"-prefixed versions), treat it as a mismatch.
 		return true
 	}
 	return !v.Equals(optVersion)

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -382,12 +382,17 @@ func NeedsVersionResourceOption(version model.Expression, schema *schema.Resourc
 
 	optVStr := optV.Value.AsString()
 	// Normalize the v prefix: semver.Version.String() never includes a "v" prefix,
-	// but program literals can (e.g. "v0.10.1"). Strip it for comparison.
+	// but program literals can (e.g. "v0.10.1"). Parse both sides as semver for proper comparison.
 	if len(optVStr) > 0 && optVStr[0] == 'v' {
 		optVStr = optVStr[1:]
 	}
-
-	return v.String() != optVStr
+	// Use semver.Version.Equals for proper version comparison instead of string comparison.
+	optVersion, err := semver.ParseTolerant(optVStr)
+	if err != nil {
+		// If we can't parse the version, fall back to string comparison
+		return v.String() != optVStr
+	}
+	return !v.Equals(optVersion)
 }
 
 func NeedsPluginDownloadURLResourceOption(pluginDownloadURL model.Expression, schema *schema.Resource) bool {

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -382,15 +382,15 @@ func NeedsVersionResourceOption(version model.Expression, schema *schema.Resourc
 	}
 
 	optVStr := optV.Value.AsString()
-	// PCL version literals may include a "v" prefix (e.g. "v0.10.1") but
-	// semver.Version.String() never does. Normalize for comparison.
+	// PCL version literals must not include a "v" prefix.
+	// The engine does not understand "v"-prefixed versions and no language SDK normalizes them.
 	if len(optVStr) > 0 && optVStr[0] == 'v' {
-		optVStr = optVStr[1:]
+		return true
 	}
 	optVersion, err := semver.Parse(optVStr)
 	if err != nil {
-		// If the literal isn't valid semver, fall back to string comparison.
-		return v.String() != optVStr
+		// If the literal isn't valid semver, treat it as a mismatch.
+		return true
 	}
 	return !v.Equals(optVersion)
 }

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -380,7 +380,14 @@ func NeedsVersionResourceOption(version model.Expression, schema *schema.Resourc
 		return true
 	}
 
-	return v.String() != optV.Value.AsString()
+	optVStr := optV.Value.AsString()
+	// Normalize the v prefix: semver.Version.String() never includes a "v" prefix,
+	// but program literals can (e.g. "v0.10.1"). Strip it for comparison.
+	if len(optVStr) > 0 && optVStr[0] == 'v' {
+		optVStr = optVStr[1:]
+	}
+
+	return v.String() != optVStr
 }
 
 func NeedsPluginDownloadURLResourceOption(pluginDownloadURL model.Expression, schema *schema.Resource) bool {

--- a/pkg/codegen/pcl/resource.go
+++ b/pkg/codegen/pcl/resource.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2"
@@ -381,15 +382,14 @@ func NeedsVersionResourceOption(version model.Expression, schema *schema.Resourc
 	}
 
 	optVStr := optV.Value.AsString()
-	// Normalize the v prefix: semver.Version.String() never includes a "v" prefix,
-	// but program literals can (e.g. "v0.10.1"). Parse both sides as semver for proper comparison.
+	// PCL version literals may include a "v" prefix (e.g. "v0.10.1") but
+	// semver.Version.String() never does. Normalize for comparison.
 	if len(optVStr) > 0 && optVStr[0] == 'v' {
 		optVStr = optVStr[1:]
 	}
-	// Use semver.Version.Equals for proper version comparison instead of string comparison.
-	optVersion, err := semver.ParseTolerant(optVStr)
+	optVersion, err := semver.Parse(optVStr)
 	if err != nil {
-		// If we can't parse the version, fall back to string comparison
+		// If the literal isn't valid semver, fall back to string comparison.
 		return v.String() != optVStr
 	}
 	return !v.Equals(optVersion)


### PR DESCRIPTION
Pulumi's PCL binder silently accepted v-prefixed version strings (e.g. v0.10.1) but treated them as invalid semver, causing the version pin to be silently ignored. The package would install latest instead of the pinned version.

The fix uses strict `semver.Parse` in both `binder_schema.go` and `resource.go`. Any non-empty version string that isn't valid semver (including v-prefixed) now errors with a clear message. Uses `semver.Version.Equals` for proper comparison after parsing.

Fixes #23441