### PR TITLE
Don't let transformations unset the Parent name in Go

### DIFF
--- a/changelog/pending/sdk-go-fix-20260605-145022.yaml
+++ b/changelog/pending/sdk-go-fix-20260605-145022.yaml
@@ -1,0 +1,6 @@
+component: sdk/go
+kind: fix
+body: Applying a transformation to a resource no longer drops the resource's parent in the `RegisterResource` call
+time: 2026-06-05T14:50:22.466583+02:00
+custom:
+    PR: "14826"

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -2034,6 +2034,9 @@ type resourceState struct {
 	transformations   []ResourceTransformation
 }
 
+var errTransformationsCannotChangeParent = errors.New(
+	"transformations cannot currently be used to change the `parent` of a resource")
+
 // Apply transformations and return the transformations themselves, as well as the transformed props and opts.
 func applyTransformations(t, name string, props Input, resource Resource, opts []ResourceOption,
 	options *resourceOptions,
@@ -2057,8 +2060,9 @@ func applyTransformations(t, name string, props Input, resource Resource, opts [
 			resOptions := merge(res.Opts...)
 
 			if resOptions.Parent != nil && resOptions.Parent.URN() != options.Parent.URN() {
-				return nil, nil, nil, errors.New("transformations cannot currently be used to change the `parent` of a resource")
+				return nil, nil, nil, errTransformationsCannotChangeParent
 			}
+			resOptions.Parent = options.Parent // Callers *must* re-apply the parent option, so we do it for them
 			props = res.Props
 			options = resOptions
 		}

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -541,6 +541,78 @@ func assertTransformations(t *testing.T, t1 []ResourceTransformation, t2 []Resou
 	}
 }
 
+func TestTransformationPreservesParent(t *testing.T) {
+	t.Parallel()
+
+	identity := func(args *ResourceTransformationArgs) *ResourceTransformationResult {
+		return &ResourceTransformationResult{
+			Props: args.Props,
+			Opts:  args.Opts,
+		}
+	}
+
+	parents := map[string]string{}
+	monitor := &testMonitor{
+		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			parents[args.Name] = args.RegisterRPC.GetParent()
+			return args.Name, resource.PropertyMap{}, nil
+		},
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		var withoutT testResource2
+		require.NoError(t, ctx.RegisterResource(
+			"test:resource:type", "without-transform",
+			&testResource2Inputs{Foo: String("oof")}, &withoutT))
+
+		var withT testResource2
+		require.NoError(t, ctx.RegisterResource(
+			"test:resource:type", "with-transform",
+			&testResource2Inputs{Foo: String("oof")}, &withT,
+			Transformations([]ResourceTransformation{identity})))
+
+		return nil
+	}, WithMocks("project", "stack", monitor))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, parents["without-transform"], "baseline should have a parent")
+	assert.Equal(t, parents["without-transform"], parents["with-transform"],
+		"transformation must not drop the parent")
+}
+
+func TestTransformationCannotChangeParent(t *testing.T) {
+	t.Parallel()
+
+	parents := map[string]string{}
+	monitor := &testMonitor{
+		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
+			parents[args.Name] = args.RegisterRPC.GetParent()
+			return args.Name, resource.PropertyMap{}, nil
+		},
+	}
+
+	err := RunErr(func(ctx *Context) error {
+		var withoutT testResource2
+		require.NoError(t, ctx.RegisterResource(
+			"test:resource:type", "without-transform",
+			&testResource2Inputs{Foo: String("oof")}, &withoutT))
+
+		var withT testResource2
+		return ctx.RegisterResource(
+			"test:resource:type", "with-transform",
+			&testResource2Inputs{Foo: String("oof")}, &withT,
+			Transformations([]ResourceTransformation{
+				func(args *ResourceTransformationArgs) *ResourceTransformationResult {
+					return &ResourceTransformationResult{
+						Props: args.Props,
+						Opts:  append(args.Opts, Parent(&withoutT)),
+					}
+				},
+			}))
+	}, WithMocks("project", "stack", monitor))
+	assert.ErrorIs(t, err, errTransformationsCannotChangeParent)
+}
+
 func TestResourceOptionMergingReplaceOnChanges(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR prevents transforms in Go from un-setting the `Parent` resource option by accident (or on purpose). 

Fixes #14826 
