### PR TITLE
add `pulumi logs ls` command

### DIFF
--- a/changelog/pending/cli-feature-20260604-101037.yaml
+++ b/changelog/pending/cli-feature-20260604-101037.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: feat
+body: Add `pulumi logs ls` to list automatic log files
+time: 2026-06-04T10:10:37+00:00
+custom:
+  PR: 23449

--- a/pkg/cmd/pulumi/logs/decrypt.go
+++ b/pkg/cmd/pulumi/logs/decrypt.go
@@ -288,7 +288,7 @@ func parseLogTimestamp(name string) (time.Time, bool) {
 	if m == "" {
 		return time.Time{}, false
 	}
-	t, err := time.Parse("20060102T150405", m)
+	t, err := time.ParseInLocation("20060102T150405", m, time.Local)
 	if err != nil {
 		return time.Time{}, false
 	}

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -198,6 +198,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 	constrictor.AttachArguments(logsCmd, constrictor.NoArgs)
 
 	logsCmd.AddCommand(newDecryptCmd(ws))
+	logsCmd.AddCommand(newLsCmd())
 
 	logsCmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",

--- a/pkg/cmd/pulumi/logs/ls.go
+++ b/pkg/cmd/pulumi/logs/ls.go
@@ -1,0 +1,211 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newLsCmd() *cobra.Command {
+	var jsonOut bool
+
+	c := &cobra.Command{
+		Use:     "ls",
+		Aliases: []string{"list"},
+		Short:   "List automatic log files",
+		Long: "List automatic log files\n" +
+			"\n" +
+			"Each entry shows the stack the log belongs to, when it was\n" +
+			"created, the associated update ID (or PID for CLI-level logs\n" +
+			"that were never attached to a stack), the file size, and the\n" +
+			"full path to the file.",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			logsDir, err := workspace.GetPulumiPath("logs")
+			if err != nil {
+				return fmt.Errorf("getting log directory: %w", err)
+			}
+
+			entries, err := listLogs(logsDir)
+			if err != nil {
+				return err
+			}
+
+			out := cobraCmd.OutOrStdout()
+			if jsonOut {
+				return printLogsJSON(out, entries)
+			}
+			return printLogsTable(out, logsDir, entries)
+		},
+	}
+
+	constrictor.AttachArguments(c, constrictor.NoArgs)
+
+	c.Flags().BoolVarP(&jsonOut, "json", "j", false, "Emit output as JSON")
+
+	return c
+}
+
+type logEntry struct {
+	path      string    // absolute path to the file
+	name      string    // basename
+	stack     string    // decoded stack name; empty for CLI-level logs
+	timestamp time.Time // timestamp parsed from the filename
+	updateID  string    // update ID, or PID for CLI-level logs; may be empty
+	cliLevel  bool      // true if the file was a CLI-level log (pulumi- prefix)
+	size      int64
+}
+
+func listLogs(logsDir string) ([]logEntry, error) {
+	dirEntries, err := os.ReadDir(logsDir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading log directory %s: %w", logsDir, err)
+	}
+
+	entries := slice.Prealloc[logEntry](len(dirEntries))
+	for _, e := range dirEntries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+			continue
+		}
+		ts, ok := parseLogTimestamp(e.Name())
+		if !ok {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(logsDir, e.Name())
+		stack, updateID, cliLevel := parseLogName(e.Name())
+		entries = append(entries, logEntry{
+			path:      path,
+			name:      e.Name(),
+			stack:     stack,
+			timestamp: ts,
+			updateID:  updateID,
+			cliLevel:  cliLevel,
+			size:      info.Size(),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].timestamp.After(entries[j].timestamp)
+	})
+
+	return entries, nil
+}
+
+func parseLogName(name string) (stack, updateID string, cliLevel bool) {
+	loc := logTimestampRe.FindStringIndex(name)
+	if loc == nil {
+		return "", "", false
+	}
+
+	prefix := strings.TrimSuffix(name[:loc[0]], "-")
+	suffix := strings.TrimSuffix(name[loc[1]:], ".log")
+	suffix = strings.TrimPrefix(suffix, "-")
+
+	if prefix == "pulumi" {
+		return "", suffix, true
+	}
+	return strings.ReplaceAll(prefix, "+", "/"), suffix, false
+}
+
+func printLogsTable(out io.Writer, logsDir string, entries []logEntry) error {
+	if len(entries) == 0 {
+		fmt.Fprintf(out, "No log files found in %s\n", logsDir)
+		return nil
+	}
+
+	rows := slice.Prealloc[cmdutil.TableRow](len(entries))
+	for _, e := range entries {
+		stack := e.stack
+		if stack == "" {
+			stack = "(cli)"
+		}
+
+		updateID := e.updateID
+		if updateID == "" {
+			updateID = "—"
+		}
+
+		rows = append(rows, cmdutil.TableRow{
+			Columns: []string{
+				stack,
+				humanize.Time(e.timestamp),
+				updateID,
+				humanize.Bytes(uint64(e.size)),
+				e.path,
+			},
+		})
+	}
+
+	ui.FprintTable(out, cmdutil.Table{
+		Headers: []string{"STACK", "CREATED", "UPDATE ID", "SIZE", "FILE"},
+		Rows:    rows,
+	}, nil)
+
+	return nil
+}
+
+type logEntryListJSON struct {
+	File      string `json:"file"`
+	Path      string `json:"path"`
+	Stack     string `json:"stack,omitempty"`
+	Timestamp string `json:"timestamp"`
+	UpdateID  string `json:"updateId,omitempty"`
+	PID       string `json:"pid,omitempty"`
+	Size      int64  `json:"size"`
+}
+
+func printLogsJSON(out io.Writer, entries []logEntry) error {
+	rows := slice.Prealloc[logEntryListJSON](len(entries))
+	for _, e := range entries {
+		row := logEntryListJSON{
+			File:      e.name,
+			Path:      e.path,
+			Stack:     e.stack,
+			Timestamp: cmd.FormatTime(e.timestamp.UTC()),
+			Size:      e.size,
+		}
+		if e.cliLevel {
+			row.PID = e.updateID
+		} else {
+			row.UpdateID = e.updateID
+		}
+		rows = append(rows, row)
+	}
+	return ui.FprintJSON(out, rows)
+}

