### PR TITLE
use a build cache for Go programs

### DIFF
--- a/sdk/go/pulumi-language-go/build_cache.go
+++ b/sdk/go/pulumi-language-go/build_cache.go
@@ -1,0 +1,184 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// compileCache deduplicates `go build` invocations within one language-host
+// process by hashing the source tree and reusing the previously-built binary
+// when the inputs match. Conformance-test hosts call compileProgram many
+// times with the same source (one Run per `pulumi up` / `preview`, repeated
+// across runs of the same test); without this cache each invocation pays the
+// ~1s linker cost even when Go's package cache is hot.
+//
+// Cached binaries live on disk at dir/<hash> (hard-linked from each
+// compile's outfile) and are evicted FIFO once the entry count exceeds the
+// cap. The cap is small on purpose — within one test the same source is
+// built repeatedly (8+× for policy tests) so a handful of slots captures the
+// win, while across tests sources differ and unbounded retention would just
+// leak hundreds of MB of /tmp per host.
+const compileCacheCap = 8
+
+type compileCache struct {
+	mu    sync.Mutex
+	dir   string
+	order []string // FIFO of cached hashes: front is the oldest
+}
+
+func newCompileCache() (*compileCache, error) {
+	dir, err := os.MkdirTemp("", "pulumi-go-build-cache-*")
+	if err != nil {
+		return nil, err
+	}
+	return &compileCache{dir: dir}, nil
+}
+
+func (c *compileCache) path(hash string) string {
+	return filepath.Join(c.dir, hash)
+}
+
+func (c *compileCache) lookup(hash string) string {
+	if c == nil || hash == "" {
+		return ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if slices.Contains(c.order, hash) {
+		return c.path(hash)
+	}
+	return ""
+}
+
+// put stores the binary at outfile in the cache under hash, evicting the
+// oldest entry when the cap is reached. Best-effort: failures leave the
+// cache untouched so the next call just rebuilds.
+func (c *compileCache) put(hash, outfile string) {
+	if c == nil || hash == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if slices.Contains(c.order, hash) {
+		return
+	}
+	if err := linkOrCopy(outfile, c.path(hash)); err != nil {
+		return
+	}
+	c.order = append(c.order, hash)
+	if len(c.order) > compileCacheCap {
+		_ = os.Remove(c.path(c.order[0]))
+		c.order = c.order[1:]
+	}
+}
+
+func (c *compileCache) close() error {
+	if c == nil {
+		return nil
+	}
+	return os.RemoveAll(c.dir)
+}
+
+// hashSourceTree returns a stable hex digest of every regular file under
+// root plus the withDebugFlags bit. Hidden directories (anything starting
+// with ".") are skipped so transient artifacts like `.git` don't bust the
+// cache, and outfile is skipped so a build target inside the source tree
+// doesn't change the hash from one build to the next. Returns "" if any
+// file can't be read — caller should treat that as a cache miss and just
+// build normally.
+//
+// Note: replace directives in go.mod that point outside root are NOT
+// followed. Within one short-lived host process those targets are stable
+// (e.g. the conformance test's packed core SDK) so this is safe in practice.
+func hashSourceTree(root, outfile string, withDebugFlags bool) string {
+	h := sha256.New()
+	flag := byte(0)
+	if withDebugFlags {
+		flag = 1
+	}
+	h.Write([]byte{flag})
+	// Include the root path so debug builds (which don't get -trimpath) from
+	// different directories don't collide on identical source content — the
+	// embedded paths in their binaries would differ.
+	h.Write([]byte(root))
+	h.Write([]byte{0})
+	// Build targets may be relative to the program directory.
+	skip := filepath.Clean(outfile)
+	if !filepath.IsAbs(skip) {
+		skip = filepath.Join(root, skip)
+	}
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != root && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if path == skip {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		h.Write([]byte(rel))
+		h.Write([]byte{0})
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		h.Write(data)
+		h.Write([]byte{0})
+		return nil
+	})
+	if walkErr != nil {
+		return ""
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// linkOrCopy hard-links src to dst, falling back to a byte-for-byte copy if
+// hard-linking fails (e.g. across filesystems).
+func linkOrCopy(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -122,7 +122,7 @@ func compileProgram(
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
 	// We add the `-buildvcs=false` flag here because it sometimes fails on Windows.
 	// See also https://github.com/pulumi/pulumi/pull/22788
-	args := []string{"build", "-buildvcs=false", "-o", outfile}
+	args := []string{"build", "-trimpath", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -83,20 +83,12 @@ const preferredDebugPort = 57134
 func compileProgram(
 	ctx context.Context,
 	engineClient pulumirpc.EngineClient,
+	cache *compileCache,
 	programDirectory string,
 	outfile string,
 	withDebugFlags bool,
 	stdout, stderr io.Writer,
 ) (string, error) {
-	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
-		Severity:  pulumirpc.LogSeverity_INFO,
-		Urn:       "",
-		Message:   "Compiling the program ...",
-		Ephemeral: true,
-	}); err != nil {
-		logging.V(6).Infof("Failed to log message: %v", err)
-	}
-
 	goFileSearchPattern := filepath.Join(programDirectory, "*.go")
 	if matches, err := filepath.Glob(goFileSearchPattern); err != nil || len(matches) == 0 {
 		return "", fmt.Errorf("Failed to find go files for 'go build' matching %s", goFileSearchPattern)
@@ -113,6 +105,32 @@ func compileProgram(
 			return "", fmt.Errorf("unable to close go program temp file: %w", err)
 		}
 		outfile = f.Name()
+	}
+
+	// Process-local build cache: skip the compile entirely when an identical
+	// source tree has already been built in this host's lifetime. Saves the
+	// ~1s linker cost per call across the many repeated Run / RunPlugin
+	// invocations a conformance-test host services.
+	// The cache is best-effort: if materializing a cached binary fails for any
+	// reason, fall through and build normally.
+	srcHash := hashSourceTree(programDirectory, outfile, withDebugFlags)
+	if cached := cache.lookup(srcHash); cached != "" {
+		if err := os.Remove(outfile); err == nil || os.IsNotExist(err) {
+			if err := linkOrCopy(cached, outfile); err == nil {
+				logging.V(5).Infof("compileProgram: build cache hit for %s", programDirectory)
+				return outfile, nil
+			}
+		}
+		logging.V(5).Infof("compileProgram: failed to reuse cached binary for %s, rebuilding", programDirectory)
+	}
+
+	if _, err := engineClient.Log(ctx, &pulumirpc.LogRequest{
+		Severity:  pulumirpc.LogSeverity_INFO,
+		Urn:       "",
+		Message:   "Compiling the program ...",
+		Ephemeral: true,
+	}); err != nil {
+		logging.V(6).Infof("Failed to log message: %v", err)
 	}
 
 	gobin, err := executable.FindExecutable("go")
@@ -151,6 +169,8 @@ func compileProgram(
 	}); err != nil {
 		logging.V(6).Infof("Failed to log message: %v", err)
 	}
+
+	cache.put(srcHash, outfile)
 
 	return outfile, nil
 }
@@ -289,6 +309,11 @@ type goLanguageHost struct {
 	otelEndpoint  string
 	cancelCtx     context.Context    // Cancelled when we receive the `Cancel` RPC
 	cancelFunc    context.CancelFunc // Cancel the cancelCtx
+	// Process-local cache of compiled binaries keyed by a hash of the source
+	// tree. Lets us skip the ~1s linker cost when the same program/plugin is
+	// built multiple times within one host lifetime (notably the conformance
+	// test host services many such calls). May be nil if init failed.
+	buildCache *compileCache
 }
 
 type goOptions struct {
@@ -325,6 +350,11 @@ func parseOptions(root string, options map[string]any) (goOptions, error) {
 
 func newLanguageHost(engineAddress, cwd, tracing, otelEndpoint string) pulumirpc.LanguageRuntimeServer {
 	ctx, cancel := context.WithCancel(context.Background())
+	cache, err := newCompileCache()
+	if err != nil {
+		logging.V(3).Infof("failed to initialize Go build cache: %v", err)
+		cache = nil
+	}
 	return &goLanguageHost{
 		engineAddress: engineAddress,
 		cwd:           cwd,
@@ -332,6 +362,7 @@ func newLanguageHost(engineAddress, cwd, tracing, otelEndpoint string) pulumirpc
 		otelEndpoint:  otelEndpoint,
 		cancelCtx:     ctx,
 		cancelFunc:    cancel,
+		buildCache:    cache,
 	}
 }
 
@@ -1116,7 +1147,8 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 	logging.V(5).Infof("No prebuilt executable specified, attempting invocation via compilation")
 
 	program, err := compileProgram(
-		ctx, engineClient, req.Info.ProgramDirectory, opts.buildTarget, req.GetAttachDebugger(), os.Stdout, os.Stderr)
+		ctx, engineClient, host.buildCache,
+		req.Info.ProgramDirectory, opts.buildTarget, req.GetAttachDebugger(), os.Stdout, os.Stderr)
 	if err != nil {
 		return nil, errutil.ErrorWithStderr(err, "error in compiling Go")
 	}
@@ -1337,7 +1369,8 @@ func (host *goLanguageHost) RunPlugin(
 	defer contract.IgnoreClose(closer)
 
 	program, err := compileProgram(
-		server.Context(), engineClient, req.Info.ProgramDirectory, "", req.GetAttachDebugger(), os.Stdout, os.Stderr)
+		server.Context(), engineClient, host.buildCache,
+		req.Info.ProgramDirectory, "", req.GetAttachDebugger(), os.Stdout, os.Stderr)
 	if err != nil {
 		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -122,9 +122,11 @@ func compileProgram(
 	logging.V(5).Infof("Attempting to build go program in %s with: %s build -o %s", programDirectory, gobin, outfile)
 	// We add the `-buildvcs=false` flag here because it sometimes fails on Windows.
 	// See also https://github.com/pulumi/pulumi/pull/22788
-	args := []string{"build", "-trimpath", "-buildvcs=false", "-o", outfile}
+	args := []string{"build", "-buildvcs=false", "-o", outfile}
 	if withDebugFlags {
 		args = append(args, "-gcflags", "all=-N -l")
+	} else {
+		args = append(args, "-trimpath")
 	}
 	buildCmd := exec.Command(gobin, args...)
 	buildCmd.Dir = programDirectory
@@ -1335,7 +1337,7 @@ func (host *goLanguageHost) RunPlugin(
 	defer contract.IgnoreClose(closer)
 
 	program, err := compileProgram(
-		server.Context(), engineClient, req.Info.ProgramDirectory, "", false, os.Stdout, os.Stderr)
+		server.Context(), engineClient, req.Info.ProgramDirectory, "", req.GetAttachDebugger(), os.Stdout, os.Stderr)
 	if err != nil {
 		return errutil.ErrorWithStderr(err, "error in compiling Go")
 	}

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -508,7 +508,7 @@ func TestCompileProgram(t *testing.T) {
 		tmp := t.TempDir()
 		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 		_, err := compileProgram(
-			t.Context(), &mockEngine{}, tmp, "", false /* withDebugFlags */, stdout, stderr)
+			t.Context(), &mockEngine{}, nil /* cache */, tmp, "", false /* withDebugFlags */, stdout, stderr)
 		require.ErrorContains(t, err, "Failed to find go files")
 	})
 
@@ -525,12 +525,51 @@ func main() {}
 		require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(program), 0o600))
 		expectedOut := filepath.Join(tmp, "out")
 		out, err := compileProgram(
-			t.Context(), engineClient, tmp, expectedOut, false /* withDebugFlags */, stdout, stderr)
+			t.Context(), engineClient, nil /* cache */, tmp, expectedOut, false /* withDebugFlags */, stdout, stderr)
 		require.NoError(t, err)
 		require.Equal(t, expectedOut, out)
 		require.Len(t, engineClient.logs, 2)
 		require.Equal(t, "Compiling the program ...", engineClient.logs[0].Message)
 		require.Equal(t, "Finished compiling", engineClient.logs[1].Message)
