### PR TITLE
Add hidden config env eject command

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -337,6 +337,15 @@ type EnvironmentsBackend interface {
 		yaml []byte,
 		etag string,
 	) (apitype.EnvironmentDiagnostics, error)
+
+	// DeleteEnvironmentWithProject deletes a named environment unconditionally, with no etag guard
+	// against concurrent revisions.
+	DeleteEnvironmentWithProject(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+	) error
 }
 
 // SpecificDeploymentExporter is an interface defining an additional capability of a Backend, specifically the

--- a/pkg/backend/diy/stack.go
+++ b/pkg/backend/diy/stack.go
@@ -70,6 +70,10 @@ func (s *diyStack) SaveRemoteConfig(ctx context.Context, projectStack *workspace
 	return fmt.Errorf("%w for the DIY backend", backend.ErrConfigNotSupported)
 }
 
+func (s *diyStack) RemoveRemoteConfig(ctx context.Context) error {
+	return fmt.Errorf("%w for the DIY backend", backend.ErrConfigNotSupported)
+}
+
 func (s *diyStack) Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error) {
 	if v := s.snapshot.Load(); v != nil {
 		return *v, nil

--- a/pkg/backend/diy/stack_tags_test.go
+++ b/pkg/backend/diy/stack_tags_test.go
@@ -429,6 +429,10 @@ func (m *mockStackForTesting) SaveRemoteConfig(context.Context, *workspace.Proje
 	return nil
 }
 
+func (m *mockStackForTesting) RemoveRemoteConfig(context.Context) error {
+	return nil
+}
+
 func (m *mockStackForTesting) Snapshot(context.Context, secrets.Provider) (*deploy.Snapshot, error) {
 	return nil, nil
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2367,6 +2367,12 @@ func (pc *Client) UpdateStackConfig(
 	return pc.restCall(ctx, "PUT", getStackPath(stack, "config"), nil, config, nil)
 }
 
+// DeleteStackConfig unlinks the stack from its remote (ESC-backed) configuration; it does not delete
+// the backing environment.
+func (pc *Client) DeleteStackConfig(ctx context.Context, stack StackIdentifier) error {
+	return pc.restCall(ctx, "DELETE", getStackPath(stack, "config"), nil, nil, nil)
+}
+
 func (pc *Client) UpdateStackDeploymentSettings(ctx context.Context, stack StackIdentifier,
 	deployment apitype.DeploymentSettings,
 ) error {

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1738,3 +1738,27 @@ func TestStreamNeoTaskEvents(t *testing.T) {
 		}
 	})
 }
+
+func TestDeleteStackConfig(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	server := newMockServerRequestProcessor(http.StatusOK, func(req *http.Request) string {
+		gotMethod = req.Method
+		gotPath = req.URL.Path
+		return "{}"
+	})
+	defer server.Close()
+	client := newMockClient(server)
+
+	identifier := StackIdentifier{
+		Owner:   "owner",
+		Project: "project",
+		Stack:   tokens.MustParseStackName("stack"),
+	}
+
+	err := client.DeleteStackConfig(t.Context(), identifier)
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, "/api/stacks/owner/project/stack/config", gotPath)
+}

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -130,3 +130,12 @@ func isConfigConflict(err error) bool {
 	}
 	return false
 }
+
+func (b *cloudBackend) DeleteEnvironmentWithProject(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+) error {
+	return b.escClient.DeleteEnvironment(ctx, org, projectName, envName)
+}

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -169,6 +169,12 @@ func (m *mockEnvironmentsBackend) UpdateEnvironmentWithProject(
 	return nil, nil
 }
 
+func (m *mockEnvironmentsBackend) DeleteEnvironmentWithProject(
+	context.Context, string, string, string,
+) error {
+	return nil
+}
+
 func TestResolveEnvironments(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -208,6 +208,18 @@ func (s *cloudStack) SaveRemoteConfig(ctx context.Context, projectStack *workspa
 	return err
 }
 
+func (s *cloudStack) RemoveRemoteConfig(ctx context.Context) error {
+	stackID, err := s.b.getCloudStackIdentifier(s.ref)
+	if err != nil {
+		return err
+	}
+	if err := s.b.client.DeleteStackConfig(ctx, stackID); err != nil {
+		return err
+	}
+	s.escConfigEnv = nil
+	return nil
+}
+
 func (s *cloudStack) Backend() backend.Backend                   { return s.b }
 func (s *cloudStack) OrgName() string                            { return s.orgName }
 func (s *cloudStack) CurrentOperation() *apitype.OperationStatus { return s.currentOperation }

--- a/pkg/backend/httpstate/stack_test.go
+++ b/pkg/backend/httpstate/stack_test.go
@@ -17,6 +17,8 @@ package httpstate
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -25,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloudBackendReference(t *testing.T) {
@@ -114,4 +117,40 @@ func TestCloudBackendReference(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("%s/%s/%s", defaultOrg, otherProject.Name, stackName), stack)
 		})
 	})
+}
+
+func TestCloudStackRemoveRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		gotMethod = req.Method
+		gotPath = req.URL.Path
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	sink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	b := &cloudBackend{
+		client: client.NewClient(server.URL, "", true, sink),
+		d:      sink,
+	}
+	ref := cloudBackendReference{
+		owner:   "owner",
+		project: "project",
+		name:    tokens.MustParseStackName("stack"),
+		b:       b,
+	}
+	env := "project/stack"
+	s := &cloudStack{ref: ref, b: b, escConfigEnv: &env}
+
+	require.True(t, s.ConfigLocation().IsRemote)
+
+	err := s.RemoveRemoteConfig(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	assert.Equal(t, "/api/stacks/owner/project/stack/config", gotPath)
+
+	assert.False(t, s.ConfigLocation().IsRemote)
 }

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -561,6 +561,13 @@ type MockEnvironmentsBackend struct {
 		yaml []byte,
 		etag string,
 	) (apitype.EnvironmentDiagnostics, error)