--- a/pkg/cmd/pulumi/logs/ls.go
+++ b/pkg/cmd/pulumi/logs/ls.go
@@ -31,13 +31,28 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type lsRender func(c *lsCmd, entries []logEntry) error
+
+type lsCmd struct {
+	logsDir string
+	w       io.Writer
+
+	output outputflag.OutputFlag[lsRender]
+}
+
 func newLsCmd() *cobra.Command {
-	var jsonOut bool
+	lc := &lsCmd{
+		output: outputflag.OutputFlag[lsRender]{
+			RenderForTerminal: (*lsCmd).renderTable,
+			RenderJSON:        (*lsCmd).renderJSON,
+		},
+	}
 
 	c := &cobra.Command{
 		Use:     "ls",
@@ -60,19 +75,24 @@ func newLsCmd() *cobra.Command {
 				return err
 			}
 
-			out := cobraCmd.OutOrStdout()
-			if jsonOut {
-				return printLogsJSON(out, entries)
-			}
-			return printLogsTable(out, logsDir, entries)
+			lc.logsDir = logsDir
+			lc.w = cobraCmd.OutOrStdout()
+			return lc.output.Get()(lc, entries)
 		},
 	}
 
 	constrictor.AttachArguments(c, constrictor.NoArgs)
-
-	c.Flags().BoolVarP(&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.Var(c.Flags(), &lc.output)
 
 	return c
+}
+
+func (c *lsCmd) renderTable(entries []logEntry) error {
+	return printLogsTable(c.w, c.logsDir, entries)
+}
+
+func (c *lsCmd) renderJSON(entries []logEntry) error {
+	return printLogsJSON(c.w, entries)
 }
 
 type logEntry struct {

--- a/pkg/cmd/pulumi/logs/ls_test.go
+++ b/pkg/cmd/pulumi/logs/ls_test.go
@@ -202,6 +202,18 @@ func TestPrintLogsTableEmpty(t *testing.T) {
 	require.Contains(t, buf.String(), "No log files found in "+dir)
 }
 
+func TestParseLogTimestampLocalZone(t *testing.T) {
+	t.Parallel()
+
+	// Filenames are written using time.Now().Format(...) in local time,
+	// so parsing must round-trip in the same zone — otherwise displays
+	// like "1 hour from now" appear when the offset is non-zero.
+	want := time.Date(2026, 4, 1, 12, 0, 0, 0, time.Local)
+	got, ok := parseLogTimestamp("dev-20260401T120000.log")
+	require.True(t, ok)
+	require.True(t, want.Equal(got), "expected %v, got %v", want, got)
+}
+
 func TestPrintLogsTableRenders(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/pulumi/logs/ls_test.go
+++ b/pkg/cmd/pulumi/logs/ls_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/engine/encryptedlog"
+)
+
+func TestParseLogName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		filename string
+		stack    string
+		updateID string
+		cliLevel bool
+	}{
+		{
+			name:     "cli-level with pid",
+			filename: "pulumi-20260401T120000-12345.log",
+			stack:    "",
+			updateID: "12345",
+			cliLevel: true,
+		},
+		{
+			name:     "stack only",
+			filename: "dev-20260401T120000.log",
+			stack:    "dev",
+			updateID: "",
+			cliLevel: false,
+		},
+		{
+			name:     "stack with update id",
+			filename: "dev-20260401T120000-abc123.log",
+			stack:    "dev",
+			updateID: "abc123",
+			cliLevel: false,
+		},
+		{
+			name:     "org/project/stack encoded with plus",
+			filename: "acme+myproj+prod-20260401T120000-u-1.log",
+			stack:    "acme/myproj/prod",
+			updateID: "u-1",
+			cliLevel: false,
+		},
+		{
+			name:     "no timestamp returns empty",
+			filename: "garbage.log",
+			stack:    "",
+			updateID: "",
+			cliLevel: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stack, updateID, cliLevel := parseLogName(tc.filename)
+			require.Equal(t, tc.stack, stack)
+			require.Equal(t, tc.updateID, updateID)
+			require.Equal(t, tc.cliLevel, cliLevel)
+		})
+	}
+}
+
+func TestListLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cliPath := filepath.Join(dir, "pulumi-20260401T100000-9999.log")
+	require.NoError(t, os.WriteFile(cliPath, []byte("plain"), 0o600))
+
+	devPath := filepath.Join(dir, "acme+proj+dev-20260401T120000-u-1.log")
+	require.NoError(t, os.WriteFile(devPath, []byte(encryptedlog.Magic), 0o600))
+
+	prodPath := filepath.Join(dir, "prod-20260401T110000.log")
+	gzFile, err := os.Create(prodPath)
+	require.NoError(t, err)
+	gz := gzip.NewWriter(gzFile)
+	_, err = gz.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.NoError(t, gzFile.Close())
+
+	// Files that should be ignored.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stray.log"), []byte("x"), 0o600))
+
+	entries, err := listLogs(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	require.Equal(t, "acme+proj+dev-20260401T120000-u-1.log", entries[0].name)
+	require.Equal(t, devPath, entries[0].path)
+	require.Equal(t, "acme/proj/dev", entries[0].stack)
+	require.Equal(t, "u-1", entries[0].updateID)
+	require.False(t, entries[0].cliLevel)
+
+	require.Equal(t, "prod-20260401T110000.log", entries[1].name)
+	require.Equal(t, prodPath, entries[1].path)
+	require.Equal(t, "prod", entries[1].stack)
+	require.Equal(t, "", entries[1].updateID)
+
+	require.Equal(t, "pulumi-20260401T100000-9999.log", entries[2].name)
+	require.Equal(t, cliPath, entries[2].path)
+	require.Equal(t, "", entries[2].stack)
+	require.True(t, entries[2].cliLevel)
+	require.Equal(t, "9999", entries[2].updateID)
+}
+
+func TestListLogsMissingDir(t *testing.T) {
+	t.Parallel()
+
+	entries, err := listLogs(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.NoError(t, err)
+	require.Empty(t, entries)
+}
+
+func TestPrintLogsJSON(t *testing.T) {
+	t.Parallel()
+
+	ts1, err := time.Parse("20060102T150405", "20260401T120000")
+	require.NoError(t, err)
+	ts2, err := time.Parse("20060102T150405", "20260401T100000")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "acme+proj+dev-20260401T120000-u-1.log")
+	cliPath := filepath.Join(dir, "pulumi-20260401T100000-9999.log")
+
+	entries := []logEntry{
+		{
+			path:      devPath,
+			name:      "acme+proj+dev-20260401T120000-u-1.log",
+			stack:     "acme/proj/dev",
+			timestamp: ts1,
+			updateID:  "u-1",
+			cliLevel:  false,
+			size:      42,
+		},
+		{
+			path:      cliPath,
+			name:      "pulumi-20260401T100000-9999.log",
+			stack:     "",
+			timestamp: ts2,
+			updateID:  "9999",
+			cliLevel:  true,
+			size:      7,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, printLogsJSON(&buf, entries))
+
+	var got []logEntryListJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+
+	require.Equal(t, devPath, got[0].Path)
+	require.Equal(t, "acme/proj/dev", got[0].Stack)
+	require.Equal(t, "u-1", got[0].UpdateID)
+	require.Empty(t, got[0].PID)
+	require.Equal(t, int64(42), got[0].Size)
+
+	require.Equal(t, cliPath, got[1].Path)
+	require.Empty(t, got[1].Stack)
+	require.Empty(t, got[1].UpdateID)
+	require.Equal(t, "9999", got[1].PID)
+}
+
+func TestPrintLogsTableEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "logs")
+
+	var buf bytes.Buffer
+	require.NoError(t, printLogsTable(&buf, dir, nil))
+	require.Contains(t, buf.String(), "No log files found in "+dir)
+}
+
+func TestPrintLogsTableRenders(t *testing.T) {
+	t.Parallel()
+
+	ts, err := time.Parse("20060102T150405", "20260401T120000")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "acme+proj+dev-20260401T120000-u-1.log")
+	cliPath := filepath.Join(dir, "pulumi-20260401T100000-9999.log")
+
+	entries := []logEntry{
+		{
+			path:      devPath,
+			name:      "acme+proj+dev-20260401T120000-u-1.log",
+			stack:     "acme/proj/dev",
+			timestamp: ts,
+			updateID:  "u-1",
+			size:      4096,
+		},
+		{
+			path:      cliPath,
+			name:      "pulumi-20260401T100000-9999.log",
+			stack:     "",
+			timestamp: ts.Add(-2 * time.Hour),
+			updateID:  "9999",
+			cliLevel:  true,
+			size:      512,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, printLogsTable(&buf, dir, entries))
+
+	out := buf.String()
+	for _, want := range []string{
+		"STACK", "CREATED", "UPDATE ID", "SIZE", "FILE",
+		"acme/proj/dev", "u-1",
+		"(cli)", "9999",
+		devPath,
+		cliPath,
+	} {
+		require.Contains(t, out, want, "missing %q in output:\n%s", want, out)
+	}
+}


### PR DESCRIPTION
Add this as a way to list all logs that have been produced by the automatic logging system.

Fixes https://github.com/pulumi/pulumi/issues/23446
