### PR TITLE
tests: build testprovider once per test process

### DIFF
--- a/tests/integration/aliases/aliases_py_test.go
+++ b/tests/integration/aliases/aliases_py_test.go
@@ -72,7 +72,7 @@ func TestPythonAliasAfterFailedUpdate(t *testing.T) {
 				filepath.Join("..", "..", "..", "sdk", "python"),
 			},
 			LocalProviders: []integration.LocalDependency{
-				{Package: "testprovider", Path: testutil.TestProvider(t)},
+				{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 			},
 			Quick: true,
 			EditDirs: []integration.EditDir{

--- a/tests/integration/aliases/aliases_py_test.go
+++ b/tests/integration/aliases/aliases_py_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestPythonAliases(t *testing.T) {
@@ -71,7 +72,7 @@ func TestPythonAliasAfterFailedUpdate(t *testing.T) {
 				filepath.Join("..", "..", "..", "sdk", "python"),
 			},
 			LocalProviders: []integration.LocalDependency{
-				{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+				{Package: "testprovider", Path: testutil.TestProvider(t)},
 			},
 			Quick: true,
 			EditDirs: []integration.EditDir{

--- a/tests/integration/bun/bun_test.go
+++ b/tests/integration/bun/bun_test.go
@@ -15,7 +15,6 @@
 package bun
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
@@ -29,7 +28,7 @@ func TestBunCallbacks(t *testing.T) {
 		Dir:          "callbacks",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -46,7 +45,7 @@ func TestBun(t *testing.T) {
 		Dir:          "simple",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			isBun := stack.Outputs["isBun"].(bool)

--- a/tests/integration/bun/bun_test.go
+++ b/tests/integration/bun/bun_test.go
@@ -28,7 +28,7 @@ func TestBunCallbacks(t *testing.T) {
 		Dir:          "callbacks",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -45,7 +45,7 @@ func TestBun(t *testing.T) {
 		Dir:          "simple",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			isBun := stack.Outputs["isBun"].(bool)

--- a/tests/integration/error_hooks/error_hooks_go_test.go
+++ b/tests/integration/error_hooks/error_hooks_go_test.go
@@ -30,7 +30,7 @@ func TestGoErrorHooks(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/error_hooks/error_hooks_go_test.go
+++ b/tests/integration/error_hooks/error_hooks_go_test.go
@@ -30,7 +30,7 @@ func TestGoErrorHooks(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/error_hooks/error_hooks_nodejs_test.go
+++ b/tests/integration/error_hooks/error_hooks_nodejs_test.go
@@ -28,7 +28,7 @@ func TestNodejsErrorHooks(t *testing.T) {
 		Dir:          filepath.Join("nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/error_hooks/error_hooks_nodejs_test.go
+++ b/tests/integration/error_hooks/error_hooks_nodejs_test.go
@@ -28,7 +28,7 @@ func TestNodejsErrorHooks(t *testing.T) {
 		Dir:          filepath.Join("nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/error_hooks/error_hooks_py_test.go
+++ b/tests/integration/error_hooks/error_hooks_py_test.go
@@ -30,7 +30,7 @@ func TestPythonErrorHooks(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/error_hooks/error_hooks_py_test.go
+++ b/tests/integration/error_hooks/error_hooks_py_test.go
@@ -30,7 +30,7 @@ func TestPythonErrorHooks(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -980,7 +980,7 @@ func TestDeletedWithGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 	})
@@ -1150,7 +1150,7 @@ func TestStackOutputsResourceErrorGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: validateOutputs(map[string]any{
@@ -1193,10 +1193,7 @@ func TestParameterizedGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			// PrePrepareProject below runs `pulumi package gen-sdk` on this
-			// path, which requires a plugin project directory, so it can't use
-			// the prebuilt testutil.TestProvider.
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		PrePrepareProject: func(info *engine.Projinfo) error {
 			e := ptesting.NewEnvironment(t)
@@ -1214,9 +1211,9 @@ func TestParameterizedGo(t *testing.T) {
 			require.NoError(t, err)
 			e.WriteTestFile("main_test.go", string(actualProgram))
 
-			// Generate the SDK for the provider.
-			path := info.Proj.Plugins.Providers[0].Path
-			_, _ = e.RunCommand("pulumi", "package", "gen-sdk", path, "pkg", "--language", "go")
+			// Generate the SDK for the provider. gen-sdk takes the plugin
+			// binary itself and infers the package name from its filename.
+			_, _ = e.RunCommand("pulumi", "package", "gen-sdk", testutil.TestProvider(t), "pkg", "--language", "go")
 
 			// Add a reference to the generated SDK in go.mod.
 			err = appendLines(filepath.Join(e.CWD, "go.mod"), []string{

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1193,7 +1193,10 @@ func TestParameterizedGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			// PrePrepareProject below runs `pulumi package gen-sdk` on this
+			// path, which requires a plugin project directory, so it can't use
+			// the prebuilt testutil.TestProvider.
+			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
 		},
 		PrePrepareProject: func(info *engine.Projinfo) error {
 			e := ptesting.NewEnvironment(t)

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 // This checks that the buildTarget option for Pulumi Go programs does build a binary.
@@ -979,7 +980,7 @@ func TestDeletedWithGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 	})
@@ -1149,7 +1150,7 @@ func TestStackOutputsResourceErrorGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: validateOutputs(map[string]any{
@@ -1192,7 +1193,7 @@ func TestParameterizedGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		PrePrepareProject: func(info *engine.Projinfo) error {
 			e := ptesting.NewEnvironment(t)

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -291,7 +291,7 @@ func TestStackOutputsResourceErrorNodeJS(t *testing.T) {
 		Dir:          filepath.Join(d, "step1"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: validateOutputs(map[string]any{
@@ -2064,7 +2064,7 @@ func TestDeletedWithNode(t *testing.T) {
 		Dir:          filepath.Join("deleted_with", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 	})
@@ -2423,7 +2423,7 @@ func TestParameterizedNode(t *testing.T) {
 		Dir:           filepath.Join("nodejs", "parameterized"),
 		Dependencies:  []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		NoParallel: true,
 		PrePrepareProject: func(project *engine.Projinfo) error {
@@ -2716,7 +2716,7 @@ func TestAutonaming(t *testing.T) {
 				Env:           env,
 				OrderedConfig: orderedConfig,
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -3386,7 +3386,7 @@ func TestNodejsOnBeforeExit(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "before-exit"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -3408,7 +3408,7 @@ func TestNodejsPromiseMessage(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "promise-message"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick:         true,
 		ExpectFailure: true,
@@ -3437,7 +3437,7 @@ func TestNodejsExitError(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "exit-error"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick:         true,
 		ExpectFailure: true,
@@ -3463,22 +3463,19 @@ func TestNodejsExitError(t *testing.T) {
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestTsExecute(t *testing.T) {
-	// This test runs `pulumi package add` on the path, which requires a plugin
-	// project directory, so it can't use the prebuilt testutil.TestProvider.
-	testProviderPath, err := filepath.Abs(filepath.Join("..", "testprovider"))
-	contract.AssertNoErrorf(err, "Test provider path must be resolvable to absolute path")
-
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("nodejs", "ts-execute"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testProviderPath},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		PrePrepareProject: func(project *engine.Projinfo) error {
 			// Do NOT provide "-- provider" arguments on purpose.
 			// This will make the provider require that Pulumi runtime is supporting parameterization.
 			// And I haven't yet figured out how to do so in these tests.
-			cmd := exec.Command("pulumi", "package", "add", testProviderPath)
+			// package add takes the plugin binary itself and infers the
+			// package name from its filename.
+			cmd := exec.Command("pulumi", "package", "add", testutil.TestProvider(t))
 			cmd.Dir = project.Root
 			out, err := cmd.CombinedOutput()
 			require.NoError(t, err, "output: %s", out)

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -3463,7 +3463,9 @@ func TestNodejsExitError(t *testing.T) {
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestTsExecute(t *testing.T) {
-	testProviderPath, err := filepath.Abs(testutil.TestProvider(t))
+	// This test runs `pulumi package add` on the path, which requires a plugin
+	// project directory, so it can't use the prebuilt testutil.TestProvider.
+	testProviderPath, err := filepath.Abs(filepath.Join("..", "testprovider"))
 	contract.AssertNoErrorf(err, "Test provider path must be resolvable to absolute path")
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/nodejs/npm"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
@@ -290,7 +291,7 @@ func TestStackOutputsResourceErrorNodeJS(t *testing.T) {
 		Dir:          filepath.Join(d, "step1"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: validateOutputs(map[string]any{
@@ -2063,7 +2064,7 @@ func TestDeletedWithNode(t *testing.T) {
 		Dir:          filepath.Join("deleted_with", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 	})
@@ -2422,7 +2423,7 @@ func TestParameterizedNode(t *testing.T) {
 		Dir:           filepath.Join("nodejs", "parameterized"),
 		Dependencies:  []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		NoParallel: true,
 		PrePrepareProject: func(project *engine.Projinfo) error {
@@ -2715,7 +2716,7 @@ func TestAutonaming(t *testing.T) {
 				Env:           env,
 				OrderedConfig: orderedConfig,
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -3385,7 +3386,7 @@ func TestNodejsOnBeforeExit(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "before-exit"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -3407,7 +3408,7 @@ func TestNodejsPromiseMessage(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "promise-message"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick:         true,
 		ExpectFailure: true,
@@ -3436,7 +3437,7 @@ func TestNodejsExitError(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "exit-error"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick:         true,
 		ExpectFailure: true,
@@ -3462,7 +3463,7 @@ func TestNodejsExitError(t *testing.T) {
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestTsExecute(t *testing.T) {
-	testProviderPath, err := filepath.Abs(filepath.Join("..", "testprovider"))
+	testProviderPath, err := filepath.Abs(testutil.TestProvider(t))
 	contract.AssertNoErrorf(err, "Test provider path must be resolvable to absolute path")
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 // This checks that error logs are not being emitted twice
@@ -2007,7 +2008,7 @@ func TestStuckEventLoop(t *testing.T) {
 				filepath.Join("..", "..", "sdk", "python"),
 			},
 			LocalProviders: []integration.LocalDependency{
-				{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+				{Package: "testprovider", Path: testutil.TestProvider(t)},
 			},
 			Stderr:        stderr,
 			Quick:         true,

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -2008,7 +2008,7 @@ func TestStuckEventLoop(t *testing.T) {
 				filepath.Join("..", "..", "sdk", "python"),
 			},
 			LocalProviders: []integration.LocalDependency{
-				{Package: "testprovider", Path: testutil.TestProvider(t)},
+				{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 			},
 			Stderr:        stderr,
 			Quick:         true,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 // TestStackTagValidation verifies various error scenarios related to stack names and tags.
@@ -1024,7 +1025,7 @@ func TestParentRename_issue13179(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		// Only run up:
 		SkipRefresh: true,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1025,7 +1025,7 @@ func TestParentRename_issue13179(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		// Only run up:
 		SkipRefresh: true,

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -413,7 +414,7 @@ func testConstructMethodsProvider(t *testing.T, lang string, dependencies ...str
 				Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir),
 			}
 			testProvider := integration.LocalDependency{
-				Package: "testprovider", Path: filepath.Join("..", "testprovider"),
+				Package: "testprovider", Path: testutil.TestProvider(t),
 			}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
 				Dir:            filepath.Join(testDir, lang),

--- a/tests/integration/integration_util_test.go
+++ b/tests/integration/integration_util_test.go
@@ -414,7 +414,7 @@ func testConstructMethodsProvider(t *testing.T, lang string, dependencies ...str
 				Package: "testcomponent", Path: filepath.Join(testDir, test.componentDir),
 			}
 			testProvider := integration.LocalDependency{
-				Package: "testprovider", Path: testutil.TestProvider(t),
+				Package: "testprovider", Path: testutil.TestProviderDir(t),
 			}
 			integration.ProgramTest(t, &integration.ProgramTestOptions{
 				Dir:            filepath.Join(testDir, lang),

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 type traceSpan struct {
@@ -52,7 +53,7 @@ func TestOtelTraces(t *testing.T) {
 		binaryName += ".exe"
 	}
 	buildCmd := exec.Command("go", "build", "-o", filepath.Join(binDir, binaryName), ".") //nolint:gosec
-	buildCmd.Dir = filepath.Join("..", "..", "testprovider")
+	buildCmd.Dir = testutil.TestProvider(t)
 	out, err := buildCmd.CombinedOutput()
 	require.NoError(t, err, "failed to build testprovider: %s", out)
 

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -45,7 +45,7 @@ func TestOtelTraces(t *testing.T) {
 	// Use the prebuilt standalone testprovider binary so the engine launches it directly in ExecPlugin rather
 	// than through RunPlugin. We currently can't gracefully shut down a RunPlugin process and wait for it to
 	// finish, so providers launched that way don't get a chance to flush their OTEL traces before being killed.
-	binDir := testutil.TestProvider(t)
+	binDir := testutil.TestProviderDir(t)
 
 	traceDir := t.TempDir()
 	tracePath, err := filepath.Abs(filepath.Join(traceDir, "traces-{command}.json"))

--- a/tests/integration/otel_traces/otel_traces_test.go
+++ b/tests/integration/otel_traces/otel_traces_test.go
@@ -18,9 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -44,18 +42,10 @@ type traceSpan struct {
 
 //nolint:paralleltest // ProgramTest calls t.Parallel()
 func TestOtelTraces(t *testing.T) {
-	// Build the testprovider as a standalone binary so the engine launches it directly in ExecPlugin rather than
-	// through RunPlugin. We currently can't gracefully shut down a RunPlugin process and wait for it to finish, so
-	// providers launched that way don't get a chance to flush their OTEL traces before being killed.
-	binDir := t.TempDir()
-	binaryName := "pulumi-resource-testprovider"
-	if runtime.GOOS == "windows" {
-		binaryName += ".exe"
-	}
-	buildCmd := exec.Command("go", "build", "-o", filepath.Join(binDir, binaryName), ".") //nolint:gosec
-	buildCmd.Dir = testutil.TestProvider(t)
-	out, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, "failed to build testprovider: %s", out)
+	// Use the prebuilt standalone testprovider binary so the engine launches it directly in ExecPlugin rather
+	// than through RunPlugin. We currently can't gracefully shut down a RunPlugin process and wait for it to
+	// finish, so providers launched that way don't get a chance to flush their OTEL traces before being killed.
+	binDir := testutil.TestProvider(t)
 
 	traceDir := t.TempDir()
 	tracePath, err := filepath.Abs(filepath.Join(traceDir, "traces-{command}.json"))

--- a/tests/integration/program_error/program_error_go_test.go
+++ b/tests/integration/program_error/program_error_go_test.go
@@ -36,7 +36,7 @@ func TestProgramErrorGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/program_error/program_error_go_test.go
+++ b/tests/integration/program_error/program_error_go_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +36,7 @@ func TestProgramErrorGo(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/program_error/program_error_nodejs_test.go
+++ b/tests/integration/program_error/program_error_nodejs_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +36,7 @@ func TestProgramErrorNodejs(t *testing.T) {
 			"@pulumi/pulumi",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/program_error/program_error_nodejs_test.go
+++ b/tests/integration/program_error/program_error_nodejs_test.go
@@ -36,7 +36,7 @@ func TestProgramErrorNodejs(t *testing.T) {
 			"@pulumi/pulumi",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/program_error/program_error_python_test.go
+++ b/tests/integration/program_error/program_error_python_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +36,7 @@ func TestProgramErrorPython(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/program_error/program_error_python_test.go
+++ b/tests/integration/program_error/program_error_python_test.go
@@ -36,7 +36,7 @@ func TestProgramErrorPython(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/resource_hooks/resource_hooks_go_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_go_test.go
@@ -33,7 +33,7 @@ func TestGoResourceHooks(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -60,7 +60,7 @@ func TestGoResourceHooksTransform(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -102,7 +102,7 @@ func TestGoResourceHooksSecrets(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/resource_hooks/resource_hooks_go_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_go_test.go
@@ -33,7 +33,7 @@ func TestGoResourceHooks(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -60,7 +60,7 @@ func TestGoResourceHooksTransform(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -102,7 +102,7 @@ func TestGoResourceHooksSecrets(t *testing.T) {
 			"github.com/pulumi/pulumi/sdk/v3",
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
@@ -31,7 +31,7 @@ func TestNodejsResourceHooks(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "step-1"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -56,7 +56,7 @@ func TestNodejsResourceHooksTransform(t *testing.T) {
 		Dir:          "nodejs_transform",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -96,7 +96,7 @@ func TestNodejsResourceHooksSecrets(t *testing.T) {
 		Dir:          "nodejs_secret",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_nodejs_test.go
@@ -31,7 +31,7 @@ func TestNodejsResourceHooks(t *testing.T) {
 		Dir:          filepath.Join("nodejs", "step-1"),
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -56,7 +56,7 @@ func TestNodejsResourceHooksTransform(t *testing.T) {
 		Dir:          "nodejs_transform",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -96,7 +96,7 @@ func TestNodejsResourceHooksSecrets(t *testing.T) {
 		Dir:          "nodejs_secret",
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/resource_hooks/resource_hooks_py_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_py_test.go
@@ -34,7 +34,7 @@ func TestPythonResourceHooks(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -61,7 +61,7 @@ func TestPythonResourceHooksTransform(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -103,7 +103,7 @@ func TestPythonResourceHooksSecrets(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -122,7 +122,7 @@ func TestPythonHookDecorator(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		PreviewCompletedHook: func(dir string) error {
 			matches, err := filepath.Glob(filepath.Join(dir, "command-output", "pulumi-preview-initial*.log"))

--- a/tests/integration/resource_hooks/resource_hooks_py_test.go
+++ b/tests/integration/resource_hooks/resource_hooks_py_test.go
@@ -34,7 +34,7 @@ func TestPythonResourceHooks(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -61,7 +61,7 @@ func TestPythonResourceHooksTransform(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
@@ -103,7 +103,7 @@ func TestPythonResourceHooksSecrets(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
@@ -122,7 +122,7 @@ func TestPythonHookDecorator(t *testing.T) {
 			filepath.Join("..", "..", "..", "sdk", "python"),
 		},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		PreviewCompletedHook: func(dir string) error {
 			matches, err := filepath.Glob(filepath.Join(dir, "command-output", "pulumi-preview-initial*.log"))

--- a/tests/integration/transformations/transformations_go_test.go
+++ b/tests/integration/transformations/transformations_go_test.go
@@ -35,7 +35,7 @@ func TestGoTransformations(t *testing.T) {
 					"github.com/pulumi/pulumi/sdk/v3",
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transformations/transformations_go_test.go
+++ b/tests/integration/transformations/transformations_go_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestGoTransformations(t *testing.T) {
@@ -34,7 +35,7 @@ func TestGoTransformations(t *testing.T) {
 					"github.com/pulumi/pulumi/sdk/v3",
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transformations/transformations_nodejs_test.go
+++ b/tests/integration/transformations/transformations_nodejs_test.go
@@ -33,7 +33,7 @@ func TestNodejsTransformations(t *testing.T) {
 				Dir:          d,
 				Dependencies: []string{"@pulumi/pulumi"},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transformations/transformations_nodejs_test.go
+++ b/tests/integration/transformations/transformations_nodejs_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestNodejsTransformations(t *testing.T) {
@@ -32,7 +33,7 @@ func TestNodejsTransformations(t *testing.T) {
 				Dir:          d,
 				Dependencies: []string{"@pulumi/pulumi"},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transformations/transformations_py_test.go
+++ b/tests/integration/transformations/transformations_py_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestPythonTransformations(t *testing.T) {
@@ -34,7 +35,7 @@ func TestPythonTransformations(t *testing.T) {
 					filepath.Join("..", "..", "..", "sdk", "python"),
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transformations/transformations_py_test.go
+++ b/tests/integration/transformations/transformations_py_test.go
@@ -35,7 +35,7 @@ func TestPythonTransformations(t *testing.T) {
 					filepath.Join("..", "..", "..", "sdk", "python"),
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transforms/transforms_go_test.go
+++ b/tests/integration/transforms/transforms_go_test.go
@@ -35,7 +35,7 @@ func TestGoTransformations(t *testing.T) {
 					"github.com/pulumi/pulumi/sdk/v3",
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transforms/transforms_go_test.go
+++ b/tests/integration/transforms/transforms_go_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestGoTransformations(t *testing.T) {
@@ -34,7 +35,7 @@ func TestGoTransformations(t *testing.T) {
 					"github.com/pulumi/pulumi/sdk/v3",
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transforms/transforms_nodejs_test.go
+++ b/tests/integration/transforms/transforms_nodejs_test.go
@@ -30,7 +30,7 @@ func TestNodejsSimpleTransforms(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick:                  true,
 		ExtraRuntimeValidation: Validator,
@@ -44,7 +44,7 @@ func TestNodejsSingleTransforms(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 	})
@@ -59,7 +59,7 @@ func TestNodejsTransformsAsyncResource(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/transforms/transforms_nodejs_test.go
+++ b/tests/integration/transforms/transforms_nodejs_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +30,7 @@ func TestNodejsSimpleTransforms(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick:                  true,
 		ExtraRuntimeValidation: Validator,
@@ -43,7 +44,7 @@ func TestNodejsSingleTransforms(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 	})
@@ -58,7 +59,7 @@ func TestNodejsTransformsAsyncResource(t *testing.T) {
 		Dir:          d,
 		Dependencies: []string{"@pulumi/pulumi"},
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 		Quick: true,
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {

--- a/tests/integration/transforms/transforms_py_test.go
+++ b/tests/integration/transforms/transforms_py_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 )
 
 func TestPythonTransforms(t *testing.T) {
@@ -34,7 +35,7 @@ func TestPythonTransforms(t *testing.T) {
 					filepath.Join("..", "..", "..", "sdk", "python"),
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: filepath.Join("..", "..", "testprovider")},
+					{Package: "testprovider", Path: testutil.TestProvider(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/integration/transforms/transforms_py_test.go
+++ b/tests/integration/transforms/transforms_py_test.go
@@ -35,7 +35,7 @@ func TestPythonTransforms(t *testing.T) {
 					filepath.Join("..", "..", "..", "sdk", "python"),
 				},
 				LocalProviders: []integration.LocalDependency{
-					{Package: "testprovider", Path: testutil.TestProvider(t)},
+					{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 				},
 				Quick:                  true,
 				ExtraRuntimeValidation: Validator,

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"github.com/pulumi/pulumi/tests/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,7 +84,7 @@ func TestPerfManyComponentUpdate(t *testing.T) {
 		OtelTraces:  otelTracesEndpoint(t),
 		Env:         otelResourceEnv(t),
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 	})
 }
@@ -108,7 +109,7 @@ func TestPerfParentChainUpdate(t *testing.T) {
 		OtelTraces:  otelTracesEndpoint(t),
 		Env:         otelResourceEnv(t),
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: filepath.Join("..", "testprovider")},
+			{Package: "testprovider", Path: testutil.TestProvider(t)},
 		},
 	})
 }

--- a/tests/performance/performance_test.go
+++ b/tests/performance/performance_test.go
@@ -84,7 +84,7 @@ func TestPerfManyComponentUpdate(t *testing.T) {
 		OtelTraces:  otelTracesEndpoint(t),
 		Env:         otelResourceEnv(t),
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 	})
 }
@@ -109,7 +109,7 @@ func TestPerfParentChainUpdate(t *testing.T) {
 		OtelTraces:  otelTracesEndpoint(t),
 		Env:         otelResourceEnv(t),
 		LocalProviders: []integration.LocalDependency{
-			{Package: "testprovider", Path: testutil.TestProvider(t)},
+			{Package: "testprovider", Path: testutil.TestProviderDir(t)},
 		},
 	})
 }

--- a/tests/testutil/testprovider.go
+++ b/tests/testutil/testprovider.go
@@ -29,19 +29,18 @@ import (
 var testProvider struct {
 	once sync.Once
 	dir  string
+	bin  string
 	err  error
 }
 
-// TestProvider builds tests/testprovider once per test process and returns the
-// directory containing the resulting pulumi-resource-testprovider binary, for
-// use as an integration.LocalDependency path.
+// buildTestProvider builds tests/testprovider once per test process.
 //
-// When a local provider path is the testprovider source directory instead, the
-// engine starts the plugin through the Go language host, which runs `go build`
-// every time the engine boots the provider: once per operation per test. On
-// CI runners those concurrent toolchain invocations dominate the test's wall
-// time, so tests should prefer this prebuilt binary.
-func TestProvider(t testing.TB) string {
+// When a test points the engine at the testprovider source directory instead,
+// the engine starts the plugin through the Go language host, which runs
+// `go build` every time the engine boots the provider: once per operation per
+// test. On CI runners those concurrent toolchain invocations dominate the
+// test's wall time, so tests should prefer the prebuilt binary.
+func buildTestProvider(t testing.TB) {
 	testProvider.once.Do(func() {
 		// Not t.TempDir(): that is removed when the test that happens to build
 		// the provider finishes, while every later test still needs the binary.
@@ -63,7 +62,24 @@ func TestProvider(t testing.TB) string {
 			return
 		}
 		testProvider.dir = dir
+		testProvider.bin = binary
 	})
 	require.NoError(t, testProvider.err)
+}
+
+// TestProviderDir returns the directory containing a prebuilt
+// pulumi-resource-testprovider binary, for use as an
+// integration.LocalDependency path: the engine resolves a project plugin path
+// by looking the binary up inside the directory.
+func TestProviderDir(t testing.TB) string {
+	buildTestProvider(t)
 	return testProvider.dir
+}
+
+// TestProvider returns the path of a prebuilt pulumi-resource-testprovider
+// binary, for commands like `pulumi package add` that take the plugin binary
+// itself and infer the package name from its filename.
+func TestProvider(t testing.TB) string {
+	buildTestProvider(t)
+	return testProvider.bin
 }

--- a/tests/testutil/testprovider.go
+++ b/tests/testutil/testprovider.go
@@ -1,0 +1,69 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testProvider struct {
+	once sync.Once
+	dir  string
+	err  error
+}
+
+// TestProvider builds tests/testprovider once per test process and returns the
+// directory containing the resulting pulumi-resource-testprovider binary, for
+// use as an integration.LocalDependency path.
+//
+// When a local provider path is the testprovider source directory instead, the
+// engine starts the plugin through the Go language host, which runs `go build`
+// every time the engine boots the provider: once per operation per test. On
+// CI runners those concurrent toolchain invocations dominate the test's wall
+// time, so tests should prefer this prebuilt binary.
+func TestProvider(t testing.TB) string {
+	testProvider.once.Do(func() {
+		// Not t.TempDir(): that is removed when the test that happens to build
+		// the provider finishes, while every later test still needs the binary.
+		dir, err := os.MkdirTemp("", "pulumi-testprovider") //nolint:usetesting
+		if err != nil {
+			testProvider.err = err
+			return
+		}
+
+		binary := filepath.Join(dir, "pulumi-resource-testprovider")
+		if runtime.GOOS == "windows" {
+			binary += ".exe"
+		}
+		// The test's working directory is inside the tests module, so the
+		// import path resolves without knowing where this file is on disk.
+		cmd := exec.Command("go", "build", "-o", binary, "github.com/pulumi/pulumi/tests/testprovider")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			testProvider.err = fmt.Errorf("building testprovider: %w\n%s", err, output)
+			return
+		}
+		testProvider.dir = dir
+	})
+	require.NoError(t, testProvider.err)
+	return testProvider.dir
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI (Claude) as part of an effort to speed up CI and the merge queue, supervised by @iwahbe. The once-per-process (`sync.Once`) design is @iwahbe's suggestion, so plain `go test` keeps working locally with no extra setup.

## Problem

Integration tests point `LocalProviders` at the `tests/testprovider` *source directory* (`PulumiPlugin.yaml`, `runtime: go`), so the engine boots the provider through the Go language host, whose `RunPlugin` runs `go build` **every time the engine starts the plugin — once per operation per test** ([`compileProgram`](https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi-language-go/main.go)).

On CI runners these concurrent toolchain invocations dominate wall time. Evidence from investigating `tests/integration/resource_hooks`: the tests are intrinsically ~15s (measured locally), but take **~6 min each on Ubuntu CI and ~20.5 min each on macOS CI**, where all seven tests finish within a 23-second window of each other — the signature of everything crawling behind a shared toolchain storm, not of tests doing 20 minutes of work.

## Change

Add `testutil.TestProvider(t)`, which builds `tests/testprovider` **once per test process** via `sync.Once` into a process-lifetime temp dir, and switch all 44 `LocalProviders` call sites (24 files) to use it. With a binary present in the plugin path, the engine execs it directly (`getPluginPath` resolves `pulumi-resource-testprovider` in the dir) and the language-host/`go build` path is skipped entirely.

Building per process rather than per CI job means local `go test` of any single package works exactly as before — no Makefile prerequisite, no stale-binary risk (each run rebuilds once, and the Go build cache makes that cheap).

## Measured locally (M-series Mac, warm build cache — best case for the *old* path)

| Scenario | before | after |
|---|---|---|
| 7 resource_hooks tests, parallel, `-race` | 30.5s wall (tests 20–29s) | **16.4s wall (tests 9.4–14.4s)** |

Cold-cache, 4-core CI runners should gain proportionally more; the macOS acceptance jobs (where `resource_hooks` is ~the whole 21-minute `tests 4/8` partition) are the biggest expected winner, though that only shows in merge-queue runs since PRs run Windows acceptance.

## Verification

- resource_hooks (7 tests) and transforms packages pass locally with the prebuilt provider.
- `make lint_golang` passes.
- This PR's CI exercises every converted package on Ubuntu and Windows; compare `tests 1/2`, `tests/integration N/8`, and Windows `tests N/3` job times against master.