+
+	DeleteEnvironmentWithProjectF func(
+		ctx context.Context,
+		org string,
+		projectName string,
+		envName string,
+	) error
 }
 
 func (be *MockEnvironmentsBackend) CreateEnvironment(
@@ -627,6 +634,18 @@ func (be *MockEnvironmentsBackend) UpdateEnvironmentWithProject(
 	panic("not implemented")
 }
 
+func (be *MockEnvironmentsBackend) DeleteEnvironmentWithProject(
+	ctx context.Context,
+	org string,
+	projectName string,
+	envName string,
+) error {
+	if be.DeleteEnvironmentWithProjectF != nil {
+		return be.DeleteEnvironmentWithProjectF(ctx, org, projectName, envName)
+	}
+	panic("not implemented")
+}
+
 //
 // Mock stack.
 //
@@ -636,6 +655,7 @@ type MockStack struct {
 	ConfigLocationF       func() StackConfigLocation
 	LoadRemoteF           func(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
 	SaveRemoteF           func(ctx context.Context, project *workspace.ProjectStack) error
+	RemoveRemoteF         func(ctx context.Context) error
 	OrgNameF              func() string
 	ConfigF               func() config.Map
 	SnapshotF             func(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
@@ -673,6 +693,13 @@ func (ms *MockStack) SaveRemoteConfig(ctx context.Context, project *workspace.Pr
 		return ms.SaveRemoteF(ctx, project)
 	}
 	panic("not implemented: MockStack.SaveRemote")
+}
+
+func (ms *MockStack) RemoveRemoteConfig(ctx context.Context) error {
+	if ms.RemoveRemoteF != nil {
+		return ms.RemoveRemoteF(ctx)
+	}
+	panic("not implemented: MockStack.RemoveRemote")
 }
 
 func (ms *MockStack) OrgName() string {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -50,6 +50,9 @@ type Stack interface {
 	LoadRemoteConfig(ctx context.Context, project *workspace.Project) (*workspace.ProjectStack, error)
 	// SaveRemoteConfig the stack's configuration remotely to the backend.
 	SaveRemoteConfig(ctx context.Context, projectStack *workspace.ProjectStack) error
+	// RemoveRemoteConfig unlinks the stack from its remote configuration so its configuration is local
+	// again. It does not delete the backing environment.
+	RemoveRemoteConfig(ctx context.Context) error
 	// Snapshot returns the latest deployment snapshot.
 	Snapshot(ctx context.Context, secretsProvider secrets.Provider) (*deploy.Snapshot, error)
 	// SnapshotStackOutputs returns the stack outputs of the latest deployment snapshot.

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -72,6 +72,7 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 	cmd.AddCommand(newConfigEnvAddCmd(&impl))
 	cmd.AddCommand(newConfigEnvRmCmd(&impl))
 	cmd.AddCommand(newConfigEnvLsCmd(&impl))
+	cmd.AddCommand(newConfigEnvEjectCmd(&impl))
 	cmd.AddCommand(newConfigEnvConsoleCmd(ws, stackRef, configFile))
 
 	return cmd

--- a/pkg/cmd/pulumi/config/config_env_eject.go
+++ b/pkg/cmd/pulumi/config/config_env_eject.go
@@ -1,0 +1,499 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newConfigEnvEjectCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvEjectCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:   "eject",
+		Short: "Convert a remote-config stack back to local configuration",
+		Long: "Converts a stack that stores its configuration remotely in an ESC environment back to a local\n" +
+			"Pulumi.<stack>.yaml file. Secrets are re-encrypted with a local secrets provider, the backing\n" +
+			"environment's imports are preserved as local stack environment imports, the stack is unlinked\n" +
+			"from remote configuration, and the now-unused environment is deleted unless --keep-env is set.",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().BoolVar(&impl.keepEnv, "keep-env", false,
+		"Keep the backing ESC environment instead of deleting it after ejecting")
+	cmd.Flags().StringVar(&impl.secretsProvider, "secrets-provider", "",
+		"The secrets provider to use for re-encrypting secrets locally "+
+			"(default, passphrase, or a cloud KMS URL such as awskms://...)")
+	cmd.Flags().BoolVarP(&impl.yes, "yes", "y", false,
+		"True to proceed without prompting")
+
+	return cmd
+}
+
+type configEnvEjectCmd struct {
+	parent *configEnvCmd
+
+	keepEnv         bool
+	secretsProvider string
+	yes             bool
+}
+
+func (cmd *configEnvEjectCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	if _, _, err := cmd.parent.ws.ReadProject(); err != nil {
+		return err
+	}
+
+	stack, err := cmd.parent.requireStack(
+		ctx,
+		cmd.parent.diags,
+		cmd.parent.ws,
+		cmdBackend.DefaultLoginManager,
+		*cmd.parent.stackRef,
+		cmdStack.OfferNew|cmdStack.SetCurrent,
+		opts,
+		*cmd.parent.configFile,
+	)
+	if err != nil {
+		return err
+	}
+
+	if !stack.ConfigLocation().IsRemote {
+		return errors.New("this stack does not use remote configuration; there is nothing to eject")
+	}
+
+	// Eject's local write, unlink, and default delete are irreversible; require --yes when no TTY can confirm.
+	if !cmd.yes && !cmd.parent.interactive {
+		return backenderr.ErrNonInteractiveRequiresYes
+	}
+
+	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+	orgName := orgNamer.OrgName()
+
+	loc := stack.ConfigLocation()
+	if loc.EscEnv == nil || *loc.EscEnv == "" {
+		return errors.New("this stack does not reference a backing environment")
+	}
+	envProject, envName, err := splitEnvRef(*loc.EscEnv)
+	if err != nil {
+		return err
+	}
+
+	// Decrypt secrets in memory (re-encrypted locally before disk); eject the pinned revision when
+	// pinned, else latest. A missing env skips to unlinking.
+	def, _, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, envRefVersion(*loc.EscEnv), true)
+	envMissing := false
+	if err != nil {
+		if isNotFound(err) {
+			envMissing = true
+		} else {
+			return fmt.Errorf("getting environment %s/%s: %w", envProject, envName, err)
+		}
+	}
+
+	ps := &workspace.ProjectStack{}
+	hasSecret := false
+	if !envMissing {
+		pulumiConfig, imports, structured, otherValues, err := parseEjectedEnvironment(def)
+		if err != nil {
+			return err
+		}
+		// A local stack file holds only config and imports. If the env carries other values
+		// (environmentVariables, files, ...), refuse before mutating: ejecting drops them and the default
+		// delete would destroy the only copy.
+		if len(otherValues) > 0 {
+			return fmt.Errorf(
+				"environment %s/%s defines values eject cannot preserve in a local stack file (values.%s); "+
+					"eject supports environments whose values contain only pulumiConfig. Inspect them with "+
+					"`pulumi config edit` or keep the stack on remote configuration",
+				envProject, envName, strings.Join(otherValues, ", values."))
+		}
+		if len(structured) > 0 {
+			fmt.Fprintf(cmd.parent.stdout,
+				"Warning: import(s) %s had merge options that are not preserved in the local stack "+
+					"file; only the environment name is kept\n", strings.Join(structured, ", "))
+		}
+
+		plaintextMap, err := buildPlaintextMap(pulumiConfig)
+		if err != nil {
+			return err
+		}
+		for _, pt := range plaintextMap {
+			if pt.Secure() {
+				hasSecret = true
+				break
+			}
+		}
+
+		encrypter, err := cmd.resolveEncrypter(ctx, stack, ps, hasSecret, opts)
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.EncryptMap(ctx, plaintextMap, encrypter)
+		if err != nil {
+			return fmt.Errorf("re-encrypting configuration: %w", err)
+		}
+
+		ps.Config = config.Map(cfg)
+		if len(imports) > 0 {
+			ps.Environment = workspace.NewEnvironment(imports)
+		}
+	}
+
+	if !cmd.yes && cmd.parent.interactive {
+		if !ui.ConfirmPrompt(
+			fmt.Sprintf("Eject stack %v: write configuration locally and unlink it from environment %s/%s?",
+				stack.Ref().Name(), envProject, envName),
+			"yes", opts) {
+			return errors.New("eject canceled")
+		}
+	}
+
+	// Write the local file before unlinking so that a re-encryption or serialization failure leaves the
+	// stack untouched (still remote, no partial/plaintext file on disk).
+	if !envMissing {
+		path := *cmd.parent.configFile
+		if path == "" {
+			_, detected, err := workspace.DetectProjectStackPath(stack.Ref().Name().Q())
+			if err != nil {
+				return fmt.Errorf("locating local stack configuration file: %w", err)
+			}
+			path = detected
+		}
+		if err := atomicWriteProjectStack(ps, path); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.parent.stdout, "Wrote local stack configuration to %s\n", path)
+	}
+
+	if err := stack.RemoveRemoteConfig(ctx); err != nil {
+		if !envMissing {
+			return fmt.Errorf(
+				"the local stack configuration was written but the stack is still linked to environment %s/%s: %w; "+
+					"re-run `pulumi config env eject` to reconcile", envProject, envName, err)
+		}
+		return fmt.Errorf("unlinking stack from environment %s/%s: %w", envProject, envName, err)
+	}
+
+	// Eject has succeeded; deleting the now-unused environment is best-effort, so warn on failure
+	// rather than erroring.
+	fmt.Fprintf(cmd.parent.stdout, "Unlinked stack %v from remote configuration\n", stack.Ref().Name())
+	deleted, err := cmd.deleteEnvironment(ctx, envBackend, orgName, envProject, envName, envMissing, opts)
+	if err != nil {
+		fmt.Fprintf(cmd.parent.stdout,
+			"Warning: could not delete environment %s/%s: %v\n"+
+				"  the stack is fully ejected; remove the environment manually with "+
+				"`pulumi env rm %s/%s`\n",
+			envProject, envName, err, envProject, envName)
+		return nil
+	}
+	if deleted {
+		fmt.Fprintf(cmd.parent.stdout, "Deleted environment %s/%s\n", envProject, envName)
+	} else {
+		fmt.Fprintf(cmd.parent.stdout, "Kept environment %s/%s\n", envProject, envName)
+	}
+	return nil
+}
+
+// resolveEncrypter builds an Encrypter for local re-encryption: NopEncrypter when there are no
+// secrets, otherwise --secrets-provider or "default".
+func (cmd *configEnvEjectCmd) resolveEncrypter(
+	ctx context.Context,
+	stack backend.Stack,
+	ps *workspace.ProjectStack,
+	hasSecret bool,
+	opts display.Options,
+) (config.Encrypter, error) {
+	if !hasSecret {
+		return config.NopEncrypter, nil
+	}
+
+	provider := cmd.secretsProvider
+	if provider == "" {
+		if !cmd.yes && cmd.parent.interactive {
+			value, err := ui.PromptForValue(
+				false, "secrets provider", "default", false,
+				func(string) error { return nil }, opts)
+			if err != nil {
+				return nil, err
+			}
+			provider = value
+		}
+		// Fall back to "default" when non-interactive or the prompt is empty.
+		if provider == "" {
+			provider = "default"
+		}
+	}
+
+	if err := cmdStack.ValidateSecretsProvider(provider); err != nil {
+		return nil, err
+	}
+	if provider != "default" {
+		ps.SecretsProvider = provider
+	}
+
+	encrypter, _, err := cmd.parent.ssml.GetEncrypter(ctx, stack, ps)
+	if err != nil {
+		return nil, fmt.Errorf("setting up secrets provider %q: %w", provider, err)
+	}
+	return encrypter, nil
+}
+
+// deleteEnvironment removes the backing environment unless --keep-env is set; an already-deleted env
+// (404 or missing from the start) is treated as success.
+//
+// There is no cross-stack reference check: if another stack imported this env, deleting it removes that
+// import's source too. Use --keep-env when the env may be shared.
+func (cmd *configEnvEjectCmd) deleteEnvironment(
+	ctx context.Context,
+	envBackend backend.EnvironmentsBackend,
+	orgName, envProject, envName string,
+	envMissing bool,
+	opts display.Options,
+) (bool, error) {
+	if cmd.keepEnv {
+		return false, nil
+	}
+	if envMissing {
+		return true, nil
+	}
+
+	if !cmd.yes && cmd.parent.interactive {
+		if !ui.ConfirmPrompt(
+			fmt.Sprintf("This will permanently delete the backing environment %s/%s; "+
+				"any stack that imports it will break.", envProject, envName),
+			"yes", opts) {
+			return false, nil
+		}
+	}
+
+	if err := envBackend.DeleteEnvironmentWithProject(ctx, orgName, envProject, envName); err != nil {
+		if isNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("deleting environment %s/%s: %w", envProject, envName, err)
+	}
+	return true, nil
+}
+
+// parseEjectedEnvironment extracts the env's own config (values.pulumiConfig) and its top-level imports
+// from a decrypted environment definition. otherValues names any values subsection other than
+// pulumiConfig (e.g. environmentVariables, files) so the caller can refuse rather than silently drop it.
+func parseEjectedEnvironment(
+	def []byte,
+) (pulumiConfig map[string]any, imports, structured, otherValues []string, err error) {
+	var doc struct {
+		Imports []yaml.Node          `yaml:"imports"`
+		Values  map[string]yaml.Node `yaml:"values"`
+	}
+	if err := yaml.Unmarshal(def, &doc); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("parsing environment definition: %w", err)
+	}
+
+	for i := range doc.Imports {
+		node := &doc.Imports[i]
+		name, ok := importEntryName(node)
+		if !ok {
+			continue
+		}
+		imports = append(imports, name)
+		// A structured import (e.g. {env: {merge: false}}) carries options the local stack file's
+		// import list cannot represent; record it so the caller can warn that only the name is kept.
+		if node.Kind == yaml.MappingNode {
+			structured = append(structured, name)
+		}
+	}
+
+	for key, node := range doc.Values {
+		if key == "pulumiConfig" {
+			if err := node.Decode(&pulumiConfig); err != nil {
+				return nil, nil, nil, nil, fmt.Errorf("parsing values.pulumiConfig: %w", err)
+			}
+			continue
+		}
+		otherValues = append(otherValues, key)
+	}
+	sort.Strings(otherValues)
+	return pulumiConfig, imports, structured, otherValues, nil
+}
+
+// buildPlaintextMap converts an ESC pulumiConfig (a Go structure with {fn::secret: plaintext} markers at
+// any depth) into a config key -> Plaintext map, with secrets marked so config.EncryptMap re-encrypts
+// them as nested secure values.
+func buildPlaintextMap(pulumiConfig map[string]any) (map[config.Key]config.Plaintext, error) {
+	result := map[config.Key]config.Plaintext{}
+	for k, v := range pulumiConfig {
+		key, err := config.ParseKey(k)
+		if err != nil {
+			return nil, fmt.Errorf("parsing config key %q: %w", k, err)
+		}
+		pt, err := escValueToPlaintext(v)
+		if err != nil {
+			return nil, err
+		}
+		result[key] = pt
+	}
+	return result, nil
+}
+
+// escValueToPlaintext maps {fn::secret: inner} markers (at any depth) to secure Plaintext, leaving
+// plain values plain.
+func escValueToPlaintext(v any) (config.Plaintext, error) {
+	switch v := v.(type) {
+	case nil:
+		// Round-trip null as a null Plaintext, not the "<nil>" string the default fmt.Sprintf path gives.
+		return config.Plaintext{}, nil
+	case map[string]any:
+		if len(v) == 1 {
+			if inner, ok := v["fn::secret"]; ok {
+				s, err := secretInnerString(inner)
+				if err != nil {
+					return config.Plaintext{}, err
+				}
+				return config.NewPlaintext(config.PlaintextSecret(s)), nil
+			}
+		}
+		m := make(map[string]config.Plaintext, len(v))
+		for k, e := range v {
+			pt, err := escValueToPlaintext(e)
+			if err != nil {
+				return config.Plaintext{}, err
+			}
+			m[k] = pt
+		}
+		return config.NewPlaintext(m), nil
+	case []any:
+		s := make([]config.Plaintext, len(v))
+		for i, e := range v {
+			pt, err := escValueToPlaintext(e)
+			if err != nil {
+				return config.Plaintext{}, err
+			}
+			s[i] = pt
+		}
+		return config.NewPlaintext(s), nil
+	case bool:
+		return config.NewPlaintext(v), nil
+	case int:
+		return config.NewPlaintext(int64(v)), nil
+	case int64:
+		return config.NewPlaintext(v), nil
+	case uint64:
+		return config.NewPlaintext(v), nil
+	case float64:
+		return config.NewPlaintext(v), nil
+	case string:
+		return config.NewPlaintext(v), nil
+	default:
+		return config.NewPlaintext(fmt.Sprintf("%v", v)), nil
+	}
+}
+
+// secretInnerString renders an fn::secret payload as plaintext. Composite payloads (object/array)
+// must be JSON-encoded, since Go's default map/slice formatting is not valid JSON.
+func secretInnerString(v any) (string, error) {
+	switch v := v.(type) {
+	case string:
+		return v, nil
+	case bool, int, int64, uint64, float64:
+		return fmt.Sprintf("%v", v), nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("serializing secret value: %w", err)
+		}
+		return string(b), nil
+	}
+}
+
+// atomicWriteProjectStack writes ps to path atomically (temp file in the same dir, then rename) so a
+// failed write never leaves a half-written (plaintext) file.
+func atomicWriteProjectStack(ps *workspace.ProjectStack, path string) error {
+	ext := filepath.Ext(path)
+	marshaler, ok := encoding.Marshalers[ext]
+	if !ok {
+		return fmt.Errorf("no marshaler found for file format %q", ext)
+	}
+	b, err := marshaler.Marshal(ps)
+	if err != nil {
+		return fmt.Errorf("serializing stack configuration: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".pulumi-eject-*"+ext)
+	if err != nil {
+		return fmt.Errorf("creating temporary stack configuration file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temporary stack configuration file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temporary stack configuration file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil { //nolint:forbidigo // same-dir rename is atomic
+		return fmt.Errorf("writing stack configuration file: %w", err)
+	}
+	return nil
+}
+
+func isNotFound(err error) bool {
+	var errResp *apitype.ErrorResponse
+	return errors.As(err, &errResp) && errResp.Code == http.StatusNotFound
+}

--- a/pkg/cmd/pulumi/config/config_env_eject_test.go
+++ b/pkg/cmd/pulumi/config/config_env_eject_test.go
@@ -1,0 +1,572 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/secrets"
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// ejectCapture records what the eject produced.
+type ejectCapture struct {
+	removeCalled  bool
+	deleteCalled  bool
+	deletedOrg    string
+	deletedEnv    string
+	removeBlocked bool
+	deleteErr     error
+}
+
+// newEjectCmdForTest builds a configEnvEjectCmd over a remote (remote-config) stack backed by an
+// environment whose decrypted definition is envYAML. envNotFound makes GetEnvironment return a 404.
+// encrypter, if non-nil, overrides the secrets manager's encrypter (used to inject a failing encrypter).
+func newEjectCmdForTest(
+	t *testing.T,
+	stdin io.Reader,
+	stdout io.Writer,
+	envYAML string,
+	envNotFound bool,
+	deleteNotFound bool,
+	cap *ejectCapture,
+	secretsManager secrets.Manager,
+) *configEnvEjectCmd {
+	t.Helper()
+	stackRef := "stack"
+	configFile := ""
+	env := "test/stack"
+
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, decrypt bool) ([]byte, string, int, error) {
+			if envNotFound {
+				return nil, "", 0, &apitype.ErrorResponse{Code: http.StatusNotFound, Message: "not found"}
+			}
+			require.True(t, decrypt, "eject must request a decrypted environment definition")
+			return []byte(envYAML), "etag", 0, nil
+		},
+		DeleteEnvironmentWithProjectF: func(_ context.Context, org, proj, name string) error {
+			cap.deleteCalled = true
+			cap.deletedOrg = org
+			cap.deletedEnv = proj + "/" + name
+			if deleteNotFound {
+				return &apitype.ErrorResponse{Code: http.StatusNotFound, Message: "not found"}
+			}
+			return cap.deleteErr
+		},
+	}
+
+	if secretsManager == nil {
+		secretsManager = b64.NewBase64SecretsManager()
+	}
+
+	parent := &configEnvCmd{
+		stdin:       stdin,
+		stdout:      stdout,
+		interactive: false,
+		ssml:        cmdStack.NewStackSecretsManagerLoaderFromEnv(),
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes(
+					[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return &backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{
+						StringV:             "org/stack",
+						NameV:               tokens.MustParseStackName("stack"),
+						ProjectV:            "test",
+						FullyQualifiedNameV: "org/test/stack",
+					}
+				},
+				OrgNameF: func() string { return "org" },
+				BackendF: func() backend.Backend { return be },
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+				},
+				DefaultSecretManagerF: func(_ context.Context, _ *workspace.ProjectStack) (secrets.Manager, error) {
+					return secretsManager, nil
+				},
+				RemoveRemoteF: func(_ context.Context) error {
+					if cap.removeBlocked {
+						return errors.New("link removal failed")
+					}
+					cap.removeCalled = true
+					return nil
+				},
+			}, nil
+		},
+		stackRef:   &stackRef,
+		configFile: &configFile,
+	}
+
+	return &configEnvEjectCmd{parent: parent, yes: true, secretsProvider: "default"}
+}
+
+// setupEjectProject chdirs into a temp dir holding Pulumi.yaml so DetectProjectStackPath resolves the
+// destination Pulumi.stack.yaml. It returns the destination path (the file does not exist yet).
+func setupEjectProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: test\nruntime: yaml\n"), 0o600))
+	t.Chdir(dir)
+	return filepath.Join(dir, "Pulumi.stack.yaml")
+}
+
+// loadEjectedConfig loads the written local stack file and returns its parsed ProjectStack.
+func loadEjectedConfig(t *testing.T, path string) *workspace.ProjectStack {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	p, err := workspace.LoadProjectBytes([]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+	require.NoError(t, err)
+	ps, err := workspace.LoadProjectStackBytes(
+		diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never}),
+		p, b, "Pulumi.stack.yaml", encoding.YAML)
+	require.NoError(t, err)
+	return ps
+}
+
+// TestConfigEnvEjectRoundTripsValues verifies plaintext, scalar-secret, object, and array values
+// round-trip into the local file: plaintext stays plaintext and a top-level secret becomes a local
+// secure value that decrypts back to the original plaintext.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectRoundTripsValues(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  pulumiConfig:
+    test:plain: hello
+    test:flag: true
+    test:obj:
+      env: prod
+    test:list:
+      - a
+      - b
+    test:password:
+      fn::secret: hunter2
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "hunter2", "plaintext secret must not be written to disk")
+
+	ps := loadEjectedConfig(t, path)
+	m, err := ps.Config.AsDecryptedPropertyMap(t.Context(), config.Base64Crypter)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", m.Get("test:plain").AsString())
+	assert.True(t, m.Get("test:flag").AsBool())
+	assert.Equal(t, "prod", m.Get("test:obj").AsMap().Get("env").AsString())
+	list := m.Get("test:list").AsArray().AsSlice()
+	require.Len(t, list, 2)
+	assert.Equal(t, "a", list[0].AsString())
+
+	pw := m.Get("test:password")
+	assert.True(t, pw.Secret(), "top-level secret must round-trip as a secret")
+	assert.Equal(t, "hunter2", pw.AsString())
+}
+
+// TestConfigEnvEjectNestedSecrets verifies a secret nested inside an object and a secret nested inside
+// an array each become an encrypted local secure value: not plaintext, and decrypting once yields the
+// original plaintext (not double-encrypted).
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectNestedSecrets(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  pulumiConfig:
+    test:obj:
+      inner:
+        fn::secret: nestedObjSecret
+    test:list:
+      - plainItem
+      - fn::secret: nestedArrSecret
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "nestedObjSecret", "nested object secret must not be plaintext on disk")
+	assert.NotContains(t, string(raw), "nestedArrSecret", "nested array secret must not be plaintext on disk")
+
+	ps := loadEjectedConfig(t, path)
+	m, err := ps.Config.AsDecryptedPropertyMap(t.Context(), config.Base64Crypter)
+	require.NoError(t, err)
+
+	inner := m.Get("test:obj").AsMap().Get("inner")
+	require.True(t, inner.Secret(), "nested object value must be a secret")
+	assert.Equal(t, "nestedObjSecret", inner.AsString())
+
+	arr := m.Get("test:list").AsArray().AsSlice()
+	require.Len(t, arr, 2)
+	assert.Equal(t, "plainItem", arr[0].AsString())
+	require.True(t, arr[1].Secret(), "nested array value must be a secret")
+	assert.Equal(t, "nestedArrSecret", arr[1].AsString())
+}
+
+// failingEncrypter errors on any encryption attempt.
+type failingEncrypter struct{}
+
+func (failingEncrypter) EncryptValue(_ context.Context, _ string) (string, error) {
+	return "", errors.New("encryption boom")
+}
+
+func (failingEncrypter) BatchEncrypt(_ context.Context, _ []string) ([]string, error) {
+	return nil, errors.New("encryption boom")
+}
+
+// failingSecretsManager hands out a failingEncrypter.
+type failingSecretsManager struct{}
+
+func (failingSecretsManager) Type() string                { return "failing" }
+func (failingSecretsManager) State() json.RawMessage      { return nil }
+func (failingSecretsManager) Encrypter() config.Encrypter { return failingEncrypter{} }
+func (failingSecretsManager) Decrypter() config.Decrypter { return config.NopDecrypter }
+
+// TestConfigEnvEjectWriteBeforeUnlinkAndNoPlaintextOnFailure verifies the file is written before
+// unlink and that a re-encryption failure leaves no file on disk and does not unlink the stack.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectWriteBeforeUnlinkAndNoPlaintextOnFailure(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  pulumiConfig:
+    test:password:
+      fn::secret: hunter2
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, failingSecretsManager{})
+	cmd.secretsProvider = "default"
+
+	err := cmd.run(t.Context())
+	require.Error(t, err)
+	assert.NoFileExists(t, path, "no file (and no plaintext) must remain after a re-encryption failure")
+	assert.False(t, cap.removeCalled, "stack must not be unlinked when the local write fails")
+	assert.False(t, cap.deleteCalled, "environment must not be deleted when the local write fails")
+}
+
+// TestConfigEnvEjectPreservesImports verifies the env's imports become the local stack's environment
+// imports.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectPreservesImports(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `imports:
+  - shared/base
+  - shared/db
+values:
+  pulumiConfig:
+    test:k: v
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	ps := loadEjectedConfig(t, path)
+	assert.Equal(t, []string{"shared/base", "shared/db"}, ps.Environment.Imports())
+}
+
+// TestConfigEnvEjectKeepEnv verifies --keep-env skips the delete but still unlinks.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectKeepEnv(t *testing.T) {
+	setupEjectProject(t)
+	envYAML := "values:\n  pulumiConfig:\n    test:k: v\n"
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	cmd.keepEnv = true
+	require.NoError(t, cmd.run(t.Context()))
+
+	assert.True(t, cap.removeCalled)
+	assert.False(t, cap.deleteCalled, "--keep-env must not delete the environment")
+}
+
+// TestConfigEnvEjectDeletesByDefault verifies the default path (with --yes) deletes the environment.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectDeletesByDefault(t *testing.T) {
+	setupEjectProject(t)
+	envYAML := "values:\n  pulumiConfig:\n    test:k: v\n"
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	assert.True(t, cap.removeCalled)
+	assert.True(t, cap.deleteCalled)
+	assert.Equal(t, "test/stack", cap.deletedEnv)
+}
+
+// TestConfigEnvEjectAlreadyDeletedEnv verifies a missing environment (GetEnvironment 404) still
+// completes the unlink and reports the env deleted.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectAlreadyDeletedEnv(t *testing.T) {
+	setupEjectProject(t)
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, "", true /*envNotFound*/, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	assert.True(t, cap.removeCalled, "unlink must still happen when the env is already gone")
+	assert.False(t, cap.deleteCalled, "no delete call is needed for an already-missing env")
+}
+
+// TestConfigEnvEjectDeleteNotFound verifies a delete that returns 404 is treated as success.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectDeleteNotFound(t *testing.T) {
+	setupEjectProject(t)
+	envYAML := "values:\n  pulumiConfig:\n    test:k: v\n"
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, true /*deleteNotFound*/, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	assert.True(t, cap.removeCalled)
+	assert.Contains(t, stdout.String(), "Deleted environment")
+}
+
+// TestConfigEnvEjectSecretsDefaultProvider verifies non-interactive eject with secrets present and no
+// --secrets-provider defaults to the "default" provider (matching stack init/new) rather than failing:
+// the secret is re-encrypted locally and the stack is unlinked.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectSecretsDefaultProvider(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  pulumiConfig:
+    test:password:
+      fn::secret: hunter2
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	cmd.secretsProvider = "" // no explicit provider in non-interactive mode
+
+	require.NoError(t, cmd.run(t.Context()))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "hunter2", "secret must be re-encrypted, not plaintext on disk")
+
+	ps := loadEjectedConfig(t, path)
+	m, err := ps.Config.AsDecryptedPropertyMap(t.Context(), config.Base64Crypter)
+	require.NoError(t, err)
+	pw := m.Get("test:password")
+	require.True(t, pw.Secret(), "the password must remain a secret")
+	assert.Equal(t, "hunter2", pw.AsString())
+
+	assert.True(t, cap.removeCalled, "the stack should be unlinked after a successful eject")
+}
+
+// TestConfigEnvEjectNullValue verifies a null config value round-trips as null rather than the literal
+// string "<nil>" the default formatting would otherwise produce.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectNullValue(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := "values:\n  pulumiConfig:\n    test:empty: null\n"
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+
+	require.NoError(t, cmd.run(t.Context()))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "<nil>", "a null value must not serialize as the string <nil>")
+}
+
+// TestConfigEnvEjectRejectsNonRemoteStack verifies a non-remote (local-config) stack is rejected.
+func TestConfigEnvEjectRejectsNonRemoteStack(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, "", false, false, &cap, nil)
+	cmd.parent.requireStack = func(
+		_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+		_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+	) (backend.Stack, error) {
+		return &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{NameV: tokens.MustParseStackName("stack")}
+			},
+			OrgNameF:        func() string { return "org" },
+			BackendF:        func() backend.Backend { return &backend.MockEnvironmentsBackend{} },
+			ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		}, nil
+	}
+
+	err := cmd.run(t.Context())
+	require.ErrorContains(t, err, "does not use remote configuration")
+	assert.False(t, cap.removeCalled)
+	assert.False(t, cap.deleteCalled)
+}
+
+// TestConfigEnvEjectCompositeSecret verifies that a composite fn::secret (one wrapping an object or
+// array, as migration produces for a secret object) round-trips as a secure JSON value rather than
+// Go's default formatting.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectCompositeSecret(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  pulumiConfig:
+    test:obj:
+      fn::secret:
+        a: 1
+        b: two
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "two", "composite secret must not be plaintext on disk")
+
+	ps := loadEjectedConfig(t, path)
+	m, err := ps.Config.AsDecryptedPropertyMap(t.Context(), config.Base64Crypter)
+	require.NoError(t, err)
+	v := m.Get("test:obj")
+	require.True(t, v.Secret(), "composite secret must be a secret value")
+	// The decrypted value is the JSON encoding of the object (valid JSON, not Go map formatting).
+	assert.JSONEq(t, `{"a":1,"b":"two"}`, v.AsString())
+}
+
+// TestConfigEnvEjectStructuredImportWarns verifies that a structured import (with merge options) is
+// preserved by name with a warning that its options are not carried into the local stack file.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectStructuredImportWarns(t *testing.T) {
+	setupEjectProject(t)
+	envYAML := `imports:
+  - plain-env
+  - structured-env:
+      merge: false
+values:
+  pulumiConfig:
+    test:k: v
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	require.NoError(t, cmd.run(t.Context()))
+	assert.Contains(t, stdout.String(), "structured-env")
+	assert.Contains(t, stdout.String(), "not preserved")
+}
+
+// TestConfigEnvEjectRefusesNonConfigValues verifies eject refuses, before any write/unlink/delete, when
+// the backing environment carries values other than pulumiConfig (here environmentVariables) that a
+// local stack file cannot hold — otherwise ejecting would drop them and the default delete would destroy
+// the only copy.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectRefusesNonConfigValues(t *testing.T) {
+	path := setupEjectProject(t)
+	envYAML := `values:
+  environmentVariables:
+    AWS_REGION: us-west-2
+  pulumiConfig:
+    test:k: v
+`
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+
+	err := cmd.run(t.Context())
+	require.ErrorContains(t, err, "environmentVariables")
+	assert.NoFileExists(t, path, "eject must not write a local file when it refuses")
+	assert.False(t, cap.removeCalled, "stack must not be unlinked when eject refuses")
+	assert.False(t, cap.deleteCalled, "environment must not be deleted when eject refuses")
+}
+
+// TestConfigEnvEjectNonInteractiveRequiresYes verifies a non-interactive eject without --yes is rejected
+// before any mutation rather than silently writing, unlinking, and deleting the backing environment.
+func TestConfigEnvEjectNonInteractiveRequiresYes(t *testing.T) {
+	t.Parallel()
+	envYAML := "values:\n  pulumiConfig:\n    test:k: v\n"
+	var stdout bytes.Buffer
+	var cap ejectCapture
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+	cmd.yes = false // parent.interactive is already false, so this is a non-TTY run with no --yes
+
+	err := cmd.run(t.Context())
+	require.ErrorIs(t, err, backenderr.ErrNonInteractiveRequiresYes)
+	assert.False(t, cap.removeCalled)
+	assert.False(t, cap.deleteCalled)
+}
+
+// TestConfigEnvEjectDeleteFailureWarns verifies that a failure to delete the environment after the
+// stack is unlinked is reported as a warning, not a fatal error: the eject succeeded.
+//
+//nolint:paralleltest // t.Chdir requires a non-parallel test
+func TestConfigEnvEjectDeleteFailureWarns(t *testing.T) {
+	setupEjectProject(t)
+	envYAML := "values:\n  pulumiConfig:\n    test:k: v\n"
+	var stdout bytes.Buffer
+	cap := ejectCapture{deleteErr: errors.New("boom")}
+	cmd := newEjectCmdForTest(t, nil, &stdout, envYAML, false, false, &cap, nil)
+
+	require.NoError(t, cmd.run(t.Context()), "delete failure after unlink must not fail the eject")
+	assert.True(t, cap.removeCalled, "stack must have been unlinked")
+	assert.Contains(t, stdout.String(), "Warning: could not delete environment")
+}

--- a/pkg/cmd/pulumi/config/coverage_sbc07_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc07_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func TestParseEjectedEnvironment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("extracts config, imports, and other values", func(t *testing.T) {
+		t.Parallel()
+		def := []byte(`imports:
+  - shared
+  - structured:
+      merge: false
+values:
+  pulumiConfig:
+    proj:key: v
+  environmentVariables:
+    FOO: bar
+`)
+		pulumiConfig, imports, structured, otherValues, err := parseEjectedEnvironment(def)
+		require.NoError(t, err)
+		require.Equal(t, "v", pulumiConfig["proj:key"])
+		require.Equal(t, []string{"shared", "structured"}, imports)
+		require.Equal(t, []string{"structured"}, structured)
+		require.Equal(t, []string{"environmentVariables"}, otherValues)
+	})
+
+	t.Run("rejects an unparseable definition", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, _, err := parseEjectedEnvironment([]byte("\tnot: [valid"))
+		require.ErrorContains(t, err, "parsing environment definition")
+	})
+
+	t.Run("rejects a non-map pulumiConfig", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, _, err := parseEjectedEnvironment([]byte("values:\n  pulumiConfig: scalar\n"))
+		require.ErrorContains(t, err, "parsing values.pulumiConfig")
+	})
+}
+
+func TestEscValueToPlaintext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("null is a non-secret empty plaintext", func(t *testing.T) {
+		t.Parallel()
+		pt, err := escValueToPlaintext(nil)
+		require.NoError(t, err)
+		require.False(t, pt.Secure())
+	})
+
+	t.Run("fn::secret marker becomes a secure plaintext", func(t *testing.T) {
+		t.Parallel()
+		pt, err := escValueToPlaintext(map[string]any{"fn::secret": "shh"})
+		require.NoError(t, err)
+		require.True(t, pt.Secure())
+		require.Equal(t, config.PlaintextSecret("shh"), pt.Value())
+	})
+
+	t.Run("scalars preserve their type", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			in   any
+			want any
+		}{
+			{true, true},
+			{int(5), int64(5)},
+			{int64(6), int64(6)},
+			{uint64(7), uint64(7)},
+			{1.5, 1.5},
+			{"s", "s"},
+			{uint(9), "9"}, // default branch renders unrecognized types
+		}
+		for _, c := range cases {
+			pt, err := escValueToPlaintext(c.in)
+			require.NoError(t, err)
+			require.Equal(t, c.want, pt.Value())
+		}
+	})
+
+	t.Run("nested map and array recurse", func(t *testing.T) {
+		t.Parallel()
+		pt, err := escValueToPlaintext(map[string]any{"a": "x", "b": []any{1, 2}})
+		require.NoError(t, err)
+		require.IsType(t, map[string]config.Plaintext{}, pt.Value())
+
+		arr, err := escValueToPlaintext([]any{"a", "b"})
+		require.NoError(t, err)
+		require.IsType(t, []config.Plaintext{}, arr.Value())
+	})
+}
+
+func TestSecretInnerString(t *testing.T) {
+	t.Parallel()
+
+	s, err := secretInnerString("plain")
+	require.NoError(t, err)
+	require.Equal(t, "plain", s)
+
+	s, err = secretInnerString(42)
+	require.NoError(t, err)
+	require.Equal(t, "42", s)
+
+	s, err = secretInnerString(map[string]any{"a": 1})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"a":1}`, s)
+}
+
+func TestBuildPlaintextMap(t *testing.T) {
+	t.Parallel()
+
+	m, err := buildPlaintextMap(map[string]any{
+		"proj:plain":  "v",
+		"proj:secret": map[string]any{"fn::secret": "shh"},
+	})
+	require.NoError(t, err)
+	require.False(t, m[config.MustMakeKey("proj", "plain")].Secure())
+	require.True(t, m[config.MustMakeKey("proj", "secret")].Secure())
+}
+
+func TestAtomicWriteProjectStack(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes the file", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "Pulumi.stack.yaml")
+		require.NoError(t, atomicWriteProjectStack(&workspace.ProjectStack{}, path))
+		_, err := os.Stat(path)
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects an unknown file extension", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "stack.unknown")
+		require.ErrorContains(t, atomicWriteProjectStack(&workspace.ProjectStack{}, path), "no marshaler found")
+	})
+}
+
+func TestEjectIsNotFound(t *testing.T) {
+	t.Parallel()
+	require.True(t, isNotFound(&apitype.ErrorResponse{Code: http.StatusNotFound}))
+	require.False(t, isNotFound(&apitype.ErrorResponse{Code: http.StatusBadRequest}))
+	require.False(t, isNotFound(errors.New("plain")))
+}


