### PR TITLE
Use packageinstallation.InstallPlugin in pulumi convert mapper

### DIFF
--- a/changelog/pending/cli-convert-registry-plugin-resolution.yaml
+++ b/changelog/pending/cli-convert-registry-plugin-resolution.yaml
@@ -1,0 +1,6 @@
+component: cli/convert
+kind: improvement
+body: Resolve provider plugins through the Pulumi Registry when converting from a third-party source
+time: 2026-06-09T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/cli-convert-registry-plugin-resolution.yaml
+++ b/changelog/pending/cli-convert-registry-plugin-resolution.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Resolve provider plugins through the Pulumi Registry when converting from a third-party source
 time: 2026-06-09T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23490"

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -35,7 +35,10 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdDiag "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/diag"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageinstallation"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageresolution"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packages"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/packageworkspace"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/project/newcmd"
 
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -44,7 +47,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -331,24 +333,34 @@ func runConvert(
 		pCtx.Diag.Logf(sev, diag.RawMessage("", msg))
 	}
 
+	reg := cmdCmd.NewDefaultRegistry(ctx, lm, ws, nil, cmdutil.Diag(), e)
+	installCtx := packageworkspace.New(pluginstorage.Instance, ws, pCtx.Host, stderr, stderr,
+		nil, packageworkspace.Options{})
+
 	installPlugin := func(pluginName string) *semver.Version {
 		// If auto plugin installs are disabled just return nil, the mapper will still carry on
 		if env.DisableAutomaticPluginAcquisition.Value() {
 			return nil
 		}
 
-		pluginSpec, err := workspace.NewPluginDescriptor(ctx, pluginName, apitype.ResourcePlugin, nil, "", nil)
-		if err != nil {
-			pCtx.Diag.Errorf(diag.Message("", "failed to create plugin spec for %q: %v"), pluginName, err)
-			return nil
-		}
-
-		version, err := pkgWorkspace.InstallPlugin(pCtx.Base(), pluginSpec, log, schema.NewLoaderServerFromHost)
+		// Resolve and install the provider plugin without running it; the mapper launches
+		// its own instance via the provider factory once the plugin is on disk.
+		_, spec, _, err := packageinstallation.InstallPlugin(ctx,
+			workspace.PackageSpec{Source: pluginName}, nil, "",
+			packageinstallation.Options{
+				Options: packageresolution.Options{
+					ResolveWithRegistry: !e.GetBool(env.DisableRegistryResolve),
+				},
+			}, reg, installCtx)
 		if err != nil {
 			pCtx.Diag.Warningf(diag.Message("", "failed to install provider %q: %v"), pluginName, err)
 			return nil
 		}
-		return version
+		version, err := semver.ParseTolerant(spec.Version)
+		if err != nil {
+			return nil
+		}
+		return &version
 	}
 
 	loader := schema.NewPluginLoader(pCtx.Host)


### PR DESCRIPTION
## What

`pulumi convert` hands the plugin mapper an `installPlugin` callback used to
install provider plugins on demand (so their Terraform mappings can be read).
That callback installed providers via the low-level
`pkgWorkspace.InstallPlugin` helper, which only resolves plugins from their
well-known download URLs.

This routes the callback through `packageinstallation.InstallPlugin` — the
unified package installation path that is meant to be the single way to
install & run packages, and which is already used by `pulumi do` and
`pulumi package get-mapping` for the same "install a provider to read its
mapping" purpose.

## Why

Part of consolidating plugin/package installation onto a single mechanism
(`packageinstallation`). Converting this call site lets `pulumi convert`
resolve providers through the Pulumi Registry (honoring
`PULUMI_DISABLE_REGISTRY_RESOLVE`), matching the behavior of the rest of the
CLI instead of relying on the legacy known-URL path.

## How

- The callback now calls `packageinstallation.InstallPlugin` with an empty
  base project / project dir, so the plugin is installed but **not** linked or
  run. The mapper still launches its own provider instance via the provider
  factory once the plugin is on disk, so behavior is otherwise unchanged.
- The registry and install context are constructed once via
  `cmdCmd.NewDefaultRegistry` and `packageworkspace.New`, mirroring
  `packages.ProviderFromSource`.
- The resolved version (a string) is parsed back into the `*semver.Version`
  the mapper expects.

Draft so CI can exercise the `convert` conformance/integration suites against
the new resolution path.