### PR TITLE
Resolve neo's tool backend the same way pulumi preview does

### DIFF
--- a/changelog/pending/cli-neo-fix-preview-token-parity.yaml
+++ b/changelog/pending/cli-neo-fix-preview-token-parity.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: fix
+body: Ensure pulumi neo resolves the same Pulumi access token as pulumi preview when running in-process preview and up operations
+time: 2026-06-04T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/cli-neo-fix-preview-token-parity.yaml
+++ b/changelog/pending/cli-neo-fix-preview-token-parity.yaml
@@ -3,4 +3,4 @@ kind: fix
 body: Ensure pulumi neo resolves the same Pulumi access token as pulumi preview when running in-process preview and up operations
 time: 2026-06-04T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23452"

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -275,7 +275,7 @@ func runNeo(
 
 	// In non-interactive mode the sink stays nil and live events are dropped; the
 	// interactive path below sets pu.Sink to push UIEvents onto uiCh.
-	pu, err := tools.NewPulumi(cwdFlag, ws, cloudBe, nil)
+	pu, err := tools.NewPulumi(cwdFlag, ws, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -68,8 +68,6 @@ type Pulumi struct {
 	Cwd string
 	// Workspace is used to read the project file from the working directory.
 	Workspace pkgWorkspace.Context
-	// Backend is the (cloud) backend used to resolve stacks and execute operations.
-	Backend backend.Backend
 	// Sink, when non-nil, receives structured events that power the Neo TUI's
 	// live preview/up block. See PulumiSink for the callback surface. All
 	// fields are optional: a nil callback on any one method is silently skipped.
@@ -103,24 +101,20 @@ type PulumiSink struct {
 	OnEnd func(toolName, err string, counts display.ResourceChanges, elapsed string)
 }
 
-// NewPulumi creates a Pulumi handler sandboxed under cwd. The workspace and backend
-// are captured at construction so tests can inject fakes. Sink may be nil when
-// running outside the interactive TUI (non-interactive mode); in that case progress
-// is silently dropped and the final result is still returned to the caller.
-func NewPulumi(cwd string, ws pkgWorkspace.Context, be backend.Backend,
-	sink *PulumiSink,
-) (*Pulumi, error) {
+// NewPulumi creates a Pulumi handler sandboxed under cwd. The workspace is captured
+// at construction so tests can inject a fake; the backend is resolved fresh on each
+// tool call (see run). Sink may be nil when running outside the interactive TUI
+// (non-interactive mode); in that case progress is silently dropped and the final
+// result is still returned to the caller.
+func NewPulumi(cwd string, ws pkgWorkspace.Context, sink *PulumiSink) (*Pulumi, error) {
 	if ws == nil {
 		return nil, errors.New("workspace is required")
-	}
-	if be == nil {
-		return nil, errors.New("backend is required")
 	}
 	abs, err := canonicalRoot(cwd)
 	if err != nil {
 		return nil, fmt.Errorf("resolving pulumi cwd: %w", err)
 	}
-	return &Pulumi{Cwd: abs, Workspace: ws, Backend: be, Sink: sink}, nil
+	return &Pulumi{Cwd: abs, Workspace: ws, Sink: sink}, nil
 }
 
 // pulumiArgs matches pulumi-service:cmd/agents/src/agents_py/mcp/pulumi_mcp.py's
@@ -243,13 +237,12 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("reading project: %w", err))
 	}
 
-	// Resolve the backend fresh, exactly as `pulumi preview`/`pulumi up` do at
-	// command-run time (stack.RequireStack -> cmdBackend.CurrentBackend -> Login).
-	// The startup backend captured in p.Backend bakes in whatever token was resolved
-	// when `pulumi neo` launched and never re-resolves it, so reusing it can make the
-	// tool authenticate (and decrypt service-managed secrets) as a different identity
-	// than an equivalent `pulumi preview` would. Resolving here — after applyEnvVars
-	// and the chdir into the project dir — keeps the identity in lockstep with the CLI.
+	// Resolve the backend fresh per tool call, the same way `pulumi preview`/`pulumi up`
+	// do (stack.RequireStack -> cmdBackend.CurrentBackend -> Login). A backend frozen at
+	// `pulumi neo` startup bakes in whatever token was resolved then and never refreshes
+	// it, which can make the tool authenticate — and decrypt service-managed secrets — as
+	// a different identity than an equivalent `pulumi preview` would. Resolving here, after
+	// applyEnvVars and the chdir into the project dir, keeps the identity in lockstep.
 	be, err := cmdBackend.CurrentBackend(
 		ctx, p.Workspace, cmdBackend.DefaultLoginManager, proj, backendDisplay.Options{Color: colors.Never})
 	if err != nil {

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/autonaming"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdConfig "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/config"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/metadata"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -242,11 +243,24 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 		return failedResult(a, "", fmt.Errorf("reading project: %w", err))
 	}
 
-	stackRef, err := p.Backend.ParseStackReference(a.StackName)
+	// Resolve the backend fresh, exactly as `pulumi preview`/`pulumi up` do at
+	// command-run time (stack.RequireStack -> cmdBackend.CurrentBackend -> Login).
+	// The startup backend captured in p.Backend bakes in whatever token was resolved
+	// when `pulumi neo` launched and never re-resolves it, so reusing it can make the
+	// tool authenticate (and decrypt service-managed secrets) as a different identity
+	// than an equivalent `pulumi preview` would. Resolving here — after applyEnvVars
+	// and the chdir into the project dir — keeps the identity in lockstep with the CLI.
+	be, err := cmdBackend.CurrentBackend(
+		ctx, p.Workspace, cmdBackend.DefaultLoginManager, proj, backendDisplay.Options{Color: colors.Never})
+	if err != nil {
+		return failedResult(a, "", fmt.Errorf("resolving backend: %w", err))
+	}
+
+	stackRef, err := be.ParseStackReference(a.StackName)
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("parsing stack reference: %w", err))
 	}
