### PR TITLE
always create the changelog/go.mod update PR from master

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,7 +37,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          # `inputs.ref` is the release tag, which points at a commit created
+          # before the freeze PR landed. Branch off master so we pick up the
+          # freeze PR's changes (sdk/.version bump, .release-pending marker).
+          ref: master
+          fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version-file: sdk/go.mod


### PR DESCRIPTION
Currently, the release-pr uses the commit of the release being done to start creating the changelog/go.mod update PR.  This is correct, however it doesn't work in conjunction with
https://github.com/pulumi/pulumi/pull/23429, because the `.release-pending` file doesn't exist yet in that commit.

Instead, always create this PR from `master`.  In practice, this has the same end result, as the freeze PR will always freeze the exact commit before it gets merged, and no PRs can be merged after the freeze PR.  Also the changelog/go.mod update PR will always be merged on top of the freeze PR anyway, so this just keeps it slightly more up-to-date.

This should fix the issues seen in https://github.com/pulumi/pulumi/pull/23438.