### PR TITLE
Add hidden config env pin and config env rollback

### DIFF
--- a/pkg/cmd/pulumi/config/config_edit.go
+++ b/pkg/cmd/pulumi/config/config_edit.go
@@ -59,7 +59,7 @@ func newConfigEditCmd(ws pkgWorkspace.Context, stackRef *string, configFile *str
 			"ciphertext unless --show-secrets is passed.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if impl.runEnvEdit == nil {
-				impl.runEnvEdit = runEnvEditCmd
+				impl.runEnvEdit = runEnvCmd
 			}
 			return impl.run(cmd.Context())
 		},
@@ -129,14 +129,14 @@ func (cmd *configEditCmd) editRemote(ctx context.Context, stack backend.Stack) e
 	return cmd.runEnvEdit(ctx, args)
 }
 
-func runEnvEditCmd(ctx context.Context, args []string) error {
-	return newEnvEditRoot(args).ExecuteContext(ctx)
+func runEnvCmd(ctx context.Context, args []string) error {
+	return newEnvRoot(args).ExecuteContext(ctx)
 }
 
 // cobra always executes from the root, so args are set on the root with the env command's name
 // prepended; setting them on the subcommand alone is ignored and the process's real os.Args
 // (`config edit`) would leak in and fail as an unknown esc command.
-func newEnvEditRoot(args []string) *cobra.Command {
+func newEnvRoot(args []string) *cobra.Command {
 	envCmd := cmdEnv.NewEnvCmd()
 	root := envCmd.Root()
 	if root != envCmd {

--- a/pkg/cmd/pulumi/config/config_edit_test.go
+++ b/pkg/cmd/pulumi/config/config_edit_test.go
@@ -111,7 +111,7 @@ func TestRunEnvEditDispatchResolves(t *testing.T) {
 	// Regression: cobra executes from the root, so the env subcommand path must be on the root's args.
 	// Passing too many args makes `env edit` fail its own MaximumNArgs(1) validation, which proves
 	// dispatch resolved to `env edit` (without contacting a backend) rather than rejecting "config".
-	root := newEnvEditRoot([]string{"edit", "x", "y", "z"})
+	root := newEnvRoot([]string{"edit", "x", "y", "z"})
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)
 	err := root.ExecuteContext(t.Context())

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -73,6 +73,8 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 	cmd.AddCommand(newConfigEnvRmCmd(&impl))
 	cmd.AddCommand(newConfigEnvLsCmd(&impl))
 	cmd.AddCommand(newConfigEnvEjectCmd(&impl))
+	cmd.AddCommand(newConfigEnvPinCmd(&impl))
+	cmd.AddCommand(newConfigEnvRollbackCmd(&impl))
 	cmd.AddCommand(newConfigEnvConsoleCmd(ws, stackRef, configFile))
 
 	return cmd

--- a/pkg/cmd/pulumi/config/config_env_rollback.go
+++ b/pkg/cmd/pulumi/config/config_env_rollback.go
@@ -1,0 +1,119 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+)
+
+// configEnvRollbackCmd rolls a remote-config stack's linked ESC environment back to a prior revision
+// by delegating to `pulumi env version rollback`, which rewrites the revision's contents as a new
+// revision (history preserved). Local stacks are not supported.
+type configEnvRollbackCmd struct {
+	parent *configEnvCmd
+
+	// runEnv runs `pulumi env <args>`. Injectable so tests do not invoke the real ESC backend.
+	runEnv func(ctx context.Context, args []string) error
+}
+
+func newConfigEnvRollbackCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvRollbackCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:    "rollback <revision>",
+		Short:  "Roll back a remote-config stack's configuration to a prior revision",
+		Hidden: true,
+		Long: "Roll back a stack that stores its configuration remotely to the contents of a prior revision\n" +
+			"of its backing ESC environment.\n\n" +
+			"This delegates to `pulumi env version rollback`: it reads the given revision and writes its\n" +
+			"contents as a new revision, so the history is preserved rather than rewritten.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			parent.stdout = cmd.OutOrStdout()
+			if impl.runEnv == nil {
+				impl.runEnv = runEnvCmd
+			}
+			return impl.run(cmd.Context(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "revision"}},
+		Required:  1,
+	})
+
+	return cmd
+}
+
+func (cmd *configEnvRollbackCmd) run(ctx context.Context, revision string) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	if _, _, err := cmd.parent.ws.ReadProject(); err != nil {
+		return err
+	}
+
+	stack, err := cmd.parent.requireStack(
+		ctx,
+		cmd.parent.diags,
+		cmd.parent.ws,
+		cmdBackend.DefaultLoginManager,
+		*cmd.parent.stackRef,
+		cmdStack.SetCurrent,
+		opts,
+		*cmd.parent.configFile,
+	)
+	if err != nil {
+		return err
+	}
+
+	if !configStoreIsRemote(stack, *cmd.parent.configFile) {
+		return errors.New("`pulumi config env rollback` is only supported for remote config stacks")
+	}
+	if err := rejectIfPinned(stack, *cmd.parent.configFile); err != nil {
+		return err
+	}
+
+	ref := stack.ConfigLocation().EscEnv
+	if ref == nil || *ref == "" {
+		return errors.New("stack is configured for remote config but has no linked environment")
+	}
+	envRef := stripEnvVersion(*ref)
+
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+
+	// Qualify with the stack's org so `env version rollback` cannot fall back to the user's default org.
+	// The rollback is last-writer-wins (no etag guard), but every revision is retained so a concurrent
+	// overwrite is recoverable by rolling back again.
+	args := []string{"version", "rollback", orgNamer.OrgName() + "/" + envRef + "@" + revision}
+
+	// env rediscovers its backend from PULUMI_BACKEND_URL or the current login and never reads the
+	// project's backend.url, so pin it to the backend this stack actually resolved to. Otherwise a
+	// project pinned to a different cloud could roll back a same-named environment in the ambient one.
+	if urler, ok := stack.Backend().(interface{ CloudURL() string }); ok {
+		defer bindBackendURL(urler.CloudURL())()
+	}
+	return cmd.runEnv(ctx, args)
+}

