### PR TITLE
keep azure CLI instead of re-installing it

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -113,23 +113,15 @@ jobs:
     steps:
       - if: contains(inputs.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        uses: tgummerer/free-disk-space@865f5375bb031bd539c76f6309945e0bdd8d7501
         with:
           # tool-cache stays off: tests need Node and Python from /opt/hostedtoolcache.
           tool-cache: false
           swap-storage: false
           large-packages: true
+          large-packages-keep: |
+            azure-cli
           dotnet: true
-
-      # `large-packages: true` strips the runner's pre-installed `azure-cli`,
-      # which TestAzureLoginAzLogin in tests/integration/backend/diy invokes
-      # via exec.Command("az", "login", ...) when the AZURE_CLIENT_* secrets
-      # are set. Put it back. None of the other packages stripped by
-      # `large-packages` are exercised by these tests.
-      - if: contains(inputs.platform, 'ubuntu')
-        name: Reinstall Azure CLI
-        run: |
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.


### PR DESCRIPTION
We currently remove a bunch of packages to free disk space, but then re-add azure-cli, because we actually need that.  There's a PR upstream (https://github.com/jlumbroso/free-disk-space/pull/47), to make it possible to keep certain packages so we don't need to do this dance, and potentially fail in the process.  Try that out.

I forked the action into my account, applying those commits after reviewing them.  The action seems unmaintained, with the last commit 3 years ago, so it's unlikely upstream is going to do anything here.

Fixes https://github.com/pulumi/pulumi/issues/23471
