### PR TITLE
ci: pin pnpm to 10.34.1

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -256,7 +256,11 @@ jobs:
           fi
       - name: Install yarn and pnpm
         run: |
-          npm install -g yarn pnpm@10
+          # pnpm is pinned because 10.34.2 changed how local directory
+          # dependencies are installed, which breaks Node.js component
+          # provider tests (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING).
+          # See https://github.com/pulumi/pulumi/issues/23523.
+          npm install -g yarn pnpm@10.34.1
       - name: Install bun
         uses: ./.github/actions/retry
         with:


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI (Claude), supervised by @iwahbe. **The merge queue is currently blocked by this issue** — every merge-queue run since ~14:00 UTC 2026-06-10 has failed.

Fixes the CI side of #23523.

## Problem

CI installs `pnpm@10` (floating) in every test job. **pnpm 10.34.2 was published 2026-06-10T13:59Z**, exactly between the last green merge-queue run (07:03 UTC) and the first failures. Since then `TestNodejsComponentProviderRun/nodejs-pnpm`, `TestPackageAddNode/pnpm`, and `TestNodePackageAddTSC/pnpm` fail deterministically on Ubuntu and Windows with:

```
Error: Stripping types is currently unsupported for files under node_modules, for ".../node_modules/.pnpm/@pulumi+nodejs-component-provider@file+sdks+.../index.ts"
  code: 'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING'
```

Node is unchanged between green and red runs (26.3.0, verified from setup logs), ruling out a runner-image change. pnpm 10.34.2's release notes describe tightened handling of local directory artifacts; the practical effect is that a `file:sdks/...` package with a TypeScript `main` now resolves to a real path under `node_modules/.pnpm/...`, where ts-node's default ignore applies and Node 26's native type stripping refuses the file.

These failures landed on unrelated PRs (observed on #23516 and #23519 runs yesterday) and every merge-queue run.

## Change

Pin `pnpm@10.34.1` with a comment linking #23523. The issue also tracks the proper follow-ups: deciding whether to adapt the component-provider test packages (compiled `main`) or report a pnpm regression, and pinning pnpm by exact version going forward so upstream releases can't break the queue again.

## Verification

This PR's own CI run is the experiment: the three pnpm tests run in the `tests/integration` partitions on Ubuntu and Windows. Green = root cause confirmed.