### PR TITLE
Affected resources in `--output json`

### DIFF
--- a/changelog/pending/cli-feature-20260608-164357.yaml
+++ b/changelog/pending/cli-feature-20260608-164357.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Include the list of affected resources (urn, type, name, op, parent) in `--output json` for `preview`, `up`, `destroy`, and `refresh`
+time: 2026-06-08T16:43:57+00:00

--- a/pkg/backend/display/summary_json.go
+++ b/pkg/backend/display/summary_json.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -40,14 +41,68 @@ type SummaryJSON struct {
 	Duration time.Duration `json:"duration"`
 	// Summary is the count per operation kind (create, update, etc).
 	Summary display.ResourceChanges `json:"summary,omitempty"`
+	// Resources lists each resource the operation acted on, with its planned
+	// (or performed) operation. Unchanged (`same`) resources are omitted unless
+	// the caller passed `--show-sames`, mirroring the human-readable display.
+	Resources []ResourceJSON `json:"resources,omitempty"`
+}
+
+// ResourceJSON is the per-resource entry that appears in SummaryJSON.Resources.
+// It is intentionally compact: callers that need full diffs / property values
+// should use `--json` (the streaming event format) instead.
+type ResourceJSON struct {
+	// URN is the canonical, globally-unique identifier of the resource.
+	URN string `json:"urn"`
+	// Type is the resource type token (e.g. "aws:s3/bucket:Bucket").
+	Type string `json:"type"`
+	// Name is the resource's program-assigned name.
+	Name string `json:"name"`
+	// Op is the planned (preview) or performed (up/destroy/refresh) operation.
+	Op apitype.OpType `json:"op"`
+	// Parent is the URN of this resource's parent, if any.
+	Parent string `json:"parent,omitempty"`
 }
 
 // summaryJSONFromEvent extracts the summary JSON shape from a SummaryEventPayload.
+// The Resources field is populated separately by the tap as resource events flow
+// past, so this helper only fills the run-level fields.
 func summaryJSONFromEvent(p engine.SummaryEventPayload) SummaryJSON {
 	return SummaryJSON{
 		Result:   p.Result,
 		Duration: p.Duration,
 		Summary:  p.ResourceChanges,
+	}
+}
+
+// resourceJSONFromEvent converts a per-resource pre-event into the summary's
+// per-resource JSON shape. Returns nil when the event should be skipped:
+// internal events never surface to users, and `same` (unchanged) resources are
+// omitted unless the display is configured to show them.
+func resourceJSONFromEvent(p engine.ResourcePreEventPayload, showSames bool) *ResourceJSON {
+	if p.Internal {
+		return nil
+	}
+	if p.Metadata.Op == deploy.OpSame && !showSames {
+		return nil
+	}
+
+	// Parent lives on the post-step state when there is one, and falls back to
+	// the pre-step state for deletes (where New is nil).
+	var parent string
+	switch {
+	case p.Metadata.New != nil:
+		parent = string(p.Metadata.New.Parent)
+	case p.Metadata.Old != nil:
+		parent = string(p.Metadata.Old.Parent)
+	}
+
+	urn := p.Metadata.URN
+	return &ResourceJSON{
+		URN:    string(urn),
+		Type:   string(urn.Type()),
+		Name:   urn.Name(),
+		Op:     apitype.OpType(p.Metadata.Op),
+		Parent: parent,
 	}
 }
 
@@ -65,8 +120,9 @@ func writeSummaryJSON(w io.Writer, s SummaryJSON) error {
 }
 
 // tapSummaryJSON returns a copy of the input channel that, in addition to
-// forwarding every event, watches for a SummaryEvent and writes its summary
-// to stdout as a single-line JSON object.
+// forwarding every event, watches for per-resource events to build up a list
+// of affected resources, and for the SummaryEvent to flush the combined
+// summary JSON to stdout as a single line.
 //
 // The tap is only attached when Options.SummaryJSON is set; the rest of the
 // display pipeline is otherwise unaffected.
