### PR TITLE
Add hidden config edit and config env console commands

### DIFF
--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -161,6 +161,7 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.AddCommand(newConfigRefreshCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
 	cmd.AddCommand(newConfigCopyCmd(ws, &stack, cmdBackend.DefaultLoginManager, &configFile))
 	cmd.AddCommand(newConfigEnvCmd(ws, &stack, &configFile))
+	cmd.AddCommand(newConfigEditCmd(ws, &stack, &configFile))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/config/config_edit.go
+++ b/pkg/cmd/pulumi/config/config_edit.go
@@ -1,0 +1,162 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdEnv "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/env"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// configEditCmd implements the hidden `pulumi config edit` command, delegating to `pulumi env edit`
+// for the linked environment. Only supported for remote-config (ESC-backed) stacks.
+type configEditCmd struct {
+	ws          pkgWorkspace.Context
+	stackRef    *string
+	configFile  *string
+	editorFlag  string
+	showSecrets bool
+
+	// Injectable so tests do not invoke the real ESC editor.
+	runEnvEdit func(ctx context.Context, args []string) error
+}
+
+func newConfigEditCmd(ws pkgWorkspace.Context, stackRef *string, configFile *string) *cobra.Command {
+	impl := &configEditCmd{ws: ws, stackRef: stackRef, configFile: configFile}
+
+	cmd := &cobra.Command{
+		Use:    "edit",
+		Short:  "Edit a remote config stack's configuration in an editor",
+		Hidden: true,
+		Long: "Open a remote config stack's linked ESC environment definition in an editor and save it on " +
+			"exit.\n\n" +
+			"This delegates to `pulumi env edit`: it downloads the definition, opens it in $VISUAL/$EDITOR " +
+			"(or --editor), and uploads the result under the environment's etag. Secrets are shown as " +
+			"ciphertext unless --show-secrets is passed.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if impl.runEnvEdit == nil {
+				impl.runEnvEdit = runEnvEditCmd
+			}
+			return impl.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVar(&impl.editorFlag, "editor", "",
+		"The editor command to use. Overrides $VISUAL and $EDITOR")
+	cmd.Flags().BoolVar(&impl.showSecrets, "show-secrets", false,
+		"Show secret values in plaintext rather than ciphertext")
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	return cmd
+}
+
+func (cmd *configEditCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	if _, _, err := cmd.ws.ReadProject(); err != nil {
+		return err
+	}
+
+	stack, err := cmdStack.RequireStack(
+		ctx, cmdutil.Diag(), cmd.ws, cmdBackend.DefaultLoginManager,
+		*cmd.stackRef, cmdStack.SetCurrent, opts, *cmd.configFile)
+	if err != nil {
+		return err
+	}
+
+	if !configStoreIsRemote(stack, *cmd.configFile) {
+		return errors.New("`pulumi config edit` is only supported for remote config stacks")
+	}
+	return cmd.editRemote(ctx, stack)
+}
+
+func (cmd *configEditCmd) editRemote(ctx context.Context, stack backend.Stack) error {
+	if err := rejectIfPinned(stack, *cmd.configFile); err != nil {
+		return err
+	}
+
+	ref := stack.ConfigLocation().EscEnv
+	if ref == nil {
+		return errors.New("stack is configured for remote config but has no linked environment")
+	}
+	// `env edit` always targets the latest revision and rejects a versioned ref, so drop any pin.
+	envRef, _, _ := strings.Cut(*ref, "@")
+
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+	// env edit accepts [<org>/][<project>/]<env>; qualify with the stack's org so it cannot fall back
+	// to the user's default org.
+	args := []string{"edit", orgNamer.OrgName() + "/" + envRef}
+	if cmd.editorFlag != "" {
+		args = append(args, "--editor", cmd.editorFlag)
+	}
+	if cmd.showSecrets {
+		args = append(args, "--show-secrets")
+	}
+
+	// env edit rediscovers its backend from PULUMI_BACKEND_URL or the current login and never reads the
+	// project's backend.url, so pin it to the backend this stack actually resolved to. Otherwise a
+	// project pinned to a different cloud could edit a same-named environment in the ambient one.
+	if urler, ok := stack.Backend().(interface{ CloudURL() string }); ok {
+		defer bindBackendURL(urler.CloudURL())()
+	}
+	return cmd.runEnvEdit(ctx, args)
+}
+
+func runEnvEditCmd(ctx context.Context, args []string) error {
+	return newEnvEditRoot(args).ExecuteContext(ctx)
+}
+
+// cobra always executes from the root, so args are set on the root with the env command's name
+// prepended; setting them on the subcommand alone is ignored and the process's real os.Args
+// (`config edit`) would leak in and fail as an unknown esc command.
+func newEnvEditRoot(args []string) *cobra.Command {
+	envCmd := cmdEnv.NewEnvCmd()
+	root := envCmd.Root()
+	if root != envCmd {
+		args = append([]string{envCmd.Name()}, args...)
+	}
+	root.SetArgs(args)
+	return root
+}
+
+// esc's GetCurrentCloudURL consults PULUMI_BACKEND_URL before the current login, so setting it makes
+// esc deterministically target url; the returned func restores the prior value.
+func bindBackendURL(url string) func() {
+	const key = "PULUMI_BACKEND_URL"
+	prev, had := os.LookupEnv(key)
+	_ = os.Setenv(key, url)
+	return func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
+}

--- a/pkg/cmd/pulumi/config/config_edit_test.go
+++ b/pkg/cmd/pulumi/config/config_edit_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+func TestConfigEditDelegatesToEnvEdit(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	cases := []struct {
+		name        string
+		escEnv      string
+		editorFlag  string
+		showSecrets bool
+		wantArgs    []string
+	}{
+		{
+			name:     "plain ref",
+			escEnv:   "testProject/testStack",
+			wantArgs: []string{"edit", "org/testProject/testStack"},
+		},
+		{
+			name:        "passes editor and show-secrets through",
+			escEnv:      "testProject/testStack",
+			editorFlag:  "code --wait",
+			showSecrets: true,
+			wantArgs:    []string{"edit", "org/testProject/testStack", "--editor", "code --wait", "--show-secrets"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			var gotArgs []string
+			cmd := &configEditCmd{
+				configFile:  new(string),
+				editorFlag:  c.editorFlag,
+				showSecrets: c.showSecrets,
+				runEnvEdit: func(_ context.Context, args []string) error {
+					gotArgs = args
+					return nil
+				},
+			}
+			require.NoError(t, cmd.editRemote(ctx, remoteEditStack(c.escEnv)))
+			require.Equal(t, c.wantArgs, gotArgs)
+		})
+	}
+}
+
+// cloudURLBackend is a MockBackend that also reports a CloudURL, so editRemote pins PULUMI_BACKEND_URL.
+type cloudURLBackend struct {
+	backend.MockBackend
+	url string
+}
+
+func (b *cloudURLBackend) CloudURL() string { return b.url }
+
+//nolint:paralleltest // mutates PULUMI_BACKEND_URL
+func TestConfigEditPinsBackendURL(t *testing.T) {
+	t.Setenv("PULUMI_BACKEND_URL", "https://ambient.example.com")
+
+	env := "testProject/testStack"
+	stack := &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return &cloudURLBackend{url: "https://stack.example.com"} },
+	}
+
+	var sawURL string
+	cmd := &configEditCmd{
+		configFile: new(string),
+		runEnvEdit: func(context.Context, []string) error {
+			sawURL = os.Getenv("PULUMI_BACKEND_URL")
+			return nil
+		},
+	}
+	require.NoError(t, cmd.editRemote(t.Context(), stack))
+	require.Equal(t, "https://stack.example.com", sawURL, "edit must run against the stack's backend")
+	require.Equal(t, "https://ambient.example.com", os.Getenv("PULUMI_BACKEND_URL"), "prior value restored")
+}
+
+func TestRunEnvEditDispatchResolves(t *testing.T) {
+	t.Parallel()
+	// Regression: cobra executes from the root, so the env subcommand path must be on the root's args.
+	// Passing too many args makes `env edit` fail its own MaximumNArgs(1) validation, which proves
+	// dispatch resolved to `env edit` (without contacting a backend) rather than rejecting "config".
+	root := newEnvEditRoot([]string{"edit", "x", "y", "z"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	err := root.ExecuteContext(t.Context())
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "unknown command")
+}
+
+func TestConfigEditNoLinkedEnv(t *testing.T) {
+	t.Parallel()
+	called := false
+	cmd := &configEditCmd{
+		configFile: new(string),
+		runEnvEdit: func(context.Context, []string) error { called = true; return nil },
+	}
+	stack := &backend.MockStack{
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: nil}
+		},
+		OrgNameF: func() string { return "org" },
+	}
+	err := cmd.editRemote(t.Context(), stack)
+	require.ErrorContains(t, err, "no linked environment")
+	require.False(t, called)
+}
+
+func TestConfigEditRejectsPinned(t *testing.T) {
+	t.Parallel()
+	called := false
+	cmd := &configEditCmd{
+		configFile: new(string),
+		runEnvEdit: func(context.Context, []string) error { called = true; return nil },
+	}
+	err := cmd.editRemote(t.Context(), remoteEditStack("testProject/testStack@7"))
+	require.ErrorContains(t, err, "pinned")
+	require.False(t, called, "edit must not be dispatched for a pinned stack")
+}
+
+// remoteEditStack builds a remote (ESC-backed) MockStack linked to escEnv in org "org".
+func remoteEditStack(escEnv string) *backend.MockStack {
+	env := escEnv
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return &backend.MockBackend{} },
+	}
+}

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -72,6 +72,7 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 	cmd.AddCommand(newConfigEnvAddCmd(&impl))
 	cmd.AddCommand(newConfigEnvRmCmd(&impl))
 	cmd.AddCommand(newConfigEnvLsCmd(&impl))
