### PR TITLE
Increase pulumi neo task-creation timeout to tolerate cold starts

### DIFF
--- a/changelog/pending/cli-neo-fix-coldstart-timeout.yaml
+++ b/changelog/pending/cli-neo-fix-coldstart-timeout.yaml
@@ -2,3 +2,5 @@ component: cli/neo
 kind: fix
 body: Increase the `pulumi neo` task-creation timeout so backend cold starts no longer fail
 time: 2026-06-04T00:00:00.000000+00:00
+custom:
+    PR: "23444"

--- a/changelog/pending/cli-neo-fix-coldstart-timeout.yaml
+++ b/changelog/pending/cli-neo-fix-coldstart-timeout.yaml
@@ -1,0 +1,4 @@
+component: cli/neo
+kind: fix
+body: Increase the `pulumi neo` task-creation timeout so backend cold starts no longer fail
+time: 2026-06-04T00:00:00.000000+00:00

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -56,8 +56,11 @@ import (
 )
 
 const (
-	// 20s before we give up on a copilot request
+	// 20s before we give up on a warm, interactive Neo request.
 	NeoRequestTimeout = 20 * time.Second
+	// Task creation can trigger a backend cold start (up to ~1 min after a new
+	// Neo version is deployed), so allow it a much longer budget than warm requests.
+	NeoCreateTaskTimeout = 120 * time.Second
 )
 
 // NeoApprovalMode controls whether the agent requires user approval before executing tools.
@@ -2663,7 +2666,7 @@ func (pc *Client) CreateNeoTask(
 	projectName string,
 	opts CreateNeoTaskOptions,
 ) (*NeoTaskResponse, error) {
-	ctx, cancel := context.WithTimeout(ctx, NeoRequestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, NeoCreateTaskTimeout)
 	defer cancel()
 
 	request := NeoTaskRequest{


### PR DESCRIPTION
The first `pulumi neo` request after a Neo version is deployed triggers a backend cold start (up to ~1 min), exceeding the shared 20s request timeout and failing with `context deadline exceeded`. Give task creation its own 120s timeout; warm interactive requests stay at 20s.

Fixes pulumi/pulumi-service#44285

🤖 Generated with [Claude Code](https://claude.com/claude-code)