### PR DESCRIPTION
## Summary

Add a hidden `pulumi config env eject` that converts a remote-config (ESC-backed) stack back to a local `Pulumi.<stack>.yaml`, reversing `config env init --remote-config`. Continues the stacked series; internally "service-backed config (SBC)", externally "remote config" for now.

Towards pulumi/pulumi-service#39624

## Changes

- **`config env eject`** (hidden) — reads the linked ESC environment with secrets decrypted (in memory only), re-encrypts every secret with a local secrets provider — including secrets nested in objects/arrays and composite `fn::secret` values — and writes `Pulumi.<stack>.yaml`.
- **Atomic, write-before-unlink** — the local file is written via a temp file in the destination directory then renamed, and before the unlink, so a failed re-encryption leaves no plaintext on disk and the stack still linked.
- **`--secrets-provider`** selects the local provider; defaults to `"default"` like `stack init`/`new`, so a Pulumi Cloud eject needs no prompt and works non-interactively.
- **Imports preserved** as local stack imports (warns that a structured import's merge options are not carried over).
- **Unlink then delete** — unlinks the stack from remote config, then deletes the backing environment unless `--keep-env`. An already-deleted environment still unlinks cleanly; a delete failure after unlink is a warning, not a failure.
- **Refuses non-config values** — if the backing environment carries values other than `pulumiConfig` (e.g. `environmentVariables`, `files`) that a local stack file cannot represent, eject refuses before any change rather than silently dropping them and then deleting the only copy.
- **Non-interactive safety** — requires `--yes` for non-interactive eject, since its write/unlink/delete are irreversible.
- **Backend primitives** added: `Stack.RemoveRemoteConfig` (unlink via `client.DeleteStackConfig`) and `EnvironmentsBackend.DeleteEnvironmentWithProject`, wired across cloud, DIY, and mock.

## Notes

- Stacked on the `config edit` / `config env console` PR; review and merge after it.
- Phase 1: hidden command with no public docs or changelog.
- Service-dependent paths (decrypt round-trip, environment delete) are covered by mock tests only; end-to-end ESC behavior needs a smoke run against a real service deployment.
- Deletion of the backing environment is not reference-checked; `--keep-env` is the escape hatch when the environment may be shared or imported by another stack.