-	s, err := p.Backend.GetStack(ctx, stackRef)
+	s, err := be.GetStack(ctx, stackRef)
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("getting stack: %w", err))
 	}

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -238,11 +238,11 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 
 	// Resolve the backend fresh per tool call, the same way `pulumi preview`/`pulumi up`
-	// do (stack.RequireStack -> cmdBackend.CurrentBackend -> Login). A backend frozen at
-	// `pulumi neo` startup bakes in whatever token was resolved then and never refreshes
-	// it, which can make the tool authenticate — and decrypt service-managed secrets — as
-	// a different identity than an equivalent `pulumi preview` would. Resolving here, after
-	// applyEnvVars and the chdir into the project dir, keeps the identity in lockstep.
+	// do (stack.RequireStack -> cmdBackend.CurrentBackend -> Login). Reusing the backend
+	// frozen at `pulumi neo` startup would pin the access token resolved back then, so the
+	// tool could authenticate — and decrypt service-managed secrets — as a different
+	// identity than the user's own `pulumi preview`. Resolving here, after applyEnvVars and
+	// the chdir into the project dir, keeps the two paths in lockstep.
 	be, err := cmdBackend.CurrentBackend(
 		ctx, p.Workspace, cmdBackend.DefaultLoginManager, proj, backendDisplay.Options{Color: colors.Never})
 	if err != nil {

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -376,7 +376,9 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 	// "previously unset is unset on restore" behavior is what we actually exercise below.
 	if orig, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN"); ok {
 		require.NoError(t, os.Unsetenv("PULUMI_ACCESS_TOKEN"))
-		t.Cleanup(func() { _ = os.Setenv("PULUMI_ACCESS_TOKEN", orig) })
+		// t.Setenv can't express "restore the prior value" (there is no t.Unsetenv), so
+		// restore it ourselves.
+		t.Cleanup(func() { _ = os.Setenv("PULUMI_ACCESS_TOKEN", orig) }) //nolint:usetesting
 	}
 
 	var capturedToken string

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -358,6 +360,111 @@ func TestPulumi_InvokeRoutesPreviewAndUp(t *testing.T) {
 				json.RawMessage(`{"project_name":"p","stack_name":"dev"}`))
 			require.Error(t, err)
 			assertFailedResult(t, value, "local_pulumi_dir is required")