+	cmd.AddCommand(newConfigEnvConsoleCmd(ws, stackRef, configFile))
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/config/config_web.go
+++ b/pkg/cmd/pulumi/config/config_web.go
@@ -1,0 +1,124 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+)
+
+// consoleURLProvider is implemented by Pulumi Cloud backends. CloudConsoleURL joins the given path
+// segments onto the console base URL; it never embeds tokens or credentials.
+type consoleURLProvider interface {
+	CloudConsoleURL(paths ...string) string
+}
+
+// configEnvConsoleCmd implements the hidden `pulumi config env console` command, opening the linked
+// ESC environment in the Pulumi Cloud console. It is only supported for remote (ESC-backed) stacks.
+type configEnvConsoleCmd struct {
+	ws         pkgWorkspace.Context
+	stackRef   *string
+	configFile *string
+
+	// Injectable so tests do not launch a browser.
+	openBrowser func(url string) error
+
+	stdout io.Writer
+}
+
+func newConfigEnvConsoleCmd(ws pkgWorkspace.Context, stackRef *string, configFile *string) *cobra.Command {
+	impl := &configEnvConsoleCmd{ws: ws, stackRef: stackRef, configFile: configFile}
+
+	cmd := &cobra.Command{
+		Use:    "console",
+		Short:  "Open the stack's ESC environment in the Pulumi Cloud console",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			impl.stdout = cmd.OutOrStdout()
+			if impl.openBrowser == nil {
+				impl.openBrowser = browser.OpenURL
+			}
+			return impl.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+	return cmd
+}
+
+func (cmd *configEnvConsoleCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+	if _, _, err := cmd.ws.ReadProject(); err != nil {
+		return err
+	}
+
+	stack, err := cmdStack.RequireStack(
+		ctx, cmdutil.Diag(), cmd.ws, cmdBackend.DefaultLoginManager,
+		*cmd.stackRef, cmdStack.LoadOnly, opts, *cmd.configFile)
+	if err != nil {
+		return err
+	}
+	return cmd.runWithStack(stack, *cmd.configFile)
+}
+
+func (cmd *configEnvConsoleCmd) runWithStack(stack backend.Stack, configFile string) error {
+	// An explicit --config-file selects the local store even on a linked stack, matching the rest of
+	// the config commands, so the remote console is unavailable in that case.
+	if !configStoreIsRemote(stack, configFile) {
+		return errors.New("config env console is only supported for remote config stacks")
+	}
+	loc := stack.ConfigLocation()
+	if loc.EscEnv == nil {
+		return errors.New("stack is configured for remote config but has no linked environment")
+	}
+	envProject, envName, err := splitEnvRef(*loc.EscEnv)
+	if err != nil {
+		return err
+	}
+
+	provider, ok := stack.Backend().(consoleURLProvider)
+	if !ok {
+		return errors.New("config env console requires a Pulumi Cloud backend")
+	}
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+
+	url := provider.CloudConsoleURL(orgNamer.OrgName(), "esc", envProject, envName)
+	if url == "" {
+		return errors.New("the backend did not provide a console URL for this environment")
+	}
+
+	ui.Fprintf(cmd.stdout, "Opening %s ...\n", url)
+	if err := cmd.openBrowser(url); err != nil {
+		ui.Fprintf(cmd.stdout, "unable to open the browser automatically; open the URL above manually.\n")
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/config/config_web_test.go
+++ b/pkg/cmd/pulumi/config/config_web_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// fakeConsoleBackend is a MockBackend that also implements consoleURLProvider, recording the path
+// segments passed to CloudConsoleURL and joining them onto a configurable base.
+type fakeConsoleBackend struct {
+	backend.MockBackend
+	base     string
+	gotPaths []string
+}
+
+func (b *fakeConsoleBackend) CloudConsoleURL(paths ...string) string {
+	b.gotPaths = paths
+	return b.base + "/" + strings.Join(paths, "/")
+}
+
+func consoleStack(t *testing.T, be backend.Backend, remote bool) *backend.MockStack {
+	t.Helper()
+	env := "envProject/envName"
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			if remote {
+				return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+			}
+			return backend.StackConfigLocation{}
+		},
+		OrgNameF: func() string { return "myorg" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+func TestConfigEnvConsoleLocalRejected(t *testing.T) {
+	t.Parallel()
+	be := &fakeConsoleBackend{base: "https://app.pulumi.com"}
+	cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}, openBrowser: func(string) error { return nil }}
+	err := cmd.runWithStack(consoleStack(t, be, false), "")
+	require.ErrorContains(t, err, "only supported for remote config stacks")
+}
+
+func TestConfigEnvConsoleConfigFileRejected(t *testing.T) {
+	t.Parallel()
+	// An explicit --config-file forces the local store even on a linked remote stack, so the remote
+	// console must be rejected just like a plain local stack.
+	be := &fakeConsoleBackend{base: "https://app.pulumi.com"}
+	cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}, openBrowser: func(string) error { return nil }}
+	err := cmd.runWithStack(consoleStack(t, be, true), "Pulumi.foo.yaml")
+	require.ErrorContains(t, err, "only supported for remote config stacks")
+}
+
+func TestConfigEnvConsoleRequiresCloudBackend(t *testing.T) {
+	t.Parallel()
+	// A plain MockBackend does not implement consoleURLProvider.
+	be := &backend.MockBackend{}
+	cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}, openBrowser: func(string) error { return nil }}
+	err := cmd.runWithStack(consoleStack(t, be, true), "")
+	require.ErrorContains(t, err, "requires a Pulumi Cloud backend")
+}
+
+func TestConfigEnvConsoleURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		base string
+	}{
+		{"default cloud", "https://app.pulumi.com"},
+		{"custom cloud", "https://pulumi.example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			be := &fakeConsoleBackend{base: c.base}
+			var opened string
+			var out bytes.Buffer
+			cmd := &configEnvConsoleCmd{
+				stdout:      &out,
+				openBrowser: func(url string) error { opened = url; return nil },
+			}
+			require.NoError(t, cmd.runWithStack(consoleStack(t, be, true), ""))
+
+			require.Equal(t, []string{"myorg", "esc", "envProject", "envName"}, be.gotPaths)
+			want := c.base + "/myorg/esc/envProject/envName"
+			require.Equal(t, want, opened)
+			require.Contains(t, out.String(), want)
+			require.NotContains(t, opened, "token=")
+			require.NotContains(t, opened, "access_token=")
+		})
+	}
+}
+
+func TestConfigEnvConsoleBrowserFailurePrintsURL(t *testing.T) {
+	t.Parallel()
+	be := &fakeConsoleBackend{base: "https://app.pulumi.com"}
+	var out bytes.Buffer
+	cmd := &configEnvConsoleCmd{
+		stdout:      &out,
+		openBrowser: func(string) error { return errors.New("browser failed") },
+	}
+	require.NoError(t, cmd.runWithStack(consoleStack(t, be, true), ""))
+	require.Contains(t, out.String(), "https://app.pulumi.com/myorg/esc/envProject/envName")
+	require.Contains(t, out.String(), "open the URL above manually")
+}

