### PR TITLE
pin mise dependencies

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,22 +1,22 @@
 [tools]
-github-cli = "latest"
-"go:github.com/go-delve/delve/cmd/dlv" = "latest"
+github-cli = "2.93.0"
+"go:github.com/go-delve/delve/cmd/dlv" = "1.26.3"
 # gopls v0.22+ requires Go 1.26; pin to the latest version compatible with Go 1.25.
 "go:golang.org/x/tools/gopls" = "0.21.0"
 go = "1.25"
 changie = "1.24.0"
 golangci-lint = "2.12.2"
-jq = "latest"
+jq = "1.8.1"
 node = "20"
 "npm:pnpm" = "10"
-"npm:typescript" = "latest"
-"npm:typescript-language-server" = "latest"
-"npm:yarn" = "latest"
-bun = "latest"
+"npm:typescript" = "6.0.3"
+"npm:typescript-language-server" = "5.3.0"
+"npm:yarn" = "1.22.22"
+bun = "1.3.14"
 python = '3.11'
 uv = "0.10.0"
 # This is a dev only dependency that fails to install on windows
-"go:github.com/mitranim/gow" = { version = "latest", os = ["linux", "macos"] }
+"go:github.com/mitranim/gow" = { version = "0.0.0-20260515002309-3b8e4d082711", os = ["linux", "macos"] }
 protoc = "29.5"
 "go:google.golang.org/protobuf/cmd/protoc-gen-go" = "v1.36.6"
 "go:google.golang.org/grpc/cmd/protoc-gen-go-grpc" = "v1.5.1"


### PR DESCRIPTION
Currently we have some dependencies in `.mise.toml` pinned to fixed versions, while others just use `latest`.

According to @blampe, this loses some of the caching benefits we could get.

Pin the dependencies as a first step for trying to re-introduce mise in CI. I'm thinking of merging this first, and then in a few days re-introduce installing dependencies via mise in CI.  This way most PRs should have the updated version of `.mise.toml`, thus utilizing the cache hopefully.

/xref https://github.com/pulumi/pulumi/issues/23079