### PR TITLE
Serve raw schema bytes from the loader service

### DIFF
--- a/changelog/pending/engine-improvement-raw-schema-loader.yaml
+++ b/changelog/pending/engine-improvement-raw-schema-loader.yaml
@@ -1,0 +1,7 @@
+component: engine
+kind: improvement
+body: Serve raw schema bytes from the engine's schema loader service instead of binding
+    and re-marshaling the full schema on every request
+time: 2026-06-12T12:43:41Z
+custom:
+    PR: "23551"

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -108,11 +108,28 @@ type ReferenceLoader interface {
 	LoadPackageReferenceV2(ctx context.Context, descriptor *PackageDescriptor) (PackageReference, error)
 }
 
+// RawLoader is an optional interface implemented by loaders that can return the raw JSON schema bytes for a
+// package descriptor without binding the schema.
+type RawLoader interface {
+	ReferenceLoader
+
+	// LoadRawSchemaBytes returns the raw JSON schema bytes for the given package descriptor.
+	//
+	// ok reports whether the bytes faithfully represent the package that LoadPackageReferenceV2 would load for the
+	// same descriptor; when ok is false the caller must fall back to a bind-based load.
+	LoadRawSchemaBytes(ctx context.Context, descriptor *PackageDescriptor) (data []byte, ok bool, err error)
+}
+
 type pluginLoader struct {
 	host plugin.Host
 
 	cacheOptions pluginLoaderCacheOptions
 }
+
+var (
+	_ ReferenceLoader = (*pluginLoader)(nil)
+	_ RawLoader       = (*pluginLoader)(nil)
+)
 
 // Caching options intended for benchmarking or debugging:
 type pluginLoaderCacheOptions struct {
@@ -225,6 +242,49 @@ func (l *pluginLoader) LoadPackageReferenceV2(
 		return nil, err
 	}
 	return p, nil
+}
+
+func (l *pluginLoader) LoadRawSchemaBytes(
+	ctx context.Context, descriptor *PackageDescriptor,
+) ([]byte, bool, error) {
+	if descriptor.Name == "pulumi" {
+		// DefaultPulumiPackage is served from memory; there are no raw bytes for it.
+		return nil, false, nil
+	}
+
+	schemaBytes, pluginVersion, err := l.loadSchemaBytes(ctx, descriptor)
+	if err != nil {
+		return nil, false, err
+	}
+	if schemaIsEmpty(schemaBytes) {
+		return nil, false, getSchemaNotImplemented{}
+	}
+
+	// LoadPackageReferenceV2 defaults a missing schema version to the resolved plugin version. Raw bytes can't
+	// carry that fix-up, so when it would apply the caller has to take the bind-based path instead.
+	if pluginVersion != nil && descriptor.Parameterization == nil && !hasTopLevelVersion(schemaBytes) {
+		return nil, false, nil
+	}
+
+	return schemaBytes, true, nil
+}
+
+// hasTopLevelVersion reports whether the top-level JSON object in schemaBytes has a "version" key with a
+// non-empty string value.
+func hasTopLevelVersion(schemaBytes []byte) bool {
+	wantValue := false
+	for tok := json.NewTokenizer(schemaBytes); tok.Next(); {
+		if tok.Depth != 1 || tok.Delim == ':' || tok.Delim == ',' {
+			continue
+		}
+		if wantValue {
+			return tok.Value.String() && len(tok.String()) > 0
+		}
+		if tok.IsKey && string(tok.String()) == "version" {
+			wantValue = true
+		}
+	}
+	return false
 }
 
 // LoadPackageReference loads a package reference for the given pkg+version using the