--- a/pkg/cmd/pulumi/config/coverage_sbc06_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc06_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+func TestConfigEditAndConsoleCommandConstruction(t *testing.T) {
+	t.Parallel()
+	ws := &pkgWorkspace.MockContext{}
+	ref, configFile := "", ""
+
+	edit := newConfigEditCmd(ws, &ref, &configFile)
+	require.Equal(t, "edit", edit.Use)
+	require.True(t, edit.Hidden)
+	require.NotNil(t, edit.Flags().Lookup("editor"))
+	require.NotNil(t, edit.Flags().Lookup("show-secrets"))
+
+	console := newConfigEnvConsoleCmd(ws, &ref, &configFile)
+	require.Equal(t, "console", console.Use)
+	require.True(t, console.Hidden)
+}
+
+// emptyURLConsoleBackend implements consoleURLProvider but returns no URL, exercising the empty-URL guard.
+type emptyURLConsoleBackend struct{ backend.MockBackend }
+
+func (emptyURLConsoleBackend) CloudConsoleURL(...string) string { return "" }
+
+func remoteStackWithEscEnv(escEnv *string, be backend.Backend) *backend.MockStack {
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("testStack")}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: escEnv}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+func TestConfigEnvConsoleErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no linked environment", func(t *testing.T) {
+		t.Parallel()
+		cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}}
+		err := cmd.runWithStack(remoteStackWithEscEnv(nil, &backend.MockBackend{}), "")
+		require.ErrorContains(t, err, "no linked environment")
+	})
+
+	t.Run("malformed environment reference", func(t *testing.T) {
+		t.Parallel()
+		bad := "noslash"
+		cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}}
+		err := cmd.runWithStack(remoteStackWithEscEnv(&bad, &backend.MockBackend{}), "")
+		require.ErrorContains(t, err, "malformed environment reference")
+	})
+
+	t.Run("empty console URL", func(t *testing.T) {
+		t.Parallel()
+		env := "proj/env"
+		cmd := &configEnvConsoleCmd{stdout: &bytes.Buffer{}}
+		err := cmd.runWithStack(remoteStackWithEscEnv(&env, &emptyURLConsoleBackend{}), "")
+		require.ErrorContains(t, err, "did not provide a console URL")
+	})
+}
+
+// TestBindBackendURLUnsetsWhenAbsent covers the restore branch where PULUMI_BACKEND_URL was unset
+// before binding (the existing edit test exercises only the restore-previous-value branch).
+//
+//nolint:paralleltest // mutates process environment
+func TestBindBackendURLUnsetsWhenAbsent(t *testing.T) {
+	const key = "PULUMI_BACKEND_URL"
+	prev, had := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if had {
+			//nolint:usetesting // conditional restore in cleanup; t.Setenv cannot unset
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+
+	require.NoError(t, os.Unsetenv(key))
+	restore := bindBackendURL("new")
+	require.Equal(t, "new", os.Getenv(key))
+	restore()
+	_, stillSet := os.LookupEnv(key)
+	require.False(t, stillSet)
+}


### PR DESCRIPTION
## Summary

Add hidden `pulumi config edit` and `pulumi config env console` for remote-config (ESC-backed) stacks. Builds on the earlier PRs in this stacked series; internally "service-backed config (SBC)", externally "remote config" for now.

Towards pulumi/pulumi-service#39624

## Changes

- **`config edit`** (hidden) — for a remote-config stack, opens the linked ESC environment definition in an editor and saves on exit by delegating to `pulumi env edit`, which owns the download, editor resolution (`$VISUAL`/`$EDITOR` or `--editor`), diagnostics, and etag-checked save. Secrets are shown as ciphertext unless `--show-secrets` is passed. Local stacks (and an explicit `--config-file`) are not supported.
- **Backend pinning** — the delegated `env edit` resolves its backend from `PULUMI_BACKEND_URL`/the current login, not the project's `backend.url`. `config edit` pins `PULUMI_BACKEND_URL` to the backend the stack actually resolved to (restoring it after), so it can't edit a same-named environment in a different cloud.
- **`config env console`** (hidden) — opens or prints the Pulumi Cloud console URL for a remote stack's backing ESC environment; errors for local stacks (including an explicit `--config-file`) and non-cloud backends. The URL carries no token or credential.

## Notes

- Stacked on the `config env init --remote-config` migration PR; review and merge after it.
- Phase 1: both commands are hidden with no public docs or changelog.
- `config edit` delegates to the esc editor rather than reimplementing one; the secret-handling, temp-file, and editor-resolution behavior is whatever `pulumi env edit` does. A local-stack editor that decrypts/re-encrypts secrets is a deliberate follow-up.
