### PR TITLE
Make plugin.Host stateless with respect to workspaces

### DIFF
--- a/changelog/pending/sdk-go-improvement-20260610-stateless-plugin-host.yaml
+++ b/changelog/pending/sdk-go-improvement-20260610-stateless-plugin-host.yaml
@@ -1,0 +1,9 @@
+component: sdk/go
+kind: improvement
+body: The `plugin.Host` interface is now stateless with respect to workspaces; host
+    methods that boot or resolve plugins take a `plugin.Context` carrying the workspace
+    state, and closing a `plugin.Context` no longer closes a host that was passed
+    in to its constructor
+time: 2026-06-10T00:00:00.000000-07:00
+custom:
+    PR: ""

--- a/changelog/pending/sdk-go-improvement-20260610-stateless-plugin-host.yaml
+++ b/changelog/pending/sdk-go-improvement-20260610-stateless-plugin-host.yaml
@@ -6,4 +6,4 @@ body: The `plugin.Host` interface is now stateless with respect to workspaces; h
     in to its constructor
 time: 2026-06-10T00:00:00.000000-07:00
 custom:
-    PR: ""
+    PR: "23508"

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -408,7 +408,7 @@ func (pack *cloudPolicyPack) Publish(
 		return err
 	}
 
-	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(tokens.QName(abs), op.PlugCtx.Pwd, nil /*opts*/)
+	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(op.PlugCtx, tokens.QName(abs), op.PlugCtx.Pwd, nil /*opts*/)
 	if err != nil {
 		return err
 	}
@@ -558,7 +558,7 @@ func installRequiredPolicy(ctx *plugin.Context, finalDir string, tgz io.ReadClos
 		}
 	}
 
