### PR TITLE
allow tests to succeed when an agent runs them

### DIFF
--- a/pkg/cmd/pulumi/agentauth/agentauth_test.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth_test.go
@@ -495,6 +495,7 @@ func setValidateAgentClaim(
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
 	for _, name := range []string{
+		"AI_AGENT",
 		"CURSOR_TRACE_ID",
 		"CURSOR_AGENT",
 		"GEMINI_CLI",

--- a/pkg/cmd/pulumi/agentauth/agentauth_test.go
+++ b/pkg/cmd/pulumi/agentauth/agentauth_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -494,28 +495,7 @@ func setValidateAgentClaim(
 
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{
-		"AI_AGENT",
-		"CURSOR_TRACE_ID",
-		"CURSOR_AGENT",
-		"GEMINI_CLI",
-		"CODEX_SANDBOX",
-		"CODEX_CI",
-		"CODEX_THREAD_ID",
-		"ANTIGRAVITY_AGENT",
-		"AUGMENT_AGENT",
-		"OPENCODE",
-		"OPENCODE_CALLER",
-		"OPENCODE_CLIENT",
-		"CLAUDE_CODE_IS_COWORK",
-		"CLAUDECODE",
-		"CLAUDE_CODE",
-		"REPL_ID",
-		"COPILOT_MODEL",
-		"COPILOT_ALLOW_ALL",
-		"COPILOT_GITHUB_TOKEN",
-		"GOOSE_PROVIDER",
-	} {
+	for _, name := range agentdetect.DetectionEnvVars() {
 		t.Setenv(name, "")
 	}
 }

--- a/pkg/cmd/pulumi/backend/backend_test.go
+++ b/pkg/cmd/pulumi/backend/backend_test.go
@@ -25,6 +25,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -200,28 +201,7 @@ func clearAIAgentEnv(t *testing.T) {
 	t.Setenv(workspace.PulumiCredentialsPathEnvVar, "")
 	t.Setenv(env.Home.Var().Name(), "")
 
-	for _, name := range []string{
-		"AI_AGENT",
-		"CURSOR_TRACE_ID",
-		"CURSOR_AGENT",
-		"GEMINI_CLI",
-		"CODEX_SANDBOX",
-		"CODEX_CI",
-		"CODEX_THREAD_ID",
-		"ANTIGRAVITY_AGENT",
-		"AUGMENT_AGENT",
-		"OPENCODE",
-		"OPENCODE_CALLER",
-		"OPENCODE_CLIENT",
-		"CLAUDE_CODE_IS_COWORK",
-		"CLAUDECODE",
-		"CLAUDE_CODE",
-		"REPL_ID",
-		"COPILOT_MODEL",
-		"COPILOT_ALLOW_ALL",
-		"COPILOT_GITHUB_TOKEN",
-		"GOOSE_PROVIDER",
-	} {
+	for _, name := range agentdetect.DetectionEnvVars() {
 		t.Setenv(name, "")
 	}
 }

--- a/pkg/cmd/pulumi/cloud/spec_fetch_test.go
+++ b/pkg/cmd/pulumi/cloud/spec_fetch_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -78,28 +79,7 @@ func TestReadCachedSpec_ReportsAge(t *testing.T) {
 
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{
-		"AI_AGENT",
-		"CURSOR_TRACE_ID",
-		"CURSOR_AGENT",
-		"GEMINI_CLI",
-		"CODEX_SANDBOX",
-		"CODEX_CI",
-		"CODEX_THREAD_ID",
-		"ANTIGRAVITY_AGENT",
-		"AUGMENT_AGENT",
-		"OPENCODE",
-		"OPENCODE_CALLER",
-		"OPENCODE_CLIENT",
-		"CLAUDE_CODE_IS_COWORK",
-		"CLAUDECODE",
-		"CLAUDE_CODE",
-		"REPL_ID",
-		"COPILOT_MODEL",
-		"COPILOT_ALLOW_ALL",
-		"COPILOT_GITHUB_TOKEN",
-		"GOOSE_PROVIDER",
-	} {
+	for _, name := range agentdetect.DetectionEnvVars() {
 		t.Setenv(name, "")
 	}
 }

--- a/pkg/cmd/pulumi/cloud/spec_fetch_test.go
+++ b/pkg/cmd/pulumi/cloud/spec_fetch_test.go
@@ -76,6 +76,34 @@ func TestReadCachedSpec_ReportsAge(t *testing.T) {
 	assert.False(t, missingOK)
 }
 
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"AI_AGENT",
+		"CURSOR_TRACE_ID",
+		"CURSOR_AGENT",
+		"GEMINI_CLI",
+		"CODEX_SANDBOX",
+		"CODEX_CI",
+		"CODEX_THREAD_ID",
+		"ANTIGRAVITY_AGENT",
+		"AUGMENT_AGENT",
+		"OPENCODE",
+		"OPENCODE_CALLER",
+		"OPENCODE_CLIENT",
+		"CLAUDE_CODE_IS_COWORK",
+		"CLAUDECODE",
+		"CLAUDE_CODE",
+		"REPL_ID",
+		"COPILOT_MODEL",
+		"COPILOT_ALLOW_ALL",
+		"COPILOT_GITHUB_TOKEN",
+		"GOOSE_PROVIDER",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
 // seedSpecCache writes data to the cache path that ensureSpec would use for
 // cloudURL, sets its mtime to now-age, and returns the resolved path. Assumes
 // PULUMI_HOME is already pointing at an isolated tempdir.
@@ -109,6 +137,7 @@ func newSpecServer(t *testing.T, serveBody []byte) (*httptest.Server, *atomic.In
 //
 //nolint:paralleltest // mutates PULUMI_HOME / PULUMI_API
 func TestEnsureSpec_CacheHitUnderTTL(t *testing.T) {
+	clearAgentEnv(t)
 	t.Setenv("PULUMI_HOME", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 	cached := []byte(`{"cached":true}`)
@@ -129,6 +158,7 @@ func TestEnsureSpec_CacheHitUnderTTL(t *testing.T) {
 //
 //nolint:paralleltest // mutates PULUMI_HOME / PULUMI_API / specCacheTTL
 func TestEnsureSpec_TTLExpiryTriggersFetch(t *testing.T) {
+	clearAgentEnv(t)
 	t.Setenv("PULUMI_HOME", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 	origTTL := specCacheTTL
@@ -156,6 +186,7 @@ func TestEnsureSpec_TTLExpiryTriggersFetch(t *testing.T) {
 //
 //nolint:paralleltest // mutates PULUMI_HOME / PULUMI_API
 func TestEnsureSpec_RefreshForcesFetch(t *testing.T) {
+	clearAgentEnv(t)
 	t.Setenv("PULUMI_HOME", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 	srv, hits := newSpecServer(t, []byte(`{"fresh":true}`))
@@ -174,6 +205,7 @@ func TestEnsureSpec_RefreshForcesFetch(t *testing.T) {
 //
 //nolint:paralleltest // mutates PULUMI_HOME / PULUMI_API / specCacheTTL
 func TestEnsureSpec_StaleFallbackOnFetchFailure(t *testing.T) {
+	clearAgentEnv(t)
 	t.Setenv("PULUMI_HOME", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 	origTTL := specCacheTTL
@@ -201,6 +233,7 @@ func TestEnsureSpec_StaleFallbackOnFetchFailure(t *testing.T) {
 //
 //nolint:paralleltest // mutates PULUMI_HOME / PULUMI_API
 func TestEnsureSpec_RefreshFlagFailsHardOnFetchError(t *testing.T) {
+	clearAgentEnv(t)
 	t.Setenv("PULUMI_HOME", t.TempDir())
 	t.Setenv("PULUMI_ACCESS_TOKEN", "")
 

--- a/pkg/cmd/pulumi/metadata/metadata_test.go
+++ b/pkg/cmd/pulumi/metadata/metadata_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 )
 
@@ -416,20 +417,7 @@ func TestAddEscMetadataToEnvironment(t *testing.T) {
 
 func TestAddExecutionMetadataToEnvironmentDetectsAgent(t *testing.T) {
 	// Don't let agent-detection env vars from the host shell mask CODEX_THREAD_ID.
-	for _, key := range []string{
-		"AI_AGENT",
-		"CURSOR_TRACE_ID", "CURSOR_AGENT",
-		"GEMINI_CLI",
-		"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID",
-		"ANTIGRAVITY_AGENT",
-		"AUGMENT_AGENT",
-		"OPENCODE", "OPENCODE_CALLER", "OPENCODE_CLIENT",
-		"CLAUDE_CODE_IS_COWORK",
-		"CLAUDECODE", "CLAUDE_CODE",
-		"REPL_ID",
-		"COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN",
-		"GOOSE_PROVIDER",
-	} {
+	for _, key := range agentdetect.DetectionEnvVars() {
 		t.Setenv(key, "")
 	}
 	t.Setenv("CODEX_THREAD_ID", "thread")

--- a/sdk/go/common/util/agentdetect/agentdetect.go
+++ b/sdk/go/common/util/agentdetect/agentdetect.go
@@ -29,6 +29,39 @@ type Metadata struct {
 	Model string
 }
 
+type detector struct {
+	name string
+	envs []string
+}
+
+// These are sourced from https://github.com/unjs/std-env/blob/main/src/agents.ts and
+// https://github.com/vercel/vercel/blob/main/packages/detect-agent/src/index.ts, as a reference for common
+// environment variables set by AI agents and tools.
+//
+// Order matters: specific forms should be identified before broad IDE/tool markers.
+var agents = []detector{
+	{name: "cursor", envs: []string{"CURSOR_TRACE_ID"}},
+	{name: "cursor-cli", envs: []string{"CURSOR_AGENT"}},
+	{name: "gemini", envs: []string{"GEMINI_CLI"}},
+	{name: "codex", envs: []string{"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"}},
+	{name: "antigravity", envs: []string{"ANTIGRAVITY_AGENT"}},
+	{name: "augment-cli", envs: []string{"AUGMENT_AGENT"}},
+	{name: "opencode", envs: []string{"OPENCODE", "OPENCODE_CALLER", "OPENCODE_CLIENT"}},
+	{name: "cowork", envs: []string{"CLAUDE_CODE_IS_COWORK"}},
+	{name: "claude", envs: []string{"CLAUDECODE", "CLAUDE_CODE"}},
+	{name: "replit", envs: []string{"REPL_ID"}},
+	{name: "github-copilot", envs: []string{"COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"}},
+	{name: "goose", envs: []string{"GOOSE_PROVIDER"}},
+}
+
+func DetectionEnvVars() []string {
+	vars := []string{"AI_AGENT"}
+	for _, d := range agents {
+		vars = append(vars, d.envs...)
+	}
+	return vars
+}
+
 // Detect returns a normalized name for the AI coding agent driving
 // the CLI (e.g. "claude", "cursor", "codex"), or "" if none is detected.
 // Detection is based on environment variables.
@@ -44,30 +77,6 @@ func Detect(getEnv func(string) string) string {
 	}
 	if agent := normalized(getEnv("AI_AGENT")); agent != "" {
 		return agent
-	}
-
-	type detector struct {
-		name string
-		envs []string
-	}
-	// These are sourced from https://github.com/unjs/std-env/blob/main/src/agents.ts and
-	// https://github.com/vercel/vercel/blob/main/packages/detect-agent/src/index.ts, as a reference for common
-	// environment variables set by AI agents and tools.
-	//
-	// Order matters: specific forms should be identified before broad IDE/tool markers.
-	agents := []detector{
-		{name: "cursor", envs: []string{"CURSOR_TRACE_ID"}},
-		{name: "cursor-cli", envs: []string{"CURSOR_AGENT"}},
-		{name: "gemini", envs: []string{"GEMINI_CLI"}},
-		{name: "codex", envs: []string{"CODEX_SANDBOX", "CODEX_CI", "CODEX_THREAD_ID"}},
-		{name: "antigravity", envs: []string{"ANTIGRAVITY_AGENT"}},
-		{name: "augment-cli", envs: []string{"AUGMENT_AGENT"}},
-		{name: "opencode", envs: []string{"OPENCODE", "OPENCODE_CALLER", "OPENCODE_CLIENT"}},
-		{name: "cowork", envs: []string{"CLAUDE_CODE_IS_COWORK"}},
-		{name: "claude", envs: []string{"CLAUDECODE", "CLAUDE_CODE"}},
-		{name: "replit", envs: []string{"REPL_ID"}},
-		{name: "github-copilot", envs: []string{"COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN"}},
-		{name: "goose", envs: []string{"GOOSE_PROVIDER"}},
 	}
 
 	for _, d := range agents {

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/agentdetect"
 )
 
 //nolint:paralleltest // mutates environment
@@ -898,28 +900,7 @@ func setAgentEnv(t *testing.T) {
 
 func clearAgentEnv(t *testing.T) {
 	t.Helper()
-	for _, name := range []string{
-		"AI_AGENT",
-		"CURSOR_TRACE_ID",
-		"CURSOR_AGENT",
-		"GEMINI_CLI",
-		"CODEX_SANDBOX",
-		"CODEX_CI",
-		"CODEX_THREAD_ID",
-		"ANTIGRAVITY_AGENT",
-		"AUGMENT_AGENT",
-		"OPENCODE",
-		"OPENCODE_CALLER",
-		"OPENCODE_CLIENT",
-		"CLAUDE_CODE_IS_COWORK",
-		"CLAUDECODE",
-		"CLAUDE_CODE",
-		"REPL_ID",
-		"COPILOT_MODEL",
-		"COPILOT_ALLOW_ALL",
-		"COPILOT_GITHUB_TOKEN",
-		"GOOSE_PROVIDER",
-	} {
+	for _, name := range agentdetect.DetectionEnvVars() {
 		t.Setenv(name, "")
 	}
 }


### PR DESCRIPTION
The agentauth tests are missing an environment variable to clear, that can be set by agents, add it to always make this test work.

Similarly the spec_fetch tests currently create an agent account when they are run within an agent.  Clear that environment to make sure that doesn't happen, and the tests test the right thing.
