### PR TITLE
fix test flake in resource_test.go

### DIFF
--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/internal"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -551,10 +552,10 @@ func TestTransformationPreservesParent(t *testing.T) {
 		}
 	}
 
-	parents := map[string]string{}
+	var parents gsync.Map[string, string]
 	monitor := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			parents[args.Name] = args.RegisterRPC.GetParent()
+			parents.Store(args.Name, args.RegisterRPC.GetParent())
 			return args.Name, resource.PropertyMap{}, nil
 		},
 	}
@@ -575,18 +576,20 @@ func TestTransformationPreservesParent(t *testing.T) {
 	}, WithMocks("project", "stack", monitor))
 	require.NoError(t, err)
 
-	require.NotEmpty(t, parents["without-transform"], "baseline should have a parent")
-	assert.Equal(t, parents["without-transform"], parents["with-transform"],
+	withoutParent, _ := parents.Load("without-transform")
+	withParent, _ := parents.Load("with-transform")
+	require.NotEmpty(t, withoutParent, "baseline should have a parent")
+	assert.Equal(t, withoutParent, withParent,
 		"transformation must not drop the parent")
 }
 
 func TestTransformationCannotChangeParent(t *testing.T) {
 	t.Parallel()
 
-	parents := map[string]string{}
+	var parents gsync.Map[string, string]
 	monitor := &testMonitor{
 		NewResourceF: func(args MockResourceArgs) (string, resource.PropertyMap, error) {
-			parents[args.Name] = args.RegisterRPC.GetParent()
+			parents.Store(args.Name, args.RegisterRPC.GetParent())
 			return args.Name, resource.PropertyMap{}, nil
 		},
 	}


### PR DESCRIPTION
Seen in https://github.com/pulumi/pulumi/actions/runs/27234643117/job/80424001578:

```
fatal error: concurrent map writes
--- PASS: TestOutputApply/ApplyT::Float64MapArrayOutput (0.00s)

goroutine 4050 [running]:
internal/runtime/maps.fatal(***0x7ff67d48fecc?, 0x19745429e800?***)
	C:/hostedtoolcache/windows/go/1.26.4/x64/src/runtime/panic.go:1181 +0x18
github.com/pulumi/pulumi/sdk/v3/go/pulumi.TestTransformationPreservesParent.func2(***0x7ff67d48a944, 0x12***, ***0x7ff67d4853a8, 0xe***, 0x1974544f3830, ***0x0, 0x0***, ***0x0, 0x0***, 0x1, ...***)
	D:/a/pulumi/pulumi/sdk/go/pulumi/resource_test.go:557 +0x8c
github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*testMonitor).NewResource(0x7ff67c673b40?, ***0x7ff67d48a944, 0x12***, ***0x7ff67d4853a8, 0xe***, 0x1974544f3830, ***0x0, 0x0***, ***0x0, 0x0***, ...***)
	D:/a/pulumi/pulumi/sdk/go/pulumi/run_test.go:82 +0x65
github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*mockMonitor).RegisterResource(0x197454641200, ***0x7ff67d4c78ac?, 0x40?***, 0x1974551a7688, ***0x2?, 0x2?, 0x7ff67d48a944?***)
	D:/a/pulumi/pulumi/sdk/go/pulumi/mocks.go:319 +0x5dc
github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*Context).registerResource.func1()
	D:/a/pulumi/pulumi/sdk/go/pulumi/context.go:1857 +0x11a3
created by github.com/pulumi/pulumi/sdk/v3/go/pulumi.(*Context).registerResource in goroutine 72
```

These maps can be written in parallel, so use a sync.Map instead. This is a test only flake fix.