### PR TITLE
Fix custom-gcl to rebuild on Go version changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,13 @@ lint_fix:: lint_golang_fix lint_pulumi_json_fix
 # bin/custom-gcl is a golangci-lint binary with the requiredfield and noosexit
 # linters baked in as module plugins. Built from .custom-gcl.yml and the
 # wrappers under .golangci/plugins/.
+#
+# It also depends on .make/go-version: golangci-lint's analysis loader rejects
+# source files that require a newer Go version than the linter binary itself,
+# so the binary must be rebuilt when the toolchain changes.
 CUSTOM_GCL := bin/custom-gcl
 CUSTOM_GCL_DEPS := .custom-gcl.yml \
+		   .make/go-version \
 		   .golangci/plugins/requiredfield/go.mod \
 		   .golangci/plugins/requiredfield/go.sum \
 		   .golangci/plugins/requiredfield/plugin.go \
@@ -184,6 +189,17 @@ CUSTOM_GCL_DEPS := .custom-gcl.yml \
 
 $(CUSTOM_GCL): $(CUSTOM_GCL_DEPS) .make/ensure/golangci-lint
 	golangci-lint custom
+
+# .make/go-version records `go version` output; the recipe only rewrites the
+# file when the output changes, so dependents rebuild on toolchain upgrades
+# without being touched on every make invocation.
+.PHONY: .check-go-version
+.make/go-version: .check-go-version
+	@mkdir -p $(dir $@)
+	@version=$$(go version); \
+	if [ "$$version" != "$$(cat $@ 2>/dev/null)" ]; then \
+		echo "$$version" > $@; \
+	fi
 
 define lint_golang_pkg
 	@echo "[golangci-lint] Linting $(1)..."


### PR DESCRIPTION
Noticed this when changing go versions in mise. `lint` started to fail with `file requires newer Go version go1.26 (application built with go1.25) [recovered, repanicked]` turns out its because we don't rebuild the custom-gcl binary when the go version changes but it's strictly tied that the version running has to be the version that built it.

Claude suggested this makefile workaround so we trigger a rebuild when the go version changes.