### PR TITLE
add `-trimpath` to compiler args for go build

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -122,7 +122,7 @@ func compileProgram(
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
 	// We add the `-buildvcs=false` flag here because it sometimes fails on Windows.
 	// See also https://github.com/pulumi/pulumi/pull/22788
-	args := []string{"build", "-buildvcs=false", "-o", outfile}
+	args := []string{"build", "-trimpath", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -122,9 +122,11 @@ func compileProgram(
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
 	// We add the `-buildvcs=false` flag here because it sometimes fails on Windows.
 	// See also https://github.com/pulumi/pulumi/pull/22788
-	args := []string{"build", "-trimpath", "-buildvcs=false", "-o", outfile}
+	args := []string{"build", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
+	} else {
+		args = append(args, "-trimpath")
 	}
 	buildCmd := exec.Command(gobin, args...)
 	buildCmd.Dir = programDirectory
@@ -1335,7 +1337,7 @@ func (host *goLanguageHost) RunPlugin(
 	defer contract.IgnoreClose(closer)
 
 	program, err := compileProgram(
-		server.Context(), engineClient, req.Info.ProgramDirectory, "", false, os.Stdout, os.Stderr)
+		server.Context(), engineClient, req.Info.ProgramDirectory, "", req.GetAttachDebugger(), os.Stdout, os.Stderr)
 	if err != nil {
 		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}


### PR DESCRIPTION
When compiling the go program in conformance tests, we do so from a random tmp directory.  This means the paths are different every time, and go's caching doesn't work as well.

We don't really need the full path in the binary, even for stack traces the trimmed path is good enough.

This brings Go conformance tests from 267s to 201s locally for me, which is some decent amount of savings, and probably worth it.
