### PR TITLE
add backwards compat layer for S3 api v1

### DIFF
--- a/changelog/pending/backend-diy-fix-20260611-124926.yaml
+++ b/changelog/pending/backend-diy-fix-20260611-124926.yaml
@@ -1,0 +1,6 @@
+component: backend/diy
+kind: fix
+body: Fix backwards incompatible gocloud.dev changes
+time: 2026-06-11T12:49:26.352498928+02:00
+custom:
+    PR: "23525"

--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -555,10 +556,14 @@ func (b *diyBackend) upgradeStack(
 }
 
 // massageBlobPath takes the path the user provided and converts it to an appropriate form go-cloud
-// can support.  Importantly, s3/azblob/gs paths should not be touched. This will only affect
-// file:// paths which have a few oddities around them that we want to ensure work properly.
+// can support.  For s3:// paths this translates AWS SDK v1-era query parameters to their v2
+// equivalents; azblob/gs paths are not touched. file:// paths have a few oddities around them that
+// we want to ensure work properly.
 func massageBlobPath(path string) (string, error) {
 	if !strings.HasPrefix(path, FilePathPrefix) {
+		if strings.HasPrefix(path, "s3://") {
+			return translateLegacyS3Params(path)
+		}
 		// Not a file:// path.  Keep this untouched and pass directly to gocloud.
 		return path, nil
 	}
@@ -618,6 +623,53 @@ func massageBlobPath(path string) (string, error) {
 	}
 
 	return FilePathPrefix + path + queryString, nil
+}
+
+// translateLegacyS3Params rewrites query parameters on s3:// URLs that were supported by the
+// AWS SDK v1-based s3blob driver in gocloud.dev before v0.46, so that backend URLs configured
+// before the upgrade keep working:
+//
+//   - disableSSL becomes disable_https; gocloud.dev v0.46 rejects the v1 name as an unknown
+//     query parameter.
+//   - a scheme-less endpoint (e.g. endpoint=minio:9000) gets an explicit http:// or https://
+//     scheme depending on disableSSL; the v1 SDK implied the scheme, while the v2 SDK
+//     requires one.
+//
+// The other v1-era parameters (s3ForcePathStyle, awssdk) are still understood by gocloud.dev
+// and need no translation.
+func translateLegacyS3Params(urlstr string) (string, error) {
+	u, err := url.Parse(urlstr)
+	if err != nil {
+		return "", fmt.Errorf("parsing the provided URL: %w", err)
+	}
+	query := u.Query()
+	changed := false
+
+	disableSSL := false
+	if values, ok := query["disableSSL"]; ok {
+		disableSSL, err = strconv.ParseBool(values[len(values)-1])
+		if err != nil {
+			return "", fmt.Errorf("invalid value for query parameter %q: %w", "disableSSL", err)
+		}
+		query.Del("disableSSL")
+		query.Set("disable_https", strconv.FormatBool(disableSSL))
+		changed = true
+	}
+
+	if endpoint := query.Get("endpoint"); endpoint != "" && !strings.Contains(endpoint, "://") {
+		scheme := "https"
+		if disableSSL {
+			scheme = "http"
+		}
+		query.Set("endpoint", scheme+"://"+endpoint)
+		changed = true
+	}
+
+	if !changed {
+		return urlstr, nil
+	}
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 func Login(ctx context.Context, d diag.Sink, url string, project *workspace.Project) (Backend, error) {

--- a/pkg/backend/diy/bucket.go
+++ b/pkg/backend/diy/bucket.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
 	"time"
 
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"gocloud.dev/blob"
 )
@@ -62,7 +64,48 @@ func retryOp(op func() error) error {
 }
 
 func (b *wrappedBucket) Copy(ctx context.Context, dstKey, srcKey string, opts *blob.CopyOptions) (err error) {
-	return b.bucket.Copy(ctx, filepath.ToSlash(dstKey), filepath.ToSlash(srcKey), opts)
+	var optsCopy blob.CopyOptions
+	if opts != nil {
+		optsCopy = *opts
+	}
+	beforeCopy := optsCopy.BeforeCopy
+	optsCopy.BeforeCopy = func(asFunc func(any) bool) error {
+		var input *awss3.CopyObjectInput
+		if asFunc(&input) {
+			fixupS3CopySource(input)
+		}
+		if beforeCopy != nil {
+			return beforeCopy(asFunc)
+		}
+		return nil
+	}
+	return b.bucket.Copy(ctx, filepath.ToSlash(dstKey), filepath.ToSlash(srcKey), &optsCopy)
+}
+
+// fixupS3CopySource rewrites the copy source gocloud.dev computes for S3
+// CopyObject calls. gocloud.dev v0.46+ percent-encodes the whole
+// "<bucket>/<key>" string, turning the "/" separators into "%2F". AWS accepts
+// that form, but stricter S3-compatible servers such as NetApp StorageGRID
+// reject it (https://github.com/pulumi/pulumi/issues/23478). Escape each path
+// segment individually and keep literal "/" separators, which both AWS and
+// S3-compatible servers accept.
+func fixupS3CopySource(input *awss3.CopyObjectInput) {
+	if input == nil || input.CopySource == nil {
+		return
+	}
+	copySource, err := url.QueryUnescape(*input.CopySource)
+	if err != nil {
+		// Not the encoding we expected; leave the value alone.
+		return
+	}
+	segments := strings.Split(copySource, "/")
+	for i, segment := range segments {
+		// PathEscape leaves "+" alone, but S3 servers decode the copy source
+		// as URL-encoded where "+" can mean a space, so escape it explicitly.
+		segments[i] = strings.ReplaceAll(url.PathEscape(segment), "+", "%2B")
+	}
+	escaped := strings.Join(segments, "/")
+	input.CopySource = &escaped
 }
 
 func (b *wrappedBucket) Delete(ctx context.Context, key string) (err error) {

--- a/pkg/backend/diy/bucket_s3_test.go
+++ b/pkg/backend/diy/bucket_s3_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
+)
+
+// strictS3Server is a minimal fake of an S3-compatible object store that
+// validates the CopyObject copy source the way strict implementations such
+// as NetApp StorageGRID do: the bucket name and the object key must be
+// separated by a literal, unencoded "/" in the x-amz-copy-source header.
+// AWS itself tolerates a fully percent-encoded copy source (with "%2F" for
+// the separators), but several S3-compatible servers do not, which is what
+// https://github.com/pulumi/pulumi/issues/23478 is about.
+type strictS3Server struct {
+	mu          sync.Mutex
+	copySources []string
+}
+
+func (s *strictS3Server) recordCopySource(src string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.copySources = append(s.copySources, src)
+}
+
+func (s *strictS3Server) lastCopySource() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.copySources) == 0 {
+		return ""
+	}
+	return s.copySources[len(s.copySources)-1]
+}
+
+func (s *strictS3Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	copySource := r.Header.Get("X-Amz-Copy-Source")
+	if r.Method == http.MethodPut && copySource != "" {
+		s.recordCopySource(copySource)
+
+		// Strict copy source validation: "<bucket>/<key>", optionally with a
+		// leading "/". The separator between the bucket and the key must be a
+		// literal slash; if the whole value is percent-encoded there is no
+		// key, which strict servers reject.
+		trimmed := strings.TrimPrefix(copySource, "/")
+		bucket, key, ok := strings.Cut(trimmed, "/")
+		w.Header().Set("Content-Type", "application/xml")
+		if !ok || bucket == "" || key == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+				`<Error><Code>InvalidArgument</Code><Message>Invalid copy source object key</Message></Error>`)
+			return
+		}
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+			`<CopyObjectResult>`+
+			`<LastModified>2026-06-11T00:00:00Z</LastModified>`+
+			`<ETag>&quot;9b2cf535f27731c974343645a3985328&quot;</ETag>`+
+			`</CopyObjectResult>`)
+		return
+	}
+
+	// The tests only exercise CopyObject; nothing else should be called.
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// decodeCopySource parses a x-amz-copy-source header value into its bucket
+// and key the way a strict S3-compatible server does: split bucket and key
+// on a literal "/", then percent-decode each path segment of the key.
+func decodeCopySource(t *testing.T, src string) (string, string) {
+	t.Helper()
+	bucket, key, ok := strings.Cut(strings.TrimPrefix(src, "/"), "/")
+	require.True(t, ok, "copy source %q does not contain a literal bucket/key separator", src)
+	segments := strings.Split(key, "/")
+	for i, segment := range segments {
+		decoded, err := url.PathUnescape(segment)
+		require.NoError(t, err, "copy source key segment %q is not valid percent-encoding", segment)
+		segments[i] = decoded
+	}
+	return bucket, strings.Join(segments, "/")
+}
+
+// TestS3LegacyURLCopy reproduces https://github.com/pulumi/pulumi/issues/23478:
+// saving a checkpoint to an S3 DIY backend performs a blob Copy (see
+// addToHistory and backupTarget in state.go), and S3-compatible servers like
+// NetApp StorageGRID reject the copy source format that gocloud.dev v0.46
+// produces. It also covers the AWS SDK v1-era URL parameters (disableSSL,
+// scheme-less endpoint) that backends configured before the gocloud.dev
+// upgrade still use.
+func TestS3LegacyURLCopy(t *testing.T) {
+	// No t.Parallel: subtests mutate process-wide env vars via t.Setenv.
+
+	tests := []struct {
+		name string
+		// query is appended to "s3://testbucket". The %s placeholders are
+		// replaced with the fake server's host (with or without scheme).
+		query        string
+		bareEndpoint bool
+	}{
+		{
+			// The exact backend URL shape reported in pulumi/pulumi#23478.
+			name:  "issue-23478",
+			query: "?endpoint=%s&s3ForcePathStyle=true&awssdk=v2",
+		},
+		{
+			// The same configuration without forcing an SDK version. Before
+			// the gocloud.dev 0.46 upgrade this selected the AWS SDK v1 code
+			// path, which was the default for S3 DIY backends.
+			name:  "no-awssdk",
+			query: "?endpoint=%s&s3ForcePathStyle=true",
+		},
+		{
+			// AWS SDK v1-era parameters: disableSSL instead of
+			// disable_https, and a scheme-less endpoint whose scheme was
+			// implied by disableSSL.
+			name:         "legacy-v1-params",
+			query:        "?endpoint=%s&disableSSL=true&s3ForcePathStyle=true",
+			bareEndpoint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+			t.Setenv("AWS_REGION", "us-east-1")
+			t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+			// Isolate from the developer's ~/.aws configuration.
+			t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "config"))
+			t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials"))
+
+			s3 := &strictS3Server{}
+			server := httptest.NewServer(s3)
+			defer server.Close()
+
+			endpoint := server.URL
+			if tt.bareEndpoint {
+				endpoint = strings.TrimPrefix(endpoint, "http://")
+			}
+			bucketURL := "s3://testbucket" + fmt.Sprintf(tt.query, endpoint)
+
+			// Open the bucket the same way newDIYBackend does.
+			ctx := t.Context()
+			u, err := massageBlobPath(bucketURL)
+			require.NoError(t, err)
+			bucket, err := blob.DefaultURLMux().OpenBucket(ctx, u)
+			require.NoError(t, err, "opening bucket %s", bucketURL)
+			defer func() {
+				require.NoError(t, bucket.Close())
+			}()
+			wbucket := &wrappedBucket{bucket: bucket}
+
+			// The copy addToHistory performs when saving update info, with
+			// the keys from the issue report.
+			err = wbucket.Copy(ctx,
+				".pulumi/history/blubb/stack/stack-1780911700522805856.checkpoint.json",
+				".pulumi/stacks/blubb/stack.json", nil)
+			require.NoError(t, err)
+
+			gotBucket, gotKey := decodeCopySource(t, s3.lastCopySource())
+			assert.Equal(t, "testbucket", gotBucket)
+			assert.Equal(t, ".pulumi/stacks/blubb/stack.json", gotKey)
+		})
+	}
+}

