### PR TITLE
Add `--disable-integrations` flag to `pulumi neo`

### DIFF
--- a/changelog/pending/cli-neo-disable-integrations.yaml
+++ b/changelog/pending/cli-neo-disable-integrations.yaml
@@ -1,0 +1,6 @@
+component: cli/neo
+kind: feat
+body: Add a `--disable-integrations` flag to `pulumi neo` that runs the task with no integration credentials
+time: 2026-06-11T13:15:08.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/cli-neo-disable-integrations.yaml
+++ b/changelog/pending/cli-neo-disable-integrations.yaml
@@ -3,4 +3,4 @@ kind: feat
 body: Add a `--disable-integrations` flag to `pulumi neo` that runs the task with no integration credentials
 time: 2026-06-11T13:15:08.000000+00:00
 custom:
-    PR: ""
+    PR: "23531"

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2658,8 +2658,7 @@ type CreateNeoTaskOptions struct {
 	ApprovalMode      NeoApprovalMode
 	PermissionMode    NeoPermissionMode
 	PlanMode          bool
-	// EnabledIntegrations is forwarded verbatim onto NeoTaskRequest; nil inherits the
-	// org's enabled integrations. See that field for the three-state semantics.
+	// Forwarded onto NeoTaskRequest.EnabledIntegrations; nil inherits the org's enabled integrations.
 	EnabledIntegrations *[]string
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -2654,11 +2654,10 @@ func (pc *Client) ExplainPreviewWithNeo(
 // CreateNeoTaskOptions bundles the optional knobs on CreateNeoTask. The zero value
 // accepts the server-side defaults for every field.
 type CreateNeoTaskOptions struct {
-	ToolExecutionMode string
-	ApprovalMode      NeoApprovalMode
-	PermissionMode    NeoPermissionMode
-	PlanMode          bool
-	// Forwarded onto NeoTaskRequest.EnabledIntegrations; nil inherits the org's enabled integrations.
+	ToolExecutionMode   string
+	ApprovalMode        NeoApprovalMode
+	PermissionMode      NeoPermissionMode
+	PlanMode            bool
 	EnabledIntegrations *[]string
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -124,6 +124,10 @@ type NeoTaskRequest struct {
 	// NeoTaskSourceCLI; the server validates against apitype.AgentTaskSource and defaults
 	// to "api" if omitted.
 	Source NeoTaskSource `json:"source,omitempty"`
+	// EnabledIntegrations is a three-state pointer matching apitype.CreateAgentTaskRequest:
+	// nil inherits all org-enabled integrations, a non-nil empty slice sends `[]` to opt out
+	// of every integration, and a populated slice allow-lists specific ones.
+	EnabledIntegrations *[]string `json:"enabledIntegrations,omitempty"`
 }
 
 // NeoTaskMessage represents the message content for a Neo task.
@@ -2654,6 +2658,9 @@ type CreateNeoTaskOptions struct {
 	ApprovalMode      NeoApprovalMode
 	PermissionMode    NeoPermissionMode
 	PlanMode          bool
+	// EnabledIntegrations is forwarded verbatim onto NeoTaskRequest; nil inherits the
+	// org's enabled integrations. See that field for the three-state semantics.
+	EnabledIntegrations *[]string
 }
 
 // CreateNeoTask creates a new Neo agent task via the Neo Tasks API. See
@@ -2675,11 +2682,12 @@ func (pc *Client) CreateNeoTask(
 			Content:   content,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		},
-		ToolExecutionMode: opts.ToolExecutionMode,
-		ApprovalMode:      opts.ApprovalMode,
-		PermissionMode:    opts.PermissionMode,
-		PlanMode:          opts.PlanMode,
-		Source:            NeoTaskSourceCLI,
+		ToolExecutionMode:   opts.ToolExecutionMode,
+		ApprovalMode:        opts.ApprovalMode,
+		PermissionMode:      opts.PermissionMode,
+		PlanMode:            opts.PlanMode,
+		EnabledIntegrations: opts.EnabledIntegrations,
+		Source:              NeoTaskSourceCLI,
 	}
 	// Only attach a stack entity when we actually have one — the backend rejects
 	// entity_diff entries with empty name/project as "unable to access stack".

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1475,6 +1475,75 @@ func TestCreateNeoTask(t *testing.T) {
 
 		assert.NotContains(t, gotBody, "permissionMode")
 	})
+
+	t.Run("EnabledIntegrationsEmptyListSerializes", func(t *testing.T) {
+		t.Parallel()
+
+		// The --disable-integrations opt-out must reach the wire as an explicit empty
+		// array, distinct from omitting the field entirely.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_7"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "stack", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode:   "cli",
+			EnabledIntegrations: &[]string{},
+		})
+		require.NoError(t, err)
+
+		require.Contains(t, gotBody, "enabledIntegrations",
+			"an explicit opt-out must send enabledIntegrations, not omit it")
+		assert.Equal(t, []any{}, gotBody["enabledIntegrations"],
+			"enabledIntegrations must serialize as an empty JSON array")
+	})
+
+	t.Run("EnabledIntegrationsOmittedWhenNil", func(t *testing.T) {
+		t.Parallel()
+
+		// A nil pointer must omit the field so the server inherits the org default.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_8"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "", "proj", CreateNeoTaskOptions{})
+		require.NoError(t, err)
+
+		assert.NotContains(t, gotBody, "enabledIntegrations",
+			"a nil EnabledIntegrations must be omitted so the server inherits the org default")
+	})
+
+	t.Run("EnabledIntegrationsAllowlistSerializes", func(t *testing.T) {
+		t.Parallel()
+
+		// A populated slice is the (future) allow-list state: named integrations
+		// must carry through verbatim.
+		var gotBody map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&gotBody))
+			rw.WriteHeader(http.StatusCreated)
+			_, _ = rw.Write([]byte(`{"taskId":"t_9"}`))
+		}))
+		defer server.Close()
+
+		client := newMockClient(server)
+		_, err := client.CreateNeoTask(t.Context(), "my-org", "hi", "stack", "proj", CreateNeoTaskOptions{
+			ToolExecutionMode:   "cli",
+			EnabledIntegrations: &[]string{"honeycomb", "datadog"},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, []any{"honeycomb", "datadog"}, gotBody["enabledIntegrations"])
+	})
 }
 
 func TestUpdateNeoTask(t *testing.T) {

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -125,12 +125,13 @@ var (
 // There is no interactive UI yet — the chat happens in the web console.
 func NewNeoCmd() *cobra.Command {
 	var (
-		stackName          string
-		orgFlag            string
-		cwdFlag            string
-		approvalModeFlag   string
-		permissionModeFlag string
-		printMode          bool
+		stackName           string
+		orgFlag             string
+		cwdFlag             string
+		approvalModeFlag    string
+		permissionModeFlag  string
+		printMode           bool
+		disableIntegrations bool
 	)
 
 	cmd := &cobra.Command{
@@ -168,7 +169,8 @@ func NewNeoCmd() *cobra.Command {
 			}
 			return runNeo(
 				ctx, cmd.OutOrStdout(), cmd.ErrOrStderr(),
-				prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode)
+				prompt, stackName, orgFlag, cwdFlag, approvalMode, permissionMode, printMode,
+				disableIntegrations)
 		},
 	}
 
@@ -187,6 +189,10 @@ func NewNeoCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&printMode, "print", "p", false,
 		"Run a single prompt non-interactively, print the agent's final response to "+
 			"stdout, and exit. Intended for use with other AI agents and scripts.")