--- a/pkg/cmd/pulumi/config/config_env_rollback_test.go
+++ b/pkg/cmd/pulumi/config/config_env_rollback_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// newRollbackCmdForTest builds a configEnvRollbackCmd over a remote stack linked to escEnv in org
+// "org". runEnv captures the `pulumi env` args the command would dispatch.
+func newRollbackCmdForTest(
+	t *testing.T, escEnv, configFile string, runEnv func(context.Context, []string) error,
+) *configEnvRollbackCmd {
+	t.Helper()
+	stackRef := "stack"
+	cf := configFile
+
+	parent := &configEnvCmd{
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes(
+					[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			env := escEnv
+			return &backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{NameV: tokens.MustParseStackName("stack")}
+				},
+				OrgNameF: func() string { return "org" },
+				BackendF: func() backend.Backend { return &backend.MockEnvironmentsBackend{} },
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+				},
+			}, nil
+		},
+		stackRef:   &stackRef,
+		configFile: &cf,
+	}
+	parent.initArgs()
+
+	return &configEnvRollbackCmd{parent: parent, runEnv: runEnv}
+}
+
+func TestConfigEnvRollbackDelegates(t *testing.T) {
+	t.Parallel()
+
+	var gotArgs []string
+	cmd := newRollbackCmdForTest(t, "testProject/testStack", "",
+		func(_ context.Context, args []string) error {
+			gotArgs = args
+			return nil
+		})
+
+	require.NoError(t, cmd.run(t.Context(), "3"))
+	require.Equal(t, []string{"version", "rollback", "org/testProject/testStack@3"}, gotArgs)
+}
+
+func TestConfigEnvRollbackRejectsPinned(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	cmd := newRollbackCmdForTest(t, "testProject/testStack@5", "",
+		func(context.Context, []string) error {
+			called = true
+			return nil
+		})
+
+	err := cmd.run(t.Context(), "3")
+	require.ErrorContains(t, err, "unpin")
+	require.False(t, called, "a pinned stack must not dispatch a rollback")
+}
+
+func TestConfigEnvRollbackRejectsConfigFile(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	cmd := newRollbackCmdForTest(t, "testProject/testStack", "Pulumi.local.yaml",
+		func(context.Context, []string) error {
+			called = true
+			return nil
+		})
+
+	err := cmd.run(t.Context(), "3")
+	require.ErrorContains(t, err, "only supported for remote")
+	require.False(t, called, "a local --config-file stack must not dispatch a rollback")
+}

