### PR TITLE
fix cache key for go binary builds

### DIFF
--- a/.github/workflows/ci-build-binaries.yml
+++ b/.github/workflows/ci-build-binaries.yml
@@ -82,7 +82,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - name: Configure Go Cache Key
         env:
-          CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}"
+          CACHE_KEY: "${{ fromJson(inputs.version-set).go }}-${{ runner.os }}-${{ runner.arch }}-target-${{ inputs.os }}-${{ inputs.arch }}-cov-${{ inputs.enable-coverage && inputs.os == 'linux' }}-race-${{ inputs.enable-race-detection }}"
         run: echo "$CACHE_KEY" > .gocache.tmp
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
We cross compile all of our Go binaries on `ubuntu-latest`.  That's fine, except our cache key is based on the runner os/arch, and thus won't be actually useful later, because it only saves 1 cache entry for 6 different cross compiled architectures.

We can see this e.g. in https://github.com/pulumi/pulumi/actions/runs/27259258303/job/80501188969, where the windows-arm64 build takes 2 minutes, but everything else takes between 5 and 7 minutes.

So fixing the cache key to be more explicit should save us ~3 minutes.
