### PR TITLE
Fix TestRunNeoIntegration_DoubleCtrlCExits flake on slow runners

### DIFF
--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -39,10 +39,9 @@ import (
 )
 
 // testWaitTimeout bounds every wait in these integration tests. Generous on
-// purpose: the failure mode they guard against is a permanent hang, so a long
-// deadline loses no detection power, while tight ones flake on starved CI
-// runners (multi-second stalls observed on coverage-instrumented Windows
-// jobs; see pulumi/pulumi#23541).
+// purpose: the tests guard against permanent hangs, so a long deadline loses
+// no detection power, while tight ones flake on starved CI runners
+// (pulumi/pulumi#23541).
 const testWaitTimeout = 30 * time.Second
 
 // neoFakeServer fakes the four Pulumi Cloud HTTP endpoints runNeo touches
@@ -278,12 +277,9 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// equivalent to "user pressed Ctrl+C twice and the TUI called tea.Quit".
 	go func() {
 		// Wait for runNeo to construct the tea.Program, then for the SSE
-		// stream to open. Both happen in milliseconds locally, but starved CI
-		// runners (notably Windows with coverage instrumentation) have been
-		// observed to take multiple seconds; see pulumi/pulumi#23541. Once the
-		// program exists, always Quit — exiting this goroutine without quitting
-		// would leave the TUI running and turn a slow run into a guaranteed
-		// timeout below.
+		// stream to open. Once the program exists, always Quit — bailing out
+		// here would leave the TUI running and turn a slow run into a
+		// guaranteed timeout below.
 		var p *tea.Program
 		deadline := time.Now().Add(testWaitTimeout)
 		for time.Now().Before(deadline) {

--- a/pkg/cmd/pulumi/neo/neo_integration_test.go
+++ b/pkg/cmd/pulumi/neo/neo_integration_test.go
@@ -38,6 +38,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// testWaitTimeout bounds every wait in these integration tests. Generous on
+// purpose: the failure mode they guard against is a permanent hang, so a long
+// deadline loses no detection power, while tight ones flake on starved CI
+// runners (multi-second stalls observed on coverage-instrumented Windows
+// jobs; see pulumi/pulumi#23541).
+const testWaitTimeout = 30 * time.Second
+
 // neoFakeServer fakes the four Pulumi Cloud HTTP endpoints runNeo touches
 // (account details, create-task, SSE event stream, and post-user-event) over
 // httptest. The handlers record the requests they observe so the test can
@@ -207,7 +214,7 @@ func (s *neoFakeServer) sawStreamConnect() bool {
 // (interactive path) against an in-process httptest.Server with a real
 // *client.Client — exercising HTTP marshalling, SSE parsing, and the real
 // Session.Run loop — then triggers the TUI to quit and asserts runNeo
-// returns within 5s. Pre-fix, p.Run returned nil from tea.Quit, errgroup
+// returns promptly. Pre-fix, p.Run returned nil from tea.Quit, errgroup
 // kept gctx alive, Session.Run blocked on `<-ctx.Done` forever, and g.Wait
 // hung — this test would time out instead of completing.
 //
@@ -270,23 +277,34 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 	// Drive shutdown once the SSE stream is established. This is the moment
 	// equivalent to "user pressed Ctrl+C twice and the TUI called tea.Quit".
 	go func() {
-		// Wait briefly for runNeo to call CreateNeoTask and open the SSE
-		// stream. 100ms is generous on local hardware; if the test ever
-		// flakes here, switch to polling srv.sawStreamConnect().
-		deadline := time.Now().Add(2 * time.Second)
+		// Wait for runNeo to construct the tea.Program, then for the SSE
+		// stream to open. Both happen in milliseconds locally, but starved CI
+		// runners (notably Windows with coverage instrumentation) have been
+		// observed to take multiple seconds; see pulumi/pulumi#23541. Once the
+		// program exists, always Quit — exiting this goroutine without quitting
+		// would leave the TUI running and turn a slow run into a guaranteed
+		// timeout below.
+		var p *tea.Program
+		deadline := time.Now().Add(testWaitTimeout)
+		for time.Now().Before(deadline) {
+			programMu.Lock()
+			p = program
+			programMu.Unlock()
+			if p != nil {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if p == nil {
+			return // runNeo never got there; the main timeout will report it.
+		}
 		for time.Now().Before(deadline) {
 			if srv.sawStreamConnect() {
 				break
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
-
-		programMu.Lock()
-		p := program
-		programMu.Unlock()
-		if p != nil {
-			p.Quit()
-		}
+		p.Quit()
 	}()
 
 	// runNeo on its own goroutine so the test can enforce a hard timeout
@@ -307,8 +325,8 @@ func TestRunNeoIntegration_DoubleCtrlCExits(t *testing.T) {
 			require.ErrorIs(t, err, context.Canceled,
 				"unexpected error from runNeo: %v", err)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("runNeo did not return within 5s — the cancel-on-TUI-exit fix has regressed " +
+	case <-time.After(testWaitTimeout):
+		t.Fatal("runNeo did not return in time — the cancel-on-TUI-exit fix has regressed " +
 			"(real *client.Client + real Session.Run hung after tea.Quit)")
 	}
 
@@ -370,7 +388,7 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	// and close the stream so Session.Run sees the channel close and returns
 	// nil. Without this nudge the handler would block forever on streamSend.
 	go func() {
-		if !srv.awaitStreamConnect(t, 2*time.Second) {
+		if !srv.awaitStreamConnect(t, testWaitTimeout) {
 			return
 		}
 		srv.sendFinalAssistantMessage(t)
@@ -386,8 +404,8 @@ func TestRunNeoIntegration_NonInteractiveHappyPath(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("non-interactive runNeo did not return within 5s")
+	case <-time.After(testWaitTimeout):
+		t.Fatal("non-interactive runNeo did not return in time")
 	}
 
 	posts := srv.recordedPosts()
@@ -452,7 +470,7 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	go func() {
-		if !srv.awaitStreamConnect(t, 2*time.Second) {
+		if !srv.awaitStreamConnect(t, testWaitTimeout) {
 			return
 		}
 		srv.sendFinalAssistantMessage(t)
@@ -471,8 +489,8 @@ func TestRunNeoIntegration_ResolvesCwdWhenEmpty(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("runNeo with empty cwd did not return within 5s")
+	case <-time.After(testWaitTimeout):
+		t.Fatal("runNeo with empty cwd did not return in time")
 	}
 }
 
@@ -646,8 +664,8 @@ func TestRunNeoIntegration_InteractiveCreateNeoTaskFailureExits(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "creating Neo task",
 			"CreateNeoTask error must propagate, not be replaced by tear-down state")
-	case <-time.After(5 * time.Second):
-		t.Fatal("runNeo did not return within 5s after CreateNeoTask failure — " +
+	case <-time.After(testWaitTimeout):
+		t.Fatal("runNeo did not return in time after CreateNeoTask failure — " +
 			"the gctx.Done → p.Quit goroutine must tear the TUI down on worker error")
 	}
 }
@@ -666,7 +684,7 @@ func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
 	installNeoTestEnv(t, srv, false /*interactive*/)
 
 	go func() {
-		if !srv.awaitStreamConnect(t, 2*time.Second) {
+		if !srv.awaitStreamConnect(t, testWaitTimeout) {
 			return
 		}
 		srv.sendFinalAssistantMessage(t)
@@ -686,8 +704,8 @@ func TestRunNeoIntegration_NewNeoCmdRunE(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("cmd.RunE did not return within 5s")
+	case <-time.After(testWaitTimeout):
+		t.Fatal("cmd.RunE did not return in time")
 	}
 
 	posts := srv.recordedPosts()

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -129,7 +129,7 @@ if not dryrun:
                         print(msg, end='', file=sys.stderr)
                     print("=== End build errors ===", file=sys.stderr)
             except Exception as json_err:
-                print(json_err, file=sys.stderr)  # Don't mask the original error
+                print(json_err, file=sys.stderr)
         raise e
 else:
     print("Would have run: " + ' '.join(args))

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -114,7 +114,10 @@ if not dryrun:
         if json_file is not None and os.path.isfile(json_file):
             try:
                 build_errors = []
-                with open(json_file, 'r') as f:
+                # gotestsum writes UTF-8; be explicit so Windows doesn't try
+                # to decode it as the legacy codepage (cp1252) and fail on
+                # non-ASCII test output.
+                with open(json_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
                         if not line:
@@ -128,9 +131,11 @@ if not dryrun:
                     for msg in build_errors:
                         print(msg, end='', file=sys.stderr)
                     print("=== End build errors ===", file=sys.stderr)
-            except Exception as e:
-                print(e, file=sys.stderr)
-                pass  # Don't mask the original error
+            except Exception as json_err:
+                # Don't mask the original error. Note this must not rebind
+                # `e`: `except ... as e` unbinds the name when the block
+                # exits, which would turn the `raise` below into a NameError.
+                print(json_err, file=sys.stderr)
         raise e
 else:
     print("Would have run: " + ' '.join(args))

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -114,9 +114,8 @@ if not dryrun:
         if json_file is not None and os.path.isfile(json_file):
             try:
                 build_errors = []
-                # gotestsum writes UTF-8; be explicit so Windows doesn't try
-                # to decode it as the legacy codepage (cp1252) and fail on
-                # non-ASCII test output.
+                # gotestsum writes UTF-8; Windows' default codepage (cp1252)
+                # can't decode non-ASCII test output.
                 with open(json_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
@@ -132,9 +131,8 @@ if not dryrun:
                         print(msg, end='', file=sys.stderr)
                     print("=== End build errors ===", file=sys.stderr)
             except Exception as json_err:
-                # Don't mask the original error. Note this must not rebind
-                # `e`: `except ... as e` unbinds the name when the block
-                # exits, which would turn the `raise` below into a NameError.
+                # Don't mask the original error; binding this as `e` would
+                # unbind the outer `e` and break the raise below.
                 print(json_err, file=sys.stderr)
         raise e
 else:

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -114,8 +114,6 @@ if not dryrun:
         if json_file is not None and os.path.isfile(json_file):
             try:
                 build_errors = []
-                # gotestsum writes UTF-8; Windows' default codepage (cp1252)
-                # can't decode non-ASCII test output.
                 with open(json_file, 'r', encoding='utf-8') as f:
                     for line in f:
                         line = line.strip()
@@ -131,9 +129,7 @@ if not dryrun:
                         print(msg, end='', file=sys.stderr)
                     print("=== End build errors ===", file=sys.stderr)
             except Exception as json_err:
-                # Don't mask the original error; binding this as `e` would
-                # unbind the outer `e` and break the raise below.
-                print(json_err, file=sys.stderr)
+                print(json_err, file=sys.stderr)  # Don't mask the original error
         raise e
 else:
     print("Would have run: " + ' '.join(args))


### PR DESCRIPTION
Fixes #23541.

## Root cause

Not a regression of the cancel-on-TUI-exit fix — a test-harness timing flake. The failure in the linked run happened on a starved `windows-latest` acceptance job (attempt 1; the rerun passed). The test's quit-driver goroutine polled for the SSE connect for only 2s and called `p.Quit()` **only if** the `tea.Program` had already been constructed — on a slow runner where `runNeo` hadn't gotten that far yet, nothing ever quit the TUI, making the 5s `t.Fatal` a certainty.

## Changes

- The quit goroutine now waits for the program, then the SSE connect, under a generous shared deadline, and always quits once the program exists.
- All hardcoded 2s/5s waits in the file use one 30s constant: these tests guard against permanent hangs, so longer deadlines lose no signal but stop flaking under load.
- `scripts/go-test.py`: open the gotestsum JSON as UTF-8 (Windows cp1252 chokes on non-ASCII test output) and rename the inner `except ... as e`, which unbound the outer `e` and turned `raise e` into the `NameError` seen in the issue's log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)