### PR TITLE
ci: partition the Go conformance tests across three jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,8 @@ jobs:
             --version-set "${VERSION_SETS_TO_TEST[@]}" \
             --partition-module pkg 1 \
             --partition-module sdk 1 \
-            --partition-module sdk/go/pulumi-language-go 1 \
+            --partition-package github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3 \
+                sdk/go/pulumi-language-go 3 \
             --partition-package github.com/pulumi/pulumi/sdk/pcl/v3/cmd/pulumi-language-pcl \
                 sdk/pcl/cmd/pulumi-language-pcl 2 \
             --partition-package github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3 \

--- a/scripts/run-conformance.sh
+++ b/scripts/run-conformance.sh
@@ -31,7 +31,9 @@ fi
 
 cd "$ROOT/sdk/pcl/cmd/pulumi-language-pcl" && go test . -v -count=1 -run "TestLanguage/$1"
 
-cd "$ROOT/sdk/go/pulumi-language-go" && go test . -v -count=1 -run "TestLanguage/.*/$1"
+cd "$ROOT/sdk/go/pulumi-language-go" && go test . -v -count=1 -run "TestLanguagePublished/$1"
+cd "$ROOT/sdk/go/pulumi-language-go" && go test . -v -count=1 -run "TestLanguageLocal/$1"
+cd "$ROOT/sdk/go/pulumi-language-go" && go test . -v -count=1 -run "TestLanguageExtraTypes/$1"
 
 cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test . -v -count=1 -run "TestLanguageTSC/.*/$1"
 cd "$ROOT/sdk/nodejs/cmd/pulumi-language-nodejs" && go test . -v -count=1 -run "TestLanguageTSNode/.*/$1"

--- a/sdk/go/pulumi-language-go/language_test.go
+++ b/sdk/go/pulumi-language-go/language_test.go
@@ -176,131 +176,135 @@ var programOverrides = map[string]*testingrpc.PrepareLanguageTestsRequest_Progra
 	},
 }
 
