### PR TITLE
ci: tolerate PR heads that predate the free-disk-space script

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -160,9 +160,17 @@ jobs:
       # Frees ~24GiB; test jobs run out of disk otherwise (#17470). The bulk of
       # the cleanup runs in the background, overlapping the setup steps below.
       # The "Wait for disk cleanup" step joins it before tests run.
+      # The script-exists check covers PR branches that predate the script:
+      # this workflow runs from the PR's merge commit, but the job checks out
+      # the PR head, which may not contain the script yet.
       - if: contains(inputs.platform, 'ubuntu')
         name: Free Disk Space (Ubuntu)
-        run: ./.github/scripts/free-disk-space start
+        run: |
+          if [ -x ./.github/scripts/free-disk-space ]; then
+            ./.github/scripts/free-disk-space start
+          else
+            echo "::warning::.github/scripts/free-disk-space not in checkout; skipping disk cleanup. Rebase onto master to restore it."
+          fi
       - name: Setup versioning env vars
         env:
           version: ${{ inputs.version }}
@@ -387,7 +395,10 @@ jobs:
           echo -n '${{ secrets.GCP_SERVICE_ACCOUNT }}' > '${{ runner.temp }}/application_default_credentials.json'
       - if: contains(inputs.platform, 'ubuntu')
         name: Wait for disk cleanup (Ubuntu)
-        run: ./.github/scripts/free-disk-space wait
+        run: |
+          if [ -x ./.github/scripts/free-disk-space ]; then
+            ./.github/scripts/free-disk-space wait
+          fi
       - name: run tests "${{ inputs.test-command }}"
         id: test
         run: ${{ inputs.test-command }}


### PR DESCRIPTION
**This PR is AI-authored** (supervised by @iwahbe), part of the CI speed/reliability effort.

### Problem

Since #23509 merged, every open PR whose head predates it fails all ubuntu test jobs immediately with:

```
./.github/scripts/free-disk-space: No such file or directory
##[error]Process completed with exit code 127.
```

(Example: [27341644507](https://github.com/pulumi/pulumi/actions/runs/27341644507).)

PR test jobs run the *workflow definition* from the PR's merge commit (which calls the script), but check out the *PR head* (`on-pr.yml` passes `github.head_ref`), which may not contain the script. Long-lived branches keep failing until they rebase onto or merge current master.

### Fix

Guard both `free-disk-space` steps with a script-exists check. Stale branches skip the disk cleanup with a workflow warning telling them to rebase, instead of failing every job. Branches that contain the script behave exactly as before.

Cost of skipping on stale branches: they run without the ~24GiB cleanup, which is the pre-#17470 behavior — heavy jobs could in principle hit out-of-disk, but that beats failing 100% of ubuntu jobs at step one.