+	})
+
+	t.Run("build cache", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		goMod := `module example`
+		program := `package main
+func main() {}
+`
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		engineClient := &mockEngine{}
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(goMod), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(program), 0o600))
+
+		cache, err := newCompileCache()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, cache.close()) })
+
+		// Note the build target inside the program directory: it must be
+		// excluded from the source hash, or the binary produced by the first
+		// build would turn every subsequent lookup into a miss.
+		outfile := filepath.Join(tmp, "out")
+		_, err = compileProgram(
+			t.Context(), engineClient, cache, tmp, outfile, false /* withDebugFlags */, stdout, stderr)
+		require.NoError(t, err)
+		require.Len(t, engineClient.logs, 2) // compiled
+
+		_, err = compileProgram(
+			t.Context(), engineClient, cache, tmp, outfile, false /* withDebugFlags */, stdout, stderr)
+		require.NoError(t, err)
+		require.Len(t, engineClient.logs, 2) // cache hit: no new compile logs
+
+		// If the cached binary can't be materialized, fall back to a rebuild
+		// instead of failing.
+		require.NoError(t, os.Remove(cache.path(hashSourceTree(tmp, outfile, false))))
+		_, err = compileProgram(
+			t.Context(), engineClient, cache, tmp, outfile, false /* withDebugFlags */, stdout, stderr)
+		require.NoError(t, err)
+		require.Len(t, engineClient.logs, 4) // rebuilt
 	})
 
 	t.Run("compile error", func(t *testing.T) {
@@ -544,7 +583,7 @@ func main() {
 		require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte(goMod), 0o600))
 		require.NoError(t, os.WriteFile(filepath.Join(tmp, "main.go"), []byte(badProgram), 0o600))
 		_, err := compileProgram(
-			t.Context(), &mockEngine{}, tmp, "", false /* withDebugFlags */, stdout, stderr)
+			t.Context(), &mockEngine{}, nil /* cache */, tmp, "", false /* withDebugFlags */, stdout, stderr)
 		require.ErrorContains(t, err, "unable to run `go build`: exit status 1")
 		require.Contains(t, stderr.String(), "main.go:3:1: syntax error")
 	})


### PR DESCRIPTION
For policy tests in particular, we seem to run Go code over and over in the conformance tests.  Each of those needs a build, which takes time.  Introducing this build cache reduces the time locally from ~230s to ~170s for the Go conformance tests.