-func TestLanguage(t *testing.T) {
-	t.Parallel()
+// The conformance suite runs in three configurations, one top-level test
+// function per configuration: CI partitions this package's tests across jobs
+// by top-level test name (see scripts/get-job-matrix.py), so keeping each
+// configuration top level lets them run on separate runners.
 
+func TestLanguagePublished(t *testing.T) {
+	t.Parallel()
+	testLanguage(t, languageTestConfig{name: "published"})
+}
+
+func TestLanguageLocal(t *testing.T) {
+	t.Parallel()
+	testLanguage(t, languageTestConfig{name: "local", local: true})
+}
+
+func TestLanguageExtraTypes(t *testing.T) {
+	t.Parallel()
+	testLanguage(t, languageTestConfig{
+		name: "extra-types",
+		// We don't expect extra-types to interact with "local", so we
+		// don't believe it is worth it to test independently.
+		languageInfo: &gocodegen.GoPackageInfo{
+			GenerateResourceContainerTypes: true,
+			// TODO[https://github.com/pulumi/pulumi/issues/21116]:
+			// l2-resource-config requires that RespectSchemaVersion
+			// is set if any language option is set.
+			RespectSchemaVersion: true,
+		},
+	})
+}
+
+type languageTestConfig struct {
+	name         string
+	local        bool
+	languageInfo *gocodegen.GoPackageInfo
+}
+
+func testLanguage(t *testing.T, config languageTestConfig) {
 	engineAddress, engine := runTestingHost(t)
 
 	tests, err := engine.GetLanguageTests(t.Context(), &testingrpc.GetLanguageTestsRequest{})
 	require.NoError(t, err)
 
-	configs := []struct {
-		name         string
-		local        bool
-		languageInfo *gocodegen.GoPackageInfo
-	}{
-		{
-			name: "published",
+	cancel := make(chan bool)
+	// Run the language plugin
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Init: func(srv *grpc.Server) error {
+			host := newLanguageHost(engineAddress, "", "", "")
+			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
+			return nil
 		},
-		{
-			name:  "local",
-			local: true,
-		},
-		{
-			name: "extra-types",
-			// We don't expect extra-types to interact with "local", so we
-			// don't believe it is worth it to test independently.
-			languageInfo: &gocodegen.GoPackageInfo{
-				GenerateResourceContainerTypes: true,
-				// TODO[https://github.com/pulumi/pulumi/issues/21116]:
-				// l2-resource-config requires that RespectSchemaVersion
-				// is set if any language option is set.
-				RespectSchemaVersion: true,
+		Cancel: cancel,
+	})
+	require.NoError(t, err)
+
+	// Create a temp project dir for the test to run in
+	rootDir := t.TempDir()
+
+	snapshotDir := filepath.Join("./testdata", config.name)
+
+	// Prepare to run the tests
+	prepare, err := engine.PrepareLanguageTests(t.Context(), &testingrpc.PrepareLanguageTestsRequest{
+		LanguagePluginName:   "go",
+		LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		TemporaryDirectory:   rootDir,
+		SnapshotDirectory:    snapshotDir,
+		CoreSdkDirectory:     "../..",
+		CoreSdkVersion:       sdk.Version.String(),
+		PolicyPackDirectory:  "./testdata/policies",
+		Local:                config.local,
+		SnapshotEdits: []*testingrpc.PrepareLanguageTestsRequest_Replacement{
+			{
+				Path:        "(.+/)?go\\.mod",
+				Pattern:     rootDir + "/",
+				Replacement: "/ROOT/",
 			},
 		},
-	}
+		ProgramOverrides: programOverrides,
+		LanguageInfo: func() string {
+			if config.languageInfo == nil {
+				return ""
+			}
+			b, err := json.Marshal(*config.languageInfo)
+			require.NoError(t, err)
+			return string(b)
+		}(),
+	})
+	require.NoError(t, err)
 
-	for _, config := range configs {
-		t.Run(config.name, func(t *testing.T) {
+	for _, tt := range tests.Tests {
+		t.Run(tt, func(t *testing.T) {
 			t.Parallel()
-			cancel := make(chan bool)
-			// Run the language plugin
-			handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
-				Init: func(srv *grpc.Server) error {
-					host := newLanguageHost(engineAddress, "", "", "")
-					pulumirpc.RegisterLanguageRuntimeServer(srv, host)
-					return nil
-				},
-				Cancel: cancel,
-			})
-			require.NoError(t, err)
 
-			// Create a temp project dir for the test to run in
-			rootDir := t.TempDir()
-
-			snapshotDir := filepath.Join("./testdata", config.name)
-
-			// Prepare to run the tests
-			prepare, err := engine.PrepareLanguageTests(t.Context(), &testingrpc.PrepareLanguageTestsRequest{
-				LanguagePluginName:   "go",
-				LanguagePluginTarget: fmt.Sprintf("127.0.0.1:%d", handle.Port),
-				TemporaryDirectory:   rootDir,
-				SnapshotDirectory:    snapshotDir,
-				CoreSdkDirectory:     "../..",
-				CoreSdkVersion:       sdk.Version.String(),
-				PolicyPackDirectory:  "./testdata/policies",
-				Local:                config.local,
-				SnapshotEdits: []*testingrpc.PrepareLanguageTestsRequest_Replacement{
-					{
-						Path:        "(.+/)?go\\.mod",
-						Pattern:     rootDir + "/",
-						Replacement: "/ROOT/",
-					},
-				},
-				ProgramOverrides: programOverrides,
-				LanguageInfo: func() string {
-					if config.languageInfo == nil {
-						return ""
-					}
-					b, err := json.Marshal(*config.languageInfo)
-					require.NoError(t, err)
-					return string(b)
-				}(),
-			})
-			require.NoError(t, err)
-
-			for _, tt := range tests.Tests {
-				t.Run(tt, func(t *testing.T) {
-					t.Parallel()
-
-					// We can skip the l1- local tests without any SDK there's nothing new being tested here.
-					if config.local && strings.HasPrefix(tt, "l1-") {
-						t.Skip("Skipping l1- tests in local mode")
-					}
-
-					// TODO[https://github.com/pulumi/pulumi/issues/21292]: Skip provider tests for now, we test these
-					// with NodeJS and Python only.
-					if strings.HasPrefix(tt, "provider-") {
-						t.Skip("Skipping provider tests")
-					}
-
-					if expected, ok := expectedFailures[tt]; ok {
-						t.Skipf("Skipping known failure: %s", expected)
-					}
-
-					if _, has := programOverrides[tt]; config.local && has {
-						t.Skip("Skipping override tests in local mode")
-					}
-
-					result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
-						Token: prepare.Token,
-						Test:  tt,
-					})
-
-					require.NoError(t, err)
-					for _, msg := range result.Messages {
-						t.Log(msg)
-					}
-					ptesting.LogIfVerbose(t, "stdout", result.Stdout)
-					ptesting.LogIfVerbose(t, "stderr", result.Stderr)
-					assert.True(t, result.Success)
-				})
+			// We can skip the l1- local tests without any SDK there's nothing new being tested here.
+			if config.local && strings.HasPrefix(tt, "l1-") {
+				t.Skip("Skipping l1- tests in local mode")
 			}
 
-			t.Cleanup(func() {
-				close(cancel)
-				require.NoError(t, <-handle.Done)
+			// TODO[https://github.com/pulumi/pulumi/issues/21292]: Skip provider tests for now, we test these
+			// with NodeJS and Python only.
+			if strings.HasPrefix(tt, "provider-") {
+				t.Skip("Skipping provider tests")
+			}
+
+			if expected, ok := expectedFailures[tt]; ok {
+				t.Skipf("Skipping known failure: %s", expected)
+			}
+
+			if _, has := programOverrides[tt]; config.local && has {
+				t.Skip("Skipping override tests in local mode")
+			}
+
+			result, err := engine.RunLanguageTest(t.Context(), &testingrpc.RunLanguageTestRequest{
+				Token: prepare.Token,
+				Test:  tt,
 			})
+
+			require.NoError(t, err)
+			for _, msg := range result.Messages {
+				t.Log(msg)
+			}
+			ptesting.LogIfVerbose(t, "stdout", result.Stdout)
+			ptesting.LogIfVerbose(t, "stderr", result.Stderr)
+			assert.True(t, result.Success)
 		})
 	}
+
+	t.Cleanup(func() {
+		close(cancel)
+		require.NoError(t, <-handle.Done)
+	})
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI (Claude) as part of an effort to speed up CI and the merge queue, supervised by @iwahbe.

## Problem

`Integration Test / sdk/go/pulumi-language-go` is the longest job in CI at **28 minutes** (e.g. [27259258303](https://github.com/pulumi/pulumi/actions/runs/27259258303)), and since integration tests gate on builds (~10.5 min in), it sets the ~42-minute critical path of every merge-queue run. 25 of those minutes are a single `go test` invocation: the whole Go conformance suite hangs off one top-level `TestLanguage` function, and `gotestsum tool ci-matrix` partitions packages by *top-level* test name, so CI cannot split it.

The NodeJS and Python language hosts don't have this problem because their conformance suites are already multiple top-level functions (`TestLanguageTSC`/`TSNode`/`Bun`, `TestLanguageDefault`/`TOML`/`Classes`), which is what lets CI partition them 3 and 4 ways.

## Change

- Split `TestLanguage` into one top-level function per configuration: `TestLanguagePublished`, `TestLanguageLocal`, `TestLanguageExtraTypes`. Each starts its own testing host (previously shared); snapshot directories (`testdata/published` etc.) and per-test behavior are unchanged — this is a mechanical restructuring, no test logic changes.
- Replace `--partition-module sdk/go/pulumi-language-go 1` with a 3-way `--partition-package` in the integration test matrix, mirroring the NodeJS/Python entries. The unit-test matrix keeps the module entry, which covers `goversion`/`buildutil`.
- Update `scripts/run-conformance.sh`, which assumed the old `TestLanguage/<config>/<test>` nesting.

Expected effect: the 28-minute long pole becomes three jobs of roughly 10–13 minutes each (per version set), cutting the merge-queue critical path by ~15 minutes once the gotestsum timing data for the new test names accumulates. The first few runs may be unevenly partitioned since the new names have no timing history.

## Verification

- All three new top-level tests verified locally (one conformance subtest each: `TestLanguagePublished/l1-empty`, `TestLanguageLocal/l2-resource-simple`, `TestLanguageExtraTypes/l1-empty` — all pass).
- `make lint_golang` and `make lint_actions` pass.
- This PR's CI runs the new 3-way partition end to end; check the three `sdk/go/pulumi-language-go N/3` job durations.