### PR TITLE
Do not download a language plugin we will not use

### DIFF
--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	diagutil "github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
@@ -133,7 +134,10 @@ func EnsureLanguageInstalled(ctx context.Context, runtime string, newLoader plug
 	if !util.SetKnownPluginDownloadURL(&spec) {
 		return nil
 	}
-	if pluginstorage.Instance.HasPlugin(ctx, spec) {
+	// If the runtime is already resolvable (on $PATH or in the plugin cache) reuse it rather than
+	// downloading, since that is the version the language host will load anyway.
+	quiet := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	if path, err := workspace.GetPluginPath(ctx, quiet, spec, nil); err == nil && path != "" {
 		return nil
 	}
 	log := func(sev diag.Severity, msg string) {

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -17,11 +17,15 @@ package workspace
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/stretchr/testify/assert"
@@ -112,6 +116,48 @@ func TestInstallPluginErrorText(t *testing.T) {
 			assert.EqualError(t, &tt.Err, tt.ExpectedError)
 		})
 	}
+}
+
+// TestEnsureLanguageInstalledUsesPathPlugin checks that EnsureLanguageInstalled does not download a
+// language runtime that is already present on $PATH — the version on $PATH is the one that the
+// language host will load, so downloading is wasted work.
+//
+// We assert no download happens offline by passing an already-cancelled context: EnsureLanguageInstalled
+// resolves the runtime on $PATH and returns nil before reaching any download, so the cancelled
+// context never matters. Were the $PATH check missing, it would reach DownloadToFile and fail.
+func TestEnsureLanguageInstalledUsesPathPlugin(t *testing.T) {
+	// Not parallel: mutates PATH and PULUMI_HOME via t.Setenv.
+
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on the unix executable bit and $PATH lookup semantics")
+	}
+
+	// Place an executable pulumi-language-hcl on $PATH. "hcl" is an unbundled language runtime with
+	// a known download URL, so EnsureLanguageInstalled will otherwise try to fetch it.
+	pathDir := t.TempDir()
+	languageBinary := filepath.Join(pathDir, "pulumi-language-hcl")
+	require.NoError(t, os.WriteFile(languageBinary, []byte("#!/bin/sh\n"), 0o600))
+	require.NoError(t, os.Chmod(languageBinary, 0o700)) // exec.LookPath requires the executable bit.
+	t.Setenv("PATH", pathDir)
+
+	// Point PULUMI_HOME at an empty directory so the plugin cache reports a miss.
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	hcl := workspace.PluginDescriptor{Kind: apitype.LanguagePlugin, Name: "hcl"}
+
+	// The standard plugin resolver finds the runtime on $PATH, so a download is unnecessary.
+	path, err := workspace.GetPluginPath(t.Context(), diagtest.LogSink(t), hcl, nil)
+	require.NoError(t, err)
+	require.Equal(t, languageBinary, path)
+
+	// An already-cancelled context makes any download attempt fail offline, so this assertion turns
+	// "tried to download" into a deterministic failure rather than a network round-trip.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = EnsureLanguageInstalled(ctx, "hcl", nil)
+
+	require.NoError(t, err, "EnsureLanguageInstalled should reuse the runtime on $PATH, not download it")
 }
 
 func TestPluginInstallCancellation(t *testing.T) {


### PR DESCRIPTION
If the language plugin is on path, we will use that anyway. We should then skip the pointless download.

I'm skipping a changelog entry, since the only language this currently effects is HCL, which is in pre-alpha.