### PR TITLE
[codex] Fix logout for tokenless current backends

### DIFF
--- a/changelog/pending/cli-auth-fix-logout-tokenless-backend.yaml
+++ b/changelog/pending/cli-auth-fix-logout-tokenless-backend.yaml
@@ -3,4 +3,4 @@ kind: fix
 body: Ensure `pulumi logout` clears the current tokenless backend in coding agent environments
 time: 2026-06-11T00:00:00.000000+01:00
 custom:
-    PR: ""
+    PR: "23540"

--- a/changelog/pending/cli-auth-fix-logout-tokenless-backend.yaml
+++ b/changelog/pending/cli-auth-fix-logout-tokenless-backend.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Ensure `pulumi logout` clears the current tokenless backend in coding agent environments
+time: 2026-06-11T00:00:00.000000+01:00
+custom:
+    PR: ""

--- a/pkg/cmd/pulumi/auth/logout.go
+++ b/pkg/cmd/pulumi/auth/logout.go
@@ -127,9 +127,21 @@ func deleteAccount(cloudURL string) error {
 	if !workspace.AgentCredentialsFallbackEnabled() {
 		return workspace.DeleteAccount(cloudURL)
 	}
-	account, err := workspace.GetAccount(cloudURL)
-	if err == nil && account.AccessToken != "" {
+	creds, err := workspace.GetStoredCredentials()
+	// Tokenless backends, such as DIY backends, still belong to the default credential store.
+	if err == nil && credentialsContainAccount(creds, cloudURL) {
 		return workspace.DeleteAccount(cloudURL)
 	}
 	return workspace.DeleteAgentAccount(cloudURL)
+}
+
+func credentialsContainAccount(creds workspace.Credentials, cloudURL string) bool {
+	if creds.Current == cloudURL {
+		return true
+	}
+	if _, ok := creds.AccessTokens[cloudURL]; ok {
+		return true
+	}
+	_, ok := creds.Accounts[cloudURL]
+	return ok
 }

--- a/pkg/cmd/pulumi/auth/logout_test.go
+++ b/pkg/cmd/pulumi/auth/logout_test.go
@@ -58,6 +58,23 @@ func TestDeleteAccountFallsBackToAgentCredentials(t *testing.T) {
 	assert.Empty(t, claim.ClaimURL)
 }
 
+func TestCredentialsContainAccountIncludesTokenlessCurrentBackend(t *testing.T) {
+	t.Parallel()
+
+	cloudURL := "file://~"
+	creds := workspace.Credentials{
+		Current: cloudURL,
+		AccessTokens: map[string]string{
+			cloudURL: "",
+		},
+		Accounts: map[string]workspace.Account{
+			cloudURL: {},
+		},
+	}
+
+	assert.True(t, credentialsContainAccount(creds, cloudURL))
+}
+
 //nolint:paralleltest // mutates env vars
 func TestDeleteAccountSkipsAgentFallbackWhenExplicitPathSet(t *testing.T) {
 	credsDir := t.TempDir()


### PR DESCRIPTION
## Summary

Fix `pulumi logout` so it clears a tokenless current backend, such as a local DIY backend, when running in a detected coding-agent environment.

This restores the previous behavior where logging out of the current local backend clears `current` from `credentials.json`, allowing a subsequent bare `pulumi login` to default to Pulumi Cloud instead of immediately selecting the local backend again.

## Root cause

Coding-agent authentication support introduced agent credential fallback routing in https://github.com/pulumi/pulumi/pull/23225 on May 22, 2026. The logout routing logic used a non-empty access token to decide whether a backend belonged to the normal credential store or the shared agent credential store.

DIY backends intentionally store an empty access token. As a result, logout misclassified a normal tokenless backend as an agent backend, attempted to delete it from the agent credential store, and left the normal credential store's `current` value unchanged.

## Fix

Determine whether a backend belongs to the normal credential store by checking whether it is selected as `current` or exists in either stored credential map, regardless of whether its token is empty. Only fall back to deleting agent credentials when no normal credential entry exists.

Add regression coverage for a tokenless local backend selected as current.

## Validation

- `GOCACHE=/tmp/go-build go test ./cmd/pulumi/auth -count=1`
- `GOCACHE=/tmp/go-build go test -race -tags all ./cmd/pulumi/auth -count=1`
- `GOCACHE=/tmp/go-build mise exec -- make format`
- `GOCACHE=/tmp/go-build mise exec -- make lint`
- `GOCACHE=/tmp/go-build mise exec -- make test_fast` ran, but failed in unrelated environment-sensitive and existing broad-test cases:
  - cloud spec tests attempted agent signup because the test session is detected as an agent
  - conversion tests used an older `pulumi-language-yaml` without the `Link` method
  - existing broad race/coverage checks reported additional unrelated failures

The changed `cmd/pulumi/auth` package passed both its focused and race-enabled runs, including within the broader fast-test execution.