### PR TITLE
Document recording PR number in changelog entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ All commands assume you're at the repo root.
   - Use `mise exec -- make work` to create a `go.work` file for cross-module development.
 - Proto-generated files must stay in sync with `proto/*.proto`. CI enforces via `mise exec -- make check_proto`.
 - `pkg/codegen/schema/pulumi.json` is the metaschema. It must be valid JSON Schema and pass biome formatting.
-- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Do not end changelog entries with punctuation.
+- Changelog entries are required for most PRs. Run `mise exec -- make changelog` to create one. Try to keep changelog entries to one sentence and focus on user-visible changes. Do not include implementation details. Do not end changelog entries with punctuation. Once the PR exists, add its number to the entry's `custom.PR` field so the changelog links back to it.
 - PRs are squash-merged — the PR description becomes the commit message.
 - Integration tests need the CLI and SDKs built first. `bin/` must be on `PATH`.
 - Copyright headers for new files should always be stamped with the current year.


### PR DESCRIPTION
Adds guidance to AGENTS.md instructing agents to record the PR number in each changelog entry's `custom.PR` field so the rendered changelog links back to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)