--- a/pkg/cmd/pulumi/config/config_pin.go
+++ b/pkg/cmd/pulumi/config/config_pin.go
@@ -1,0 +1,171 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newConfigEnvPinCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvPinCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:    "pin <version-or-tag>",
+		Short:  "Pin a remote-config stack to an environment revision or tag",
+		Hidden: true,
+		Long: "Pin a stack that stores its configuration remotely to a specific revision or tag of its\n" +
+			"backing ESC environment. While pinned, configuration mutations are refused. Pass `latest`\n" +
+			"to unpin and track the most recent revision again.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			parent.stdout = cmd.OutOrStdout()
+			return impl.run(cmd.Context(), args[0])
+		},
+	}
+
+	constrictor.AttachArguments(cmd, &constrictor.Arguments{
+		Arguments: []constrictor.Argument{{Name: "version-or-tag"}},
+		Required:  1,
+	})
+
+	return cmd
+}
+
+type configEnvPinCmd struct {
+	parent *configEnvCmd
+
+	// getEnvironment is injectable so tests can validate a version without a real backend.
+	getEnvironment func(
+		ctx context.Context, org, project, env, version string, decrypt bool,
+	) ([]byte, string, int, error)
+}
+
+func (cmd *configEnvPinCmd) run(ctx context.Context, version string) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	project, _, err := cmd.parent.ws.ReadProject()
+	if err != nil {
+		return err
+	}
+
+	stack, err := cmd.parent.requireStack(
+		ctx,
+		cmd.parent.diags,
+		cmd.parent.ws,
+		cmdBackend.DefaultLoginManager,
+		*cmd.parent.stackRef,
+		cmdStack.SetCurrent,
+		opts,
+		*cmd.parent.configFile,
+	)
+	if err != nil {
+		return err
+	}
+
+	loc := stack.ConfigLocation()
+	// An explicit --config-file selects a local file; pinning operates only on the remote environment.
+	if !configStoreIsRemote(stack, *cmd.parent.configFile) {
+		return errors.New("this stack does not use remote configuration; there is nothing to pin")
+	}
+	if loc.EscEnv == nil || *loc.EscEnv == "" {
+		return errors.New("this stack does not reference a backing environment")
+	}
+	baseRef := stripEnvVersion(*loc.EscEnv)
+
+	if strings.EqualFold(version, "latest") {
+		if err := cmd.link(ctx, stack, project, baseRef); err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.parent.stdout, "Unpinned configuration.")
+		return nil
+	}
+
+	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+	if !ok {
+		return fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+	}
+	orgNamer, ok := stack.(interface{ OrgName() string })
+	if !ok {
+		return errors.New("internal error: stack does not provide an organization name")
+	}
+	envProject, envName, err := splitEnvRef(baseRef)
+	if err != nil {
+		return err
+	}
+
+	getEnv := cmd.getEnvironment
+	if getEnv == nil {
+		getEnv = envBackend.GetEnvironment
+	}
+	if _, _, _, err := getEnv(ctx, orgNamer.OrgName(), envProject, envName, version, false); err != nil {
+		if isNotFound(err) {
+			return fmt.Errorf("version %q not found for environment %s", version, baseRef)
+		}
+		return fmt.Errorf("validating version %q: %w", version, err)
+	}
+
+	if err := cmd.link(ctx, stack, project, baseRef+"@"+version); err != nil {
+		return err
+	}
+
+	kind := "tag"
+	if _, err := strconv.Atoi(version); err == nil {
+		kind = "revision"
+	}
+	fmt.Fprintf(cmd.parent.stdout, "Pinned configuration to %s %s.\n", kind, version)
+	return nil
+}
+
+// link repoints the stack's remote configuration to ref via SaveRemoteConfig, which requires a
+// project stack with a nil Config and exactly one environment import that it adopts as the new link.
+func (cmd *configEnvPinCmd) link(
+	ctx context.Context, stack backend.Stack, project *workspace.Project, ref string,
+) error {
+	// SaveRemoteConfig replaces the config link wholesale, so carry over the current secrets-provider
+	// metadata; re-linking with empty metadata would clear it and break decryption for a passphrase/KMS
+	// stack. Read it from the remote stack config (empty config-file) — a local --config-file would
+	// carry the wrong provider metadata into the remote link.
+	current, err := cmd.parent.loadProjectStack(ctx, cmd.parent.diags, project, stack, "")
+	if err != nil {
+		return fmt.Errorf("reading current stack configuration: %w", err)
+	}
+
+	ps := &workspace.ProjectStack{
+		Environment: workspace.NewEnvironment([]string{ref}),
+		Config:      nil,
+	}
+	if current != nil {
+		ps.SecretsProvider = current.SecretsProvider
+		ps.EncryptedKey = current.EncryptedKey
+		ps.EncryptionSalt = current.EncryptionSalt
+	}
+	if err := stack.SaveRemoteConfig(ctx, ps); err != nil {
+		return fmt.Errorf("updating remote configuration link: %w", err)
+	}
+	return nil
+}