+	cmd.Flags().BoolVar(&disableIntegrations, "disable-integrations", false,
+		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
+			"integrations. Useful for debugging, reduced latency, or working around a "+
+			"misconfigured integration.")
 
 	return cmd
 }
@@ -221,7 +227,15 @@ func runNeo(
 	approvalMode client.NeoApprovalMode,
 	permissionMode client.NeoPermissionMode,
 	printMode bool,
+	disableIntegrations bool,
 ) error {
+	// A non-nil empty slice sends `[]` to opt the task out of every integration; nil lets
+	// the server inherit the org's enabled integrations.
+	var enabledIntegrations *[]string
+	if disableIntegrations {
+		enabledIntegrations = &[]string{}
+	}
+
 	if cwdFlag == "" {
 		var err error
 		cwdFlag, err = os.Getwd()
@@ -289,9 +303,10 @@ func runNeo(
 		taskPrompt := nonInteractivePromptPreamble + "\n\n" + prompt
 		resp, err := createNeoTaskWithEntityRetry(
 			ctx, pc, orgName, taskPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
-				ToolExecutionMode: "cli",
-				ApprovalMode:      approvalMode,
-				PermissionMode:    permissionMode,
+				ToolExecutionMode:   "cli",
+				ApprovalMode:        approvalMode,
+				PermissionMode:      permissionMode,
+				EnabledIntegrations: enabledIntegrations,
 			}, nil)
 		if err != nil {
 			return err
@@ -379,10 +394,11 @@ func runNeo(
 			) error {
 				resp, err := createNeoTaskWithEntityRetry(
 					gctx, pc, orgName, initialPrompt, stackRefName, projectName, client.CreateNeoTaskOptions{
-						ToolExecutionMode: "cli",
-						ApprovalMode:      createApprovalMode,
-						PermissionMode:    createPermissionMode,
-						PlanMode:          planMode,
+						ToolExecutionMode:   "cli",
+						ApprovalMode:        createApprovalMode,
+						PermissionMode:      createPermissionMode,
+						PlanMode:            planMode,
+						EnabledIntegrations: enabledIntegrations,
 					}, func(originalErr error) {
 						sendUI(uiCh, UIWarning{Message: fmt.Sprintf(
 							"could not attach stack %s/%s/%s to Neo task: %s; "+

--- a/pkg/cmd/pulumi/neo/neo.go
+++ b/pkg/cmd/pulumi/neo/neo.go
@@ -191,8 +191,7 @@ func NewNeoCmd() *cobra.Command {
 			"stdout, and exit. Intended for use with other AI agents and scripts.")
 	cmd.Flags().BoolVar(&disableIntegrations, "disable-integrations", false,
 		"Run the Neo task with no integration credentials, ignoring any org-enabled "+
-			"integrations. Useful for debugging, reduced latency, or working around a "+
-			"misconfigured integration.")
+			"integrations.")
 
 	return cmd
 }
@@ -229,8 +228,7 @@ func runNeo(
 	printMode bool,
 	disableIntegrations bool,
 ) error {
-	// A non-nil empty slice sends `[]` to opt the task out of every integration; nil lets
-	// the server inherit the org's enabled integrations.
+	// nil lets the server inherit the org's enabled integrations; the empty slice opts out.
 	var enabledIntegrations *[]string
 	if disableIntegrations {
 		enabledIntegrations = &[]string{}

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -696,10 +696,6 @@ func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
 		"prompt from positional args must reach CreateNeoTask")
 }
 
-// TestRunNeoIntegration_DisableIntegrationsSendsEmptyList pins the end-to-end
-// wiring of --disable-integrations: setting it must put an explicit empty
-// `enabledIntegrations` array in the CreateNeoTask body.
-//
 //nolint:paralleltest // mutates package globals
 func TestRunNeoIntegration_DisableIntegrationsSendsEmptyList(t *testing.T) {
 	isolateWorkspace(t)

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -294,7 +294,7 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	}()
 
 	select {
@@ -380,7 +380,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	}()
 
 	select {
@@ -408,7 +408,7 @@ func TestRunNeoIntegration_NonInteractiveRequiresPrompt(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "" /*prompt*/, "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "prompt argument is required")
 
@@ -434,7 +434,7 @@ func TestRunNeoIntegration_RequiresCloudBackend(t *testing.T) {
 	t.Cleanup(func() { pkgWorkspace.Instance = prevWorkspace })
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Pulumi Cloud backend",
 		"non-cloud backends must surface a clear error rather than panic on the type assertion")
@@ -465,7 +465,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 		// directory is always a real, readable path, so the tools constructors
 		// accept it and runNeo proceeds.
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", "", /*cwd*/
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	}()
 
 	select {
@@ -489,7 +489,7 @@ func TestRunNeoIntegration_RejectsNonexistentCwd(t *testing.T) {
 
 	missing := t.TempDir() + "/does-not-exist"
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", missing,
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	require.Error(t, err)
 	// The exact wrapping is internal to tools.NewFilesystem, but the missing
 	// path should be referenced so the user can see what went wrong.
@@ -518,7 +518,7 @@ func TestRunNeoIntegration_PropagatesReadProjectError(t *testing.T) {
 	}
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "synthetic ReadProject failure")
 	assert.Empty(t, srv.recordedPosts(),
@@ -563,7 +563,7 @@ func TestRunNeoIntegration_PropagatesCreateNeoTaskError(t *testing.T) {
 	t.Cleanup(func() { isInteractive = prevInteractive })
 
 	err := runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "", "test-org", t.TempDir(),
-		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+		client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating Neo task")
 }
@@ -636,7 +636,7 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		done <- runNeo(t.Context(), io.Discard, io.Discard, "do a thing", "" /*stack*/, "test-org", t.TempDir(),
-			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/)
+			client.NeoApprovalModeManual, client.NeoPermissionModeDefault, false /*printMode*/, false /*disableIntegrations*/)
 	}()
 
 	select {
@@ -694,4 +694,52 @@ func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
 	require.NotEmpty(t, posts, "RunE did not reach CreateNeoTask")
 	assert.Contains(t, string(posts[0].body), "my prompt",
 		"prompt from positional args must reach CreateNeoTask")
+}
+
+// TestRunNeoIntegration_DisableIntegrationsSendsEmptyList pins the end-to-end
+// wiring of --disable-integrations: setting it must put an explicit empty
+// `enabledIntegrations` array in the CreateNeoTask body.
+//
+//nolint:paralleltest // mutates package globals
+func TestRunNeoIntegration_DisableIntegrationsSendsEmptyList(t *testing.T) {
+	isolateWorkspace(t)
+
+	srv := newNeoFakeServer(t)
+	installNeoTestEnv(t, srv, false /*interactive*/)
+
+	go func() {
+		if !srv.awaitStreamConnect(t, 2*time.Second) {
+			return
+		}
+		srv.sendFinalAssistantMessage(t)
+		srv.endStream()
+	}()
+
+	cmd := NewNeoCmd()
+	cmd.SetContext(t.Context())
+	require.NoError(t, cmd.Flags().Set("org", "test-org"))
+	require.NoError(t, cmd.Flags().Set("cwd", t.TempDir()))
+	require.NoError(t, cmd.Flags().Set("disable-integrations", "true"))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.RunE(cmd, []string{"my prompt"})
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cmd.RunE did not return within 5s")
+	}
+
+	posts := srv.recordedPosts()
+	require.NotEmpty(t, posts, "RunE did not reach CreateNeoTask")
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(posts[0].body, &body))
+	require.Contains(t, body, "enabledIntegrations",
+		"--disable-integrations must send an explicit enabledIntegrations field")
+	assert.Equal(t, []any{}, body["enabledIntegrations"],
+		"--disable-integrations must send an empty enabledIntegrations array")
 }

--- a/pkg/cmd/pulumi/neo/neo_test.go
+++ b/pkg/cmd/pulumi/neo/neo_test.go
@@ -341,6 +341,10 @@ func TestNewNeoCmd_RegistersFlags(t *testing.T) {
 	require.NotNil(t, print, "--print flag must be registered")
 	assert.Equal(t, "p", print.Shorthand)
 
+	disableIntegrations := cmd.Flags().Lookup("disable-integrations")
+	require.NotNil(t, disableIntegrations, "--disable-integrations flag must be registered")
+	assert.Equal(t, "false", disableIntegrations.DefValue, "--disable-integrations must default to off")
+
 	// cobra.MaximumNArgs(1): 0 or 1 prompt args OK, 2+ rejected.
 	require.NoError(t, cmd.Args(cmd, []string{}))
 	require.NoError(t, cmd.Args(cmd, []string{"hello"}))


### PR DESCRIPTION
Fixes #23527

## What

Adds a `--disable-integrations` flag to `pulumi neo` that runs the task with **no integration credentials**:

```
pulumi neo --disable-integrations "Who are you?"
```

When set, the CLI includes an explicit empty array `"enabledIntegrations": []` in the `POST /api/preview/agents/{orgName}/tasks` body, which the service already accepts as "no integrations for this task".

## Why

To run Neo without integrations for debugging and warming the cache variant of CLI x no-integrations.


## Testing
<img width="826" height="574" alt="image" src="https://github.com/user-attachments/assets/81d119d7-a3ea-4ad0-beb8-2320fc175629" />


And the task has integrations = [] stored against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)