### PR TITLE
tests: avoid output that breaks json

### DIFF
--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -2944,9 +2944,7 @@ func newRunEngineActionFixture(
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
 		},
 		Opts: backend.UpdateOptions{Display: display.Options{
-			Color: colors.Never,
-			// Keep the event renderer and its progress spinner off the real stdout:
-			// raw writes corrupt the `go test -json` stream that gotestsum parses.
+			Color:            colors.Never,
 			Stdout:           io.Discard,
 			Stderr:           io.Discard,
 			SuppressProgress: true,

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -2943,7 +2943,14 @@ func newRunEngineActionFixture(
 			Name:    tokens.PackageName("project"),
 			Runtime: workspace.NewProjectRuntimeInfo("go", nil),
 		},
-		Opts:            backend.UpdateOptions{Display: display.Options{Color: colors.Never}},
+		Opts: backend.UpdateOptions{Display: display.Options{
+			Color: colors.Never,
+			// Keep the event renderer and its progress spinner off the real stdout:
+			// raw writes corrupt the `go test -json` stream that gotestsum parses.
+			Stdout:           io.Discard,
+			Stderr:           io.Discard,
+			SuppressProgress: true,
+		}},
 		SecretsManager:  opSecretsManager,
 		SecretsProvider: secretsProvider,
 		StackConfiguration: backend.StackConfiguration{

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -101,7 +102,8 @@ type configEnvCmd struct {
 	saveProjectStack func(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, configFile string) error
 
 	// prompt asks the user to pick one of options.
-	prompt func(msg string, options []string, defaultOption string, colorization colors.Colorization) string
+	prompt func(msg string, options []string, defaultOption string, colorization colors.Colorization,
+		surveyAskOpts ...survey.AskOpt) string
 
 	stackRef   *string
 	configFile *string

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -111,11 +111,7 @@ type configEnvCmd struct {
 func (cmd *configEnvCmd) initArgs() {
 	cmd.interactive = cmdutil.Interactive()
 	cmd.color = cmdutil.GetGlobalColorization()
-
-	cmd.prompt = func(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
-		return ui.PromptUser(msg, options, defaultOption, colorization)
-	}
-
+	cmd.prompt = ui.PromptUser
 	cmd.ssml = cmdStack.NewStackSecretsManagerLoaderFromEnv()
 }
 

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -100,6 +100,10 @@ type configEnvCmd struct {
 
 	saveProjectStack func(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, configFile string) error
 
+	// prompt asks the user to pick one of options. It is indirected so tests can answer
+	// the question without an interactive prompt being rendered to the process's stdout.
+	prompt func(msg string, options []string, defaultOption string, colorization colors.Colorization) string
+
 	stackRef   *string
 	configFile *string
 }
@@ -107,6 +111,10 @@ type configEnvCmd struct {
 func (cmd *configEnvCmd) initArgs() {
 	cmd.interactive = cmdutil.Interactive()
 	cmd.color = cmdutil.GetGlobalColorization()
+
+	cmd.prompt = func(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
+		return ui.PromptUser(msg, options, defaultOption, colorization)
+	}
 
 	cmd.ssml = cmdStack.NewStackSecretsManagerLoaderFromEnv()
 }
@@ -220,7 +228,7 @@ func (cmd *configEnvCmd) editStackEnvironment(
 	if !yes {
 		fmt.Fprintln(cmd.stdout)
 
-		response := ui.PromptUser("Save?", []string{"yes", "no"}, "yes", cmdutil.GetGlobalColorization())
+		response := cmd.prompt("Save?", []string{"yes", "no"}, "yes", cmdutil.GetGlobalColorization())
 		switch response {
 		case "no":
 			return errors.New("canceled")

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -100,8 +100,7 @@ type configEnvCmd struct {
 
 	saveProjectStack func(ctx context.Context, stack backend.Stack, ps *workspace.ProjectStack, configFile string) error
 
-	// prompt asks the user to pick one of options. It is indirected so tests can answer
-	// the question without an interactive prompt being rendered to the process's stdout.
+	// prompt asks the user to pick one of options.
 	prompt func(msg string, options []string, defaultOption string, colorization colors.Colorization) string
 
 	stackRef   *string

--- a/pkg/cmd/pulumi/config/config_env_add_test.go
+++ b/pkg/cmd/pulumi/config/config_env_add_test.go
@@ -52,7 +52,7 @@ aws:region  us-west-2
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env
@@ -83,7 +83,7 @@ aws:region  us-west-2
 aws:region  us-west-2
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env
@@ -107,7 +107,7 @@ aws:region  us-west-2
 			"The stack's environment does not define the `environmentVariables`, `files`, or `pulumiConfig` properties.\n" +
 			"Without at least one of these properties, the environment will not affect the stack's behavior.\n\n"
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env
@@ -145,7 +145,7 @@ aws:region    us-west-2
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env
@@ -184,7 +184,7 @@ aws:region    us-west-2
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env

--- a/pkg/cmd/pulumi/config/config_env_init.go
+++ b/pkg/cmd/pulumi/config/config_env_init.go
@@ -33,7 +33,6 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
-	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -169,7 +168,7 @@ func (cmd *configEnvInitCmd) run(ctx context.Context, args []string) error {
 	fmt.Fprint(cmd.parent.stdout, preview)
 
 	if !cmd.yes {
-		response := ui.PromptUser("Save?", []string{"yes", "no"}, "yes", cmdutil.GetGlobalColorization())
+		response := cmd.parent.prompt("Save?", []string{"yes", "no"}, "yes", cmdutil.GetGlobalColorization())
 		switch response {
 		case "no":
 			return errors.New("canceled")

--- a/pkg/cmd/pulumi/config/config_env_init_test.go
+++ b/pkg/cmd/pulumi/config/config_env_init_test.go
@@ -82,7 +82,7 @@ runtime: yaml`
 			"```\n" +
 			""
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - test/stack
@@ -147,7 +147,7 @@ runtime: yaml`
 			"```\n" +
 			""
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - test/stack
@@ -210,7 +210,7 @@ runtime: yaml`
 			"```\n" +
 			""
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - test/stack
@@ -278,7 +278,7 @@ runtime: yaml`
 			"```\n" +
 			""
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env

--- a/pkg/cmd/pulumi/config/config_env_list_test.go
+++ b/pkg/cmd/pulumi/config/config_env_list_test.go
@@ -56,7 +56,7 @@ runtime: yaml`
 		const expectedOut = "This stack configuration has no environments listed. " +
 			"Try adding one with `pulumi config env add <projectName>/<envName>`.\n"
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 
 	t.Run("no imports, json", func(t *testing.T) {
@@ -80,7 +80,7 @@ runtime: yaml`
 
 		const expectedOut = "[]\n"
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 
 	t.Run("with imports", func(t *testing.T) {
@@ -115,7 +115,7 @@ otherEnv
 thirdEnv
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 
 	t.Run("with imports, json", func(t *testing.T) {
@@ -151,7 +151,7 @@ thirdEnv
 ]
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 
 	t.Run("with imports", func(t *testing.T) {
@@ -186,7 +186,7 @@ otherEnv
 thirdEnv
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 
 	t.Run("repeated imports", func(t *testing.T) {
@@ -224,6 +224,6 @@ thirdEnv
 ]
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 	})
 }

--- a/pkg/cmd/pulumi/config/config_env_remove_test.go
+++ b/pkg/cmd/pulumi/config/config_env_remove_test.go
@@ -46,7 +46,7 @@ runtime: yaml`
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = "{}\n"
 
@@ -66,7 +66,7 @@ runtime: yaml`
 
 		const expectedOut = "KEY  VALUE\n"
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = "{}\n"
 
@@ -91,7 +91,7 @@ runtime: yaml`
 
 		const expectedOut = "KEY  VALUE\n"
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = "{}\n"
 
@@ -130,7 +130,7 @@ aws:region    us-west-2
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env
@@ -171,7 +171,7 @@ aws:region    us-west-2
 
 `
 
-		assert.Equal(t, expectedOut, cleanStdoutIncludingPrompt(stdout.String()))
+		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
 
 		const expectedYAML = `environment:
   - env

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -33,6 +33,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -89,6 +90,10 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		stdin:       stdin,
 		stdout:      stdout,
 		interactive: true,
+
+		prompt: func(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
+			return defaultOption
+		},
 
 		ws: &pkgWorkspace.MockContext{
 			ReadProjectF: func() (*workspace.Project, string, error) {
@@ -246,11 +251,8 @@ func newConfigEnvCmdForInitTest(
 	)
 }
 
-// The library sending the confirmation prompt may be able to print the prompt
-// in full before recognizing the character we send to stdin for the test.
-// There's nothing really wrong with that other than it makes the tests flake.
-// This cleans the extra output from stdout in case it happens, as it either
-// happening or not happening is fine.
-func cleanStdoutIncludingPrompt(stdout string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(stripansi.Strip(stdout), "\r", ""), "Save? ▸Yes  No", "")
+// cleanStdout strips ANSI escape codes and carriage returns from captured output so
+// assertions can compare plain text.
+func cleanStdout(stdout string) string {
+	return strings.ReplaceAll(stripansi.Strip(stdout), "\r", "")
 }

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"strings"
 
+	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/acarl005/stripansi"
 	"github.com/pulumi/esc"
 	"github.com/pulumi/esc/eval"
@@ -91,7 +92,9 @@ func newConfigEnvCmdForTestWithCheckYAMLEnvironment(
 		stdout:      stdout,
 		interactive: true,
 
-		prompt: func(msg string, options []string, defaultOption string, colorization colors.Colorization) string {
+		prompt: func(msg string, options []string, defaultOption string, colorization colors.Colorization,
+			surveyAskOpts ...survey.AskOpt,
+		) string {
 			return defaultOption
 		},
 


### PR DESCRIPTION
When running `make test_fast` locally, some tests currently print output that then ends up breaking the parsing of gotestsum.  This makes the tests look failed even though they succeed.

Not entirely sure why this isn't happening in CI, but with this change (and the couple other PRs I submitted today), I can run `make test_fast` locally successfully.

In particular the config env tests feel cleaner like this as well, when we don't need to try and clean up the stdout afterwards, but can avoid it in the first place.
