### PR TITLE
add `pulumi logs rm` command

### DIFF
--- a/changelog/pending/cli-feature-logs-rm.yaml
+++ b/changelog/pending/cli-feature-logs-rm.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Add `pulumi logs rm` to remove automatic log files
+time: 2026-06-08T00:00:00+00:00

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -199,6 +199,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	logsCmd.AddCommand(newDecryptCmd(ws))
 	logsCmd.AddCommand(newLsCmd())
+	logsCmd.AddCommand(newRmCmd())
 
 	logsCmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "",

--- a/pkg/cmd/pulumi/logs/rm.go
+++ b/pkg/cmd/pulumi/logs/rm.go
@@ -133,17 +133,18 @@ func selectLogsToRemove(
 		return []logEntry{entry}, nil
 	}
 
-	entries, err := listLogs(logsDir)
-	if err != nil {
-		return nil, err
-	}
-
 	var beforeTime *time.Time
 	if before != "" {
+		var err error
 		beforeTime, err = parseSince(before, time.Now())
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse --before as duration or timestamp: %w", err)
 		}
+	}
+
+	entries, err := listLogs(logsDir)
+	if err != nil {
+		return nil, err
 	}
 
 	return filterLogs(entries, stackName, beforeTime), nil

--- a/pkg/cmd/pulumi/logs/rm.go
+++ b/pkg/cmd/pulumi/logs/rm.go
@@ -1,0 +1,285 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newRmCmd() *cobra.Command {
+	var before string
+	var all bool
+	var yes bool
+
+	command := &cobra.Command{
+		Use:   "rm",
+		Short: "Remove automatic log files",
+		Long: "Remove automatic log files.\n" +
+			"\n" +
+			"If no filters are given, a list of available log files is\n" +
+			"displayed and the user is prompted to choose one to remove.\n" +
+			"\n" +
+			"Logs can also be removed in bulk by passing --stack to limit\n" +
+			"removal to a single stack, --before to remove logs older than\n" +
+			"a given date or duration, or --all to remove every log file.\n" +
+			"\n" +
+			"By default the user is asked to confirm by typing the stack\n" +
+			"name (or 'yes' when multiple stacks are involved). Pass --yes\n" +
+			"to skip the prompt.",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			stackName, _ := cobraCmd.Flags().GetString("stack")
+			yes = yes || env.SkipConfirmations.Value()
+
+			logsDir, err := workspace.GetPulumiPath("logs")
+			if err != nil {
+				return fmt.Errorf("getting log directory: %w", err)
+			}
+
+			opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+
+			targets, err := selectLogsToRemove(logsDir, stackName, before, all)
+			if err != nil {
+				return err
+			}
+			if len(targets) == 0 {
+				fmt.Fprintf(cobraCmd.OutOrStdout(), "No matching log files found in %s\n", logsDir)
+				return nil
+			}
+
+			out := cobraCmd.OutOrStdout()
+			if !yes {
+				if !cmdutil.Interactive() {
+					return backenderr.ErrNonInteractiveRequiresYes
+				}
+
+				suffix := "s"
+				if len(targets) == 1 {
+					suffix = ""
+				}
+				fmt.Fprintln(out, opts.Color.Colorize(
+					fmt.Sprintf("%sThis will permanently remove %d log file%s:%s",
+						colors.SpecAttention, len(targets), suffix, colors.Reset)))
+				printRemovalTable(out, targets)
+
+				if !ui.ConfirmPrompt("", confirmToken(targets), opts) {
+					return errors.New("confirmation declined")
+				}
+			}
+
+			for _, t := range targets {
+				if err := os.Remove(t.path); err != nil {
+					return fmt.Errorf("removing %s: %w", t.path, err)
+				}
+				fmt.Fprintf(out, "removed %s\n", t.path)
+			}
+			return nil
+		},
+	}
+
+	constrictor.AttachArguments(command, constrictor.NoArgs)
+
+	command.Flags().StringVar(&before, "before", "",
+		"Remove logs created before this date or duration (e.g. '24h', '2026-01-01')")
+	command.Flags().BoolVar(&all, "all", false, "Remove all log files")
+	command.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+
+	return command
+}
+
+func selectLogsToRemove(
+	logsDir string, stackName, before string, all bool,
+) ([]logEntry, error) {
+	if !all && before == "" && stackName == "" {
+		if !cmdutil.Interactive() {
+			return nil, errors.New(
+				"cannot prompt for a log file in non-interactive mode; " +
+					"pass --all, --before, or --stack")
+		}
+		entry, err := chooseLogToRemove(logsDir)
+		if err != nil {
+			return nil, err
+		}
+		return []logEntry{entry}, nil
+	}
+
+	entries, err := listLogs(logsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var beforeTime *time.Time
+	if before != "" {
+		beforeTime, err = parseSince(before, time.Now())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse --before as duration or timestamp: %w", err)
+		}
+	}
+
+	return filterLogs(entries, stackName, beforeTime), nil
+}
+
+func filterLogs(entries []logEntry, stackName string, beforeTime *time.Time) []logEntry {
+	var matches []logEntry
+	for _, e := range entries {
+		if stackName != "" && e.stack != stackName {
+			continue
+		}
+		if beforeTime != nil && !e.timestamp.Before(*beforeTime) {
+			continue
+		}
+		matches = append(matches, e)
+	}
+	return matches
+}
+
+func confirmToken(targets []logEntry) string {
+	var stack string
+	for _, t := range targets {
+		if t.stack == "" {
+			return "yes"
+		}
+		if stack == "" {
+			stack = t.stack
+		} else if stack != t.stack {
+			return "yes"
+		}
+	}
+	if stack == "" {
+		return "yes"
+	}
+	return stack
+}
+
+func chooseLogToRemove(logsDir string) (logEntry, error) {
+	entries, err := listLogs(logsDir)
+	if err != nil {
+		return logEntry{}, err
+	}
+	if len(entries) == 0 {
+		return logEntry{}, fmt.Errorf("no log files found in %s", logsDir)
+	}
+
+	options, optionMap := formatLogRemovalChoices(entries)
+
+	var choice string
+	if err := survey.AskOne(&survey.Select{
+		Message:  "Select a log file to remove:",
+		Options:  options,
+		PageSize: cmd.OptimalPageSize(cmd.OptimalPageSizeOpts{Nopts: len(options)}),
+	}, &choice, ui.SurveyIcons(cmdutil.GetGlobalColorization())); err != nil {
+		return logEntry{}, errors.New("no log file selected")
+	}
+
+	selected := optionMap[choice]
+	for _, e := range entries {
+		if e.path == selected {
+			return e, nil
+		}
+	}
+	return logEntry{}, errors.New("internal error: selected log not found")
+}
+
+func printRemovalTable(out io.Writer, entries []logEntry) {
+	rows := slice.Prealloc[cmdutil.TableRow](len(entries))
+	for _, e := range entries {
+		stack := e.stack
+		if stack == "" {
+			stack = "(cli)"
+		}
+		updateID := e.updateID
+		if updateID == "" {
+			updateID = "—"
+		}
+		rows = append(rows, cmdutil.TableRow{
+			Columns: []string{
+				stack,
+				humanize.Time(e.timestamp),
+				updateID,
+				humanize.Bytes(uint64(e.size)),
+			},
+		})
+	}
+
+	ui.FprintTable(out, cmdutil.Table{
+		Headers: []string{"STACK", "CREATED", "UPDATE ID", "SIZE"},
+		Rows:    rows,
+	}, nil)
+}
+
+func formatLogRemovalChoices(entries []logEntry) ([]string, map[string]string) {
+	type row struct {
+		stack, created, updateID, path string
+	}
+
+	rows := make([]row, len(entries))
+	stackWidth, createdWidth := 0, 0
+	for i, e := range entries {
+		stack := e.stack
+		if stack == "" {
+			stack = "(cli)"
+		}
+		updateID := e.updateID
+		if updateID == "" {
+			updateID = "—"
+		}
+		created := humanize.Time(e.timestamp)
+
+		rows[i] = row{
+			stack:    stack,
+			created:  created,
+			updateID: updateID,
+			path:     e.path,
+		}
+		if l := len(stack); l > stackWidth {
+			stackWidth = l
+		}
+		if l := len(created); l > createdWidth {
+			createdWidth = l
+		}
+	}
+
+	options := make([]string, len(rows))
+	optionMap := make(map[string]string, len(rows))
+	for i, r := range rows {
+		// Append the index to disambiguate identical (stack, created,
+		// updateID) rows that map to different files.
+		line := fmt.Sprintf("%-*s  %-*s  %s", stackWidth, r.stack, createdWidth, r.created, r.updateID)
+		if _, dup := optionMap[line]; dup {
+			line = fmt.Sprintf("%s  [%d]", line, i+1)
+		}
+		options[i] = line
+		optionMap[line] = r.path
+	}
+	return options, optionMap
+}