+		})
+	}
+}
+
+// newProjectDir creates a canonical sandbox dir containing a minimal Pulumi.yaml so
+// run() gets past its Pulumi.yaml existence check and into backend resolution.
+func newProjectDir(t *testing.T) string {
+	t.Helper()
+	dir, err := canonicalRoot(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "Pulumi.yaml"), []byte("name: p\nruntime: nodejs\n"), 0o600))
+	return dir
+}
+
+// TestPulumi_Run_ResolvesBackendFromLiveEnv proves the tool resolves its backend
+// via cmdBackend.CurrentBackend against the live (post-applyEnvVars) environment,
+// rather than reusing the backend frozen into p.Backend at neo startup. The frozen
+// backend is wired to fail the test if it is ever consulted.
+func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
+	// Not parallel: mutates the global cmdBackend.BackendInstance and process env.
+	dir := newProjectDir(t)
+
+	var capturedToken string
+	var resolved bool
+	resolvedBackend := &backend.MockBackend{
+		ParseStackReferenceF: func(string) (backend.StackReference, error) {
+			resolved = true
+			// The agent-injected PULUMI_ACCESS_TOKEN must be visible here, proving the
+			// backend was resolved after applyEnvVars. Stop run() early with an error.
+			capturedToken = os.Getenv("PULUMI_ACCESS_TOKEN")
+			return nil, errors.New("stop after resolution")
+		},
+	}
+	prev := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = resolvedBackend
+	t.Cleanup(func() { cmdBackend.BackendInstance = prev })
+
+	frozenBackend := &backend.MockBackend{
+		ParseStackReferenceF: func(string) (backend.StackReference, error) {
+			t.Error("frozen p.Backend was used instead of the freshly resolved backend")
+			return nil, errors.New("frozen backend should not be consulted")
+		},
+	}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "p"}, dir, nil
+		},
+	}
+	p := &Pulumi{Cwd: dir, Workspace: ws, Backend: frozenBackend}
+
+	args, err := json.Marshal(map[string]any{
+		"project_name":     "p",
+		"stack_name":       "dev",
+		"local_pulumi_dir": dir,
+		"environment_variables": map[string]any{
+			"PULUMI_ACCESS_TOKEN": map[string]any{"secret": "live-token"},
+		},
+	})
+	require.NoError(t, err)
+
+	value, err := p.Invoke(t.Context(), "pulumi_preview", args)
+	require.Error(t, err)
+	assert.True(t, resolved, "freshly resolved backend was never consulted")
+	assert.Equal(t, "live-token", capturedToken)
+	assertFailedResult(t, value, "parsing stack reference")
+	// The injected env var is restored after the call.
+	_, present := os.LookupEnv("PULUMI_ACCESS_TOKEN")
+	assert.False(t, present, "PULUMI_ACCESS_TOKEN should be restored after the tool call")
+}
+
+// TestPulumi_Run_PreviewAndUpResolveBackend proves both pulumi_preview and pulumi_up
+// share the same fresh backend resolution (they share run()).
+func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
+	for _, method := range []string{"pulumi_preview", "pulumi_up"} {
+		t.Run(method, func(t *testing.T) {
+			dir := newProjectDir(t)
+
+			var resolved bool
+			cmdBackend.BackendInstance = &backend.MockBackend{
+				ParseStackReferenceF: func(string) (backend.StackReference, error) {
+					resolved = true
+					return nil, errors.New("stop after resolution")
+				},
+			}
+			t.Cleanup(func() { cmdBackend.BackendInstance = nil })
+
+			ws := &pkgWorkspace.MockContext{
+				ReadProjectF: func() (*workspace.Project, string, error) {
+					return &workspace.Project{Name: "p"}, dir, nil
+				},
+			}
+			p := &Pulumi{Cwd: dir, Workspace: ws, Backend: newFakePulumiBackend()}
+
+			args, err := json.Marshal(map[string]any{
+				"project_name":     "p",
+				"stack_name":       "dev",
+				"local_pulumi_dir": dir,
+			})
+			require.NoError(t, err)
+
+			value, err := p.Invoke(t.Context(), method, args)
+			require.Error(t, err)
+			assert.True(t, resolved, "backend was not resolved via CurrentBackend")
+			assertFailedResult(t, value, "parsing stack reference")
 		})
 	}
 }

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -41,22 +41,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func TestPulumi_NewPulumiRejectsMissingDependencies(t *testing.T) {
+func TestPulumi_NewPulumiRejectsMissingWorkspace(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewPulumi(t.TempDir(), nil, nil, nil)
+	_, err := NewPulumi(t.TempDir(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workspace")
-}
-
-func TestPulumi_NewPulumiRejectsNilBackend(t *testing.T) {
-	t.Parallel()
-
-	// Workspace present, backend nil — covers the second guard distinct from
-	// the workspace-only case above.
-	_, err := NewPulumi(t.TempDir(), &pkgWorkspace.MockContext{}, nil, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "backend")
 }
 
 func TestPulumi_NewPulumiHappyPath(t *testing.T) {
@@ -64,10 +54,9 @@ func TestPulumi_NewPulumiHappyPath(t *testing.T) {
 
 	cwd := t.TempDir()
 	ws := &pkgWorkspace.MockContext{}
-	be := newFakePulumiBackend()
 	sink := &PulumiSink{}
 
-	pu, err := NewPulumi(cwd, ws, be, sink)
+	pu, err := NewPulumi(cwd, ws, sink)
 	require.NoError(t, err)
 	require.NotNil(t, pu)
 
@@ -79,7 +68,6 @@ func TestPulumi_NewPulumiHappyPath(t *testing.T) {
 	assert.Equal(t, want, pu.Cwd)
 
 	assert.Same(t, ws, pu.Workspace)
-	assert.Same(t, be, pu.Backend)
 	assert.Same(t, sink, pu.Sink)
 }
 
@@ -376,16 +364,18 @@ func newProjectDir(t *testing.T) string {
 }
 
 // TestPulumi_Run_ResolvesBackendFromLiveEnv proves the tool resolves its backend
-// via cmdBackend.CurrentBackend against the live (post-applyEnvVars) environment,
-// rather than reusing the backend frozen into p.Backend at neo startup. The frozen
-// backend is wired to fail the test if it is ever consulted.
+// via cmdBackend.CurrentBackend against the live (post-applyEnvVars) environment, so
+// an agent-injected PULUMI_ACCESS_TOKEN is honored rather than a token frozen at neo
+// startup — keeping the tool's identity in lockstep with `pulumi preview`.
+//
+//nolint:paralleltest // mutates the global cmdBackend.BackendInstance and process env
 func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
-	// Not parallel: mutates the global cmdBackend.BackendInstance and process env.
 	dir := newProjectDir(t)
 
 	var capturedToken string
 	var resolved bool
-	resolvedBackend := &backend.MockBackend{
+	prev := cmdBackend.BackendInstance
+	cmdBackend.BackendInstance = &backend.MockBackend{
 		ParseStackReferenceF: func(string) (backend.StackReference, error) {
 			resolved = true
 			// The agent-injected PULUMI_ACCESS_TOKEN must be visible here, proving the
@@ -394,22 +384,14 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 			return nil, errors.New("stop after resolution")
 		},
 	}
-	prev := cmdBackend.BackendInstance
-	cmdBackend.BackendInstance = resolvedBackend
 	t.Cleanup(func() { cmdBackend.BackendInstance = prev })
 
-	frozenBackend := &backend.MockBackend{
-		ParseStackReferenceF: func(string) (backend.StackReference, error) {
-			t.Error("frozen p.Backend was used instead of the freshly resolved backend")
-			return nil, errors.New("frozen backend should not be consulted")
-		},
-	}
 	ws := &pkgWorkspace.MockContext{
 		ReadProjectF: func() (*workspace.Project, string, error) {
 			return &workspace.Project{Name: "p"}, dir, nil
 		},
 	}
-	p := &Pulumi{Cwd: dir, Workspace: ws, Backend: frozenBackend}
+	p := &Pulumi{Cwd: dir, Workspace: ws}
 
 	args, err := json.Marshal(map[string]any{
 		"project_name":     "p",
@@ -433,8 +415,11 @@ func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 
 // TestPulumi_Run_PreviewAndUpResolveBackend proves both pulumi_preview and pulumi_up
 // share the same fresh backend resolution (they share run()).
+//
+//nolint:paralleltest // mutates the global cmdBackend.BackendInstance
 func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 	for _, method := range []string{"pulumi_preview", "pulumi_up"} {
+		//nolint:paralleltest // mutates the global cmdBackend.BackendInstance
 		t.Run(method, func(t *testing.T) {
 			dir := newProjectDir(t)
 
@@ -452,7 +437,7 @@ func TestPulumi_Run_PreviewAndUpResolveBackend(t *testing.T) {
 					return &workspace.Project{Name: "p"}, dir, nil
 				},
 			}
-			p := &Pulumi{Cwd: dir, Workspace: ws, Backend: newFakePulumiBackend()}
+			p := &Pulumi{Cwd: dir, Workspace: ws}
 
 			args, err := json.Marshal(map[string]any{
 				"project_name":     "p",
@@ -910,21 +895,6 @@ func (f *fakeHTTPStack) StackIdentifier() client.StackIdentifier {
 	return client.StackIdentifier{}
 }
 
-// fakePulumiBackend is a backend.Backend used by NewPulumi happy-path test.
-// All cloud-specific calls are no-ops because NewPulumi only stores the
-// reference — it never dispatches anything against it at construction time.
-type fakePulumiBackend struct {
-	*backend.MockBackend
-}
-
-func newFakePulumiBackend() *fakePulumiBackend {
-	return &fakePulumiBackend{MockBackend: &backend.MockBackend{}}
-}
-
-// Compile-time assertions: fakeHTTPStack must satisfy httpstate.Stack so the
-// type assertion in autonamingStackContextFor succeeds. fakePulumiBackend
-// must satisfy backend.Backend.
-var (
-	_ httpstate.Stack = (*fakeHTTPStack)(nil)
-	_ backend.Backend = (*fakePulumiBackend)(nil)
-)
+// Compile-time assertion: fakeHTTPStack must satisfy httpstate.Stack so the
+// type assertion in autonamingStackContextFor succeeds.
+var _ httpstate.Stack = (*fakeHTTPStack)(nil)

--- a/pkg/cmd/pulumi/neo/tools/pulumi_test.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi_test.go
@@ -372,6 +372,13 @@ func newProjectDir(t *testing.T) string {
 func TestPulumi_Run_ResolvesBackendFromLiveEnv(t *testing.T) {
 	dir := newProjectDir(t)
 
+	// Ensure PULUMI_ACCESS_TOKEN is unset in the ambient environment (CI sets it) so the
+	// "previously unset is unset on restore" behavior is what we actually exercise below.
+	if orig, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN"); ok {
+		require.NoError(t, os.Unsetenv("PULUMI_ACCESS_TOKEN"))
+		t.Cleanup(func() { _ = os.Setenv("PULUMI_ACCESS_TOKEN", orig) })
+	}
+
 	var capturedToken string
 	var resolved bool
 	prev := cmdBackend.BackendInstance


### PR DESCRIPTION
`pulumi neo`'s in-process `pulumi_preview`/`pulumi_up` tools reused the backend frozen at neo startup, so they could authenticate — and decrypt service-managed secrets — as a different identity than an equivalent `pulumi preview`, surfacing as `[400] could not decrypt secret at index 0`.

This resolves the backend fresh per tool call via `CurrentBackend` (after env injection), matching the regular CLI path so the identity stays in lockstep with `pulumi preview`.

Fixes pulumi/pulumi-service#44224

🤖 Generated with [Claude Code](https://claude.com/claude-code)