### PR TITLE
Resolve PCL config defaults derived from invokes

### DIFF
--- a/changelog/pending/pcl-fix-config-default-from-invoke.yaml
+++ b/changelog/pending/pcl-fix-config-default-from-invoke.yaml
@@ -1,0 +1,6 @@
+component: pcl
+kind: fix
+body: Resolve config variables whose default value is derived from an invoke to the invoke's result instead of an unknown value
+time: 2026-06-09T14:09:11.000000+00:00
+custom:
+  PR: "23494"

--- a/pkg/pcl/runtime/evalContext.go
+++ b/pkg/pcl/runtime/evalContext.go
@@ -104,6 +104,14 @@ func (ectx *EvalContext) SetVariable(name string, value cty.Value) {
 	ectx.evalContext.Variables[name] = value
 }
 
+// HasVariable reports whether a variable with the given name has been set.
+func (ectx *EvalContext) HasVariable(name string) bool {
+	ectx.evalLock.Lock()
+	defer ectx.evalLock.Unlock()
+	_, ok := ectx.evalContext.Variables[name]
+	return ok
+}
+
 // Evaluate evaluates an expression in the context of the interpreter's evalContext and returns a PropertyValue. If the
 // expression evaluates to a poisoned value, the culprit resource's name will be returned in the second return value. If
 // there are any errors during evaluation, they will be returned in the diagnostics.

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -443,14 +443,6 @@ func (i *Interpreter) Run(ctx context.Context) error {
 		i.call,
 	)
 
-	if diags := i.bindConfigVariables(ctx); diags.HasErrors() {
-		return diags
-	}
-
-	if err := i.enforceRequiredVersion(ctx); err != nil {
-		return err
-	}
-
 	if err := i.registerStack(ctx); err != nil {
 		return err
 	}
@@ -508,15 +500,40 @@ func (i *Interpreter) executeProgramNodes(ctx context.Context) (resource.Propert
 		}
 	}
 
