### PR TITLE
set `-w -s` for language program builds

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -126,7 +126,7 @@ func compileProgram(
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
 	} else {
-		args = append(args, "-trimpath")
+		args = append(args, "-trimpath", "-ldflags", "-w -s")
 	}
 	buildCmd := exec.Command(gobin, args...)
 	buildCmd.Dir = programDirectory


### PR DESCRIPTION
Using these linker flags we omit some debugging information from the binary, which shouldn't be required unless dlv/other debugging tools are used.  Because we have a separate mode for debugging, we don't need to include this information in the regular binary.

This brings the time for running the whole conformance test suite locally from 228s to 168s. (Note that the times in https://github.com/pulumi/pulumi/pull/23495 are measured only with the `-w` flag on, hence the discrepancy in numbers)

Based on https://github.com/pulumi/pulumi/pull/23495