### PR TITLE
Add pulumi neo debug command

### DIFF
--- a/changelog/pending/cli-chore-neo-debug-local.yaml
+++ b/changelog/pending/cli-chore-neo-debug-local.yaml
@@ -1,0 +1,5 @@
+kind: chore
+body: Add a `pulumi neo debug` command to investigate a failed update or preview, suggested in the failure output
+component: cli
+custom:
+    PR: "23499"

--- a/changelog/pending/cli-chore-neo-debug-local.yaml
+++ b/changelog/pending/cli-chore-neo-debug-local.yaml
@@ -1,5 +1,5 @@
 kind: chore
-body: Add a `pulumi neo debug` command to investigate a failed update or preview, suggested in the failure output
+body: Add `pulumi neo --debug-update` and `pulumi neo --debug-preview` flags to investigate a failed update or preview, suggested in the failure output
 component: cli
 custom:
     PR: "23499"

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -84,7 +84,7 @@ func PrintNeoLink(out io.Writer, opts Options, permalink string) {
 	fmt.Fprintln(out, "  "+"Would you like additional help with this update?")
 	fmt.Fprintln(out, "  "+
 		opts.Color.Colorize(colors.Underline+colors.BrightBlue+ExplainFailureLink(permalink)+colors.Reset))
-	fmt.Fprintln(out, "  "+"Or run `pulumi neo` for an interactive agent in your terminal.")
+	fmt.Fprintln(out, "  "+"Or run `pulumi neo debug` in your terminal.")
 	fmt.Fprintln(out)
 }
 

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -45,8 +45,11 @@ func neoDelimiterEmoji() string {
 	return cmdutil.EmojiOr(" ✨", ":")
 }
 