-	language, err := ctx.Host.LanguageRuntime(proj.Runtime.Name())
+	language, err := ctx.Host.LanguageRuntime(ctx, proj.Runtime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 	}

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -155,7 +155,7 @@ func getSummaryAbout(
 			}
 
 			if proj.Runtime.Name() != "" {
-				lang, err := pluginContext.Host.LanguageRuntime(proj.Runtime.Name())
+				lang, err := pluginContext.Host.LanguageRuntime(pluginContext, proj.Runtime.Name())
 				if err != nil {
 					addError(err, "Failed to load language plugin "+proj.Runtime.Name())
 				} else {
@@ -634,5 +634,5 @@ func getProjectPluginsSilently(
 
 	programInfo := plugin.NewProgramInfo(ctx.Root, pwd, main, proj.Runtime.Options())
 	runtimeName := proj.Runtime.Name()
-	return engine.GetRequiredPlugins(ctx.Request(), ctx.Host, runtimeName, programInfo)
+	return engine.GetRequiredPlugins(ctx.Request(), ctx, runtimeName, programInfo)
 }

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -248,7 +248,7 @@ func runConvert(
 		) (hcl.Diagnostics, error) {
 			contract.Requiref(proj != nil, "proj", "must not be nil")
 
-			languagePlugin, err := pCtx.Host.LanguageRuntime(language)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(pCtx, language)
 			if err != nil {
 				return nil, err
 			}
@@ -334,7 +334,7 @@ func runConvert(
 	}
 
 	reg := cmdCmd.NewDefaultRegistry(ctx, lm, ws, nil, cmdutil.Diag(), e)
-	installCtx := packageworkspace.New(pluginstorage.Instance, ws, pCtx.Host, stderr, stderr,
+	installCtx := packageworkspace.New(pluginstorage.Instance, ws, pCtx, stderr, stderr,
 		nil, packageworkspace.Options{})
 
 	installPlugin := func(pluginName string) *semver.Version {
@@ -363,12 +363,12 @@ func runConvert(
 		return &version
 	}
 
-	loader := schema.NewPluginLoader(pCtx.Host)
+	loader := schema.NewPluginLoader(pCtx)
 
 	baseMapper, err := convert.NewBasePluginMapper(
 		pluginstorage.Instance,
 		from, /*conversionKey*/
-		convert.ProviderFactoryFromHost(ctx, pCtx.Host),
+		convert.ProviderFactoryFromHost(ctx, pCtx),
 		installPlugin,
 		mappings,
 	)

--- a/pkg/cmd/pulumi/convert/io.go
+++ b/pkg/cmd/pulumi/convert/io.go
@@ -49,7 +49,7 @@ func LoadConverterPlugin(
 			return nil, fmt.Errorf("load %q: %w", name, err)
 		}
 
-		_, err = pkgWorkspace.InstallPlugin(ctx.Base(), pluginSpec, log, schema.NewLoaderServerFromHost)
+		_, err = pkgWorkspace.InstallPlugin(ctx.Base(), pluginSpec, log, schema.NewLoaderServerFromContext)
 		if err != nil {
 			return nil, fmt.Errorf("install %q: %w", name, err)
 		}

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -158,7 +158,7 @@ func NewDoCmd(
 
 		pctx, err := plugin.NewContext(
 			ctx, sink, sink, host, nil, wd, nil, false,
-			nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+			nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, fmt.Errorf("create plugin context: %w", err)
 		}
@@ -242,7 +242,7 @@ func NewDoCmd(
 			args:              pargs,
 			evalContext:       evalContext,
 			converter:         loadConverter,
-			loaderTarget:      pctx.Host.LoaderAddr(),
+			loaderTarget:      pctx.LoaderAddr(),
 			packageDescriptor: packageDescriptor,
 			provider:          p,
 			spec:              boundpkg,

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -1816,11 +1816,7 @@ func TestDoCmdFunctionInvokeWithYAMLInputFile(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func() (plugin.Host, error) {
-		return &plugin.MockHost{
-			LoaderAddrF: func() string {
-				return "loader-address"
-			},
-		}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		pctx *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -1944,11 +1940,7 @@ func TestDoCmdFunctionInvokeWithYAMLInputFileParameterized(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func() (plugin.Host, error) {
-		return &plugin.MockHost{
-			LoaderAddrF: func() string {
-				return "loader-address"
-			},
-		}, nil
+		return &plugin.MockHost{}, nil
 	}
 	subVersion := semver.MustParse("1.2.3")
 	parameterValue := []byte("opaque-parameter-blob")
@@ -2087,9 +2079,7 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func() (plugin.Host, error) {
-		return &plugin.MockHost{
-			LoaderAddrF: func() string { return "loader-address" },
-		}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2174,7 +2164,7 @@ func TestDoCmdFunctionInvokeWithUnknownInputFormat(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	host := func() (plugin.Host, error) {
-		return &plugin.MockHost{LoaderAddrF: func() string { return "loader-address" }}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2232,7 +2222,7 @@ func TestDoCmdFunctionInvokeWithConverterMissingConvertSnippet(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	host := func() (plugin.Host, error) {
-		return &plugin.MockHost{LoaderAddrF: func() string { return "loader-address" }}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2291,7 +2281,7 @@ func TestDoCmdFunctionInvokeWithConverterDiagnostics(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	host := func() (plugin.Host, error) {
-		return &plugin.MockHost{LoaderAddrF: func() string { return "loader-address" }}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2358,7 +2348,7 @@ func TestDoCmdFunctionInvokeWithConverterReturningInvalidPCL(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	host := func() (plugin.Host, error) {
-		return &plugin.MockHost{LoaderAddrF: func() string { return "loader-address" }}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2497,9 +2487,7 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func() (plugin.Host, error) {
-		return &plugin.MockHost{
-			LoaderAddrF: func() string { return "loader-address" },
-		}, nil
+		return &plugin.MockHost{}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -159,7 +159,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			// First make sure the language plugin is present.  We need this to load the required resource plugins.
 			// TODO: we need to think about how best to version this.  For now, it always picks the latest.
 			runtime := proj.Runtime
-			lang, err := pctx.Host.LanguageRuntime(runtime.Name())
+			lang, err := pctx.Host.LanguageRuntime(pctx, runtime.Name())
 			if err != nil {
 				return fmt.Errorf("load language plugin %s: %w", runtime.Name(), err)
 			}
@@ -190,7 +190,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 				}
 
 				ws := packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance,
-					pctx.Host, cmd.OutOrStderr(), cmd.ErrOrStderr(), nil,
+					pctx, cmd.OutOrStderr(), cmd.ErrOrStderr(), nil,
 					packageworkspace.Options{
 						UseLanguageVersionTools: useLanguageVersionTools,
 					})

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -84,7 +84,7 @@ func GetLanguageRuntimeMetadata(
 		defer pctx.Close()
 
 		programInfo := plugin.NewProgramInfo(root, pwd, main, proj.Runtime.Options())
-		lang, err := pctx.Host.LanguageRuntime(proj.Runtime.Name())
+		lang, err := pctx.Host.LanguageRuntime(pctx, proj.Runtime.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -731,7 +731,7 @@ func NewImportCmd() *cobra.Command {
 			}
 			sink := cmdutil.Diag()
 			pCtx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil,
-				schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return fmt.Errorf("create plugin context: %w", err)
 			}
@@ -776,7 +776,7 @@ func NewImportCmd() *cobra.Command {
 						pCtx.Diag.Warningf(diag.Message("", "failed to create plugin spec for provider %q: %v"), pluginName, err)
 						return nil
 					}
-					version, err := pkgWorkspace.InstallPlugin(ctx, pluginSpec, log, schema.NewLoaderServerFromHost)
+					version, err := pkgWorkspace.InstallPlugin(ctx, pluginSpec, log, schema.NewLoaderServerFromContext)
 					if err != nil {
 						pCtx.Diag.Warningf(diag.Message("", "failed to install provider %q: %v"), pluginName, err)
 						return nil
@@ -955,7 +955,7 @@ func NewImportCmd() *cobra.Command {
 				sink := cmdutil.Diag()
 
 				ctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, cwd, nil, true, nil,
-					schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+					schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -576,7 +576,7 @@ func generateImportedDefinitions(ctx *plugin.Context,
 		return false, nil
 	}
 
-	loader := schema.NewPluginLoader(ctx.Host)
+	loader := schema.NewPluginLoader(ctx)
 	err := importer.GenerateLanguageDefinitions(
 		out,
 		loader,
@@ -787,7 +787,7 @@ func NewImportCmd() *cobra.Command {
 				baseMapper, err := convert.NewBasePluginMapper(
 					pluginstorage.Instance,
 					from, /*conversionKey*/
-					convert.ProviderFactoryFromHost(ctx, pCtx.Host),
+					convert.ProviderFactoryFromHost(ctx, pCtx),
 					installPlugin,
 					nil, /*mappings*/
 				)
@@ -960,7 +960,7 @@ func NewImportCmd() *cobra.Command {
 					return nil, nil, err
 				}
 				defer contract.IgnoreClose(pCtx.Host)
-				languagePlugin, err := ctx.Host.LanguageRuntime(proj.Runtime.Name())
+				languagePlugin, err := ctx.Host.LanguageRuntime(ctx, proj.Runtime.Name())
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -128,8 +128,8 @@ from the parameters, as in:
 
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(),
-				sink, sink, nil, nil, target.installRoot, nil, false, nil, schema.NewLoaderServerFromHost,
-				convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				sink, sink, nil, nil, target.installRoot, nil, false, nil, schema.NewLoaderServerFromContext,
+				convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -60,7 +60,7 @@ empty string.`,
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -52,7 +52,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -62,7 +62,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -59,7 +59,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}
 			sink := cmdutil.Diag()
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_pack_sdk.go
@@ -47,7 +47,7 @@ func newPackagePackSdkCmd() *cobra.Command {
 			language := args[0]
 			path := args[1]
 
-			languagePlugin, err := pCtx.Host.LanguageRuntime(language)
+			languagePlugin, err := pCtx.Host.LanguageRuntime(pCtx, language)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -165,7 +165,7 @@ func (cmd *packagePublishCmd) Run(
 	}
 	sink := cmdutil.Diag()
 	pctx, err := plugin.NewContext(ctx, sink, sink, nil, nil, wd, nil, false, nil,
-		schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -730,6 +730,6 @@ func installResourcePluginFromFiles(t *testing.T, spec workspace.PluginDescripto
 		require.NoError(t, err)
 	}
 	err := pkgWorkspace.InstallPluginContent(t.Context(), spec, pluginstorage.DirPlugin(dir),
-		true, schema.NewLoaderServerFromHost)
+		true, schema.NewLoaderServerFromContext)
 	require.NoError(t, err)
 }

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -338,7 +338,7 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, nil, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -189,12 +189,12 @@ func GenSDK(
 			return nil, fmt.Errorf("create plugin context: %w", err)
 		}
 		defer contract.IgnoreClose(pCtx)
-		languagePlugin, err := pCtx.Host.LanguageRuntime(language)
+		languagePlugin, err := pCtx.Host.LanguageRuntime(pCtx, language)
 		if err != nil {
 			return nil, err
 		}
 
-		loader := schema.NewPluginLoader(pCtx.Host)
+		loader := schema.NewPluginLoader(pCtx)
 		loaderServer := schema.NewLoaderServer(loader)
 		grpcServer, err := plugin.NewServer(pCtx, schema.LoaderRegistration(loaderServer))
 		if err != nil {
@@ -274,7 +274,7 @@ func LinkPackages(ctx *LinkPackagesContext) error {
 	if ctx.Project.RuntimeInfo().Name() == "" {
 		return errors.New("cannot link packages into a project without a runtime")
 	}
-	languagePlugin, err := ctx.PluginContext.Host.LanguageRuntime(ctx.Project.RuntimeInfo().Name())
+	languagePlugin, err := ctx.PluginContext.Host.LanguageRuntime(ctx.PluginContext, ctx.Project.RuntimeInfo().Name())
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func LinkPackages(ctx *LinkPackagesContext) error {
 	for _, pkg := range ctx.Packages {
 		entries[pkg.Pkg.Identity()] = pkg.Pkg.Reference()
 	}
-	loader := schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(ctx.PluginContext.Host), entries)
+	loader := schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(ctx.PluginContext), entries)
 	loaderServer := schema.NewLoaderServer(loader)
 	grpcServer, err := plugin.NewServer(ctx.PluginContext, schema.LoaderRegistration(loaderServer))
 	if err != nil {
@@ -452,7 +452,7 @@ func ProviderFromSource(
 ) (plugin.Provider, workspace.PackageSpec, error) {
 	// Helper without a *cobra.Command writer; plumbing the writer into
 	// packageworkspace.New would require a much larger API change.
-	installCtx := packageworkspace.New(pluginstorage.Instance, ws, pctx.Host, os.Stderr, os.Stderr, //nolint:forbidigo
+	installCtx := packageworkspace.New(pluginstorage.Instance, ws, pctx, os.Stderr, os.Stderr, //nolint:forbidigo
 		nil, packageworkspace.Options{})
 	return providerFromSource(pctx, packageSource, reg, e, concurrency, installCtx)
 }

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -173,7 +173,7 @@ func TestProviderFromSource(t *testing.T) {
 		installCtx.t = t
 
 		pctx, err := plugin.NewContext(
-			t.Context(), nil, nil, nil, nil, t.TempDir(), nil, false, nil, schema.NewLoaderServerFromHost, nil, nil)
+			t.Context(), nil, nil, nil, nil, t.TempDir(), nil, false, nil, schema.NewLoaderServerFromContext, nil, nil)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pctx.Close()) }()
 

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -57,13 +57,13 @@ type Options struct {
 func New(
 	packageresolution pluginstorage.Context,
 	pkgworkspace pkgWorkspace.Context,
-	host plugin.Host, stdout, stderr io.Writer,
+	pctx *plugin.Context, stdout, stderr io.Writer,
 	parentSpan opentracing.Span, options Options,
 ) Workspace {
 	return Workspace{
 		packageresolution,
 		pkgworkspace,
-		host, stdout, stderr,
+		pctx, stdout, stderr,
 		options, parentSpan,
 		new(sync.Mutex),
 		map[string][]schema.PackageReference{},
@@ -78,7 +78,7 @@ type (
 type Workspace struct {
 	pluginStorageContext
 	pkgWorkspaceContext
-	host           plugin.Host
+	pctx           *plugin.Context
 	stdout, stderr io.Writer
 	options        Options
 	parentSpan     opentracing.Span
@@ -101,7 +101,7 @@ func (Workspace) GetPluginPath(ctx context.Context, spec workspace.PluginDescrip
 // InstallPlugin should assume that all dependencies of the plugin are already
 // installed.
 func (w Workspace) InstallPluginAt(ctx context.Context, dirPath string, project *workspace.PluginProject) error {
-	lang, err := w.host.LanguageRuntime(project.Runtime.Name())
+	lang, err := w.pctx.Host.LanguageRuntime(w.pctx, project.Runtime.Name())
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (w Workspace) InstallPluginAt(ctx context.Context, dirPath string, project 
 func (w Workspace) GetRequiredPackages(
 	ctx context.Context, dirPath string, project *workspace.PluginProject,
 ) ([]workspace.PackageDescriptor, []workspace.PackageSpec, error) {
-	lang, err := w.host.LanguageRuntime(project.Runtime.Name())
+	lang, err := w.pctx.Host.LanguageRuntime(w.pctx, project.Runtime.Name())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +238,7 @@ func (w Workspace) GenerateLocalSDK(
 		return workspace.LinkablePackageDescriptor{}, err
 	}
 
-	boundSchema, err := bindSpec(schemaSpec, schema.NewPluginLoader(w.host))
+	boundSchema, err := bindSpec(schemaSpec, schema.NewPluginLoader(w.pctx))
 	if err != nil {
 		return workspace.LinkablePackageDescriptor{}, fmt.Errorf("failed to bind schema: %w", err)
 	}
@@ -363,7 +363,7 @@ func (w Workspace) servers(
 	tracer := otel.Tracer("pulumi-cli")
 	_, langSpan := diagutils.StartSpan(ctx, tracer, "load-language-host",
 		trace.WithAttributes(attribute.String("language", language)))
-	languageRuntime, err := w.host.LanguageRuntime(language)
+	languageRuntime, err := w.pctx.Host.LanguageRuntime(w.pctx, language)
 	langSpan.End()
 	if err != nil {
 		return servers{}, err
@@ -378,8 +378,8 @@ func (w Workspace) servers(
 		refs[v.Identity()] = v
 	}
 
-	pctx := plugin.NewContextWithHost(ctx, d, d, noopCloseHost{w.host}, dir, dir, w.parentSpan)
-	loader := schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx.Host), refs)
+	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, dir, dir, w.parentSpan)
+	loader := schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx), refs)
 	loaderServer := schema.NewLoaderServer(loader)
 	grpcServer, err := plugin.NewServer(pctx, schema.LoaderRegistration(loaderServer))
 	if err != nil {
@@ -443,8 +443,8 @@ func (w Workspace) RunPackage(
 		Color: diagutils.GetGlobalColorization(),
 	})
 
-	pctx := plugin.NewContextWithHost(ctx, d, d, w.host, rootDir, rootDir, w.parentSpan)
-	p, err := plugin.NewProviderFromPath(w.host, pctx, pluginPath)
+	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, rootDir, rootDir, w.parentSpan)
+	p, err := plugin.NewProviderFromPath(w.pctx.Host, pctx, pluginPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not run plugin at %q: %w", pluginPath, err)
 	}
@@ -543,9 +543,3 @@ func (p pluginProvider) Parameterize(
 	}
 	return p.Provider.Parameterize(ctx, req)
 }
-
-type noopCloseHost struct {
-	plugin.Host
-}
-
-func (h noopCloseHost) Close() error { return nil }

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -335,7 +336,7 @@ func (w Workspace) LinkIntoProject(
 		ctx,
 		plugin.NewProgramInfo(projectDir, projectDir, ".", runtimeInfo.Options()),
 		packageDescriptors,
-		servers.grpc.Addr(),
+		servers.pctx.LoaderAddr(),
 	)
 	if err != nil {
 		return errors.Join(fmt.Errorf("linking package: %w", err), servers.Close())
@@ -347,13 +348,13 @@ func (w Workspace) LinkIntoProject(
 type servers struct {
 	pctx *plugin.Context
 	lang plugin.LanguageRuntime
-	grpc *plugin.GrpcServer
 }
 
 func (s servers) Close() error {
 	// We do not call s.lang.Close() since that closes the original host,
-	// and thus effectively closes the Workspace.
-	return errors.Join(s.grpc.Close(), s.pctx.Close())
+	// and thus effectively closes the Workspace. The context's loader service dies with the
+	// context.
+	return s.pctx.Close()
 }
 
 func (w Workspace) servers(
@@ -379,16 +380,15 @@ func (w Workspace) servers(
 	}
 
 	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, dir, dir, w.parentSpan)
-	loader := schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx), refs)
-	loaderServer := schema.NewLoaderServer(loader)
-	grpcServer, err := plugin.NewServer(pctx, schema.LoaderRegistration(loaderServer))
+	err = pctx.StartLoader(func(pctx *plugin.Context) codegenrpc.LoaderServer {
+		return schema.NewLoaderServer(schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx), refs))
+	})
 	if err != nil {
 		return servers{}, err
 	}
 	return servers{
 		pctx: pctx,
 		lang: languageRuntime,
-		grpc: grpcServer,
 	}, nil
 }
 
@@ -414,7 +414,7 @@ func (w Workspace) genSDK(ctx context.Context, language string, pkg *schema.Pack
 		return "", errors.Join(err, os.RemoveAll(tmpDir))
 	}
 
-	diags, err := s.lang.GeneratePackage(ctx, tmpDir, string(jsonBytes), nil, s.grpc.Addr(), nil, true /* local */)
+	diags, err := s.lang.GeneratePackage(ctx, tmpDir, string(jsonBytes), nil, s.pctx.LoaderAddr(), nil, true /* local */)
 	if err != nil {
 		return "", errors.Join(err, s.Close(), os.RemoveAll(tmpDir))
 	}
@@ -444,6 +444,9 @@ func (w Workspace) RunPackage(
 	})
 
 	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, rootDir, rootDir, w.parentSpan)
+	if err := pctx.StartLoader(schema.NewLoaderServerFromContext); err != nil {
+		return nil, fmt.Errorf("could not start loader for plugin at %q: %w", pluginPath, err)
+	}
 	p, err := plugin.NewProviderFromPath(w.pctx.Host, pctx, pluginPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not run plugin at %q: %w", pluginPath, err)

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -80,7 +80,7 @@ func getProjectPlugins(ctx context.Context) ([]workspace.PluginDescriptor, error
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	plugins, err := engine.GetRequiredPlugins(
 		pctx.Request(),
-		pctx.Host,
+		pctx,
 		proj.Runtime.Name(),
 		programInfo)
 	if err != nil {
@@ -109,7 +109,7 @@ func resolvePlugins(ctx context.Context, plugins []workspace.PluginDescriptor) (
 	// a plugin required by the project hasn't yet been installed, we will simply skip any errors we encounter.
 	var results []workspace.PluginInfo
 	for _, plugin := range plugins {
-		info, err := workspace.GetPluginInfo(pctx.Base(), d, plugin, pctx.Host.GetProjectPlugins())
+		info, err := workspace.GetPluginInfo(pctx.Base(), d, plugin, pctx.ProjectPlugins())
 		if err != nil {
 			contract.IgnoreError(err)
 		}

--- a/pkg/cmd/pulumi/plugin/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin/plugin_install.go
@@ -341,7 +341,7 @@ func installPluginSpec(
 	}
 	logging.V(1).Infof("%s installing tarball ...", label)
 	if err = pkgWorkspace.InstallPluginContent(
-		ctx, install, payload, reinstall, schema.NewLoaderServerFromHost,
+		ctx, install, payload, reinstall, schema.NewLoaderServerFromContext,
 	); err != nil {
 		return fmt.Errorf("installing %s from %s: %w", label, source, err)
 	}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -120,7 +120,7 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 						d.Logf(sev, diag.RawMessage("", msg))
 					}
 
-					_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log, schema.NewLoaderServerFromHost)
+					_, err = pkgWorkspace.InstallPlugin(ctx, pluginSpec, log, schema.NewLoaderServerFromContext)
 					if err != nil {
 						return err
 					}
@@ -135,7 +135,7 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 			pluginArgs := args[1:]
 
 			pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil,
-				schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 			if err != nil {
 				return fmt.Errorf("could not create plugin context: %w", err)
 			}

--- a/pkg/cmd/pulumi/plugin/plugin_run_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run_test.go
@@ -38,7 +38,7 @@ func testSetup(t *testing.T) (context.Context, *plugin.Context, *plugin.GrpcServ
 
 	ctx := t.Context()
 	pctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromHost, nil, nil)
+		schema.NewLoaderServerFromContext, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { pctx.Close() })
 
@@ -245,7 +245,7 @@ func TestNewInstallPluginFunc_DisabledAcquisition(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
 	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromHost, nil, nil)
+		schema.NewLoaderServerFromContext, nil, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 
@@ -262,7 +262,7 @@ func TestNewInstallPluginFunc_PluginInstallError(t *testing.T) {
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
 	pctx, err := plugin.NewContext(t.Context(), nil, nil, nil, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromHost, nil, nil)
+		schema.NewLoaderServerFromContext, nil, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 

--- a/pkg/cmd/pulumi/plugin/rpc.go
+++ b/pkg/cmd/pulumi/plugin/rpc.go
@@ -69,7 +69,7 @@ func createPluginRPCServer(
 	baseMapper, err := pconvert.NewBasePluginMapper(
 		pluginstorage.Instance,
 		"terraform",
-		pconvert.ProviderFactoryFromHost(ctx, pctx.Host),
+		pconvert.ProviderFactoryFromHost(ctx, pctx),
 		installPlugin,
 		nil,
 	)
@@ -80,7 +80,7 @@ func createPluginRPCServer(
 	// Wrap in a caching mapper for better performance
 	mapper := pconvert.NewCachingMapper(baseMapper)
 
-	loader := schema.NewPluginLoader(pctx.Host)
+	loader := schema.NewPluginLoader(pctx)
 
 	mapperServer := pconvert.NewMapperServer(mapper)
 	loaderServer := schema.NewLoaderServer(loader)

--- a/pkg/cmd/pulumi/plugin/rpc.go
+++ b/pkg/cmd/pulumi/plugin/rpc.go
@@ -47,7 +47,7 @@ func newInstallPluginFunc(pctx *plugin.Context) func(string) *semver.Version {
 			Name: pluginName,
 			Kind: apitype.ResourcePlugin,
 		}
-		version, err := pkgWorkspace.InstallPlugin(pctx.Base(), pluginSpec, log, schema.NewLoaderServerFromHost)
+		version, err := pkgWorkspace.InstallPlugin(pctx.Base(), pluginSpec, log, schema.NewLoaderServerFromContext)
 		if err != nil {
 			log(diag.Warning, fmt.Sprintf("failed to install provider %s: %v", pluginName, err))
 			return nil

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -75,7 +75,7 @@ func InstallPluginDependencies(
 	}
 	defer pluginCtx.Close()
 
-	lang, err := pluginCtx.Host.LanguageRuntime(projRuntime.Name())
+	lang, err := pluginCtx.Host.LanguageRuntime(pluginCtx, projRuntime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", projRuntime.Name(), err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -88,8 +88,8 @@ func newPolicyAnalyzeCmd(
 						return nil, nil, fmt.Errorf("getting working directory: %w", err)
 					}
 					pctx, err := plugin.NewContext(ctx, cmdutil.Diag(), cmdutil.Diag(),
-						nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromHost,
-						convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+						nil, nil, cwd, nil, true, nil, schema.NewLoaderServerFromContext,
+						convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 					if err != nil {
 						return nil, nil, fmt.Errorf("creating plugin context: %w", err)
 					}

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -126,7 +126,7 @@ func (cmd *policyInstallCmd) Run(
 	}
 
 	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, nil, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return fmt.Errorf("creating plugin context: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -127,8 +127,8 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 	}
 
 	plugctx, err := plugin.NewContextWithRoot(ctx, cmdutil.Diag(), cmdutil.Diag(), nil, pwd, projinfo.Root,
-		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil, schema.NewLoaderServerFromHost,
-		convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, nil, schema.NewLoaderServerFromContext,
+		convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -46,7 +46,7 @@ func InstallDependencies(ctx *plugin.Context, runtime *workspace.ProjectRuntimeI
 
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	lang, err := ctx.Host.LanguageRuntime(runtime.Name())
+	lang, err := ctx.Host.LanguageRuntime(ctx, runtime.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load language plugin %s: %w", runtime.Name(), err)
 	}
@@ -81,7 +81,7 @@ func InstallPackagesFromProject(
 	if err != nil {
 		return packageinstallation.State{}, err
 	}
-	ws := packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance, pctx.Host, stdout, stderr, nil,
+	ws := packageworkspace.New(pluginstorage.Instance, pkgWorkspace.Instance, pctx, stdout, stderr, nil,
 		packageworkspace.Options{
 			UseLanguageVersionTools: useLanguageVersionTools,
 		})

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -77,7 +77,7 @@ func InstallPackagesFromProject(
 		Color: utilCmdutil.GetGlobalColorization(),
 	})
 	pctx, err := plugin.NewContext(ctx, d, d, nil, nil, root, nil, false, nil,
-		schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return packageinstallation.State{}, err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -417,7 +417,7 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	// If we're creating an empty project we won't have a runtime name
 	if proj.Runtime.Name() != "" {
-		lang, err := pluginCtx.Host.LanguageRuntime(proj.Runtime.Name())
+		lang, err := pluginCtx.Host.LanguageRuntime(pluginCtx, proj.Runtime.Name())
 		if err != nil {
 			return fmt.Errorf("failed to load language plugin %s: %w", proj.Runtime.Name(), err)
 		}

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -110,7 +110,7 @@ func schemaFromSourceOrStdin(cmd *cobra.Command, source string, extraArgs []stri
 	}
 	sink := cmdutil.Diag()
 	pctx, err := plugin.NewContext(cmd.Context(), sink, sink, nil, nil, wd, nil, false,
-		nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/convert/mapper_server.go
+++ b/pkg/codegen/convert/mapper_server.go
@@ -32,13 +32,12 @@ import (
 // plugin storage, booting them via the given host. It has the signature required by [plugin.NewMapperFunc]. The
 // underlying mapper is constructed lazily on first request because enumerating installed plugins can fail, and host
 // construction has no way to surface that error.
-func NewMapperServerFromHost(ctx context.Context, host plugin.Host) codegenrpc.MapperServer {
-	return NewMapperServer(&hostMapper{baseCtx: ctx, host: host})
+func NewMapperServerFromHost(host plugin.Host, pctx *plugin.Context) codegenrpc.MapperServer {
+	return NewMapperServer(&hostMapper{pctx: pctx})
 }
 
 type hostMapper struct {
-	baseCtx context.Context
-	host    plugin.Host
+	pctx *plugin.Context
 
 	once   sync.Once
 	mapper Mapper
@@ -50,7 +49,7 @@ func (m *hostMapper) GetMapping(ctx context.Context, provider string, hint *Mapp
 		base, err := NewBasePluginMapper(
 			pluginstorage.Instance,
 			"terraform",
-			ProviderFactoryFromHost(m.baseCtx, m.host),
+			ProviderFactoryFromHost(m.pctx.Base(), m.pctx),
 			func(string) *semver.Version { return nil },
 			nil,
 		)

--- a/pkg/codegen/convert/mapper_server.go
+++ b/pkg/codegen/convert/mapper_server.go
@@ -28,15 +28,15 @@ import (
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
-// NewMapperServerFromHost creates a MapperServer that sources mappings from the plugins installed in the global
-// plugin storage, booting them via the given host. It has the signature required by [plugin.NewMapperFunc]. The
-// underlying mapper is constructed lazily on first request because enumerating installed plugins can fail, and host
-// construction has no way to surface that error.
-func NewMapperServerFromHost(host plugin.Host, pctx *plugin.Context) codegenrpc.MapperServer {
-	return NewMapperServer(&hostMapper{pctx: pctx})
+// NewMapperServerFromContext creates a MapperServer that sources mappings from the plugins installed in the global
+// plugin storage, booting them via the given context's host. It has the signature required by
+// [plugin.NewMapperFunc]. The underlying mapper is constructed lazily on first request because enumerating installed
+// plugins can fail, and context construction has no way to surface that error.
+func NewMapperServerFromContext(pctx *plugin.Context) codegenrpc.MapperServer {
+	return NewMapperServer(&contextMapper{pctx: pctx})
 }
 
-type hostMapper struct {
+type contextMapper struct {
 	pctx *plugin.Context
 
 	once   sync.Once
@@ -44,7 +44,7 @@ type hostMapper struct {
 	err    error
 }
 
-func (m *hostMapper) GetMapping(ctx context.Context, provider string, hint *MapperPackageHint) ([]byte, error) {
+func (m *contextMapper) GetMapping(ctx context.Context, provider string, hint *MapperPackageHint) ([]byte, error) {
 	m.once.Do(func() {
 		base, err := NewBasePluginMapper(
 			pluginstorage.Instance,

--- a/pkg/codegen/convert/mapper_server_test.go
+++ b/pkg/codegen/convert/mapper_server_test.go
@@ -61,7 +61,7 @@ func TestMapperServerFromHost_RealProvider(t *testing.T) {
 
 	sink := diagtest.LogSink(t)
 	pctx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, t.TempDir(), nil, false, nil,
-		nil, NewMapperServerFromHost, nil)
+		nil, NewMapperServerFromContext, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 

--- a/pkg/codegen/convert/mapper_server_test.go
+++ b/pkg/codegen/convert/mapper_server_test.go
@@ -65,7 +65,7 @@ func TestMapperServerFromHost_RealProvider(t *testing.T) {
 	require.NoError(t, err)
 	defer pctx.Close()
 
-	p, err := pctx.Host.Provider(workspace.PluginDescriptor{
+	p, err := pctx.Host.Provider(pctx, workspace.PluginDescriptor{
 		Name: "mapptest",
 		Kind: apitype.ResourcePlugin,
 	}, env.Global())

--- a/pkg/codegen/convert/provider_factory.go
+++ b/pkg/codegen/convert/provider_factory.go
@@ -30,15 +30,15 @@ import (
 // parameterized.
 type ProviderFactory func(descriptor workspace.PackageDescriptor) (plugin.Provider, error)
 
-// ProviderFactoryFromHost builds a ProviderFactory that uses the given plugin host to create providers and manage their
-// lifecycles.
-func ProviderFactoryFromHost(ctx context.Context, host plugin.Host) ProviderFactory {
+// ProviderFactoryFromHost builds a ProviderFactory that uses the given plugin context's host to create providers and
+// manage their lifecycles.
+func ProviderFactoryFromHost(ctx context.Context, pctx *plugin.Context) ProviderFactory {
 	return func(descriptor workspace.PackageDescriptor) (plugin.Provider, error) {
 		if descriptor.Kind != apitype.ResourcePlugin {
 			return nil, fmt.Errorf("provider factory must be a resource plugin package, was %v", descriptor.Kind)
 		}
 
-		provider, err := host.Provider(descriptor.PluginDescriptor, env.Global())
+		provider, err := pctx.Host.Provider(pctx, descriptor.PluginDescriptor, env.Global())
 		if err != nil {
 			desc := descriptor.PackageName()
 			v := descriptor.PackageVersion()

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -433,7 +433,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(utils.NewHost(testdataPath)))
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(utils.NewContext(testdataPath)))
 	if err != nil {
 		t.Fatalf("could not bind program: %v", err)
 	}
@@ -471,7 +471,7 @@ func parseAndBindProgram(t *testing.T,
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+	options = append(options, pcl.PluginHost(utils.NewContext(testdataPath)))
 
 	return pcl.BindProgram(parser.Files, options...)
 }

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -224,7 +224,7 @@ func readSchemaFile(file string) *schema.Package {
 	if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
 		panic(err)
 	}
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -249,7 +249,7 @@ func readYamlSchemaFile(file string) *schema.Package {
 	if err = yaml.Unmarshal(schemaBytes, &pkgSpec); err != nil {
 		panic(err)
 	}
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -610,7 +610,7 @@ func TestRegressTypeDuplicatesInChunking(t *testing.T) {
 		}
 	}
 
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})

--- a/pkg/codegen/go/import_path_pattern_test.go
+++ b/pkg/codegen/go/import_path_pattern_test.go
@@ -134,7 +134,7 @@ func bindImportPathProgram(t *testing.T) *pcl.Program {
 	require.NoError(t, pclParser.ParseFile(strings.NewReader(importPathPatternProgram), "importpath.pp"))
 	require.False(t, pclParser.Diagnostics.HasErrors(), "parse diagnostics: %v", pclParser.Diagnostics)
 
-	host := utils.NewHostWithProviders(testdataPath, utils.NewSchemaProvider("importpath", "1.0.0"))
+	host := utils.NewContextWithProviders(testdataPath, utils.NewSchemaProvider("importpath", "1.0.0"))
 	program, diags, err := pcl.BindProgram(pclParser.Files, pcl.PluginHost(host))
 	require.NoError(t, err)
 	require.False(t, diags.HasErrors(), "bind diagnostics: %v", diags)

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -82,21 +82,22 @@ resource "app" "scaleway:iam/application:Application" {}
 	parser := syntax.NewParser()
 	err = parser.ParseFile(bytes.NewReader([]byte(hcl)), "infra.tf")
 	require.NoError(t, err, "parse failed")
-	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(&plugin.MockHost{
-		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
-			return &workspace.PluginInfo{Name: spec.Name}, nil
-		},
-		ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
-			return &plugin.MockProvider{
-				GetSchemaF: func(
-					ctx context.Context,
-					gsr plugin.GetSchemaRequest,
-				) (plugin.GetSchemaResponse, error) {
-					return plugin.GetSchemaResponse{Schema: scalewaySchemaBytes}, nil
-				},
-			}, nil
-		},
-	}))
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(plugin.NewContextWithHost(
+		t.Context(), nil, nil, &plugin.MockHost{
+			ResolvePluginF: func(_ *plugin.Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+				return &workspace.PluginInfo{Name: spec.Name}, nil
+			},
+			ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+				return &plugin.MockProvider{
+					GetSchemaF: func(
+						ctx context.Context,
+						gsr plugin.GetSchemaRequest,
+					) (plugin.GetSchemaResponse, error) {
+						return plugin.GetSchemaResponse{Schema: scalewaySchemaBytes}, nil
+					},
+				}, nil
+			},
+		}, "", "", nil)))
 	if err != nil || diags.HasErrors() {
 		for _, d := range diags {
 			t.Logf("%s: %s", d.Summary, d.Detail)
@@ -134,7 +135,7 @@ func parseAndBindProgram(t *testing.T,
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+	options = append(options, pcl.PluginHost(utils.NewContext(testdataPath)))
 	return pcl.BindProgram(parser.Files, options...)
 }
 

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -126,8 +126,8 @@ func SkipInvokeTypechecking(options *bindOptions) {
 	options.skipInvokeTypecheck = true
 }
 
-func PluginHost(host plugin.Host) BindOption {
-	return Loader(schema.NewPluginLoader(host))
+func PluginHost(pctx *plugin.Context) BindOption {
+	return Loader(schema.NewPluginLoader(pctx))
 }
 
 func Loader(loader schema.Loader) BindOption {
@@ -394,7 +394,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		if err != nil {
 			return nil, nil, err
 		}
-		options.loader = schema.NewPluginLoader(ctx.Host)
+		options.loader = schema.NewPluginLoader(ctx)
 
 		defer contract.IgnoreClose(ctx)
 	}

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -390,7 +390,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 			return nil, nil, err
 		}
 		ctx, err := plugin.NewContext(ctx, nil, nil, nil, nil, cwd, nil, false, nil,
-			schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/pcl/binder_schema_test.go
+++ b/pkg/codegen/pcl/binder_schema_test.go
@@ -30,7 +30,7 @@ import (
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")
 
 func BenchmarkLoadPackage(b *testing.B) {
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	for n := 0; n < b.N; n++ {
 		_, err := NewPackageCache().loadPackageSchema(b.Context(), loader, "aws", "", "")

--- a/pkg/codegen/pcl/binder_test.go
+++ b/pkg/codegen/pcl/binder_test.go
@@ -91,7 +91,7 @@ func TestBindProgram(t *testing.T) {
 
 				var bindError error
 				var diags hcl.Diagnostics
-				loader := pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath)))
+				loader := pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath)))
 				absoluteFolderPath, err := filepath.Abs(folderPath)
 				if err != nil {
 					t.Fatalf("failed to bind program: unable to find the absolute path of %v", folderPath)
@@ -146,7 +146,7 @@ func TestWritingProgramSource(t *testing.T) {
 	}
 
 	program, diags, bindError := pcl.BindProgram(parser.Files,
-		pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath))),
+		pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath))),
 		pcl.DirPath(absoluteProgramPath),
 		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 
@@ -1134,7 +1134,7 @@ func TestBindingSelfReferencingComponentFailsWithCircularReferenceError(t *testi
 	}
 
 	program, diags, bindError := pcl.BindProgram(parser.Files,
-		pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath))),
+		pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath))),
 		pcl.DirPath(absoluteProgramPath),
 		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 
@@ -1175,7 +1175,7 @@ func TestBindingMutuallyDependantComponentsSucceeds(t *testing.T) {
 	}
 
 	program, diags, bindError := pcl.BindProgram(parser.Files,
-		pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath))),
+		pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath))),
 		pcl.DirPath(absoluteProgramPath),
 		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 
@@ -1306,7 +1306,7 @@ component myComp "./myComponent" {
 	require.NoError(t, err)
 
 	_, diags, _ := pcl.BindProgram(parser.Files,
-		pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath))),
+		pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath))),
 		pcl.DirPath(absDir),
 		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 
@@ -1341,7 +1341,7 @@ component myComp "./myComponent" {
 	require.NoError(t, err)
 
 	program, diags, bindErr := pcl.BindProgram(parser.Files,
-		pcl.Loader(schema.NewPluginLoader(utils.NewHost(testdataPath))),
+		pcl.Loader(schema.NewPluginLoader(utils.NewContext(testdataPath))),
 		pcl.DirPath(absDir),
 		pcl.ComponentBinder(pcl.ComponentProgramBinderFromFileSystem()))
 	require.NoError(t, bindErr)

--- a/pkg/codegen/pcl/utilities_test.go
+++ b/pkg/codegen/pcl/utilities_test.go
@@ -38,7 +38,7 @@ func ParseAndBindProgram(t *testing.T,
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+	options = append(options, pcl.PluginHost(utils.NewContext(testdataPath)))
 
 	return pcl.BindProgram(parser.Files, options...)
 }

--- a/pkg/codegen/python/utilities_test.go
+++ b/pkg/codegen/python/utilities_test.go
@@ -40,7 +40,7 @@ func parseAndBindProgram(t *testing.T, text, name string, options ...pcl.BindOpt
 		t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 	}
 
-	options = append(options, pcl.PluginHost(utils.NewHost(testdataPath)))
+	options = append(options, pcl.PluginHost(utils.NewContext(testdataPath)))
 
 	program, diags, err := pcl.BindProgram(parser.Files, options...)
 	if err != nil {

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -367,7 +367,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 			return nil, nil, err
 		}
 		ctx, err := plugin.NewContext(context.TODO(), nil, nil, nil, nil, cwd, nil, false, nil,
-			NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+			NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -372,7 +372,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 			return nil, nil, err
 		}
 
-		loader, loadCtx = NewPluginLoader(ctx.Host), ctx
+		loader, loadCtx = NewPluginLoader(ctx), ctx
 	}
 
 	// Create a type binder.

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -147,7 +147,7 @@ func TestParseAndRenderDocs(t *testing.T) {
 		t.Fatalf("could not read test data: %v", err)
 	}
 
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	for _, f := range files {
 		if filepath.Ext(f.Name()) != ".json" {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -121,7 +121,7 @@ type RawLoader interface {
 }
 
 type pluginLoader struct {
-	host plugin.Host
+	pctx *plugin.Context
 
 	cacheOptions pluginLoaderCacheOptions
 }
@@ -141,14 +141,16 @@ type pluginLoaderCacheOptions struct {
 	disableMmap bool
 }
 
-func NewPluginLoader(host plugin.Host) ReferenceLoader {
-	return newPluginLoaderWithOptions(host, pluginLoaderCacheOptions{})
+// NewPluginLoader creates a loader that resolves and boots provider plugins through the given
+// plugin context's host to load package schemas.
+func NewPluginLoader(pctx *plugin.Context) ReferenceLoader {
+	return newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{})
 }
 
-func newPluginLoaderWithOptions(host plugin.Host, cacheOptions pluginLoaderCacheOptions) ReferenceLoader {
+func newPluginLoaderWithOptions(pctx *plugin.Context, cacheOptions pluginLoaderCacheOptions) ReferenceLoader {
 	var l ReferenceLoader
 	l = &pluginLoader{
-		host: host,
+		pctx: pctx,
 
 		cacheOptions: cacheOptions,
 	}
@@ -489,7 +491,7 @@ func (l *pluginLoader) loadSchemaBytes(
 		return schemaBytes, pluginVersion, nil
 	}
 
-	pluginInfo, err := l.host.ResolvePlugin(pluginSpecFromPackageDescriptor(descriptor))
+	pluginInfo, err := l.pctx.Host.ResolvePlugin(l.pctx, pluginSpecFromPackageDescriptor(descriptor))
 	if err != nil {
 		// Try and install the plugin if it was missing and try again, unless auto plugin installs are turned off.
 		var missingError *workspace.MissingError
@@ -505,7 +507,7 @@ func (l *pluginLoader) loadSchemaBytes(
 		}
 
 		log := func(sev diag.Severity, msg string) {
-			l.host.Log(sev, "", msg, 0)
+			l.pctx.Host.Log(sev, "", msg, 0)
 		}
 
 		_, err = pkgWorkspace.InstallPlugin(ctx, spec, log, NewLoaderServerFromHost)
@@ -513,7 +515,7 @@ func (l *pluginLoader) loadSchemaBytes(
 			return nil, nil, err
 		}
 
-		pluginInfo, err = l.host.ResolvePlugin(pluginSpecFromPackageDescriptor(descriptor))
+		pluginInfo, err = l.pctx.Host.ResolvePlugin(l.pctx, pluginSpecFromPackageDescriptor(descriptor))
 		if err != nil {
 			return nil, descriptor.Version, err
 		}
@@ -585,7 +587,7 @@ func (l *pluginLoader) loadPluginSchemaBytes(
 		Kind:              apitype.ResourcePlugin,
 	}
 
-	provider, err := l.host.Provider(wsDescriptor, env.Global())
+	provider, err := l.pctx.Host.Provider(l.pctx, wsDescriptor, env.Global())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -510,7 +510,7 @@ func (l *pluginLoader) loadSchemaBytes(
 			l.pctx.Host.Log(sev, "", msg, 0)
 		}
 
-		_, err = pkgWorkspace.InstallPlugin(ctx, spec, log, NewLoaderServerFromHost)
+		_, err = pkgWorkspace.InstallPlugin(ctx, spec, log, NewLoaderServerFromContext)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/loader_caching_test.go
+++ b/pkg/codegen/schema/loader_caching_test.go
@@ -45,10 +45,10 @@ func minimalSchemaJSON(name, version string) []byte {
 // newCachingHost returns a mock host backed by the given provider and pluginInfo.
 func newCachingHost(provider plugin.Provider, pluginInfo *workspace.PluginInfo) *plugin.MockHost {
 	return &plugin.MockHost{
-		ProviderF: func(workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
+		ProviderF: func(*plugin.Context, workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(*plugin.Context, workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return pluginInfo, nil
 		},
 	}
@@ -57,7 +57,8 @@ func newCachingHost(provider plugin.Provider, pluginInfo *workspace.PluginInfo) 
 // fileCacheLoader creates a loader with the in-memory caches disabled so that
 // only the file-based cache is exercised.
 func fileCacheLoader(host plugin.Host) ReferenceLoader {
-	return newPluginLoaderWithOptions(host, pluginLoaderCacheOptions{
+	pctx := plugin.NewContextWithHost(context.Background(), nil, nil, host, "", "", nil)
+	return newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
 	})

--- a/pkg/codegen/schema/loader_server.go
+++ b/pkg/codegen/schema/loader_server.go
@@ -27,10 +27,10 @@ import (
 	"github.com/segmentio/encoding/json"
 )
 
-// NewLoaderServerFromHost constructs the loader service registered on a host's RPC server. It
+// NewLoaderServerFromContext constructs the loader service bound to a plugin context. It
 // matches [plugin.NewLoaderFunc]: the loader resolves and boots plugins through the given
 // context's workspace view.
-func NewLoaderServerFromHost(_ plugin.Host, pctx *plugin.Context) codegenrpc.LoaderServer {
+func NewLoaderServerFromContext(pctx *plugin.Context) codegenrpc.LoaderServer {
 	return NewLoaderServer(NewPluginLoader(pctx))
 }
 

--- a/pkg/codegen/schema/loader_server.go
+++ b/pkg/codegen/schema/loader_server.go
@@ -27,8 +27,11 @@ import (
 	"github.com/segmentio/encoding/json"
 )
 
-func NewLoaderServerFromHost(host plugin.Host) codegenrpc.LoaderServer {
-	return NewLoaderServer(NewPluginLoader(host))
+// NewLoaderServerFromHost constructs the loader service registered on a host's RPC server. It
+// matches [plugin.NewLoaderFunc]: the loader resolves and boots plugins through the given
+// context's workspace view.
+func NewLoaderServerFromHost(_ plugin.Host, pctx *plugin.Context) codegenrpc.LoaderServer {
+	return NewLoaderServer(NewPluginLoader(pctx))
 }
 
 type loaderServer struct {

--- a/pkg/codegen/schema/loader_server_test.go
+++ b/pkg/codegen/schema/loader_server_test.go
@@ -33,16 +33,17 @@ import (
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
-// mockSchemaHost returns a plugin host that resolves pluginName@pluginVersion to the given provider.
+// mockSchemaHost returns a plugin context whose host resolves pluginName@pluginVersion to the
+// given provider.
 func mockSchemaHost(
 	t *testing.T, pluginName string, pluginVersion semver.Version, provider plugin.Provider,
-) plugin.Host {
-	return &plugin.MockHost{
-		ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+) *plugin.Context {
+	host := &plugin.MockHost{
+		ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 			assert.Equal(t, pluginName, descriptor.Name)
 			return provider, nil
 		},
-		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(_ *plugin.Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    pluginName,
 				Kind:    apitype.ResourcePlugin,
@@ -50,6 +51,7 @@ func mockSchemaHost(
 			}, nil
 		},
 	}
+	return plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
 }
 
 func schemaProvider(schemaBytes []byte) *plugin.MockProvider {
@@ -90,8 +92,8 @@ func TestLoaderServerRawSchemaBytes(t *testing.T) {
 	// Distinctive whitespace: re-marshaling would not preserve it, so byte equality proves the raw path was taken.
 	rawSchema := []byte(`{ "name": "test",  "version": "1.2.3",` +
 		` "resources": { "test:index:Resource": { "properties": { "foo": { "type": "string" } } } } }`)
-	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
-	client := serveLoader(t, NewPluginLoader(host))
+	pctx := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
+	client := serveLoader(t, NewPluginLoader(pctx))
 
 	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
 		Package: "test",
@@ -105,7 +107,7 @@ func TestLoaderServerRawSchemaBytes(t *testing.T) {
 
 	clientPkg, err := client.LoadPackageV2(t.Context(), descriptor)
 	require.NoError(t, err)
-	inProcessPkg, err := NewPluginLoader(host).LoadPackageV2(t.Context(), descriptor)
+	inProcessPkg, err := NewPluginLoader(pctx).LoadPackageV2(t.Context(), descriptor)
 	require.NoError(t, err)
 
 	clientSpec, err := clientPkg.MarshalSpec()
@@ -122,8 +124,8 @@ func TestLoaderServerRawSchemaBytesNoVersionFallback(t *testing.T) {
 
 	rawSchema := []byte(`{ "name": "test",` +
 		` "resources": { "test:index:Resource": { "properties": { "foo": { "type": "string" } } } } }`)
-	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
-	client := serveLoader(t, NewPluginLoader(host))
+	pctx := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
+	client := serveLoader(t, NewPluginLoader(pctx))
 
 	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
 		Package: "test",
@@ -140,7 +142,7 @@ func TestLoaderServerRawSchemaBytesNoVersionFallback(t *testing.T) {
 
 	clientRef, err := client.LoadPackageReferenceV2(t.Context(), descriptor)
 	require.NoError(t, err)
-	inProcessRef, err := NewPluginLoader(host).LoadPackageReferenceV2(t.Context(), descriptor)
+	inProcessRef, err := NewPluginLoader(pctx).LoadPackageReferenceV2(t.Context(), descriptor)
 	require.NoError(t, err)
 	assert.Equal(t, &version, clientRef.Version())
 	assert.Equal(t, inProcessRef.Version(), clientRef.Version())
@@ -164,8 +166,8 @@ func TestLoaderServerRawSchemaBytesParameterized(t *testing.T) {
 			Version: semver.MustParse("3.0.0"),
 		}, nil
 	}
-	host := mockSchemaHost(t, "base", semver.MustParse("1.0.0"), provider)
-	client := serveLoader(t, NewPluginLoader(host))
+	pctx := mockSchemaHost(t, "base", semver.MustParse("1.0.0"), provider)
+	client := serveLoader(t, NewPluginLoader(pctx))
 
 	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
 		Package: "base",
@@ -211,12 +213,13 @@ func TestLoaderServerCachedEntryBypassesRawPath(t *testing.T) {
 
 	// A host whose plugin resolution always fails: the cached entry is the only way to serve the schema.
 	host := &plugin.MockHost{
-		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(_ *plugin.Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return nil, workspace.NewMissingError(spec, false)
 		},
 	}
+	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
 	loader := NewCachedLoaderWithEntries(
-		NewPluginLoader(host),
+		NewPluginLoader(pctx),
 		map[string]PackageReference{pkg.Reference().Identity(): pkg.Reference()},
 	)
 	client := serveLoader(t, loader)
@@ -232,8 +235,8 @@ func TestLoaderServerCachedEntryBypassesRawPath(t *testing.T) {
 func TestLoaderServerRawSchemaBytesEmptySchema(t *testing.T) {
 	t.Setenv("PULUMI_HOME", t.TempDir())
 
-	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider([]byte(" { } ")))
-	client := serveLoader(t, NewPluginLoader(host))
+	pctx := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider([]byte(" { } ")))
+	client := serveLoader(t, NewPluginLoader(pctx))
 
 	_, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
 		Package: "test",

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -38,7 +38,7 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	ctx, err := plugin.NewContext(
 		b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil, nil)
 	require.NoError(b, err)
-	loader := newPluginLoaderWithOptions(ctx.Host, options)
+	loader := newPluginLoaderWithOptions(ctx, options)
 
 	return loader
 }
@@ -162,12 +162,12 @@ func TestLoadParameterized(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+		ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 			assert.Equal(t, "terraform-provider", descriptor.Name)
 			assert.Equal(t, semver.MustParse("1.0.0"), *descriptor.Version)
 			return mockProvider, nil
 		},
-		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(_ *plugin.Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			assert.Equal(t, apitype.ResourcePlugin, spec.Kind)
 			assert.Equal(t, "terraform-provider", spec.Name)
 			assert.Equal(t, semver.MustParse("1.0.0"), *spec.Version)
@@ -180,7 +180,8 @@ func TestLoadParameterized(t *testing.T) {
 		},
 	}
 
-	loader := newPluginLoaderWithOptions(host, pluginLoaderCacheOptions{
+	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
 		disableFileCache:  true,
@@ -230,10 +231,10 @@ func TestLoadNameMismatch(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
+		ProviderF: func(*plugin.Context, workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(*plugin.Context, workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    notPkg,
 				Kind:    apitype.ResourcePlugin,
@@ -242,7 +243,8 @@ func TestLoadNameMismatch(t *testing.T) {
 		},
 	}
 
-	loader := newPluginLoaderWithOptions(host, pluginLoaderCacheOptions{
+	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
 		disableFileCache:  true,
@@ -301,10 +303,10 @@ func TestLoadVersionMismatch(t *testing.T) {
 	}
 
 	host := &plugin.MockHost{
-		ProviderF: func(workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
+		ProviderF: func(*plugin.Context, workspace.PluginDescriptor, env.Env) (plugin.Provider, error) {
 			return provider, nil
 		},
-		ResolvePluginF: func(workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+		ResolvePluginF: func(*plugin.Context, workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 			return &workspace.PluginInfo{
 				Name:    pkg,
 				Kind:    apitype.ResourcePlugin,
@@ -313,7 +315,8 @@ func TestLoadVersionMismatch(t *testing.T) {
 		},
 	}
 
-	loader := newPluginLoaderWithOptions(host, pluginLoaderCacheOptions{
+	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
 		disableFileCache:  true,

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -36,7 +36,7 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	sink := diagtest.LogSink(b)
 	//nolint:usetesting // plugin.NewContext manages gRPC providers; b.Context cancels too early
 	ctx, err := plugin.NewContext(
-		b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil, nil)
+		b.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromContext, nil, nil)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx, options)
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2658,7 +2658,8 @@ func debugProvidersHelperContext(t *testing.T) *plugin.Context {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	//nolint:usetesting // plugin.NewContext manages the lifecycle of gRPC providers; t.Context cancels before they shut down
-	pluginCtx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil, nil)
+	pluginCtx, err := plugin.NewContext(
+		t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromContext, nil, nil)
 	require.NoError(t, err)
 	return pluginCtx
 }

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -72,7 +72,7 @@ func TestRoundtripRemoteTypeRef(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("remoteref-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -96,7 +96,7 @@ func TestRoundtripLocalTypeRef(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("localref-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -133,7 +133,7 @@ func TestRoundtripEnum(t *testing.T) {
 	}
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("enum-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -245,7 +245,7 @@ func TestRoundtripPlainProperties(t *testing.T) {
 	}
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("plain-properties-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -651,7 +651,7 @@ func TestRejectDuplicateNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, diags, err := BindSpec(tt.spec, NewPluginLoader(utils.NewHost(testdataPath)), ValidationOptions{
+			_, diags, err := BindSpec(tt.spec, NewPluginLoader(utils.NewContext(testdataPath)), ValidationOptions{
 				AllowDanglingReferences: true,
 			})
 			require.NoError(t, err)
@@ -724,7 +724,7 @@ func TestImportResourceRef(t *testing.T) {
 		},
 	}
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -898,7 +898,7 @@ func Test_parseTypeSpecRef(t *testing.T) {
 
 func TestUsingReservedWordInResourcePropertiesEmitsWarning(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -949,7 +949,7 @@ func TestUsingReservedWordInResourcePropertiesEmitsWarning(t *testing.T) {
 
 func TestUsingVersionKeywordInResourcePropertiesIsOk(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -991,7 +991,7 @@ func TestUsingVersionKeywordInResourcePropertiesIsOk(t *testing.T) {
 
 func TestUsingReservedWordInFunctionsEmitsError(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1028,7 +1028,7 @@ func TestUsingReservedWordInFunctionsEmitsError(t *testing.T) {
 
 func TestUsingVersionInFunctionParamsIsOk(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1057,7 +1057,7 @@ func TestUsingVersionInFunctionParamsIsOk(t *testing.T) {
 
 func TestUsingReservedWordInFunctionParamsIsNotOk(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1086,7 +1086,7 @@ func TestUsingReservedWordInFunctionParamsIsNotOk(t *testing.T) {
 
 func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1123,7 +1123,7 @@ func TestUsingReservedWordInTypesEmitsError(t *testing.T) {
 
 func TestUsingVersionPropertyNameIsOk(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1153,7 +1153,7 @@ func TestUsingVersionPropertyNameIsOk(t *testing.T) {
 
 func TestUsingReservedWordPropertyNameIsNotOk(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1398,7 +1398,7 @@ func TestBindSpecPrintableNames(t *testing.T) {
 
 func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1431,7 +1431,7 @@ func TestUsingIdInResourcePropertiesEmitsWarning(t *testing.T) {
 
 func TestUsingIdInStateInputsIsAnError(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -1472,7 +1472,7 @@ func TestUsingIdInStateInputsIsAnError(t *testing.T) {
 
 func TestOmittingVersionWhenSupportsPackEnabledGivesError(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name: "test",
 		Meta: &MetadataSpec{
@@ -1491,7 +1491,7 @@ func TestOmittingVersionWhenSupportsPackEnabledGivesError(t *testing.T) {
 
 func TestUsingIdInComponentResourcePropertiesEmitsNoWarning(t *testing.T) {
 	t.Parallel()
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := PackageSpec{
 		Name:    "test",
 		Version: "1.0.0",
@@ -2591,8 +2591,9 @@ func TestFunctionToFunctionSpecTurnaround(t *testing.T) {
 }
 
 func TestLoaderRespectsDebugProviders(t *testing.T) {
-	host := debugProvidersHelperHost(t)
-	loader := NewPluginLoader(host)
+	pluginCtx := debugProvidersHelperContext(t)
+	host := pluginCtx.Host
+	loader := NewPluginLoader(pluginCtx)
 	cancel := make(chan bool)
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Cancel: cancel,
@@ -2649,9 +2650,9 @@ func (*debugProvidersHelperServer) Attach(
 	return &emptypb.Empty{}, nil
 }
 
-// This is the host that pulumi-yaml is using. Somehow the test does not work with utils.NewHost,
+// This is the host that pulumi-yaml is using. Somehow the test does not work with utils.NewContext,
 // perhaps that does not support PULUMI_DEBUG_PROVIDERS yet.
-func debugProvidersHelperHost(t *testing.T) plugin.Host {
+func debugProvidersHelperContext(t *testing.T) *plugin.Context {
 	cwd := t.TempDir()
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
@@ -2659,14 +2660,14 @@ func debugProvidersHelperHost(t *testing.T) plugin.Host {
 	//nolint:usetesting // plugin.NewContext manages the lifecycle of gRPC providers; t.Context cancels before they shut down
 	pluginCtx, err := plugin.NewContext(t.Context(), sink, sink, nil, nil, cwd, nil, true, nil, NewLoaderServerFromHost, nil, nil)
 	require.NoError(t, err)
-	return pluginCtx.Host
+	return pluginCtx
 }
 
 func TestProviderReservedKeywordsIsAnError(t *testing.T) {
 	// c.f. https://github.com/pulumi/pulumi/issues/16757
 	t.Parallel()
 
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	// Test that certain names aren't allowed as a property in the package config.
 	pkgSpec := PackageSpec{
@@ -2785,7 +2786,7 @@ func TestProviderReservedKeywordsIsAnError(t *testing.T) {
 func TestResourceWithKeynameOverlapFunction(t *testing.T) {
 	t.Parallel()
 
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	pkgSpec := PackageSpec{
 		Name:    "xyz",
@@ -2806,7 +2807,7 @@ func TestResourceWithKeynameOverlapFunction(t *testing.T) {
 func TestResourceWithKeynameOverlapResource(t *testing.T) {
 	t.Parallel()
 
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	pkgSpec := PackageSpec{
 		Name:    "xyz",
@@ -2827,7 +2828,7 @@ func TestResourceWithKeynameOverlapResource(t *testing.T) {
 func TestResourceWithKeynameOverlapType(t *testing.T) {
 	t.Parallel()
 
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 
 	pkgSpec := PackageSpec{
 		Name:    "xyz",
@@ -2861,7 +2862,7 @@ func TestRoundtripAliasesJSON(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("aliases-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -2885,7 +2886,7 @@ func TestRoundtripAliasesYAML(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("aliases-1.0.0.yaml")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,
@@ -2909,7 +2910,7 @@ func TestDanglingReferences(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("dangling-reference-bad-0.1.0.json")
 	_, diags, _ := BindSpec(pkgSpec, loader, ValidationOptions{})
 
@@ -2925,7 +2926,7 @@ func TestNoDanglingReferences(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("dangling-reference-good-0.1.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{})
 	require.NoError(t, err)
@@ -3085,7 +3086,7 @@ func TestBindParameterizedExternals(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("..", "testing", "test", "testdata", "parameterized-schemas")
-	loader := NewPluginLoader(utils.NewHost(testdataPath))
+	loader := NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("parameterized-schemas/parameterizedref-1.0.0.json")
 	pkg, diags, err := BindSpec(pkgSpec, loader, ValidationOptions{
 		AllowDanglingReferences: true,

--- a/pkg/codegen/testing/test/helpers.go
+++ b/pkg/codegen/testing/test/helpers.go
@@ -59,7 +59,7 @@ func generatePackageFilesFromSchema(
 		return nil, err
 	}
 
-	loader := schema.NewPluginLoader(utils.NewHost(loaderDir))
+	loader := schema.NewPluginLoader(utils.NewContext(loaderDir))
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})

--- a/pkg/codegen/testing/test/program_driver.go
+++ b/pkg/codegen/testing/test/program_driver.go
@@ -58,7 +58,7 @@ type ProgramTest struct {
 	SkipCompile        codegen.StringSet
 	BindOptions        []pcl.BindOption
 	MockPluginVersions map[string]string
-	PluginHost         plugin.Host
+	PluginContext      *plugin.Context
 }
 
 var testdataPath = filepath.Join("..", "testing", "test", "testdata")
@@ -361,14 +361,12 @@ func TestProgramCodegen(
 			hclFiles := map[string]*hcl.File{
 				tt.Directory + ".pp": {Body: parser.Files[0].Body, Bytes: parser.Files[0].Bytes},
 			}
-			var pluginHost plugin.Host
-			if tt.PluginHost != nil {
-				pluginHost = tt.PluginHost
-			} else {
-				pluginHost = utils.NewHost(testcase.inputDirectory())
+			pluginCtx := tt.PluginContext
+			if pluginCtx == nil {
+				pluginCtx = utils.NewContext(testcase.inputDirectory())
 			}
 
-			opts := append(tt.BindOptions, pcl.PluginHost(pluginHost))
+			opts := append(tt.BindOptions, pcl.PluginHost(pluginCtx))
 			absoluteProgramPath, err := filepath.Abs(testInputDir)
 			if err != nil {
 				t.Fatalf("failed to bind program: unable to find the absolute path of %v", testInputDir)

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -37,10 +37,10 @@ func NewSchemaProvider(name, version string) SchemaProvider {
 	return SchemaProvider{name, version}
 }
 
-// NewHost creates a schema-only plugin host, supporting multiple package versions in tests. This
-// enables running tests offline. If this host is used to load a plugin, that is, to run a Pulumi
-// program, it will panic.
-func NewHostWithProviders(schemaDirectoryPath string, providers ...SchemaProvider) plugin.Host {
+// NewContextWithProviders creates a plugin context with a schema-only plugin host, supporting
+// multiple package versions in tests. This enables running tests offline. If this host is used
+// to load a plugin, that is, to run a Pulumi program, it will panic.
+func NewContextWithProviders(schemaDirectoryPath string, providers ...SchemaProvider) *plugin.Context {
 	mockProvider := func(name tokens.Package, version string) *deploytest.PluginLoader {
 		return deploytest.NewProviderLoader(name, semver.MustParse(version), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -79,19 +79,20 @@ func NewHostWithProviders(schemaDirectoryPath string, providers ...SchemaProvide
 	// For the pulumi/pulumi repository, this must be kept in sync with the makefile and/or committed
 	// schema files in the given schema directory. This is the minimal set of schemas that must be
 	// supplied.
-	return deploytest.NewPluginHost(nil, nil, nil,
+	host := deploytest.NewPluginHost(nil, nil, nil,
 		pluginLoaders...,
 	)
+	return plugin.NewContextWithHost(context.Background(), nil, nil, host, "", "", nil)
 }
 
-// NewHost creates a schema-only plugin host, supporting multiple package versions in tests. This
-// enables running tests offline. If this host is used to load a plugin, that is, to run a Pulumi
-// program, it will panic.
-func NewHost(schemaDirectoryPath string) plugin.Host {
+// NewContext creates a plugin context with a schema-only plugin host, supporting multiple package
+// versions in tests. This enables running tests offline. If this host is used to load a plugin,
+// that is, to run a Pulumi program, it will panic.
+func NewContext(schemaDirectoryPath string) *plugin.Context {
 	// For the pulumi/pulumi repository, this must be kept in sync with the makefile and/or committed
 	// schema files in the given schema directory. This is the minimal set of schemas that must be
 	// supplied.
-	return NewHostWithProviders(schemaDirectoryPath,
+	return NewContextWithProviders(schemaDirectoryPath,
 		SchemaProvider{"tls", "4.10.0"},
 		SchemaProvider{"random", "4.11.2"},
 		SchemaProvider{"std", "1.0.0"},

--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -54,7 +54,7 @@ func TestResolvingPackageReferences(t *testing.T) {
 	t.Parallel()
 
 	testdataPath := filepath.Join("testing", "test", "testdata")
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 	pkgSpec := readSchemaFile("remoteref-1.0.0.json")
 	pkg, diags, err := schema.BindSpec(pkgSpec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -67,7 +67,7 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 	pctx, err := plugin.NewContextWithRoot(pluginCtx, diag, statusDiag, host, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
 		projinfo.Proj.GetPackageSpecs(), config, debugging,
-		schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -151,7 +151,7 @@ func newDestroySource(
 	allPlugins := snapshotPackages.ToPluginSet().Deduplicate()
 
 	if err := EnsurePluginsAreInstalled(ctx, opts, plugctx.Diag, allPlugins,
-		plugctx.Host.GetProjectPlugins(), false /*reinstall*/, false /*explicitInstall*/); err != nil {
+		plugctx.ProjectPlugins(), false /*reinstall*/, false /*explicitInstall*/); err != nil {
 		logging.V(7).Infof("newDestroySource(): failed to install missing plugins: %v", err)
 	}
 

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -46,7 +46,7 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 }
 
 func (host *clientLanguageRuntimeHost) LanguageRuntime(
-	runtime string,
+	ctx *plugin.Context, runtime string,
 ) (plugin.LanguageRuntime, error) {
 	// If the system has asked for the special "client" runtime, return the connection we have to the language runtime
 	// plugin. Else, delegate to the host's LanguageRuntime method for loading other actual runtimes like
@@ -54,7 +54,7 @@ func (host *clientLanguageRuntimeHost) LanguageRuntime(
 	if runtime == clientRuntimeName {
 		return host.languageRuntime, nil
 	}
-	return host.Host.LanguageRuntime(runtime)
+	return host.Host.LanguageRuntime(ctx, runtime)
 }
 
 func langRuntimePluginDialOptions(ctx *plugin.Context, address string) []grpc.DialOption {

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -282,7 +282,7 @@ func (p PackageSet) UpdatesTo(old PackageSet) []PackageUpdate {
 // GetRequiredPlugins lists a full set of plugins that will be required by the given program.
 func GetRequiredPlugins(
 	ctx context.Context,
-	host plugin.Host,
+	plugctx *plugin.Context,
 	runtime string,
 	info plugin.ProgramInfo,
 ) ([]workspace.PluginDescriptor, error) {
@@ -290,10 +290,11 @@ func GetRequiredPlugins(
 	if runtime == "" {
 		return plugins, nil
 	}
+	host := plugctx.Host
 
 	// First make sure the language plugin is present.  We need this to load the required resource plugins.
 	// TODO: we need to think about how best to version this.  For now, it always picks the latest.
-	lang, err := host.LanguageRuntime(runtime)
+	lang, err := host.LanguageRuntime(plugctx, runtime)
 	if lang == nil || err != nil {
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
@@ -337,7 +338,7 @@ func gatherPackagesFromProgram(plugctx *plugin.Context, runtime string, info plu
 		return NewPackageSet(), nil
 	}
 
-	lang, err := plugctx.Host.LanguageRuntime(runtime)
+	lang, err := plugctx.Host.LanguageRuntime(plugctx, runtime)
 	if lang == nil || err != nil {
 		return nil, fmt.Errorf("failed to load language plugin %s: %w", runtime, err)
 	}
@@ -541,21 +542,21 @@ func ensurePluginsAreLoaded(plugctx *plugin.Context, plugins PluginSet, kinds pl
 		switch p.Kind {
 		case apitype.AnalyzerPlugin:
 			if kinds&plugin.AnalyzerPlugins != 0 {
-				if _, err := host.Analyzer(tokens.QName(p.Name)); err != nil {
+				if _, err := host.Analyzer(plugctx, tokens.QName(p.Name)); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load analyzer plugin %s: %w", p.Name, err))
 				}
 			}
 		case apitype.LanguagePlugin:
 			if kinds&plugin.LanguagePlugins != 0 {
-				if _, err := host.LanguageRuntime(p.Name); err != nil {
+				if _, err := host.LanguageRuntime(plugctx, p.Name); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load language plugin %s: %w", p.Name, err))
 				}
 			}
 		case apitype.ResourcePlugin:
 			if kinds&plugin.ResourcePlugins != 0 {
-				if _, err := host.Provider(p, env.Global()); err != nil {
+				if _, err := host.Provider(plugctx, p, env.Global()); err != nil {
 					result = multierror.Append(result,
 						fmt.Errorf("failed to load resource plugin %s: %w", p.Name, err))
 				}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -123,7 +123,7 @@ func (defaultPluginManager) InstallPlugin(
 	content pluginstorage.Content,
 	reinstall bool,
 ) error {
-	return pkgWorkspace.InstallPluginContent(ctx, plugin, content, reinstall, schema.NewLoaderServerFromHost)
+	return pkgWorkspace.InstallPluginContent(ctx, plugin, content, reinstall, schema.NewLoaderServerFromContext)
 }
 
 // PluginSet represents a set of plugins.

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -119,7 +119,7 @@ func newRefreshSource(
 
 	// Like Update, if we're missing plugins, attempt to download the missing plugins.
 	if err := EnsurePluginsAreInstalled(ctx, opts, plugctx.Diag, snapshotPackages.ToPluginSet().Deduplicate(),
-		plugctx.Host.GetProjectPlugins(), false /*reinstall*/, false /*explicitInstall*/); err != nil {
+		plugctx.ProjectPlugins(), false /*reinstall*/, false /*explicitInstall*/); err != nil {
 		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
 	}
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -581,7 +581,7 @@ func loadPolicyAnalyzer(
 		plugctx.Host.Log(sev, "", msg, 0)
 	}
 
-	_, installErr := installPluginFunc(ctx, me.Spec(), log, schema.NewLoaderServerFromHost)
+	_, installErr := installPluginFunc(ctx, me.Spec(), log, schema.NewLoaderServerFromContext)
 	if installErr != nil {
 		return nil, fmt.Errorf("failed to automatically install analyzer plugin %q: %w: %w",
 			string(name), installErr, me)

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -530,7 +530,7 @@ func installPlugins(
 	// When SkipPluginPreInstall is set we skip this up-front install attempt — the provider registry will install
 	// plugins lazily when they are actually requested.
 	if opts == nil || !opts.SkipPluginPreInstall {
-		if err := ensurePluginsAreInstalled(ctx, opts, plugctx.Diag, allPlugins, plugctx.Host.GetProjectPlugins(),
+		if err := ensurePluginsAreInstalled(ctx, opts, plugctx.Diag, allPlugins, plugctx.ProjectPlugins(),
 			false /*reinstall*/, false /*explicitInstall*/, manager); err != nil {
 			if returnInstallErrors {
 				return nil, nil, err
@@ -563,7 +563,7 @@ func loadPolicyAnalyzer(
 	ctx context.Context, plugctx *plugin.Context,
 	name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
-	analyzer, err := plugctx.Host.PolicyAnalyzer(name, path, opts)
+	analyzer, err := plugctx.Host.PolicyAnalyzer(plugctx, name, path, opts)
 	if err == nil {
 		return analyzer, nil
 	}
@@ -587,7 +587,7 @@ func loadPolicyAnalyzer(
 			string(name), installErr, me)
 	}
 
-	analyzer, err = plugctx.Host.PolicyAnalyzer(name, path, opts)
+	analyzer, err = plugctx.Host.PolicyAnalyzer(plugctx, name, path, opts)
 	if err != nil {
 		var retryMe *workspace.MissingError
 		if errors.As(err, &retryMe) {

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -123,7 +123,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 		t.Parallel()
 
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				_ *plugin.Context, name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				return &mockAnalyzer{name: name}, nil
 			},
 		}
@@ -142,7 +144,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 
 		expectedErr := errors.New("some other error")
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(tokens.QName, string, *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				*plugin.Context, tokens.QName, string, *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				return nil, expectedErr
 			},
 		}
@@ -159,7 +163,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 		t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(tokens.QName, string, *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				*plugin.Context, tokens.QName, string, *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				return nil, workspace.NewMissingError(workspace.PluginDescriptor{
 					Name: "policy-opa",
 					Kind: apitype.AnalyzerPlugin,
@@ -197,7 +203,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 
 		calls := 0
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(name tokens.QName, _ string, _ *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				_ *plugin.Context, name tokens.QName, _ string, _ *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				calls++
 				if calls == 1 {
 					return nil, workspace.NewMissingError(workspace.PluginDescriptor{
@@ -232,7 +240,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 		t.Cleanup(func() { installPluginFunc = origInstall })
 
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(tokens.QName, string, *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				*plugin.Context, tokens.QName, string, *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				return nil, workspace.NewMissingError(workspace.PluginDescriptor{
 					Name: "policy-opa",
 					Kind: apitype.AnalyzerPlugin,
@@ -266,7 +276,9 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 
 		// Even after install, PolicyAnalyzer still returns MissingError.
 		host := &plugin.MockHost{
-			PolicyAnalyzerF: func(tokens.QName, string, *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			PolicyAnalyzerF: func(
+				*plugin.Context, tokens.QName, string, *plugin.PolicyAnalyzerOptions,
+			) (plugin.Analyzer, error) {
 				return nil, workspace.NewMissingError(workspace.PluginDescriptor{
 					Name: "policy-opa",
 					Kind: apitype.AnalyzerPlugin,

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -320,7 +320,7 @@ func readTestCases(path string) (testCases, error) {
 func TestGenerateHCL2Definition(t *testing.T) {
 	t.Parallel()
 
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 	cases, err := readTestCases("testdata/cases.json")
 	require.NoError(t, err)
 
@@ -433,7 +433,7 @@ func TestGenerateHCL2DefinitionWithProviderDeclaration(t *testing.T) {
 	t.Parallel()
 
 	// Arrange
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	state := &resource.State{
 		ID:       "someProvider",
@@ -503,7 +503,7 @@ func TestGenerateHCL2DefinitionsWithVersionMismatches(t *testing.T) {
 	})
 
 	host := deploytest.NewPluginHost(nil /*sink*/, nil /*statusSink*/, nil /*languageRuntime*/, pluginLoader)
-	schemaLoader := schema.NewPluginLoader(host)
+	schemaLoader := schema.NewPluginLoader(plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil))
 
 	state := &resource.State{
 		Type:     "aws:cloudformation/stack:Stack",
@@ -540,7 +540,7 @@ func TestGenerateHCL2DefinitionsWithVersionMismatches(t *testing.T) {
 
 func TestGenerateHCL2DefinitionsWithDependantResources(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	snapshot := []*resource.State{
 		{
@@ -616,7 +616,7 @@ resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
 // Also shows that the logical name is emitted in the form of the __logicalName attribute.
 func TestGenerateHCL2DefinitionsWithDependantResourcesUsesLexicalNameInGeneratedCode(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	snapshot := []*resource.State{
 		{
@@ -696,7 +696,7 @@ resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
 
 func TestGenerateHCL2DefinitionsWithDependantResourcesUsingNameOrArnProperty(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	snapshot := []*resource.State{
 		{
@@ -791,7 +791,7 @@ resource exampleBucketObjectUsingArn "aws:s3/bucketObject:BucketObject" {
 
 func TestGenerateHCL2DefinitionsWithAmbiguousReferencesMaintainsLiteralValue(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	snapshot := []*resource.State{
 		{
@@ -876,7 +876,7 @@ resource exampleBucketObject "aws:s3/bucketObject:BucketObject" {
 
 func TestGenerateHCL2DefinitionsDoesNotMakeSelfReferences(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	snapshot := []*resource.State{
 		{

--- a/pkg/importer/language_test.go
+++ b/pkg/importer/language_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestGenerateLanguageDefinition(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	cases, err := readTestCases("testdata/cases.json")
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestGenerateLanguageDefinition(t *testing.T) {
 
 func TestGenerateLanguageDefinitionsReferencesOtherResources(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	var generatedProgram strings.Builder
 	generator := func(_ io.Writer, p *pcl.Program) error {
@@ -184,7 +184,7 @@ func TestGenerateLanguageDefinitionsReferencesOtherResourcesByName(t *testing.T)
 
 	testAttribute := func(t *testing.T, names NameTable, expectedCode string) {
 		t.Helper()
-		loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+		loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 		var generatedProgram strings.Builder
 		generator := func(_ io.Writer, p *pcl.Program) error {
@@ -287,7 +287,7 @@ resource obj "aws:s3/bucketObject:BucketObject" {
 
 func TestGenerateLanguageDefinitionsRetriesCodegenWhenEncounteringCircularReferences(t *testing.T) {
 	t.Parallel()
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	var generatedProgram strings.Builder
 	generator := func(_ io.Writer, p *pcl.Program) error {
@@ -365,7 +365,7 @@ resource second "aws:s3/bucketObject:BucketObject" {
 func TestGenerateLanguageDefinitionsAllowsGeneratingParentVariables(t *testing.T) {
 	t.Parallel()
 
-	loader := schema.NewPluginLoader(utils.NewHost(testdataPath))
+	loader := schema.NewPluginLoader(utils.NewContext(testdataPath))
 
 	var generatedProgram strings.Builder
 	generator := func(_ io.Writer, p *pcl.Program) error {

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -599,7 +599,7 @@ func NewDeployment(
 	// Create a new provider registry. Although we really only need to pass in any providers that were present in the
 	// old resource list, the registry itself will filter out other sorts of resources when processing the prior state,
 	// so we just pass all of the old resources.
-	reg := providers.NewRegistry(ctx.Host, opts.DryRun, builtins)
+	reg := providers.NewRegistry(ctx, opts.DryRun, builtins)
 
 	deployment := &Deployment{
 		ctx:                             ctx,

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -518,14 +518,6 @@ func (host *pluginHost) ServerAddr() string {
 	return host.engine.address
 }
 
-func (host *pluginHost) LoaderAddr() string {
-	return host.engine.address
-}
-
-func (host *pluginHost) MapperAddr() string {
-	return ""
-}
-
 func (host *pluginHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
 	if !host.isClosed() {
 		host.sink.Logf(sev, diag.StreamMessage(urn, msg, streamID))

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -439,7 +439,9 @@ func (host *pluginHost) plugin(kind apitype.PluginKind, name string, version *se
 	return plug, nil
 }
 
-func (host *pluginHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+func (host *pluginHost) Provider(
+	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
+) (plugin.Provider, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}
@@ -457,7 +459,7 @@ func (host *pluginHost) Provider(descriptor workspace.PluginDescriptor, e env.En
 	return plug.(plugin.Provider), nil
 }
 
-func (host *pluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime, error) {
+func (host *pluginHost) LanguageRuntime(ctx *plugin.Context, runtime string) (plugin.LanguageRuntime, error) {
 	if host.isClosed() {
 		return nil, ErrHostIsClosed
 	}
@@ -544,12 +546,12 @@ func (host *pluginHost) AttachDebugger(_ plugin.DebugSpec) bool {
 	return false
 }
 
-func (host *pluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
-	return host.PolicyAnalyzer(nm, "", nil)
+func (host *pluginHost) Analyzer(ctx *plugin.Context, nm tokens.QName) (plugin.Analyzer, error) {
+	return host.PolicyAnalyzer(ctx, nm, "", nil)
 }
 
 func (host *pluginHost) ResolvePlugin(
-	spec workspace.PluginDescriptor,
+	ctx *plugin.Context, spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	plugins := slice.Prealloc[workspace.PluginInfo](len(host.pluginLoaders))
 
@@ -585,11 +587,7 @@ func (host *pluginHost) GetRequiredPackages(
 	return host.languageRuntime.GetRequiredPackages(context.TODO(), info)
 }
 
-func (host *pluginHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	return nil
-}
-
-func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string,
+func (host *pluginHost) PolicyAnalyzer(ctx *plugin.Context, name tokens.QName, path string,
 	opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
 	if host.isClosed() {

--- a/pkg/resource/deploy/deploytest/pluginhost_test.go
+++ b/pkg/resource/deploy/deploytest/pluginhost_test.go
@@ -122,7 +122,7 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Parallel()
 		expectedVersion := semver.MustParse("1.0.0")
 		host := &pluginHost{}
-		_, err := host.Provider(workspace.PluginDescriptor{
+		_, err := host.Provider(nil, workspace.PluginDescriptor{
 			Name:    "pkgA",
 			Version: &expectedVersion,
 		}, nil)
@@ -133,7 +133,7 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("Provider", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.Provider(workspace.PluginDescriptor{
+			_, err := host.Provider(nil, workspace.PluginDescriptor{
 				Name:    "pkgA",
 				Version: &semver.Version{},
 			}, nil)
@@ -142,7 +142,7 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("LanguageRuntime", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.LanguageRuntime("")
+			_, err := host.LanguageRuntime(nil, "")
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 		t.Run("SignalCancellation", func(t *testing.T) {
@@ -154,13 +154,13 @@ func TestPluginHostProvider(t *testing.T) {
 		t.Run("Analyzer", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.Analyzer("")
+			_, err := host.Analyzer(nil, "")
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 		t.Run("PolicyAnalyzer", func(t *testing.T) {
 			t.Parallel()
 			host := &pluginHost{closed: true}
-			_, err := host.PolicyAnalyzer("", "", nil)
+			_, err := host.PolicyAnalyzer(nil, "", "", nil)
 			assert.ErrorIs(t, err, ErrHostIsClosed)
 		})
 	})

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -138,7 +138,7 @@ func NewImportDeployment(
 	)
 
 	// Create a new provider registry.
-	reg := providers.NewRegistry(ctx.Host, opts.DryRun, builtins)
+	reg := providers.NewRegistry(ctx, opts.DryRun, builtins)
 
 	// Return the prepared deployment.
 	return &Deployment{
@@ -154,7 +154,7 @@ func NewImportDeployment(
 		goals:                           newGoals,
 		imports:                         imports,
 		isImport:                        true,
-		schemaLoader:                    schema.NewPluginLoader(ctx.Host),
+		schemaLoader:                    schema.NewPluginLoader(ctx),
 		source:                          NewErrorSource(projectName),
 		providers:                       reg,
 		newPlans:                        newResourcePlan(target.Config),

--- a/pkg/resource/deploy/import_test.go
+++ b/pkg/resource/deploy/import_test.go
@@ -34,6 +34,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newMockRegistryContext wraps a mock host in a plugin context for constructing a Registry.
+func newMockRegistryContext(host plugin.Host) *plugin.Context {
+	return &plugin.Context{Diag: &deploytest.NoopSink{}, Host: host}
+}
+
 func TestImportDeployment(t *testing.T) {
 	t.Parallel()
 	t.Run("NewImportDeployment", func(t *testing.T) {
@@ -103,13 +108,13 @@ func TestImporter(t *testing.T) {
 						Name: tokens.MustParseStackName("stack-name"),
 					},
 					source: &nullSource{},
-					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+					providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+						ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 							assert.Equal(t, "foo", descriptor.Name)
 							assert.Equal(t, "1.0.0", descriptor.Version.String())
 							return nil, expectedErr
 						},
-					}, true, nil),
+					}), true, nil),
 					imports: []Import{
 						{
 							Version:           &version,
@@ -144,8 +149,8 @@ func TestImporter(t *testing.T) {
 						Name: tokens.MustParseStackName("stack-name"),
 					},
 					source: &nullSource{},
-					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+					providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+						ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 							return &deploytest.Provider{
 								CheckConfigF: func(
 									_ context.Context, req plugin.CheckConfigRequest,
@@ -154,7 +159,7 @@ func TestImporter(t *testing.T) {
 								},
 							}, nil
 						},
-					}, true, nil),
+					}), true, nil),
 					imports: []Import{
 						{
 							Type:              "foo:bar:Bar",
@@ -185,8 +190,8 @@ func TestImporter(t *testing.T) {
 						Name: tokens.MustParseStackName("stack-name"),
 					},
 					source: &nullSource{},
-					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+					providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+						ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 							return &deploytest.Provider{
 								CheckConfigF: func(
 									_ context.Context, req plugin.CheckConfigRequest,
@@ -201,7 +206,7 @@ func TestImporter(t *testing.T) {
 								},
 							}, nil
 						},
-					}, true, nil),
+					}), true, nil),
 					imports: []Import{
 						{
 							Type:     "foo:bar:Bar",
@@ -238,12 +243,12 @@ func TestImporter(t *testing.T) {
 							Type: "pulumi:providers:foo",
 						},
 					},
-					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+					providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+						ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 							t.Fatal("ProviderF should not be called for provider already in state")
 							return nil, nil
 						},
-					}, true, nil),
+					}), true, nil),
 					imports: []Import{
 						{
 							Type:     "foo:bar:Bar",
@@ -274,8 +279,8 @@ func TestImporter(t *testing.T) {
 						Name: tokens.MustParseStackName("stack-name"),
 					},
 					source: &nullSource{},
-					providers: providers.NewRegistry(&plugin.MockHost{
-						ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+					providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+						ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 							return &deploytest.Provider{
 								CheckConfigF: func(
 									_ context.Context, req plugin.CheckConfigRequest,
@@ -284,7 +289,7 @@ func TestImporter(t *testing.T) {
 								},
 							}, nil
 						},
-					}, true, nil),
+					}), true, nil),
 					imports: []Import{
 						{
 							Type:     "foo:bar:Bar",
@@ -435,13 +440,13 @@ func TestImporterParameterizedProvider(t *testing.T) {
 				Name: tokens.MustParseStackName("stack-name"),
 			},
 			source: &nullSource{},
-			providers: providers.NewRegistry(&plugin.MockHost{
-				ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+			providers: providers.NewRegistry(newMockRegistryContext(&plugin.MockHost{
+				ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
 					assert.Equal(t, "foo", descriptor.Name)
 					assert.Equal(t, "1.0.0", descriptor.Version.String())
 					return &mockProvider, nil
 				},
-			}, true, nil),
+			}), true, nil),
 			imports: []Import{
 				{
 					Version:           &version,

--- a/pkg/resource/deploy/program_source.go
+++ b/pkg/resource/deploy/program_source.go
@@ -65,12 +65,12 @@ func (src *programSource) run(resourceMonitorTarget string) *promise.Promise[str
 
 	// Also start up a schema loader for the language runtime to use to fetch schema information.
 	loaderRegistration := schema.LoaderRegistration(
-		schema.NewLoaderServer(schema.NewPluginLoader(src.plugctx.Host)))
+		schema.NewLoaderServer(schema.NewPluginLoader(src.plugctx)))
 
 	baseMapper, err := convert.NewBasePluginMapper(
 		pluginstorage.Instance,
 		"terraform",
-		convert.ProviderFactoryFromHost(context.Background(), src.plugctx.Host),
+		convert.ProviderFactoryFromHost(context.Background(), src.plugctx),
 		func(string) *semver.Version { return nil },
 		nil,
 	)
@@ -110,7 +110,7 @@ func (src *programSource) forkRun(
 				return nil
 			}
 
-			langhost, err := src.plugctx.Host.LanguageRuntime(rt)
+			langhost, err := src.plugctx.Host.LanguageRuntime(src.plugctx, rt)
 			if err != nil {
 				return fmt.Errorf("failed to launch language host %s: %w", rt, err)
 			}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -408,7 +408,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 		pctx.Host.Log(sev, "", msg, 0)
 	}
 
-	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor, log, schema.NewLoaderServerFromHost)
+	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor, log, schema.NewLoaderServerFromContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -358,7 +358,7 @@ func GetProviderParameterization(
 type Registry struct {
 	plugin.NotForwardCompatibleProvider
 
-	host      plugin.Host
+	pctx      *plugin.Context
 	isPreview bool
 	providers map[providers.Reference]plugin.Provider
 	builtins  plugin.Provider
@@ -369,7 +369,7 @@ type Registry struct {
 var _ plugin.Provider = (*Registry)(nil)
 
 func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Version, downloadURL string,
-	checksums map[string][]byte, host plugin.Host, builtins plugin.Provider, e env.Env,
+	checksums map[string][]byte, pctx *plugin.Context, builtins plugin.Provider, e env.Env,
 ) (plugin.Provider, error) {
 	if builtins != nil && pkg == "pulumi" {
 		return builtins, nil
@@ -383,7 +383,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 		Checksums:         checksums,
 	}
 
-	provider, err := host.Provider(descriptor, e)
+	provider, err := pctx.Host.Provider(pctx, descriptor, e)
 	if err == nil {
 		return provider, nil
 	}
@@ -405,7 +405,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 	}
 
 	log := func(sev diag.Severity, msg string) {
-		host.Log(sev, "", msg, 0)
+		pctx.Host.Log(sev, "", msg, 0)
 	}
 
 	_, err = pkgWorkspace.InstallPlugin(ctx, descriptor, log, schema.NewLoaderServerFromHost)
@@ -414,7 +414,7 @@ func loadProvider(ctx context.Context, pkg tokens.Package, version *semver.Versi
 	}
 
 	// Try to load the provider again, this time it should succeed.
-	return host.Provider(descriptor, e)
+	return pctx.Host.Provider(pctx, descriptor, e)
 }
 
 // loadParameterizedProvider wraps loadProvider to also support loading parameterized providers.
@@ -422,10 +422,10 @@ func loadParameterizedProvider(
 	ctx context.Context,
 	name tokens.Package, version *semver.Version, downloadURL string, checksums map[string][]byte,
 	parameter *workspace.Parameterization,
-	host plugin.Host, builtins plugin.Provider,
+	pctx *plugin.Context, builtins plugin.Provider,
 	e env.Env,
 ) (plugin.Provider, error) {
-	provider, err := loadProvider(ctx, name, version, downloadURL, checksums, host, builtins, e)
+	provider, err := loadProvider(ctx, name, version, downloadURL, checksums, pctx, builtins, e)
 	if err != nil {
 		return nil, err
 	}
@@ -461,10 +461,10 @@ func FilterProviderConfig(inputs resource.PropertyMap) resource.PropertyMap {
 	return result
 }
 
-// NewRegistry creates a new provider registry using the given host.
-func NewRegistry(host plugin.Host, isPreview bool, builtins plugin.Provider) *Registry {
+// NewRegistry creates a new provider registry using the given plugin context.
+func NewRegistry(pctx *plugin.Context, isPreview bool, builtins plugin.Provider) *Registry {
 	return &Registry{
-		host:      host,
+		pctx:      pctx,
 		isPreview: isPreview,
 		providers: make(map[providers.Reference]plugin.Provider),
 		builtins:  builtins,
@@ -660,7 +660,7 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 
 	// TODO: We should thread checksums through here.
 	provider, err := loadParameterizedProvider(
-		ctx, name, version, downloadURL, nil, parameter, r.host, r.builtins, buildEnvWithMappings(envVarMappings))
+		ctx, name, version, downloadURL, nil, parameter, r.pctx, r.builtins, buildEnvWithMappings(envVarMappings))
 	if err != nil {
 		return plugin.CheckResponse{}, err
 	}
@@ -708,7 +708,7 @@ func (r *Registry) Check(ctx context.Context, req plugin.CheckRequest) (plugin.C
 	if _, has := req.News[internalKey]; has {
 		// Before we reset it warn the user that the providers data is being discarded
 		if _, has := resp.Properties[internalKey]; has {
-			r.host.Log(diag.Warning, req.URN, "provider attempted to use __internal key that is reserved by the engine", 0)
+			r.pctx.Host.Log(diag.Warning, req.URN, "provider attempted to use __internal key that is reserved by the engine", 0)
 		}
 		resp.Properties[internalKey] = req.News[internalKey]
 	}
@@ -845,7 +845,7 @@ func (r *Registry) Same(ctx context.Context, res *resource.State, fromCheck bool
 
 		// TODO: We should thread checksums through here.
 		provider, err = loadParameterizedProvider(
-			ctx, name, version, downloadURL, nil, parameter, r.host, r.builtins, buildEnvWithMappings(envVarMappings))
+			ctx, name, version, downloadURL, nil, parameter, r.pctx, r.builtins, buildEnvWithMappings(envVarMappings))
 		if err != nil {
 			return fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, urn, err)
 		}
@@ -933,7 +933,7 @@ func (r *Registry) Create(ctx context.Context, req plugin.CreateRequest) (plugin
 
 		// TODO: We should thread checksums through here.
 		provider, err = loadParameterizedProvider(
-			ctx, name, version, downloadURL, nil, parameter, r.host, r.builtins, buildEnvWithMappings(envVarMappings))
+			ctx, name, version, downloadURL, nil, parameter, r.pctx, r.builtins, buildEnvWithMappings(envVarMappings))
 		if err != nil {
 			return plugin.CreateResponse{Status: resource.StatusUnknown},
 				fmt.Errorf("load plugin for %v provider '%v': %w", providerPkg, req.URN, err)

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -76,32 +76,30 @@ func (host *testPluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg s
 	host.t.Logf("[%v] %v@%v: %v", sev, urn, streamID, msg)
 }
 
-func (host *testPluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
+func (host *testPluginHost) Analyzer(ctx *plugin.Context, nm tokens.QName) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")
 }
 
-func (host *testPluginHost) PolicyAnalyzer(name tokens.QName, path string,
+func (host *testPluginHost) PolicyAnalyzer(ctx *plugin.Context, name tokens.QName, path string,
 	opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")
 }
 
-func (host *testPluginHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+func (host *testPluginHost) Provider(
+	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
+) (plugin.Provider, error) {
 	return host.provider(descriptor)
 }
 
-func (host *testPluginHost) LanguageRuntime(root string) (plugin.LanguageRuntime, error) {
+func (host *testPluginHost) LanguageRuntime(ctx *plugin.Context, runtime string) (plugin.LanguageRuntime, error) {
 	return nil, errors.New("unsupported")
 }
 
 func (host *testPluginHost) ResolvePlugin(
-	spec workspace.PluginDescriptor,
+	ctx *plugin.Context, spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	return nil, nil
-}
-
-func (host *testPluginHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	return nil
 }
 
 func (host *testPluginHost) GetRequiredPlugins(project string, info plugin.ProgramInfo,
@@ -181,6 +179,11 @@ type providerLoader struct {
 	pkg     tokens.Package
 	version semver.Version
 	load    func() (plugin.Provider, error)
+}
+
+// newTestContext wraps a test host in a plugin context for constructing a Registry.
+func newTestContext(host plugin.Host) *plugin.Context {
+	return &plugin.Context{Host: host}
 }
 
 func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
@@ -273,10 +276,10 @@ func newProviderState(pkg, name, id string, del bool, inputs resource.PropertyMa
 func TestNewRegistryNoOldState(t *testing.T) {
 	t.Parallel()
 
-	r := NewRegistry(&testPluginHost{}, false, nil)
+	r := NewRegistry(newTestContext(&testPluginHost{}), false, nil)
 	require.NotNil(t, r)
 
-	r = NewRegistry(&testPluginHost{}, true, nil)
+	r = NewRegistry(newTestContext(&testPluginHost{}), true, nil)
 	require.NotNil(t, r)
 }
 
@@ -306,7 +309,7 @@ func TestNewRegistryOldState(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	for _, old := range olds {
@@ -355,7 +358,7 @@ func TestCRUD(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	for _, old := range olds {
@@ -541,7 +544,7 @@ func TestCRUDPreview(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, true, nil)
+	r := NewRegistry(newTestContext(host), true, nil)
 	require.NotNil(t, r)
 
 	for _, old := range olds {
@@ -676,7 +679,7 @@ func TestCRUDNoProviders(t *testing.T) {
 
 	host := newPluginHost(t, []*providerLoader{})
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType("pkgA")
@@ -702,7 +705,7 @@ func TestCRUDWrongPackage(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType("pkgA")
@@ -728,7 +731,7 @@ func TestCRUDWrongVersion(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType("pkgA")
@@ -754,7 +757,7 @@ func TestCRUDBadVersionNotString(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType("pkgA")
@@ -781,7 +784,7 @@ func TestCRUDBadVersion(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType("pkgA")
@@ -827,7 +830,7 @@ func TestLoadProvider_missingError(t *testing.T) {
 		_, err := loadProvider(
 			t.Context(),
 			"myplugin", &version, srv.URL,
-			nil, host, nil /* builtins */, nil)
+			nil, newTestContext(host), nil /* builtins */, nil)
 		assert.ErrorContains(t, err,
 			"no resource plugin 'pulumi-resource-myplugin' found in the workspace at version v1.2.3")
 		assert.Equal(t, 0, count)
@@ -839,7 +842,7 @@ func TestLoadProvider_missingError(t *testing.T) {
 		_, err := loadProvider(
 			t.Context(),
 			"myplugin", &version, srv.URL,
-			nil, host, nil /* builtins */, nil)
+			nil, newTestContext(host), nil /* builtins */, nil)
 		assert.ErrorContains(t, err,
 			"Could not automatically download and install resource plugin 'pulumi-resource-myplugin' at version v1.2.3")
 		assert.ErrorContains(t, err,
@@ -859,7 +862,7 @@ func TestConcurrentRegistryUsage(t *testing.T) {
 	}
 	host := newPluginHost(t, loaders)
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 	require.NotNil(t, r)
 
 	// We're going to create a few thousand providers in parallel, registering a load of aliases for each of
@@ -1084,7 +1087,7 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 		}
 		host := newPluginHost(t, loaders)
 
-		r := NewRegistry(host, false, nil)
+		r := NewRegistry(newTestContext(host), false, nil)
 		require.NotNil(t, r)
 
 		// Same the provider
@@ -1113,7 +1116,7 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 		}
 		host := newPluginHost(t, loaders)
 
-		r := NewRegistry(host, false, nil)
+		r := NewRegistry(newTestContext(host), false, nil)
 		require.NotNil(t, r)
 
 		typ := providers.MakeProviderType(tokens.Package("testPackage"))
@@ -1147,7 +1150,7 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 		}
 		host := newPluginHost(t, loaders)
 
-		r := NewRegistry(host, false, nil)
+		r := NewRegistry(newTestContext(host), false, nil)
 		require.NotNil(t, r)
 
 		typ := providers.MakeProviderType(tokens.Package("testPackage"))
@@ -1191,7 +1194,9 @@ type testPluginHostWithEnvCapture struct {
 }
 
 //nolint:lll
-func (host *testPluginHostWithEnvCapture) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+func (host *testPluginHostWithEnvCapture) Provider(
+	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
+) (plugin.Provider, error) {
 	host.capturedEnv = e
 	return host.provider(descriptor)
 }
@@ -1224,7 +1229,7 @@ func TestEnvMappingsPassedToHost(t *testing.T) {
 		},
 	}
 
-	r := NewRegistry(customHost, false, nil)
+	r := NewRegistry(newTestContext(customHost), false, nil)
 	require.NotNil(t, r)
 
 	typ := providers.MakeProviderType(tokens.Package("testPackage"))
@@ -1311,7 +1316,7 @@ func TestSameUpdateRace_UpdateFirst(t *testing.T) {
 	}
 	host := newPluginHost(t, []*providerLoader{loader})
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 
 	urn := resource.NewURN("test", "test", "", providers.MakeProviderType("pkgA"), "default")
 	id := resource.ID("id1")
@@ -1399,7 +1404,7 @@ func TestSameUpdateRace_SameFirst(t *testing.T) {
 	}
 	host := newPluginHost(t, []*providerLoader{loader})
 
-	r := NewRegistry(host, false, nil)
+	r := NewRegistry(newTestContext(host), false, nil)
 
 	urn := resource.NewURN("test", "test", "", providers.MakeProviderType("pkgA"), "default")
 	id := resource.ID("id1")
@@ -1498,7 +1503,7 @@ func TestSameUpdateRace_Concurrent(t *testing.T) {
 			}
 			host := newPluginHost(t, []*providerLoader{loader})
 
-			r := NewRegistry(host, false, nil)
+			r := NewRegistry(newTestContext(host), false, nil)
 
 			urn := resource.NewURN("test", "test", "", providers.MakeProviderType("pkgA"), "default")
 			id := resource.ID("id1")

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -58,16 +58,6 @@ func (host *testPluginHost) ServerAddr() string {
 	return ""
 }
 
-func (host *testPluginHost) LoaderAddr() string {
-	host.t.Fatalf("Loader RPC address not available")
-	return ""
-}
-
-func (host *testPluginHost) MapperAddr() string {
-	host.t.Fatalf("Mapper RPC address not available")
-	return ""
-}
-
 func (host *testPluginHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
 	host.t.Logf("[%v] %v@%v: %v", sev, urn, streamID, msg)
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -176,7 +176,7 @@ func newRunMapper(ctx context.Context, pctx *plugin.Context) (pconvert.Mapper, e
 	baseMapper, err := pconvert.NewBasePluginMapper(
 		pluginstorage.Instance,
 		"terraform",
-		pconvert.ProviderFactoryFromHost(ctx, pctx.Host),
+		pconvert.ProviderFactoryFromHost(ctx, pctx),
 		installPlugin,
 		nil, /*mappings*/
 	)
@@ -235,7 +235,7 @@ func (src *evalSource) Iterate(ctx context.Context, providers ProviderSource) (S
 	// Also start up a schema loader and a provider mapper for the language runtime to use to fetch
 	// schema and mapping information.
 	loaderRegistration := schema.LoaderRegistration(
-		schema.NewLoaderServer(schema.NewPluginLoader(src.plugctx.Host)))
+		schema.NewLoaderServer(schema.NewPluginLoader(src.plugctx)))
 
 	mapper, err := newRunMapper(ctx, src.plugctx)
 	if err != nil {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -165,7 +165,7 @@ func newRunMapper(ctx context.Context, pctx *plugin.Context) (pconvert.Mapper, e
 			Name: pluginName,
 			Kind: apitype.ResourcePlugin,
 		}
-		version, err := pkgWorkspace.InstallPlugin(pctx.Base(), pluginSpec, log, schema.NewLoaderServerFromHost)
+		version, err := pkgWorkspace.InstallPlugin(pctx.Base(), pluginSpec, log, schema.NewLoaderServerFromContext)
 		if err != nil {
 			log(diag.Warning, fmt.Sprintf("failed to install provider %q: %v", pluginName, err))
 			return nil

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -232,7 +232,7 @@ func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
 	return plugin.NewContext(t.Context(), sink, statusSink, host, nil, "", nil, false,
-		nil, schema.NewLoaderServerFromHost, nil, nil)
+		nil, schema.NewLoaderServerFromContext, nil, nil)
 }
 
 type testProviderSource struct {

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -734,10 +734,11 @@ func (eng *languageTestServer) RunLanguageTest(
 		Color: colors.Never,
 	})
 
-	// Start up a plugin context
+	// Start up a plugin context. No loader factory is passed here: the test host's own loader is
+	// started on this context below, once the host exists.
 	pctx, err := plugin.NewContextWithRoot(
 		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
-		nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
+		nil, nil, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -338,6 +338,7 @@ func (eng *languageTestServer) RequirePulumiVersion(ctx context.Context, req *pu
 type providerLoader struct {
 	language, languageInfo string
 
+	pctx *plugin.Context
 	host plugin.Host
 }
 
@@ -363,7 +364,7 @@ func (l *providerLoader) LoadPackageReferenceV2(
 		PluginDownloadURL: descriptor.DownloadURL,
 	}
 
-	provider, err := l.host.Provider(workspaceDescriptor, env.Global())
+	provider, err := l.host.Provider(l.pctx, workspaceDescriptor, env.Global())
 	if err != nil {
 		return nil, fmt.Errorf("could not load schema for %s: %w", descriptor.Name, err)
 	}
@@ -770,6 +771,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	loader := &providerLoader{
 		language:     token.LanguagePluginName,
 		languageInfo: token.LanguageInfo,
+		pctx:         pctx,
 		host:         host,
 	}
 	loaderServer := schema.NewLoaderServer(loader)

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -59,6 +59,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
@@ -547,7 +548,7 @@ func (eng *languageTestServer) PrepareLanguageTests(
 
 	// Start up a plugin context
 	pctx, err := plugin.NewContextWithRoot(ctx, snk, snk, nil, "", "", nil, false, nil, nil, nil, nil,
-		nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -736,7 +737,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	// Start up a plugin context
 	pctx, err := plugin.NewContextWithRoot(
 		ctx, snk, snk, nil, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
-		nil, schema.NewLoaderServerFromHost, convert.NewMapperServerFromHost, pkgWorkspace.EnsureLanguageInstalled)
+		nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext, pkgWorkspace.EnsureLanguageInstalled)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -775,13 +776,9 @@ func (eng *languageTestServer) RunLanguageTest(
 		host:         host,
 	}
 	loaderServer := schema.NewLoaderServer(loader)
-	grpcServer, err := plugin.NewServer(pctx, schema.LoaderRegistration(loaderServer))
-	if err != nil {
+	if err := pctx.StartLoader(func(*plugin.Context) codegenrpc.LoaderServer { return loaderServer }); err != nil {
 		return nil, err
 	}
-	defer contract.IgnoreClose(grpcServer)
-
-	host.loaderAddress = grpcServer.Addr()
 
 	// And fill that host with our test providers
 	for _, provider := range test.Providers {
@@ -839,7 +836,7 @@ func (eng *languageTestServer) RunLanguageTest(
 						},
 					},
 				}}
-				_, err = languageClient.Link(ctx, providerInfo, linkDeps, grpcServer.Addr())
+				_, err = languageClient.Link(ctx, providerInfo, linkDeps, pctx.LoaderAddr())
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("link program: %v", err)), nil
 				}
@@ -986,7 +983,7 @@ func (eng *languageTestServer) RunLanguageTest(
 				}
 
 				diags, err := languageClient.GeneratePackage(ctx,
-					sdkTempDir, string(schemaBytes), nil, grpcServer.Addr(), localDependencies, false)
+					sdkTempDir, string(schemaBytes), nil, pctx.LoaderAddr(), localDependencies, false)
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("generate package %s: %v", pkg.Name, err)), nil
 				}
@@ -1077,7 +1074,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	}
 
 	languageTestResult, err := runLanguageTests(ctx, token, req.Test, test, loader, packages,
-		sdks, localDependencies, languageClient, grpcServer,
+		sdks, localDependencies, languageClient,
 		eng.DisableSnapshotWriting, snapshotEdits, testBackend, stdout, stderr, pctx, "projects", eng.testdata)
 	if err != nil || !languageTestResult.Success || token.ConverterPluginTarget == "" || req.SkipConvertTests {
 		return languageTestResult, err
@@ -1123,7 +1120,7 @@ func (eng *languageTestServer) RunLanguageTest(
 	}
 
 	return runLanguageTests(ctx, ejectToken, req.Test, test, loader, packages,
-		sdks, localDependencies, ejectTestingClient, grpcServer,
+		sdks, localDependencies, ejectTestingClient,
 		eng.DisableSnapshotWriting, snapshotEdits, ejectTestBackend, stdout, stderr, pctx,
 		"round-tripped-project", eng.testdata)
 }
@@ -1176,7 +1173,7 @@ func createStackReferences(
 func runLanguageTests(
 	ctx context.Context, token testToken, testName string, test tests.LanguageTest,
 	loader schema.ReferenceLoader, packages []*schema.Package, sdks, localDependencies map[string]string,
-	languageClient plugin.LanguageRuntime, grpcServer *plugin.GrpcServer,
+	languageClient plugin.LanguageRuntime,
 	disableSnapshotWriting bool, snapshotEdits []compiledReplacement,
 	testBackend diy.Backend,
 	stdout, stderr *bytes.Buffer,
@@ -1259,7 +1256,7 @@ func runLanguageTests(
 					}
 
 					diags, err := languageClient.GeneratePackage(ctx,
-						sdkTargetDir, string(schemaBytes), nil, grpcServer.Addr(), localDependencies, false)
+						sdkTargetDir, string(schemaBytes), nil, pctx.LoaderAddr(), localDependencies, false)
 					if err != nil {
 						return makeTestResponse(fmt.Sprintf("generate package %s: %v", pkg.Name, err)), nil
 					}
@@ -1281,7 +1278,7 @@ func runLanguageTests(
 			} else {
 				diagnostics, err = languageClient.GenerateProject(
 					ctx,
-					sourceDir, projectDir, projectJSON, true, grpcServer.Addr(), localDependencies)
+					sourceDir, projectDir, projectJSON, true, pctx.LoaderAddr(), localDependencies)
 				if err != nil {
 					return makeTestResponse(fmt.Sprintf("generate project: %v", err)), nil
 				}
@@ -1597,7 +1594,7 @@ func runLanguageTests(
 					},
 				},
 			}}
-			_, err = languageClient.Link(ctx, policyInfo, linkDeps, grpcServer.Addr())
+			_, err = languageClient.Link(ctx, policyInfo, linkDeps, pctx.LoaderAddr())
 			if err != nil {
 				return makeTestResponse(fmt.Sprintf("link program: %v", err)), nil
 			}

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -102,12 +102,12 @@ func (h *testHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, st
 	panic("not implemented")
 }
 
-func (h *testHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
+func (h *testHost) Analyzer(ctx *plugin.Context, nm tokens.QName) (plugin.Analyzer, error) {
 	panic("not implemented")
 }
 
 func (h *testHost) PolicyAnalyzer(
-	name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
+	ctx *plugin.Context, name tokens.QName, path string, opts *plugin.PolicyAnalyzerOptions,
 ) (plugin.Analyzer, error) {
 	hasPlugin := func(spec workspace.PluginDescriptor) bool {
 		// This is only called for the language runtime, so we can just do a simple check.
@@ -121,7 +121,9 @@ func (h *testHost) PolicyAnalyzer(
 	return analyzer, nil
 }
 
-func (h *testHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+func (h *testHost) Provider(
+	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
+) (plugin.Provider, error) {
 	// If we've not been given a version, we'll try and find the provider by name alone, picking the latest if there are
 	// multiple versions of the named provider. Otherwise, we can attempt to find an exact match.
 	var key string
@@ -179,7 +181,7 @@ func (h *testHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (p
 
 // LanguageRuntime returns the language runtime initialized by the test host.
 // ProgramInfo is only used here for compatibility reasons and will be removed from this function.
-func (h *testHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
+func (h *testHost) LanguageRuntime(ctx *plugin.Context, runtime string) (plugin.LanguageRuntime, error) {
 	if runtime != h.runtimeName {
 		return nil, fmt.Errorf("unexpected runtime %s", runtime)
 	}
@@ -187,7 +189,7 @@ func (h *testHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, erro
 }
 
 func (h *testHost) ResolvePlugin(
-	spec workspace.PluginDescriptor,
+	ctx *plugin.Context, spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	if spec.Kind == apitype.ResourcePlugin {
 		for key, provider := range h.providers {
@@ -219,12 +221,6 @@ func (h *testHost) ResolvePlugin(
 		Kind:    spec.Kind,
 		Version: spec.Version,
 	}, nil
-}
-
-func (h *testHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	// We're not using project plugins, in fact this method shouldn't even really exists on Host given it's
-	// just reading off Pulumi.yaml.
-	return nil
 }
 
 func (h *testHost) SignalCancellation() error {

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -53,22 +53,12 @@ type testHost struct {
 	policies []plugin.Analyzer
 
 	closeMutex sync.Mutex
-
-	loaderAddress string
 }
 
 var _ plugin.Host = (*testHost)(nil)
 
 func (h *testHost) ServerAddr() string {
 	return h.engine.addr
-}
-
-func (h *testHost) LoaderAddr() string {
-	return h.loaderAddress
-}
-
-func (h *testHost) MapperAddr() string {
-	return ""
 }
 
 func (h *testHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -215,7 +215,7 @@ func InstallPluginAtPath(pctx *plugin.Context, proj *workspace.PluginProject, st
 	if err := proj.Validate(); err != nil {
 		return err
 	}
-	runtime, err := pctx.Host.LanguageRuntime(proj.Runtime.Name())
+	runtime, err := pctx.Host.LanguageRuntime(pctx, proj.Runtime.Name())
 	if err != nil {
 		return err
 	}

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -72,10 +72,32 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 	log func(sev diag.Severity, msg string),
 	newLoader plugin.NewLoaderFunc,
 ) (*semver.Version, error) {
-	util.SetKnownPluginDownloadURL(&pluginSpec)
+	downloadedFile, err := downloadPlugin(ctx, &pluginSpec, log)
+	if err != nil {
+		return nil, err
+	}
+
+	logging.V(1).Infof("Automatically installing provider %s", pluginSpec.Name)
+	err = InstallPluginContent(ctx, pluginSpec, pluginstorage.TarPlugin(downloadedFile), false, newLoader)
+	if err != nil {
+		return nil, &InstallPluginError{
+			Spec: pluginSpec,
+			Err:  fmt.Errorf("error installing provider %s: %w", pluginSpec.Name, err),
+		}
+	}
+
+	return pluginSpec.Version, nil
+}
+
+// downloadPlugin resolves the plugin's version, if unset, and downloads its archive to a file,
+// retrying and logging progress along the way.
+func downloadPlugin(
+	ctx context.Context, pluginSpec *workspace.PluginDescriptor, log func(sev diag.Severity, msg string),
+) (*os.File, error) {
+	util.SetKnownPluginDownloadURL(pluginSpec)
 	if pluginSpec.Version == nil {
 		var err error
-		pluginSpec.Version, err = pluginstorage.Instance.GetLatestVersion(ctx, pluginSpec)
+		pluginSpec.Version, err = pluginstorage.Instance.GetLatestVersion(ctx, *pluginSpec)
 		if err != nil {
 			return nil, fmt.Errorf("could not find latest version for provider %s: %w", pluginSpec.Name, err)
 		}
@@ -93,24 +115,14 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 	}
 
 	logging.V(1).Infof("Automatically downloading provider %s", pluginSpec.Name)
-	downloadedFile, err := workspace.DownloadToFile(ctx, pluginSpec, wrapper, retry)
+	downloadedFile, err := workspace.DownloadToFile(ctx, *pluginSpec, wrapper, retry)
 	if err != nil {
 		return nil, &InstallPluginError{
-			Spec: pluginSpec,
+			Spec: *pluginSpec,
 			Err:  fmt.Errorf("error downloading provider %s to file: %w", pluginSpec.Name, err),
 		}
 	}
-
-	logging.V(1).Infof("Automatically installing provider %s", pluginSpec.Name)
-	err = InstallPluginContent(ctx, pluginSpec, pluginstorage.TarPlugin(downloadedFile), false, newLoader)
-	if err != nil {
-		return nil, &InstallPluginError{
-			Spec: pluginSpec,
-			Err:  fmt.Errorf("error installing provider %s: %w", pluginSpec.Name, err),
-		}
-	}
-
-	return pluginSpec.Version, nil
+	return downloadedFile, nil
 }
 
 // EnsureLanguageInstalled downloads and installs the named language runtime if it is not
@@ -121,7 +133,7 @@ func InstallPlugin(ctx context.Context, pluginSpec workspace.PluginDescriptor,
 // It satisfies plugin.LanguageInstaller and is wired into the plugin host at construction so
 // that every load of a language runtime through a default host triggers the install, rather
 // than each caller of Host.LanguageRuntime having to ensure the plugin is present.
-func EnsureLanguageInstalled(ctx context.Context, runtime string, newLoader plugin.NewLoaderFunc) error {
+func EnsureLanguageInstalled(ctx context.Context, runtime string) error {
 	if runtime == "" {
 		return nil
 	}
@@ -144,8 +156,29 @@ func EnsureLanguageInstalled(ctx context.Context, runtime string, newLoader plug
 	log := func(sev diag.Severity, msg string) {
 		logging.V(7).Infof("EnsureLanguageInstalled(%s): %s", runtime, msg)
 	}
-	_, err := InstallPlugin(ctx, spec, log, newLoader)
-	return err
+
+	// Language hosts are self-contained executables, shared across workspaces and never run with
+	// the support of another language runtime (which would be a bootstrapping cycle). Installing
+	// one is therefore a plain download-and-unpack with no dependency-install step.
+	downloadedFile, err := downloadPlugin(ctx, &spec, log)
+	if err != nil {
+		return err
+	}
+	logging.V(1).Infof("Automatically installing language runtime %s", runtime)
+	done, err := pluginstorage.UnpackContents(ctx, spec, pluginstorage.TarPlugin(downloadedFile), false)
+	if err != nil {
+		return &InstallPluginError{Spec: spec, Err: fmt.Errorf("error installing language runtime %s: %w", runtime, err)}
+	}
+	done(true)
+
+	if dir, err := spec.DirPath(); err == nil {
+		pluginYaml := filepath.Join(dir, spec.SubDir(), "PulumiPlugin.yaml")
+		if _, err := os.Stat(pluginYaml); err == nil {
+			logging.Warningf("language runtime %s ships a PulumiPlugin.yaml; language hosts must be "+
+				"self-contained executables, so its dependencies will not be installed", runtime)
+		}
+	}
+	return nil
 }
 
 // InstallPluginContent installs a plugin's tarball into the cache, then installs it's
@@ -201,7 +234,7 @@ func installDependenciesForPluginSpec(
 		nil, // config
 		nil, // debugging
 		newLoader,
-		convert.NewMapperServerFromHost,
+		convert.NewMapperServerFromContext,
 		EnsureLanguageInstalled,
 	)
 	if err != nil {

--- a/pkg/workspace/plugin_test.go
+++ b/pkg/workspace/plugin_test.go
@@ -155,7 +155,7 @@ func TestEnsureLanguageInstalledUsesPathPlugin(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err = EnsureLanguageInstalled(ctx, "hcl", nil)
+	err = EnsureLanguageInstalled(ctx, "hcl")
 
 	require.NoError(t, err, "EnsureLanguageInstalled should reuse the runtime on $PATH, not download it")
 }

--- a/sdk/go/common/resource/plugin/analyzer_plugin.go
+++ b/sdk/go/common/resource/plugin/analyzer_plugin.go
@@ -75,7 +75,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 			Name: strings.ReplaceAll(string(name), tokens.QNameDelimiter, "_"),
 			Kind: apitype.AnalyzerPlugin,
 		},
-		host.GetProjectPlugins())
+		ctx.ProjectPlugins())
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	}
@@ -152,7 +152,7 @@ func NewPolicyAnalyzer(
 				ctx.baseContext,
 				ctx.Diag,
 				spec,
-				host.GetProjectPlugins())
+				ctx.ProjectPlugins())
 			return err == nil && path != ""
 		}
 	}
@@ -168,7 +168,7 @@ func NewPolicyAnalyzer(
 		var pluginPath string
 		pluginPath, err = workspace.GetPluginPath(
 			ctx.baseContext, ctx.Diag,
-			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, host.GetProjectPlugins())
+			workspace.PluginDescriptor{Name: policyAnalyzerName, Kind: apitype.AnalyzerPlugin}, ctx.ProjectPlugins())
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -53,12 +53,53 @@ type Context struct {
 
 	cancel      context.CancelFunc
 	baseContext context.Context
+
+	// Per-workspace state used when booting plugins. A Host is stateless with respect to
+	// workspaces; each Host method takes a Context and reads this state from it, so a single
+	// host can serve plugins for many workspaces.
+	runtimeOptions         map[string]any
+	disableProviderPreview bool
+	config                 map[config.Key]string
+	projectName            tokens.PackageName
+	projectPlugins         []workspace.ProjectPlugin
+
+	// ownsHost is true when this context constructed its own (default) host. Context.Close
+	// only closes the host it owns; hosts passed in by the caller are caller-owned and must
+	// be closed by the caller.
+	ownsHost bool
 }
 
-// NewContext allocates a new context with a given sink and host. Note
-// that the host is "owned" by this context from here forwards, such
-// that when the context's resources are reclaimed, so too are the
-// host's.
+// RuntimeOptions returns the runtime options of the project this context was built for, passed
+// to resource providers to support dynamic providers.
+func (ctx *Context) RuntimeOptions() map[string]any {
+	return ctx.runtimeOptions
+}
+
+// DisableProviderPreview returns true if provider plugins booted via this context should have
+// previews disabled.
+func (ctx *Context) DisableProviderPreview() bool {
+	return ctx.disableProviderPreview
+}
+
+// Config returns the stack configuration this context was built with, if any.
+func (ctx *Context) Config() map[config.Key]string {
+	return ctx.config
+}
+
+// ProjectName returns the name of the project this context was built for, if any.
+func (ctx *Context) ProjectName() tokens.PackageName {
+	return ctx.projectName
+}
+
+// ProjectPlugins returns the plugins defined by the project this context was built for. These
+// take precedence over installed plugins when resolving plugin binaries.
+func (ctx *Context) ProjectPlugins() []workspace.ProjectPlugin {
+	return ctx.projectPlugins
+}
+
+// NewContext allocates a new context with a given sink and host. If host is nil a default host
+// is constructed and owned by the returned context: closing the context closes the host. A
+// non-nil host is owned by the caller and is not closed with the context.
 func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSource,
 	pwd string, runtimeOptions map[string]any, disableProviderPreview bool,
 	parentSpan opentracing.Span, newLoader NewLoaderFunc, newMapper NewMapperFunc,
@@ -108,25 +149,36 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	ctx, cancel := context.WithCancel(ctx)
 
 	pctx := &Context{
-		Diag:            d,
-		StatusDiag:      statusD,
-		Host:            host,
-		Pwd:             pwd,
-		Root:            root,
-		tracingSpan:     parentSpan,
-		DebugTraceMutex: &sync.Mutex{},
-		baseContext:     ctx,
-		cancel:          cancel,
+		Diag:                   d,
+		StatusDiag:             statusD,
+		Host:                   host,
+		Pwd:                    pwd,
+		Root:                   root,
+		tracingSpan:            parentSpan,
+		DebugTraceMutex:        &sync.Mutex{},
+		baseContext:            ctx,
+		cancel:                 cancel,
+		runtimeOptions:         runtimeOptions,
+		disableProviderPreview: disableProviderPreview,
+		config:                 config,
+		projectName:            projectName,
 	}
+
+	projectPlugins, err := projectPluginsFromProject(pctx, plugins, packages)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	pctx.projectPlugins = projectPlugins
+
 	if host == nil {
-		h, err := NewDefaultHost(
-			pctx, runtimeOptions, disableProviderPreview, plugins, packages, config, debugging, projectName,
-			newLoader, newMapper, installLang,
-		)
+		h, err := NewDefaultHost(pctx, debugging, newLoader, newMapper, installLang)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		pctx.Host = h
+		pctx.ownsHost = true
 	}
 
 	if logFile := env.DebugGRPC.Value(); logFile != "" {
@@ -149,8 +201,8 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 
 // NewContextWithHost creates a new [Context] without interacting with global state.
 //
-// Unilke [NewDefaultContext] or [NewContextWithRoot], NewContextWithHost does not accept
-// a nil host.
+// Unlike [NewContext] or [NewContextWithRoot], NewContextWithHost does not accept a nil host.
+// The host is owned by the caller: closing the returned context does not close the host.
 //
 // d, statusD and parentSpan may all be nil.
 func NewContextWithHost(
@@ -194,11 +246,17 @@ func (ctx *Context) Request() context.Context {
 	return opentracing.ContextWithSpan(ctx.baseContext, ctx.tracingSpan)
 }
 
-// Close reclaims all resources associated with this context.
+// Close reclaims all resources associated with this context. The host is only closed if this
+// context constructed it (a default host built because no host was passed in); a host supplied
+// by the caller is caller-owned and must be closed separately, since a single host may be
+// shared by several contexts.
 func (ctx *Context) Close() error {
 	defer ctx.cancel()
 	if ctx.tracingSpan != nil {
 		ctx.tracingSpan.Finish()
+	}
+	if !ctx.ownsHost {
+		return nil
 	}
 	err := ctx.Host.Close()
 	if err != nil && !rpcutil.IsBenignCloseErr(err) {

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -246,10 +246,10 @@ func (ctx *Context) Request() context.Context {
 	return opentracing.ContextWithSpan(ctx.baseContext, ctx.tracingSpan)
 }
 
-// Close reclaims all resources associated with this context. The host is only closed if this
-// context constructed it (a default host built because no host was passed in); a host supplied
-// by the caller is caller-owned and must be closed separately, since a single host may be
-// shared by several contexts.
+// Close reclaims all resources associated with this context. The host itself is only closed if
+// this context constructed it (a default host built because no host was passed in); a host
+// supplied by the caller is caller-owned and must be closed separately, since a single host may
+// be shared by several contexts.
 func (ctx *Context) Close() error {
 	defer ctx.cancel()
 	if ctx.tracingSpan != nil {

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -28,9 +28,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	interceptors "github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/rpcdebug"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 // Context is used to group related operations together so that
@@ -67,6 +69,64 @@ type Context struct {
 	// only closes the host it owns; hosts passed in by the caller are caller-owned and must
 	// be closed by the caller.
 	ownsHost bool
+
+	// loaderServer serves the schema loader bound to this context's workspace view, if any.
+	// The loader is a workspace service, not a host service: it boots plugins to load
+	// schemas, and which plugins resolve depends on the workspace. It dies with the context.
+	loaderServer *GrpcServer
+
+	// mapperServer serves the conversion mapper bound to this context's workspace view, if
+	// any. Like the loader, the mapper is a workspace service: it boots plugins to source
+	// mappings, and which plugins resolve depends on the workspace. It dies with the context.
+	mapperServer *GrpcServer
+}
+
+// LoaderAddr returns the address of the schema loader service bound to this context, or the
+// empty string if the context has none.
+func (ctx *Context) LoaderAddr() string {
+	if ctx.loaderServer == nil {
+		return ""
+	}
+	return ctx.loaderServer.Addr()
+}
+
+// StartLoader starts a schema loader service bound to this context's workspace view. The
+// service is shut down when the context is closed. A context may have at most one loader;
+// contexts constructed with a non-nil NewLoaderFunc already have one.
+func (ctx *Context) StartLoader(newLoader NewLoaderFunc) error {
+	contract.Assertf(ctx.loaderServer == nil, "context already has a loader")
+	server, err := NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterLoaderServer(srv, newLoader(ctx))
+	})
+	if err != nil {
+		return err
+	}
+	ctx.loaderServer = server
+	return nil
+}
+
+// MapperAddr returns the address of the conversion mapper service bound to this context, or
+// the empty string if the context has none.
+func (ctx *Context) MapperAddr() string {
+	if ctx.mapperServer == nil {
+		return ""
+	}
+	return ctx.mapperServer.Addr()
+}
+
+// StartMapper starts a conversion mapper service bound to this context's workspace view. The
+// service is shut down when the context is closed. A context may have at most one mapper;
+// contexts constructed with a non-nil NewMapperFunc already have one.
+func (ctx *Context) StartMapper(newMapper NewMapperFunc) error {
+	contract.Assertf(ctx.mapperServer == nil, "context already has a mapper")
+	server, err := NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterMapperServer(srv, newMapper(ctx))
+	})
+	if err != nil {
+		return err
+	}
+	ctx.mapperServer = server
+	return nil
 }
 
 // RuntimeOptions returns the runtime options of the project this context was built for, passed
@@ -172,13 +232,27 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	pctx.projectPlugins = projectPlugins
 
 	if host == nil {
-		h, err := NewDefaultHost(pctx, debugging, newLoader, newMapper, installLang)
+		h, err := NewDefaultHost(pctx, debugging, installLang)
 		if err != nil {
 			cancel()
 			return nil, err
 		}
 		pctx.Host = h
 		pctx.ownsHost = true
+	}
+
+	if newLoader != nil {
+		if err := pctx.StartLoader(newLoader); err != nil {
+			contract.IgnoreClose(pctx)
+			return nil, err
+		}
+	}
+
+	if newMapper != nil {
+		if err := pctx.StartMapper(newMapper); err != nil {
+			contract.IgnoreClose(pctx)
+			return nil, err
+		}
 	}
 
 	if logFile := env.DebugGRPC.Value(); logFile != "" {
@@ -254,6 +328,16 @@ func (ctx *Context) Close() error {
 	defer ctx.cancel()
 	if ctx.tracingSpan != nil {
 		ctx.tracingSpan.Finish()
+	}
+	if ctx.loaderServer != nil {
+		if err := ctx.loaderServer.Close(); err != nil && !rpcutil.IsBenignCloseErr(err) {
+			logging.V(5).Infof("Error closing the context's loader service; ignoring: %v", err)
+		}
+	}
+	if ctx.mapperServer != nil {
+		if err := ctx.mapperServer.Close(); err != nil && !rpcutil.IsBenignCloseErr(err) {
+			logging.V(5).Infof("Error closing the context's mapper service; ignoring: %v", err)
+		}
 	}
 	if !ctx.ownsHost {
 		return nil

--- a/sdk/go/common/resource/plugin/converter_plugin.go
+++ b/sdk/go/common/resource/plugin/converter_plugin.go
@@ -48,7 +48,7 @@ func NewConverter(ctx *Context, name string, version *semver.Version) (Converter
 	path, err := workspace.GetPluginPath(
 		ctx.baseContext, ctx.Diag,
 		workspace.PluginDescriptor{Name: name, Version: version, Kind: apitype.ConverterPlugin},
-		ctx.Host.GetProjectPlugins())
+		ctx.ProjectPlugins())
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -40,6 +40,11 @@ import (
 )
 
 // A Host hosts provider plugins and makes them easily accessible by package name.
+//
+// A host is stateless with respect to workspaces: methods that boot or resolve plugins take a
+// [Context] carrying the per-workspace state (working directory, project plugins, stack
+// configuration, and so on), so a single host may be shared by several contexts. The host is
+// not owned by any context it is used with; it must be closed by whoever constructed it.
 type Host interface {
 	// ServerAddr returns the address at which the host's RPC interface may be found.
 	ServerAddr() string
@@ -63,25 +68,25 @@ type Host interface {
 	// Analyzer fetches the analyzer with a given name, possibly lazily allocating the plugins for
 	// it.  If an analyzer could not be found, or an error occurred while creating it, a non-nil
 	// error is returned.
-	Analyzer(nm tokens.QName) (Analyzer, error)
+	Analyzer(ctx *Context, nm tokens.QName) (Analyzer, error)
 
 	// PolicyAnalyzer boots the nodejs analyzer plugin located at a given path. This is useful
 	// because policy analyzers generally do not need to be "discovered" -- the engine is given a
 	// set of policies that are required to be run during an update, so they tend to be in a
 	// well-known place.
-	PolicyAnalyzer(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
+	PolicyAnalyzer(ctx *Context, name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
 
 	// Provider loads a new copy of the provider for a given package.  If a provider for this package could not be
-	// found, or an error occurs while creating it, a non-nil error is returned.
-	Provider(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
+	// found, or an error occurs while creating it, a non-nil error is returned. The provider is booted with the
+	// workspace state carried by ctx (stack configuration, runtime options, project name).
+	Provider(ctx *Context, descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
 	// LanguageRuntime fetches the language runtime plugin for a given language, lazily allocating if necessary.  If
 	// an implementation of this language runtime wasn't found, on an error occurs, a non-nil error is returned.
-	LanguageRuntime(runtime string) (LanguageRuntime, error)
+	LanguageRuntime(ctx *Context, runtime string) (LanguageRuntime, error)
 
-	// ResolvePlugin resolves a pluginspec to a candidate plugin to load.
-	ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
-
-	GetProjectPlugins() []workspace.ProjectPlugin
+	// ResolvePlugin resolves a pluginspec to a candidate plugin to load, consulting the project
+	// plugins carried by ctx.
+	ResolvePlugin(ctx *Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 
 	// SignalCancellation asks all resource providers to gracefully shut down and abort any ongoing
 	// operations. Operation aborted in this way will return an error (e.g., `Update` and `Create`
@@ -178,9 +183,13 @@ func collectPluginsFromPackages(
 	return result, nil
 }
 
-type NewLoaderFunc = func(h Host) codegenrpc.LoaderServer
+// NewLoaderFunc constructs the loader service registered on a host's RPC server. The Context
+// supplies the workspace view the loader resolves and boots plugins against.
+type NewLoaderFunc = func(h Host, ctx *Context) codegenrpc.LoaderServer
 
-type NewMapperFunc = func(ctx context.Context, h Host) codegenrpc.MapperServer
+// NewMapperFunc constructs the mapper service registered on a host's RPC server. The Context
+// supplies the workspace view the mapper boots conversion plugins against.
+type NewMapperFunc = func(h Host, ctx *Context) codegenrpc.MapperServer
 
 // LanguageInstaller downloads and installs an unbundled language runtime on demand, so that
 // loading it via Host.LanguageRuntime works even when the runtime is not bundled with the CLI
@@ -192,13 +201,11 @@ type NewMapperFunc = func(ctx context.Context, h Host) codegenrpc.MapperServer
 // disables on-demand install (the host then relies on the runtime already being present).
 type LanguageInstaller = func(ctx context.Context, runtime string, newLoader NewLoaderFunc) error
 
-// NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
-func NewDefaultHost(ctx *Context, runtimeOptions map[string]any,
-	disableProviderPreview bool, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, debugging DebugContext, projectName tokens.PackageName,
-	newLoader NewLoaderFunc, newMapper NewMapperFunc, installLang LanguageInstaller,
-) (Host, error) {
-	// Create plugin info from providers
+// projectPluginsFromProject parses the plugins and packages declared by a project into the list
+// of project plugins that take precedence over installed plugins when resolving plugin binaries.
+func projectPluginsFromProject(
+	ctx *Context, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
+) ([]workspace.ProjectPlugin, error) {
 	projectPlugins := make([]workspace.ProjectPlugin, 0)
 	if plugins != nil {
 		for _, providerOpts := range plugins.Providers {
@@ -228,23 +235,31 @@ func NewDefaultHost(ctx *Context, runtimeOptions map[string]any,
 	if err != nil {
 		return nil, err
 	}
-	projectPlugins = append(projectPlugins, pluginsFromPackages...)
+	return append(projectPlugins, pluginsFromPackages...), nil
+}
 
+// NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
+//
+// ctx is only used to wire up the host's RPC server and logging; the host does not retain it.
+// Per-workspace state (project plugins, stack configuration, and so on) is carried by the
+// Context passed to each host method, so the host may be shared across workspaces. The host is
+// owned by ctx if ctx was constructed with a nil host, and by the caller otherwise.
+func NewDefaultHost(
+	ctx *Context, debugging DebugContext, newLoader NewLoaderFunc, newMapper NewMapperFunc,
+	installLang LanguageInstaller,
+) (Host, error) {
 	host := &defaultHost{
-		ctx:                     ctx,
-		runtimeOptions:          runtimeOptions,
-		analyzerPlugins:         make(map[tokens.QName]*analyzerPlugin),
-		languagePlugins:         make(map[string]*languagePlugin),
-		resourcePlugins:         make(map[Provider]*resourcePlugin),
-		reportedResourcePlugins: make(map[string]struct{}),
+		diag:                    ctx.Diag,
+		statusDiag:              ctx.StatusDiag,
+		shutdownCtx:             context.WithoutCancel(ctx.Request()),
+		analyzerPlugins:         map[string]*analyzerPlugin{},
+		languagePlugins:         map[languagePluginKey]*languagePlugin{},
+		resourcePlugins:         map[Provider]*resourcePlugin{},
+		reportedResourcePlugins: map[string]struct{}{},
 		languageLoadRequests:    make(chan pluginLoadRequest),
 		loadRequests:            make(chan pluginLoadRequest),
-		disableProviderPreview:  disableProviderPreview,
-		config:                  config,
 		closer:                  new(sync.Once),
-		projectPlugins:          projectPlugins,
 		debugContext:            debugging,
-		projectName:             projectName,
 		hasLoaderServer:         newLoader != nil,
 		newLoader:               newLoader,
 		hasMapperServer:         newMapper != nil,
@@ -350,27 +365,27 @@ type pluginLoadRequest struct {
 }
 
 type defaultHost struct {
-	ctx *Context // the shared context for this host.
+	diag       diag.Sink // the sink to use for diagnostics, e.g. plugins logging through the host.
+	statusDiag diag.Sink // the sink to use for status messages.
 
-	// the runtime options for the project, passed to resource providers to support dynamic providers.
-	runtimeOptions          map[string]any
-	analyzerPlugins         map[tokens.QName]*analyzerPlugin // a cache of analyzer plugins and their processes.
-	languagePlugins         map[string]*languagePlugin       // a cache of language plugins and their processes.
-	resourcePlugins         map[Provider]*resourcePlugin     // the set of loaded resource plugins.
-	reportedResourcePlugins map[string]struct{}              // the set of unique resource plugins we'll report.
-	languageLoadRequests    chan pluginLoadRequest           // a channel used to satisfy language load requests.
-	loadRequests            chan pluginLoadRequest           // a channel used to satisfy plugin load requests.
-	server                  *hostServer                      // the server's RPC machinery.
-	disableProviderPreview  bool                             // true if provider plugins should disable provider preview
-	config                  map[config.Key]string            // the configuration map for the stack, if any.
-	projectName             tokens.PackageName               // name of the project
+	// the parent context for plugin shutdown RPCs. It preserves the active tracing span of the
+	// context the host was built with but strips cancellation, so shutdown still gets its
+	// timeout budget even if that context has already been cancelled.
+	shutdownCtx context.Context
+
+	analyzerPlugins         map[string]*analyzerPlugin            // a cache of analyzer plugins and their processes.
+	languagePlugins         map[languagePluginKey]*languagePlugin // a cache of language plugins and their processes.
+	resourcePlugins         map[Provider]*resourcePlugin          // the set of loaded resource plugins.
+	reportedResourcePlugins map[string]struct{}                   // the set of unique resource plugins we'll report.
+	languageLoadRequests    chan pluginLoadRequest                // a channel used to satisfy language load requests.
+	loadRequests            chan pluginLoadRequest                // a channel used to satisfy plugin load requests.
+	server                  *hostServer                           // the server's RPC machinery.
 	debugContext            DebugContext
 
 	// Used to synchronize shutdown with in-progress plugin loads.
 	pluginLock sync.RWMutex
 
-	closer         *sync.Once
-	projectPlugins []workspace.ProjectPlugin
+	closer *sync.Once
 
 	hasLoaderServer bool
 	newLoader       NewLoaderFunc // the loader the host was built with, passed to installLang.
@@ -384,6 +399,14 @@ type analyzerPlugin struct {
 	Plugin Analyzer
 	Info   PluginInfo
 	Name   string
+}
+
+// languagePluginKey identifies a booted language plugin. The working directory is part of the
+// key because language plugins are spawned in the workspace's working directory: a host shared
+// across workspaces must not serve one workspace's language process to another.
+type languagePluginKey struct {
+	runtime          string
+	workingDirectory string
 }
 
 type languagePlugin struct {
@@ -417,11 +440,11 @@ func (host *defaultHost) MapperAddr() string {
 }
 
 func (host *defaultHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.ctx.Diag.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	host.diag.Logf(sev, diag.StreamMessage(urn, msg, streamID))
 }
 
 func (host *defaultHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.ctx.StatusDiag.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	host.statusDiag.Logf(sev, diag.StreamMessage(urn, msg, streamID))
 }
 
 func (host *defaultHost) StartDebugging(info DebuggingInfo) error {
@@ -460,24 +483,27 @@ func (host *defaultHost) loadPlugin(
 	return plugin, <-result
 }
 
-func (host *defaultHost) Analyzer(name tokens.QName) (Analyzer, error) {
+func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, error) {
+	// Analyzers are spawned in the workspace's working directory and resolved against its
+	// project plugins, so the cache key must identify the workspace as well as the analyzer.
+	key := fmt.Sprintf("analyzer\x00%s\x00%s", name, ctx.Pwd)
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
-		if plug, has := host.analyzerPlugins[name]; has {
+		if plug, has := host.analyzerPlugins[key]; has {
 			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
 			return plug.Plugin, nil
 		}
 
 		// If not, try to load and bind to a plugin.
-		plug, err := NewAnalyzer(host, host.ctx, name)
+		plug, err := NewAnalyzer(host, ctx, name)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
+			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
 
 			// Memoize the result.
-			host.analyzerPlugins[name] = &analyzerPlugin{Plugin: plug, Info: info, Name: string(name)}
+			host.analyzerPlugins[key] = &analyzerPlugin{Plugin: plug, Info: info, Name: string(name)}
 		}
 
 		return plug, err
@@ -488,24 +514,35 @@ func (host *defaultHost) Analyzer(name tokens.QName) (Analyzer, error) {
 	return plugin.(Analyzer), nil
 }
 
-func (host *defaultHost) PolicyAnalyzer(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error) {
+func (host *defaultHost) PolicyAnalyzer(
+	ctx *Context, name tokens.QName, path string, opts *PolicyAnalyzerOptions,
+) (Analyzer, error) {
+	// The options are part of the cache key: they configure the analyzer process (stack,
+	// configuration, environment), so a cached analyzer may only be reused for a call that
+	// would boot an identical one. fmt prints maps with sorted keys, making the
+	// representation deterministic.
+	optsKey := ""
+	if opts != nil {
+		optsKey = fmt.Sprintf("%v", *opts)
+	}
+	key := fmt.Sprintf("policy\x00%s\x00%s\x00%s", name, path, optsKey)
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
-		if plug, has := host.analyzerPlugins[name]; has {
+		if plug, has := host.analyzerPlugins[key]; has {
 			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
 			return plug.Plugin, nil
 		}
 
 		// If not, try to load and bind to a plugin.
-		plug, err := NewPolicyAnalyzer(host, host.ctx, name, path, opts, nil)
+		plug, err := NewPolicyAnalyzer(host, ctx, name, path, opts, nil)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
+			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
 
 			// Memoize the result.
-			host.analyzerPlugins[name] = &analyzerPlugin{Plugin: plug, Info: info}
+			host.analyzerPlugins[key] = &analyzerPlugin{Plugin: plug, Info: info, Name: string(name)}
 		}
 
 		return plug, err
@@ -516,7 +553,7 @@ func (host *defaultHost) PolicyAnalyzer(name tokens.QName, path string, opts *Po
 	return plugin.(Analyzer), nil
 }
 
-func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {
+func (host *defaultHost) Provider(ctx *Context, descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		pkg := descriptor.Name
 		version := descriptor.Version
@@ -524,7 +561,7 @@ func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor, e env.E
 		// Try to load and bind to a plugin.
 
 		result := make(map[string]string)
-		for k, v := range host.config {
+		for k, v := range ctx.Config() {
 			if k.Namespace() != pkg {
 				continue
 			}
@@ -535,10 +572,10 @@ func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor, e env.E
 			return nil, fmt.Errorf("Could not marshal config to JSON: %w", err)
 		}
 		plug, err := NewProvider(
-			host, host.ctx, descriptor,
-			host.runtimeOptions, host.disableProviderPreview, string(jsonConfig), host.projectName, e)
+			host, ctx, descriptor,
+			ctx.RuntimeOptions(), ctx.DisableProviderPreview(), string(jsonConfig), ctx.ProjectName(), e)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
+			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
@@ -550,7 +587,7 @@ func (host *defaultHost) Provider(descriptor workspace.PluginDescriptor, e env.E
 					if info.Version != nil {
 						v = info.Version.String()
 					}
-					host.ctx.Diag.Warningf(
+					ctx.Diag.Warningf(
 						diag.Message("", /*urn*/
 							"resource plugin %s is expected to have version >=%s, but has %s; "+
 								"the wrong version may be on your path, or this may be a bug in the plugin"),
@@ -588,17 +625,6 @@ type hostManagedProvider struct {
 	host *defaultHost
 }
 
-// shutdownParentContext returns the context to use as the parent for plugin shutdown RPCs
-// (Cancel, SignalCancellation). It preserves the active OTel / OpenTracing span from the plugin
-// Context so those RPCs appear as children of the current operation rather than emitting fresh
-// root spans, but strips cancellation — shutdown still gets its timeout budget even if the caller
-// context has already been cancelled. Falls back to context.Background() when the plugin Context
-// has no base, which happens in tests that construct Context literals directly.
-func shutdownParentContext(ctx *Context) context.Context {
-	base := ctx.Request()
-	return context.WithoutCancel(base)
-}
-
 // Overrides the wrapped provider's implementation of Provider.Close to ask the managing plugin host to close the
 // provider.
 func (pc hostManagedProvider) Close() error {
@@ -606,7 +632,7 @@ func (pc hostManagedProvider) Close() error {
 	// Plugin.Close does not treat the subsequent exit as a premature crash. defaultHost.Close does the same for
 	// providers still in resourcePlugins at shutdown, but callers that Close individual providers (e.g. the
 	// convert mapper) bypass that path.
-	cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(pc.host.ctx), 5*time.Second)
+	cancelCtx, cancelCancel := context.WithTimeout(pc.host.shutdownCtx, 5*time.Second)
 	defer cancelCancel()
 	contract.IgnoreError(pc.SignalCancellation(cancelCtx))
 
@@ -621,33 +647,34 @@ func (pc hostManagedProvider) Close() error {
 	return err
 }
 
-func (host *defaultHost) LanguageRuntime(runtime string,
+func (host *defaultHost) LanguageRuntime(ctx *Context, runtime string,
 ) (LanguageRuntime, error) {
+	key := languagePluginKey{runtime: runtime, workingDirectory: ctx.Pwd}
 	// Language runtimes use their own loading channel not the main one
 	plugin, err := host.loadPlugin(host.languageLoadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
-		if plug, has := host.languagePlugins[runtime]; has {
+		if plug, has := host.languagePlugins[key]; has {
 			contract.Assertf(plug != nil, "language plugin %v was loaded but is nil", runtime)
 			return plug.Plugin, nil
 		}
 
 		// Download and install the language runtime on demand if it is unbundled and missing.
 		if host.installLang != nil {
-			if err := host.installLang(host.ctx.Request(), runtime, host.newLoader); err != nil {
+			if err := host.installLang(ctx.Request(), runtime, host.newLoader); err != nil {
 				return nil, fmt.Errorf("failed to install language plugin %s: %w", runtime, err)
 			}
 		}
 
 		// If not, allocate a new one.
-		plug, err := NewLanguageRuntime(host, host.ctx, runtime, host.ctx.Pwd)
+		plug, err := NewLanguageRuntime(host, ctx, runtime, ctx.Pwd)
 		if err == nil && plug != nil {
-			info, infoerr := plug.GetPluginInfo(host.ctx.Request())
+			info, infoerr := plug.GetPluginInfo(ctx.Request())
 			if infoerr != nil {
 				return nil, infoerr
 			}
 
 			// Memoize the result.
-			host.languagePlugins[runtime] = &languagePlugin{Plugin: plug, Info: info, Name: runtime}
+			host.languagePlugins[key] = &languagePlugin{Plugin: plug, Info: info, Name: runtime}
 		}
 
 		return plug, err
@@ -658,18 +685,14 @@ func (host *defaultHost) LanguageRuntime(runtime string,
 	return plugin.(LanguageRuntime), nil
 }
 
-func (host *defaultHost) ResolvePlugin(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
-	return workspace.GetPluginInfo(host.ctx.baseContext, host.ctx.Diag, spec, host.GetProjectPlugins())
-}
-
-func (host *defaultHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	return host.projectPlugins
+func (host *defaultHost) ResolvePlugin(ctx *Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+	return workspace.GetPluginInfo(ctx.baseContext, ctx.Diag, spec, ctx.ProjectPlugins())
 }
 
 func (host *defaultHost) SignalCancellation() error {
 	// NOTE: we're abusing loadPlugin in order to ensure proper synchronization.
 	_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-		cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(host.ctx), 30*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(host.shutdownCtx, 30*time.Second)
 		defer cancelCancel()
 
 		// Cancel in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based providers
@@ -728,7 +751,7 @@ func (host *defaultHost) Close() (err error) {
 		host.pluginLock.Lock()
 		// N.B We purposefully do not unlock this.
 
-		cancelCtx, cancelCancel := context.WithTimeout(shutdownParentContext(host.ctx), 5*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(host.shutdownCtx, 5*time.Second)
 		defer cancelCancel()
 
 		// Close plugins in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based
@@ -765,9 +788,9 @@ func (host *defaultHost) Close() (err error) {
 		wg.Wait()
 
 		// Empty out all maps.
-		host.analyzerPlugins = make(map[tokens.QName]*analyzerPlugin)
-		host.languagePlugins = make(map[string]*languagePlugin)
-		host.resourcePlugins = make(map[Provider]*resourcePlugin)
+		host.analyzerPlugins = map[string]*analyzerPlugin{}
+		host.languagePlugins = map[languagePluginKey]*languagePlugin{}
+		host.resourcePlugins = map[Provider]*resourcePlugin{}
 
 		// Shut down the plugin loader.
 		close(host.languageLoadRequests)

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -48,13 +49,6 @@ import (
 type Host interface {
 	// ServerAddr returns the address at which the host's RPC interface may be found.
 	ServerAddr() string
-
-	// LoaderAddr returns the address at which a plugin loader service may be found.
-	LoaderAddr() string
-
-	// MapperAddr returns the address at which a mapper service may be found, or an empty string if the host was not
-	// built with a mapper.
-	MapperAddr() string
 
 	// Log logs a message, including errors and warnings.  Messages can have a resource URN
 	// associated with them.  If no urn is provided, the message is global.
@@ -183,23 +177,25 @@ func collectPluginsFromPackages(
 	return result, nil
 }
 
-// NewLoaderFunc constructs the loader service registered on a host's RPC server. The Context
-// supplies the workspace view the loader resolves and boots plugins against.
-type NewLoaderFunc = func(h Host, ctx *Context) codegenrpc.LoaderServer
+// NewLoaderFunc constructs the schema loader service bound to a context. The Context supplies
+// the workspace view the loader resolves and boots plugins against.
+type NewLoaderFunc = func(ctx *Context) codegenrpc.LoaderServer
 
-// NewMapperFunc constructs the mapper service registered on a host's RPC server. The Context
+// NewMapperFunc constructs the conversion mapper service bound to a context. The Context
 // supplies the workspace view the mapper boots conversion plugins against.
-type NewMapperFunc = func(h Host, ctx *Context) codegenrpc.MapperServer
+type NewMapperFunc = func(ctx *Context) codegenrpc.MapperServer
 
 // LanguageInstaller downloads and installs an unbundled language runtime on demand, so that
 // loading it via Host.LanguageRuntime works even when the runtime is not bundled with the CLI
 // or already cached. It is the language-runtime analogue of the engine's plugin install path.
 //
 // The install machinery lives in the pkg module, which the SDK cannot import, so a host is
-// given its installer at construction. newLoader is the same loader the host was built with;
-// installing a plugin may need it to install the plugin's dependencies. A nil LanguageInstaller
-// disables on-demand install (the host then relies on the runtime already being present).
-type LanguageInstaller = func(ctx context.Context, runtime string, newLoader NewLoaderFunc) error
+// given its installer at construction. Language hosts are self-contained executables — they
+// are shared across workspaces and are never run with the support of another language runtime
+// — so installation is a plain download-and-unpack and needs no workspace state. A nil
+// LanguageInstaller disables on-demand install (the host then relies on the runtime already
+// being present).
+type LanguageInstaller = func(ctx context.Context, runtime string) error
 
 // projectPluginsFromProject parses the plugins and packages declared by a project into the list
 // of project plugins that take precedence over installed plugins when resolving plugin binaries.
@@ -241,14 +237,10 @@ func projectPluginsFromProject(
 // newHost constructs the default host implementation. This is the shape we plan to move to
 // pkg/host as NewHost: the host is independent of any workspace, and ctx is its lifetime
 // context — cancelling it is the hard stop that aborts graceful shutdown, so callers wanting a
-// graceful teardown must call Close before cancelling ctx.
-//
-// bootCtx is only needed to wire up the host's RPC server: its tracing span parents the
-// server's interceptors, and the loader and mapper services resolve plugins against its
-// workspace view. It must go away before NewHost can move to pkg/host.
+// graceful teardown must call Close before cancelling ctx. The host's RPC server parents its
+// tracing interceptors on the span carried by ctx, if any.
 func newHost(
-	ctx context.Context, d, statusD diag.Sink, debugging DebugContext,
-	newLoader NewLoaderFunc, newMapper NewMapperFunc, installLang LanguageInstaller, bootCtx *Context,
+	ctx context.Context, d, statusD diag.Sink, debugging DebugContext, installLang LanguageInstaller,
 ) (Host, error) {
 	hostCtx, hostCancel := context.WithCancel(ctx)
 	host := &defaultHost{
@@ -265,15 +257,12 @@ func newHost(
 		watchedContexts:         map[*Context]struct{}{},
 		closer:                  new(sync.Once),
 		debugContext:            debugging,
-		hasLoaderServer:         newLoader != nil,
-		newLoader:               newLoader,
-		hasMapperServer:         newMapper != nil,
 		installLang:             installLang,
 	}
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
 	// to "phone home" in case there are things the host must do on behalf of the plugins (like log, etc).
-	svr, err := newHostServer(host, bootCtx, newLoader, newMapper)
+	svr, err := newHostServer(host, opentracing.SpanFromContext(hostCtx))
 	if err != nil {
 		hostCancel()
 		return nil, err
@@ -304,18 +293,12 @@ func newHost(
 // Per-workspace state (project plugins, stack configuration, and so on) is carried by the
 // Context passed to each host method, so the host may be shared across workspaces. The host is
 // owned by ctx if ctx was constructed with a nil host, and by the caller otherwise.
-func NewDefaultHost(
-	ctx *Context, debugging DebugContext, newLoader NewLoaderFunc, newMapper NewMapperFunc,
-	installLang LanguageInstaller,
-) (Host, error) {
+func NewDefaultHost(ctx *Context, debugging DebugContext, installLang LanguageInstaller) (Host, error) {
 	// The host's lifetime context deliberately strips the bootstrap context's cancellation: the
 	// host is responsible for calling Close, and a caller's cancelled context must not turn
 	// into an accidental hard kill of plugin shutdown. Once host construction moves to pkg and
 	// takes a caller context directly, that context will become the exposed hard cut-off.
-	return newHost(
-		context.WithoutCancel(ctx.Request()), ctx.Diag, ctx.StatusDiag, debugging, newLoader, newMapper,
-		installLang, ctx,
-	)
+	return newHost(context.WithoutCancel(ctx.Request()), ctx.Diag, ctx.StatusDiag, debugging, installLang)
 }
 
 func resolvePluginPath(root string, path string) (string, error) {
@@ -422,10 +405,7 @@ type defaultHost struct {
 
 	closer *sync.Once
 
-	hasLoaderServer bool
-	newLoader       NewLoaderFunc // the loader the host was built with, passed to installLang.
-	hasMapperServer bool
-	installLang     LanguageInstaller // installs unbundled language runtimes on demand; may be nil.
+	installLang LanguageInstaller // installs unbundled language runtimes on demand; may be nil.
 }
 
 var _ Host = (*defaultHost)(nil)
@@ -461,20 +441,6 @@ type resourcePlugin struct {
 
 func (host *defaultHost) ServerAddr() string {
 	return host.server.Address()
-}
-
-func (host *defaultHost) LoaderAddr() string {
-	if host.hasLoaderServer {
-		return host.ServerAddr()
-	}
-	return ""
-}
-
-func (host *defaultHost) MapperAddr() string {
-	if host.hasMapperServer {
-		return host.ServerAddr()
-	}
-	return ""
 }
 
 func (host *defaultHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
@@ -709,7 +675,7 @@ func (host *defaultHost) LanguageRuntime(ctx *Context, runtime string,
 
 		// Download and install the language runtime on demand if it is unbundled and missing.
 		if host.installLang != nil {
-			if err := host.installLang(ctx.Request(), runtime, host.newLoader); err != nil {
+			if err := host.installLang(ctx.Request(), runtime); err != nil {
 				return nil, fmt.Errorf("failed to install language plugin %s: %w", runtime, err)
 			}
 		}

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -238,26 +238,31 @@ func projectPluginsFromProject(
 	return append(projectPlugins, pluginsFromPackages...), nil
 }
 
-// NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
+// newHost constructs the default host implementation. This is the shape we plan to move to
+// pkg/host as NewHost: the host is independent of any workspace, and ctx is its lifetime
+// context — cancelling it is the hard stop that aborts graceful shutdown, so callers wanting a
+// graceful teardown must call Close before cancelling ctx.
 //
-// ctx is only used to wire up the host's RPC server and logging; the host does not retain it.
-// Per-workspace state (project plugins, stack configuration, and so on) is carried by the
-// Context passed to each host method, so the host may be shared across workspaces. The host is
-// owned by ctx if ctx was constructed with a nil host, and by the caller otherwise.
-func NewDefaultHost(
-	ctx *Context, debugging DebugContext, newLoader NewLoaderFunc, newMapper NewMapperFunc,
-	installLang LanguageInstaller,
+// bootCtx is only needed to wire up the host's RPC server: its tracing span parents the
+// server's interceptors, and the loader and mapper services resolve plugins against its
+// workspace view. It must go away before NewHost can move to pkg/host.
+func newHost(
+	ctx context.Context, d, statusD diag.Sink, debugging DebugContext,
+	newLoader NewLoaderFunc, newMapper NewMapperFunc, installLang LanguageInstaller, bootCtx *Context,
 ) (Host, error) {
+	hostCtx, hostCancel := context.WithCancel(ctx)
 	host := &defaultHost{
-		diag:                    ctx.Diag,
-		statusDiag:              ctx.StatusDiag,
-		shutdownCtx:             context.WithoutCancel(ctx.Request()),
+		diag:                    d,
+		statusDiag:              statusD,
+		hostCtx:                 hostCtx,
+		hostCancel:              hostCancel,
 		analyzerPlugins:         map[string]*analyzerPlugin{},
 		languagePlugins:         map[languagePluginKey]*languagePlugin{},
 		resourcePlugins:         map[Provider]*resourcePlugin{},
 		reportedResourcePlugins: map[string]struct{}{},
 		languageLoadRequests:    make(chan pluginLoadRequest),
 		loadRequests:            make(chan pluginLoadRequest),
+		watchedContexts:         map[*Context]struct{}{},
 		closer:                  new(sync.Once),
 		debugContext:            debugging,
 		hasLoaderServer:         newLoader != nil,
@@ -268,8 +273,9 @@ func NewDefaultHost(
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
 	// to "phone home" in case there are things the host must do on behalf of the plugins (like log, etc).
-	svr, err := newHostServer(host, ctx, newLoader, newMapper)
+	svr, err := newHostServer(host, bootCtx, newLoader, newMapper)
 	if err != nil {
+		hostCancel()
 		return nil, err
 	}
 	host.server = svr
@@ -290,6 +296,26 @@ func NewDefaultHost(
 	}()
 
 	return host, nil
+}
+
+// NewDefaultHost implements the standard plugin logic, using the standard installation root to find them.
+//
+// ctx is only used to wire up the host's RPC server and logging; the host does not retain it.
+// Per-workspace state (project plugins, stack configuration, and so on) is carried by the
+// Context passed to each host method, so the host may be shared across workspaces. The host is
+// owned by ctx if ctx was constructed with a nil host, and by the caller otherwise.
+func NewDefaultHost(
+	ctx *Context, debugging DebugContext, newLoader NewLoaderFunc, newMapper NewMapperFunc,
+	installLang LanguageInstaller,
+) (Host, error) {
+	// The host's lifetime context deliberately strips the bootstrap context's cancellation: the
+	// host is responsible for calling Close, and a caller's cancelled context must not turn
+	// into an accidental hard kill of plugin shutdown. Once host construction moves to pkg and
+	// takes a caller context directly, that context will become the exposed hard cut-off.
+	return newHost(
+		context.WithoutCancel(ctx.Request()), ctx.Diag, ctx.StatusDiag, debugging, newLoader, newMapper,
+		installLang, ctx,
+	)
 }
 
 func resolvePluginPath(root string, path string) (string, error) {
@@ -368,10 +394,14 @@ type defaultHost struct {
 	diag       diag.Sink // the sink to use for diagnostics, e.g. plugins logging through the host.
 	statusDiag diag.Sink // the sink to use for status messages.
 
-	// the parent context for plugin shutdown RPCs. It preserves the active tracing span of the
-	// context the host was built with but strips cancellation, so shutdown still gets its
-	// timeout budget even if that context has already been cancelled.
-	shutdownCtx context.Context
+	// hostCtx is the host's lifetime context: the context watchers and the graceful shutdown
+	// RPCs (Cancel, SignalCancellation) run under it. It is independent of any workspace
+	// context, so a cancelled workspace still leaves plugin shutdown its timeout budget;
+	// cancelling hostCtx is the hard stop that aborts graceful shutdown. Close cancels it as
+	// its final act. It preserves the active tracing span of the context the host was built
+	// with so shutdown RPCs parent onto the current operation.
+	hostCtx    context.Context
+	hostCancel context.CancelFunc
 
 	analyzerPlugins         map[string]*analyzerPlugin            // a cache of analyzer plugins and their processes.
 	languagePlugins         map[languagePluginKey]*languagePlugin // a cache of language plugins and their processes.
@@ -384,6 +414,11 @@ type defaultHost struct {
 
 	// Used to synchronize shutdown with in-progress plugin loads.
 	pluginLock sync.RWMutex
+
+	// The contexts whose cancellation the host is watching, so that each context's plugins are
+	// released when it is cancelled (Context.Close cancels the context's base context).
+	watchedContexts map[*Context]struct{}
+	watchedMu       sync.Mutex
 
 	closer *sync.Once
 
@@ -399,6 +434,7 @@ type analyzerPlugin struct {
 	Plugin Analyzer
 	Info   PluginInfo
 	Name   string
+	refs   map[*Context]struct{} // the contexts this plugin was loaded for; it dies with the last one.
 }
 
 // languagePluginKey identifies a booted language plugin. The working directory is part of the
@@ -413,12 +449,14 @@ type languagePlugin struct {
 	Plugin LanguageRuntime
 	Info   PluginInfo
 	Name   string
+	refs   map[*Context]struct{} // the contexts this plugin was loaded for; it dies with the last one.
 }
 
 type resourcePlugin struct {
 	Plugin Provider
 	Info   PluginInfo
 	Name   string
+	ctx    *Context // the context the provider was booted for; providers are never shared across contexts.
 }
 
 func (host *defaultHost) ServerAddr() string {
@@ -484,6 +522,7 @@ func (host *defaultHost) loadPlugin(
 }
 
 func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, error) {
+	host.watchContext(ctx)
 	// Analyzers are spawned in the workspace's working directory and resolved against its
 	// project plugins, so the cache key must identify the workspace as well as the analyzer.
 	key := fmt.Sprintf("analyzer\x00%s\x00%s", name, ctx.Pwd)
@@ -491,6 +530,7 @@ func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, er
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[key]; has {
 			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
+			plug.refs[ctx] = struct{}{}
 			return plug.Plugin, nil
 		}
 
@@ -503,7 +543,9 @@ func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, er
 			}
 
 			// Memoize the result.
-			host.analyzerPlugins[key] = &analyzerPlugin{Plugin: plug, Info: info, Name: string(name)}
+			host.analyzerPlugins[key] = &analyzerPlugin{
+				Plugin: plug, Info: info, Name: string(name), refs: map[*Context]struct{}{ctx: {}},
+			}
 		}
 
 		return plug, err
@@ -517,6 +559,7 @@ func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, er
 func (host *defaultHost) PolicyAnalyzer(
 	ctx *Context, name tokens.QName, path string, opts *PolicyAnalyzerOptions,
 ) (Analyzer, error) {
+	host.watchContext(ctx)
 	// The options are part of the cache key: they configure the analyzer process (stack,
 	// configuration, environment), so a cached analyzer may only be reused for a call that
 	// would boot an identical one. fmt prints maps with sorted keys, making the
@@ -530,6 +573,7 @@ func (host *defaultHost) PolicyAnalyzer(
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[key]; has {
 			contract.Assertf(plug != nil, "analyzer plugin %v was loaded but is nil", name)
+			plug.refs[ctx] = struct{}{}
 			return plug.Plugin, nil
 		}
 
@@ -542,7 +586,9 @@ func (host *defaultHost) PolicyAnalyzer(
 			}
 
 			// Memoize the result.
-			host.analyzerPlugins[key] = &analyzerPlugin{Plugin: plug, Info: info, Name: string(name)}
+			host.analyzerPlugins[key] = &analyzerPlugin{
+				Plugin: plug, Info: info, Name: string(name), refs: map[*Context]struct{}{ctx: {}},
+			}
 		}
 
 		return plug, err
@@ -554,6 +600,7 @@ func (host *defaultHost) PolicyAnalyzer(
 }
 
 func (host *defaultHost) Provider(ctx *Context, descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {
+	host.watchContext(ctx)
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		pkg := descriptor.Name
 		version := descriptor.Version
@@ -605,7 +652,7 @@ func (host *defaultHost) Provider(ctx *Context, descriptor workspace.PluginDescr
 			if !alreadyReported {
 				host.reportedResourcePlugins[key] = struct{}{}
 			}
-			host.resourcePlugins[plug] = &resourcePlugin{Plugin: plug, Info: info, Name: pkg}
+			host.resourcePlugins[plug] = &resourcePlugin{Plugin: plug, Info: info, Name: pkg, ctx: ctx}
 		}
 
 		return plug, err
@@ -632,7 +679,7 @@ func (pc hostManagedProvider) Close() error {
 	// Plugin.Close does not treat the subsequent exit as a premature crash. defaultHost.Close does the same for
 	// providers still in resourcePlugins at shutdown, but callers that Close individual providers (e.g. the
 	// convert mapper) bypass that path.
-	cancelCtx, cancelCancel := context.WithTimeout(pc.host.shutdownCtx, 5*time.Second)
+	cancelCtx, cancelCancel := context.WithTimeout(pc.host.hostCtx, 5*time.Second)
 	defer cancelCancel()
 	contract.IgnoreError(pc.SignalCancellation(cancelCtx))
 
@@ -649,12 +696,14 @@ func (pc hostManagedProvider) Close() error {
 
 func (host *defaultHost) LanguageRuntime(ctx *Context, runtime string,
 ) (LanguageRuntime, error) {
+	host.watchContext(ctx)
 	key := languagePluginKey{runtime: runtime, workingDirectory: ctx.Pwd}
 	// Language runtimes use their own loading channel not the main one
 	plugin, err := host.loadPlugin(host.languageLoadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
 		if plug, has := host.languagePlugins[key]; has {
 			contract.Assertf(plug != nil, "language plugin %v was loaded but is nil", runtime)
+			plug.refs[ctx] = struct{}{}
 			return plug.Plugin, nil
 		}
 
@@ -674,7 +723,9 @@ func (host *defaultHost) LanguageRuntime(ctx *Context, runtime string,
 			}
 
 			// Memoize the result.
-			host.languagePlugins[key] = &languagePlugin{Plugin: plug, Info: info, Name: runtime}
+			host.languagePlugins[key] = &languagePlugin{
+				Plugin: plug, Info: info, Name: runtime, refs: map[*Context]struct{}{ctx: {}},
+			}
 		}
 
 		return plug, err
@@ -689,10 +740,110 @@ func (host *defaultHost) ResolvePlugin(ctx *Context, spec workspace.PluginDescri
 	return workspace.GetPluginInfo(ctx.baseContext, ctx.Diag, spec, ctx.ProjectPlugins())
 }
 
+// watchContext arranges for the plugins booted on behalf of ctx to be released once ctx's base
+// context is cancelled, which Context.Close guarantees. Watching is idempotent per context.
+// Release is asynchronous: it happens shortly after cancellation, and host.Close remains the
+// synchronous backstop that tears down anything still running.
+func (host *defaultHost) watchContext(ctx *Context) {
+	base := ctx.Base()
+	if base == nil {
+		// A context without a base can never signal cancellation; its plugins live until the
+		// host closes.
+		return
+	}
+
+	host.watchedMu.Lock()
+	if _, has := host.watchedContexts[ctx]; has {
+		host.watchedMu.Unlock()
+		return
+	}
+	host.watchedContexts[ctx] = struct{}{}
+	host.watchedMu.Unlock()
+
+	go func() {
+		select {
+		case <-base.Done():
+			host.releaseContextPlugins(ctx)
+		case <-host.hostCtx.Done():
+			// The host closed every plugin already; nothing left to release.
+		}
+	}()
+}
+
+// releaseContextPlugins closes the plugins booted on behalf of ctx: every provider the context
+// booted, and every cached language runtime or analyzer that no other context still references.
+// The load-request channels serialize access to the plugin maps, so this synchronizes with
+// in-flight loads the same way Close and SignalCancellation do.
+//
+// A plugin load that is in flight while its context is released is not torn down here; it stays
+// cached until the host closes.
+func (host *defaultHost) releaseContextPlugins(ctx *Context) {
+	closePlugins := func(channel chan pluginLoadRequest, close func(cancelCtx context.Context)) error {
+		_, err := host.loadPlugin(channel, func() (any, error) {
+			cancelCtx, cancelCancel := context.WithTimeout(host.hostCtx, 5*time.Second)
+			defer cancelCancel()
+			close(cancelCtx)
+			return nil, nil
+		})
+		return err
+	}
+
+	err := closePlugins(host.loadRequests, func(cancelCtx context.Context) {
+		for key, plug := range host.resourcePlugins {
+			if plug.ctx != ctx {
+				continue
+			}
+			contract.IgnoreError(plug.Plugin.SignalCancellation(cancelCtx))
+			if err := plug.Plugin.Close(); err != nil {
+				logging.V(5).Infof("Error closing '%s' resource plugin during context close; ignoring: %v", plug.Name, err)
+			}
+			delete(host.resourcePlugins, key)
+		}
+		for key, plug := range host.analyzerPlugins {
+			if _, has := plug.refs[ctx]; !has {
+				continue
+			}
+			delete(plug.refs, ctx)
+			if len(plug.refs) > 0 {
+				continue
+			}
+			contract.IgnoreError(plug.Plugin.Cancel(cancelCtx))
+			if err := plug.Plugin.Close(); err != nil {
+				logging.V(5).Infof("Error closing '%s' analyzer plugin during context close; ignoring: %v", plug.Name, err)
+			}
+			delete(host.analyzerPlugins, key)
+		}
+	})
+	if err != nil {
+		// The only error loadPlugin returns here is that the host is shutting down, in which
+		// case Close is already tearing every plugin down; there is nothing left to release.
+		return
+	}
+
+	// Language plugins are guarded by their own load channel.
+	err = closePlugins(host.languageLoadRequests, func(cancelCtx context.Context) {
+		for key, plug := range host.languagePlugins {
+			if _, has := plug.refs[ctx]; !has {
+				continue
+			}
+			delete(plug.refs, ctx)
+			if len(plug.refs) > 0 {
+				continue
+			}
+			contract.IgnoreError(plug.Plugin.Cancel(cancelCtx))
+			if err := plug.Plugin.Close(); err != nil {
+				logging.V(5).Infof("Error closing '%s' language plugin during context close; ignoring: %v", plug.Name, err)
+			}
+			delete(host.languagePlugins, key)
+		}
+	})
+	contract.IgnoreError(err)
+}
+
 func (host *defaultHost) SignalCancellation() error {
 	// NOTE: we're abusing loadPlugin in order to ensure proper synchronization.
 	_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-		cancelCtx, cancelCancel := context.WithTimeout(host.shutdownCtx, 30*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(host.hostCtx, 30*time.Second)
 		defer cancelCancel()
 
 		// Cancel in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based providers
@@ -751,7 +902,7 @@ func (host *defaultHost) Close() (err error) {
 		host.pluginLock.Lock()
 		// N.B We purposefully do not unlock this.
 
-		cancelCtx, cancelCancel := context.WithTimeout(host.shutdownCtx, 5*time.Second)
+		cancelCtx, cancelCancel := context.WithTimeout(host.hostCtx, 5*time.Second)
 		defer cancelCancel()
 
 		// Close plugins in two phases: first resource providers and analyzers, then language hosts. RunPlugin-based
@@ -796,8 +947,13 @@ func (host *defaultHost) Close() (err error) {
 		close(host.languageLoadRequests)
 		close(host.loadRequests)
 
-		// Finally, shut down the host's gRPC server.
+		// Shut down the host's gRPC server.
 		err = host.server.Cancel()
+
+		// Finally, cancel the host's lifetime context. This stops the context watchers, and is
+		// the hard stop for anything still running; it must come last so the graceful close-out
+		// above keeps its timeout budget.
+		host.hostCancel()
 	})
 	return err
 }

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -248,7 +248,7 @@ func newHost(
 		statusDiag:              statusD,
 		hostCtx:                 hostCtx,
 		hostCancel:              hostCancel,
-		analyzerPlugins:         map[string]*analyzerPlugin{},
+		analyzerPlugins:         map[analyzerPluginKey]*analyzerPlugin{},
 		languagePlugins:         map[languagePluginKey]*languagePlugin{},
 		resourcePlugins:         map[Provider]*resourcePlugin{},
 		reportedResourcePlugins: map[string]struct{}{},
@@ -386,7 +386,7 @@ type defaultHost struct {
 	hostCtx    context.Context
 	hostCancel context.CancelFunc
 
-	analyzerPlugins         map[string]*analyzerPlugin            // a cache of analyzer plugins and their processes.
+	analyzerPlugins         map[analyzerPluginKey]*analyzerPlugin // a cache of analyzer plugins and their processes.
 	languagePlugins         map[languagePluginKey]*languagePlugin // a cache of language plugins and their processes.
 	resourcePlugins         map[Provider]*resourcePlugin          // the set of loaded resource plugins.
 	reportedResourcePlugins map[string]struct{}                   // the set of unique resource plugins we'll report.
@@ -409,6 +409,18 @@ type defaultHost struct {
 }
 
 var _ Host = (*defaultHost)(nil)
+
+// analyzerPluginKey identifies a booted analyzer plugin. Analyzers are spawned in the
+// workspace's working directory and resolved against its project plugins; policy analyzers are
+// instead booted from an explicit path and configured by their options. A host shared across
+// workspaces must not serve one workspace's analyzer process to another.
+type analyzerPluginKey struct {
+	name             tokens.QName
+	policy           bool   // true for policy analyzers.
+	workingDirectory string // the workspace's working directory; empty for policy analyzers.
+	path             string // the policy pack path; empty for regular analyzers.
+	options          string // the policy analyzer's options, deterministically rendered; empty for regular analyzers.
+}
 
 type analyzerPlugin struct {
 	Plugin Analyzer
@@ -489,9 +501,7 @@ func (host *defaultHost) loadPlugin(
 
 func (host *defaultHost) Analyzer(ctx *Context, name tokens.QName) (Analyzer, error) {
 	host.watchContext(ctx)
-	// Analyzers are spawned in the workspace's working directory and resolved against its
-	// project plugins, so the cache key must identify the workspace as well as the analyzer.
-	key := fmt.Sprintf("analyzer\x00%s\x00%s", name, ctx.Pwd)
+	key := analyzerPluginKey{name: name, workingDirectory: ctx.Pwd}
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[key]; has {
@@ -534,7 +544,7 @@ func (host *defaultHost) PolicyAnalyzer(
 	if opts != nil {
 		optsKey = fmt.Sprintf("%v", *opts)
 	}
-	key := fmt.Sprintf("policy\x00%s\x00%s\x00%s", name, path, optsKey)
+	key := analyzerPluginKey{name: name, policy: true, path: path, options: optsKey}
 	plugin, err := host.loadPlugin(host.loadRequests, func() (any, error) {
 		// First see if we already loaded this plugin.
 		if plug, has := host.analyzerPlugins[key]; has {
@@ -905,7 +915,7 @@ func (host *defaultHost) Close() (err error) {
 		wg.Wait()
 
 		// Empty out all maps.
-		host.analyzerPlugins = map[string]*analyzerPlugin{}
+		host.analyzerPlugins = map[analyzerPluginKey]*analyzerPlugin{}
 		host.languagePlugins = map[languagePluginKey]*languagePlugin{}
 		host.resourcePlugins = map[Provider]*resourcePlugin{}
 

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -22,12 +22,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 // hostServer is the server side of the host RPC machinery.
@@ -35,7 +36,6 @@ type hostServer struct {
 	pulumirpc.UnsafeEngineServer // opt out of forward compat
 
 	host   Host         // the host for this RPC server.
-	ctx    *Context     // the associated plugin context.
 	addr   string       // the address the host is listening on.
 	cancel chan bool    // a channel that can cancel the server.
 	done   <-chan error // a channel that resolves when the server completes.
@@ -44,12 +44,12 @@ type hostServer struct {
 	rootUrn atomic.Value // a root resource URN that has been saved via SetRootResource
 }
 
-// newHostServer creates a new host server wired up to the given host and context.
-func newHostServer(host Host, ctx *Context, newLoader NewLoaderFunc, newMapper NewMapperFunc) (*hostServer, error) {
+// newHostServer creates a new host server wired up to the given host. The given span, which may
+// be nil, parents the server's tracing interceptors.
+func newHostServer(host Host, span opentracing.Span) (*hostServer, error) {
 	// New up an engine RPC server.
 	engine := &hostServer{
 		host:   host,
-		ctx:    ctx,
 		cancel: make(chan bool),
 	}
 
@@ -58,15 +58,9 @@ func newHostServer(host Host, ctx *Context, newLoader NewLoaderFunc, newMapper N
 		Cancel: engine.cancel,
 		Init: func(srv *grpc.Server) error {
 			pulumirpc.RegisterEngineServer(srv, engine)
-			if newLoader != nil {
-				codegenrpc.RegisterLoaderServer(srv, newLoader(host, ctx))
-			}
-			if newMapper != nil {
-				codegenrpc.RegisterMapperServer(srv, newMapper(host, ctx))
-			}
 			return nil
 		},
-		Options: rpcutil.TracingServerInterceptorOptions(ctx.tracingSpan),
+		Options: rpcutil.TracingServerInterceptorOptions(span),
 	})
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/resource/plugin/host_server.go
+++ b/sdk/go/common/resource/plugin/host_server.go
@@ -59,10 +59,10 @@ func newHostServer(host Host, ctx *Context, newLoader NewLoaderFunc, newMapper N
 		Init: func(srv *grpc.Server) error {
 			pulumirpc.RegisterEngineServer(srv, engine)
 			if newLoader != nil {
-				codegenrpc.RegisterLoaderServer(srv, newLoader(host))
+				codegenrpc.RegisterLoaderServer(srv, newLoader(host, ctx))
 			}
 			if newMapper != nil {
-				codegenrpc.RegisterMapperServer(srv, newMapper(ctx.Base(), host))
+				codegenrpc.RegisterMapperServer(srv, newMapper(host, ctx))
 			}
 			return nil
 		},

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -65,6 +66,225 @@ func TestHostManagedProviderCloseSignalsCancellation(t *testing.T) {
 
 	require.Equal(t, []string{"SignalCancellation", "Close"}, calls)
 	require.NotContains(t, host.resourcePlugins, Provider(mockProv))
+}
+
+// TestContextCloseReleasesProviders locks in that closing a context releases the providers
+// booted on its behalf without touching providers booted for other contexts sharing the same
+// host. Release happens asynchronously once the context's base context is cancelled, so the
+// test polls through the host's load channel, which serializes access to the plugin maps.
+func TestContextCloseReleasesProviders(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+	ctxA, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil, nil)
+	require.NoError(t, err)
+	host, ok := ctxA.Host.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, ctxA.Close()) })
+
+	ctxB := NewContextWithHost(t.Context(), sink, sink, ctxA.Host, "", "", nil)
+
+	var mu sync.Mutex
+	var aCalls, bCalls []string
+	record := func(calls *[]string, call string) {
+		mu.Lock()
+		defer mu.Unlock()
+		*calls = append(*calls, call)
+	}
+	provA := &MockProvider{
+		SignalCancellationF: func(context.Context) error { record(&aCalls, "SignalCancellation"); return nil },
+		CloseF:              func() error { record(&aCalls, "Close"); return nil },
+	}
+	provB := &MockProvider{
+		SignalCancellationF: func(context.Context) error { record(&bCalls, "SignalCancellation"); return nil },
+		CloseF:              func() error { record(&bCalls, "Close"); return nil },
+	}
+	host.resourcePlugins[provA] = &resourcePlugin{Plugin: provA, Name: "a", ctx: ctxA}
+	host.resourcePlugins[provB] = &resourcePlugin{Plugin: provB, Name: "b", ctx: ctxB}
+	host.watchContext(ctxA)
+	host.watchContext(ctxB)
+
+	readPlugins := func() (hasA, hasB bool) {
+		_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
+			_, hasA = host.resourcePlugins[Provider(provA)]
+			_, hasB = host.resourcePlugins[Provider(provB)]
+			return nil, nil
+		})
+		require.NoError(t, err)
+		return hasA, hasB
+	}
+
+	require.NoError(t, ctxB.Close())
+	require.Eventually(t, func() bool {
+		_, hasB := readPlugins()
+		return !hasB
+	}, 10*time.Second, 10*time.Millisecond)
+
+	hasA, _ := readPlugins()
+	assert.True(t, hasA, "provider booted for another context must survive")
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"SignalCancellation", "Close"}, bCalls)
+	assert.Empty(t, aCalls)
+}
+
+// TestContextCloseGracefulShutdownBudget locks in that plugins released because their context
+// was closed still get the full graceful-shutdown budget: the Cancel RPC runs under the host's
+// lifetime context, not the (already cancelled) workspace context. Closing a workspace context
+// is graceful; only the host's own lifetime context is a hard stop.
+func TestContextCloseGracefulShutdownBudget(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+	ctxA, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil, nil)
+	require.NoError(t, err)
+	host, ok := ctxA.Host.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, ctxA.Close()) })
+
+	ctxB := NewContextWithHost(t.Context(), sink, sink, ctxA.Host, "", "", nil)
+
+	var mu sync.Mutex
+	var gotErr error
+	var hasDeadline bool
+	var gotBudget time.Duration
+	prov := &MockProvider{
+		SignalCancellationF: func(cancelCtx context.Context) error {
+			mu.Lock()
+			defer mu.Unlock()
+			gotErr = cancelCtx.Err()
+			var deadline time.Time
+			if deadline, hasDeadline = cancelCtx.Deadline(); hasDeadline {
+				gotBudget = time.Until(deadline)
+			}
+			return nil
+		},
+		CloseF: func() error { return nil },
+	}
+	host.resourcePlugins[prov] = &resourcePlugin{Plugin: prov, Name: "b", ctx: ctxB}
+	host.watchContext(ctxB)
+
+	require.NoError(t, ctxB.Close())
+	require.Eventually(t, func() bool {
+		var has bool
+		_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
+			_, has = host.resourcePlugins[Provider(prov)]
+			return nil, nil
+		})
+		require.NoError(t, err)
+		return !has
+	}, 10*time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The workspace context was already cancelled when the shutdown RPC ran, yet the RPC's
+	// context must be alive with (roughly) the full 5 second budget remaining.
+	require.NoError(t, gotErr)
+	require.True(t, hasDeadline)
+	assert.Greater(t, gotBudget, 2*time.Second)
+	assert.LessOrEqual(t, gotBudget, 5*time.Second)
+}
+
+type stubLanguageRuntime struct {
+	LanguageRuntime
+	closed bool
+}
+
+func (s *stubLanguageRuntime) Cancel(context.Context) error { return nil }
+func (s *stubLanguageRuntime) Close() error                 { s.closed = true; return nil }
+
+type stubAnalyzer struct {
+	Analyzer
+	closed bool
+}
+
+func (s *stubAnalyzer) Cancel(context.Context) error { return nil }
+func (s *stubAnalyzer) Close() error                 { s.closed = true; return nil }
+
+// TestContextCloseRefcountsSharedPlugins locks in that cached plugins shared by several
+// contexts only close once the last context referencing them closes. The stubs' closed flags
+// are only read through the load channels that serialize plugin map access, which orders those
+// reads after the asynchronous release writes.
+func TestContextCloseRefcountsSharedPlugins(t *testing.T) {
+	t.Parallel()
+
+	sink := diagtest.LogSink(t)
+	ctxA, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil, nil)
+	require.NoError(t, err)
+	host, ok := ctxA.Host.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, ctxA.Close()) })
+
+	ctxB := NewContextWithHost(t.Context(), sink, sink, ctxA.Host, "", "", nil)
+	ctxC := NewContextWithHost(t.Context(), sink, sink, ctxA.Host, "", "", nil)
+
+	runtime := &stubLanguageRuntime{}
+	langKey := languagePluginKey{runtime: "test", workingDirectory: ""}
+	host.languagePlugins[langKey] = &languagePlugin{
+		Plugin: runtime, Name: "test", refs: map[*Context]struct{}{ctxB: {}, ctxC: {}},
+	}
+
+	analyzer := &stubAnalyzer{}
+	host.analyzerPlugins["test-analyzer"] = &analyzerPlugin{
+		Plugin: analyzer, Name: "test-analyzer", refs: map[*Context]struct{}{ctxB: {}, ctxC: {}},
+	}
+	host.watchContext(ctxB)
+	host.watchContext(ctxC)
+
+	type pluginState struct {
+		langCached, langClosed, analyzerCached, analyzerClosed bool
+		langRefs, analyzerRefs                                 int
+	}
+	readState := func() pluginState {
+		var state pluginState
+		_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
+			plug, has := host.analyzerPlugins["test-analyzer"]
+			state.analyzerCached = has
+			state.analyzerClosed = analyzer.closed
+			if has {
+				state.analyzerRefs = len(plug.refs)
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+		_, err = host.loadPlugin(host.languageLoadRequests, func() (any, error) {
+			plug, has := host.languagePlugins[langKey]
+			state.langCached = has
+			state.langClosed = runtime.closed
+			if has {
+				state.langRefs = len(plug.refs)
+			}
+			return nil, nil
+		})
+		require.NoError(t, err)
+		return state
+	}
+
+	// Closing the first context must not close the shared plugins, only drop its references.
+	require.NoError(t, ctxB.Close())
+	require.Eventually(t, func() bool {
+		state := readState()
+		return state.langRefs == 1 && state.analyzerRefs == 1
+	}, 10*time.Second, 10*time.Millisecond)
+	state := readState()
+	assert.Equal(t, pluginState{
+		langCached:     true,
+		analyzerCached: true,
+		langRefs:       1,
+		analyzerRefs:   1,
+	}, state)
+
+	// Closing the last referencing context closes them.
+	require.NoError(t, ctxC.Close())
+	require.Eventually(t, func() bool {
+		state := readState()
+		return state.langClosed && state.analyzerClosed
+	}, 10*time.Second, 10*time.Millisecond)
+	state = readState()
+	assert.Equal(t, pluginState{
+		langClosed:     true,
+		analyzerClosed: true,
+	}, state)
 }
 
 func TestClosePanic(t *testing.T) {

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -225,7 +225,8 @@ func TestContextCloseRefcountsSharedPlugins(t *testing.T) {
 	}
 
 	analyzer := &stubAnalyzer{}
-	host.analyzerPlugins["test-analyzer"] = &analyzerPlugin{
+	analyzerKey := analyzerPluginKey{name: "test-analyzer"}
+	host.analyzerPlugins[analyzerKey] = &analyzerPlugin{
 		Plugin: analyzer, Name: "test-analyzer", refs: map[*Context]struct{}{ctxB: {}, ctxC: {}},
 	}
 	host.watchContext(ctxB)
@@ -238,7 +239,7 @@ func TestContextCloseRefcountsSharedPlugins(t *testing.T) {
 	readState := func() pluginState {
 		var state pluginState
 		_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
-			plug, has := host.analyzerPlugins["test-analyzer"]
+			plug, has := host.analyzerPlugins[analyzerKey]
 			state.analyzerCached = has
 			state.analyzerClosed = analyzer.closed
 			if has {

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -530,62 +530,48 @@ func TestProjectPluginsFromProject_BothPluginsAndPackages(t *testing.T) {
 	assert.False(t, pluginNames["azure"])
 }
 
-func TestNewDefaultHost_LoaderAddress(t *testing.T) {
+// TestContextLoaderAddr locks in that a context constructed with a NewLoaderFunc serves the
+// loader for the lifetime of the context, bound to that context's workspace view.
+func TestContextLoaderAddr(t *testing.T) {
 	t.Parallel()
 
-	ctx := &Context{
-		baseContext: t.Context(),
-		Root:        t.TempDir(),
-		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
-			Color: colors.Never,
-		}),
-	}
+	sink := diagtest.LogSink(t)
 
-	var captureHost Host
-	mockLoader := func(h Host, _ *Context) codegenrpc.LoaderServer {
-		captureHost = h
+	var captureCtx *Context
+	mockLoader := func(ctx *Context) codegenrpc.LoaderServer {
+		captureCtx = ctx
 		return codegenrpc.UnimplementedLoaderServer{}
 	}
 
-	host, err := NewDefaultHost(ctx, nil, mockLoader, nil, nil)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, mockLoader, nil, nil)
 	require.NoError(t, err)
-	defer host.Close()
 
-	assert.Equal(t, host, captureHost, "loader function should be called during host creation")
+	assert.Equal(t, ctx, captureCtx, "the loader is bound to the context it was constructed with")
+	assert.NotEmpty(t, ctx.LoaderAddr())
+	assert.Equal(t, "", ctx.MapperAddr(), "a context built without a mapper should have no mapper address")
 
-	loaderAddr := host.LoaderAddr()
-	assert.NotEmpty(t, loaderAddr)
-	assert.Equal(t, host.ServerAddr(), loaderAddr)
-
-	assert.Equal(t, "", host.MapperAddr(), "a host built without a mapper should have no mapper address")
+	require.NoError(t, ctx.Close())
 }
 
-func TestNewDefaultHost_MapperAddress(t *testing.T) {
+func TestContextMapperAddr(t *testing.T) {
 	t.Parallel()
 
-	ctx := &Context{
-		baseContext: t.Context(),
-		Root:        t.TempDir(),
-		Diag: diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
-			Color: colors.Never,
-		}),
-	}
+	sink := diagtest.LogSink(t)
 
-	var captureHost Host
-	mockMapper := func(h Host, _ *Context) codegenrpc.MapperServer {
-		captureHost = h
+	var captureCtx *Context
+	mockMapper := func(ctx *Context) codegenrpc.MapperServer {
+		captureCtx = ctx
 		return codegenrpc.UnimplementedMapperServer{}
 	}
 
-	host, err := NewDefaultHost(ctx, nil, nil, mockMapper, nil)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, mockMapper, nil)
 	require.NoError(t, err)
-	defer host.Close()
 
-	assert.Equal(t, host, captureHost, "mapper function should be called during host creation")
+	assert.Equal(t, ctx, captureCtx, "the mapper is bound to the context it was constructed with")
+	assert.NotEmpty(t, ctx.MapperAddr())
+	assert.Equal(t, "", ctx.LoaderAddr(), "a context built without a loader should have no loader address")
 
-	mapperAddr := host.MapperAddr()
-	assert.NotEmpty(t, mapperAddr)
-	assert.Equal(t, host.ServerAddr(), mapperAddr)
+	require.NoError(t, ctx.Close())
 }
 
 func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
@@ -593,36 +579,23 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 
 	sink := diagtest.LogSink(t)
 
-	var loaderCalls int
-	mockLoader := func(Host, *Context) codegenrpc.LoaderServer {
-		loaderCalls++
-		return codegenrpc.UnimplementedLoaderServer{}
-	}
-
 	errInstall := errors.New("install boom")
 	var (
-		installCalls   int
-		gotRuntime     string
-		gotLoaderIsNil bool
+		installCalls int
+		gotRuntime   string
 	)
-	installLang := func(_ context.Context, runtime string, newLoader NewLoaderFunc) error {
+	installLang := func(_ context.Context, runtime string) error {
 		installCalls++
 		gotRuntime = runtime
-		gotLoaderIsNil = newLoader == nil
-		// Invoke the loader we were handed to prove it is the host's loader, not nil.
-		if newLoader != nil {
-			newLoader(nil, nil)
-		}
 		return errInstall
 	}
 
-	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, mockLoader, nil, installLang)
+	ctx, err := NewContext(t.Context(), sink, sink, nil, nil, "", nil, false, nil, nil, nil, installLang)
 	require.NoError(t, err)
 	host, ok := ctx.Host.(*defaultHost)
 	require.True(t, ok)
 	t.Cleanup(func() { require.NoError(t, host.Close()) })
 
-	loaderCallsBeforeLoad := loaderCalls
 	lang, err := host.LanguageRuntime(ctx, "test-lang")
 
 	// The installer ran exactly once, for the requested runtime, and its error gated the load so we never
@@ -631,8 +604,4 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 	assert.Nil(t, lang)
 	assert.Equal(t, 1, installCalls)
 	assert.Equal(t, "test-lang", gotRuntime)
-
-	// The installer received the host's loader, not nil, and was able to invoke it.
-	assert.False(t, gotLoaderIsNil, "host should thread its loader to the installer")
-	assert.Greater(t, loaderCalls, loaderCallsBeforeLoad, "installer should have invoked the host's loader")
 }

--- a/sdk/go/common/resource/plugin/host_test.go
+++ b/sdk/go/common/resource/plugin/host_test.go
@@ -197,7 +197,7 @@ func TestIsLocalPluginPath(t *testing.T) {
 	}
 }
 
-func TestNewDefaultHost_PackagesResolution(t *testing.T) {
+func TestProjectPluginsFromProject_PackagesResolution(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary directory for our test
@@ -231,13 +231,8 @@ func TestNewDefaultHost_PackagesResolution(t *testing.T) {
 		"git-plugin":      {Source: "git://github.com/pulumi/pulumi-aws"}, // This should be skipped
 	}
 
-	// Create the host with our packages
-	host, err := NewDefaultHost(ctx, nil, false, nil, packages, nil, nil, "", nil, nil, nil)
+	projectPlugins, err := projectPluginsFromProject(ctx, nil, packages)
 	require.NoError(t, err)
-	defer host.Close()
-
-	// Get the project plugins
-	projectPlugins := host.GetProjectPlugins()
 
 	// We should have 2 plugins (local-plugin and relative-plugin)
 	require.Len(t, projectPlugins, 2)
@@ -260,8 +255,8 @@ func TestNewDefaultHost_PackagesResolution(t *testing.T) {
 	assert.NotContains(t, pluginMap, "git-plugin")
 }
 
-// TestNewDefaultHost_BothPluginsAndPackages tests the combined resolution of plugins and packages
-func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
+// TestProjectPluginsFromProject_BothPluginsAndPackages tests the combined resolution of plugins and packages
+func TestProjectPluginsFromProject_BothPluginsAndPackages(t *testing.T) {
 	t.Parallel()
 
 	// Create a temporary directory for our test
@@ -298,11 +293,8 @@ func TestNewDefaultHost_BothPluginsAndPackages(t *testing.T) {
 		"azure":        {Source: "azure"}, // This should be skipped as it's not a local path
 	}
 
-	host, err := NewDefaultHost(ctx, nil, false, plugins, packages, nil, nil, "", nil, nil, nil)
+	projectPlugins, err := projectPluginsFromProject(ctx, plugins, packages)
 	require.NoError(t, err)
-	defer host.Close()
-
-	projectPlugins := host.GetProjectPlugins()
 
 	// We should have 2 plugins (1 from plugins, 1 from packages)
 	require.Len(t, projectPlugins, 2)
@@ -330,12 +322,12 @@ func TestNewDefaultHost_LoaderAddress(t *testing.T) {
 	}
 
 	var captureHost Host
-	mockLoader := func(h Host) codegenrpc.LoaderServer {
+	mockLoader := func(h Host, _ *Context) codegenrpc.LoaderServer {
 		captureHost = h
 		return codegenrpc.UnimplementedLoaderServer{}
 	}
 
-	host, err := NewDefaultHost(ctx, nil, false, nil, nil, nil, nil, "", mockLoader, nil, nil)
+	host, err := NewDefaultHost(ctx, nil, mockLoader, nil, nil)
 	require.NoError(t, err)
 	defer host.Close()
 
@@ -360,12 +352,12 @@ func TestNewDefaultHost_MapperAddress(t *testing.T) {
 	}
 
 	var captureHost Host
-	mockMapper := func(_ context.Context, h Host) codegenrpc.MapperServer {
+	mockMapper := func(h Host, _ *Context) codegenrpc.MapperServer {
 		captureHost = h
 		return codegenrpc.UnimplementedMapperServer{}
 	}
 
-	host, err := NewDefaultHost(ctx, nil, false, nil, nil, nil, nil, "", nil, mockMapper, nil)
+	host, err := NewDefaultHost(ctx, nil, nil, mockMapper, nil)
 	require.NoError(t, err)
 	defer host.Close()
 
@@ -382,7 +374,7 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 	sink := diagtest.LogSink(t)
 
 	var loaderCalls int
-	mockLoader := func(Host) codegenrpc.LoaderServer {
+	mockLoader := func(Host, *Context) codegenrpc.LoaderServer {
 		loaderCalls++
 		return codegenrpc.UnimplementedLoaderServer{}
 	}
@@ -399,7 +391,7 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 		gotLoaderIsNil = newLoader == nil
 		// Invoke the loader we were handed to prove it is the host's loader, not nil.
 		if newLoader != nil {
-			newLoader(nil)
+			newLoader(nil, nil)
 		}
 		return errInstall
 	}
@@ -411,7 +403,7 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, host.Close()) })
 
 	loaderCallsBeforeLoad := loaderCalls
-	lang, err := host.LanguageRuntime("test-lang")
+	lang, err := host.LanguageRuntime(ctx, "test-lang")
 
 	// The installer ran exactly once, for the requested runtime, and its error gated the load so we never
 	// got a runtime back.

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -112,7 +112,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime, workingDirectory strin
 				Name: strings.ReplaceAll(runtime, tokens.QNameDelimiter, "_"),
 				Kind: apitype.LanguagePlugin,
 			},
-			host.GetProjectPlugins(),
+			ctx.ProjectPlugins(),
 		)
 		if err != nil {
 			return nil, err

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -29,8 +29,6 @@ import (
 
 type MockHost struct {
 	ServerAddrF         func() string
-	LoaderAddrF         func() string
-	MapperAddrF         func() string
 	LogF                func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
 	LogStatusF          func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
 	AnalyzerF           func(ctx *Context, nm tokens.QName) (Analyzer, error)
@@ -49,20 +47,6 @@ var _ Host = (*MockHost)(nil)
 func (m *MockHost) ServerAddr() string {
 	if m.ServerAddrF != nil {
 		return m.ServerAddrF()
-	}
-	return ""
-}
-
-func (m *MockHost) LoaderAddr() string {
-	if m.LoaderAddrF != nil {
-		return m.LoaderAddrF()
-	}
-	return ""
-}
-
-func (m *MockHost) MapperAddr() string {
-	if m.MapperAddrF != nil {
-		return m.MapperAddrF()
 	}
 	return ""
 }

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -33,12 +33,11 @@ type MockHost struct {
 	MapperAddrF         func() string
 	LogF                func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
 	LogStatusF          func(sev diag.Severity, urn resource.URN, msg string, streamID int32)
-	AnalyzerF           func(nm tokens.QName) (Analyzer, error)
-	PolicyAnalyzerF     func(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
-	ProviderF           func(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
-	LanguageRuntimeF    func(runtime string) (LanguageRuntime, error)
-	ResolvePluginF      func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
-	GetProjectPluginsF  func() []workspace.ProjectPlugin
+	AnalyzerF           func(ctx *Context, nm tokens.QName) (Analyzer, error)
+	PolicyAnalyzerF     func(ctx *Context, name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error)
+	ProviderF           func(ctx *Context, descriptor workspace.PluginDescriptor, e env.Env) (Provider, error)
+	LanguageRuntimeF    func(ctx *Context, runtime string) (LanguageRuntime, error)
+	ResolvePluginF      func(ctx *Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 	SignalCancellationF func() error
 	CloseF              func() error
 	StartDebuggingF     func(info DebuggingInfo) error
@@ -80,48 +79,43 @@ func (m *MockHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, st
 	}
 }
 
-func (m *MockHost) Analyzer(nm tokens.QName) (Analyzer, error) {
+func (m *MockHost) Analyzer(ctx *Context, nm tokens.QName) (Analyzer, error) {
 	if m.AnalyzerF != nil {
-		return m.AnalyzerF(nm)
+		return m.AnalyzerF(ctx, nm)
 	}
 	return nil, status.Error(codes.Unimplemented, "Analyzer not implemented")
 }
 
-func (m *MockHost) PolicyAnalyzer(name tokens.QName, path string, opts *PolicyAnalyzerOptions) (Analyzer, error) {
+func (m *MockHost) PolicyAnalyzer(
+	ctx *Context, name tokens.QName, path string, opts *PolicyAnalyzerOptions,
+) (Analyzer, error) {
 	if m.PolicyAnalyzerF != nil {
-		return m.PolicyAnalyzerF(name, path, opts)
+		return m.PolicyAnalyzerF(ctx, name, path, opts)
 	}
 	return nil, status.Error(codes.Unimplemented, "PolicyAnalyzer not implemented")
 }
 
-func (m *MockHost) Provider(descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {
+func (m *MockHost) Provider(ctx *Context, descriptor workspace.PluginDescriptor, e env.Env) (Provider, error) {
 	if m.ProviderF != nil {
-		return m.ProviderF(descriptor, e)
+		return m.ProviderF(ctx, descriptor, e)
 	}
 	return nil, status.Error(codes.Unimplemented, "Provider not implemented")
 }
 
-func (m *MockHost) LanguageRuntime(runtime string) (LanguageRuntime, error) {
+func (m *MockHost) LanguageRuntime(ctx *Context, runtime string) (LanguageRuntime, error) {
 	if m.LanguageRuntimeF != nil {
-		return m.LanguageRuntimeF(runtime)
+		return m.LanguageRuntimeF(ctx, runtime)
 	}
 	return nil, status.Error(codes.Unimplemented, "LanguageRuntime not implemented")
 }
 
 func (m *MockHost) ResolvePlugin(
-	spec workspace.PluginDescriptor,
+	ctx *Context, spec workspace.PluginDescriptor,
 ) (*workspace.PluginInfo, error) {
 	if m.ResolvePluginF != nil {
-		return m.ResolvePluginF(spec)
+		return m.ResolvePluginF(ctx, spec)
 	}
 	return nil, status.Error(codes.Unimplemented, "ResolvePlugin not implemented")
-}
-
-func (m *MockHost) GetProjectPlugins() []workspace.ProjectPlugin {
-	if m.GetProjectPluginsF != nil {
-		return m.GetProjectPluginsF()
-	}
-	return nil
 }
 
 func (m *MockHost) SignalCancellation() error {

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -549,7 +549,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			Env:              environment,
 			Kind:             string(kind),
 			AttachDebugger:   attachDebugger,
-			LoaderAddress:    ctx.Host.LoaderAddr(),
+			LoaderAddress:    ctx.LoaderAddr(),
 		})
 		if err != nil {
 			return nil, err //nolint:govet // lostcancel

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -534,7 +534,7 @@ func ExecPlugin(ctx *Context, bin, prefix string, kind apitype.PluginKind,
 			return nil, fmt.Errorf("getting absolute path for plugin directory: %w", err)
 		}
 
-		runtime, err := ctx.Host.LanguageRuntime(runtimeInfo.Name())
+		runtime, err := ctx.Host.LanguageRuntime(ctx, runtimeInfo.Name())
 		if err != nil {
 			return nil, fmt.Errorf("loading runtime: %w", err)
 		}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -222,7 +222,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 		}
 	} else {
 		// Load the plugin's path by using the standard workspace logic.
-		path, err := workspace.GetPluginPath(ctx.baseContext, ctx.Diag, spec, host.GetProjectPlugins())
+		path, err := workspace.GetPluginPath(ctx.baseContext, ctx.Diag, spec, ctx.ProjectPlugins())
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -186,6 +186,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 	}
 
 	prefix := fmt.Sprintf("%v (resource)", pkg)
+	mapperAddr := mapperTarget(ctx)
 
 	if attachPort != nil {
 		port := *attachPort
@@ -202,7 +203,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 				SupportsViews:               true,
 				SupportsRefreshBeforeUpdate: supportsRefreshBeforeUpdate,
 				InvokeWithPreview:           true,
-				MapperTarget:                hostMapperTarget(host),
+				MapperTarget:                mapperAddr,
 			}
 			return handshake(ctx, bin, prefix, conn, req)
 		}
@@ -266,7 +267,7 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 				SupportsViews:               true,
 				SupportsRefreshBeforeUpdate: supportsRefreshBeforeUpdate,
 				InvokeWithPreview:           true,
-				MapperTarget:                hostMapperTarget(host),
+				MapperTarget:                mapperAddr,
 			}
 			return handshake(ctx, bin, prefix, conn, req)
 		}
@@ -320,10 +321,10 @@ func NewProvider(host Host, ctx *Context, spec workspace.PluginDescriptor,
 	return p, nil
 }
 
-// hostMapperTarget returns the host's mapper address as an optional handshake field, nil when the host has no mapper
-// service.
-func hostMapperTarget(host Host) *string {
-	if addr := host.MapperAddr(); addr != "" {
+// mapperTarget returns the context's mapper address as an optional handshake field, nil when the context has no
+// mapper service.
+func mapperTarget(ctx *Context) *string {
+	if addr := ctx.MapperAddr(); addr != "" {
 		return &addr
 	}
 	return nil
@@ -392,6 +393,7 @@ func providerPluginDialOptions(ctx *Context, pkg tokens.Package, path string) []
 
 // NewProviderFromPath creates a new provider by loading the plugin binary located at `path`.
 func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error) {
+	mapperAddr := mapperTarget(ctx)
 	handshake := func(
 		ctx context.Context, bin string, prefix string, conn *grpc.ClientConn,
 	) (*ProviderHandshakeResponse, error) {
@@ -404,7 +406,7 @@ func NewProviderFromPath(host Host, ctx *Context, path string) (Provider, error)
 			SupportsViews:               true,
 			SupportsRefreshBeforeUpdate: supportsRefreshBeforeUpdate,
 			InvokeWithPreview:           true,
-			MapperTarget:                hostMapperTarget(host),
+			MapperTarget:                mapperAddr,
 		}
 		return handshake(ctx, bin, prefix, conn, req)
 	}

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -65,10 +65,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		host, err := plugin.NewDefaultHost(pCtx, nil, false, nil, nil, nil, nil, tokens.PackageName("test"), nil, nil, nil)
-		if err != nil {
-			return err
-		}
+		host := pCtx.Host
 
 		err = testProvider(ctx.Context(), host, pCtx, "provider-nodejs")
 		if err != nil {


### PR DESCRIPTION
## What this does

This PR refactors `plugin.Host` so that a single host can serve plugins for many workspaces (projects/stacks), scopes plugin lifetimes to the context that booted them, and separates host ownership from `plugin.Context` ownership. It is the first step toward moving default host construction out of the SDK and into `pkg` (where the engine lives), so the SDK stops owning engine-side policy — the planned `pkg/host.NewHost` shape already exists here as the package-private `newHost`.

### Why

The default host implementation captured one workspace's state at construction time: the plugin context itself, the project's plugins and packages, the stack configuration, runtime options, and the project name. That design had several consequences we want to get rid of:

1. **A host could not be shared across workspaces.** Anything that wanted to boot plugins for a second project (or even resolve a schema for a different stack) had to build a whole new host — a new gRPC engine server, new plugin processes, new caches.
2. **Host lifetime was welded to context lifetime.** `Context.Close()` unconditionally closed the host and vice versa, so callers that wanted to share a host had to invent wrappers (see the deleted `noopCloseHost` in `packageworkspace`).
3. **Plugin lifetimes had no owner smaller than the host.** Plugins booted for an ephemeral context lingered until the whole host closed.

The key observation is that `plugin.Context` is already the per-workspace object: it carries the working directory, root, and diagnostic sinks, and its constructors *already received* the plugins/packages/config/runtime-options — only to curry them into the default host. So this PR moves that state onto the `Context` and makes the host read it per call.



>[!IMPORTANT]
> This PR defines `plugin.Host` as an operation level object (you only ever need one of them). When you want to do something, you will need to bring your own `*plugin.Context`. This is the key choice of this PR.

<details>

<summary> Details on what changed. It's AI written but human checked </summary>

### What changed

**`Host` interface (sdk/go/common/resource/plugin):**
- `Provider`, `LanguageRuntime`, `Analyzer`, `PolicyAnalyzer`, and `ResolvePlugin` take a `*plugin.Context` as their first argument. The provider boot reads stack config, runtime options, project name, and `DisableProviderPreview` from it.
- `GetProjectPlugins()` and `LoaderAddr()` are removed from the interface. Project plugins are parsed by the `Context` constructors and exposed via `Context.ProjectPlugins()`; the loader moved to the `Context` (below).

**`defaultHost` is workspace-free:**
- It retains only session-scoped wiring: diagnostic sinks, a lifetime context, its RPC server, plugin caches, and debug wiring. The internal constructor is `newHost(ctx, d, statusD, debugging, installLang)` — the shape that will move to `pkg/host` as `NewHost`.
- Plugin caches are workspace-keyed where the booted process depends on it: language runtimes by `(runtime, working directory)`, analyzers by name + working directory, policy analyzers by name + path + options (previously a cached policy analyzer was reused even if the per-call options differed).

**Plugins are scoped to the context that booted them.**
- The default host watches each context's base context — `Context.Close()` cancels it — and releases that context's plugins when it fires: providers booted by the context are cancelled and closed; cached language runtimes and analyzers are reference-counted per context and close with the last context referencing them. Release is asynchronous; closing the host remains the synchronous backstop.
- A nice side effect: ephemeral contexts that share a long-lived host (e.g. `packageworkspace`'s per-call contexts) now clean up their plugins instead of leaking them until host close.

**Shutdown has three explicit tiers.** Closing (or cancelling) a workspace `Context` is graceful: its plugins' shutdown RPCs run under the host's lifetime context with their full timeout budget, unaffected by the dead workspace context (pinned by `TestContextCloseGracefulShutdownBudget`). `Host.Close()` is graceful and cancels the lifetime context as its final act. Cancelling the lifetime context is the hard stop that aborts graceful shutdown — `NewDefaultHost` derives it with `context.WithoutCancel` so a caller's cancelled context can't become an accidental hard kill; `pkg/host.NewHost(ctx, …)` will expose the hard cut-off.

**Ownership:** `Context.Close()` only closes the host when the context *constructed* it (the nil-host default path). A host passed into a constructor is caller-owned and must be closed by the caller.

**The schema loader service moved from the Host to the Context.** The loader boots plugins to load schemas, and which plugins resolve depends on the workspace — so a host-level loader cannot serve a multi-workspace host. Contexts constructed with a `NewLoaderFunc` (now `func(*plugin.Context) codegenrpc.LoaderServer`) start a loader server automatically, expose it via `Context.LoaderAddr()`, and shut it down on `Close`; `Context.StartLoader` exists for callers that wire custom loaders (the conformance runner, `packageworkspace`). `schema.NewLoaderServerFromHost` is renamed `schema.NewLoaderServerFromContext`.

**`LanguageInstaller` shrank to `func(ctx context.Context, runtime string) error`.** Language hosts are self-contained executables: they are shared across workspaces and are never run with the support of another language runtime (a bootstrapping cycle), so installing one is a plain download-and-unpack — no dependency-install step, no loader. `EnsureLanguageInstalled` warns if a language plugin ships a `PulumiPlugin.yaml` rather than attempting to install its dependencies. The generic plugin-install path (which legitimately installs language-authored plugins' dependencies) is unchanged.

**Ripple:** `providers.Registry`, the engine plugin paths, `pcl.PluginHost`, `convert.ProviderFactoryFromHost`, `schema.NewPluginLoader`, and `packageworkspace.Workspace` carry a `*plugin.Context` where they previously carried a bare `plugin.Host`. All in-repo `Host` implementations (deploytest, pulumi-test-language, engine clientHost, mocks) are updated, and `codegen/testing/utils.NewHost` became `utils.NewContext`.

### Compatibility

This changes the exported `plugin.Host` interface and several SDK/pkg signatures, so downstream implementations and callers (pulumi-yaml, pulumi-terraform-bridge, pulumi-lsp, …) need mechanical updates on their next SDK upgrade: add the `*plugin.Context` parameter, read the loader address from the context, and close hosts they pass into contexts. The nil-host convenience path in `NewContext`/`NewContextWithRoot` still works: the context owns and closes the default host it builds.

</details>

### Follow-up (next PRs)

- Move `defaultHost` to `pkg/host`, exposed as:
  ```go
  func NewHost(ctx context.Context, d, statusD diag.Sink, debugging DebugContext, installLang plugin.LanguageInstaller) plugin.Host
  ```
  This will make a non-nil `plugin.Host` a requirement to construct a `*plugin.Context`.

- After ☝️, fold the language installer, resolver, newly merged mapper (https://github.com/pulumi/pulumi/pull/23506) into the host, since we can now do that without cycles.
- After ☝️, fold creation functions for the new spec->descriptor resolver & schema loading into the `host.NewHost` implementation. (cause we can do that now, its not a cycle)
- Cleanup the mess the installer currently deals with to break the cycle between `*plugin.Context` & `plugin.Host` (since this PR removes the cycle, that's just cleanup).
- Remove dir state from language runners (`About`, respecting the passed in `Pwd` from gRPC methods), then we can share language plugins across directories.