### PR TITLE
pip: avoid writing output when it's not requested

### DIFF
--- a/sdk/python/toolchain/pip.go
+++ b/sdk/python/toolchain/pip.go
@@ -519,7 +519,9 @@ func InstallDependencies(ctx context.Context, cwd, venvDir string, useLanguageVe
 				return nil
 			}
 			if attempt < maxAttempts-1 && pipErrorIsTransient(stderrBuf.String()) {
-				fmt.Fprintf(errorWriter, "Retrying (%d/%d)...\n", attempt+1, maxAttempts)
+				if showOutput {
+					fmt.Fprintf(errorWriter, "Retrying (%d/%d)...\n", attempt+1, maxAttempts)
+				}
 				continue
 			}
 			return lastErr


### PR DESCRIPTION
Currently we always write the attempts to stderrWriter if `pip install` fails.  However this is not the expected behaviour, and in fact panics in some tests that set showOutput false, and then don't pass a stderrWriter, when there are pip issues.

Fix this by only writing to the errorWriter if showOutput is set. This is consistent with how the rest of the function works.
