### PR TITLE
make sure no non-changelog/go.mod update commits can be merged when release is pending

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -96,9 +96,11 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --depth=1 origin master
+          git fetch --depth=2 origin "$BASE_SHA"
 
           # No release in progress - nothing to enforce.
-          if ! git cat-file -e origin/master:.release-pending 2>/dev/null; then
+          if ! git cat-file -e origin/master:.release-pending 2>/dev/null &&
+              ! git cat-file -e "$BASE_SHA":.release-pending 2>/dev/null; then
             exit 0
           fi
 
@@ -118,31 +120,29 @@ jobs:
           #
           # The merge queue will kick out PRs in order, from the earliest failing one, so it'll
           # kick out all of the PRs before the changelog/go.mod update PR.
-          git fetch --depth=2 origin "$BASE_SHA"
-
           if ! git cat-file -e "$BASE_SHA":.release-pending 2>/dev/null; then
             echo "::error::The merge base ($BASE_SHA) does not contain .release-pending."
             echo "This PR is not stacked directly on the freeze commit."
             exit 1
           fi
-          # if git cat-file -e "$BASE_SHA^":.release-pending 2>/dev/null; then
-          #   echo "::error::The merge base ($BASE_SHA) did not introduce .release-pending - it was already present in its parent."
-          #   echo "Another commit slipped between the freeze and this PR."
-          #   exit 1
-          # fi
+          if git cat-file -e "$BASE_SHA^":.release-pending 2>/dev/null; then
+            echo "::error::The merge base ($BASE_SHA) did not introduce .release-pending - it was already present in its parent."
+            echo "Another commit slipped between the freeze and this PR."
+            exit 1
+          fi
 
-          # EXPECTED_VERSION=$(git show "$BASE_SHA^":sdk/.version | tr -d '[:space:]')
-          # DEPENDED_VERSION=$(awk '$1 == "github.com/pulumi/pulumi/sdk/v3" && $2 ~ /^v[0-9]/ {print $2; exit}' pkg/go.mod | sed 's/^v//')
-          # if [ -z "$DEPENDED_VERSION" ]; then
-          #   echo "::error::Could not read the github.com/pulumi/pulumi/sdk/v3 dependency from pkg/go.mod."
-          #   exit 1
-          # fi
-          # if [ "$EXPECTED_VERSION" != "$DEPENDED_VERSION" ]; then
-          #   echo "::error::Version mismatch between the freeze commit's sdk/.version and this PR's pkg/go.mod dependency:"
-          #   echo "  sdk/.version at merge base: $EXPECTED_VERSION"
-          #   echo "  pkg/go.mod sdk/v3:          $DEPENDED_VERSION"
-          #   exit 1
-          # fi
+          EXPECTED_VERSION=$(git show "$BASE_SHA^":sdk/.version | tr -d '[:space:]')
+          DEPENDED_VERSION=$(awk '$1 == "github.com/pulumi/pulumi/sdk/v3" && $2 ~ /^v[0-9]/ {print $2; exit}' pkg/go.mod | sed 's/^v//')
+          if [ -z "$DEPENDED_VERSION" ]; then
+            echo "::error::Could not read the github.com/pulumi/pulumi/sdk/v3 dependency from pkg/go.mod."
+            exit 1
+          fi
+          if [ "$EXPECTED_VERSION" != "$DEPENDED_VERSION" ]; then
+            echo "::error::Version mismatch between the freeze commit's sdk/.version and this PR's pkg/go.mod dependency:"
+            echo "  sdk/.version at merge base: $EXPECTED_VERSION"
+            echo "  pkg/go.mod sdk/v3:          $DEPENDED_VERSION"
+            exit 1
+          fi
       - name: Cancel sibling jobs on block
         if: failure()
         env:


### PR DESCRIPTION
In the last release it happened that another PR was added to the queue after the freeze PR was added, but before the freeze PR was merged.

This means the `.release-pending` file was not on `origin/master` yet, and thus the PR was not stopped from merging, when it should have.

This shouldn't be happening, so also check that `$BASE_SHA` (the commit before the one currently building) doesn't contain the `.release-pending` either.  This should make sure that a commit added to the merge queue after the freeze commit doesn't get merged until the changelog/go.mod update PR is merged.

Also uncomment the other bits, that have been commented out to get https://github.com/pulumi/pulumi/pull/23538 to merge.

Stacked on top of https://github.com/pulumi/pulumi/pull/23538