--- a/pkg/cmd/pulumi/logs/rm_test.go
+++ b/pkg/cmd/pulumi/logs/rm_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfirmToken(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		targets []logEntry
+		want    string
+	}{
+		{
+			name:    "empty targets falls back to yes",
+			targets: nil,
+			want:    "yes",
+		},
+		{
+			name: "single stack target uses stack name",
+			targets: []logEntry{
+				{stack: "dev"},
+			},
+			want: "dev",
+		},
+		{
+			name: "multiple targets in same stack use stack name",
+			targets: []logEntry{
+				{stack: "dev"},
+				{stack: "dev"},
+				{stack: "dev"},
+			},
+			want: "dev",
+		},
+		{
+			name: "multiple stacks fall back to yes",
+			targets: []logEntry{
+				{stack: "dev"},
+				{stack: "prod"},
+			},
+			want: "yes",
+		},
+		{
+			name: "cli-level log falls back to yes",
+			targets: []logEntry{
+				{stack: "", cliLevel: true},
+			},
+			want: "yes",
+		},
+		{
+			name: "stack mixed with cli-level falls back to yes",
+			targets: []logEntry{
+				{stack: "dev"},
+				{stack: "", cliLevel: true},
+			},
+			want: "yes",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, confirmToken(tc.targets))
+		})
+	}
+}
+
+func TestFilterLogs(t *testing.T) {
+	t.Parallel()
+
+	t0 := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	entries := []logEntry{
+		{stack: "dev", timestamp: t0},
+		{stack: "dev", timestamp: t0.Add(-24 * time.Hour)},
+		{stack: "prod", timestamp: t0.Add(-48 * time.Hour)},
+		{stack: "", timestamp: t0.Add(-72 * time.Hour), cliLevel: true},
+	}
+
+	t.Run("no filter returns everything", func(t *testing.T) {
+		t.Parallel()
+		got := filterLogs(entries, "", nil)
+		require.Len(t, got, 4)
+	})
+
+	t.Run("stack filter narrows by stack", func(t *testing.T) {
+		t.Parallel()
+		got := filterLogs(entries, "dev", nil)
+		require.Len(t, got, 2)
+		for _, e := range got {
+			require.Equal(t, "dev", e.stack)
+		}
+	})
+
+	t.Run("stack filter does not match cli-level logs", func(t *testing.T) {
+		t.Parallel()
+		got := filterLogs(entries, "", nil)
+		require.Len(t, got, 4)
+		// And with an explicit stack name, cli-level is excluded.
+		got = filterLogs(entries, "dev", nil)
+		for _, e := range got {
+			require.False(t, e.cliLevel)
+		}
+	})
+
+	t.Run("before filter excludes newer logs", func(t *testing.T) {
+		t.Parallel()
+		cutoff := t0.Add(-36 * time.Hour)
+		got := filterLogs(entries, "", &cutoff)
+		require.Len(t, got, 2)
+		for _, e := range got {
+			require.True(t, e.timestamp.Before(cutoff))
+		}
+	})
+
+	t.Run("stack and before combine", func(t *testing.T) {
+		t.Parallel()
+		cutoff := t0.Add(-12 * time.Hour)
+		got := filterLogs(entries, "dev", &cutoff)
+		require.Len(t, got, 1)
+		require.Equal(t, "dev", got[0].stack)
+		require.True(t, got[0].timestamp.Before(cutoff))
+	})
+
+	t.Run("nothing matches yields empty slice", func(t *testing.T) {
+		t.Parallel()
+		got := filterLogs(entries, "missing", nil)
+		require.Empty(t, got)
+	})
+}
+
+func TestSelectLogsToRemoveByFilter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "dev-20260401T120000.log")
+	prodPath := filepath.Join(dir, "prod-20260401T100000.log")
+	require.NoError(t, os.WriteFile(devPath, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(prodPath, []byte("x"), 0o600))
+
+	t.Run("--all picks everything", func(t *testing.T) {
+		t.Parallel()
+		targets, err := selectLogsToRemove(dir, "", "", true)
+		require.NoError(t, err)
+		require.Len(t, targets, 2)
+	})
+
+	t.Run("--stack narrows", func(t *testing.T) {
+		t.Parallel()
+		targets, err := selectLogsToRemove(dir, "dev", "", false)
+		require.NoError(t, err)
+		require.Len(t, targets, 1)
+		require.Equal(t, "dev", targets[0].stack)
+	})
+
+	t.Run("--before with bad value errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := selectLogsToRemove(dir, "", "not-a-time", false)
+		require.Error(t, err)
+	})
+
+	t.Run("non-matching filter returns empty without erroring", func(t *testing.T) {
+		t.Parallel()
+		targets, err := selectLogsToRemove(dir, "missing", "", false)
+		require.NoError(t, err)
+		require.Empty(t, targets)
+	})
+}
+
+func TestFormatLogRemovalChoicesDisambiguatesDuplicates(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	entries := []logEntry{
+		{stack: "dev", timestamp: ts, updateID: "u-1", path: "/a.log"},
+		{stack: "dev", timestamp: ts, updateID: "u-1", path: "/b.log"},
+	}
+
+	options, optionMap := formatLogRemovalChoices(entries)
+	require.Len(t, options, 2)
+	require.Len(t, optionMap, 2, "duplicates must be disambiguated to distinct keys")
+	require.NotEqual(t, options[0], options[1])
+
+	got := map[string]bool{}
+	for _, opt := range options {
+		got[optionMap[opt]] = true
+	}
+	require.True(t, got["/a.log"])
+	require.True(t, got["/b.log"])
+}


### PR DESCRIPTION
Give the users an easy to use `pulumi logs rm` command, where they can either use flags to choose to bulk remove logs, or choose certain logs from a list.

Note that we do not accept positional arguments here, since that would just be a filename, and it's just as easy to just use `rm` directly. If there's demand for that in the future, we can still easily add it.

Fixes https://github.com/pulumi/pulumi/issues/23447