### PR TITLE
Upgrade the pulumi-labs/pulumi-hcl version to 0.5.0

### DIFF
--- a/pkg/util/plugin.go
+++ b/pkg/util/plugin.go
@@ -42,7 +42,7 @@ var knownLanguageRuntimes = map[string]knownLanguageRuntime{
 	"hcl": {
 		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
 		// renovate: datasource=github-releases depName=pulumi-labs/pulumi-hcl extractVersion=^v(?<version>.+)$
-		Version: semver.MustParse("0.4.0"),
+		Version: semver.MustParse("0.5.0"),
 	},
 }
 

--- a/pkg/util/plugin_test.go
+++ b/pkg/util/plugin_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -58,12 +59,17 @@ func TestKnownLanguageRuntimeHCL(t *testing.T) {
 	}
 	res := SetKnownPluginDownloadURL(&spec)
 	assert.True(t, res)
-	pinned := semver.MustParse("0.4.0")
+
+	// Check that version was set
+	require.NotNil(t, spec.Version)
+	assert.NotZero(t, *spec.Version)
+	// Now unset it for the comparison
+	spec.Version = nil
+
 	assert.Equal(t, workspace.PluginDescriptor{
 		Name:              "hcl",
 		Kind:              apitype.LanguagePlugin,
 		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
-		Version:           &pinned,
 	}, spec)
 }
 


### PR DESCRIPTION
This enables `pulumi` to run TF compatible code with just a `Pulumi.yaml` present. 

>[!WARNING]
> This is very much in beta.