### PR TITLE
Fix TODO in archive code around ZipSlip

### DIFF
--- a/changelog/pending/sdk-fix-20260609-094101.yaml
+++ b/changelog/pending/sdk-fix-20260609-094101.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: fix
+body: Reject tar entries with path traversal components when extracting archives
+time: 2026-06-09T09:41:01.473364+01:00
+custom:
+    PR: 23485

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -114,6 +114,12 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 
 // ExtractTGZ uncompresses a .tar.gz/.tgz file into a specific directory.
 func ExtractTGZ(r io.Reader, dir string) error {
+	// Convert to absolute path so that path traversal checks in extractFile are reliable.
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolving destination path: %w", err)
+	}
+
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("uncompressing: %w", err)
@@ -129,7 +135,7 @@ func ExtractTGZ(r io.Reader, dir string) error {
 			return fmt.Errorf("extracting: %w", err)
 		}
 
-		if err = extractFile(tr, header, dir); err != nil {
+		if err = extractFile(tr, header, absDir); err != nil {
 			return err
 		}
 	}

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -62,10 +62,13 @@ func TGZ(dir, prefixPathInsideTar string, useDefaultExcludes bool) ([]byte, erro
 }
 
 func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
-	// TODO: check the name to ensure that it does not contain path traversal characters.
-	//
-	//nolint:gosec
-	path := filepath.Join(dir, header.Name)
+	// Guard against ZipSlip path traversal: ensure the resolved target stays inside dir.
+	cleanDir := filepath.Clean(dir)
+	//nolint:gosec // G305: path traversal is explicitly checked immediately below.
+	path := filepath.Join(cleanDir, header.Name)
+	if path != cleanDir && !strings.HasPrefix(path, cleanDir+string(os.PathSeparator)) {
+		return fmt.Errorf("tar entry %q escapes destination directory", header.Name)
+	}
 
 	switch header.Typeflag {
 	case tar.TypeDir:

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -204,3 +204,90 @@ type fileContents struct {
 	contents     []byte
 	shouldRetain bool
 }
+
+// buildTGZ produces an in-memory .tar.gz containing the given regular-file entries.
+func buildTGZ(t *testing.T, entries map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range entries {
+		typ := tar.TypeReg
+		if len(content) == 0 {
+			typ = tar.TypeDir
+		}
+
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     0o600,
+			Size:     int64(len(content)),
+			Typeflag: byte(typ),
+		}))
+		_, err := tw.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func TestExtractTGZ(t *testing.T) {
+	t.Parallel()
+
+	tarball := buildTGZ(t, map[string][]byte{
+		"file.txt":        []byte("hello"),
+		"sub":             {},
+		"sub/nested.txt":  []byte("world"),
+		"sub/dir/leaf.go": []byte("package main"),
+	})
+
+	dest := t.TempDir()
+	require.NoError(t, ExtractTGZ(bytes.NewReader(tarball), dest))
+
+	for name, want := range map[string]string{
+		"file.txt":        "hello",
+		"sub/nested.txt":  "world",
+		"sub/dir/leaf.go": "package main",
+	} {
+		got, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(name)))
+		require.NoError(t, err)
+		assert.Equal(t, want, string(got))
+	}
+}
+
+func TestExtractTGZRejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		entry string
+	}{
+		{"parent", "../escape.txt"},
+		{"nested-parent", "a/../../escape.txt"},
+		{"deep-parent", "../../../../etc/passwd"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tarball := buildTGZ(t, map[string][]byte{tc.entry: []byte("malicious")})
+
+			// Extract into a nested directory so the parent of dest is itself a temp dir
+			// — that way if the guard fails, the escape lands somewhere observable but
+			// still inside the test's tempdir tree.
+			parent := t.TempDir()
+			dest := filepath.Join(parent, "dest")
+			require.NoError(t, os.Mkdir(dest, 0o700))
+
+			err := ExtractTGZ(bytes.NewReader(tarball), dest)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "escapes destination directory")
+
+			// Make sure nothing was written outside dest.
+			escaped, err := filepath.Glob(filepath.Join(parent, "escape.txt"))
+			require.NoError(t, err)
+			assert.Empty(t, escaped, "file escaped destination directory")
+		})
+	}
+}

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -291,3 +291,29 @@ func TestExtractTGZRejectsPathTraversal(t *testing.T) {
 		})
 	}
 }
+
+//nolint:paralleltest // t.Chdir() requires sequential test execution
+func TestExtractTGZRelativePathWithEscape(t *testing.T) {
+	// Test that path traversal is caught even when passing a relative destination path.
+	// This ensures the absolute path conversion in ExtractTGZ is working.
+	tarball := buildTGZ(t, map[string][]byte{
+		"../../../../escape.txt": []byte("malicious"),
+	})
+
+	// Create a temp directory and use a relative path.
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "dest")
+	require.NoError(t, os.Mkdir(dest, 0o700))
+
+	t.Chdir(parent)
+
+	// Extract using relative path "dest".
+	err := ExtractTGZ(bytes.NewReader(tarball), "dest")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes destination directory")
+
+	// Verify no file was written outside dest.
+	escaped, err := filepath.Glob("escape.txt")
+	require.NoError(t, err)
+	assert.Empty(t, escaped, "file escaped destination directory using relative path")
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/home/issues/4796

Validate that tar paths do not escape the target directory. Its still valid for a tar file to have an entry like "foo/../bar.txt" which resolves to just "bar.txt", but entries like "../bar.txt" will now error.