--- a/pkg/cmd/pulumi/config/config_pin_test.go
+++ b/pkg/cmd/pulumi/config/config_pin_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// newPinCmdForTest builds a configEnvPinCmd over a remote stack whose linked ref is escEnv. The new
+// link passed to SaveRemoteConfig is captured into *linked; getErr is returned by GetEnvironment when
+// validating a version.
+func newPinCmdForTest(
+	t *testing.T,
+	stdout *bytes.Buffer,
+	escEnv string,
+	linked *string,
+	getErr error,
+) *configEnvPinCmd {
+	t.Helper()
+	stackRef := "stack"
+	configFile := ""
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte("values:\n  pulumiConfig: {}\n"), "etag", 0, getErr
+		},
+	}
+
+	parent := &configEnvCmd{
+		stdout: stdout,
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				p, err := workspace.LoadProjectBytes(
+					[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+				if err != nil {
+					return nil, "", err
+				}
+				return p, "", nil
+			},
+		},
+		loadProjectStack: func(
+			_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+		) (*workspace.ProjectStack, error) {
+			// Existing remote config carries secrets-provider metadata that re-linking must preserve.
+			return &workspace.ProjectStack{SecretsProvider: "passphrase", EncryptionSalt: "salt"}, nil
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			env := escEnv
+			return &backend.MockStack{
+				RefF: func() backend.StackReference {
+					return &backend.MockStackReference{NameV: tokens.MustParseStackName("stack")}
+				},
+				OrgNameF: func() string { return "org" },
+				BackendF: func() backend.Backend { return be },
+				ConfigLocationF: func() backend.StackConfigLocation {
+					return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+				},
+				SaveRemoteF: func(_ context.Context, ps *workspace.ProjectStack) error {
+					require.Nil(t, ps.Config, "SaveRemoteConfig requires a nil Config")
+					imports := ps.Environment.Imports()
+					require.Len(t, imports, 1, "SaveRemoteConfig requires exactly one import")
+					// Re-linking must preserve the stack's secrets-provider metadata.
+					require.Equal(t, "passphrase", ps.SecretsProvider, "pin must preserve the secrets provider")
+					require.Equal(t, "salt", ps.EncryptionSalt, "pin must preserve the encryption salt")
+					if linked != nil {
+						*linked = imports[0]
+					}
+					return nil
+				},
+			}, nil
+		},
+		stackRef:   &stackRef,
+		configFile: &configFile,
+	}
+	parent.initArgs()
+
+	return &configEnvPinCmd{parent: parent}
+}
+
+func TestConfigEnvPinRevision(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv", &linked, nil)
+	require.NoError(t, cmd.run(t.Context(), "5"))
+
+	require.Equal(t, "testProject/testEnv@5", linked)
+	require.Contains(t, stdout.String(), "revision 5")
+}
+
+func TestConfigEnvPinTag(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv", &linked, nil)
+	require.NoError(t, cmd.run(t.Context(), "stable"))
+
+	require.Equal(t, "testProject/testEnv@stable", linked)
+	require.Contains(t, stdout.String(), "tag stable")
+}
+
+func TestConfigEnvPinMissingVersion(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv", &linked, &apitype.ErrorResponse{
+		Code: http.StatusNotFound, Message: "not found",
+	})
+	err := cmd.run(t.Context(), "999")
+	require.ErrorContains(t, err, "not found")
+	require.Empty(t, linked, "a failed validation must not change the link")
+}
+
+func TestConfigEnvPinLatestUnpins(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv@5", &linked, nil)
+	require.NoError(t, cmd.run(t.Context(), "latest"))
+
+	require.Equal(t, "testProject/testEnv", linked)
+	require.Contains(t, stdout.String(), "Unpinned")
+}
+
+// TestConfigEnvPinAbortsOnLoadError verifies that if reading the current stack configuration fails,
+// pin aborts the re-link instead of re-linking with empty secrets metadata — which would silently
+// clear the stack's secrets-provider settings and break decryption for a passphrase/KMS stack.
+func TestConfigEnvPinAbortsOnLoadError(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv", &linked, nil)
+	cmd.parent.loadProjectStack = func(
+		_ context.Context, _ diag.Sink, _ *workspace.Project, _ backend.Stack, _ string,
+	) (*workspace.ProjectStack, error) {
+		return nil, errors.New("service unavailable")
+	}
+
+	err := cmd.run(t.Context(), "5")
+	require.ErrorContains(t, err, "service unavailable")
+	require.Empty(t, linked, "a load failure must abort the re-link, not write empty secrets metadata")
+}
+
+// remotePinTestStack builds a remote (ESC-backed) MockStack linked to escEnv in org "org".
+func remotePinTestStack(escEnv string) *backend.MockStack {
+	env := escEnv
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{NameV: tokens.MustParseStackName("stack")}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return &backend.MockEnvironmentsBackend{} },
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+}
+
+// TestConfigEnvPinRejectsConfigFile verifies that pin refuses when --config-file selects a local file:
+// pinning operates only on the remote environment, and honoring the flag would read the wrong secrets
+// metadata and write it back to the remote link.
+func TestConfigEnvPinRejectsConfigFile(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var linked string
+	cmd := newPinCmdForTest(t, &stdout, "testProject/testEnv", &linked, nil)
+	configFile := "Pulumi.local.yaml"
+	cmd.parent.configFile = &configFile
+
+	err := cmd.run(t.Context(), "5")
+	require.ErrorContains(t, err, "nothing to pin")
+	require.Empty(t, linked, "--config-file must not re-link the remote stack")
+}
+
+// TestConfigSetRejectsPinned verifies the rejectIfPinned guard fires on a mutating command (config
+// set) before any write when the stack is pinned, and that an explicit --config-file (a local write)
+// bypasses the guard.
+func TestConfigSetRejectsPinned(t *testing.T) {
+	t.Parallel()
+
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			p, err := workspace.LoadProjectBytes(
+				[]byte("name: test\nruntime: yaml"), "Pulumi.yaml", encoding.YAML)
+			if err != nil {
+				return nil, "", err
+			}
+			return p, "", nil
+		},
+	}
+	c := &configSetCmd{}
+
+	pinned := remotePinTestStack("testProject/testEnv@5")
+	err := c.Run(t.Context(), ws, []string{"k", "v"}, &workspace.Project{Name: "test"}, pinned, "")
+	require.ErrorContains(t, err, "unpin")
+}

