### PR TITLE
Treat affirmative neo approval replies as ok=true

### DIFF
--- a/changelog/pending/cli-neo-affirmative-approvals.yaml
+++ b/changelog/pending/cli-neo-affirmative-approvals.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Treat affirmative replies such as "ok", "approve" and "go ahead" to `pulumi neo` approval prompts as approvals
 time: 2026-06-04T00:00:00.000000+00:00
 custom:
-    PR: "0"
+    PR: "23450"

--- a/changelog/pending/cli-neo-affirmative-approvals.yaml
+++ b/changelog/pending/cli-neo-affirmative-approvals.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: improvement
+body: Treat affirmative replies such as "ok", "approve" and "go ahead" to `pulumi neo` approval prompts as approvals
+time: 2026-06-04T00:00:00.000000+00:00
+custom:
+    PR: "0"

--- a/pkg/cmd/pulumi/neo/approval_classify.go
+++ b/pkg/cmd/pulumi/neo/approval_classify.go
@@ -1,0 +1,56 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import "strings"
+
+// approvalPhrases mirrors APPROVAL_PHRASES in the console
+// (cmd/console2/src/app/agents/utils/text-approval.util.ts) and approvalPhrases
+// in the service (cmd/service/services/agents/approval_classifier.go). Keep the
+// shared phrases in sync so the same reply classifies identically whether it
+// arrives via CLI, console, or Slack.
+//
+// "go on", "all right", and "alright" are CLI-only additions (not in the
+// service/console lists); they only ever widen what the CLI accepts as an
+// affirmative, so they're safe to carry locally.
+var approvalPhrases = map[string]struct{}{
+	"yes": {}, "approve": {}, "approved": {}, "ok": {}, "okay": {},
+	"confirm": {}, "confirmed": {}, "go ahead": {}, "proceed": {},
+	"lgtm": {}, "go for it": {}, "do it": {}, "ship it": {}, "y": {},
+	// CLI-only additions:
+	"go on": {}, "all right": {}, "alright": {},
+}
+
+// normalizeApprovalReply lowercases, trims, and collapses internal whitespace so
+// "  Go   Ahead " matches "go ahead".
+func normalizeApprovalReply(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+// classifyApprovalReply maps a free-text reply to a pending approval to
+// (approved, instructions). A recognized affirmative phrase approves with no
+// instructions; anything else denies and forwards the typed text as the agent's
+// instructions.
+//
+// Only whole-input affirmatives count — a compound reply like "yes but only on
+// dev" stays a denial so its instructions reach the agent. We intentionally do
+// not classify rejection phrases here: a bare "no" still denies with its text as
+// instructions, matching prior CLI behavior.
+func classifyApprovalReply(text string) (approved bool, instructions string) {
+	if _, ok := approvalPhrases[normalizeApprovalReply(text)]; ok {
+		return true, ""
+	}
+	return false, strings.TrimSpace(text)
+}

--- a/pkg/cmd/pulumi/neo/approval_classify.go
+++ b/pkg/cmd/pulumi/neo/approval_classify.go
@@ -16,41 +16,22 @@ package neo
 
 import "strings"
 
-// approvalPhrases mirrors APPROVAL_PHRASES in the console
-// (cmd/console2/src/app/agents/utils/text-approval.util.ts) and approvalPhrases
-// in the service (cmd/service/services/agents/approval_classifier.go). Keep the
-// shared phrases in sync so the same reply classifies identically whether it
-// arrives via CLI, console, or Slack.
-//
-// "go on", "all right", and "alright" are CLI-only additions (not in the
-// service/console lists); they only ever widen what the CLI accepts as an
-// affirmative, so they're safe to carry locally.
-var approvalPhrases = map[string]struct{}{
-	"yes": {}, "approve": {}, "approved": {}, "ok": {}, "okay": {},
-	"confirm": {}, "confirmed": {}, "go ahead": {}, "proceed": {},
-	"lgtm": {}, "go for it": {}, "do it": {}, "ship it": {}, "y": {},
-	// CLI-only additions:
-	"go on": {}, "all right": {}, "alright": {},
+// affirmativeReplies are the whole-input replies the CLI accepts as an approval.
+// The shared phrases mirror the console "Yes" button and the service classifier
+// (pulumi-service cmd/service/services/agents/approval_classifier.go) — keep them
+// in sync so a reply classifies the same via CLI, console, or Slack. "go on",
+// "all right" and "alright" are CLI-only; they only widen what counts as a yes.
+var affirmativeReplies = map[string]struct{}{
+	"yes": {}, "y": {}, "ok": {}, "okay": {}, "approve": {}, "approved": {},
+	"confirm": {}, "confirmed": {}, "proceed": {}, "go ahead": {}, "go for it": {},
+	"do it": {}, "ship it": {}, "lgtm": {}, "go on": {}, "all right": {}, "alright": {},
 }
 
-// normalizeApprovalReply lowercases, trims, and collapses internal whitespace so
-// "  Go   Ahead " matches "go ahead".
-func normalizeApprovalReply(s string) string {
-	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
-}
-
-// classifyApprovalReply maps a free-text reply to a pending approval to
-// (approved, instructions). A recognized affirmative phrase approves with no
-// instructions; anything else denies and forwards the typed text as the agent's
-// instructions.
-//
-// Only whole-input affirmatives count — a compound reply like "yes but only on
-// dev" stays a denial so its instructions reach the agent. We intentionally do
-// not classify rejection phrases here: a bare "no" still denies with its text as
-// instructions, matching prior CLI behavior.
-func classifyApprovalReply(text string) (approved bool, instructions string) {
-	if _, ok := approvalPhrases[normalizeApprovalReply(text)]; ok {
-		return true, ""
-	}
-	return false, strings.TrimSpace(text)
+// isAffirmative reports whether an approval reply is a bare yes, case- and
+// whitespace-insensitive ("  Go  Ahead " == "go ahead"). A compound reply like
+// "yes but only on dev" is not affirmative, so its text still reaches the agent
+// as instructions.
+func isAffirmative(reply string) bool {
+	_, ok := affirmativeReplies[strings.Join(strings.Fields(strings.ToLower(reply)), " ")]
+	return ok
 }

--- a/pkg/cmd/pulumi/neo/approval_classify_test.go
+++ b/pkg/cmd/pulumi/neo/approval_classify_test.go
@@ -20,45 +20,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClassifyApprovalReply(t *testing.T) {
+func TestIsAffirmative(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		text             string
-		wantApproved     bool
-		wantInstructions string
-	}{
-		// Affirmatives → approved, no instructions.
-		{"y", true, ""},
-		{"yes", true, ""},
-		{"YES", true, ""},
-		{"ok", true, ""},
-		{"okay", true, ""},
-		{"approve", true, ""},
-		{"approved", true, ""},
-		{"confirm", true, ""},
-		{"go ahead", true, ""},
-		{"  Go   Ahead ", true, ""}, // whitespace collapses
-		{"lgtm", true, ""},
-		{"ship it", true, ""},
-		// CLI-only additions.
-		{"go on", true, ""},
-		{"all right", true, ""},
-		{"alright", true, ""},
-		// Non-affirmatives → denial, text forwarded as instructions.
-		{"not on prod", false, "not on prod"},
-		{"yes but only on dev", false, "yes but only on dev"}, // compound is not a bare affirmative
-		{"no", false, "no"},                                   // rejection phrases are not special-cased
-		{"cancel", false, "cancel"},
-		{"  trim me  ", false, "trim me"},
-		{"", false, ""},
+	for _, s := range []string{
+		"y", "yes", "YES", "ok", "okay", "approve", "approved", "confirm",
+		"confirmed", "proceed", "go ahead", "  Go   Ahead ", "go for it",
+		"do it", "ship it", "lgtm", "go on", "all right", "alright",
+	} {
+		assert.True(t, isAffirmative(s), "%q should be affirmative", s)
 	}
-	for _, tt := range tests {
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-			approved, instructions := classifyApprovalReply(tt.text)
-			assert.Equal(t, tt.wantApproved, approved)
-			assert.Equal(t, tt.wantInstructions, instructions)
-		})
+	for _, s := range []string{"", "no", "cancel", "not on prod", "yes but only on dev"} {
+		assert.False(t, isAffirmative(s), "%q should not be affirmative", s)
 	}
 }

--- a/pkg/cmd/pulumi/neo/approval_classify_test.go
+++ b/pkg/cmd/pulumi/neo/approval_classify_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyApprovalReply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		text             string
+		wantApproved     bool
+		wantInstructions string
+	}{
+		// Affirmatives → approved, no instructions.
+		{"y", true, ""},
+		{"yes", true, ""},
+		{"YES", true, ""},
+		{"ok", true, ""},
+		{"okay", true, ""},
+		{"approve", true, ""},
+		{"approved", true, ""},
+		{"confirm", true, ""},
+		{"go ahead", true, ""},
+		{"  Go   Ahead ", true, ""}, // whitespace collapses
+		{"lgtm", true, ""},
+		{"ship it", true, ""},
+		// CLI-only additions.
+		{"go on", true, ""},
+		{"all right", true, ""},
+		{"alright", true, ""},
+		// Non-affirmatives → denial, text forwarded as instructions.
+		{"not on prod", false, "not on prod"},
+		{"yes but only on dev", false, "yes but only on dev"}, // compound is not a bare affirmative
+		{"no", false, "no"},                                   // rejection phrases are not special-cased
+		{"cancel", false, "cancel"},
+		{"  trim me  ", false, "trim me"},
+		{"", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+			approved, instructions := classifyApprovalReply(tt.text)
+			assert.Equal(t, tt.wantApproved, approved)
+			assert.Equal(t, tt.wantInstructions, instructions)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -779,7 +779,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					answerCmd := m.commitBlock(block{kind: blockAnswerSubmitted, raw: text})
 					return m, tea.Batch(answerCmd, m.showBusy(thinkingLabel, shimmerVerb))
 				}
-				approved, denialMsg := classifyApprovalReply(text)
+				approved := isAffirmative(text)
+				denialMsg := ""
+				if !approved {
+					denialMsg = text
+				}
 				wasPlanApproval := m.pendingApprovalType == approvalTypePlanExit
 				m.sendOut(outboundEvent{
 					event: apitype.AgentUserEventUserConfirmation{

--- a/pkg/cmd/pulumi/neo/tui.go
+++ b/pkg/cmd/pulumi/neo/tui.go
@@ -779,11 +779,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					answerCmd := m.commitBlock(block{kind: blockAnswerSubmitted, raw: text})
 					return m, tea.Batch(answerCmd, m.showBusy(thinkingLabel, shimmerVerb))
 				}
-				approved := strings.EqualFold(text, "y") || strings.EqualFold(text, "yes")
-				var denialMsg string
-				if !approved {
-					denialMsg = text
-				}
+				approved, denialMsg := classifyApprovalReply(text)
 				wasPlanApproval := m.pendingApprovalType == approvalTypePlanExit
 				m.sendOut(outboundEvent{
 					event: apitype.AgentUserEventUserConfirmation{

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -833,14 +833,8 @@ func TestModel_Update_UIApprovalRequest_ShowsPromptAndPausesAgent(t *testing.T) 
 func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 	t.Parallel()
 
-	cases := []string{
-		"y", "Y", "yes", "YES", "Yes",
-		"ok", "okay", "approve", "approved", "confirm", "confirmed",
-		"proceed", "lgtm", "LGTM", "ship it", "do it", "go for it",
-		"go ahead", "  Go   Ahead ",
-		// CLI-only additions.
-		"go on", "all right", "alright",
-	}
+	// Representative sample — exhaustive phrase coverage lives in TestIsAffirmative.
+	cases := []string{"y", "yes", "ok", "go ahead"}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
@@ -881,39 +875,27 @@ func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 
 	// Anything that isn't a recognized affirmative is treated as a denial; the
 	// typed text becomes the instructions field so the agent can act on the
-	// user's reasoning. A bare "no" is NOT special-cased — it denies with "no"
-	// as instructions, matching prior CLI behavior (we don't import the
-	// service's rejection-phrase stripping).
-	cases := map[string]string{
-		"reason":      "not on prod",
-		"compound":    "yes but only on dev",
-		"bare-no":     "no",
-		"bare-cancel": "cancel",
+	// user's reasoning.
+	outCh := make(chan outboundEvent, 1)
+	m := newApprovalPendingModel(t, outCh)
+	m.textInput.SetValue("not on prod")
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	um := updated.(Model)
+
+	select {
+	case got := <-outCh:
+		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+		require.True(t, ok, "expected UserConfirmation, got %T", got.event)
+		assert.False(t, conf.Approved)
+		assert.Equal(t, "appr_1", conf.ApprovalID)
+		assert.Equal(t, "not on prod", conf.Message, "denial must forward the typed reason")
+	default:
+		t.Fatal("Enter must post a confirmation event")
 	}
-	for name, reason := range cases {
-		t.Run(name, func(t *testing.T) {
-			outCh := make(chan outboundEvent, 1)
-			m := newApprovalPendingModel(t, outCh)
-			m.textInput.SetValue(reason)
 
-			updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-			um := updated.(Model)
-
-			select {
-			case got := <-outCh:
-				conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
-				require.True(t, ok, "expected UserConfirmation, got %T", got.event)
-				assert.False(t, conf.Approved)
-				assert.Equal(t, "appr_1", conf.ApprovalID)
-				assert.Equal(t, reason, conf.Message, "denial must forward the typed reason")
-			default:
-				t.Fatal("Enter must post a confirmation event")
-			}
-
-			assert.False(t, um.pendingApproval)
-			assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
-		})
-	}
+	assert.False(t, um.pendingApproval)
+	assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
 }
 
 func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/tui_test.go
+++ b/pkg/cmd/pulumi/neo/tui_test.go
@@ -833,7 +833,14 @@ func TestModel_Update_UIApprovalRequest_ShowsPromptAndPausesAgent(t *testing.T) 
 func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 	t.Parallel()
 
-	cases := []string{"y", "Y", "yes", "YES", "Yes"}
+	cases := []string{
+		"y", "Y", "yes", "YES", "Yes",
+		"ok", "okay", "approve", "approved", "confirm", "confirmed",
+		"proceed", "lgtm", "LGTM", "ship it", "do it", "go for it",
+		"go ahead", "  Go   Ahead ",
+		// CLI-only additions.
+		"go on", "all right", "alright",
+	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {
 			t.Parallel()
@@ -872,28 +879,41 @@ func TestModel_Update_KeyEnter_Approval_ApproveYes(t *testing.T) {
 func TestModel_Update_KeyEnter_Approval_DenyWithReason(t *testing.T) {
 	t.Parallel()
 
-	// Anything that isn't "y"/"yes" is treated as a denial; the typed text becomes
-	// the instructions field so the agent can act on the user's reasoning.
-	outCh := make(chan outboundEvent, 1)
-	m := newApprovalPendingModel(t, outCh)
-	m.textInput.SetValue("not on prod")
-
-	updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
-	um := updated.(Model)
-
-	select {
-	case got := <-outCh:
-		conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
-		require.True(t, ok, "expected UserConfirmation, got %T", got.event)
-		assert.False(t, conf.Approved)
-		assert.Equal(t, "appr_1", conf.ApprovalID)
-		assert.Equal(t, "not on prod", conf.Message, "denial must forward the typed reason")
-	default:
-		t.Fatal("Enter must post a confirmation event")
+	// Anything that isn't a recognized affirmative is treated as a denial; the
+	// typed text becomes the instructions field so the agent can act on the
+	// user's reasoning. A bare "no" is NOT special-cased — it denies with "no"
+	// as instructions, matching prior CLI behavior (we don't import the
+	// service's rejection-phrase stripping).
+	cases := map[string]string{
+		"reason":      "not on prod",
+		"compound":    "yes but only on dev",
+		"bare-no":     "no",
+		"bare-cancel": "cancel",
 	}
+	for name, reason := range cases {
+		t.Run(name, func(t *testing.T) {
+			outCh := make(chan outboundEvent, 1)
+			m := newApprovalPendingModel(t, outCh)
+			m.textInput.SetValue(reason)
 
-	assert.False(t, um.pendingApproval)
-	assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
+			updated, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+			um := updated.(Model)
+
+			select {
+			case got := <-outCh:
+				conf, ok := got.event.(apitype.AgentUserEventUserConfirmation)
+				require.True(t, ok, "expected UserConfirmation, got %T", got.event)
+				assert.False(t, conf.Approved)
+				assert.Equal(t, "appr_1", conf.ApprovalID)
+				assert.Equal(t, reason, conf.Message, "denial must forward the typed reason")
+			default:
+				t.Fatal("Enter must post a confirmation event")
+			}
+
+			assert.False(t, um.pendingApproval)
+			assert.False(t, um.busy, "denial must NOT re-arm busy — the agent is not running")
+		})
+	}
 }
 
 func TestModel_Update_KeyEnter_Approval_DenyEmpty(t *testing.T) {


### PR DESCRIPTION
`pulumi neo` only recognized `y`/`yes` as approvals, so other affirmatives ("ok", "approve", "go ahead", …) were sent as `ok=false` with the text in `instructions`, breaking service logic gated on `confirmation.Ok()` (e.g. plan-mode exit).

Now classifies replies against the affirmative phrase set used by the console "Yes" button / service `approval_classifier.go`: whole-input affirmatives send `ok=true`; free-text replies still send `ok=false` + `instructions`.

Fixes pulumi/pulumi-service#44223

🤖 Generated with [Claude Code](https://claude.com/claude-code)