### PR TITLE
Tighten validation for names in schemas

### DIFF
--- a/changelog/pending/sdkgen-fix-20260604-201905.yaml
+++ b/changelog/pending/sdkgen-fix-20260604-201905.yaml
@@ -1,0 +1,6 @@
+component: sdkgen
+kind: fix
+body: Schema names are validated to not contain whitespace or control characters
+time: 2026-06-04T20:19:05.187697+01:00
+custom:
+    PR: "23460"

--- a/changelog/pending/sdkgen-fix-20260604-201905.yaml
+++ b/changelog/pending/sdkgen-fix-20260604-201905.yaml
@@ -1,6 +1,6 @@
 component: sdkgen
 kind: fix
-body: Schema names are validated to not contain whitespace or control characters
+body: Validate schema names to not contain whitespace or control characters
 time: 2026-06-04T20:19:05.187697+01:00
 custom:
     PR: "23460"

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -33,6 +33,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
@@ -95,6 +96,15 @@ func warningf(path, message string, args ...any) *hcl.Diagnostic {
 		Severity: hcl.DiagWarning,
 		Summary:  summary,
 	}
+}
+
+func validatePrintableName(path, kind, name string) *hcl.Diagnostic {
+	for _, r := range name {
+		if !unicode.IsPrint(r) || unicode.IsSpace(r) {
+			return errorf(path, "%s must contain only printable, non-whitespace characters (found U+%04X)", kind, r)
+		}
+	}
+	return nil
 }
 
 func validateSpec(spec PackageSpec) (hcl.Diagnostics, error) {
@@ -891,6 +901,9 @@ func (t *types) bindTypeDef(token string, options ValidationOptions) (Type, hcl.
 
 	var diags hcl.Diagnostics
 	path := memberPath("types", token)
+	if diag := validatePrintableName(path, "type name", token); diag != nil {
+		diags = diags.Append(diag)
+	}
 	parts := strings.Split(token, ":")
 	if len(parts) == 3 {
 		name := parts[2]
@@ -1325,8 +1338,12 @@ func (t *types) bindProperties(path string, properties map[string]PropertySpec, 
 ) ([]*Property, map[string]*Property, hcl.Diagnostics, error) {
 	var diags hcl.Diagnostics
 	for name := range properties {
+		propertyPath := path + "/" + url.PathEscape(name)
+		if diag := validatePrintableName(propertyPath, "property name", name); diag != nil {
+			diags = diags.Append(diag)
+		}
 		if isReservedKeyword(name) {
-			diags = diags.Append(errorf(path+"/"+name, "%s", name+" is a reserved property name"))
+			diags = diags.Append(errorf(propertyPath, "%s", name+" is a reserved property name"))
 		}
 	}
 	if diags.HasErrors() {
@@ -1970,6 +1987,9 @@ func (t *types) bindResourceDef(
 		t.resourceDefs[token] = res
 
 		path := memberPath("resources", token)
+		if diag := validatePrintableName(path, "resource name", token); diag != nil {
+			diags = diags.Append(diag)
+		}
 		parts := strings.Split(token, ":")
 		if len(parts) == 3 {
 			name := parts[2]
@@ -2185,6 +2205,9 @@ func (t *types) bindFunctionDef(token string, options ValidationOptions) (*Funct
 	var diags hcl.Diagnostics
 
 	path := memberPath("functions", token)
+	if diag := validatePrintableName(path, "function name", token); diag != nil {
+		diags = diags.Append(diag)
+	}
 	parts := strings.Split(token, ":")
 	if len(parts) == 3 {
 		name := parts[2]

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -1180,6 +1180,221 @@ func TestUsingReservedWordPropertyNameIsNotOk(t *testing.T) {
 	assert.Nil(t, pkg)
 }
 
+func TestBindSpecPrintableNames(t *testing.T) {
+	t.Parallel()
+
+	stringProperty := PropertySpec{TypeSpec: TypeSpec{Type: "string"}}
+	tests := []struct {
+		name        string
+		spec        PackageSpec
+		wantSummary string
+	}{
+		{
+			name: "config property",
+			spec: PackageSpec{
+				Name: "test",
+				Config: ConfigSpec{
+					Variables: map[string]PropertySpec{
+						"bad\nproperty": stringProperty,
+					},
+				},
+			},
+			wantSummary: "#/config/variables/bad%0Aproperty: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "config property space",
+			spec: PackageSpec{
+				Name: "test",
+				Config: ConfigSpec{
+					Variables: map[string]PropertySpec{
+						"bad property": stringProperty,
+					},
+				},
+			},
+			wantSummary: "#/config/variables/bad%20property: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "resource output property",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:TestResource": {
+						ObjectTypeSpec: ObjectTypeSpec{
+							Properties: map[string]PropertySpec{
+								"bad\tproperty": stringProperty,
+							},
+						},
+					},
+				},
+			},
+			wantSummary: "#/resources/test:index:TestResource/properties/bad%09property: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "resource input property",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:TestResource": {
+						InputProperties: map[string]PropertySpec{
+							"bad\x7fproperty": stringProperty,
+						},
+					},
+				},
+			},
+			wantSummary: "#/resources/test:index:TestResource/inputProperties/bad%7Fproperty: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "object type property",
+			spec: PackageSpec{
+				Name: "test",
+				Types: map[string]ComplexTypeSpec{
+					"test:index:TestType": {
+						ObjectTypeSpec: ObjectTypeSpec{
+							Type: "object",
+							Properties: map[string]PropertySpec{
+								"bad\x00property": stringProperty,
+							},
+						},
+					},
+				},
+			},
+			wantSummary: "#/types/test:index:TestType/properties/bad%00property: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "resource name",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:Bad\tResource": {},
+				},
+			},
+			wantSummary: "#/resources/test:index:Bad%09Resource: " +
+				"resource name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "resource name space",
+			spec: PackageSpec{
+				Name: "test",
+				Resources: map[string]ResourceSpec{
+					"test:index:Bad Resource": {},
+				},
+			},
+			wantSummary: "#/resources/test:index:Bad%20Resource: " +
+				"resource name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "type name",
+			spec: PackageSpec{
+				Name: "test",
+				Types: map[string]ComplexTypeSpec{
+					"test:index:Bad\x00Type": {
+						ObjectTypeSpec: ObjectTypeSpec{
+							Type: "object",
+						},
+					},
+				},
+			},
+			wantSummary: "#/types/test:index:Bad%00Type: " +
+				"type name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "type name space",
+			spec: PackageSpec{
+				Name: "test",
+				Types: map[string]ComplexTypeSpec{
+					"test:index:Bad Type": {
+						ObjectTypeSpec: ObjectTypeSpec{
+							Type: "object",
+						},
+					},
+				},
+			},
+			wantSummary: "#/types/test:index:Bad%20Type: " +
+				"type name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "function name",
+			spec: PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					"test:index:bad\x7ffunction": {},
+				},
+			},
+			wantSummary: "#/functions/test:index:bad%7Ffunction: " +
+				"function name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "function name space",
+			spec: PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					"test:index:bad function": {},
+				},
+			},
+			wantSummary: "#/functions/test:index:bad%20function: " +
+				"function name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "function input property",
+			spec: PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					"test:index:function": {
+						Inputs: &ObjectTypeSpec{
+							Properties: map[string]PropertySpec{
+								"bad\nproperty": stringProperty,
+							},
+						},
+					},
+				},
+			},
+			wantSummary: "#/functions/test:index:function/inputs/properties/bad%0Aproperty: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+		{
+			name: "function output property",
+			spec: PackageSpec{
+				Name: "test",
+				Functions: map[string]FunctionSpec{
+					"test:index:function": {
+						Outputs: &ObjectTypeSpec{
+							Properties: map[string]PropertySpec{
+								"bad\nproperty": stringProperty,
+							},
+						},
+					},
+				},
+			},
+			wantSummary: "#/functions/test:index:function/outputs/properties/bad%0Aproperty: " +
+				"property name must contain only printable, non-whitespace characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, diags, _ := BindSpec(tt.spec, noOpLoader{}, ValidationOptions{
+				AllowDanglingReferences: true,
+			})
+			require.True(t, diags.HasErrors(), "expected errors for %s", tt.name)
+			found := false
+			for _, d := range diags {
+				if strings.Contains(d.Summary, tt.wantSummary) {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected diagnostic containing %q, got %v", tt.wantSummary, diags)
+		})
+	}
+}
+
 func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 	t.Parallel()
 	loader := NewPluginLoader(utils.NewHost(testdataPath))

--- a/scripts/check-registry-schemas.sh
+++ b/scripts/check-registry-schemas.sh
@@ -38,7 +38,7 @@ make -C "$REPO" bin/pulumi
 # continuationToken automatically and merges pages.
 PACKAGES_JSON="$WORK_DIR/packages.json"
 echo "Listing packages..."
-"$PULUMI_BIN" cloud api ListPackages --paginate >"$PACKAGES_JSON"
+"$PULUMI_BIN" api ListPackages --all >"$PACKAGES_JSON"
 TOTAL=$(jq '.packages | length' "$PACKAGES_JSON")
 echo "Found $TOTAL packages."
 


### PR DESCRIPTION
This adds some _very_ basic name validation to schemas to assert that names are printable, non-whitespace characters. This is extremely lax, but locks in that we won't get any odd names with spaces, newlines or control characters, which we have seen in resource names.

Also fixes the check-registry-schemas.sh script given the changes to the `api` command.