--- a/pkg/cmd/pulumi/config/coverage_sbc08_test.go
+++ b/pkg/cmd/pulumi/config/coverage_sbc08_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func projectReadingWS() *pkgWorkspace.MockContext {
+	return &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "testProject"}, "", nil
+		},
+	}
+}
+
+// configEnvParentReturning builds a configEnvCmd whose requireStack always resolves to stack, so the
+// hidden config env subcommands can be driven without a real backend.
+func configEnvParentReturning(ws pkgWorkspace.Context, stack backend.Stack) *configEnvCmd {
+	ref, configFile := "testStack", ""
+	return &configEnvCmd{
+		stdout:     &bytes.Buffer{},
+		ws:         ws,
+		stackRef:   &ref,
+		configFile: &configFile,
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return stack, nil
+		},
+	}
+}
+
+func TestConfigEnvRollbackRun(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("delegates to env version rollback qualified with the org", func(t *testing.T) {
+		t.Parallel()
+		env := "proj/env"
+		var got []string
+		cmd := &configEnvRollbackCmd{
+			parent: configEnvParentReturning(projectReadingWS(), remoteStackWithEscEnv(&env, &backend.MockBackend{})),
+			runEnv: func(_ context.Context, args []string) error { got = args; return nil },
+		}
+		require.NoError(t, cmd.run(ctx, "5"))
+		require.Equal(t, []string{"version", "rollback", "org/proj/env@5"}, got)
+	})
+
+	t.Run("rejects a local stack", func(t *testing.T) {
+		t.Parallel()
+		local := &backend.MockStack{
+			ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		}
+		cmd := &configEnvRollbackCmd{
+			parent: configEnvParentReturning(projectReadingWS(), local),
+			runEnv: func(context.Context, []string) error { return nil },
+		}
+		require.ErrorContains(t, cmd.run(ctx, "5"), "only supported for remote config")
+	})
+
+	t.Run("rejects a pinned stack", func(t *testing.T) {
+		t.Parallel()
+		env := "proj/env@3"
+		cmd := &configEnvRollbackCmd{
+			parent: configEnvParentReturning(projectReadingWS(), remoteStackWithEscEnv(&env, &backend.MockBackend{})),
+			runEnv: func(context.Context, []string) error { return nil },
+		}
+		require.ErrorContains(t, cmd.run(ctx, "5"), "pinned")
+	})
+
+	t.Run("rejects a stack with no linked environment", func(t *testing.T) {
+		t.Parallel()
+		cmd := &configEnvRollbackCmd{
+			parent: configEnvParentReturning(projectReadingWS(), remoteStackWithEscEnv(nil, &backend.MockBackend{})),
+			runEnv: func(context.Context, []string) error { return nil },
+		}
+		require.ErrorContains(t, cmd.run(ctx, "5"), "no linked environment")
+	})
+}
+
+// TestConfigEnvRollbackPinsBackendURL covers the branch that pins PULUMI_BACKEND_URL to the stack's
+// own backend so env version rollback targets the right cloud.
+//
+//nolint:paralleltest // mutates PULUMI_BACKEND_URL
+func TestConfigEnvRollbackPinsBackendURL(t *testing.T) {
+	t.Setenv("PULUMI_BACKEND_URL", "https://ambient.example.com")
+	env := "proj/env"
+	be := &cloudURLBackend{url: "https://stack.example.com"}
+	var sawURL string
+	cmd := &configEnvRollbackCmd{
+		parent: configEnvParentReturning(projectReadingWS(), remoteStackWithEscEnv(&env, be)),
+		runEnv: func(context.Context, []string) error { sawURL = os.Getenv("PULUMI_BACKEND_URL"); return nil },
+	}
+	require.NoError(t, cmd.run(t.Context(), "5"))
+	require.Equal(t, "https://stack.example.com", sawURL)
+	require.Equal(t, "https://ambient.example.com", os.Getenv("PULUMI_BACKEND_URL"))
+}
+
+func TestConfigEnvPinLink(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	loaderReturning := func(ps *workspace.ProjectStack, err error) *configEnvCmd {
+		return &configEnvCmd{
+			loadProjectStack: func(
+				context.Context, diag.Sink, *workspace.Project, backend.Stack, string,
+			) (*workspace.ProjectStack, error) {
+				return ps, err
+			},
+		}
+	}
+
+	t.Run("carries over secrets metadata and writes the new link", func(t *testing.T) {
+		t.Parallel()
+		var saved *workspace.ProjectStack
+		stack := &backend.MockStack{
+			SaveRemoteF: func(_ context.Context, ps *workspace.ProjectStack) error { saved = ps; return nil },
+		}
+		cmd := &configEnvPinCmd{
+			parent: loaderReturning(&workspace.ProjectStack{SecretsProvider: "passphrase", EncryptionSalt: "salt"}, nil),
+		}
+		require.NoError(t, cmd.link(ctx, stack, &workspace.Project{Name: "p"}, "proj/env@5"))
+		require.NotNil(t, saved)
+		require.Equal(t, "passphrase", saved.SecretsProvider)
+		require.Equal(t, "salt", saved.EncryptionSalt)
+		require.Nil(t, saved.Config)
+	})
+
+	t.Run("aborts when the current configuration cannot be read", func(t *testing.T) {
+		t.Parallel()
+		cmd := &configEnvPinCmd{parent: loaderReturning(nil, errors.New("load failed"))}
+		err := cmd.link(ctx, &backend.MockStack{}, &workspace.Project{}, "proj/env")
+		require.ErrorContains(t, err, "reading current stack configuration")
+	})
+
+	t.Run("surfaces a save failure", func(t *testing.T) {
+		t.Parallel()
+		stack := &backend.MockStack{
+			SaveRemoteF: func(context.Context, *workspace.ProjectStack) error { return errors.New("nope") },
+		}
+		cmd := &configEnvPinCmd{parent: loaderReturning(&workspace.ProjectStack{}, nil)}
+		err := cmd.link(ctx, stack, &workspace.Project{}, "proj/env")
+		require.ErrorContains(t, err, "updating remote configuration link")
+	})
+}