@@ -82,10 +138,20 @@ func tapSummaryJSON(in <-chan engine.Event, opts Options) <-chan engine.Event {
 	}
 	go func() {
 		defer close(out)
+		var resources []ResourceJSON
 		for e := range in {
-			if e.Type == engine.SummaryEvent {
+			switch e.Type { //nolint:exhaustive // we only care about two event types here
+			case engine.ResourcePreEvent:
+				if payload, ok := e.Payload().(engine.ResourcePreEventPayload); ok {
+					if r := resourceJSONFromEvent(payload, opts.ShowSameResources); r != nil {
+						resources = append(resources, *r)
+					}
+				}
+			case engine.SummaryEvent:
 				if payload, ok := e.Payload().(engine.SummaryEventPayload); ok {
-					if err := writeSummaryJSON(stdout, summaryJSONFromEvent(payload)); err != nil {
+					s := summaryJSONFromEvent(payload)
+					s.Resources = resources
+					if err := writeSummaryJSON(stdout, s); err != nil {
 						fmt.Fprintf(stderr, "warning: failed to write summary JSON: %v\n", err)
 					}
 				}

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -232,7 +232,7 @@ func TestTapSummaryJSON_OmitsResourcesFieldWhenEmpty(t *testing.T) {
 	t.Parallel()
 
 	// No per-resource events: the summary JSON should not include a "resources"
-	// key at all, preserving the pre-existing wire shape for consumers.
+	// key at all.
 	in := make(chan engine.Event, 1)
 	in <- engine.NewEvent(engine.SummaryEventPayload{
 		Result:   apitype.OperationResultSucceeded,

--- a/pkg/backend/display/summary_json_test.go
+++ b/pkg/backend/display/summary_json_test.go
@@ -24,10 +24,28 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// makePreEvent is a small helper to keep the per-resource event tests readable.
+func makePreEvent(op display.StepOp, urn resource.URN, newParent, oldParent resource.URN, internal bool,
+) engine.ResourcePreEventPayload {
+	meta := engine.StepEventMetadata{
+		Op:  op,
+		URN: urn,
+	}
+	if newParent != "" || op != deploy.OpDelete {
+		meta.New = &engine.StepEventStateMetadata{URN: urn, Parent: newParent}
+	}
+	if oldParent != "" {
+		meta.Old = &engine.StepEventStateMetadata{URN: urn, Parent: oldParent}
+	}
+	return engine.ResourcePreEventPayload{Metadata: meta, Internal: internal}
+}
 
 func TestSummaryJSONFromEvent(t *testing.T) {
 	t.Parallel()
@@ -97,6 +115,137 @@ func TestTapSummaryJSON_EmitsOnSummaryEvent(t *testing.T) {
 	assert.Equal(t, apitype.OperationResultSucceeded, summary.Result)
 	assert.Equal(t, 1*time.Second, summary.Duration)
 	assert.Equal(t, 5, summary.Summary["same"])
+}
+
+func TestResourceJSONFromEvent_SkipsInternal(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	payload := makePreEvent(deploy.OpCreate, urn, "parent-urn", "", true /* internal */)
+
+	got := resourceJSONFromEvent(payload, false)
+	assert.Nil(t, got, "internal events must not surface in the summary")
+}
+
+func TestResourceJSONFromEvent_SkipsSameByDefault(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
+
+	got := resourceJSONFromEvent(payload, false /* showSames */)
+	assert.Nil(t, got, "same resources are filtered out unless --show-sames is set")
+}
+
+func TestResourceJSONFromEvent_IncludesSameWhenShowSames(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	payload := makePreEvent(deploy.OpSame, urn, "parent-urn", "", false)
+
+	got := resourceJSONFromEvent(payload, true /* showSames */)
+	require.NotNil(t, got)
+	assert.Equal(t, apitype.OpType("same"), got.Op)
+}
+
+func TestResourceJSONFromEvent_ExtractsTypeAndName(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	parentURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
+	payload := makePreEvent(deploy.OpUpdate, urn, parentURN, "", false)
+
+	got := resourceJSONFromEvent(payload, false)
+	require.NotNil(t, got)
+	assert.Equal(t, string(urn), got.URN)
+	assert.Equal(t, "aws:s3/bucket:Bucket", got.Type)
+	assert.Equal(t, "mybucket", got.Name)
+	assert.Equal(t, apitype.OpType("update"), got.Op)
+	assert.Equal(t, string(parentURN), got.Parent)
+}
+
+func TestResourceJSONFromEvent_ParentFallsBackToOldOnDelete(t *testing.T) {
+	t.Parallel()
+
+	// Deletes carry only the Old state — New is nil. The parent URN must still
+	// be reported.
+	urn := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	parentURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
+	payload := engine.ResourcePreEventPayload{
+		Metadata: engine.StepEventMetadata{
+			Op:  deploy.OpDelete,
+			URN: urn,
+			Old: &engine.StepEventStateMetadata{URN: urn, Parent: parentURN},
+			// New is nil for deletes.
+		},
+	}
+
+	got := resourceJSONFromEvent(payload, false)
+	require.NotNil(t, got)
+	assert.Equal(t, string(parentURN), got.Parent)
+	assert.Equal(t, apitype.OpType("delete"), got.Op)
+}
+
+func TestTapSummaryJSON_AccumulatesResources(t *testing.T) {
+	t.Parallel()
+
+	bucketURN := resource.NewURN("dev", "myapp", "", "aws:s3/bucket:Bucket", "mybucket")
+	stackURN := resource.NewURN("dev", "myapp", "", "pulumi:pulumi:Stack", "myapp-dev")
+	tableURN := resource.NewURN("dev", "myapp", "", "aws:dynamodb/table:Table", "mytable")
+
+	in := make(chan engine.Event, 5)
+	// Stack: surfaced (not internal, not same).
+	in <- engine.NewEvent(makePreEvent(deploy.OpCreate, stackURN, "", "", false))
+	// Bucket: surfaced with parent.
+	in <- engine.NewEvent(makePreEvent(deploy.OpCreate, bucketURN, stackURN, "", false))
+	// Table same: filtered out (showSames = false below).
+	in <- engine.NewEvent(makePreEvent(deploy.OpSame, tableURN, stackURN, "", false))
+	// Internal create: filtered out regardless.
+	in <- engine.NewEvent(makePreEvent(deploy.OpCreate, bucketURN, stackURN, "", true))
+	in <- engine.NewEvent(engine.SummaryEventPayload{
+		Result:          apitype.OperationResultSucceeded,
+		Duration:        2 * time.Second,
+		ResourceChanges: display.ResourceChanges{"create": 2},
+	})
+	close(in)
+
+	var buf bytes.Buffer
+	out := tapSummaryJSON(in, Options{Stdout: &buf})
+	for range out { //nolint:revive // intentional drain
+	}
+
+	var summary SummaryJSON
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &summary))
+
+	require.Len(t, summary.Resources, 2, "expected stack + bucket; same and internal must be filtered")
+	assert.Equal(t, string(stackURN), summary.Resources[0].URN)
+	assert.Equal(t, apitype.OpType("create"), summary.Resources[0].Op)
+	assert.Empty(t, summary.Resources[0].Parent)
+
+	assert.Equal(t, string(bucketURN), summary.Resources[1].URN)
+	assert.Equal(t, "aws:s3/bucket:Bucket", summary.Resources[1].Type)
+	assert.Equal(t, "mybucket", summary.Resources[1].Name)
+	assert.Equal(t, string(stackURN), summary.Resources[1].Parent)
+}
+
+func TestTapSummaryJSON_OmitsResourcesFieldWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	// No per-resource events: the summary JSON should not include a "resources"
+	// key at all, preserving the pre-existing wire shape for consumers.
+	in := make(chan engine.Event, 1)
+	in <- engine.NewEvent(engine.SummaryEventPayload{
+		Result:   apitype.OperationResultSucceeded,
+		Duration: 1 * time.Second,
+	})
+	close(in)
+
+	var buf bytes.Buffer
+	out := tapSummaryJSON(in, Options{Stdout: &buf})
+	for range out { //nolint:revive // intentional drain
+	}
+
+	assert.NotContains(t, buf.String(), `"resources"`)
 }
 
 func TestTapSummaryJSON_ReturnsOnCancelEvent(t *testing.T) {

--- a/tests/integration/destroy_output_summary_test.go
+++ b/tests/integration/destroy_output_summary_test.go
@@ -68,4 +68,12 @@ func TestDestroy_OutputJSONSummary(t *testing.T) {
 
 	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
 	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
+	require.NotEmpty(t, summary.Resources, "summary should list the affected resources")
+	for i, r := range summary.Resources {
+		require.NotEmptyf(t, r.URN, "resource %d should have a URN", i)
+		require.NotEmptyf(t, r.Type, "resource %d should have a type", i)
+		require.NotEmptyf(t, r.Name, "resource %d should have a name", i)
+		// Destroy emits delete ops; the stack itself also disappears.
+		require.Equalf(t, apitype.OpDelete, r.Op, "resource %d should be a delete", i)
+	}
 }

--- a/tests/integration/preview_output_summary_test.go
+++ b/tests/integration/preview_output_summary_test.go
@@ -76,4 +76,14 @@ func TestPreview_OutputJSONSummary(t *testing.T) {
 
 	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
 	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
+	require.NotEmpty(t, summary.Resources, "summary should list the affected resources")
+	for i, r := range summary.Resources {
+		require.NotEmptyf(t, r.URN, "resource %d should have a URN", i)
+		require.NotEmptyf(t, r.Type, "resource %d should have a type", i)
+		require.NotEmptyf(t, r.Name, "resource %d should have a name", i)
+		require.NotEmptyf(t, r.Op, "resource %d should have an op", i)
+		// `same` resources are filtered out by default, so every entry should be
+		// an actual planned change. Preview against an empty stack is all creates.
+		require.NotEqualf(t, apitype.OpSame, r.Op, "resource %d should not be a same", i)
+	}
 }

--- a/tests/integration/refresh_output_summary_test.go
+++ b/tests/integration/refresh_output_summary_test.go
@@ -68,4 +68,15 @@ func TestRefresh_OutputJSONSummary(t *testing.T) {
 		"expected stdout to be exactly one JSON summary object, got:\n%s", raw)
 
 	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
+	// Refresh emits a ResourcePreEvent with Op=refresh for every resource it
+	// inspects (the per-resource ResultOp — same/update — is a separate
+	// post-step computation that doesn't surface here). So Resources is
+	// populated even when nothing actually changes.
+	require.NotEmpty(t, summary.Resources, "summary should list the refreshed resources")
+	for i, r := range summary.Resources {
+		require.NotEmptyf(t, r.URN, "resource %d should have a URN", i)
+		require.NotEmptyf(t, r.Type, "resource %d should have a type", i)
+		require.NotEmptyf(t, r.Name, "resource %d should have a name", i)
+		require.Equalf(t, apitype.OpRefresh, r.Op, "resource %d should be a refresh", i)
+	}
 }

--- a/tests/integration/up_output_summary_test.go
+++ b/tests/integration/up_output_summary_test.go
@@ -87,4 +87,12 @@ func TestUp_OutputJSONSummary(t *testing.T) {
 
 	require.Equal(t, apitype.OperationResultSucceeded, summary.Result)
 	require.NotEmpty(t, summary.Summary, "summary should record the resource changes")
+	require.NotEmpty(t, summary.Resources, "summary should list the affected resources")
+	for i, r := range summary.Resources {
+		require.NotEmptyf(t, r.URN, "resource %d should have a URN", i)
+		require.NotEmptyf(t, r.Type, "resource %d should have a type", i)
+		require.NotEmptyf(t, r.Name, "resource %d should have a name", i)
+		require.NotEmptyf(t, r.Op, "resource %d should have an op", i)
+		require.NotEqualf(t, apitype.OpSame, r.Op, "resource %d should not be a same", i)
+	}
 }


### PR DESCRIPTION
The JSON output for operations is more useful if it contains the resources affected.

```json
{
  "result": "succeeded",
  "duration": 5000000000,
  "summary": {"create": 2},
  "resources": [
    {
      "urn": "urn:pulumi:dev::myapp::pulumi:pulumi:Stack::myapp-dev",
      "type": "pulumi:pulumi:Stack",
      "name": "myapp-dev",
      "op": "create"
    },
    {
      "urn": "urn:pulumi:dev::myapp::aws:s3/bucket:Bucket::mybucket",
      "type": "aws:s3/bucket:Bucket",
      "name": "mybucket",
      "op": "create",
      "parent": "urn:pulumi:dev::myapp::pulumi:pulumi:Stack::myapp-dev"
    }
  ]
}
```

This respects `--show-sames`. Closes #22068.