-// RenderNeoErrorSummary renders a Neo error summary to the console.
-func RenderNeoErrorSummary(summary *NeoErrorSummaryMetadata, err error, opts Options, permalink string) {
+// RenderNeoErrorSummary renders a Neo error summary to the console. isPreview selects which debug
+// command the link suggestion offers (`pulumi neo --debug-preview` vs `--debug-update`).
+func RenderNeoErrorSummary(
+	summary *NeoErrorSummaryMetadata, err error, opts Options, permalink string, isPreview bool,
+) {
 	out := opts.Stdout
 	if out == nil {
 		out = os.Stdout
@@ -77,15 +80,26 @@ func RenderNeoErrorSummary(summary *NeoErrorSummaryMetadata, err error, opts Opt
 
 	fmt.Fprintln(out)
 
-	PrintNeoLink(out, opts, permalink)
+	PrintNeoLink(out, opts, permalink, isPreview)
 }
 
-func PrintNeoLink(out io.Writer, opts Options, permalink string) {
+// PrintNeoLink prints the "would you like help" link plus the terminal command to debug the
+// failure. isPreview picks `pulumi neo --debug-preview` for a failed preview and
+// `pulumi neo --debug-update` otherwise.
+func PrintNeoLink(out io.Writer, opts Options, permalink string, isPreview bool) {
 	fmt.Fprintln(out, "  "+"Would you like additional help with this update?")
 	fmt.Fprintln(out, "  "+
 		opts.Color.Colorize(colors.Underline+colors.BrightBlue+ExplainFailureLink(permalink)+colors.Reset))
-	fmt.Fprintln(out, "  "+"Or run `pulumi neo debug` in your terminal.")
+	fmt.Fprintln(out, "  "+"Or run `"+neoDebugCommand(isPreview)+"` in your terminal.")
 	fmt.Fprintln(out)
+}
+
+// neoDebugCommand returns the `pulumi neo` debug invocation that targets the failed operation kind.
+func neoDebugCommand(isPreview bool) string {
+	if isPreview {
+		return "pulumi neo --debug-preview"
+	}
+	return "pulumi neo --debug-update"
 }
 
 // RenderNeoThinking displays a "Thinking..." message.

--- a/pkg/backend/display/ai.go
+++ b/pkg/backend/display/ai.go
@@ -45,8 +45,8 @@ func neoDelimiterEmoji() string {
 	return cmdutil.EmojiOr(" ✨", ":")
 }
 
-// RenderNeoErrorSummary renders a Neo error summary to the console. isPreview selects which debug
-// command the link suggestion offers (`pulumi neo --debug-preview` vs `--debug-update`).
+// RenderNeoErrorSummary renders a Neo error summary to the console. isPreview selects the debug
+// command suggested in the link (`--debug-preview` vs `--debug-update`).
 func RenderNeoErrorSummary(
 	summary *NeoErrorSummaryMetadata, err error, opts Options, permalink string, isPreview bool,
 ) {
@@ -84,8 +84,7 @@ func RenderNeoErrorSummary(
 }
 
 // PrintNeoLink prints the "would you like help" link plus the terminal command to debug the
-// failure. isPreview picks `pulumi neo --debug-preview` for a failed preview and
-// `pulumi neo --debug-update` otherwise.
+// failure. isPreview picks `--debug-preview` for a failed preview, `--debug-update` otherwise.
 func PrintNeoLink(out io.Writer, opts Options, permalink string, isPreview bool) {
 	fmt.Fprintln(out, "  "+"Would you like additional help with this update?")
 	fmt.Fprintln(out, "  "+

--- a/pkg/backend/display/ai_test.go
+++ b/pkg/backend/display/ai_test.go
@@ -46,7 +46,7 @@ func TestRenderCopilotErrorSummary(t *testing.T) {
 
   Would you like additional help with this update?
   http://foo.bar/baz?explainFailure
-  Or run `+"`pulumi neo`"+` for an interactive agent in your terminal.
+  Or run `+"`pulumi neo debug`"+` in your terminal.
 
 `, neoDelimiterEmoji())
 	assert.Equal(t, expectedCopilotSummary, buf.String())

--- a/pkg/backend/display/ai_test.go
+++ b/pkg/backend/display/ai_test.go
@@ -36,20 +36,38 @@ func TestRenderCopilotErrorSummary(t *testing.T) {
 		ShowLinkToNeo: true,
 	}
 
-	// Render to buffer
+	// Render to buffer. isPreview=false, so the suggestion targets a failed update.
 	RenderNeoErrorSummary(&NeoErrorSummaryMetadata{
 		Summary: summary,
-	}, nil, opts, "http://foo.bar/baz")
+	}, nil, opts, "http://foo.bar/baz", false)
 
 	expectedCopilotSummary := fmt.Sprintf(`Neo Diagnostics%s
   This is a test summary
 
   Would you like additional help with this update?
   http://foo.bar/baz?explainFailure
-  Or run `+"`pulumi neo debug`"+` in your terminal.
+  Or run `+"`pulumi neo --debug-update`"+` in your terminal.
 
 `, neoDelimiterEmoji())
 	assert.Equal(t, expectedCopilotSummary, buf.String())
+}
+
+func TestRenderCopilotErrorSummaryPreview(t *testing.T) {
+	t.Parallel()
+
+	// For a failed preview the suggestion targets --debug-preview instead of --debug-update.
+	buf := new(bytes.Buffer)
+	opts := Options{
+		Stdout:        buf,
+		Color:         colors.Never,
+		ShowLinkToNeo: true,
+	}
+
+	RenderNeoErrorSummary(&NeoErrorSummaryMetadata{
+		Summary: "This is a test summary",
+	}, nil, opts, "http://foo.bar/baz", true)
+
+	assert.Contains(t, buf.String(), "Or run `pulumi neo --debug-preview` in your terminal.")
 }
 
 func TestRenderCopilotErrorSummaryError(t *testing.T) {
@@ -61,7 +79,7 @@ func TestRenderCopilotErrorSummaryError(t *testing.T) {
 		Color:  colors.Never,
 	}
 
-	RenderNeoErrorSummary(nil, errors.New("test error"), opts, "http://foo.bar/baz")
+	RenderNeoErrorSummary(nil, errors.New("test error"), opts, "http://foo.bar/baz", false)
 
 	expectedCopilotSummaryWithError := fmt.Sprintf(`Neo Diagnostics%s
   error summarizing update output: test error
@@ -79,7 +97,7 @@ func TestRenderCopilotErrorSummaryNoSummaryOrError(t *testing.T) {
 		Color:  colors.Never,
 	}
 
-	RenderNeoErrorSummary(nil, nil, opts, "http://foo.bar/baz")
+	RenderNeoErrorSummary(nil, nil, opts, "http://foo.bar/baz", false)
 
 	assert.Equal(t, "", buf.String())
 }
@@ -97,7 +115,7 @@ func TestRenderCopilotErrorSummaryWithError(t *testing.T) {
 
 	RenderNeoErrorSummary(&NeoErrorSummaryMetadata{
 		Summary: summary,
-	}, errors.New("test error"), opts, "http://foo.bar/baz")
+	}, errors.New("test error"), opts, "http://foo.bar/baz", false)
 
 	expectedCopilotSummaryWithErrorAndSummary := fmt.Sprintf(`Neo Diagnostics%s
   error summarizing update output: test error

--- a/pkg/backend/display/ai_test.go
+++ b/pkg/backend/display/ai_test.go
@@ -36,7 +36,7 @@ func TestRenderCopilotErrorSummary(t *testing.T) {
 		ShowLinkToNeo: true,
 	}
 
-	// Render to buffer. isPreview=false, so the suggestion targets a failed update.
+	// isPreview=false, so the suggestion targets a failed update.
 	RenderNeoErrorSummary(&NeoErrorSummaryMetadata{
 		Summary: summary,
 	}, nil, opts, "http://foo.bar/baz", false)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -846,7 +846,7 @@ func (display *ProgressDisplay) printDiagnostics() {
 			colors.SpecCreateReplacement + "[Pulumi Neo]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + ExplainFailureLink(display.permalink) + colors.Reset)
-		display.println("    " + "Or run `pulumi neo debug` in your terminal.")
+		display.println("    " + "Or run `" + neoDebugCommand(display.isPreview) + "` in your terminal.")
 		display.println("")
 	}
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -846,7 +846,7 @@ func (display *ProgressDisplay) printDiagnostics() {
 			colors.SpecCreateReplacement + "[Pulumi Neo]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + ExplainFailureLink(display.permalink) + colors.Reset)
-		display.println("    " + "Or run `pulumi neo` for an interactive agent in your terminal.")
+		display.println("    " + "Or run `pulumi neo debug` in your terminal.")
 		display.println("")
 	}
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -846,7 +846,7 @@ func (display *ProgressDisplay) printDiagnostics() {
 			colors.SpecCreateReplacement + "[Pulumi Neo]" + colors.Reset + " Would you like help with these diagnostics?")
 		display.println("    " +
 			colors.Underline + colors.Blue + ExplainFailureLink(display.permalink) + colors.Reset)
-		display.println("    " + "Or run `" + neoDebugCommand(display.isPreview) + "` in your terminal.")
+		display.println("    " + "Or run `pulumi neo` for an interactive agent in your terminal.")
 		display.println("")
 	}
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2262,6 +2262,29 @@ func (b *cloudBackend) GetHistory(
 	return beUpdates, nil
 }
 
+// GetLatestStackPreview returns the stack's most recent preview operation, or nil if the stack
+// has no previews. Previews are tracked separately from update history (GetHistory), so this is
+// the only way to surface them; the returned UpdateID is the UUID that appears in the console
+// preview URL.
+func (b *cloudBackend) GetLatestStackPreview(
+	ctx context.Context,
+	stackRef backend.StackReference,
+) (*apitype.StackPreview, error) {
+	stack, err := b.getCloudStackIdentifier(stackRef)
+	if err != nil {
+		return nil, err
+	}
+
+	previews, err := b.client.GetLatestStackPreviews(ctx, stack, 1, 1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stack previews: %w", err)
+	}
+	if len(previews) == 0 {
+		return nil, nil
+	}
+	return &previews[0], nil
+}
+
 func (b *cloudBackend) GetLatestConfiguration(ctx context.Context,
 	stack backend.Stack,
 ) (backend.LatestConfiguration, error) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -241,6 +241,10 @@ type Backend interface {
 	PromptAI(ctx context.Context, requestBody AIPromptRequestBody) (*http.Response, error)
 	// Capabilities returns the capabilities of the backend indicating what features are available.
 	Capabilities(ctx context.Context) apitype.Capabilities
+
+	// GetLatestStackPreview returns the stack's most recent preview operation, or nil if the
+	// stack has no previews. Previews are tracked separately from update history (GetHistory).
+	GetLatestStackPreview(ctx context.Context, stackRef backend.StackReference) (*apitype.StackPreview, error)
 }
 
 // userInfo holds the user account details fetched from the backend.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2266,10 +2266,7 @@ func (b *cloudBackend) GetHistory(
 	return beUpdates, nil
 }
 
-// GetLatestStackPreview returns the stack's most recent preview operation, or nil if the stack
-// has no previews. Previews are tracked separately from update history (GetHistory), so this is
-// the only way to surface them; the returned UpdateID is the UUID that appears in the console
-// preview URL.
+// GetLatestStackPreview returns the stack's most recent preview operation, or nil if it has none.
 func (b *cloudBackend) GetLatestStackPreview(
 	ctx context.Context,
 	stackRef backend.StackReference,
@@ -2279,7 +2276,7 @@ func (b *cloudBackend) GetLatestStackPreview(
 		return nil, err
 	}
 
-	previews, err := b.client.GetLatestStackPreviews(ctx, stack, 1, 1)
+	previews, err := b.client.GetLatestStackPreviews(ctx, stack)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get stack previews: %w", err)
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1766,7 +1766,7 @@ func (b *cloudBackend) renderAndSummarizeOutput(
 			summary, err := b.summarizeErrorWithNeo(ctx, renderer.Output(), stack.Ref(), op.Opts.Display)
 			// Pass the error into the renderer to ensure it's displayed. We don't want to fail the update/preview
 			// if we can't generate a summary.
-			display.RenderNeoErrorSummary(summary, err, op.Opts.Display, permalink)
+			display.RenderNeoErrorSummary(summary, err, op.Opts.Display, permalink, dryRun)
 		}
 	}
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1423,26 +1423,15 @@ func (pc *Client) GetStackUpdates(
 	return response.Updates, nil
 }
 
-// GetLatestStackPreviews returns the indicated stack's most recent preview operations,
-// newest-first. Previews are tracked separately from update history (see GetStackUpdates),
-// so this is the only way to discover them; each carries the opaque UUID that appears in its
-// console preview URL.
+// GetLatestStackPreviews returns the stack's most recent preview operations, newest-first.
+// Previews are tracked separately from update history (see GetStackUpdates).
 func (pc *Client) GetLatestStackPreviews(
 	ctx context.Context,
 	stack StackIdentifier,
-	pageSize int,
-	page int,
 ) ([]apitype.StackPreview, error) {
 	var response apitype.GetLatestStackPreviewsResponse
-	// asc=false requests newest-first; the endpoint otherwise defaults to oldest-first, which
-	// would make response.Updates[0] the oldest preview rather than the most recent one.
-	path := getStackPath(stack, "updates", "latest", "previews") + "?asc=false"
-	if pageSize > 0 {
-		if page < 1 {
-			page = 1
-		}
-		path += fmt.Sprintf("&pageSize=%d&page=%d", pageSize, page)
-	}
+	// asc=false requests newest-first; the endpoint otherwise defaults to oldest-first.
+	path := getStackPath(stack, "updates", "latest", "previews") + "?asc=false&pageSize=1&page=1"
 	if err := pc.restCall(ctx, "GET", path, nil, nil, &response); err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -1423,6 +1423,33 @@ func (pc *Client) GetStackUpdates(
 	return response.Updates, nil
 }
 
+// GetLatestStackPreviews returns the indicated stack's most recent preview operations,
+// newest-first. Previews are tracked separately from update history (see GetStackUpdates),
+// so this is the only way to discover them; each carries the opaque UUID that appears in its
+// console preview URL.
+func (pc *Client) GetLatestStackPreviews(
+	ctx context.Context,
+	stack StackIdentifier,
+	pageSize int,
+	page int,
+) ([]apitype.StackPreview, error) {
+	var response apitype.GetLatestStackPreviewsResponse
+	// asc=false requests newest-first; the endpoint otherwise defaults to oldest-first, which
+	// would make response.Updates[0] the oldest preview rather than the most recent one.
+	path := getStackPath(stack, "updates", "latest", "previews") + "?asc=false"
+	if pageSize > 0 {
+		if page < 1 {
+			page = 1
+		}
+		path += fmt.Sprintf("&pageSize=%d&page=%d", pageSize, page)
+	}
+	if err := pc.restCall(ctx, "GET", path, nil, nil, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Updates, nil
+}
+
 // ExportStackDeployment exports the indicated stack's deployment as a raw JSON message.
 // If version is nil, will export the latest version of the stack.
 func (pc *Client) ExportStackDeployment(

--- a/pkg/backend/httpstate/mock.go
+++ b/pkg/backend/httpstate/mock.go
@@ -43,7 +43,8 @@ type MockHTTPBackend struct {
 		deploymentInitiator string,
 		suppressStreamLogs bool,
 	) error
-	FGetCloudRegistry func() (backend.CloudRegistry, error)
+	FGetCloudRegistry      func() (backend.CloudRegistry, error)
+	FGetLatestStackPreview func(ctx context.Context, stackRef backend.StackReference) (*apitype.StackPreview, error)
 }
 
 func (b *MockHTTPBackend) Client() *client.Client {
@@ -93,6 +94,12 @@ func (b *MockHTTPBackend) Capabilities(context.Context) apitype.Capabilities {
 
 func (b *MockHTTPBackend) GetCloudRegistry() (backend.CloudRegistry, error) {
 	return b.FGetCloudRegistry()
+}
+
+func (b *MockHTTPBackend) GetLatestStackPreview(
+	ctx context.Context, stackRef backend.StackReference,
+) (*apitype.StackPreview, error) {
+	return b.FGetLatestStackPreview(ctx, stackRef)
 }
 
 var _ Backend = (*MockHTTPBackend)(nil)

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -56,6 +56,24 @@ func (k debugKind) latestID(ctx context.Context, be httpstate.Backend, stackRef 
 	return ""
 }
 
+// buildDebugPrompt assembles the full initial prompt for a debug session: the seed trigger line
+// (so Neo's skill evaluator loads the debugging skill) followed by the stack context. An empty id
+// is resolved to the latest operation of kind; any userPrompt sits between the two as extra
+// guidance. Every lookup is best-effort, so the prompt is always well-formed.
+func buildDebugPrompt(
+	ctx context.Context, be httpstate.Backend,
+	target taskTarget, kind debugKind, id, userPrompt string,
+) string {
+	if id == "" {
+		id = kind.latestID(ctx, be, target.ref)
+	}
+	seed := debugSeedPrompt(kind, id)
+	if userPrompt != "" {
+		seed += "\n\n" + userPrompt
+	}
+	return seed + "\n\n" + debugStackContext(be, target, kind, id)
+}
+
 // debugSeedPrompt builds Neo's initial prompt for a debug session. It is a short trigger line, not
 // a procedure: Neo's skill evaluator matches it and loads the debugging skill. With no id it targets
 // the most recent operation of that kind; with an id, that specific run.

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -1,0 +1,94 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// newNeoDebugCmd creates the `pulumi neo debug [id]` subcommand: a structured entry to the same
+// interactive Neo experience as `pulumi neo`, seeded to investigate a failed update or preview.
+// The CLI suggests this command in failed `up`/`preview` output (see display.PrintNeoLink), so the
+// user can drop straight into Neo with the failure in context. It carries its own copy of the
+// shared flags so it honors the same --stack/--org/--cwd/--approval-mode/--permission-mode/--print
+// options as the parent command.
+func newNeoDebugCmd() *cobra.Command {
+	flags := &neoFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "debug [update-or-preview-id]",
+		Short: "Start a Pulumi Neo agent task to debug a failed update or preview",
+		Long: "Starts the interactive Pulumi Neo experience seeded to investigate a failed update " +
+			"or preview and propose a fix. With no argument, Neo debugs your most recent operation on " +
+			"the stack and confirms which one before acting; pass an update version or preview id to " +
+			"target a specific one. Neo runs against the current stack, so run this from the same " +
+			"project directory as the failed operation.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			approvalMode, permissionMode, err := flags.resolveModes(cmd)
+			if err != nil {
+				return err
+			}
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runNeo(
+				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
+				debugSeedPrompt(id), flags.stackName, flags.orgFlag, flags.cwdFlag,
+				approvalMode, permissionMode, flags.printMode,
+				flags.disableIntegrations)
+		},
+	}
+
+	flags.register(cmd)
+
+	return cmd
+}
+
+// debugSeedPrompt builds the initial Neo prompt for `pulumi neo debug`. It is deliberately a short
+// trigger line, not a procedure: Neo's skill evaluator matches "debug ... failed update/preview" and
+// loads the pulumi-debug-failed-operation skill, which carries the actual debugging steps. With no id
+// the seed targets the user's most recent operation (the skill confirms which one); with an id it
+// targets that specific run. Either way the fix should land locally in the working directory.
+func debugSeedPrompt(id string) string {
+	if id == "" {
+		return "Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n"
+	}
+	operation := "update"
+	if !isUpdateID(id) {
+		operation = "preview"
+	}
+	return fmt.Sprintf(
+		"Debug the failed %s %s of this stack and fix it directly in this working directory.\n",
+		operation, id)
+}
+
+// isUpdateID reports whether id looks like an update version rather than a preview id. Update
+// versions are sequential integers; preview ids are UUIDs, so a digits-only id is an update.
+func isUpdateID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -17,130 +17,90 @@ package neo
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
-
-	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 )
 
-// newNeoDebugCmd creates the `pulumi neo debug [id]` subcommand: a structured entry to the same
-// interactive Neo experience as `pulumi neo`, seeded to investigate a failed update or preview.
-// The CLI suggests this command in failed `up`/`preview` output (see display.PrintNeoLink), so the
-// user can drop straight into Neo with the failure in context. It carries its own copy of the
-// shared flags so it honors the same --stack/--org/--cwd/--approval-mode/--permission-mode/--print
-// options as the parent command.
-func newNeoDebugCmd() *cobra.Command {
-	flags := &neoFlags{}
+// debugKind identifies which kind of failed operation `pulumi neo --debug-update`/`--debug-preview`
+// targets. The constant values double as the noun used in Neo's seed prompt and the debug context,
+// so callers can format a debugKind directly instead of mapping it.
+type debugKind string
 
-	cmd := &cobra.Command{
-		Use:   "debug [update-or-preview-id]",
-		Short: "Start a Pulumi Neo agent task to debug a failed update or preview",
-		Long: "Starts the interactive Pulumi Neo experience seeded to investigate a failed update " +
-			"or preview and propose a fix. With no argument, Neo debugs your most recent operation on " +
-			"the stack and confirms which one before acting; pass an update version or preview id to " +
-			"target a specific one. Neo runs against the current stack, so run this from the same " +
-			"project directory as the failed operation.",
-		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			approvalMode, permissionMode, err := flags.resolveModes(cmd)
-			if err != nil {
-				return err
-			}
-			id := ""
-			if len(args) == 1 {
-				id = args[0]
-			}
-			return runNeo(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), neoRunOptions{
-				prompt:              debugSeedPrompt(id),
-				stackName:           flags.stackName,
-				orgFlag:             flags.orgFlag,
-				cwdFlag:             flags.cwdFlag,
-				approvalMode:        approvalMode,
-				permissionMode:      permissionMode,
-				printMode:           flags.printMode,
-				includeStackContext: true,
-				disableIntegrations: flags.disableIntegrations,
-			})
-		},
+const (
+	debugNone    debugKind = ""
+	debugUpdate  debugKind = "update"
+	debugPreview debugKind = "preview"
+)
+
+// latestID returns the id of the stack's most recent operation of this kind, or "" when none is
+// available. Updates and previews are tracked separately — previews never appear in GetHistory — so
+// each kind has its own lookup: an update resolves to its history version (an integer), a preview to
+// its opaque UpdateID (a UUID). Both lookups are best-effort.
+func (k debugKind) latestID(ctx context.Context, be httpstate.Backend, stackRef backend.StackReference) string {
+	if stackRef == nil {
+		return ""
 	}
-
-	flags.register(cmd)
-
-	return cmd
+	switch k {
+	case debugUpdate:
+		if updates, err := be.GetHistory(ctx, stackRef, 1, 1); err == nil && len(updates) > 0 {
+			return strconv.Itoa(updates[0].Version)
+		}
+	case debugPreview:
+		if p, err := be.GetLatestStackPreview(ctx, stackRef); err == nil && p != nil {
+			return p.UpdateID
+		}
+	case debugNone:
+		// Not a debug session; nothing to look up.
+	}
+	return ""
 }
 
-// debugSeedPrompt builds the initial Neo prompt for `pulumi neo debug`. It is deliberately a short
-// trigger line, not a procedure: Neo's skill evaluator matches "debug ... failed operation" and
-// loads the pulumi-debug-failed-operation skill, which carries the actual debugging steps. With no id
-// the seed targets the user's most recent operation (the skill confirms which one); with an id it
-// targets that specific run. The id itself tells Neo whether it is an update version (a sequential
-// integer) or a preview (a UUID), so the seed doesn't classify it. Either way the fix should land
-// locally in the working directory.
-func debugSeedPrompt(id string) string {
+// debugSeedPrompt builds the initial Neo prompt for `pulumi neo --debug-update`/`--debug-preview`.
+// It is deliberately a short trigger line, not a procedure: Neo's skill evaluator matches
+// "debug ... failed update/preview" and loads the pulumi-debug-failed-operation skill, which
+// carries the actual debugging steps. With no id the seed targets the user's most recent operation
+// of that kind (the skill confirms which one); with an id it targets that specific run. Either way
+// the fix should land locally in the working directory.
+func debugSeedPrompt(kind debugKind, id string) string {
 	if id == "" {
-		return "Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n"
+		return fmt.Sprintf(
+			"Debug my most recent Pulumi %s on this stack and fix it directly in this working directory.\n",
+			kind)
 	}
 	return fmt.Sprintf(
-		"Debug the failed Pulumi operation %s of this stack and fix it directly in this working directory.\n",
-		id)
+		"Debug the failed Pulumi %s %s of this stack and fix it directly in this working directory.\n",
+		kind, id)
 }
 
 // debugStackContext builds a short, human-readable block describing where the debug session is
-// running — the organization, user, project, and stack — plus the stack's most recent operation
-// (its kind, version/id, and result). `pulumi neo debug` appends this to the seed prompt so Neo
-// starts with the failure already in context instead of rediscovering it. Every lookup is
-// best-effort: anything that errors or is unavailable is simply omitted so debug still works when,
-// for example, the backend can't return history or no stack is selected.
-func debugStackContext(
-	ctx context.Context,
-	be httpstate.Backend,
-	stackRef backend.StackReference,
-	org, project string,
-) string {
+// running — the organization, user, project, and stack — plus the specific operation being
+// debugged. `pulumi neo --debug-update`/`--debug-preview` append this to the seed prompt so Neo
+// starts with the failure already in context instead of rediscovering it. kind/id describe the
+// resolved target (id is "" when none could be inferred). Every field is best-effort: anything that
+// is empty or unavailable is simply omitted so debug still works when, for example, the user isn't
+// logged in or no stack is selected.
+func debugStackContext(be httpstate.Backend, target taskTarget, kind debugKind, id string) string {
 	var b strings.Builder
 	b.WriteString("Context for this debug session:\n")
-	if org != "" {
-		fmt.Fprintf(&b, "- Organization: %s\n", org)
+	if target.org != "" {
+		fmt.Fprintf(&b, "- Organization: %s\n", target.org)
 	}
 	if user, _, _, err := be.CurrentUser(); err == nil && user != "" {
 		fmt.Fprintf(&b, "- User: %s\n", user)
 	}
-	if project != "" {
-		fmt.Fprintf(&b, "- Project: %s\n", project)
+	if target.project != "" {
+		fmt.Fprintf(&b, "- Project: %s\n", target.project)
 	}
-	// The stack name and most recent operation both come from the resolved reference, so they
-	// share the same nil guard: with no stack selected we emit neither.
-	if stackRef != nil {
-		fmt.Fprintf(&b, "- Stack: %s\n", stackRef.Name())
-		if op := mostRecentOperation(ctx, be, stackRef); op != "" {
-			fmt.Fprintf(&b, "- Most recent operation: %s\n", op)
-		}
+	if name := target.stackName(); name != "" {
+		fmt.Fprintf(&b, "- Stack: %s\n", name)
+	}
+	// The id was resolved (explicitly or inferred) before this call, so we just report it; the
+	// phrasing matches the seed prompt's "<kind> <id>".
+	if id != "" {
+		fmt.Fprintf(&b, "- Debugging: %s %s\n", kind, id)
 	}
 	return b.String()
-}
-
-// mostRecentOperation describes the stack's most recent operation across both updates and
-// previews, or "" if neither is available. Updates and previews are tracked separately — previews
-// never appear in GetHistory — so we look at both and report whichever ran most recently (by start
-// time). This is what lets `pulumi neo debug` target a failed preview that is newer than the last
-// deployment, rather than always reporting the latest update. Both lookups are best-effort.
-func mostRecentOperation(ctx context.Context, be httpstate.Backend, stackRef backend.StackReference) string {
-	var (
-		bestStart int64 = -1
-		best      string
-	)
-	// Most recent entry from update history (updates/refreshes/destroys/imports — never previews).
-	if updates, err := be.GetHistory(ctx, stackRef, 1, 1); err == nil && len(updates) > 0 {
-		u := updates[0]
-		bestStart = u.StartTime
-		best = fmt.Sprintf("%s (version %d, result: %s)", u.Kind, u.Version, u.Result)
-	}
-	// Most recent preview, which is tracked separately from history.
-	if p, err := be.GetLatestStackPreview(ctx, stackRef); err == nil && p != nil && p.Info.StartTime > bestStart {
-		best = fmt.Sprintf("preview %s (result: %s)", p.UpdateID, p.Info.Result)
-	}
-	return best
 }

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -24,9 +24,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 )
 
-// debugKind identifies which kind of failed operation `pulumi neo --debug-update`/`--debug-preview`
-// targets. The constant values double as the noun used in Neo's seed prompt and the debug context,
-// so callers can format a debugKind directly instead of mapping it.
+// debugKind identifies which failed operation a debug session targets. The values double as the
+// noun used in the seed prompt, so callers can format a debugKind directly.
 type debugKind string
 
 const (
@@ -36,9 +35,8 @@ const (
 )
 
 // latestID returns the id of the stack's most recent operation of this kind, or "" when none is
-// available. Updates and previews are tracked separately — previews never appear in GetHistory — so
-// each kind has its own lookup: an update resolves to its history version (an integer), a preview to
-// its opaque UpdateID (a UUID). Both lookups are best-effort.
+// available. Updates and previews are looked up separately (previews never appear in GetHistory):
+// an update resolves to its history version, a preview to its opaque UpdateID. Best-effort.
 func (k debugKind) latestID(ctx context.Context, be httpstate.Backend, stackRef backend.StackReference) string {
 	if stackRef == nil {
 		return ""
@@ -58,12 +56,9 @@ func (k debugKind) latestID(ctx context.Context, be httpstate.Backend, stackRef 
 	return ""
 }
 
-// debugSeedPrompt builds the initial Neo prompt for `pulumi neo --debug-update`/`--debug-preview`.
-// It is deliberately a short trigger line, not a procedure: Neo's skill evaluator matches
-// "debug ... failed update/preview" and loads the pulumi-debug-failed-operation skill, which
-// carries the actual debugging steps. With no id the seed targets the user's most recent operation
-// of that kind (the skill confirms which one); with an id it targets that specific run. Either way
-// the fix should land locally in the working directory.
+// debugSeedPrompt builds Neo's initial prompt for a debug session. It is a short trigger line, not
+// a procedure: Neo's skill evaluator matches it and loads the debugging skill. With no id it targets
+// the most recent operation of that kind; with an id, that specific run.
 func debugSeedPrompt(kind debugKind, id string) string {
 	if id == "" {
 		return fmt.Sprintf(
@@ -75,13 +70,9 @@ func debugSeedPrompt(kind debugKind, id string) string {
 		kind, id)
 }
 
-// debugStackContext builds a short, human-readable block describing where the debug session is
-// running — the organization, user, project, and stack — plus the specific operation being
-// debugged. `pulumi neo --debug-update`/`--debug-preview` append this to the seed prompt so Neo
-// starts with the failure already in context instead of rediscovering it. kind/id describe the
-// resolved target (id is "" when none could be inferred). Every field is best-effort: anything that
-// is empty or unavailable is simply omitted so debug still works when, for example, the user isn't
-// logged in or no stack is selected.
+// debugStackContext builds a block describing the debug session's org, user, project, stack, and
+// resolved operation, appended to the seed prompt so Neo starts with the failure in context. Every
+// field is best-effort: anything empty or unavailable is omitted.
 func debugStackContext(be httpstate.Backend, target taskTarget, kind debugKind, id string) string {
 	var b strings.Builder
 	b.WriteString("Context for this debug session:\n")
@@ -97,8 +88,6 @@ func debugStackContext(be httpstate.Backend, target taskTarget, kind debugKind, 
 	if name := target.stackName(); name != "" {
 		fmt.Fprintf(&b, "- Stack: %s\n", name)
 	}
-	// The id was resolved (explicitly or inferred) before this call, so we just report it; the
-	// phrasing matches the seed prompt's "<kind> <id>".
 	if id != "" {
 		fmt.Fprintf(&b, "- Debugging: %s %s\n", kind, id)
 	}

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 // newNeoDebugCmd creates the `pulumi neo debug [id]` subcommand: a structured entry to the same
@@ -54,11 +53,17 @@ func newNeoDebugCmd() *cobra.Command {
 			if len(args) == 1 {
 				id = args[0]
 			}
-			return runNeo(
-				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				debugSeedPrompt(id), flags.stackName, flags.orgFlag, flags.cwdFlag,
-				approvalMode, permissionMode, flags.printMode,
-				flags.disableIntegrations, true)
+			return runNeo(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), neoRunOptions{
+				prompt:              debugSeedPrompt(id),
+				stackName:           flags.stackName,
+				orgFlag:             flags.orgFlag,
+				cwdFlag:             flags.cwdFlag,
+				approvalMode:        approvalMode,
+				permissionMode:      permissionMode,
+				printMode:           flags.printMode,
+				includeStackContext: true,
+				disableIntegrations: flags.disableIntegrations,
+			})
 		},
 	}
 
@@ -68,29 +73,19 @@ func newNeoDebugCmd() *cobra.Command {
 }
 
 // debugSeedPrompt builds the initial Neo prompt for `pulumi neo debug`. It is deliberately a short
-// trigger line, not a procedure: Neo's skill evaluator matches "debug ... failed update/preview" and
+// trigger line, not a procedure: Neo's skill evaluator matches "debug ... failed operation" and
 // loads the pulumi-debug-failed-operation skill, which carries the actual debugging steps. With no id
 // the seed targets the user's most recent operation (the skill confirms which one); with an id it
-// targets that specific run. Either way the fix should land locally in the working directory.
+// targets that specific run. The id itself tells Neo whether it is an update version (a sequential
+// integer) or a preview (a UUID), so the seed doesn't classify it. Either way the fix should land
+// locally in the working directory.
 func debugSeedPrompt(id string) string {
 	if id == "" {
 		return "Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n"
 	}
-	operation := "update"
-	if !isUpdateID(id) {
-		operation = "preview"
-	}
 	return fmt.Sprintf(
-		"Debug the failed %s %s of this stack and fix it directly in this working directory.\n",
-		operation, id)
-}
-
-// stackPreviewLister is the subset of the cloud backend that can fetch a stack's most recent
-// preview. It is kept separate from httpstate.Backend — which must stay backwards-compatible, so
-// we can't add methods to it — and detected via a type assertion, degrading gracefully (skipping
-// the preview lookup) on backends that don't implement it.
-type stackPreviewLister interface {
-	GetLatestStackPreview(ctx context.Context, stackRef backend.StackReference) (*apitype.StackPreview, error)
+		"Debug the failed Pulumi operation %s of this stack and fix it directly in this working directory.\n",
+		id)
 }
 
 // debugStackContext builds a short, human-readable block describing where the debug session is
@@ -103,7 +98,7 @@ func debugStackContext(
 	ctx context.Context,
 	be httpstate.Backend,
 	stackRef backend.StackReference,
-	org, project, stack string,
+	org, project string,
 ) string {
 	var b strings.Builder
 	b.WriteString("Context for this debug session:\n")
@@ -116,10 +111,10 @@ func debugStackContext(
 	if project != "" {
 		fmt.Fprintf(&b, "- Project: %s\n", project)
 	}
-	if stack != "" {
-		fmt.Fprintf(&b, "- Stack: %s\n", stack)
-	}
+	// The stack name and most recent operation both come from the resolved reference, so they
+	// share the same nil guard: with no stack selected we emit neither.
 	if stackRef != nil {
+		fmt.Fprintf(&b, "- Stack: %s\n", stackRef.Name())
 		if op := mostRecentOperation(ctx, be, stackRef); op != "" {
 			fmt.Fprintf(&b, "- Most recent operation: %s\n", op)
 		}
@@ -144,24 +139,8 @@ func mostRecentOperation(ctx context.Context, be httpstate.Backend, stackRef bac
 		best = fmt.Sprintf("%s (version %d, result: %s)", u.Kind, u.Version, u.Result)
 	}
 	// Most recent preview, which is tracked separately from history.
-	if pl, ok := be.(stackPreviewLister); ok {
-		if p, err := pl.GetLatestStackPreview(ctx, stackRef); err == nil && p != nil && p.Info.StartTime > bestStart {
-			best = fmt.Sprintf("preview %s (result: %s)", p.UpdateID, p.Info.Result)
-		}
+	if p, err := be.GetLatestStackPreview(ctx, stackRef); err == nil && p != nil && p.Info.StartTime > bestStart {
+		best = fmt.Sprintf("preview %s (result: %s)", p.UpdateID, p.Info.Result)
 	}
 	return best
-}
-
-// isUpdateID reports whether id looks like an update version rather than a preview id. Update
-// versions are sequential integers; preview ids are UUIDs, so a digits-only id is an update.
-func isUpdateID(id string) bool {
-	if id == "" {
-		return false
-	}
-	for _, r := range id {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/cmd/pulumi/neo/debug.go
+++ b/pkg/cmd/pulumi/neo/debug.go
@@ -15,9 +15,15 @@
 package neo
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
 // newNeoDebugCmd creates the `pulumi neo debug [id]` subcommand: a structured entry to the same
@@ -52,7 +58,7 @@ func newNeoDebugCmd() *cobra.Command {
 				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
 				debugSeedPrompt(id), flags.stackName, flags.orgFlag, flags.cwdFlag,
 				approvalMode, permissionMode, flags.printMode,
-				flags.disableIntegrations)
+				flags.disableIntegrations, true)
 		},
 	}
 
@@ -77,6 +83,73 @@ func debugSeedPrompt(id string) string {
 	return fmt.Sprintf(
 		"Debug the failed %s %s of this stack and fix it directly in this working directory.\n",
 		operation, id)
+}
+
+// stackPreviewLister is the subset of the cloud backend that can fetch a stack's most recent
+// preview. It is kept separate from httpstate.Backend — which must stay backwards-compatible, so
+// we can't add methods to it — and detected via a type assertion, degrading gracefully (skipping
+// the preview lookup) on backends that don't implement it.
+type stackPreviewLister interface {
+	GetLatestStackPreview(ctx context.Context, stackRef backend.StackReference) (*apitype.StackPreview, error)
+}
+
+// debugStackContext builds a short, human-readable block describing where the debug session is
+// running — the organization, user, project, and stack — plus the stack's most recent operation
+// (its kind, version/id, and result). `pulumi neo debug` appends this to the seed prompt so Neo
+// starts with the failure already in context instead of rediscovering it. Every lookup is
+// best-effort: anything that errors or is unavailable is simply omitted so debug still works when,
+// for example, the backend can't return history or no stack is selected.
+func debugStackContext(
+	ctx context.Context,
+	be httpstate.Backend,
+	stackRef backend.StackReference,
+	org, project, stack string,
+) string {
+	var b strings.Builder
+	b.WriteString("Context for this debug session:\n")
+	if org != "" {
+		fmt.Fprintf(&b, "- Organization: %s\n", org)
+	}
+	if user, _, _, err := be.CurrentUser(); err == nil && user != "" {
+		fmt.Fprintf(&b, "- User: %s\n", user)
+	}
+	if project != "" {
+		fmt.Fprintf(&b, "- Project: %s\n", project)
+	}
+	if stack != "" {
+		fmt.Fprintf(&b, "- Stack: %s\n", stack)
+	}
+	if stackRef != nil {
+		if op := mostRecentOperation(ctx, be, stackRef); op != "" {
+			fmt.Fprintf(&b, "- Most recent operation: %s\n", op)
+		}
+	}
+	return b.String()
+}
+
+// mostRecentOperation describes the stack's most recent operation across both updates and
+// previews, or "" if neither is available. Updates and previews are tracked separately — previews
+// never appear in GetHistory — so we look at both and report whichever ran most recently (by start
+// time). This is what lets `pulumi neo debug` target a failed preview that is newer than the last
+// deployment, rather than always reporting the latest update. Both lookups are best-effort.
+func mostRecentOperation(ctx context.Context, be httpstate.Backend, stackRef backend.StackReference) string {
+	var (
+		bestStart int64 = -1
+		best      string
+	)
+	// Most recent entry from update history (updates/refreshes/destroys/imports — never previews).
+	if updates, err := be.GetHistory(ctx, stackRef, 1, 1); err == nil && len(updates) > 0 {
+		u := updates[0]
+		bestStart = u.StartTime
+		best = fmt.Sprintf("%s (version %d, result: %s)", u.Kind, u.Version, u.Result)
+	}
+	// Most recent preview, which is tracked separately from history.
+	if pl, ok := be.(stackPreviewLister); ok {
+		if p, err := pl.GetLatestStackPreview(ctx, stackRef); err == nil && p != nil && p.Info.StartTime > bestStart {
+			best = fmt.Sprintf("preview %s (result: %s)", p.UpdateID, p.Info.Result)
+		}
+	}
+	return best
 }
 
 // isUpdateID reports whether id looks like an update version rather than a preview id. Update

--- a/pkg/cmd/pulumi/neo/debug_test.go
+++ b/pkg/cmd/pulumi/neo/debug_test.go
@@ -28,48 +28,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func TestIsUpdateID(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		id   string
-		want bool
-	}{
-		{"5", true},
-		{"123", true},
-		{"0", true},
-		{"", false},
-		{"7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d", false}, // preview UUID
-		{"v5", false},
-		{"5a", false},
-	}
-	for _, tt := range tests {
-		assert.Equalf(t, tt.want, isUpdateID(tt.id), "isUpdateID(%q)", tt.id)
-	}
-}
-
-func TestDebugSeedPromptUpdate(t *testing.T) {
+func TestDebugSeedPromptWithID(t *testing.T) {
 	t.Parallel()
 
 	// The seed is a short trigger line; the debugging procedure lives in the
-	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text.
-	want := "Debug the failed update 5 of this stack and fix it directly in this working directory.\n"
-	got := debugSeedPrompt("5")
-	assert.Equal(t, want, got)
+	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text. The id
+	// itself tells Neo whether it is an update version or a preview UUID, so the seed is the
+	// same generic line for both — only the id varies.
+	for _, id := range []string{"5", "7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d"} {
+		got := debugSeedPrompt(id)
+		assert.Equal(t,
+			"Debug the failed Pulumi operation "+id+
+				" of this stack and fix it directly in this working directory.\n",
+			got)
 
-	// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
-	assert.NotContains(t, got, "<details>")
-	assert.NotContains(t, got, "/api/console")
-}
-
-func TestDebugSeedPromptPreview(t *testing.T) {
-	t.Parallel()
-
-	prompt := debugSeedPrompt("7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d")
-	assert.Equal(t,
-		"Debug the failed preview 7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d of this stack "+
-			"and fix it directly in this working directory.\n",
-		prompt)
+		// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
+		assert.NotContains(t, got, "<details>")
+		assert.NotContains(t, got, "/api/console")
+	}
 }
 
 func TestDebugSeedPromptNoID(t *testing.T) {
@@ -98,7 +74,7 @@ func TestDebugStackContext_FullContext(t *testing.T) {
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
 
 	assert.Contains(t, got, "- Organization: acme\n")
 	assert.Contains(t, got, "- User: alice\n")
@@ -136,7 +112,7 @@ func TestDebugStackContext_NewerPreviewWins(t *testing.T) {
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
 
 	assert.Contains(t, got,
 		"- Most recent operation: preview 2e07637b-d20b-4d4f-9d29-a7bcb1631cf7 (result: failed)\n")
@@ -168,7 +144,7 @@ func TestDebugStackContext_OlderPreviewLosesToUpdate(t *testing.T) {
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
 
 	assert.Contains(t, got, "- Most recent operation: update (version 42, result: failed)\n")
 	assert.NotContains(t, got, "preview")
@@ -190,7 +166,7 @@ func TestDebugStackContext_GracefulOmission(t *testing.T) {
 		return nil, nil
 	}
 
-	got := debugStackContext(t.Context(), be, nil, "acme", "", "")
+	got := debugStackContext(t.Context(), be, nil, "acme", "")
 
 	assert.Contains(t, got, "- Organization: acme\n")
 	assert.NotContains(t, got, "- User:")
@@ -213,7 +189,7 @@ func TestDebugStackContext_EmptyHistory(t *testing.T) {
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
 
 	// A stack with no operation history shouldn't produce a dangling operation line.
 	assert.NotContains(t, got, "Most recent operation")

--- a/pkg/cmd/pulumi/neo/debug_test.go
+++ b/pkg/cmd/pulumi/neo/debug_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package neo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUpdateID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"5", true},
+		{"123", true},
+		{"0", true},
+		{"", false},
+		{"7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d", false}, // preview UUID
+		{"v5", false},
+		{"5a", false},
+	}
+	for _, tt := range tests {
+		assert.Equalf(t, tt.want, isUpdateID(tt.id), "isUpdateID(%q)", tt.id)
+	}
+}
+
+func TestDebugSeedPromptUpdate(t *testing.T) {
+	t.Parallel()
+
+	// The seed is a short trigger line; the debugging procedure lives in the
+	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text.
+	want := "Debug the failed update 5 of this stack and fix it directly in this working directory.\n"
+	got := debugSeedPrompt("5")
+	assert.Equal(t, want, got)
+
+	// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
+	assert.NotContains(t, got, "<details>")
+	assert.NotContains(t, got, "/api/console")
+}
+
+func TestDebugSeedPromptPreview(t *testing.T) {
+	t.Parallel()
+
+	prompt := debugSeedPrompt("7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d")
+	assert.Equal(t,
+		"Debug the failed preview 7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d of this stack "+
+			"and fix it directly in this working directory.\n",
+		prompt)
+}
+
+func TestDebugSeedPromptNoID(t *testing.T) {
+	t.Parallel()
+
+	// With no id, the seed targets the user's most recent operation; the skill confirms which one.
+	assert.Equal(t,
+		"Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n",
+		debugSeedPrompt(""))
+}
+
+func TestNeoDebugCmdRegistered(t *testing.T) {
+	t.Parallel()
+
+	cmd := newNeoDebugCmd()
+	assert.Equal(t, "debug [update-or-preview-id]", cmd.Use)
+	require.NotNil(t, cmd.Args)
+	// The id is optional (0 or 1 args); two or more is an error.
+	require.NoError(t, cmd.Args(cmd, []string{}))
+	require.NoError(t, cmd.Args(cmd, []string{"5"}))
+	assert.Error(t, cmd.Args(cmd, []string{"5", "6"}))
+
+	// The shared flags are present so `debug` honors the same options as `pulumi neo`.
+	for _, name := range []string{"stack", "org", "cwd", "approval-mode", "permission-mode", "print"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "flag %q", name)
+	}
+}

--- a/pkg/cmd/pulumi/neo/debug_test.go
+++ b/pkg/cmd/pulumi/neo/debug_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -32,74 +31,44 @@ func TestDebugSeedPromptWithID(t *testing.T) {
 	t.Parallel()
 
 	// The seed is a short trigger line; the debugging procedure lives in the
-	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text. The id
-	// itself tells Neo whether it is an update version or a preview UUID, so the seed is the
-	// same generic line for both — only the id varies.
-	for _, id := range []string{"5", "7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d"} {
-		got := debugSeedPrompt(id)
-		assert.Equal(t,
-			"Debug the failed Pulumi operation "+id+
-				" of this stack and fix it directly in this working directory.\n",
-			got)
+	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text. The kind
+	// selects the noun (update vs preview) and the id pins the specific run.
+	assert.Equal(t,
+		"Debug the failed Pulumi update 42 of this stack and fix it directly in this working directory.\n",
+		debugSeedPrompt(debugUpdate, "42"))
+	assert.Equal(t,
+		"Debug the failed Pulumi preview 7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d "+
+			"of this stack and fix it directly in this working directory.\n",
+		debugSeedPrompt(debugPreview, "7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d"))
 
-		// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
-		assert.NotContains(t, got, "<details>")
-		assert.NotContains(t, got, "/api/console")
-	}
+	// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
+	got := debugSeedPrompt(debugUpdate, "42")
+	assert.NotContains(t, got, "<details>")
+	assert.NotContains(t, got, "/api/console")
 }
 
 func TestDebugSeedPromptNoID(t *testing.T) {
 	t.Parallel()
 
-	// With no id, the seed targets the user's most recent operation; the skill confirms which one.
+	// With no id, the seed targets the user's most recent operation of the given kind; the skill
+	// confirms which one.
 	assert.Equal(t,
-		"Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n",
-		debugSeedPrompt(""))
+		"Debug my most recent Pulumi update on this stack and fix it directly in this working directory.\n",
+		debugSeedPrompt(debugUpdate, ""))
+	assert.Equal(t,
+		"Debug my most recent Pulumi preview on this stack and fix it directly in this working directory.\n",
+		debugSeedPrompt(debugPreview, ""))
 }
 
-func TestDebugStackContext_FullContext(t *testing.T) {
+func TestLatestOperationID(t *testing.T) {
 	t.Parallel()
 
 	be := newFakeBackend()
-	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
-		return "alice", []string{"acme"}, nil, nil
-	}
 	be.GetHistoryF = func(
 		_ context.Context, _ backend.StackReference, _ int, _ int,
 	) ([]backend.UpdateInfo, error) {
 		return []backend.UpdateInfo{
 			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.FailedResult, StartTime: 100},
-			{Kind: apitype.UpdateUpdate, Version: 41, Result: backend.SucceededResult, StartTime: 50},
-		}, nil
-	}
-	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
-
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
-
-	assert.Contains(t, got, "- Organization: acme\n")
-	assert.Contains(t, got, "- User: alice\n")
-	assert.Contains(t, got, "- Project: my-proj\n")
-	assert.Contains(t, got, "- Stack: dev\n")
-	// With no newer preview, the most recent history entry (newest-first) is surfaced.
-	assert.Contains(t, got, "- Most recent operation: update (version 42, result: failed)\n")
-	assert.NotContains(t, got, "version 41")
-}
-
-func TestDebugStackContext_NewerPreviewWins(t *testing.T) {
-	t.Parallel()
-
-	// Regression: a preview that ran more recently than the last deployment must be reported as
-	// the most recent operation. Previews are not in GetHistory, so without the separate lookup
-	// `neo debug` would wrongly target the older update.
-	be := newFakeBackend()
-	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
-		return "alice", nil, nil, nil
-	}
-	be.GetHistoryF = func(
-		_ context.Context, _ backend.StackReference, _ int, _ int,
-	) ([]backend.UpdateInfo, error) {
-		return []backend.UpdateInfo{
-			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.SucceededResult, StartTime: 100},
 		}, nil
 	}
 	be.GetLatestStackPreviewF = func(
@@ -112,102 +81,90 @@ func TestDebugStackContext_NewerPreviewWins(t *testing.T) {
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
-
-	assert.Contains(t, got,
-		"- Most recent operation: preview 2e07637b-d20b-4d4f-9d29-a7bcb1631cf7 (result: failed)\n")
-	assert.NotContains(t, got, "version 42")
+	// An update resolves to its history version; a preview to its opaque UpdateID. The two are
+	// looked up independently, so each kind ignores the other.
+	assert.Equal(t, "42", debugUpdate.latestID(t.Context(), be, ref))
+	assert.Equal(t, "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7", debugPreview.latestID(t.Context(), be, ref))
 }
 
-func TestDebugStackContext_OlderPreviewLosesToUpdate(t *testing.T) {
+func TestLatestOperationID_BestEffort(t *testing.T) {
 	t.Parallel()
 
-	// When the last deployment is newer than the latest preview, the update wins.
+	// A nil stack ref, an error, or empty history all resolve to "" rather than panicking.
 	be := newFakeBackend()
-	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
-		return "alice", nil, nil, nil
-	}
-	be.GetHistoryF = func(
-		_ context.Context, _ backend.StackReference, _ int, _ int,
-	) ([]backend.UpdateInfo, error) {
-		return []backend.UpdateInfo{
-			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.FailedResult, StartTime: 300},
-		}, nil
-	}
-	be.GetLatestStackPreviewF = func(
-		_ context.Context, _ backend.StackReference,
-	) (*apitype.StackPreview, error) {
-		return &apitype.StackPreview{
-			UpdateID: "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
-			Info:     apitype.UpdateInfo{Result: apitype.SucceededResult, StartTime: 200},
-		}, nil
-	}
-	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
-
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
-
-	assert.Contains(t, got, "- Most recent operation: update (version 42, result: failed)\n")
-	assert.NotContains(t, got, "preview")
-}
-
-func TestDebugStackContext_GracefulOmission(t *testing.T) {
-	t.Parallel()
-
-	// Every lookup is best-effort: a CurrentUser error, a nil stack reference, and no
-	// resolved project/stack must all be omitted rather than break the debug prompt.
-	be := newFakeBackend()
-	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
-		return "", nil, nil, errors.New("not logged in")
-	}
 	be.GetHistoryF = func(
 		_ context.Context, _ backend.StackReference, _ int, _ int,
 	) ([]backend.UpdateInfo, error) {
 		t.Fatal("GetHistory must not be called when the stack reference is nil")
 		return nil, nil
 	}
+	assert.Equal(t, "", debugUpdate.latestID(t.Context(), be, nil))
 
-	got := debugStackContext(t.Context(), be, nil, "acme", "")
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return nil, errors.New("boom")
+	}
+	assert.Equal(t, "", debugUpdate.latestID(t.Context(), be, ref))
 
-	assert.Contains(t, got, "- Organization: acme\n")
-	assert.NotContains(t, got, "- User:")
-	assert.NotContains(t, got, "- Project:")
-	assert.NotContains(t, got, "- Stack:")
-	assert.NotContains(t, got, "Most recent operation")
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return nil, nil
+	}
+	assert.Equal(t, "", debugUpdate.latestID(t.Context(), be, ref))
 }
 
-func TestDebugStackContext_EmptyHistory(t *testing.T) {
+func TestDebugStackContext_FullContext(t *testing.T) {
+	t.Parallel()
+
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "alice", []string{"acme"}, nil, nil
+	}
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	got := debugStackContext(be, taskTarget{org: "acme", project: "my-proj", ref: ref}, debugUpdate, "42")
+
+	assert.Contains(t, got, "- Organization: acme\n")
+	assert.Contains(t, got, "- User: alice\n")
+	assert.Contains(t, got, "- Project: my-proj\n")
+	assert.Contains(t, got, "- Stack: dev\n")
+	// The context phrasing matches the seed prompt's "<kind> <id>".
+	assert.Contains(t, got, "- Debugging: update 42\n")
+}
+
+func TestDebugStackContext_Preview(t *testing.T) {
 	t.Parallel()
 
 	be := newFakeBackend()
 	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
 		return "alice", nil, nil, nil
 	}
-	be.GetHistoryF = func(
-		_ context.Context, _ backend.StackReference, _ int, _ int,
-	) ([]backend.UpdateInfo, error) {
-		return nil, nil
-	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj")
+	got := debugStackContext(be, taskTarget{org: "acme", project: "my-proj", ref: ref}, debugPreview,
+		"2e07637b-d20b-4d4f-9d29-a7bcb1631cf7")
 
-	// A stack with no operation history shouldn't produce a dangling operation line.
-	assert.NotContains(t, got, "Most recent operation")
+	assert.Contains(t, got, "- Debugging: preview 2e07637b-d20b-4d4f-9d29-a7bcb1631cf7\n")
 }
 
-func TestNeoDebugCmdRegistered(t *testing.T) {
+func TestDebugStackContext_GracefulOmission(t *testing.T) {
 	t.Parallel()
 
-	cmd := newNeoDebugCmd()
-	assert.Equal(t, "debug [update-or-preview-id]", cmd.Use)
-	require.NotNil(t, cmd.Args)
-	// The id is optional (0 or 1 args); two or more is an error.
-	require.NoError(t, cmd.Args(cmd, []string{}))
-	require.NoError(t, cmd.Args(cmd, []string{"5"}))
-	assert.Error(t, cmd.Args(cmd, []string{"5", "6"}))
-
-	// The shared flags are present so `debug` honors the same options as `pulumi neo`.
-	for _, name := range []string{"stack", "org", "cwd", "approval-mode", "permission-mode", "print"} {
-		assert.NotNilf(t, cmd.Flags().Lookup(name), "flag %q", name)
+	// Every lookup is best-effort: a CurrentUser error, a nil stack reference, no resolved
+	// project/stack, and no resolved id must all be omitted rather than break the debug prompt.
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "", nil, nil, errors.New("not logged in")
 	}
+
+	got := debugStackContext(be, taskTarget{org: "acme"}, debugUpdate, "")
+
+	assert.Contains(t, got, "- Organization: acme\n")
+	assert.NotContains(t, got, "- User:")
+	assert.NotContains(t, got, "- Project:")
+	assert.NotContains(t, got, "- Stack:")
+	assert.NotContains(t, got, "- Debugging:")
 }

--- a/pkg/cmd/pulumi/neo/debug_test.go
+++ b/pkg/cmd/pulumi/neo/debug_test.go
@@ -30,9 +30,7 @@ import (
 func TestDebugSeedPromptWithID(t *testing.T) {
 	t.Parallel()
 
-	// The seed is a short trigger line; the debugging procedure lives in the
-	// pulumi-debug-failed-operation skill, which Neo's evaluator loads from this text. The kind
-	// selects the noun (update vs preview) and the id pins the specific run.
+	// The kind selects the noun (update vs preview) and the id pins the specific run.
 	assert.Equal(t,
 		"Debug the failed Pulumi update 42 of this stack and fix it directly in this working directory.\n",
 		debugSeedPrompt(debugUpdate, "42"))
@@ -40,18 +38,12 @@ func TestDebugSeedPromptWithID(t *testing.T) {
 		"Debug the failed Pulumi preview 7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d "+
 			"of this stack and fix it directly in this working directory.\n",
 		debugSeedPrompt(debugPreview, "7f3a2b9c-1d4e-4f6a-8b2c-9e0d1a2b3c4d"))
-
-	// The procedure moved to the skill, so the seed stays a one-liner with no embedded steps.
-	got := debugSeedPrompt(debugUpdate, "42")
-	assert.NotContains(t, got, "<details>")
-	assert.NotContains(t, got, "/api/console")
 }
 
 func TestDebugSeedPromptNoID(t *testing.T) {
 	t.Parallel()
 
-	// With no id, the seed targets the user's most recent operation of the given kind; the skill
-	// confirms which one.
+	// With no id, the seed targets the user's most recent operation of the given kind.
 	assert.Equal(t,
 		"Debug my most recent Pulumi update on this stack and fix it directly in this working directory.\n",
 		debugSeedPrompt(debugUpdate, ""))
@@ -74,15 +66,11 @@ func TestLatestOperationID(t *testing.T) {
 	be.GetLatestStackPreviewF = func(
 		_ context.Context, _ backend.StackReference,
 	) (*apitype.StackPreview, error) {
-		return &apitype.StackPreview{
-			UpdateID: "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
-			Info:     apitype.UpdateInfo{Result: apitype.FailedResult, StartTime: 200},
-		}, nil
+		return &apitype.StackPreview{UpdateID: "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7"}, nil
 	}
 	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
 
-	// An update resolves to its history version; a preview to its opaque UpdateID. The two are
-	// looked up independently, so each kind ignores the other.
+	// An update resolves to its history version; a preview to its opaque UpdateID.
 	assert.Equal(t, "42", debugUpdate.latestID(t.Context(), be, ref))
 	assert.Equal(t, "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7", debugPreview.latestID(t.Context(), be, ref))
 }
@@ -131,7 +119,6 @@ func TestDebugStackContext_FullContext(t *testing.T) {
 	assert.Contains(t, got, "- User: alice\n")
 	assert.Contains(t, got, "- Project: my-proj\n")
 	assert.Contains(t, got, "- Stack: dev\n")
-	// The context phrasing matches the seed prompt's "<kind> <id>".
 	assert.Contains(t, got, "- Debugging: update 42\n")
 }
 

--- a/pkg/cmd/pulumi/neo/debug_test.go
+++ b/pkg/cmd/pulumi/neo/debug_test.go
@@ -15,10 +15,17 @@
 package neo
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 func TestIsUpdateID(t *testing.T) {
@@ -72,6 +79,144 @@ func TestDebugSeedPromptNoID(t *testing.T) {
 	assert.Equal(t,
 		"Debug my most recent Pulumi operation on this stack and fix it directly in this working directory.\n",
 		debugSeedPrompt(""))
+}
+
+func TestDebugStackContext_FullContext(t *testing.T) {
+	t.Parallel()
+
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "alice", []string{"acme"}, nil, nil
+	}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return []backend.UpdateInfo{
+			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.FailedResult, StartTime: 100},
+			{Kind: apitype.UpdateUpdate, Version: 41, Result: backend.SucceededResult, StartTime: 50},
+		}, nil
+	}
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+
+	assert.Contains(t, got, "- Organization: acme\n")
+	assert.Contains(t, got, "- User: alice\n")
+	assert.Contains(t, got, "- Project: my-proj\n")
+	assert.Contains(t, got, "- Stack: dev\n")
+	// With no newer preview, the most recent history entry (newest-first) is surfaced.
+	assert.Contains(t, got, "- Most recent operation: update (version 42, result: failed)\n")
+	assert.NotContains(t, got, "version 41")
+}
+
+func TestDebugStackContext_NewerPreviewWins(t *testing.T) {
+	t.Parallel()
+
+	// Regression: a preview that ran more recently than the last deployment must be reported as
+	// the most recent operation. Previews are not in GetHistory, so without the separate lookup
+	// `neo debug` would wrongly target the older update.
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "alice", nil, nil, nil
+	}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return []backend.UpdateInfo{
+			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.SucceededResult, StartTime: 100},
+		}, nil
+	}
+	be.GetLatestStackPreviewF = func(
+		_ context.Context, _ backend.StackReference,
+	) (*apitype.StackPreview, error) {
+		return &apitype.StackPreview{
+			UpdateID: "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
+			Info:     apitype.UpdateInfo{Result: apitype.FailedResult, StartTime: 200},
+		}, nil
+	}
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+
+	assert.Contains(t, got,
+		"- Most recent operation: preview 2e07637b-d20b-4d4f-9d29-a7bcb1631cf7 (result: failed)\n")
+	assert.NotContains(t, got, "version 42")
+}
+
+func TestDebugStackContext_OlderPreviewLosesToUpdate(t *testing.T) {
+	t.Parallel()
+
+	// When the last deployment is newer than the latest preview, the update wins.
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "alice", nil, nil, nil
+	}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return []backend.UpdateInfo{
+			{Kind: apitype.UpdateUpdate, Version: 42, Result: backend.FailedResult, StartTime: 300},
+		}, nil
+	}
+	be.GetLatestStackPreviewF = func(
+		_ context.Context, _ backend.StackReference,
+	) (*apitype.StackPreview, error) {
+		return &apitype.StackPreview{
+			UpdateID: "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
+			Info:     apitype.UpdateInfo{Result: apitype.SucceededResult, StartTime: 200},
+		}, nil
+	}
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+
+	assert.Contains(t, got, "- Most recent operation: update (version 42, result: failed)\n")
+	assert.NotContains(t, got, "preview")
+}
+
+func TestDebugStackContext_GracefulOmission(t *testing.T) {
+	t.Parallel()
+
+	// Every lookup is best-effort: a CurrentUser error, a nil stack reference, and no
+	// resolved project/stack must all be omitted rather than break the debug prompt.
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "", nil, nil, errors.New("not logged in")
+	}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		t.Fatal("GetHistory must not be called when the stack reference is nil")
+		return nil, nil
+	}
+
+	got := debugStackContext(t.Context(), be, nil, "acme", "", "")
+
+	assert.Contains(t, got, "- Organization: acme\n")
+	assert.NotContains(t, got, "- User:")
+	assert.NotContains(t, got, "- Project:")
+	assert.NotContains(t, got, "- Stack:")
+	assert.NotContains(t, got, "Most recent operation")
+}
+
+func TestDebugStackContext_EmptyHistory(t *testing.T) {
+	t.Parallel()
+
+	be := newFakeBackend()
+	be.CurrentUserF = func() (string, []string, *workspace.TokenInformation, error) {
+		return "alice", nil, nil, nil
+	}
+	be.GetHistoryF = func(
+		_ context.Context, _ backend.StackReference, _ int, _ int,
+	) ([]backend.UpdateInfo, error) {
+		return nil, nil
+	}
+	ref := &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+
+	got := debugStackContext(t.Context(), be, ref, "acme", "my-proj", "dev")
+
+	// A stack with no operation history shouldn't produce a dangling operation line.
+	assert.NotContains(t, got, "Most recent operation")
 }
 
 func TestNeoDebugCmdRegistered(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -148,7 +149,7 @@ func NewNeoCmd() *cobra.Command {
 				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
 				prompt, flags.stackName, flags.orgFlag, flags.cwdFlag,
 				approvalMode, permissionMode, flags.printMode,
-				flags.disableIntegrations)
+				flags.disableIntegrations, false)
 		},
 	}
 
@@ -247,6 +248,7 @@ func runNeo(
 	permissionMode client.NeoPermissionMode,
 	printMode bool,
 	disableIntegrations bool,
+	includeStackContext bool,
 ) error {
 	// nil lets the server inherit the org's enabled integrations; the empty slice opts out.
 	var enabledIntegrations *[]string
@@ -284,9 +286,17 @@ func runNeo(
 		return result.FprintBailf(stderr, "%s", msg)
 	}
 
-	orgName, projectName, stackRefName, err := resolveTaskTarget(ctx, ws, cloudBe, project, stackName, orgFlag)
+	orgName, projectName, stackRefName, stackRef, err := resolveTaskTarget(ctx, ws, cloudBe, project, stackName, orgFlag)
 	if err != nil {
 		return err
+	}
+
+	// `pulumi neo debug` seeds Neo with the current identity/target and the most recent
+	// operation so it starts with the failure already in context instead of rediscovering
+	// it. We append after the trigger line so debugSeedPrompt stays first and Neo's skill
+	// evaluator still matches the debug skill.
+	if includeStackContext && prompt != "" {
+		prompt += "\n\n" + debugStackContext(ctx, cloudBe, stackRef, orgName, projectName, stackRefName)
 	}
 
 	// Allow tools to read/write under temp directories in addition to cwd: the agent
@@ -622,7 +632,7 @@ func resolveTaskTarget(
 	be httpstate.Backend,
 	project *workspace.Project,
 	stackName, orgFlag string,
-) (org, projectName, stack string, err error) {
+) (org, projectName, stack string, stackRef backend.StackReference, err error) {
 	if project != nil {
 		projectName = string(project.Name)
 	}
@@ -631,8 +641,9 @@ func resolveTaskTarget(
 	if stackName != "" {
 		ref, err := be.ParseStackReference(stackName)
 		if err != nil {
-			return "", "", "", err
+			return "", "", "", nil, err
 		}
+		stackRef = ref
 		stack = ref.Name().String()
 		if owned, ok := ref.(stackRefWithOrg); ok {
 			if o, has := owned.Organization(); has {
@@ -642,6 +653,7 @@ func resolveTaskTarget(
 	} else {
 		s, err := state.CurrentStack(ctx, ws, be)
 		if err == nil && s != nil {
+			stackRef = s.Ref()
 			stack = s.Ref().Name().String()
 			if owned, ok := s.Ref().(stackRefWithOrg); ok {
 				if o, has := owned.Organization(); has {
@@ -659,13 +671,13 @@ func resolveTaskTarget(
 	default:
 		org, err = be.GetDefaultOrg(ctx)
 		if err != nil {
-			return "", "", "", fmt.Errorf("determining default organization: %w", err)
+			return "", "", "", nil, fmt.Errorf("determining default organization: %w", err)
 		}
 	}
 	if org == "" {
-		return "", "", "", errors.New("could not determine an organization for the Neo task; pass --org")
+		return "", "", "", nil, errors.New("could not determine an organization for the Neo task; pass --org")
 	}
-	return org, projectName, stack, nil
+	return org, projectName, stack, stackRef, nil
 }
 
 // dedupeExistingRoots returns candidates with duplicates removed by canonical path,

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -325,18 +325,10 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	}
 	orgName, projectName, stackRefName := target.org, target.project, target.stackName()
 
-	// In a debug session, prepend the seed trigger line (so Neo's skill evaluator matches) and
-	// append the stack context. Any positional prompt sits between them as extra guidance.
+	// In a debug session, replace the prompt with the seed that points Neo at the failed
+	// operation, folding any positional prompt in as extra guidance.
 	if opts.debugKind != debugNone {
-		id := opts.debugID
-		if id == "" {
-			id = opts.debugKind.latestID(ctx, cloudBe, target.ref)
-		}
-		seed := debugSeedPrompt(opts.debugKind, id)
-		if opts.prompt != "" {
-			seed += "\n\n" + opts.prompt
-		}
-		opts.prompt = seed + "\n\n" + debugStackContext(cloudBe, target, opts.debugKind, id)
+		opts.prompt = buildDebugPrompt(ctx, cloudBe, target, opts.debugKind, opts.debugID, opts.prompt)
 	}
 
 	// Allow tools to read/write under temp directories in addition to cwd: the agent

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -145,6 +145,9 @@ func NewNeoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// --debug-update/--debug-preview seed Neo to investigate a failed operation. The
+			// positional prompt (if any) is still honored as extra guidance appended to the seed.
+			debugKind, debugID := flags.debugRequest(cmd)
 			return runNeo(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), neoRunOptions{
 				prompt:              prompt,
 				stackName:           flags.stackName,
@@ -153,20 +156,26 @@ func NewNeoCmd() *cobra.Command {
 				approvalMode:        approvalMode,
 				permissionMode:      permissionMode,
 				printMode:           flags.printMode,
+				debugKind:           debugKind,
+				debugID:             debugID,
 				disableIntegrations: flags.disableIntegrations,
 			})
 		},
 	}
 
 	flags.register(cmd)
-	cmd.AddCommand(newNeoDebugCmd())
 
 	return cmd
 }
 
-// neoFlags holds the options shared by `pulumi neo` and its `debug` subcommand. Both start the
-// same Neo experience and differ only in how the initial prompt is produced, so they register
-// and resolve the same flags.
+// debugLatestSentinel is the NoOptDefVal for --debug-update/--debug-preview: pflag requires a
+// non-empty NoOptDefVal to make a flag's value optional, so a bare `--debug-update` records this
+// sentinel (meaning "infer the latest"). It is deliberately untypeable as a real id so it can't
+// collide with a value the user passes via `--debug-update=<id>`.
+const debugLatestSentinel = "\x00latest"
+
+// neoFlags holds the options for `pulumi neo`, including the --debug-update/--debug-preview flags
+// that seed Neo to investigate a failed operation.
 type neoFlags struct {
 	stackName           string
 	orgFlag             string
@@ -174,6 +183,8 @@ type neoFlags struct {
 	approvalModeFlag    string
 	permissionModeFlag  string
 	printMode           bool
+	debugUpdate         string
+	debugPreview        string
 	disableIntegrations bool
 }
 
@@ -196,6 +207,39 @@ func (f *neoFlags) register(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.disableIntegrations, "disable-integrations", false,
 		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
 			"integrations.")
+	cmd.Flags().StringVar(&f.debugUpdate, "debug-update", "",
+		"Debug a failed update. With no value, targets the stack's latest update; "+
+			"pass =<version> (e.g. --debug-update=42) to target a specific one")
+	cmd.Flags().StringVar(&f.debugPreview, "debug-preview", "",
+		"Debug a failed preview. With no value, targets the stack's latest preview; "+
+			"pass =<preview-id> to target a specific one")
+	// A non-empty NoOptDefVal makes the flag's value optional: bare `--debug-update` records the
+	// sentinel ("infer latest"), while `--debug-update=42` records the explicit id.
+	cmd.Flags().Lookup("debug-update").NoOptDefVal = debugLatestSentinel
+	cmd.Flags().Lookup("debug-preview").NoOptDefVal = debugLatestSentinel
+	cmd.MarkFlagsMutuallyExclusive("debug-update", "debug-preview")
+}
+
+// debugRequest reports which debug flag (if any) was set and the explicit id the user passed. kind
+// is debugNone when neither flag is present; id is "" when the flag was given bare (meaning "infer
+// the latest"), so runNeo resolves it against the backend. --debug-update and --debug-preview are
+// mutually exclusive, so at most one is ever Changed.
+func (f *neoFlags) debugRequest(cmd *cobra.Command) (kind debugKind, id string) {
+	switch {
+	case cmd.Flags().Changed("debug-update"):
+		return debugUpdate, valueOrEmpty(f.debugUpdate)
+	case cmd.Flags().Changed("debug-preview"):
+		return debugPreview, valueOrEmpty(f.debugPreview)
+	}
+	return debugNone, ""
+}
+
+// valueOrEmpty maps the bare-flag sentinel back to "" so callers see an explicit id or nothing.
+func valueOrEmpty(v string) string {
+	if v == debugLatestSentinel {
+		return ""
+	}
+	return v
 }
 
 // resolveModes validates the approval/permission flags and applies the --print adjustments:
@@ -247,7 +291,7 @@ func parsePermissionMode(s string) (client.NeoPermissionMode, error) {
 
 // neoRunOptions carries everything runNeo needs to start a Neo session. It is a struct rather
 // than a positional argument list because the set has grown past the point where positional
-// bools (printMode, includeStackContext) are safe to read or extend at the call site.
+// bools (printMode, disableIntegrations) are safe to read or extend at the call site.
 type neoRunOptions struct {
 	prompt         string
 	stackName      string
@@ -256,9 +300,13 @@ type neoRunOptions struct {
 	approvalMode   client.NeoApprovalMode
 	permissionMode client.NeoPermissionMode
 	printMode      bool
-	// includeStackContext seeds the prompt with the current target and most recent operation;
-	// `pulumi neo debug` sets this so Neo starts with the failure already in context.
-	includeStackContext bool
+	// debugKind, when debugUpdate or debugPreview, makes this a debug session: runNeo builds a
+	// seed prompt targeting a failed operation of that kind and appends the stack context so Neo
+	// starts with the failure already in scope. debugNone for a normal `pulumi neo` session.
+	debugKind debugKind
+	// debugID is the explicit update version / preview id to debug, or "" to infer the latest of
+	// debugKind. Ignored unless debugKind is set.
+	debugID string
 	// disableIntegrations runs the Neo task with no integration credentials, ignoring any
 	// org-enabled integrations.
 	disableIntegrations bool
@@ -307,12 +355,21 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	}
 	orgName, projectName, stackRefName := target.org, target.project, target.stackName()
 
-	// `pulumi neo debug` seeds Neo with the current identity/target and the most recent
-	// operation so it starts with the failure already in context instead of rediscovering
-	// it. We append after the trigger line so debugSeedPrompt stays first and Neo's skill
-	// evaluator still matches the debug skill.
-	if opts.includeStackContext && opts.prompt != "" {
-		opts.prompt += "\n\n" + debugStackContext(ctx, cloudBe, target.ref, orgName, projectName)
+	// --debug-update/--debug-preview seed Neo with a trigger line targeting a failed operation
+	// plus the current identity/target, so it starts with the failure already in context instead
+	// of rediscovering it. With no explicit id we infer the latest operation of the requested
+	// kind. The seed trigger line stays first so Neo's skill evaluator still matches the debug
+	// skill; any positional prompt follows it as extra guidance, then the context block.
+	if opts.debugKind != debugNone {
+		id := opts.debugID
+		if id == "" {
+			id = opts.debugKind.latestID(ctx, cloudBe, target.ref)
+		}
+		seed := debugSeedPrompt(opts.debugKind, id)
+		if opts.prompt != "" {
+			seed += "\n\n" + opts.prompt
+		}
+		opts.prompt = seed + "\n\n" + debugStackContext(cloudBe, target, opts.debugKind, id)
 	}
 
 	// Allow tools to read/write under temp directories in addition to cwd: the agent

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -145,11 +145,16 @@ func NewNeoCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runNeo(
-				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				prompt, flags.stackName, flags.orgFlag, flags.cwdFlag,
-				approvalMode, permissionMode, flags.printMode,
-				flags.disableIntegrations, false)
+			return runNeo(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), neoRunOptions{
+				prompt:              prompt,
+				stackName:           flags.stackName,
+				orgFlag:             flags.orgFlag,
+				cwdFlag:             flags.cwdFlag,
+				approvalMode:        approvalMode,
+				permissionMode:      permissionMode,
+				printMode:           flags.printMode,
+				disableIntegrations: flags.disableIntegrations,
+			})
 		},
 	}
 
@@ -240,39 +245,49 @@ func parsePermissionMode(s string) (client.NeoPermissionMode, error) {
 	return "", fmt.Errorf("invalid --permission-mode %q: expected one of default, read-only", s)
 }
 
-func runNeo(
-	ctx context.Context,
-	stdout, stderr io.Writer,
-	prompt, stackName, orgFlag, cwdFlag string,
-	approvalMode client.NeoApprovalMode,
-	permissionMode client.NeoPermissionMode,
-	printMode bool,
-	disableIntegrations bool,
-	includeStackContext bool,
-) error {
+// neoRunOptions carries everything runNeo needs to start a Neo session. It is a struct rather
+// than a positional argument list because the set has grown past the point where positional
+// bools (printMode, includeStackContext) are safe to read or extend at the call site.
+type neoRunOptions struct {
+	prompt         string
+	stackName      string
+	orgFlag        string
+	cwdFlag        string
+	approvalMode   client.NeoApprovalMode
+	permissionMode client.NeoPermissionMode
+	printMode      bool
+	// includeStackContext seeds the prompt with the current target and most recent operation;
+	// `pulumi neo debug` sets this so Neo starts with the failure already in context.
+	includeStackContext bool
+	// disableIntegrations runs the Neo task with no integration credentials, ignoring any
+	// org-enabled integrations.
+	disableIntegrations bool
+}
+
+func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) error {
 	// nil lets the server inherit the org's enabled integrations; the empty slice opts out.
 	var enabledIntegrations *[]string
-	if disableIntegrations {
+	if opts.disableIntegrations {
 		enabledIntegrations = &[]string{}
 	}
 
-	if cwdFlag == "" {
+	if opts.cwdFlag == "" {
 		var err error
-		cwdFlag, err = os.Getwd()
+		opts.cwdFlag, err = os.Getwd()
 		if err != nil {
 			return fmt.Errorf("resolving working directory: %w", err)
 		}
 	}
 
 	ws := pkgWorkspace.Instance
-	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	displayOpts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
 	project, _, err := ws.ReadProject()
 	if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 		return err
 	}
 
-	be, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, opts)
+	be, err := cmdBackend.CurrentBackend(ctx, ws, cmdBackend.DefaultLoginManager, project, displayOpts)
 	if err != nil {
 		return err
 	}
@@ -286,28 +301,29 @@ func runNeo(
 		return result.FprintBailf(stderr, "%s", msg)
 	}
 
-	orgName, projectName, stackRefName, stackRef, err := resolveTaskTarget(ctx, ws, cloudBe, project, stackName, orgFlag)
+	target, err := resolveTaskTarget(ctx, ws, cloudBe, project, opts.stackName, opts.orgFlag)
 	if err != nil {
 		return err
 	}
+	orgName, projectName, stackRefName := target.org, target.project, target.stackName()
 
 	// `pulumi neo debug` seeds Neo with the current identity/target and the most recent
 	// operation so it starts with the failure already in context instead of rediscovering
 	// it. We append after the trigger line so debugSeedPrompt stays first and Neo's skill
 	// evaluator still matches the debug skill.
-	if includeStackContext && prompt != "" {
-		prompt += "\n\n" + debugStackContext(ctx, cloudBe, stackRef, orgName, projectName, stackRefName)
+	if opts.includeStackContext && opts.prompt != "" {
+		opts.prompt += "\n\n" + debugStackContext(ctx, cloudBe, target.ref, orgName, projectName)
 	}
 
 	// Allow tools to read/write under temp directories in addition to cwd: the agent
 	// stages scratch files there (downloads, intermediate state) and the CLI sandbox
 	// would otherwise reject those paths. See pulumi/pulumi-service#42027.
 	extraRoots := dedupeExistingRoots("/tmp", os.TempDir())
-	fs, err := tools.NewFilesystem(cwdFlag, extraRoots...)
+	fs, err := tools.NewFilesystem(opts.cwdFlag, extraRoots...)
 	if err != nil {
 		return err
 	}
-	sh, err := tools.NewShell(cwdFlag, extraRoots...)
+	sh, err := tools.NewShell(opts.cwdFlag, extraRoots...)
 	if err != nil {
 		return err
 	}
@@ -318,28 +334,28 @@ func runNeo(
 
 	// In non-interactive mode the sink stays nil and live events are dropped; the
 	// interactive path below sets pu.Sink to push UIEvents onto uiCh.
-	pu, err := tools.NewPulumi(cwdFlag, ws, nil)
+	pu, err := tools.NewPulumi(opts.cwdFlag, ws, nil)
 	if err != nil {
 		return err
 	}
 	handlers["pulumi"] = pu
 
-	if printMode || !isInteractive() {
-		if prompt == "" {
+	if opts.printMode || !isInteractive() {
+		if opts.prompt == "" {
 			return errors.New("a prompt argument is required in non-interactive mode")
 		}
-		taskPrompt := nonInteractivePromptPreamble + "\n\n" + prompt
+		taskPrompt := nonInteractivePromptPreamble + "\n\n" + opts.prompt
 		resp, err := createNeoTaskWithEntityRetry(
 			ctx, pc, orgName, taskPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
 				ToolExecutionMode:   "cli",
-				ApprovalMode:        approvalMode,
-				PermissionMode:      permissionMode,
+				ApprovalMode:        opts.approvalMode,
+				PermissionMode:      opts.permissionMode,
 				EnabledIntegrations: enabledIntegrations,
 			}, nil)
 		if err != nil {
 			return err
 		}
-		if !printMode {
+		if !opts.printMode {
 			consoleURL := client.CloudConsoleURL(pc.URL(), orgName, "neo", "tasks", resp.TaskID)
 			if consoleURL != "" {
 				fmt.Fprintln(stderr, consoleURL)
@@ -354,7 +370,7 @@ func runNeo(
 			TaskID:   resp.TaskID,
 			Log:      stderr,
 		}
-		if printMode {
+		if opts.printMode {
 			session.Output = stdout
 		}
 		return session.Run(ctx)
@@ -379,15 +395,15 @@ func runNeo(
 
 	model := NewModel(ModelConfig{
 		Org:                   orgName,
-		WorkDir:               cwdFlag,
+		WorkDir:               opts.cwdFlag,
 		Username:              username,
 		Version:               version.Version,
 		EventCh:               uiCh,
 		OutCh:                 outCh,
-		Busy:                  prompt != "",
-		InitialPrompt:         prompt,
-		InitialApprovalMode:   approvalMode,
-		InitialPermissionMode: permissionMode,
+		Busy:                  opts.prompt != "",
+		InitialPrompt:         opts.prompt,
+		InitialApprovalMode:   opts.approvalMode,
+		InitialPermissionMode: opts.permissionMode,
 		HasDarkBackground:     hasDarkBackground,
 	})
 
@@ -458,12 +474,12 @@ func runNeo(
 				return session.Run(gctx)
 			}
 
-			if prompt != "" {
+			if opts.prompt != "" {
 				// The command-line prompt path always passes false for planMode and
 				// uses the modes parsed from the CLI flags (which the TUI also seeds
 				// into its model). A subsequent toggle still routes through the TUI.
 				g.Go(func() error {
-					return createTask(prompt, approvalMode, permissionMode, false)
+					return createTask(opts.prompt, opts.approvalMode, opts.permissionMode, false)
 				})
 			}
 
@@ -485,7 +501,7 @@ func runNeo(
 			g.Go(func() error {
 				return dispatchUserEvents(
 					gctx, outCh, uiCh,
-					prompt != "",
+					opts.prompt != "",
 					func() string {
 						ts.mu.Lock()
 						defer ts.mu.Unlock()
@@ -617,9 +633,26 @@ type stackRefWithOrg interface {
 	Organization() (string, bool)
 }
 
-// resolveTaskTarget figures out the org, project, and stack name to attach to the new Neo
-// task. The stack flag is optional — if it's empty we try the currently selected stack and
-// fall back to a project-only attachment if there isn't one.
+// taskTarget is the resolved org, project, and stack a Neo task attaches to. The stack name is
+// carried by ref (ref.Name()), so it isn't stored separately; ref is nil when no stack could be
+// resolved, in which case the task runs without stack context.
+type taskTarget struct {
+	org     string
+	project string
+	ref     backend.StackReference
+}
+
+// stackName returns the resolved stack's name, or "" when no stack was resolved.
+func (t taskTarget) stackName() string {
+	if t.ref == nil {
+		return ""
+	}
+	return t.ref.Name().String()
+}
+
+// resolveTaskTarget figures out the org, project, and stack to attach to the new Neo task. The
+// stack flag is optional — if it's empty we try the currently selected stack and fall back to a
+// project-only attachment if there isn't one.
 //
 // Org resolution: --org wins if provided; otherwise we use the owner carried
 // by the stack reference (so a workspace-selected `otherorg/proj/dev` keeps
@@ -632,19 +665,19 @@ func resolveTaskTarget(
 	be httpstate.Backend,
 	project *workspace.Project,
 	stackName, orgFlag string,
-) (org, projectName, stack string, stackRef backend.StackReference, err error) {
+) (taskTarget, error) {
+	var t taskTarget
 	if project != nil {
-		projectName = string(project.Name)
+		t.project = string(project.Name)
 	}
 
 	var stackOwner string
 	if stackName != "" {
 		ref, err := be.ParseStackReference(stackName)
 		if err != nil {
-			return "", "", "", nil, err
+			return taskTarget{}, err
 		}
-		stackRef = ref
-		stack = ref.Name().String()
+		t.ref = ref
 		if owned, ok := ref.(stackRefWithOrg); ok {
 			if o, has := owned.Organization(); has {
 				stackOwner = o
@@ -653,8 +686,7 @@ func resolveTaskTarget(
 	} else {
 		s, err := state.CurrentStack(ctx, ws, be)
 		if err == nil && s != nil {
-			stackRef = s.Ref()
-			stack = s.Ref().Name().String()
+			t.ref = s.Ref()
 			if owned, ok := s.Ref().(stackRefWithOrg); ok {
 				if o, has := owned.Organization(); has {
 					stackOwner = o
@@ -665,19 +697,20 @@ func resolveTaskTarget(
 
 	switch {
 	case orgFlag != "":
-		org = orgFlag
+		t.org = orgFlag
 	case stackOwner != "":
-		org = stackOwner
+		t.org = stackOwner
 	default:
-		org, err = be.GetDefaultOrg(ctx)
+		org, err := be.GetDefaultOrg(ctx)
 		if err != nil {
-			return "", "", "", nil, fmt.Errorf("determining default organization: %w", err)
+			return taskTarget{}, fmt.Errorf("determining default organization: %w", err)
 		}
+		t.org = org
 	}
-	if org == "" {
-		return "", "", "", nil, errors.New("could not determine an organization for the Neo task; pass --org")
+	if t.org == "" {
+		return taskTarget{}, errors.New("could not determine an organization for the Neo task; pass --org")
 	}
-	return org, projectName, stack, stackRef, nil
+	return t, nil
 }
 
 // dedupeExistingRoots returns candidates with duplicates removed by canonical path,

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -124,15 +124,7 @@ var (
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {
-	var (
-		stackName           string
-		orgFlag             string
-		cwdFlag             string
-		approvalModeFlag    string
-		permissionModeFlag  string
-		printMode           bool
-		disableIntegrations bool
-	)
+	flags := &neoFlags{}
 
 	cmd := &cobra.Command{
 		Use:   "neo [prompt]",
@@ -148,52 +140,80 @@ func NewNeoCmd() *cobra.Command {
 			if len(args) > 0 {
 				prompt = args[0]
 			}
-			approvalMode, err := parseApprovalMode(approvalModeFlag)
+			approvalMode, permissionMode, err := flags.resolveModes(cmd)
 			if err != nil {
 				return err
-			}
-			permissionMode, err := parsePermissionMode(permissionModeFlag)
-			if err != nil {
-				return err
-			}
-			// --print has no UI; manual approval would deadlock. Reject if explicit,
-			// otherwise upgrade the default.
-			if printMode {
-				switch {
-				case cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual:
-					return errors.New(
-						"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
-				case !cmd.Flags().Changed("approval-mode"):
-					approvalMode = client.NeoApprovalModeAuto
-				}
 			}
 			return runNeo(
 				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode,
-				disableIntegrations)
+				prompt, flags.stackName, flags.orgFlag, flags.cwdFlag,
+				approvalMode, permissionMode, flags.printMode,
+				flags.disableIntegrations)
 		},
 	}
 
-	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
-		"The name of the stack to attach to the Neo task")
-	cmd.Flags().StringVar(&orgFlag, "org", "",
-		"The organization that owns the Neo task (defaults to the user's default org)")
-	cmd.Flags().StringVar(&cwdFlag, "cwd", "",
-		"Working directory for local tool execution (defaults to the current directory)")
-	cmd.Flags().StringVar(&approvalModeFlag, "approval-mode", string(client.NeoApprovalModeManual),
-		"Approval mode for tool calls: 'manual' prompts on every call, 'balanced' "+
-			"auto-approves low-risk calls, 'auto' executes everything without prompting")
-	cmd.Flags().StringVar(&permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
-		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
-			"'read-only' blocks state-mutating operations")
-	cmd.Flags().BoolVarP(&printMode, "print", "p", false,
-		"Run a single prompt non-interactively, print the agent's final response to "+
-			"stdout, and exit. Intended for use with other AI agents and scripts.")
-	cmd.Flags().BoolVar(&disableIntegrations, "disable-integrations", false,
-		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
-			"integrations.")
+	flags.register(cmd)
+	cmd.AddCommand(newNeoDebugCmd())
 
 	return cmd
+}
+
+// neoFlags holds the options shared by `pulumi neo` and its `debug` subcommand. Both start the
+// same Neo experience and differ only in how the initial prompt is produced, so they register
+// and resolve the same flags.
+type neoFlags struct {
+	stackName           string
+	orgFlag             string
+	cwdFlag             string
+	approvalModeFlag    string
+	permissionModeFlag  string
+	printMode           bool
+	disableIntegrations bool
+}
+
+func (f *neoFlags) register(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.stackName, "stack", "s", "",
+		"The name of the stack to attach to the Neo task")
+	cmd.Flags().StringVar(&f.orgFlag, "org", "",
+		"The organization that owns the Neo task (defaults to the user's default org)")
+	cmd.Flags().StringVar(&f.cwdFlag, "cwd", "",
+		"Working directory for local tool execution (defaults to the current directory)")
+	cmd.Flags().StringVar(&f.approvalModeFlag, "approval-mode", string(client.NeoApprovalModeManual),
+		"Approval mode for tool calls: 'manual' prompts on every call, 'balanced' "+
+			"auto-approves low-risk calls, 'auto' executes everything without prompting")
+	cmd.Flags().StringVar(&f.permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
+		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
+			"'read-only' blocks state-mutating operations")
+	cmd.Flags().BoolVarP(&f.printMode, "print", "p", false,
+		"Run a single prompt non-interactively, print the agent's final response to "+
+			"stdout, and exit. Intended for use with other AI agents and scripts.")
+	cmd.Flags().BoolVar(&f.disableIntegrations, "disable-integrations", false,
+		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
+			"integrations.")
+}
+
+// resolveModes validates the approval/permission flags and applies the --print adjustments:
+// manual approval can't work without a UI, so reject it when explicit and upgrade the default
+// to auto otherwise.
+func (f *neoFlags) resolveModes(cmd *cobra.Command) (client.NeoApprovalMode, client.NeoPermissionMode, error) {
+	approvalMode, err := parseApprovalMode(f.approvalModeFlag)
+	if err != nil {
+		return "", "", err
+	}
+	permissionMode, err := parsePermissionMode(f.permissionModeFlag)
+	if err != nil {
+		return "", "", err
+	}
+	if f.printMode {
+		switch {
+		case cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual:
+			return "", "", errors.New(
+				"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
+		case !cmd.Flags().Changed("approval-mode"):
+			approvalMode = client.NeoApprovalModeAuto
+		}
+	}
+	return approvalMode, permissionMode, nil
 }
 
 // parseApprovalMode validates the --approval-mode flag value against the

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -125,7 +125,17 @@ var (
 // browser, and runs the local tool-execution loop in the foreground until the task ends.
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {
-	flags := &neoFlags{}
+	var (
+		stackName           string
+		orgFlag             string
+		cwdFlag             string
+		approvalModeFlag    string
+		permissionModeFlag  string
+		printMode           bool
+		debugUpdateFlag     string
+		debugPreviewFlag    string
+		disableIntegrations bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "neo [prompt]",
@@ -141,98 +151,88 @@ func NewNeoCmd() *cobra.Command {
 			if len(args) > 0 {
 				prompt = args[0]
 			}
-			approvalMode, permissionMode, err := flags.resolveModes(cmd)
+			approvalMode, err := parseApprovalMode(approvalModeFlag)
 			if err != nil {
 				return err
 			}
-			// --debug-update/--debug-preview seed Neo to investigate a failed operation. The
-			// positional prompt (if any) is still honored as extra guidance appended to the seed.
-			debugKind, debugID := flags.debugRequest(cmd)
+			permissionMode, err := parsePermissionMode(permissionModeFlag)
+			if err != nil {
+				return err
+			}
+			// --print has no UI; manual approval would deadlock. Reject if explicit,
+			// otherwise upgrade the default.
+			if printMode {
+				switch {
+				case cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual:
+					return errors.New(
+						"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
+				case !cmd.Flags().Changed("approval-mode"):
+					approvalMode = client.NeoApprovalModeAuto
+				}
+			}
+			// --debug-update/--debug-preview seed Neo to investigate a failed operation. A bare
+			// flag infers the latest of that kind; =<id> targets a specific run. They are mutually
+			// exclusive, so at most one is ever Changed.
+			var debugKind debugKind
+			var debugID string
+			switch {
+			case cmd.Flags().Changed("debug-update"):
+				debugKind, debugID = debugUpdate, valueOrEmpty(debugUpdateFlag)
+			case cmd.Flags().Changed("debug-preview"):
+				debugKind, debugID = debugPreview, valueOrEmpty(debugPreviewFlag)
+			}
 			return runNeo(ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(), neoRunOptions{
 				prompt:              prompt,
-				stackName:           flags.stackName,
-				orgFlag:             flags.orgFlag,
-				cwdFlag:             flags.cwdFlag,
+				stackName:           stackName,
+				orgFlag:             orgFlag,
+				cwdFlag:             cwdFlag,
 				approvalMode:        approvalMode,
 				permissionMode:      permissionMode,
-				printMode:           flags.printMode,
+				printMode:           printMode,
 				debugKind:           debugKind,
 				debugID:             debugID,
-				disableIntegrations: flags.disableIntegrations,
+				disableIntegrations: disableIntegrations,
 			})
 		},
 	}
 
-	flags.register(cmd)
+	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
+		"The name of the stack to attach to the Neo task")
+	cmd.Flags().StringVar(&orgFlag, "org", "",
+		"The organization that owns the Neo task (defaults to the user's default org)")
+	cmd.Flags().StringVar(&cwdFlag, "cwd", "",
+		"Working directory for local tool execution (defaults to the current directory)")
+	cmd.Flags().StringVar(&approvalModeFlag, "approval-mode", string(client.NeoApprovalModeManual),
+		"Approval mode for tool calls: 'manual' prompts on every call, 'balanced' "+
+			"auto-approves low-risk calls, 'auto' executes everything without prompting")
+	cmd.Flags().StringVar(&permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
+		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
+			"'read-only' blocks state-mutating operations")
+	cmd.Flags().BoolVarP(&printMode, "print", "p", false,
+		"Run a single prompt non-interactively, print the agent's final response to "+
+			"stdout, and exit. Intended for use with other AI agents and scripts.")
+	cmd.Flags().BoolVar(&disableIntegrations, "disable-integrations", false,
+		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
+			"integrations.")
+	cmd.Flags().StringVar(&debugUpdateFlag, "debug-update", "",
+		"Debug a failed update. With no value, targets the stack's latest update; "+
+			"pass =<version> (e.g. --debug-update=42) to target a specific one")
+	cmd.Flags().StringVar(&debugPreviewFlag, "debug-preview", "",
+		"Debug a failed preview. With no value, targets the stack's latest preview; "+
+			"pass =<preview-id> to target a specific one")
+	// A non-empty NoOptDefVal makes the flag's value optional: a bare flag records the sentinel
+	// ("infer latest"), while =<id> records the explicit id.
+	cmd.Flags().Lookup("debug-update").NoOptDefVal = debugLatestSentinel
+	cmd.Flags().Lookup("debug-preview").NoOptDefVal = debugLatestSentinel
+	cmd.MarkFlagsMutuallyExclusive("debug-update", "debug-preview")
 
 	return cmd
 }
 
 // debugLatestSentinel is the NoOptDefVal for --debug-update/--debug-preview: pflag requires a
-// non-empty NoOptDefVal to make a flag's value optional, so a bare `--debug-update` records this
-// sentinel (meaning "infer the latest"). It is deliberately untypeable as a real id so it can't
-// collide with a value the user passes via `--debug-update=<id>`.
+// non-empty NoOptDefVal to make a flag's value optional, so a bare flag records this sentinel
+// ("infer the latest"). It is untypeable as a real id so it can't collide with a user-passed value.
 const debugLatestSentinel = "\x00latest"
-
-// neoFlags holds the options for `pulumi neo`, including the --debug-update/--debug-preview flags
-// that seed Neo to investigate a failed operation.
-type neoFlags struct {
-	stackName           string
-	orgFlag             string
-	cwdFlag             string
-	approvalModeFlag    string
-	permissionModeFlag  string
-	printMode           bool
-	debugUpdate         string
-	debugPreview        string
-	disableIntegrations bool
-}
-
-func (f *neoFlags) register(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.stackName, "stack", "s", "",
-		"The name of the stack to attach to the Neo task")
-	cmd.Flags().StringVar(&f.orgFlag, "org", "",
-		"The organization that owns the Neo task (defaults to the user's default org)")
-	cmd.Flags().StringVar(&f.cwdFlag, "cwd", "",
-		"Working directory for local tool execution (defaults to the current directory)")
-	cmd.Flags().StringVar(&f.approvalModeFlag, "approval-mode", string(client.NeoApprovalModeManual),
-		"Approval mode for tool calls: 'manual' prompts on every call, 'balanced' "+
-			"auto-approves low-risk calls, 'auto' executes everything without prompting")
-	cmd.Flags().StringVar(&f.permissionModeFlag, "permission-mode", string(client.NeoPermissionModeDefault),
-		"Permission mode for the agent: 'default' grants full role-based capabilities, "+
-			"'read-only' blocks state-mutating operations")
-	cmd.Flags().BoolVarP(&f.printMode, "print", "p", false,
-		"Run a single prompt non-interactively, print the agent's final response to "+
-			"stdout, and exit. Intended for use with other AI agents and scripts.")
-	cmd.Flags().BoolVar(&f.disableIntegrations, "disable-integrations", false,
-		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
-			"integrations.")
-	cmd.Flags().StringVar(&f.debugUpdate, "debug-update", "",
-		"Debug a failed update. With no value, targets the stack's latest update; "+
-			"pass =<version> (e.g. --debug-update=42) to target a specific one")
-	cmd.Flags().StringVar(&f.debugPreview, "debug-preview", "",
-		"Debug a failed preview. With no value, targets the stack's latest preview; "+
-			"pass =<preview-id> to target a specific one")
-	// A non-empty NoOptDefVal makes the flag's value optional: bare `--debug-update` records the
-	// sentinel ("infer latest"), while `--debug-update=42` records the explicit id.
-	cmd.Flags().Lookup("debug-update").NoOptDefVal = debugLatestSentinel
-	cmd.Flags().Lookup("debug-preview").NoOptDefVal = debugLatestSentinel
-	cmd.MarkFlagsMutuallyExclusive("debug-update", "debug-preview")
-}
-
-// debugRequest reports which debug flag (if any) was set and the explicit id the user passed. kind
-// is debugNone when neither flag is present; id is "" when the flag was given bare (meaning "infer
-// the latest"), so runNeo resolves it against the backend. --debug-update and --debug-preview are
-// mutually exclusive, so at most one is ever Changed.
-func (f *neoFlags) debugRequest(cmd *cobra.Command) (kind debugKind, id string) {
-	switch {
-	case cmd.Flags().Changed("debug-update"):
-		return debugUpdate, valueOrEmpty(f.debugUpdate)
-	case cmd.Flags().Changed("debug-preview"):
-		return debugPreview, valueOrEmpty(f.debugPreview)
-	}
-	return debugNone, ""
-}
 
 // valueOrEmpty maps the bare-flag sentinel back to "" so callers see an explicit id or nothing.
 func valueOrEmpty(v string) string {
@@ -240,30 +240,6 @@ func valueOrEmpty(v string) string {
 		return ""
 	}
 	return v
-}
-
-// resolveModes validates the approval/permission flags and applies the --print adjustments:
-// manual approval can't work without a UI, so reject it when explicit and upgrade the default
-// to auto otherwise.
-func (f *neoFlags) resolveModes(cmd *cobra.Command) (client.NeoApprovalMode, client.NeoPermissionMode, error) {
-	approvalMode, err := parseApprovalMode(f.approvalModeFlag)
-	if err != nil {
-		return "", "", err
-	}
-	permissionMode, err := parsePermissionMode(f.permissionModeFlag)
-	if err != nil {
-		return "", "", err
-	}
-	if f.printMode {
-		switch {
-		case cmd.Flags().Changed("approval-mode") && approvalMode == client.NeoApprovalModeManual:
-			return "", "", errors.New(
-				"--approval-mode=manual is incompatible with --print: there is no UI to approve from")
-		case !cmd.Flags().Changed("approval-mode"):
-			approvalMode = client.NeoApprovalModeAuto
-		}
-	}
-	return approvalMode, permissionMode, nil
 }
 
 // parseApprovalMode validates the --approval-mode flag value against the
@@ -289,9 +265,7 @@ func parsePermissionMode(s string) (client.NeoPermissionMode, error) {
 	return "", fmt.Errorf("invalid --permission-mode %q: expected one of default, read-only", s)
 }
 
-// neoRunOptions carries everything runNeo needs to start a Neo session. It is a struct rather
-// than a positional argument list because the set has grown past the point where positional
-// bools (printMode, disableIntegrations) are safe to read or extend at the call site.
+// neoRunOptions carries everything runNeo needs to start a Neo session.
 type neoRunOptions struct {
 	prompt         string
 	stackName      string
@@ -300,15 +274,11 @@ type neoRunOptions struct {
 	approvalMode   client.NeoApprovalMode
 	permissionMode client.NeoPermissionMode
 	printMode      bool
-	// debugKind, when debugUpdate or debugPreview, makes this a debug session: runNeo builds a
-	// seed prompt targeting a failed operation of that kind and appends the stack context so Neo
-	// starts with the failure already in scope. debugNone for a normal `pulumi neo` session.
-	debugKind debugKind
-	// debugID is the explicit update version / preview id to debug, or "" to infer the latest of
-	// debugKind. Ignored unless debugKind is set.
-	debugID string
-	// disableIntegrations runs the Neo task with no integration credentials, ignoring any
-	// org-enabled integrations.
+	// debugKind/debugID make this a debug session: runNeo seeds a prompt targeting a failed
+	// operation of that kind and appends the stack context. debugKind is debugNone for a normal
+	// session; debugID is "" to infer the latest of debugKind.
+	debugKind           debugKind
+	debugID             string
 	disableIntegrations bool
 }
 
@@ -355,11 +325,8 @@ func runNeo(ctx context.Context, stdout, stderr io.Writer, opts neoRunOptions) e
 	}
 	orgName, projectName, stackRefName := target.org, target.project, target.stackName()
 
-	// --debug-update/--debug-preview seed Neo with a trigger line targeting a failed operation
-	// plus the current identity/target, so it starts with the failure already in context instead
-	// of rediscovering it. With no explicit id we infer the latest operation of the requested
-	// kind. The seed trigger line stays first so Neo's skill evaluator still matches the debug
-	// skill; any positional prompt follows it as extra guidance, then the context block.
+	// In a debug session, prepend the seed trigger line (so Neo's skill evaluator matches) and
+	// append the stack context. Any positional prompt sits between them as extra guidance.
 	if opts.debugKind != debugNone {
 		id := opts.debugID
 		if id == "" {
@@ -690,9 +657,8 @@ type stackRefWithOrg interface {
 	Organization() (string, bool)
 }
 
-// taskTarget is the resolved org, project, and stack a Neo task attaches to. The stack name is
-// carried by ref (ref.Name()), so it isn't stored separately; ref is nil when no stack could be
-// resolved, in which case the task runs without stack context.
+// taskTarget is the resolved org, project, and stack a Neo task attaches to. The stack name comes
+// from ref; ref is nil when no stack could be resolved, so the task runs without stack context.
 type taskTarget struct {
 	org     string
 	project string

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -308,7 +308,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	}()
 
 	select {
@@ -394,7 +394,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	}()
 
 	select {
@@ -422,7 +422,7 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "" /*prompt*/, "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
 
@@ -448,7 +448,7 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
 		"non-cloud backends must surface a clear error rather than panic on the type assertion")
@@ -479,7 +479,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", "", /*cwd*/
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	}()
 
 	select {
@@ -503,7 +503,7 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 
 	missing := t.TempDir() + "/does-not-exist"
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", missing,
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
 	// path should be referenced so the user can see what went wrong.
@@ -532,7 +532,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 	}
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
 	assert.Empty(t, srv.recordedPosts(),
@@ -577,7 +577,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
@@ -650,7 +650,7 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
 	}()
 
 	select {

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -307,8 +307,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// rather than relying on `go test -timeout` to catch a hang.
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+		done <- runNeoTest(t.Context(), "do a thing", t.TempDir())
 	}()
 
 	select {
@@ -338,6 +337,19 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 		"CreateNeoTask body must include the prompt")
 	assert.True(t, srv.sawStreamConnect(),
 		"SSE stream was never opened — test did not exercise Session.Run")
+}
+
+// runNeoTest invokes runNeo with the option defaults shared by these integration tests
+// (the test org, manual approval, default permissions, no stack context). Tests vary only
+// the prompt and working directory, so those are the parameters here.
+func runNeoTest(ctx context.Context, prompt, cwd string) error {
+	return runNeo(ctx, io.Discard, io.Discard, neoRunOptions{
+		prompt:         prompt,
+		orgFlag:        "test-org",
+		cwdFlag:        cwd,
+		approvalMode:   client.NeoApprovalModeManual,
+		permissionMode: client.NeoPermissionModeDefault,
+	})
 }
 
 // installNeoTestEnv wires the fake backend and workspace globals for an
@@ -393,8 +405,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+		done <- runNeoTest(t.Context(), "do a thing", t.TempDir())
 	}()
 
 	select {
@@ -421,8 +432,7 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	srv := newNeoFakeServer(t)
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
-	err := runNeo(t.Context(), io.Discard, io.Discard, "" /*prompt*/, "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+	err := runNeoTest(t.Context(), "" /*prompt*/, t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
 
@@ -447,8 +457,7 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	pkgWorkspace.Instance = &pkgWorkspace.MockContext{}
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
-	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+	err := runNeoTest(t.Context(), "do a thing", t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
 		"non-cloud backends must surface a clear error rather than panic on the type assertion")
@@ -478,8 +487,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// cwdFlag empty → runNeo calls os.Getwd. The test's own working
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
-		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", "", /*cwd*/
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+		done <- runNeoTest(t.Context(), "do a thing", "" /*cwd*/)
 	}()
 
 	select {
@@ -502,8 +510,7 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	missing := t.TempDir() + "/does-not-exist"
-	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", missing,
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+	err := runNeoTest(t.Context(), "do a thing", missing)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
 	// path should be referenced so the user can see what went wrong.
@@ -531,8 +538,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 		},
 	}
 
-	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+	err := runNeoTest(t.Context(), "do a thing", t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
 	assert.Empty(t, srv.recordedPosts(),
@@ -576,8 +582,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	isInteractive = func() bool { return false }
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
-	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+	err := runNeoTest(t.Context(), "do a thing", t.TempDir())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
@@ -649,8 +654,7 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/, false /*includeStackContext*/)
+		done <- runNeoTest(t.Context(), "do a thing", t.TempDir())
 	}()
 
 	select {

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -339,9 +339,8 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 		"SSE stream was never opened — test did not exercise Session.Run")
 }
 
-// runNeoTest invokes runNeo with the option defaults shared by these integration tests
-// (the test org, manual approval, default permissions, no stack context). Tests vary only
-// the prompt and working directory, so those are the parameters here.
+// runNeoTest invokes runNeo with the option defaults shared by these integration tests; tests
+// vary only the prompt and working directory.
 func runNeoTest(ctx context.Context, prompt, cwd string) error {
 	return runNeo(ctx, io.Discard, io.Discard, neoRunOptions{
 		prompt:         prompt,

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -47,49 +46,28 @@ import (
 func TestNeoDebugFlags(t *testing.T) {
 	t.Parallel()
 
-	// The flags live on `pulumi neo` itself and carry the optional-value sentinel, so a bare
-	// `--debug-update` is legal (pflag otherwise requires `--debug-update=<v>`).
-	root := NewNeoCmd()
+	// The flags carry the optional-value sentinel, so a bare flag is legal (pflag otherwise
+	// requires `--debug-update=<v>`).
 	for _, name := range []string{"debug-update", "debug-preview"} {
-		fl := root.Flags().Lookup(name)
+		fl := NewNeoCmd().Flags().Lookup(name)
 		require.NotNilf(t, fl, "flag %q", name)
 		assert.Equalf(t, debugLatestSentinel, fl.NoOptDefVal, "flag %q NoOptDefVal", name)
 	}
 
-	// debugRequest maps a bare flag to an infer-latest request (empty id) and `=value` to the
-	// explicit id; with neither flag it reports no debug request.
-	parse := func(args ...string) (debugKind, string) {
-		f := &neoFlags{}
-		cmd := &cobra.Command{Use: "neo", RunE: func(*cobra.Command, []string) error { return nil }}
-		f.register(cmd)
+	// A bare flag parses to the sentinel (→ infer latest); `=value` records the explicit id.
+	parse := func(name string, args ...string) string {
+		cmd := NewNeoCmd()
 		require.NoError(t, cmd.ParseFlags(args))
-		return f.debugRequest(cmd)
+		return valueOrEmpty(cmd.Flags().Lookup(name).Value.String())
 	}
-
-	cases := []struct {
-		args []string
-		kind debugKind
-		want string
-	}{
-		{nil, debugNone, ""},
-		{[]string{"--debug-update"}, debugUpdate, ""},
-		{[]string{"--debug-update=42"}, debugUpdate, "42"},
-		{[]string{"--debug-preview"}, debugPreview, ""},
-		{
-			[]string{"--debug-preview=2e07637b-d20b-4d4f-9d29-a7bcb1631cf7"},
-			debugPreview, "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
-		},
-	}
-	for _, c := range cases {
-		kind, id := parse(c.args...)
-		assert.Equalf(t, c.kind, kind, "kind for %v", c.args)
-		assert.Equalf(t, c.want, id, "id for %v", c.args)
-	}
+	assert.Equal(t, "", parse("debug-update", "--debug-update"))
+	assert.Equal(t, "42", parse("debug-update", "--debug-update=42"))
+	assert.Equal(t, "", parse("debug-preview", "--debug-preview"))
+	assert.Equal(t, "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
+		parse("debug-preview", "--debug-preview=2e07637b-d20b-4d4f-9d29-a7bcb1631cf7"))
 
 	// The two debug flags are mutually exclusive; cobra rejects them before RunE.
-	f := &neoFlags{}
-	cmd := &cobra.Command{Use: "neo", RunE: func(*cobra.Command, []string) error { return nil }}
-	f.register(cmd)
+	cmd := NewNeoCmd()
 	cmd.SetArgs([]string{"--debug-update", "--debug-preview"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
@@ -105,8 +83,7 @@ type fakeHTTPBackend struct {
 	// ClientV is returned from Client(); leave nil for tests that don't need a
 	// live client (the integration test wires a real *client.Client here).
 	ClientV *client.Client
-	// GetLatestStackPreviewF backs the stackPreviewLister capability used by
-	// `pulumi neo --debug-preview`; leave nil to report no previews.
+	// GetLatestStackPreviewF backs --debug-preview's lookup; leave nil to report no previews.
 	GetLatestStackPreviewF func(context.Context, backend.StackReference) (*apitype.StackPreview, error)
 }
 

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -132,11 +132,11 @@ func TestResolveTaskTarget_UsesStackFlag(t *testing.T) {
 	ws := &pkgWorkspace.MockContext{}
 	project := &workspace.Project{Name: tokens.PackageName("my-proj")}
 
-	org, proj, stack, _, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "")
 	require.NoError(t, err)
-	assert.Equal(t, "default-org", org)
-	assert.Equal(t, "my-proj", proj)
-	assert.Equal(t, "prod", stack)
+	assert.Equal(t, "default-org", target.org)
+	assert.Equal(t, "my-proj", target.project)
+	assert.Equal(t, "prod", target.stackName())
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -152,9 +152,9 @@ func TestResolveTaskTarget_OrgFlagOverridesDefault(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	org, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit")
 	require.NoError(t, err)
-	assert.Equal(t, "explicit", org)
+	assert.Equal(t, "explicit", target.org)
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -165,9 +165,9 @@ func TestResolveTaskTarget_FallsBackToBackendDefaultOrg(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "backend-default", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	org, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	target, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.NoError(t, err)
-	assert.Equal(t, "backend-default", org)
+	assert.Equal(t, "backend-default", target.org)
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -181,7 +181,7 @@ func TestResolveTaskTarget_ErrorsWhenOrgUnresolvable(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pass --org")
 }
@@ -196,7 +196,7 @@ func TestResolveTaskTarget_DefaultOrgLookupErrorIsWrapped(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "determining default organization")
 	assert.Contains(t, err.Error(), "boom")
@@ -212,7 +212,7 @@ func TestResolveTaskTarget_InvalidStackReferenceErrors(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "")
+	_, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid stack")
 }
@@ -224,10 +224,10 @@ func TestResolveTaskTarget_OmitsProjectNameWhenProjectNil(t *testing.T) {
 	// `pulumi neo` can be run outside a project — resolveTaskTarget must tolerate
 	// a nil project and return an empty projectName rather than panicking.
 	be := newFakeBackend()
-	org, proj, _, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit")
 	require.NoError(t, err)
-	assert.Equal(t, "explicit", org)
-	assert.Empty(t, proj)
+	assert.Equal(t, "explicit", target.org)
+	assert.Empty(t, target.project)
 }
 
 // parseQualifiedStackRefF builds a MockStackReference from `owner/project/name`,
@@ -265,10 +265,10 @@ func TestResolveTaskTarget_StackFlagOwnerWinsOverDefaultOrg(t *testing.T) {
 		return "", nil
 	}
 
-	org, _, stack, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "")
 	require.NoError(t, err)
-	assert.Equal(t, "otherorg", org)
-	assert.Equal(t, "dev", stack)
+	assert.Equal(t, "otherorg", target.org)
+	assert.Equal(t, "dev", target.stackName())
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -304,10 +304,10 @@ func TestResolveTaskTarget_WorkspaceStackOwnerWinsOverDefaultOrg(t *testing.T) {
 		},
 	}
 
-	org, _, stack, _, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "")
+	target, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "")
 	require.NoError(t, err)
-	assert.Equal(t, "otherorg", org)
-	assert.Equal(t, "dev", stack)
+	assert.Equal(t, "otherorg", target.org)
+	assert.Equal(t, "dev", target.stackName())
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -321,10 +321,10 @@ func TestResolveTaskTarget_OrgFlagOverridesStackOwner(t *testing.T) {
 	be := newFakeBackend()
 	be.ParseStackReferenceF = parseQualifiedStackRefF
 
-	org, _, stack, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit")
+	target, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit")
 	require.NoError(t, err)
-	assert.Equal(t, "explicit", org)
-	assert.Equal(t, "dev", stack)
+	assert.Equal(t, "explicit", target.org)
+	assert.Equal(t, "dev", target.stackName())
 }
 
 func ws() pkgWorkspace.Context { return &pkgWorkspace.MockContext{} }

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -42,6 +44,58 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+func TestNeoDebugFlags(t *testing.T) {
+	t.Parallel()
+
+	// The flags live on `pulumi neo` itself and carry the optional-value sentinel, so a bare
+	// `--debug-update` is legal (pflag otherwise requires `--debug-update=<v>`).
+	root := NewNeoCmd()
+	for _, name := range []string{"debug-update", "debug-preview"} {
+		fl := root.Flags().Lookup(name)
+		require.NotNilf(t, fl, "flag %q", name)
+		assert.Equalf(t, debugLatestSentinel, fl.NoOptDefVal, "flag %q NoOptDefVal", name)
+	}
+
+	// debugRequest maps a bare flag to an infer-latest request (empty id) and `=value` to the
+	// explicit id; with neither flag it reports no debug request.
+	parse := func(args ...string) (debugKind, string) {
+		f := &neoFlags{}
+		cmd := &cobra.Command{Use: "neo", RunE: func(*cobra.Command, []string) error { return nil }}
+		f.register(cmd)
+		require.NoError(t, cmd.ParseFlags(args))
+		return f.debugRequest(cmd)
+	}
+
+	cases := []struct {
+		args []string
+		kind debugKind
+		want string
+	}{
+		{nil, debugNone, ""},
+		{[]string{"--debug-update"}, debugUpdate, ""},
+		{[]string{"--debug-update=42"}, debugUpdate, "42"},
+		{[]string{"--debug-preview"}, debugPreview, ""},
+		{
+			[]string{"--debug-preview=2e07637b-d20b-4d4f-9d29-a7bcb1631cf7"},
+			debugPreview, "2e07637b-d20b-4d4f-9d29-a7bcb1631cf7",
+		},
+	}
+	for _, c := range cases {
+		kind, id := parse(c.args...)
+		assert.Equalf(t, c.kind, kind, "kind for %v", c.args)
+		assert.Equalf(t, c.want, id, "id for %v", c.args)
+	}
+
+	// The two debug flags are mutually exclusive; cobra rejects them before RunE.
+	f := &neoFlags{}
+	cmd := &cobra.Command{Use: "neo", RunE: func(*cobra.Command, []string) error { return nil }}
+	f.register(cmd)
+	cmd.SetArgs([]string{"--debug-update", "--debug-preview"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	assert.Error(t, cmd.Execute())
+}
+
 // fakeHTTPBackend embeds a generic MockBackend and adds the few extra methods the
 // httpstate.Backend interface requires. resolveTaskTarget only dips into the base
 // backend.Backend surface (ParseStackReference, GetDefaultOrg, CurrentUser), so the
@@ -52,7 +106,7 @@ type fakeHTTPBackend struct {
 	// live client (the integration test wires a real *client.Client here).
 	ClientV *client.Client
 	// GetLatestStackPreviewF backs the stackPreviewLister capability used by
-	// `pulumi neo debug`; leave nil to report no previews.
+	// `pulumi neo --debug-preview`; leave nil to report no previews.
 	GetLatestStackPreviewF func(context.Context, backend.StackReference) (*apitype.StackPreview, error)
 }
 

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -51,11 +51,23 @@ type fakeHTTPBackend struct {
 	// ClientV is returned from Client(); leave nil for tests that don't need a
 	// live client (the integration test wires a real *client.Client here).
 	ClientV *client.Client
+	// GetLatestStackPreviewF backs the stackPreviewLister capability used by
+	// `pulumi neo debug`; leave nil to report no previews.
+	GetLatestStackPreviewF func(context.Context, backend.StackReference) (*apitype.StackPreview, error)
 }
 
 func (f *fakeHTTPBackend) CloudURL() string                                       { return "" }
 func (f *fakeHTTPBackend) StackConsoleURL(backend.StackReference) (string, error) { return "", nil }
 func (f *fakeHTTPBackend) Client() *client.Client                                 { return f.ClientV }
+
+func (f *fakeHTTPBackend) GetLatestStackPreview(
+	ctx context.Context, stackRef backend.StackReference,
+) (*apitype.StackPreview, error) {
+	if f.GetLatestStackPreviewF != nil {
+		return f.GetLatestStackPreviewF(ctx, stackRef)
+	}
+	return nil, nil
+}
 
 func (f *fakeHTTPBackend) RunDeployment(
 	context.Context, backend.StackReference, apitype.CreateDeploymentRequest,
@@ -120,7 +132,7 @@ func TestResolveTaskTarget_UsesStackFlag(t *testing.T) {
 	ws := &pkgWorkspace.MockContext{}
 	project := &workspace.Project{Name: tokens.PackageName("my-proj")}
 
-	org, proj, stack, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "")
+	org, proj, stack, _, err := resolveTaskTarget(t.Context(), ws, be, project, "prod", "")
 	require.NoError(t, err)
 	assert.Equal(t, "default-org", org)
 	assert.Equal(t, "my-proj", proj)
@@ -140,7 +152,7 @@ func TestResolveTaskTarget_OrgFlagOverridesDefault(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	org, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit")
+	org, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "explicit")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", org)
 }
@@ -153,7 +165,7 @@ func TestResolveTaskTarget_FallsBackToBackendDefaultOrg(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "backend-default", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	org, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	org, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "backend-default", org)
 }
@@ -169,7 +181,7 @@ func TestResolveTaskTarget_ErrorsWhenOrgUnresolvable(t *testing.T) {
 	be.GetDefaultOrgF = func(context.Context) (string, error) { return "", nil }
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pass --org")
 }
@@ -184,7 +196,7 @@ func TestResolveTaskTarget_DefaultOrgLookupErrorIsWrapped(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
+	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "determining default organization")
 	assert.Contains(t, err.Error(), "boom")
@@ -200,7 +212,7 @@ func TestResolveTaskTarget_InvalidStackReferenceErrors(t *testing.T) {
 	}
 
 	ws := &pkgWorkspace.MockContext{}
-	_, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "")
+	_, _, _, _, err := resolveTaskTarget(t.Context(), ws, be, nil, "bad/stack/name/here", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid stack")
 }
@@ -212,7 +224,7 @@ func TestResolveTaskTarget_OmitsProjectNameWhenProjectNil(t *testing.T) {
 	// `pulumi neo` can be run outside a project — resolveTaskTarget must tolerate
 	// a nil project and return an empty projectName rather than panicking.
 	be := newFakeBackend()
-	org, proj, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit")
+	org, proj, _, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "", "explicit")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", org)
 	assert.Empty(t, proj)
@@ -253,7 +265,7 @@ func TestResolveTaskTarget_StackFlagOwnerWinsOverDefaultOrg(t *testing.T) {
 		return "", nil
 	}
 
-	org, _, stack, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "")
+	org, _, stack, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "")
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", org)
 	assert.Equal(t, "dev", stack)
@@ -292,7 +304,7 @@ func TestResolveTaskTarget_WorkspaceStackOwnerWinsOverDefaultOrg(t *testing.T) {
 		},
 	}
 
-	org, _, stack, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "")
+	org, _, stack, _, err := resolveTaskTarget(t.Context(), wsCtx, be, nil, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "otherorg", org)
 	assert.Equal(t, "dev", stack)
@@ -309,7 +321,7 @@ func TestResolveTaskTarget_OrgFlagOverridesStackOwner(t *testing.T) {
 	be := newFakeBackend()
 	be.ParseStackReferenceF = parseQualifiedStackRefF
 
-	org, _, stack, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit")
+	org, _, stack, _, err := resolveTaskTarget(t.Context(), ws(), be, nil, "otherorg/proj/dev", "explicit")
 	require.NoError(t, err)
 	assert.Equal(t, "explicit", org)
 	assert.Equal(t, "dev", stack)

--- a/sdk/go/common/apitype/history.go
+++ b/sdk/go/common/apitype/history.go
@@ -123,21 +123,13 @@ type GetHistoryResponse struct {
 	Updates []UpdateInfo `json:"updates"`
 }
 
-// StackPreview describes a single preview operation on a stack. Unlike the entries in
-// GetHistoryResponse, previews are not part of the stack's update history and carry their own
-// opaque UpdateID — the UUID that appears in the console preview URL
-// (https://app.pulumi.com/{org}/{project}/{stack}/previews/{updateID}).
+// StackPreview describes a single preview operation on a stack. Previews are tracked separately
+// from update history and carry their own opaque UpdateID — the UUID in the console preview URL.
 type StackPreview struct {
-	// Info carries the preview's timing and result (e.g. whether it failed).
-	Info UpdateInfo `json:"info"`
-	// UpdateID is the opaque id of the preview (the UUID in its console URL).
 	UpdateID string `json:"updateID"`
-	// Version is the stack version the preview was run against.
-	Version int `json:"version"`
 }
 
-// GetLatestStackPreviewsResponse is the response from the Pulumi Service when requesting a
-// stack's most recent previews. Previews are returned newest-first.
+// GetLatestStackPreviewsResponse is the Pulumi Service response for a stack's most recent previews.
 type GetLatestStackPreviewsResponse struct {
 	Updates []StackPreview `json:"updates"`
 }

--- a/sdk/go/common/apitype/history.go
+++ b/sdk/go/common/apitype/history.go
@@ -122,3 +122,22 @@ type UpdateInfo struct {
 type GetHistoryResponse struct {
 	Updates []UpdateInfo `json:"updates"`
 }
+
+// StackPreview describes a single preview operation on a stack. Unlike the entries in
+// GetHistoryResponse, previews are not part of the stack's update history and carry their own
+// opaque UpdateID — the UUID that appears in the console preview URL
+// (https://app.pulumi.com/{org}/{project}/{stack}/previews/{updateID}).
+type StackPreview struct {
+	// Info carries the preview's timing and result (e.g. whether it failed).
+	Info UpdateInfo `json:"info"`
+	// UpdateID is the opaque id of the preview (the UUID in its console URL).
+	UpdateID string `json:"updateID"`
+	// Version is the stack version the preview was run against.
+	Version int `json:"version"`
+}
+
+// GetLatestStackPreviewsResponse is the response from the Pulumi Service when requesting a
+// stack's most recent previews. Previews are returned newest-first.
+type GetLatestStackPreviewsResponse struct {
+	Updates []StackPreview `json:"updates"`
+}


### PR DESCRIPTION
Adds `pulumi neo --debug-update` and `pulumi neo --debug-preview` flags that open an interactive Neo session seeded to investigate a failed update or preview, and updates the `pulumi up` / `pulumi preview` failure output to suggest the matching command.

Run bare (e.g. `pulumi neo --debug-update`), each flag targets the stack's most recent operation of that kind; pass `=<id>` (e.g. `--debug-update=42`) to target a specific update version or preview id. Updates and previews are resolved separately since previews never appear in update history.

**Part of a cross-repo series.** The seed prompt routes to the `pulumi-debug-failed-operation` skill (pulumi/agent-skills#35), which reaches Neo via pulumi/pulumi-service#44486. Works without the skill, but the guided procedure needs it deployed. Independent of the console-prompt PR (pulumi/pulumi-service#44487).