--- a/pkg/backend/diy/legacy_s3_params_test.go
+++ b/pkg/backend/diy/legacy_s3_params_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diy
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateLegacyS3Params(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give string
+		// wantQuery is the expected decoded query; nil means the URL must be
+		// returned unchanged.
+		wantQuery url.Values
+	}{
+		{
+			name: "no query",
+			give: "s3://bucket",
+		},
+		{
+			name: "v2 params untouched",
+			give: "s3://bucket?endpoint=https://example.com&s3ForcePathStyle=true&awssdk=v2",
+		},
+		{
+			name: "disableSSL translated",
+			give: "s3://bucket?endpoint=https://minio:9000&disableSSL=true",
+			wantQuery: url.Values{
+				"endpoint":      {"https://minio:9000"},
+				"disable_https": {"true"},
+			},
+		},
+		{
+			name: "disableSSL false translated",
+			give: "s3://bucket?disableSSL=false",
+			wantQuery: url.Values{
+				"disable_https": {"false"},
+			},
+		},
+		{
+			name: "bare endpoint gets https scheme",
+			give: "s3://bucket?endpoint=minio:9000",
+			wantQuery: url.Values{
+				"endpoint": {"https://minio:9000"},
+			},
+		},
+		{
+			name: "bare endpoint with disableSSL gets http scheme",
+			give: "s3://bucket?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true",
+			wantQuery: url.Values{
+				"endpoint":         {"http://minio:9000"},
+				"disable_https":    {"true"},
+				"s3ForcePathStyle": {"true"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := translateLegacyS3Params(tt.give)
+			require.NoError(t, err)
+			if tt.wantQuery == nil {
+				assert.Equal(t, tt.give, got)
+				return
+			}
+			u, err := url.Parse(got)
+			require.NoError(t, err)
+			assert.Equal(t, "s3", u.Scheme)
+			assert.Equal(t, "bucket", u.Host)
+			assert.Equal(t, tt.wantQuery, u.Query())
+		})
+	}
+
+	t.Run("invalid disableSSL value", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := translateLegacyS3Params("s3://bucket?disableSSL=banana")
+		assert.ErrorContains(t, err, `invalid value for query parameter "disableSSL"`)
+	})
+}


### PR DESCRIPTION
The gocloud.dev 0.46.0 upgrade forced an upgrade of the s3 API to v2, and dropped support for the v1 version.  Unfortunately, since we exposed the v1 style query strings directly, this means that upgrading was a backwards incompatible change.

Introduce a compatibility layer, so the old options will continue working.

Fixes #23478