+	// The required version check must run before any resource is created. Make every resource and
+	// component depend on the pulumi block so the gate is enforced once its own dependencies (e.g. a
+	// config variable holding the version) have been evaluated.
+	if gate := i.requiredVersionGate(); gate != nil {
+		gateDagNode := nodes[gate]
+		for _, node := range i.program.Nodes {
+			switch node.(type) {
+			case *pcl.Resource, *pcl.Component:
+				if err := dag.NewEdge(gateDagNode, nodes[node]); err != nil {
+					return nil, fmt.Errorf("failed to create edge from %s to %s: %w",
+						gate.Name(), node.Name(), err)
+				}
+			}
+		}
+	}
+
 	var outputsLock sync.Mutex
 	outputs := resource.PropertyMap{}
 	err := dag.Walk(ctx, func(ctx context.Context, node pcl.Node) error {
 		switch node := node.(type) {
 		case *pcl.ConfigVariable:
-			// handled before node execution
+			// When executing a component program, config variables are supplied as component inputs
+			// and set before the walk; don't override them with the enclosing program's config.
+			if i.evalContext.HasVariable(node.Name()) {
+				return nil
+			}
+			if diags := i.bindConfigVariable(ctx, node); diags.HasErrors() {
+				return diags
+			}
 			return nil
 		case *pcl.PulumiBlock:
-			// handled before node execution
+			if err := i.enforceRequiredVersion(ctx); err != nil {
+				return err
+			}
 			return nil
 		case *pcl.Hook:
 			if err := i.registerHookNode(ctx, node); err != nil {
@@ -693,56 +710,65 @@ func (i *Interpreter) registerPackages(ctx context.Context) error {
 	return nil
 }
 
-func (i *Interpreter) bindConfigVariables(ctx context.Context) hcl.Diagnostics {
+// requiredVersionGate returns the pulumi block that enforces a required engine version, or nil if the
+// program has no such constraint.
+func (i *Interpreter) requiredVersionGate() pcl.Node {
+	for _, node := range i.program.Nodes {
+		if block, ok := node.(*pcl.PulumiBlock); ok && block.RequiredVersion != nil {
+			return node
+		}
+	}
+	return nil
+}
+
+func (i *Interpreter) bindConfigVariable(ctx context.Context, cfg *pcl.ConfigVariable) hcl.Diagnostics {
 	var diagnostics hcl.Diagnostics
 	secretKeys := map[string]struct{}{}
 	for _, key := range i.info.ConfigSecrets {
 		secretKeys[key] = struct{}{}
 	}
-	for _, cfg := range i.program.ConfigVariables() {
-		key := fmt.Sprintf("%s:%s", i.info.Project, cfg.LogicalName())
-		raw, has := i.info.Config[key]
-		if !has {
-			if cfg.DefaultValue != nil {
-				value, poison, diags := i.evalContext.Evaluate(cfg.DefaultValue)
-				contract.Assertf(poison == nil, "config variables can't be poisoned")
-				diagnostics = append(diagnostics, diags...)
-				if _, isSecret := secretKeys[key]; isSecret || cfg.Secret {
-					value = resource.MakeSecret(value)
-				}
-				if !diags.HasErrors() {
-					if err := i.setVariable(ctx, cfg.Name(), value); err != nil {
-						diagnostics = append(diagnostics, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  err.Error(),
-						})
-					}
-				}
-				continue
-			}
-			if !cfg.Nullable {
-				rng := cfg.SyntaxNode().Range()
-				diagnostics = append(diagnostics, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  fmt.Sprintf("missing required configuration value %q", cfg.LogicalName()),
-					Subject:  &rng,
-				})
-			}
-			continue
-		}
-
-		value, diags := parseConfigPropertyValue(raw, cfg.Type())
-		diagnostics = append(diagnostics, diags...)
-		if !diags.HasErrors() {
+	key := fmt.Sprintf("%s:%s", i.info.Project, cfg.LogicalName())
+	raw, has := i.info.Config[key]
+	if !has {
+		if cfg.DefaultValue != nil {
+			value, poison, diags := i.evalContext.Evaluate(cfg.DefaultValue)
+			contract.Assertf(poison == nil, "config variables can't be poisoned")
+			diagnostics = append(diagnostics, diags...)
 			if _, isSecret := secretKeys[key]; isSecret || cfg.Secret {
 				value = resource.MakeSecret(value)
 			}
-			if err := i.setVariable(ctx, cfg.Name(), value); err != nil {
-				diagnostics = append(diagnostics, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  err.Error(),
-				})
+			if !diags.HasErrors() {
+				if err := i.setVariable(ctx, cfg.Name(), value); err != nil {
+					diagnostics = append(diagnostics, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  err.Error(),
+					})
+				}
 			}
+			return diagnostics
+		}
+		if !cfg.Nullable {
+			rng := cfg.SyntaxNode().Range()
+			diagnostics = append(diagnostics, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("missing required configuration value %q", cfg.LogicalName()),
+				Subject:  &rng,
+			})
+		}
+		return diagnostics
+	}
+
+	value, diags := parseConfigPropertyValue(raw, cfg.Type())
+	diagnostics = append(diagnostics, diags...)
+	if !diags.HasErrors() {
+		if _, isSecret := secretKeys[key]; isSecret || cfg.Secret {
+			value = resource.MakeSecret(value)
+		}
+		if err := i.setVariable(ctx, cfg.Name(), value); err != nil {
+			diagnostics = append(diagnostics, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  err.Error(),
+			})
 		}
 	}
 	return diagnostics

--- a/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
+++ b/sdk/pcl/cmd/pulumi-language-pcl/language_test.go
@@ -98,8 +98,6 @@ var expectedFailures = map[string]string{
 	"l3-component-nested": "nested component outputs are not propagated correctly",
 	"l2-resource-read":    "need to update pkg",
 	"l1-builtin-min-max":  "cannot pin the current commit",
-	"l2-config-default-from-invoke": "config variable defaulting to an invoke result resolves to unknown " +
-		"instead of the invoke value",
 }
 
 func TestLanguage(t *testing.T) {

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-config-default-from-invoke
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/main.pp
@@ -1,0 +1,9 @@
+myInvokeResult = invoke("simple-invoke:index:myInvoke", { value = "hello" })
+
+config "defaultFromInvoke" "string" {
+    default = myInvokeResult.result
+}
+
+output "result" {
+    value = defaultFromInvoke
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/simple-invoke.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-config-default-from-invoke/simple-invoke.pp
@@ -1,0 +1,4 @@
+package "simple-invoke" {
+  baseProviderName    = "simple-invoke"
+  baseProviderVersion = "10.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-config-default-from-invoke
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/main.pp
@@ -1,0 +1,9 @@
+myInvokeResult = invoke("simple-invoke:index:myInvoke", { value = "hello" })
+
+config "defaultFromInvoke" "string" {
+    default = myInvokeResult.result
+}
+
+output "result" {
+    value = defaultFromInvoke
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/simple-invoke.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-config-default-from-invoke/simple-invoke.pp
@@ -1,0 +1,4 @@
+package "simple-invoke" {
+  baseProviderName    = "simple-invoke"
+  baseProviderVersion = "10.0.0"
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/Pulumi.yaml
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-config-default-from-invoke
+runtime: pcl

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/main.pp
@@ -1,0 +1,9 @@
+myInvokeResult = invoke("simple-invoke:index:myInvoke", { value = "hello" })
+
+config "defaultFromInvoke" "string" {
+    default = myInvokeResult.result
+}
+
+output "result" {
+    value = defaultFromInvoke
+}

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/simple-invoke.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-config-default-from-invoke/simple-invoke.pp
@@ -1,0 +1,4 @@
+package "simple-invoke" {
+  baseProviderName    = "simple-invoke"
+  baseProviderVersion = "10.0.0"
+}


### PR DESCRIPTION
## Description

The PCL interpreter bound config variables *before* executing the program's DAG. A config variable whose default referenced an invoke result (e.g. `default = myInvokeResult.result`) was therefore evaluated before the invoke ran, resolving to an **unknown** value instead of the invoke's output.

This change binds config variables *within* the DAG walk, so their dependencies (such as an invoke) are evaluated first — config is now just another node in dependency order, with no special-casing.

The required-version check must still run before any resource is created. Previously it ran as a pre-walk step; now the `pulumi` block is a gate node and every `Resource`/`Component` is given a DAG edge depending on it. This keeps the version gate ahead of resource creation while still letting the gate's own dependency (e.g. a config variable holding the version) resolve first. Config variables supplied as component inputs are left untouched during the walk.

This enables the `l2-config-default-from-invoke` conformance test for PCL (removed from `expectedFailures`).

## Base branch

Targets `iwahbe/remove-heavy-schema-tests` (the branch that adds the conformance test), not `master`.

## Checklist

- [x] Full PCL conformance suite passes (`l2-config-default-from-invoke`, `l1-builtin-require-pulumi-version`, `l3-rewrite-conversions`, and all others)
- [x] `pkg/pcl/runtime` unit tests pass
- [x] Changelog entry added