### PR TITLE
ci: run disk-space cleanup in the background of test jobs

### DIFF
--- a/.github/scripts/free-disk-space
+++ b/.github/scripts/free-disk-space
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Frees disk space on Ubuntu runners without blocking the job.
+#
+# This replaces the tgummerer/free-disk-space action (added in #17470 because
+# test jobs ran out of disk; azure-cli kept in #23470). It performs the same
+# cleanup, but everything later steps don't depend on runs in the background
+# so job setup proceeds concurrently. Callers must run `free-disk-space wait`
+# before any step that needs the space (or quiet I/O, e.g. performance tests).
+#
+# Usage:
+#   free-disk-space start   # quick synchronous cleanup, then background the rest
+#   free-disk-space wait    # block until the background cleanup finishes
+#
+# Cleanup is best-effort: `wait` reports the log but never fails the job.
+
+set -uo pipefail
+
+LOG_FILE="${RUNNER_TEMP:-/tmp}/free-disk-space.log"
+PID_FILE="${RUNNER_TEMP:-/tmp}/free-disk-space.pid"
+
+background() {
+  # Android SDK (~10GiB) and Haskell (~3.6GiB).
+  sudo rm -rf /usr/local/lib/android
+  sudo rm -rf /opt/ghc /usr/local/.ghcup
+
+  # Pre-fetched Docker images (~1.9GiB); tests pull what they need.
+  sudo docker image prune --all --force
+
+  # Large apt packages (~3.9GiB). This mirrors the package list of
+  # tgummerer/free-disk-space@865f5375 minus azure-cli (tests need it) and the
+  # aspnetcore/dotnet patterns (/usr/share/dotnet is removed synchronously in
+  # `start`, and no dotnet apt packages exist on the runner image).
+  packages=$(dpkg-query -W -f '${binary:Package}\n' \
+    | grep -E 'firefox|google-chrome-stable|libgl1-mesa-dri|mono-devel|powershell|google-cloud-sdk|google-cloud-cli|(php|^(llvm|mongodb|mysql)-).*$' \
+    | sort -u || true)
+  if [ -n "$packages" ]; then
+    # shellcheck disable=SC2086 # word splitting of the package list is intended
+    sudo apt-get remove -y --fix-missing $packages || echo "apt-get remove failed; proceeding"
+  fi
+  sudo apt-get autoremove -y || echo "apt-get autoremove failed; proceeding"
+  sudo apt-get clean || echo "apt-get clean failed; proceeding"
+
+  echo "Disk space after background cleanup:"
+  df -h /
+}
+
+case "${1:-}" in
+  start)
+    echo "Disk space before cleanup:"
+    df -h /
+    # actions/setup-dotnet installs into /usr/share/dotnet later in the job;
+    # remove it synchronously (~5GiB) so the cleanup cannot race the install.
+    sudo rm -rf /usr/share/dotnet
+    nohup "$0" background >"$LOG_FILE" 2>&1 &
+    echo "$!" >"$PID_FILE"
+    ;;
+  background)
+    background
+    ;;
+  wait)
+    if [ -f "$PID_FILE" ]; then
+      tail --pid="$(cat "$PID_FILE")" -f /dev/null
+      cat "$LOG_FILE"
+    fi
+    ;;
+  *)
+    echo "usage: $0 {start|wait}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -111,18 +111,6 @@ jobs:
     timeout-minutes: 70
     continue-on-error: ${{ inputs.continue-on-error }}
     steps:
-      - if: contains(inputs.platform, 'ubuntu')
-        name: Free Disk Space (Ubuntu)
-        uses: tgummerer/free-disk-space@865f5375bb031bd539c76f6309945e0bdd8d7501
-        with:
-          # tool-cache stays off: tests need Node and Python from /opt/hostedtoolcache.
-          tool-cache: false
-          swap-storage: false
-          large-packages: true
-          large-packages-keep: |
-            azure-cli
-          dotnet: true
-
       # Create a coverage file to register a testing job was started.
       # This artifact will be overwritten with "OK" at the end of the job.
       - name: Write test started file
@@ -169,6 +157,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+      # Frees ~24GiB; test jobs run out of disk otherwise (#17470). The bulk of
+      # the cleanup runs in the background, overlapping the setup steps below.
+      # The "Wait for disk cleanup" step joins it before tests run.
+      - if: contains(inputs.platform, 'ubuntu')
+        name: Free Disk Space (Ubuntu)
+        run: ./.github/scripts/free-disk-space start
       - name: Setup versioning env vars
         env:
           version: ${{ inputs.version }}
@@ -391,6 +385,9 @@ jobs:
       - name: Create GCP service account key file
         run: |
           echo -n '${{ secrets.GCP_SERVICE_ACCOUNT }}' > '${{ runner.temp }}/application_default_credentials.json'
+      - if: contains(inputs.platform, 'ubuntu')
+        name: Wait for disk cleanup (Ubuntu)
+        run: ./.github/scripts/free-disk-space wait
       - name: run tests "${{ inputs.test-command }}"
         id: test
         run: ${{ inputs.test-command }}


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI (Claude) as part of an effort to speed up CI and the merge queue, supervised by @iwahbe.

## Problem

The `Free Disk Space (Ubuntu)` step runs sequentially at the start of every Ubuntu test job, before any setup begins. In a recent merge-queue run ([27259258303](https://github.com/pulumi/pulumi/actions/runs/27259258303)) it took between 55s and **336s per job**. A merge-queue run has ~100 Ubuntu test jobs, so this costs several runner-hours per run and inflates the critical path of every job — including the 28-minute long pole (`Integration Test / sdk/go/pulumi-language-go`).

## Change

Replace the `tgummerer/free-disk-space` action with `.github/scripts/free-disk-space`, which frees the same ~24GiB but does almost all of the work in the background, overlapping the ~5 minutes of toolchain setup that follows:

- `start` (right after checkout): synchronously removes `/usr/share/dotnet` (~5GiB) — this one must not race `actions/setup-dotnet`, which installs into that directory later — then backgrounds the rest: Android SDK (~10GiB), Haskell (~3.6GiB), Docker images (~1.9GiB), and the large apt packages (~3.9GiB, keeping `azure-cli` per #23470).
- `wait` (right before tests run): joins the background work and prints its log, so tests still start with the space freed and without competing disk I/O (this also keeps performance-gate jobs quiet).

Expected effect: ~1–5 minutes saved on every Ubuntu test job's wall clock, with identical disk space available when tests start. As a side effect, apt flakes during cleanup no longer fail jobs (cleanup is best-effort, with its log surfaced by the wait step).

## Verification

This PR's own CI run exercises the change in every Ubuntu test job. Compare the step timings (`Free Disk Space` + `Wait for disk cleanup` vs the old single step) and check the wait step's output to confirm the cleanup finished before tests started.