### PR TITLE
fix pnpm test

### DIFF
--- a/changelog/pending/20260610--sdk-nodejs--fix-local-sdk-builds-with-pnpm-10-34-2.yaml
+++ b/changelog/pending/20260610--sdk-nodejs--fix-local-sdk-builds-with-pnpm-10-34-2.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: fix
+body: Fix local SDKs added with `pulumi package add` not being built when using pnpm 10.34.2 or newer
+time: 2026-06-10T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -117,13 +117,8 @@ func (pnpm *pnpmManager) Link(ctx context.Context, dir, packageName, path string
 	if version.GTE(semver.MustParse("10.34.2")) {
 		key = packageName + "@file:" + filepath.ToSlash(path)
 	}
-	return pnpm.addOnlyBuiltDependency(ctx, dir, key)
-}
 
-// addOnlyBuiltDependency adds key to the `onlyBuiltDependencies` setting, which decides which dependencies may run
-// lifecycle scripts.
-func (pnpm *pnpmManager) addOnlyBuiltDependency(ctx context.Context, dir, key string) error {
-	cmd := exec.CommandContext(ctx, "pnpm", "config", "get", "onlyBuiltDependencies", "--json")
+	cmd = exec.CommandContext(ctx, "pnpm", "config", "get", "onlyBuiltDependencies", "--json")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/sdk/nodejs/npm/pnpm.go
+++ b/sdk/nodejs/npm/pnpm.go
@@ -103,8 +103,27 @@ func (pnpm *pnpmManager) Link(ctx context.Context, dir, packageName, path string
 
 	// Local SDKs have a postInstall script that needs to run. By default pnpm does not run these scripts. We have to
 	// add the package to the `onlyBuiltDependencies` setting to allow this.
-	// https://pnpm.io/next/settings#onlybuiltdependencies
-	cmd = exec.CommandContext(ctx, "pnpm", "config", "get", "onlyBuiltDependencies", "--json")
+	// https://pnpm.io/settings#onlybuiltdependencies
+	//
+	// The key pnpm expects depends on its version: the 10.34.2 security release requires local directory
+	// dependencies to be allowlisted by their lockfile depPath ("name@file:path"); bare package names are silently
+	// ignored. Conversely, versions before 10.34.2 reject the depPath form with ERR_PNPM_INVALID_VERSION_UNION, so
+	// we can't write both keys unconditionally.
+	version, err := pnpm.Version()
+	if err != nil {
+		return err
+	}
+	key := packageName
+	if version.GTE(semver.MustParse("10.34.2")) {
+		key = packageName + "@file:" + filepath.ToSlash(path)
+	}
+	return pnpm.addOnlyBuiltDependency(ctx, dir, key)
+}
+
+// addOnlyBuiltDependency adds key to the `onlyBuiltDependencies` setting, which decides which dependencies may run
+// lifecycle scripts.
+func (pnpm *pnpmManager) addOnlyBuiltDependency(ctx context.Context, dir, key string) error {
+	cmd := exec.CommandContext(ctx, "pnpm", "config", "get", "onlyBuiltDependencies", "--json")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -112,13 +131,13 @@ func (pnpm *pnpmManager) Link(ctx context.Context, dir, packageName, path string
 	}
 	out = bytes.TrimSpace(out)
 	var dependencies []string
-	if len(out) > 0 && string(out) != "undefined\n" {
+	if len(out) > 0 && string(out) != "undefined" {
 		if err := json.Unmarshal(out, &dependencies); err != nil {
 			dependencies = []string{}
 		}
 	}
-	if !slices.Contains(dependencies, packageName) {
-		dependencies = append(dependencies, packageName)
+	if !slices.Contains(dependencies, key) {
+		dependencies = append(dependencies, key)
 	}
 	jsonData, err := json.Marshal(dependencies)
 	if err != nil {


### PR DESCRIPTION
Newer pnpm versions require local dependencies to be allowlisted by their full lockfile depPath, because of a security fix.  This is different than versions before 10.34.2, which do not allow that same thing, and only want the package name.

So we need to version gate the way we add stuff to onlyBuiltDependencies.

This should fix our broken test.

Fixes https://github.com/pulumi/pulumi/issues/23523