### PR DESCRIPTION
## Summary

This should be the final PR in the stack.

Add two hidden commands for managing the configuration version of a remote-config (ESC-backed) stack: `pulumi config env pin` and `pulumi config env rollback`. Continues the stacked series; internally "service-backed config (SBC)", externally "remote config" for now.

Closes pulumi/pulumi-service#39624

## Changes

- **`config env pin <revision-or-tag>`** (hidden) — pins a remote-config stack to a specific ESC environment revision or tag by linking it to `<env>@<version>`; `pin latest` unpins. Preserves the stack's secrets-provider metadata (read from the remote stack config) across the re-link, and aborts rather than clearing it if the current configuration cannot be read. Refuses `--config-file`, since pinning operates only on the remote environment.
- **`config env rollback <revision>`** (hidden) — rolls a remote-config stack back to a prior revision by delegating to `pulumi env version rollback`, which reads that revision and writes its contents as a new revision (history preserved, not rewritten). Local stacks are not supported.
- **Pinned reads** — the ESC editor and `config env eject` pass the linked ref's `@version` through to `GetEnvironment`; the editor's `Save` refuses to write to a pinned environment.
- **Mutation guard** — while a stack is pinned, `config set`/`set-all`/`rm`/`rm-all`, `config env add`/`rm`, `config edit`, and `config env rollback` refuse with a message pointing at `pin latest`. The guards honor `--config-file`: a local-file write is allowed regardless of the remote pin.
- **Shared helpers** — env-ref `@version` / `<project>/<name>` parsing is factored into helpers reused by the ESC editor; the in-process `pulumi env` dispatch (already used by `config edit`) is reused by rollback.

## Notes

- Stacked on the `config env eject` PR; review and merge after it.
- Phase 1: hidden commands, no public docs or changelog.
- `config env rollback` is intentionally not concurrency-guarded — it matches esc's native `env version rollback` (an unconditional write); a concurrent edit is last-writer-wins but every revision is retained, so an overwrite is recoverable by rolling back again.
- Service-dependent paths (pinned reads, rollback write) are covered by mock tests only; end-to-end ESC behavior needs a smoke run against a real service deployment.
