### PR TITLE
Skip S3 directory-marker objects when listing DIY backend state (Fixed #23532)

### DIFF
--- a/changelog/pending/.changie-20260611--backend-diy--skip-s3-directory-markers.yaml
+++ b/changelog/pending/.changie-20260611--backend-diy--skip-s3-directory-markers.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Skip S3 directory-marker objects when listing DIY backend state
+component: backend/diy

--- a/changelog/pending/.changie-20260611--backend-diy--skip-s3-directory-markers.yaml
+++ b/changelog/pending/.changie-20260611--backend-diy--skip-s3-directory-markers.yaml
@@ -1,3 +1,5 @@
 kind: fix
 body: Skip S3 directory-marker objects when listing DIY backend state
 component: backend/diy
+custom:
+  PR: "23533"

--- a/pkg/backend/diy/bucket.go
+++ b/pkg/backend/diy/bucket.go
@@ -153,6 +153,14 @@ func listBucket(ctx context.Context, bucket Bucket, dir string) ([]*blob.ListObj
 		if err != nil {
 			return nil, fmt.Errorf("could not list bucket: %w", err)
 		}
+		// Some S3-compatible stores (e.g. Hitachi HCP) auto-create 0-byte
+		// "directory marker" objects whose key equals the listed prefix and
+		// ends in "/". They are not real state files; skip them so callers
+		// don't read/parse them as JSON (which fails with
+		// "unexpected end of JSON input").
+		if !file.IsDir && strings.HasSuffix(file.Key, "/") {
+			continue
+		}
 		files = append(files, file)
 	}
 

--- a/pkg/backend/diy/bucket_s3_test.go
+++ b/pkg/backend/diy/bucket_s3_test.go
@@ -185,3 +185,83 @@ func TestS3LegacyURLCopy(t *testing.T) {
 		})
 	}
 }
+
+// directoryMarkerS3Server is a minimal S3-compatible server whose ListObjectsV2
+// responses include 0-byte directory-marker objects (keys ending in "/") in
+// Contents, the way Hitachi HCP and similar stores do.
+type directoryMarkerS3Server struct{}
+
+func (s *directoryMarkerS3Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet && r.URL.Query().Get("list-type") == "2" {
+		prefix := r.URL.Query().Get("prefix")
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprint(w, `<?xml version="1.0" encoding="UTF-8"?>`+
+			`<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`+
+			`<Name>testbucket</Name>`+
+			`<Prefix>`+prefix+`</Prefix>`+
+			`<Delimiter>/</Delimiter>`+
+			`<IsTruncated>false</IsTruncated>`+
+			`<Contents>`+
+			`<Key>`+prefix+`</Key>`+
+			`<LastModified>2026-06-11T00:00:00.000Z</LastModified>`+
+			`<ETag>&quot;d41d8cd98f00b204e9800998ecf8427e&quot;</ETag>`+
+			`<Size>0</Size>`+
+			`<StorageClass>STANDARD</StorageClass>`+
+			`</Contents>`+
+			`<Contents>`+
+			`<Key>`+prefix+`stack.json</Key>`+
+			`<LastModified>2026-06-11T00:00:00.000Z</LastModified>`+
+			`<ETag>&quot;098f6bcd4621d373cade4e832627b4f6&quot;</ETag>`+
+			`<Size>2</Size>`+
+			`<StorageClass>STANDARD</StorageClass>`+
+			`</Contents>`+
+			`<CommonPrefixes>`+
+			`<Prefix>`+prefix+`history/</Prefix>`+
+			`</CommonPrefixes>`+
+			`</ListBucketResult>`)
+		return
+	}
+
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+func TestListBucketSkipsS3DirectoryMarkers(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials"))
+
+	server := httptest.NewServer(&directoryMarkerS3Server{})
+	defer server.Close()
+
+	bucketURL := fmt.Sprintf("s3://testbucket?endpoint=%s&s3ForcePathStyle=true&awssdk=v2", server.URL)
+
+	ctx := t.Context()
+	u, err := massageBlobPath(bucketURL)
+	require.NoError(t, err)
+	bucket, err := blob.DefaultURLMux().OpenBucket(ctx, u)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, bucket.Close())
+	}()
+
+	objects, err := listBucket(ctx, &wrappedBucket{bucket: bucket}, ".pulumi/stacks/dev")
+	require.NoError(t, err)
+
+	var keys []string
+	for _, obj := range objects {
+		keys = append(keys, obj.Key)
+	}
+	assert.Equal(t, []string{
+		".pulumi/stacks/dev/history/",
+		".pulumi/stacks/dev/stack.json",
+	}, keys)
+
+	for _, obj := range objects {
+		if strings.HasSuffix(obj.Key, "history/") {
+			assert.True(t, obj.IsDir, "common-prefix entries must be preserved for traversal")
+		}
+	}
+}


### PR DESCRIPTION
## Why

Some S3-compatible object stores (notably Hitachi HCP) auto-create 0-byte "directory marker" objects whose key equals the listed prefix and ends in `/` (e.g. `.pulumi/stacks/dev/`). These appear in `ListObjectsV2` `Contents`, not as `CommonPrefixes`.

Pulumi's DIY backend `listBucket` returned them as regular files. Downstream callers (`checkForLock`, stack/history enumeration) then `ReadAll` + `json.Unmarshal` them and fail with:

```
unexpected end of JSON input
```

Reproduced against Hitachi HCP (`esimw.s3b.uits.iu.edu`). Related S3-compatible hardening in the same file: #23478 (`fixupS3CopySource`).

## How

In `listBucket`, skip non-directory entries whose key ends in `/`. Common-prefix entries (`IsDir == true`) used for traversal are unchanged.

## Test plan

- [x] Added `TestListBucketSkipsS3DirectoryMarkers` using an httptest S3 server that returns a directory-marker object in `Contents` plus a real state file and a `CommonPrefixes` entry
- [x] `cd pkg && go test -count=1 -tags all -run TestListBucketSkipsS3DirectoryMarkers ./backend/diy/... -v`

```
=== RUN   TestListBucketSkipsS3DirectoryMarkers
--- PASS: TestListBucketSkipsS3DirectoryMarkers
PASS
ok      github.com/pulumi/pulumi/pkg/backend/diy
```


- [x] `cd pkg && go test -count=1 -tags all ./backend/diy/...` (201 tests passed)

Assistance from Cursor & Claude.