--- a/pkg/codegen/schema/loader_cached.go
+++ b/pkg/codegen/schema/loader_cached.go
@@ -72,12 +72,7 @@ func (l *cachedLoader) LoadPackageReferenceV2(
 	l.m.Lock()
 	defer l.m.Unlock()
 
-	var key string
-	if descriptor.Parameterization == nil {
-		key = packageIdentity(descriptor.Name, descriptor.Version)
-	} else {
-		key = packageIdentity(descriptor.Parameterization.Name, &descriptor.Parameterization.Version)
-	}
+	key := entryKey(descriptor)
 	if p, ok := l.entries[key]; ok {
 		return p, nil
 	}
@@ -89,4 +84,34 @@ func (l *cachedLoader) LoadPackageReferenceV2(
 
 	l.entries[key] = p
 	return p, nil
+}
+
+// LoadRawSchemaBytes implements RawLoader when the underlying loader does. A cached entry takes precedence over
+// whatever the underlying loader would serve — entries may be pre-seeded with packages the underlying loader
+// can't load at all, such as file-based schemas during package linking — so its presence forces ok=false and a
+// bind-based load. The cache is never populated here: raw bytes are unbound.
+func (l *cachedLoader) LoadRawSchemaBytes(
+	ctx context.Context, descriptor *PackageDescriptor,
+) ([]byte, bool, error) {
+	raw, ok := l.loader.(RawLoader)
+	if !ok {
+		return nil, false, nil
+	}
+
+	l.m.RLock()
+	_, cached := l.entries[entryKey(descriptor)]
+	l.m.RUnlock()
+	if cached {
+		return nil, false, nil
+	}
+
+	return raw.LoadRawSchemaBytes(ctx, descriptor)
+}
+
+// entryKey returns the entry cache key for a package descriptor.
+func entryKey(descriptor *PackageDescriptor) string {
+	if descriptor.Parameterization == nil {
+		return packageIdentity(descriptor.Name, descriptor.Version)
+	}
+	return packageIdentity(descriptor.Parameterization.Name, &descriptor.Parameterization.Version)
 }

--- a/pkg/codegen/schema/loader_server.go
+++ b/pkg/codegen/schema/loader_server.go
@@ -76,6 +76,22 @@ func (m *loaderServer) GetSchema(ctx context.Context,
 		descriptor.Parameterization.Version = v
 	}
 
+	// If the loader can hand us the raw schema bytes, ship those directly: the client parses and lazily binds
+	// them anyway, so binding and re-marshaling the package here would be pure overhead.
+	if rawLoader, ok := m.loader.(RawLoader); ok {
+		data, ok, err := rawLoader.LoadRawSchemaBytes(ctx, descriptor)
+		if err != nil {
+			logging.V(7).Infof("%s failed: %v", label, err)
+			return nil, err
+		}
+		if ok {
+			logging.V(7).Infof("%s success: data=#%d", label, len(data))
+			return &codegenrpc.GetSchemaResponse{
+				Schema: data,
+			}, nil
+		}
+	}
+
 	pkg, err := m.loader.LoadPackageV2(ctx, descriptor)
 	if err != nil {
 		logging.V(7).Infof("%s failed: %v", label, err)

--- a/pkg/codegen/schema/loader_server_test.go
+++ b/pkg/codegen/schema/loader_server_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+)
+
+// mockSchemaHost returns a plugin host that resolves pluginName@pluginVersion to the given provider.
+func mockSchemaHost(
+	t *testing.T, pluginName string, pluginVersion semver.Version, provider plugin.Provider,
+) plugin.Host {
+	return &plugin.MockHost{
+		ProviderF: func(descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+			assert.Equal(t, pluginName, descriptor.Name)
+			return provider, nil
+		},
+		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+			return &workspace.PluginInfo{
+				Name:    pluginName,
+				Kind:    apitype.ResourcePlugin,
+				Version: &pluginVersion,
+			}, nil
+		},
+	}
+}
+
+func schemaProvider(schemaBytes []byte) *plugin.MockProvider {
+	return &plugin.MockProvider{
+		GetSchemaF: func(context.Context, plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+			return plugin.GetSchemaResponse{Schema: schemaBytes}, nil
+		},
+	}
+}
+
+// serveLoader serves loader over gRPC and returns a LoaderClient connected to it.
+func serveLoader(t *testing.T, loader ReferenceLoader) *LoaderClient {
+	cancel := make(chan bool)
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			codegenrpc.RegisterLoaderServer(srv, NewLoaderServer(loader))
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		close(cancel)
+		require.NoError(t, <-handle.Done)
+	})
+
+	client, err := NewLoaderClient(fmt.Sprintf("127.0.0.1:%d", handle.Port))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	return client
+}
+
+// Tests that when the schema declares its own version, GetSchema serves the raw provider bytes verbatim and the
+// client binds them to a package equivalent to an in-process load.
+func TestLoaderServerRawSchemaBytes(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	// Distinctive whitespace: re-marshaling would not preserve it, so byte equality proves the raw path was taken.
+	rawSchema := []byte(`{ "name": "test",  "version": "1.2.3",` +
+		` "resources": { "test:index:Resource": { "properties": { "foo": { "type": "string" } } } } }`)
+	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
+	client := serveLoader(t, NewPluginLoader(host))
+
+	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
+		Package: "test",
+		Version: "1.2.3",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, rawSchema, resp.Schema)
+
+	version := semver.MustParse("1.2.3")
+	descriptor := &PackageDescriptor{Name: "test", Version: &version}
+
+	clientPkg, err := client.LoadPackageV2(t.Context(), descriptor)
+	require.NoError(t, err)
+	inProcessPkg, err := NewPluginLoader(host).LoadPackageV2(t.Context(), descriptor)
+	require.NoError(t, err)
+
+	clientSpec, err := clientPkg.MarshalSpec()
+	require.NoError(t, err)
+	inProcessSpec, err := inProcessPkg.MarshalSpec()
+	require.NoError(t, err)
+	assert.Equal(t, inProcessSpec, clientSpec)
+}
+
+// Tests that when the schema lacks a top-level version, GetSchema falls back to the bind-based path so the
+// plugin version is defaulted into the schema, and the client sees the same package as an in-process load.
+func TestLoaderServerRawSchemaBytesNoVersionFallback(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	rawSchema := []byte(`{ "name": "test",` +
+		` "resources": { "test:index:Resource": { "properties": { "foo": { "type": "string" } } } } }`)
+	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider(rawSchema))
+	client := serveLoader(t, NewPluginLoader(host))
+
+	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
+		Package: "test",
+		Version: "1.2.3",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, rawSchema, resp.Schema)
+	var spec PackageSpec
+	require.NoError(t, json.Unmarshal(resp.Schema, &spec))
+	assert.Equal(t, "1.2.3", spec.Version)
+
+	version := semver.MustParse("1.2.3")
+	descriptor := &PackageDescriptor{Name: "test", Version: &version}
+
+	clientRef, err := client.LoadPackageReferenceV2(t.Context(), descriptor)
+	require.NoError(t, err)
+	inProcessRef, err := NewPluginLoader(host).LoadPackageReferenceV2(t.Context(), descriptor)
+	require.NoError(t, err)
+	assert.Equal(t, &version, clientRef.Version())
+	assert.Equal(t, inProcessRef.Version(), clientRef.Version())
+}
+
+// Tests that parameterized packages take the raw-bytes path: the provider is parameterized exactly as before
+// and the parameterized schema is served verbatim.
+func TestLoaderServerRawSchemaBytesParameterized(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	rawSchema := []byte(`{ "name": "sub",  "version": "3.0.0" }`)
+	provider := schemaProvider(rawSchema)
+	provider.ParameterizeF = func(_ context.Context, req plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error) {
+		assert.Equal(t, &plugin.ParameterizeValue{
+			Name:    "sub",
+			Version: semver.MustParse("3.0.0"),
+			Value:   []byte("testdata"),
+		}, req.Parameters)
+		return plugin.ParameterizeResponse{
+			Name:    "sub",
+			Version: semver.MustParse("3.0.0"),
+		}, nil
+	}
+	host := mockSchemaHost(t, "base", semver.MustParse("1.0.0"), provider)
+	client := serveLoader(t, NewPluginLoader(host))
+
+	resp, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
+		Package: "base",
+		Version: "1.0.0",
+		Parameterization: &codegenrpc.Parameterization{
+			Name:    "sub",
+			Version: "3.0.0",
+			Value:   []byte("testdata"),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, rawSchema, resp.Schema)
+
+	version := semver.MustParse("1.0.0")
+	ref, err := client.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{
+		Name:    "base",
+		Version: &version,
+		Parameterization: &ParameterizationDescriptor{
+			Name:    "sub",
+			Version: semver.MustParse("3.0.0"),
+			Value:   []byte("testdata"),
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "sub", ref.Name())
+}
+
+// Tests that pre-seeded entry cache entries are served via the bind-based path instead of the raw-bytes path.
+// `pulumi package add` seeds the loader with file-based schemas whose plugins don't exist; the raw path must not
+// bypass them.
+func TestLoaderServerCachedEntryBypassesRawPath(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
+
+	pkg, err := ImportSpec(PackageSpec{
+		Name:    "mypkg",
+		Version: "0.1.0",
+		Resources: map[string]ResourceSpec{
+			"mypkg:index:Resource": {},
+		},
+	}, nil, ValidationOptions{})
+	require.NoError(t, err)
+
+	// A host whose plugin resolution always fails: the cached entry is the only way to serve the schema.
+	host := &plugin.MockHost{
+		ResolvePluginF: func(spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
+			return nil, workspace.NewMissingError(spec, false)
+		},
+	}
+	loader := NewCachedLoaderWithEntries(
+		NewPluginLoader(host),
+		map[string]PackageReference{pkg.Reference().Identity(): pkg.Reference()},
+	)
+	client := serveLoader(t, loader)
+
+	version := semver.MustParse("0.1.0")
+	ref, err := client.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{Name: "mypkg", Version: &version})
+	require.NoError(t, err)
+	assert.Equal(t, "mypkg", ref.Name())
+	assert.Equal(t, &version, ref.Version())
+}
+
+// Tests that empty schemas still surface the getSchemaNotImplemented error instead of empty bytes.
+func TestLoaderServerRawSchemaBytesEmptySchema(t *testing.T) {
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	host := mockSchemaHost(t, "test", semver.MustParse("1.2.3"), schemaProvider([]byte(" { } ")))
+	client := serveLoader(t, NewPluginLoader(host))
+
+	_, err := client.clientRaw.GetSchema(t.Context(), &codegenrpc.GetSchemaRequest{
+		Package: "test",
+		Version: "1.2.3",
+	})
+	require.ErrorContains(t, err, getSchemaNotImplemented{}.Error())
+}
+
+func TestHasTopLevelVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		schema   string
+		expected bool
+	}{
+		{`{"name":"test","version":"1.0.0"}`, true},
+		{`{"version":"1.0.0"}`, true},
+		{`{ "version" : "1.0.0" }`, true},
+		{`{"resources":{"a":{"version":"9.9.9"}},"version":"1.0.0"}`, true},
+		{`{"name":"test"}`, false},
+		{`{"name":"test","version":""}`, false},
+		{`{"name":"test","version":null}`, false},
+		{`{"name":"test","version":{"x":1}}`, false},
+		{`{"resources":{"a":{"version":"9.9.9"}}}`, false},
+		{`{"meta":[{"version":"9.9.9"}],"name":"test"}`, false},
+		{`[]`, false},
+		{`{}`, false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, hasTopLevelVersion([]byte(c.schema)), "schema: %s", c.schema)
+	}
+}


### PR DESCRIPTION
Fixes #23550.

The loader service that the engine exposes to language hosts (`loaderServer.GetSchema`) fully bound and re-marshaled every schema it served, even though the client only ever sees JSON bytes that it parses and lazily binds itself. For large schemas (aws is 47MB) this costs roughly 700ms of CPU per `GetSchema` RPC and keeps the fully bound type graph alive in the engine (~520MB peak on an aws preview).

This change adds an optional `RawLoader` interface that returns the raw schema bytes `loadSchemaBytes` already has in hand (disk cache, mmap, or fresh from the provider), implements it on `pluginLoader`, and has `loaderServer.GetSchema` prefer it. The bind-based path remains as a fallback for:

- loaders that don't implement the interface (e.g. the server constructed over non-plugin loaders in `packageworkspace`);
- schemas without a top-level `version`, where `LoadPackageReferenceV2` would have defaulted the resolved plugin version into the schema. A streaming token scan detects this cheaply (it early-exits on the first top-level `version` key, which Go-marshaled schemas place near the front).

Empty-schema handling (`GetSchema` unimplemented), parameterized packages, and the in-memory bound-package entry cache keep their existing behavior.

## Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have formatted my code using `gofumpt`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change