### PR TITLE
Add engine support for snippets

### DIFF
--- a/changelog/pending/engine-feat-20260603-170122.yaml
+++ b/changelog/pending/engine-feat-20260603-170122.yaml
@@ -1,0 +1,6 @@
+component: engine
+kind: feat
+body: Add support for 'snippets', blocks of PCL kept in state to track ad-hoc resources
+time: 2026-06-03T17:01:22.611717+01:00
+custom:
+    PR: "23286"

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -75,6 +75,14 @@ type bindOptions struct {
 	// which refer to a component resource in a relative directory
 	dirPath                string
 	componentProgramBinder ComponentProgramBinder
+	// extraScopeVariables, if non-empty, are additional variables to define in the binder's root scope before
+	// binding the input file. Used by snippet bindings to inject references to resources owned by another source.
+	extraScopeVariables map[string]*model.Variable
+	// extraPackageDescriptors, if non-empty, are package descriptors supplied by the caller rather than read from
+	// `package { ... }` blocks in the source. Used by snippet bindings, which carry the descriptor structurally on
+	// the Snippet record rather than as PCL syntax. Merged into the descriptor map read from files; same-key entries
+	// from this option take precedence.
+	extraPackageDescriptors map[string]*schema.PackageDescriptor
 }
 
 func (opts bindOptions) modelOptions() []model.BindOption {
@@ -151,6 +159,24 @@ func DirPath(path string) BindOption {
 func ComponentBinder(binder ComponentProgramBinder) BindOption {
 	return func(options *bindOptions) {
 		options.componentProgramBinder = binder
+	}
+}
+
+// ExtraScopeVariables returns a BindOption that defines additional variables in the binder's root scope before
+// the input file is bound. Used by snippet bindings to inject references to resources owned by another source so
+// expressions like `someResource.someProp` can typecheck without the binder seeing a `resource` block for them.
+func ExtraScopeVariables(extras map[string]*model.Variable) BindOption {
+	return func(options *bindOptions) {
+		options.extraScopeVariables = extras
+	}
+}
+
+// PackageDescriptors returns a BindOption that supplies pre-built package descriptors to BindProgram, as if they
+// were declared by `package { ... }` blocks in the source. Used by snippet bindings, which carry the descriptor
+// structurally on the Snippet record rather than as PCL syntax.
+func PackageDescriptors(descriptors map[string]*schema.PackageDescriptor) BindOption {
+	return func(options *bindOptions) {
+		options.extraPackageDescriptors = descriptors
 	}
 }
 
@@ -286,6 +312,49 @@ func BindResource(
 	}
 
 	return args, inputType, diagnostics
+}
+
+// BindResourceProgram binds a PCL file body as a single resource program. Unlike BindResource,
+// this binds the full resource shape, including options and range, so the resulting program can be
+// evaluated through the normal resource registration path.
+func BindResourceProgram(
+	file *syntax.File, name, token string,
+	opts ...BindOption,
+) (*Program, hcl.Diagnostics, error) {
+	bodyRange := file.Body.Range()
+	labelRange := hcl.Range{
+		Filename: bodyRange.Filename,
+		Start:    bodyRange.Start,
+		End:      bodyRange.Start,
+	}
+	block := &hclsyntax.Block{
+		Type:        "resource",
+		Labels:      []string{name, token},
+		Body:        file.Body,
+		TypeRange:   labelRange,
+		LabelRanges: []hcl.Range{labelRange, labelRange},
+		OpenBraceRange: hcl.Range{
+			Filename: bodyRange.Filename,
+			Start:    bodyRange.Start,
+			End:      bodyRange.Start,
+		},
+		CloseBraceRange: hcl.Range{
+			Filename: bodyRange.Filename,
+			Start:    bodyRange.End,
+			End:      bodyRange.End,
+		},
+	}
+	resourceFile := &syntax.File{
+		Name: file.Name,
+		Body: &hclsyntax.Body{
+			Blocks:   []*hclsyntax.Block{block},
+			SrcRange: bodyRange,
+			EndRange: bodyRange,
+		},
+		Bytes:  file.Bytes,
+		Tokens: file.Tokens,
+	}
+	return BindProgram([]*syntax.File{resourceFile}, opts...)
 }
 
 // BindResourceList binds a PCL file as a resource list input and returns the bound arguments. This is used for `do` to
@@ -425,6 +494,11 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 	b.root.DefineFunction(Invoke, model.NewFunction(model.GenericFunctionSignature(b.bindInvokeSignature)))
 	// Define the call function.
 	b.root.DefineFunction(Call, model.NewFunction(model.GenericFunctionSignature(b.bindCallSignature)))
+	// Define any external scope variables supplied by the caller (e.g. resources owned by another source that
+	// a snippet program references). The caller chooses each variable's VariableType.
+	for name, v := range options.extraScopeVariables {
+		b.root.Define(name, v)
+	}
 
 	var diagnostics hcl.Diagnostics
 
@@ -432,6 +506,11 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 	descriptorMap, descriptorDiags := ReadAllPackageDescriptors(files)
 	diagnostics = append(diagnostics, descriptorDiags...)
 	for packageName, descriptor := range descriptorMap {
+		b.packageDescriptors[packageName] = descriptor
+	}
+	// Caller-supplied descriptors (snippet bindings carry these structurally rather than as PCL syntax)
+	// take precedence over any file-declared block for the same package.
+	for packageName, descriptor := range options.extraPackageDescriptors {
 		b.packageDescriptors[packageName] = descriptor
 	}
 

--- a/pkg/codegen/pcl/binder_resource_test.go
+++ b/pkg/codegen/pcl/binder_resource_test.go
@@ -164,6 +164,73 @@ func TestBindResourceOptions(t *testing.T) {
 	}
 }
 
+func TestBindResourceProgram(t *testing.T) {
+	t.Parallel()
+
+	fooPkg := schema.Package{
+		Name: "foo",
+		Provider: &schema.Resource{
+			Token: "foo:index:Foo",
+			InputProperties: []*schema.Property{
+				{Name: "property", Type: schema.StringType},
+			},
+			Properties: []*schema.Property{
+				{Name: "property", Type: schema.StringType},
+			},
+		},
+		Resources: []*schema.Resource{
+			{
+				Token: "foo:index:Foo",
+				InputProperties: []*schema.Property{
+					{Name: "property", Type: schema.StringType},
+				},
+				Properties: []*schema.Property{
+					{Name: "property", Type: schema.StringType},
+				},
+			},
+		},
+	}
+
+	parser := syntax.NewParser()
+	require.NoError(t, parser.ParseFile(strings.NewReader(`
+property = external.value
+options {
+	range = 2
+	protect = true
+}
+`), "snippet.pcl"))
+	require.False(t, parser.Diagnostics.HasErrors())
+
+	program, diags, err := BindResourceProgram(
+		parser.Files[0],
+		"example",
+		"foo:index:Foo",
+		Loader(&stubSchemaLoader{Package: &fooPkg}),
+		ExtraScopeVariables(map[string]*model.Variable{
+			"external": {Name: "external", VariableType: model.DynamicType},
+		}),
+	)
+	require.NoError(t, err)
+	require.False(t, diags.HasErrors())
+	require.Len(t, program.Nodes, 1)
+
+	res, ok := program.Nodes[0].(*Resource)
+	require.True(t, ok)
+	require.Equal(t, "example", res.Name())
+	token, _ := res.GetToken()
+	require.Equal(t, "foo::Foo", token)
+	require.Len(t, res.Inputs, 1)
+	require.NotNil(t, res.Options)
+
+	rangeValue, rangeDiags := res.Options.Range.Evaluate(&hcl.EvalContext{})
+	require.False(t, rangeDiags.HasErrors())
+	require.True(t, rangeValue.RawEquals(cty.NumberIntVal(2)))
+
+	protectValue, protectDiags := res.Options.Protect.Evaluate(&hcl.EvalContext{})
+	require.False(t, protectDiags.HasErrors())
+	require.True(t, protectValue.RawEquals(cty.True))
+}
+
 func TestBindReadResourceOptions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -1,0 +1,1622 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lifecycletest
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/gofrs/uuid"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
+	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+// pclSnippetTestProvider returns a loader for a single-resource "pkgA" provider whose schema is
+// passed in by the caller. The provider counts create/update/delete calls into the supplied slices.
+func pclSnippetTestProvider(
+	schema string, created, updated, deleted *[]resource.URN,
+) []*deploytest.ProviderLoader {
+	return []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(ctx context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schema)}, nil
+				},
+				CreateF: func(ctx context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					if created != nil {
+						*created = append(*created, cr.URN)
+					}
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
+				},
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+					if !req.OldInputs.DeepEquals(req.NewInputs) {
+						return plugin.DiffResult{Changes: plugin.DiffSome}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					if updated != nil {
+						*updated = append(*updated, req.URN)
+					}
+					return plugin.UpdateResponse{Properties: req.NewInputs, Status: resource.StatusOK}, nil
+				},
+				DeleteF: func(_ context.Context, req plugin.DeleteRequest) (plugin.DeleteResponse, error) {
+					if deleted != nil {
+						*deleted = append(*deleted, req.URN)
+					}
+					return plugin.DeleteResponse{Status: resource.StatusOK}, nil
+				},
+			}, nil
+		}),
+	}
+}
+
+const pclSnippetSchemaPropA = `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "propA": { "type": "boolean" }
+      },
+      "requiredInputs": ["propA"]
+    }
+  }
+}`
+
+// TestPclSnippet checks that we can run a PCL snippet via an engine update.
+func TestPclSnippet(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(ctx context.Context, gsr plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(`{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "propA": { "type": "boolean" }
+      },
+      "requiredInputs": ["propA"]
+    }
+  }
+}`)}, nil
+				},
+				CreateF: func(ctx context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{
+						ID:         resource.ID(id),
+						Properties: cr.Properties,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	snippets := []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            hostF,
+		},
+	}
+
+	// Make an empty snapshot.
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	// Add a snippet to the snapshot and rerun the update to execute it.
+	snap.Snippets = snippets
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	// Check that the snippet is still present in the snapshot.
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, `test-resource`, snap.Snippets[0].Name)
+	require.Equal(t, `pkgA:index:res`, snap.Snippets[0].Type)
+	require.Equal(t, `propA = true`, snap.Snippets[0].Code)
+
+	// Check the resource was created.
+	require.Len(t, snap.Resources, 2)
+	require.Equal(t, tokens.Type("pulumi:providers:pkgA"), snap.Resources[0].Type)
+	require.Equal(t, tokens.Type("pkgA:index:res"), snap.Resources[1].Type)
+	require.Equal(t, resource.PropertyMap{"propA": resource.NewProperty(true)}, snap.Resources[1].Inputs)
+}
+
+// TestPclInvalidSnippet checks that a snippet that does not type-check returns an error.
+func TestPclInvalidSnippet(t *testing.T) {
+	t.Parallel()
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(ctx context.Context, gsr plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(`{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "propA": { "type": "boolean" },
+        "propB": { "type": "string" }
+      },
+      "requiredInputs": ["propA", "propB"]
+    }
+  }
+}`)}, nil
+				},
+				CreateF: func(ctx context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{
+						ID:         resource.ID(id),
+						Properties: cr.Properties,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	snippets := []resource.Snippet{
+		// Only set one property.
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            hostF,
+		},
+	}
+
+	// Make an empty snapshot.
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	// Add a snippet to the snapshot and rerun the update to execute it.
+	snap.Snippets = snippets
+	_, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	// The binder type-checks the snippet body against the loaded schema before any
+	// RegisterResource call goes out, so the missing required input is caught at bind time
+	// rather than by the resource monitor.
+	require.ErrorContains(t, err, "missing required attribute 'propB'")
+}
+
+// TestPclSnippetUpdate checks that mutating the code on a snippet between updates causes the
+// underlying resource to be updated rather than recreated.
+func TestPclSnippetUpdate(t *testing.T) {
+	t.Parallel()
+
+	var created, updated, deleted []resource.URN
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, &created, &updated, &deleted)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+	require.Len(t, created, 1)
+	require.Empty(t, updated)
+	require.Equal(t, resource.PropertyMap{"propA": resource.NewProperty(true)}, snap.Resources[1].Inputs)
+
+	// Change the snippet code and rerun: we expect an Update, not a Create or Delete.
+	snap.Snippets[0].Code = `propA = false`
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+	require.Len(t, created, 1, "resource should not be recreated")
+	require.Len(t, updated, 1, "resource should be updated once")
+	require.Empty(t, deleted)
+	require.Equal(t, resource.PropertyMap{"propA": resource.NewProperty(false)}, snap.Resources[1].Inputs)
+}
+
+// TestPclSnippetDelete checks that removing a snippet from the snapshot causes the engine to
+// delete the resource it had previously registered.
+func TestPclSnippetDelete(t *testing.T) {
+	t.Parallel()
+
+	var created, updated, deleted []resource.URN
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, &created, &updated, &deleted)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+	require.Len(t, snap.Resources, 2)
+	require.Len(t, created, 1)
+
+	// Remove the snippet and rerun. The snippet resource should be deleted; the default
+	// provider for pkgA should also disappear since nothing references it.
+	snap.Snippets = nil
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+	require.Empty(t, snap.Snippets)
+	require.Empty(t, updated)
+	require.Len(t, deleted, 1)
+	for _, r := range snap.Resources {
+		require.NotEqual(t, tokens.Type("pkgA:index:res"), r.Type, "snippet resource should be gone")
+	}
+}
+
+// TestPclMultipleSnippets checks that several snippets in a snapshot each register their own
+// resource and that all of them survive a round trip.
+func TestPclMultipleSnippets(t *testing.T) {
+	t.Parallel()
+
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, nil, nil, nil)
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "r1", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+		{
+			Name: "r2", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = false`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+	require.Len(t, snap.Snippets, 2)
+
+	// Index resources by URN name so the assertions don't depend on engine ordering.
+	resourcesByName := map[string]*resource.State{}
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			resourcesByName[r.URN.Name()] = r
+		}
+	}
+	require.Len(t, resourcesByName, 2)
+	require.Equal(t,
+		resource.PropertyMap{"propA": resource.NewProperty(true)},
+		resourcesByName["r1"].Inputs)
+	require.Equal(t,
+		resource.PropertyMap{"propA": resource.NewProperty(false)},
+		resourcesByName["r2"].Inputs)
+}
+
+// TestPclSnippetBuiltins checks that snippets can access deployment context (project, stack,
+// organization) and standard PCL builtins (max, length).
+func TestPclSnippetBuiltins(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "projectName":  { "type": "string" },
+        "stackName":    { "type": "string" },
+        "orgName":      { "type": "string" },
+        "maxValue":     { "type": "integer" },
+        "lengthValue":  { "type": "integer" }
+      },
+      "requiredInputs": [
+        "projectName", "stackName", "orgName",
+        "maxValue", "lengthValue"
+      ]
+    }
+  },
+  "functions": {
+    "pkgA:index:echo": {
+      "inputs": {
+        "properties": {
+          "input": { "type": "string" }
+        }
+      },
+      "outputs": {
+        "properties": {
+          "result": { "type": "string" }
+        },
+        "required": ["result"]
+      }
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Project: "my-project",
+		Stack:   "my-stack",
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code: `projectName = project()
+stackName = stack()
+orgName = organization()
+maxValue = max(1, 7, 3)
+lengthValue = length(["a", "b", "c", "d"])`,
+		},
+	}
+
+	target := p.GetTarget(t, snap)
+	target.Organization = "my-org"
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), target, p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	// Find the resource registered by the snippet.
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{
+		"projectName": resource.NewProperty("my-project"),
+		"stackName":   resource.NewProperty("my-stack"),
+		"orgName":     resource.NewProperty("my-org"),
+		"maxValue":    resource.NewProperty(7.0),
+		"lengthValue": resource.NewProperty(4.0),
+	}, res.Inputs)
+}
+
+// TestPclSnippetDirectories checks that the cwd() and rootDirectory() builtins are wired through to
+// the snippet evaluator. In the lifecycle test framework the project root is "/", so both should
+// resolve to that.
+func TestPclSnippetDirectories(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "workingDir": { "type": "string" },
+        "rootDir":    { "type": "string" }
+      },
+      "requiredInputs": ["workingDir", "rootDir"]
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code: `workingDir = cwd()
+rootDir = rootDirectory()`,
+		},
+	}
+
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{
+		"workingDir": resource.NewProperty("/"),
+		"rootDir":    resource.NewProperty("/"),
+	}, res.Inputs)
+}
+
+// TestPclSnippetInvoke checks that a snippet can invoke a provider function through the resource
+// monitor and use the returned value as a resource input.
+func TestPclSnippetInvoke(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    }
+  },
+  "functions": {
+    "pkgA:index:echo": {
+      "inputs": {
+        "properties": {
+          "input": { "type": "string" }
+        },
+        "required": ["input"]
+      },
+      "outputs": {
+        "properties": {
+          "result": { "type": "string" }
+        },
+        "required": ["result"]
+      }
+    }
+  }
+}`
+
+	var invoked []string
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
+				},
+				InvokeF: func(_ context.Context, req plugin.InvokeRequest) (plugin.InvokeResponse, error) {
+					input := req.Args["input"].StringValue()
+					invoked = append(invoked, input)
+					return plugin.InvokeResponse{
+						Properties: resource.PropertyMap{
+							"result": resource.NewProperty("echoed: " + input),
+						},
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `message = invoke("pkgA:index:echo", { input = "hi" }).result`,
+		},
+	}
+
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"hi"}, invoked, "invoke should be called exactly once with input \"hi\"")
+
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{
+		"message": resource.NewProperty("echoed: hi"),
+	}, res.Inputs)
+}
+
+// TestPclSnippetResourceReference checks that a snippet can use an output from a custom resource
+// registered by the main program. It also checks that the reference survives a targeted delete and
+// resolves when a later update recreates the producer.
+func TestPclSnippetResourceReference(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    },
+    "pkgA:index:producer": {
+      "inputProperties": {
+        "seed": { "type": "string" }
+      },
+      "requiredInputs": ["seed"],
+      "properties": {
+        "value": { "type": "string" }
+      },
+      "required": ["value"]
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					out := resource.PropertyMap{}
+					for k, v := range cr.Properties {
+						out[k] = v
+					}
+					// Give the producer a deterministic output for the snippet to consume.
+					if seed, ok := cr.Properties["seed"]; ok {
+						out["value"] = resource.NewProperty("value-of-" + seed.StringValue())
+					}
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: out}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, err := monitor.RegisterResource("pkgA:index:producer", "producer", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{"seed": resource.NewProperty("hello")},
+		})
+		return err
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{
+				"producer": producerURN,
+			},
+			Code: `message = producer.value`,
+		},
+	})
+
+	// Step 0: the program registers the producer while the snippet waits for its reference.
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{
+		"message": resource.NewProperty("value-of-hello"),
+	}, res.Inputs)
+
+	// Step 1: target-delete the producer and its dependent snippet resource. The snippet definition
+	// remains in the snapshot with a reference to the absent producer.
+	destroyOpts := p.Options
+	destroyOpts.Targets = deploy.NewUrnTargets([]string{producerURN})
+	destroyOpts.TargetDependents = true
+	snap, err = lt.TestOp(Destroy).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), destroyOpts, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, producerURN, snap.Snippets[0].References["producer"])
+	for _, r := range snap.Resources {
+		require.NotEqual(t, resource.URN(producerURN), r.URN)
+		require.NotEqual(t, "test-resource", r.URN.Name())
+	}
+
+	// Step 2: a normal update recreates the producer and resolves the existing snippet reference.
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+
+	res = nil
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "test-resource" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been recreated")
+	require.Equal(t, resource.PropertyMap{
+		"message": resource.NewProperty("value-of-hello"),
+	}, res.Inputs)
+}
+
+// TestPclSnippetReferenceLocalComponent checks that a snippet sees the final outputs of a local
+// component. Local component registrations are published to the registration observer only after
+// RegisterResourceOutputs, rather than after the initial RegisterResource call.
+func TestPclSnippetReferenceLocalComponent(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    },
+    "pkgA:index:Comp": {
+      "isComponent": true,
+      "inputProperties": {
+        "seed": { "type": "string" }
+      },
+      "requiredInputs": ["seed"],
+      "properties": {
+        "value": { "type": "string" }
+      },
+      "required": ["value"]
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+			}, nil
+		}),
+	}
+
+	// Register the local component, then publish the outputs that should resolve its observed
+	// registration.
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		resp, err := monitor.RegisterResource("pkgA:index:Comp", "comp", false, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{"seed": resource.NewProperty("hello")},
+		})
+		if err != nil {
+			return err
+		}
+		return monitor.RegisterResourceOutputs(resp.URN, resource.PropertyMap{
+			"value": resource.NewProperty("value-of-hello"),
+		})
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	const compURN = "urn:pulumi:test::test::pkgA:index:Comp::comp"
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{
+				"comp": compURN,
+			},
+			Code: `message = comp.value`,
+		},
+	})
+
+	// The program registers comp and publishes its final outputs before
+	// the observer resolves the snippet's reference.
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{
+		"message": resource.NewProperty("value-of-hello"),
+	}, res.Inputs)
+}
+
+// TestPclSnippetMissingProgramReference checks that an update fails instead of hanging when the
+// main program stops registering a resource referenced by a snippet. The registration observer
+// detects that every remaining source is blocked and rejects the unresolved reference.
+//
+// The test first establishes a successful update, then makes the main program stop registering the
+// producer.
+func TestPclSnippetMissingProgramReference(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    },
+    "pkgA:index:producer": {
+      "inputProperties": {
+        "seed": { "type": "string" }
+      },
+      "requiredInputs": ["seed"],
+      "properties": {
+        "value": { "type": "string" }
+      },
+      "required": ["value"]
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					out := resource.PropertyMap{}
+					for k, v := range cr.Properties {
+						out[k] = v
+					}
+					if seed, ok := cr.Properties["seed"]; ok {
+						out["value"] = resource.NewProperty("value-of-" + seed.StringValue())
+					}
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: out}, nil
+				},
+			}, nil
+		}),
+	}
+
+	// The main program and the test execute concurrently, so use an atomic to control whether the
+	// program registers the producer.
+	var programRegistersProducer atomic.Bool
+	programRegistersProducer.Store(true)
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		if !programRegistersProducer.Load() {
+			return nil
+		}
+		_, err := monitor.RegisterResource("pkgA:index:producer", "producer", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{"seed": resource.NewProperty("hello")},
+		})
+		return err
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{
+				"producer": producerURN,
+			},
+			Code: `message = producer.value`,
+		},
+	})
+
+	// Step 0: the program registers the producer while the snippet waits for its reference.
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	var res *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == "pkgA:index:res" {
+			res = r
+			break
+		}
+	}
+	require.NotNil(t, res, "snippet resource should have been created on the first run")
+	require.Equal(t, resource.PropertyMap{"message": resource.NewProperty("value-of-hello")}, res.Inputs)
+
+	// Step 1: the program stops registering producer. Once all remaining sources are blocked, the
+	// observer rejects the unresolved reference and the update fails instead of hanging.
+	programRegistersProducer.Store(false)
+	_, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.ErrorContains(t, err, "no source registered this URN")
+}
+
+// TestPclSnippetMissingSnippetReference checks that a chain of snippet references succeeds while
+// every producer is present, then fails instead of deadlocking when the first producer is removed.
+func TestPclSnippetMissingSnippetReference(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    },
+    "pkgA:index:producer": {
+      "inputProperties": {
+        "seed": { "type": "string" }
+      },
+      "requiredInputs": ["seed"],
+      "properties": {
+        "value": { "type": "string" }
+      },
+      "required": ["value"]
+    }
+  }
+}`
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					out := resource.PropertyMap{}
+					for k, v := range cr.Properties {
+						out[k] = v
+					}
+					// Give each producer a deterministic output for the next snippet to consume.
+					if seed, ok := cr.Properties["seed"]; ok {
+						out["value"] = resource.NewProperty("value-of-" + seed.StringValue())
+					}
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: out}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
+	const middleURN = "urn:pulumi:test::test::pkgA:index:producer::middle"
+	producerSnippet := resource.Snippet{
+		Name: "producer", Type: "pkgA:index:producer",
+		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+		Code:       `seed = "abc"`,
+	}
+	middleSnippet := resource.Snippet{
+		Name: "middle", Type: "pkgA:index:producer",
+		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+		References: map[string]string{"producer": producerURN},
+		Code:       `seed = producer.value`,
+	}
+	consumerSnippet := resource.Snippet{
+		Name: "consumer", Type: "pkgA:index:res",
+		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+		References: map[string]string{"middle": middleURN},
+		Code:       `message = middle.value`,
+	}
+
+	// Step 0: run the complete producer -> middle -> consumer chain side-by-side.
+	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{},
+		[]resource.Snippet{producerSnippet, middleSnippet, consumerSnippet})
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	var consumer *resource.State
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "consumer" {
+			consumer = r
+			break
+		}
+	}
+	require.NotNil(t, consumer, "consumer snippet resource should have been created")
+	require.Equal(t, resource.PropertyMap{"message": resource.NewProperty("value-of-value-of-abc")}, consumer.Inputs)
+
+	// Step 1: drop the first producer. Its old state remains at the start of the update, but snippet
+	// references resolve from current registrations, so the remaining sources become blocked.
+	snap.Snippets = []resource.Snippet{middleSnippet, consumerSnippet}
+	_, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.ErrorContains(t, err, "no source registered this URN")
+}
+
+// TestPclSnippetReferenceFollowsAlias checks that a snippet reference follows a resource renamed
+// with an alias. The registration observer resolves both canonical and alias URNs, and the saved
+// snippet reference is rewritten to the new canonical URN.
+func TestPclSnippetReferenceFollowsAlias(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON := `{
+  "version": "0.0.1",
+  "name": "pkgA",
+  "resources": {
+    "pkgA:index:res": {
+      "inputProperties": {
+        "message": { "type": "string" }
+      },
+      "requiredInputs": ["message"]
+    },
+    "pkgA:index:Producer": {
+      "inputProperties": {
+        "value": { "type": "string" }
+      },
+      "requiredInputs": ["value"],
+      "properties": {
+        "value": { "type": "string" }
+      },
+      "required": ["value"]
+    }
+  }
+}`
+
+	// registerAsB toggles which name the program uses for the producer between the two updates.
+	var registerAsB atomic.Bool
+
+	const (
+		aURN = "urn:pulumi:test::test::pkgA:index:Producer::A"
+		bURN = "urn:pulumi:test::test::pkgA:index:Producer::B"
+	)
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				GetSchemaF: func(_ context.Context, _ plugin.GetSchemaRequest) (plugin.GetSchemaResponse, error) {
+					return plugin.GetSchemaResponse{Schema: []byte(schemaJSON)}, nil
+				},
+				CreateF: func(_ context.Context, cr plugin.CreateRequest) (plugin.CreateResponse, error) {
+					uuid, err := uuid.NewV4()
+					if err != nil {
+						return plugin.CreateResponse{}, err
+					}
+					id := uuid.String()
+					if cr.Preview {
+						id = ""
+					}
+					return plugin.CreateResponse{ID: resource.ID(id), Properties: cr.Properties}, nil
+				},
+				DiffF: func(_ context.Context, req plugin.DiffRequest) (plugin.DiffResult, error) {
+					if !req.OldInputs.DeepEquals(req.NewInputs) {
+						return plugin.DiffResult{Changes: plugin.DiffSome}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				UpdateF: func(_ context.Context, req plugin.UpdateRequest) (plugin.UpdateResponse, error) {
+					return plugin.UpdateResponse{Properties: req.NewInputs, Status: resource.StatusOK}, nil
+				},
+			}, nil
+		}),
+	}
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		name := "A"
+		var aliases []resource.URN
+		if registerAsB.Load() {
+			name = "B"
+			aliases = []resource.URN{aURN}
+		}
+		_, err := monitor.RegisterResource("pkgA:index:Producer", name, true, deploytest.ResourceOptions{
+			AliasURNs: aliases,
+			Inputs:    resource.PropertyMap{"value": resource.NewProperty("hello")},
+		})
+		return err
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "consumer", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{"comp": aURN},
+			Code:       `message = comp.value`,
+		},
+	}
+
+	// First update: the program registers the producer as A, and the snippet resolves comp.value.
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	var consumer *resource.State
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "consumer" {
+			consumer = r
+			break
+		}
+	}
+	require.NotNil(t, consumer, "consumer snippet resource should have been created on the first run")
+	require.Equal(t, resource.PropertyMap{"message": resource.NewProperty("hello")}, consumer.Inputs)
+	require.Equal(t, aURN, snap.Snippets[0].References["comp"], "References should still point at A before the rename")
+
+	// Second update: rename A to B via an alias. The observer resolves the old reference through
+	// the alias, and the saved snippet is rewritten to reference B.
+	registerAsB.Store(true)
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+
+	consumer = nil
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "consumer" {
+			consumer = r
+			break
+		}
+	}
+	require.NotNil(t, consumer, "consumer should survive the producer being aliased to a new name")
+	require.Equal(t, resource.PropertyMap{"message": resource.NewProperty("hello")}, consumer.Inputs)
+
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, bURN, snap.Snippets[0].References["comp"],
+		"References should be rewritten from the aliased URN to the canonical (post-rename) URN")
+}
+
+// TestPclSnippetResourceOptions checks that a snippet's `options { ... }` block flows through to
+// the state of the resource it registers.
+func TestPclSnippetResourceOptions(t *testing.T) {
+	t.Parallel()
+
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, nil, nil, nil)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code: `propA = true
+options {
+    protect = true
+    retainOnDelete = true
+    ignoreChanges = [propA]
+    additionalSecretOutputs = [propA]
+    replaceOnChanges = [propA]
+    deleteBeforeReplace = true
+    customTimeouts = {
+        create = "5m"
+        update = "10m"
+        delete = "15m"
+    }
+}`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	var snippetRes *resource.State
+	for _, r := range snap.Resources {
+		if r.Type == tokens.Type("pkgA:index:res") {
+			snippetRes = r
+			break
+		}
+	}
+	require.NotNil(t, snippetRes, "snippet resource should exist")
+	require.True(t, snippetRes.Protect, "expected protect to flow through")
+	require.True(t, snippetRes.RetainOnDelete, "expected retainOnDelete to flow through")
+	require.Equal(t, []string{"propA"}, snippetRes.IgnoreChanges, "expected ignoreChanges to flow through")
+	require.Equal(t, []resource.PropertyKey{"propA"}, snippetRes.AdditionalSecretOutputs,
+		"expected additionalSecretOutputs to flow through")
+	require.Equal(t, []string{"propA"}, snippetRes.ReplaceOnChanges, "expected replaceOnChanges to flow through")
+	require.NotNil(t, snippetRes.CustomTimeouts, "expected customTimeouts to flow through")
+	require.Equal(t, 5.0*60, snippetRes.CustomTimeouts.Create, "create timeout")
+	require.Equal(t, 10.0*60, snippetRes.CustomTimeouts.Update, "update timeout")
+	require.Equal(t, 15.0*60, snippetRes.CustomTimeouts.Delete, "delete timeout")
+}
+
+// TestPclSnippetResourceOptionsResourceRefs checks the resource-typed options (dependsOn, deletedWith,
+// replaceWith). The snippet refers to another custom resource via the References map and uses it
+// on each option; after the update the snippet resource's state should carry the referenced URN.
+func TestPclSnippetResourceOptionsResourceRefs(t *testing.T) {
+	t.Parallel()
+
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, nil, nil, nil)
+
+	// Register a custom resource from the main program that the snippet will reference.
+	var targetURN resource.URN
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		resp, err := monitor.RegisterResource("pkgA:index:res", "target", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{"propA": resource.NewProperty(true)},
+		})
+		if err != nil {
+			return err
+		}
+		targetURN = resp.URN
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+	require.NotEmpty(t, targetURN, "target URN should have been captured")
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "snippet-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{
+				"target": string(targetURN),
+			},
+			Code: `propA = true
+options {
+    dependsOn = [target]
+    deletedWith = target
+    replaceWith = [target]
+}`,
+		},
+	}
+
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	var snippetRes *resource.State
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "snippet-resource" {
+			snippetRes = r
+			break
+		}
+	}
+	require.NotNil(t, snippetRes, "snippet resource should exist")
+	require.Contains(t, snippetRes.Dependencies, targetURN, "expected dependsOn to include the target URN")
+	require.Equal(t, targetURN, snippetRes.DeletedWith, "expected deletedWith to point at the target")
+	require.Contains(t, snippetRes.ReplaceWith, targetURN, "expected replaceWith to include the target URN")
+}
+
+// TestPclSnippetResourceOptionsParent checks that a referenced resource can be used as a snippet's
+// parent and that the engine records both the parent relationship and the parent-qualified URN.
+func TestPclSnippetResourceOptionsParent(t *testing.T) {
+	t.Parallel()
+
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, nil, nil, nil)
+
+	var parentURN resource.URN
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		resp, err := monitor.RegisterResource("pkgA:index:res", "parent", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{"propA": resource.NewProperty(true)},
+		})
+		if err != nil {
+			return err
+		}
+		parentURN = resp.URN
+		return nil
+	})
+
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+	require.NotEmpty(t, parentURN, "parent URN should have been captured")
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "child", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			References: map[string]string{
+				"parent": string(parentURN),
+			},
+			Code: `propA = true
+options {
+    parent = parent
+}`,
+		},
+	}
+
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	var child *resource.State
+	for _, r := range snap.Resources {
+		if r.URN.Name() == "child" {
+			child = r
+			break
+		}
+	}
+	require.NotNil(t, child, "snippet child resource should exist")
+	require.Equal(t, parentURN, child.Parent)
+	require.Equal(t, resource.URN("urn:pulumi:test::test::pkgA:index:res$pkgA:index:res::child"), child.URN)
+}
+
+// TestPclSnippetResourceOptionsAlias checks that a snippet's `options { aliases = [...] }` flows
+// through to the engine: a snippet renamed between updates should refresh in place when its old
+// URN is listed as an alias rather than triggering a delete+create.
+func TestPclSnippetResourceOptionsAlias(t *testing.T) {
+	t.Parallel()
+
+	var created, deleted []resource.URN
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, &created, nil, &deleted)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	// First update creates a resource at "old-name".
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "old-name", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+	require.Len(t, created, 1)
+	require.Empty(t, deleted)
+
+	oldURN := created[0]
+
+	// Second update renames to "new-name" but declares the old URN as an alias, so no delete should occur.
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "new-name", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code: fmt.Sprintf(`propA = true
+options {
+    aliases = [%q]
+}`, string(oldURN)),
+		},
+	}
+	_, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "2")
+	require.NoError(t, err)
+	require.Len(t, created, 1, "alias should have prevented a second create")
+	require.Empty(t, deleted, "alias should have prevented a delete")
+}
+
+// TestPclSnippetResourceOptionsRange checks that `options { range = N }` expands a snippet into N
+// resources using the normal PCL resource registration behavior.
+func TestPclSnippetResourceOptionsRange(t *testing.T) {
+	t.Parallel()
+
+	var created []resource.URN
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, &created, nil, nil)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
+	require.NoError(t, err)
+
+	snap.Snippets = []resource.Snippet{
+		{
+			Name: "fan", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code: `propA = true
+options {
+    range = 3
+}`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "1")
+	require.NoError(t, err)
+
+	// Three custom resources, named fan-0/-1/-2, should now exist in the snapshot.
+	wantNames := map[string]bool{"fan-0": false, "fan-1": false, "fan-2": false}
+	for _, r := range snap.Resources {
+		if r.Type != tokens.Type("pkgA:index:res") {
+			continue
+		}
+		name := r.URN.Name()
+		_, expected := wantNames[name]
+		require.True(t, expected, "unexpected snippet resource %q", name)
+		wantNames[name] = true
+	}
+	for name, found := range wantNames {
+		require.True(t, found, "expected fan-out resource %q in snapshot", name)
+	}
+	require.Len(t, created, 3, "range = 3 should have produced three Create calls")
+}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -34,6 +34,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -930,9 +931,28 @@ func newUpdateSource(ctx context.Context,
 
 	program := deploy.NewProgramSource(plugctx, runinfo, evalOpts, panicErrs)
 
+	var observer *deploy.RegistrationObserver
+	// Now create sources for _any_ snippets in the snapshot and mux them with the main source.
+	if target.Snapshot != nil && len(target.Snapshot.Snippets) > 0 {
+		// Create a registration observer so concurrent sources (the program + any snippet sources below) can wait for
+		// each other's RegisterResource calls. The resource monitor publishes outputs on the observer; snippet sources
+		// consume them when their Snippet.References needs to read another resource's outputs.
+		observer = deploy.NewRegistrationObserver()
+
+		// We need a loader for snippets
+		loader := schema.NewPluginLoader(plugctx)
+
+		snippetSources := make([]func(string) *promise.Promise[struct{}], len(target.Snapshot.Snippets))
+		for i, snippet := range target.Snapshot.Snippets {
+			snippetSources[i] = deploy.NewSnippetSource(
+				ctx, snippet, loader, runinfo.ProjectRoot, runinfo.Pwd, observer)
+		}
+		program = deploy.NewMuxSource(ctx, observer, program, snippetSources...)
+	}
+
 	// If that succeeded, create a new source that will perform interpretation of the compiled program.
 	return deploy.NewEvalSource(plugctx, runinfo,
-		defaultProviderVersions, resourceHooks, evalOpts, panicErrs, nil, program), nil
+		defaultProviderVersions, resourceHooks, evalOpts, panicErrs, observer, program), nil
 }
 
 func update(

--- a/pkg/pcl/runtime/interpreter.go
+++ b/pkg/pcl/runtime/interpreter.go
@@ -478,6 +478,59 @@ func (i *Interpreter) Run(ctx context.Context) error {
 	return nil
 }
 
+// RunEmbedded runs the interpreter against a pre-existing monitor and loader supplied by the
+// caller, skipping the steps that only make sense for a top-level program run (stack registration,
+// stack-output emission, and the SignalAndWaitForShutdown handshake). It is the entry point for
+// callers that drive the interpreter as a sub-source inside a larger update — for example, the
+// engine evaluating a PCL snippet alongside the main program.
+//
+// scopeVars, if non-nil, are converted and installed on the eval context as root-scope variables
+// after init so the program body can reference resources resolved elsewhere (e.g. snippet
+// References resolved via the engine's registration observer).
+func (i *Interpreter) RunEmbedded(
+	ctx context.Context,
+	monitor pulumirpc.ResourceMonitorClient,
+	loader schema.ReferenceLoader,
+	scopeVars map[string]resource.PropertyValue,
+) error {
+	i.monitor = monitor
+	i.loader = loader
+
+	i.evalContext = NewEvalContext(
+		i.info.WorkingDir,
+		i.info.RootDirectory,
+		i.info.Organization,
+		i.info.Project,
+		i.info.Stack,
+		i.lookupResource,
+		i.lookupFunction,
+		i.getResource,
+		i.invoke,
+		i.call,
+	)
+	for name, val := range scopeVars {
+		ctyVal, err := propertyValueToCty(ctx, i.getResource, val)
+		if err != nil {
+			return fmt.Errorf("converting scope variable %q: %w", name, err)
+		}
+		i.evalContext.SetVariable(name, ctyVal)
+	}
+
+	if err := i.registerPackages(ctx); err != nil {
+		return err
+	}
+
+	if _, err := i.executeProgramNodes(ctx); err != nil {
+		return err
+	}
+
+	if i.callbacks != nil {
+		close(i.callbacks.stop)
+	}
+
+	return nil
+}
+
 func (i *Interpreter) executeProgramNodes(ctx context.Context) (resource.PropertyMap, error) {
 	dag := pdag.New[pcl.Node]()
 	nodes := map[pcl.Node]pdag.Node{}

--- a/pkg/resource/deploy/registration_observer.go
+++ b/pkg/resource/deploy/registration_observer.go
@@ -15,6 +15,7 @@
 package deploy
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
@@ -23,8 +24,8 @@ import (
 
 // URNRegistration carries the information a consumer needs to reason about a resource that has been
 // registered: its provider-assigned ID and its output property map. The URN itself isn't stored
-// here because callers look the registration up by URN via [RegistrationObserver.Get]. ID may be
-// empty for resources that don't have provider IDs (e.g. components).
+// here because callers wait for the registration by URN. ID may be empty for resources that don't
+// have provider IDs (e.g. components).
 type URNRegistration struct {
 	ID      resource.ID
 	Outputs resource.PropertyMap
@@ -36,58 +37,98 @@ type URNRegistration struct {
 //
 // The intended pattern:
 //
-//   - Anyone that needs the outputs of a resource by URN calls Get(urn) to receive a promise, then
-//     blocks on it via Result(ctx).
+//   - Sources that need the outputs of a resource by URN call Wait(urn) to receive a promise, then
+//     block on it via Result(ctx).
 //   - The resource monitor calls Resolve(urn, id, outputs) after each successful registration. The
 //     first Resolve for a URN wins; subsequent calls are no-ops.
-//   - URNs that some still-running source intends to register are pre-declared via MarkExpected.
-//     When the engine knows no more registrations are coming from the program (and only Expected
-//     URNs might still arrive from snippets), it calls RejectUnresolved to surface "no source
-//     registered this URN" failures for any pending entry that wasn't pre-declared.
+//   - Each source registers itself with NewSource before execution and calls Done when it exits.
+//   - If every remaining source is waiting, no source can make progress and unresolved references
+//     are rejected. This detects missing references and dependency cycles.
 type RegistrationObserver struct {
-	mu       sync.Mutex
-	promises map[resource.URN]*promise.CompletionSource[URNRegistration]
-	expected map[resource.URN]struct{}
-	// closedErr, if non-nil, indicates RejectUnresolved has been called: any subsequent Get for a URN that
-	// wasn't marked Expected returns an already-rejected promise. Without this flag a slow source that calls
-	// Get *after* the sweep would create a fresh pending entry that no one will ever resolve.
-	closedErr error
+	mu           sync.Mutex
+	promises     map[resource.URN]*promise.CompletionSource[URNRegistration]
+	sources      map[*RegistrationObserverSource]resource.URN
+	sourcesReady bool
+	closedErr    error
 }
 
 // NewRegistrationObserver returns an observer with no pending or resolved entries.
 func NewRegistrationObserver() *RegistrationObserver {
 	return &RegistrationObserver{
 		promises: map[resource.URN]*promise.CompletionSource[URNRegistration]{},
-		expected: map[resource.URN]struct{}{},
+		sources:  map[*RegistrationObserverSource]resource.URN{},
 	}
 }
 
-// MarkExpected records that some still-running source intends to Resolve urn. Subsequent calls to
-// RejectUnresolved will leave Expected URNs alone (they're still in flight, not dead). Repeated calls
-// for the same URN are no-ops.
-func (o *RegistrationObserver) MarkExpected(urn resource.URN) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	o.expected[urn] = struct{}{}
+// RegistrationObserverSource tracks whether one source can still register resources or is blocked
+// waiting for another source to register a referenced resource.
+type RegistrationObserverSource struct {
+	observer *RegistrationObserver
+	once     sync.Once
 }
 
-// RejectUnresolved rejects every currently-pending promise that has not been marked as Expected, and
-// causes any subsequent [RegistrationObserver.Get] for a non-Expected URN to return an
-// already-rejected promise. Used once the engine knows no further registrations are coming from
-// sources that didn't pre-declare their URNs (typically called after the main program's promise
-// resolves). Repeated calls are no-ops: the first err is the one observed by Get callers.
-func (o *RegistrationObserver) RejectUnresolved(err error) {
+// NewSource registers a source with the observer. All sources must be registered before SourcesReady
+// is called and execution begins.
+func (o *RegistrationObserver) NewSource() *RegistrationObserverSource {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	if o.closedErr != nil {
+	source := &RegistrationObserverSource{observer: o}
+	o.sources[source] = ""
+	return source
+}
+
+// SourcesReady enables quiescence detection after all sources have been registered.
+func (o *RegistrationObserver) SourcesReady() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.sourcesReady = true
+	o.rejectIfQuiescent()
+}
+
+// Wait returns a promise for urn and marks this source as blocked until that URN is resolved or
+// rejected. Settling the URN makes the source runnable while holding the observer lock, before any
+// other source can finish and trigger quiescence detection.
+func (s *RegistrationObserverSource) Wait(urn resource.URN) *promise.Promise[URNRegistration] {
+	s.observer.mu.Lock()
+	defer s.observer.mu.Unlock()
+	cs := s.observer.entry(urn)
+	if s.observer.closedErr != nil {
+		cs.Reject(s.observer.closedErr)
+		return cs.Promise()
+	}
+	if _, _, settled := cs.Promise().TryResult(); !settled {
+		if _, ok := s.observer.sources[s]; ok {
+			s.observer.sources[s] = urn
+			s.observer.rejectIfQuiescent()
+		}
+	}
+	return cs.Promise()
+}
+
+// Done removes this source from the active source set.
+func (s *RegistrationObserverSource) Done() {
+	s.once.Do(func() {
+		s.observer.mu.Lock()
+		defer s.observer.mu.Unlock()
+		delete(s.observer.sources, s)
+		s.observer.rejectIfQuiescent()
+	})
+}
+
+// rejectIfQuiescent rejects unresolved references when no source can make progress.
+// Caller must hold o.mu.
+func (o *RegistrationObserver) rejectIfQuiescent() {
+	if !o.sourcesReady || o.closedErr != nil {
 		return
 	}
-	o.closedErr = err
-	for urn, cs := range o.promises {
-		if _, ok := o.expected[urn]; ok {
-			continue
+	for _, waitingFor := range o.sources {
+		if waitingFor == "" {
+			return
 		}
-		cs.Reject(err)
+	}
+	o.closedErr = errors.New("no source registered this URN")
+	for _, cs := range o.promises {
+		cs.Reject(o.closedErr)
 	}
 }
 
@@ -101,31 +142,13 @@ func (o *RegistrationObserver) entry(urn resource.URN) *promise.CompletionSource
 	return cs
 }
 
-// Get returns a promise that will be fulfilled with the registration (id + outputs) of the resource
-// registered at the given URN. Subsequent Gets for the same URN return the same promise. Safe to
-// call from any goroutine.
-//
-// If [RegistrationObserver.RejectUnresolved] has already been called, a Get for a URN that has not
-// been marked Expected returns a promise that is already rejected — this closes a race where a slow
-// source might otherwise call Get after the sweep and sit forever on a freshly-created pending entry.
-func (o *RegistrationObserver) Get(urn resource.URN) *promise.Promise[URNRegistration] {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	cs := o.entry(urn)
-	if o.closedErr != nil {
-		if _, ok := o.expected[urn]; !ok {
-			cs.Reject(o.closedErr)
-		}
-	}
-	return cs.Promise()
-}
-
 // Resolve fulfills the promise for the given URN with the supplied id and outputs. id may be empty
 // for resources that don't have provider IDs (e.g. components). Repeated Resolve calls for the
 // same URN are no-ops.
 func (o *RegistrationObserver) Resolve(urn resource.URN, id resource.ID, outputs resource.PropertyMap) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	o.makeWaitersRunnable(urn)
 	o.entry(urn).Fulfill(URNRegistration{ID: id, Outputs: outputs})
 }
 
@@ -134,5 +157,16 @@ func (o *RegistrationObserver) Resolve(urn resource.URN, id resource.ID, outputs
 func (o *RegistrationObserver) Reject(urn resource.URN, err error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	o.makeWaitersRunnable(urn)
 	o.entry(urn).Reject(err)
+}
+
+// makeWaitersRunnable marks sources waiting for urn as able to register resources again.
+// Caller must hold o.mu.
+func (o *RegistrationObserver) makeWaitersRunnable(urn resource.URN) {
+	for source, waitingFor := range o.sources {
+		if waitingFor == urn {
+			o.sources[source] = ""
+		}
+	}
 }

--- a/pkg/resource/deploy/registration_observer_test.go
+++ b/pkg/resource/deploy/registration_observer_test.go
@@ -178,9 +178,8 @@ func TestRegistrationObserver_RunnableSourceProtectsWaiter(t *testing.T) {
 	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
 	p := consumer.Wait(urn)
 
-	if _, _, ok := p.TryResult(); ok {
-		t.Fatal("a runnable producer should keep the reference pending")
-	}
+	_, _, ok := p.TryResult()
+	require.False(t, ok, "a runnable producer should keep the reference pending")
 
 	outputs := resource.PropertyMap{"k": resource.NewProperty("v")}
 	b.Resolve(urn, "", outputs)
@@ -208,9 +207,8 @@ func TestRegistrationObserver_WaitResolvedURNKeepsSourceRunnable(t *testing.T) {
 
 	producer.Done()
 	pending := observeRegistration(b, pendingURN)
-	if _, _, ok := pending.TryResult(); ok {
-		t.Fatal("waiting on an already-resolved URN must leave the source runnable")
-	}
+	_, _, ok := pending.TryResult()
+	require.False(t, ok, "waiting on a pending URN should leave the source blocked")
 
 	b.Resolve(pendingURN, "", resource.PropertyMap{})
 	_, err = pending.Result(t.Context())
@@ -268,9 +266,8 @@ func TestRegistrationObserver_ResolvedWaiterBecomesRunnableProducer(t *testing.T
 	_, err := middleP.Result(t.Context())
 	require.NoError(t, err)
 
-	if _, _, ok := consumerP.TryResult(); ok {
-		t.Fatal("the newly runnable middle source should keep its consumer pending")
-	}
+	_, _, ok := consumerP.TryResult()
+	require.False(t, ok, "the newly runnable middle source should keep its consumer pending")
 
 	b.Resolve(consumerDependency, "", resource.PropertyMap{})
 	_, err = consumerP.Result(t.Context())

--- a/pkg/resource/deploy/registration_observer_test.go
+++ b/pkg/resource/deploy/registration_observer_test.go
@@ -21,10 +21,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func TestRegistrationObserver_ResolveBeforeGet(t *testing.T) {
+// observeRegistration returns a promise for urn without affecting source liveness. Tests use this
+// to inspect observer publication independently of source waiting behavior.
+func observeRegistration(o *RegistrationObserver, urn resource.URN) *promise.Promise[URNRegistration] {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	cs := o.entry(urn)
+	if o.closedErr != nil {
+		cs.Reject(o.closedErr)
+	}
+	return cs.Promise()
+}
+
+func TestRegistrationObserver_ResolveBeforeObserve(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
@@ -33,19 +46,19 @@ func TestRegistrationObserver_ResolveBeforeGet(t *testing.T) {
 
 	b.Resolve(urn, "", outputs)
 
-	got, err := b.Get(urn).Result(t.Context())
+	got, err := observeRegistration(b, urn).Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, outputs, got.Outputs)
 }
 
-func TestRegistrationObserver_GetBeforeResolve(t *testing.T) {
+func TestRegistrationObserver_ObserveBeforeResolve(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
 	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
 	outputs := resource.PropertyMap{"k": resource.NewProperty("v")}
 
-	p := b.Get(urn)
+	p := observeRegistration(b, urn)
 
 	// Resolve from another goroutine; Result should unblock.
 	go b.Resolve(urn, "", outputs)
@@ -56,7 +69,7 @@ func TestRegistrationObserver_GetBeforeResolve(t *testing.T) {
 }
 
 // TestRegistrationObserver_ResolvePropagatesID pins the contract that the provider-assigned ID supplied to
-// Resolve round-trips through Get's URNRegistration. The other tests use "" for ID since they're
+// Resolve round-trips through URNRegistration. The other tests use "" for ID since they're
 // about other behavior (sticky rejection, expected URNs, etc.).
 func TestRegistrationObserver_ResolvePropagatesID(t *testing.T) {
 	t.Parallel()
@@ -68,20 +81,20 @@ func TestRegistrationObserver_ResolvePropagatesID(t *testing.T) {
 
 	b.Resolve(urn, id, outputs)
 
-	got, err := b.Get(urn).Result(t.Context())
+	got, err := observeRegistration(b, urn).Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, id, got.ID)
 	require.Equal(t, outputs, got.Outputs)
 }
 
-func TestRegistrationObserver_GetReturnsSamePromise(t *testing.T) {
+func TestRegistrationObserver_ObserveReturnsSamePromise(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
 	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
-	p1 := b.Get(urn)
-	p2 := b.Get(urn)
-	require.Same(t, p1, p2, "repeated Gets for the same URN should return the same promise")
+	p1 := observeRegistration(b, urn)
+	p2 := observeRegistration(b, urn)
+	require.Same(t, p1, p2, "repeated observations of the same URN should return the same promise")
 }
 
 func TestRegistrationObserver_FirstResolveWins(t *testing.T) {
@@ -95,7 +108,7 @@ func TestRegistrationObserver_FirstResolveWins(t *testing.T) {
 	b.Resolve(urn, "", first)
 	b.Resolve(urn, "", second)
 
-	got, err := b.Get(urn).Result(t.Context())
+	got, err := observeRegistration(b, urn).Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, first, got.Outputs, "the first Resolve should win; later ones are no-ops")
 }
@@ -107,16 +120,16 @@ func TestRegistrationObserver_Reject(t *testing.T) {
 	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
 	rejErr := errors.New("nope")
 
-	p := b.Get(urn)
+	p := observeRegistration(b, urn)
 	b.Reject(urn, rejErr)
 
 	_, err := p.Result(t.Context())
 	require.ErrorIs(t, err, rejErr)
 }
 
-// TestRegistrationObserver_ConcurrentGetsAndResolves stresses the broker with many goroutines all racing to
-// Get and Resolve the same set of URNs, asserting every Get observes the resolved value.
-func TestRegistrationObserver_ConcurrentGetsAndResolves(t *testing.T) {
+// TestRegistrationObserver_ConcurrentObserversAndResolves stresses the observer with many goroutines
+// all racing to observe and Resolve the same set of URNs.
+func TestRegistrationObserver_ConcurrentObserversAndResolves(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
@@ -139,7 +152,7 @@ func TestRegistrationObserver_ConcurrentGetsAndResolves(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				got, err := b.Get(urn).Result(ctx)
+				got, err := observeRegistration(b, urn).Result(ctx)
 				require.NoError(t, err)
 				require.Equal(t, want[urn], got.Outputs)
 			}()
@@ -154,108 +167,171 @@ func TestRegistrationObserver_ConcurrentGetsAndResolves(t *testing.T) {
 	wg.Wait()
 }
 
-func TestRegistrationObserver_RejectUnresolvedRejectsPendingNonExpected(t *testing.T) {
+func TestRegistrationObserver_RunnableSourceProtectsWaiter(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
-	pending := resource.URN("urn:pulumi:s::p::pkg:typ::pending")
-	expected := resource.URN("urn:pulumi:s::p::pkg:typ::expected")
-	resolved := resource.URN("urn:pulumi:s::p::pkg:typ::resolved")
-
-	pendingP := b.Get(pending)
-	expectedP := b.Get(expected)
-	b.MarkExpected(expected)
-
-	resolvedOutputs := resource.PropertyMap{"k": resource.NewProperty("v")}
-	b.Resolve(resolved, "", resolvedOutputs)
-	resolvedP := b.Get(resolved)
-
-	rejErr := errors.New("nobody registered this")
-	b.RejectUnresolved(rejErr)
-
-	// Pending non-Expected: rejected.
-	_, err := pendingP.Result(t.Context())
-	require.ErrorIs(t, err, rejErr)
-
-	// Expected: untouched.
-	if _, _, ok := expectedP.TryResult(); ok {
-		t.Fatal("Expected URN should not have been resolved or rejected by RejectUnresolved")
-	}
-
-	// Already resolved: untouched.
-	got, err := resolvedP.Result(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, resolvedOutputs, got.Outputs)
-}
-
-func TestRegistrationObserver_RejectUnresolvedIsIdempotent(t *testing.T) {
-	t.Parallel()
-	b := NewRegistrationObserver()
+	producer := b.NewSource()
+	consumer := b.NewSource()
+	b.SourcesReady()
 
 	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
-	p := b.Get(urn)
+	p := consumer.Wait(urn)
 
-	first := errors.New("first rejection")
-	second := errors.New("second rejection")
-
-	b.RejectUnresolved(first)
-	b.RejectUnresolved(second)
-
-	_, err := p.Result(t.Context())
-	require.ErrorIs(t, err, first, "first rejection should win; second is a no-op")
-}
-
-func TestRegistrationObserver_MarkExpectedAfterGetStillProtects(t *testing.T) {
-	t.Parallel()
-	b := NewRegistrationObserver()
-
-	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
-	p := b.Get(urn)
-	b.MarkExpected(urn)
-
-	b.RejectUnresolved(errors.New("sweep"))
-
-	// Still pending — MarkExpected after Get still protected the entry.
 	if _, _, ok := p.TryResult(); ok {
-		t.Fatal("Expected URN should not have been rejected")
+		t.Fatal("a runnable producer should keep the reference pending")
 	}
 
-	// And a later Resolve should still work.
 	outputs := resource.PropertyMap{"k": resource.NewProperty("v")}
 	b.Resolve(urn, "", outputs)
 	got, err := p.Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, outputs, got.Outputs)
+
+	consumer.Done()
+	producer.Done()
 }
 
-// TestRegistrationObserver_GetAfterRejectUnresolvedIsStickyRejected guards a race where a slow source calls Get
-// after the sweep. Without stickiness it would create a fresh pending entry and hang.
-func TestRegistrationObserver_GetAfterRejectUnresolvedIsStickyRejected(t *testing.T) {
+func TestRegistrationObserver_WaitResolvedURNKeepsSourceRunnable(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
 
-	expected := resource.URN("urn:pulumi:s::p::pkg:typ::expected")
-	other := resource.URN("urn:pulumi:s::p::pkg:typ::other")
-	b.MarkExpected(expected)
+	producer := b.NewSource()
+	consumer := b.NewSource()
+	b.SourcesReady()
 
-	rejErr := errors.New("sweep")
-	b.RejectUnresolved(rejErr)
-
-	// A late Get for a non-Expected URN returns an already-rejected promise.
-	_, err := b.Get(other).Result(t.Context())
-	require.ErrorIs(t, err, rejErr)
-
-	// A late Get for an Expected URN is still allowed to wait; a subsequent Resolve still works.
-	expectedP := b.Get(expected)
-	outputs := resource.PropertyMap{"k": resource.NewProperty("v")}
-	b.Resolve(expected, "", outputs)
-	got, err := expectedP.Result(t.Context())
+	resolvedURN := resource.URN("urn:pulumi:s::p::pkg:typ::resolved")
+	pendingURN := resource.URN("urn:pulumi:s::p::pkg:typ::pending")
+	b.Resolve(resolvedURN, "", resource.PropertyMap{})
+	_, err := consumer.Wait(resolvedURN).Result(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, outputs, got.Outputs)
+
+	producer.Done()
+	pending := observeRegistration(b, pendingURN)
+	if _, _, ok := pending.TryResult(); ok {
+		t.Fatal("waiting on an already-resolved URN must leave the source runnable")
+	}
+
+	b.Resolve(pendingURN, "", resource.PropertyMap{})
+	_, err = pending.Result(t.Context())
+	require.NoError(t, err)
+	consumer.Done()
 }
 
-// TestRegistrationObserver_ResolveDoesNotBlock checks that Resolve does not block even if no one has Got the
-// URN yet; the resolved outputs should be observable by later Gets.
+func TestRegistrationObserver_ProducerCanResolveAnyURN(t *testing.T) {
+	t.Parallel()
+	b := NewRegistrationObserver()
+
+	producer := b.NewSource()
+	consumer := b.NewSource()
+	b.SourcesReady()
+
+	// These are representative of URNs whose names or qualified types cannot be inferred from
+	// Snippet.Name and Snippet.Type alone.
+	parented := resource.URN("urn:pulumi:s::p::pkg:parent$pkg:typ::child")
+	ranged := resource.URN("urn:pulumi:s::p::pkg:typ::child-0")
+	parentedP := consumer.Wait(parented)
+
+	b.Resolve(parented, "", resource.PropertyMap{"kind": resource.NewProperty("parented")})
+	parentedResult, err := parentedP.Result(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "parented", parentedResult.Outputs["kind"].StringValue())
+
+	rangedP := consumer.Wait(ranged)
+	b.Resolve(ranged, "", resource.PropertyMap{"kind": resource.NewProperty("ranged")})
+	rangedResult, err := rangedP.Result(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "ranged", rangedResult.Outputs["kind"].StringValue())
+
+	consumer.Done()
+	producer.Done()
+}
+
+func TestRegistrationObserver_ResolvedWaiterBecomesRunnableProducer(t *testing.T) {
+	t.Parallel()
+	b := NewRegistrationObserver()
+
+	producer := b.NewSource()
+	middle := b.NewSource()
+	consumer := b.NewSource()
+	b.SourcesReady()
+
+	middleDependency := resource.URN("urn:pulumi:s::p::pkg:typ::producer")
+	consumerDependency := resource.URN("urn:pulumi:s::p::pkg:typ::middle")
+	middleP := middle.Wait(middleDependency)
+	consumerP := consumer.Wait(consumerDependency)
+
+	b.Resolve(middleDependency, "", resource.PropertyMap{})
+	// The producer may finish before the middle source's goroutine observes its resolved promise.
+	// Resolve must make middle runnable atomically so this does not falsely reject consumerP.
+	producer.Done()
+	_, err := middleP.Result(t.Context())
+	require.NoError(t, err)
+
+	if _, _, ok := consumerP.TryResult(); ok {
+		t.Fatal("the newly runnable middle source should keep its consumer pending")
+	}
+
+	b.Resolve(consumerDependency, "", resource.PropertyMap{})
+	_, err = consumerP.Result(t.Context())
+	require.NoError(t, err)
+
+	middle.Done()
+	consumer.Done()
+}
+
+func TestRegistrationObserver_LastRunnableSourceDoneRejectsWaiter(t *testing.T) {
+	t.Parallel()
+	b := NewRegistrationObserver()
+
+	producer := b.NewSource()
+	consumer := b.NewSource()
+	b.SourcesReady()
+
+	urn := resource.URN("urn:pulumi:s::p::pkg:typ::a")
+	p := consumer.Wait(urn)
+	producer.Done()
+
+	_, err := p.Result(t.Context())
+	require.ErrorContains(t, err, "no source registered this URN")
+
+	consumer.Done()
+}
+
+func TestRegistrationObserver_AllWaitingRejectsCycle(t *testing.T) {
+	t.Parallel()
+	b := NewRegistrationObserver()
+
+	a := b.NewSource()
+	c := b.NewSource()
+	b.SourcesReady()
+
+	aP := a.Wait(resource.URN("urn:pulumi:s::p::pkg:typ::a"))
+	cP := c.Wait(resource.URN("urn:pulumi:s::p::pkg:typ::c"))
+
+	_, err := aP.Result(t.Context())
+	require.ErrorContains(t, err, "no source registered this URN")
+	_, err = cP.Result(t.Context())
+	require.ErrorContains(t, err, "no source registered this URN")
+
+	a.Done()
+	c.Done()
+}
+
+func TestRegistrationObserver_ObserveAfterQuiescenceIsStickyRejected(t *testing.T) {
+	t.Parallel()
+	b := NewRegistrationObserver()
+
+	source := b.NewSource()
+	b.SourcesReady()
+	source.Done()
+
+	_, err := observeRegistration(b, resource.URN("urn:pulumi:s::p::pkg:typ::other")).Result(t.Context())
+	require.ErrorContains(t, err, "no source registered this URN")
+}
+
+// TestRegistrationObserver_ResolveDoesNotBlock checks that Resolve does not block even if no one is
+// observing the URN yet; the resolved outputs should be observable later.
 func TestRegistrationObserver_ResolveDoesNotBlock(t *testing.T) {
 	t.Parallel()
 	b := NewRegistrationObserver()
@@ -275,7 +351,7 @@ func TestRegistrationObserver_ResolveDoesNotBlock(t *testing.T) {
 		t.Fatal("Resolve should not block")
 	}
 
-	got, err := b.Get(urn).Result(t.Context())
+	got, err := observeRegistration(b, urn).Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, outputs, got.Outputs)
 }

--- a/pkg/resource/deploy/snippet_source.go
+++ b/pkg/resource/deploy/snippet_source.go
@@ -286,24 +286,20 @@ func (m *muxSource) run(input string) *promise.Promise[struct{}] {
 		// before fulfilling so callers don't observe a partial completion.
 		errs := make([]error, len(sourceP)+1)
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if m.mainObserverSource != nil {
 				defer m.mainObserverSource.Done()
 			}
 			if _, err := mainP.Result(m.ctx); err != nil {
 				errs[0] = err
 			}
-		}()
+		})
 		for i, p := range sourceP {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				if _, err := p.Result(m.ctx); err != nil {
 					errs[i+1] = err
 				}
-			}()
+			})
 		}
 		wg.Wait()
 

--- a/pkg/resource/deploy/snippet_source.go
+++ b/pkg/resource/deploy/snippet_source.go
@@ -1,0 +1,327 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !js || !wasm
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	hclsyntax "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	pclruntime "github.com/pulumi/pulumi/pkg/v3/pcl/runtime"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+type snippet struct {
+	ctx            context.Context
+	snippet        *resource.Snippet
+	loader         schema.ReferenceLoader
+	rootDir        string
+	workingDir     string
+	observer       *RegistrationObserver
+	observerSource *RegistrationObserverSource
+}
+
+// NewSnippetSource creates a Source that registers a single PCL resource snippet.
+func NewSnippetSource(ctx context.Context,
+	s resource.Snippet,
+	loader schema.ReferenceLoader,
+	rootDir, workingDir string,
+	observer *RegistrationObserver,
+) func(string) *promise.Promise[struct{}] {
+	contract.Requiref(observer != nil, "observer", "must not be nil")
+
+	src := &snippet{
+		ctx: ctx, snippet: &s, loader: loader,
+		rootDir: rootDir, workingDir: workingDir,
+		observer:       observer,
+		observerSource: observer.NewSource(),
+	}
+	return src.run
+}
+
+func (s *snippet) run(resourceMonitorTarget string) *promise.Promise[struct{}] {
+	cts := &promise.CompletionSource[struct{}]{}
+
+	fail := func(err error) {
+		cts.Reject(err)
+	}
+
+	go func() {
+		defer s.observerSource.Done()
+		if err := s.ctx.Err(); err != nil {
+			fail(err)
+			return
+		}
+		// Build the schema.PackageDescriptor from the structurally-attached Snippet.Descriptor. The binder and
+		// interpreter both consult this to load the right (possibly parameterized) package schema.
+		var parameterization *schema.ParameterizationDescriptor
+		if s.snippet.Descriptor.Parameterization != nil {
+			parameterization = &schema.ParameterizationDescriptor{
+				Name:    s.snippet.Descriptor.Parameterization.Name,
+				Version: s.snippet.Descriptor.Parameterization.Version,
+				Value:   s.snippet.Descriptor.Parameterization.Value,
+			}
+		}
+		descriptor := &schema.PackageDescriptor{
+			Name:             s.snippet.Descriptor.Name,
+			Version:          s.snippet.Descriptor.Version,
+			DownloadURL:      s.snippet.Descriptor.DownloadURL,
+			Parameterization: parameterization,
+		}
+
+		// Determine the package name the binder will key the descriptor by. For unparameterized snippets this is
+		// the descriptor's Name; for parameterized snippets it's the parameterization's Name (the alias visible
+		// to PCL code). DecomposeToken on the snippet's Type gives us that key directly.
+		pkgName, _, _, diags := pcl.DecomposeToken(s.snippet.Type, hcl.Range{})
+		if diags.HasErrors() {
+			fail(fmt.Errorf("invalid snippet type %q: %s", s.snippet.Type, diags.Error()))
+			return
+		}
+		packageDescriptors := map[string]*schema.PackageDescriptor{pkgName: descriptor}
+
+		// Parse the snippet as a resource body. Use the snippet's name in the filename so diagnostics
+		// distinguish between multiple snippets in the same update.
+		filename := fmt.Sprintf("<snippet:%s>", s.snippet.Name)
+		parser := hclsyntax.NewParser()
+		if err := parser.ParseFile(strings.NewReader(s.snippet.Code), filename); err != nil {
+			fail(fmt.Errorf("parse snippet: %w", err))
+			return
+		}
+		if parser.Diagnostics.HasErrors() {
+			fail(fmt.Errorf("parse snippet: %v", parser.Diagnostics))
+			return
+		}
+
+		// Pre-declare scope variables for References so the binder typechecks `producer.value` and friends
+		// without seeing a `resource` block for them. The runtime values are injected on the eval context
+		// further down once the registration observer has resolved each URN.
+		bindOpts := []pcl.BindOption{
+			pcl.Loader(s.loader),
+			pcl.PackageDescriptors(packageDescriptors),
+		}
+		if len(s.snippet.References) > 0 {
+			extras := make(map[string]*model.Variable, len(s.snippet.References))
+			for name := range s.snippet.References {
+				extras[name] = &model.Variable{Name: name, VariableType: model.DynamicType}
+			}
+			bindOpts = append(bindOpts, pcl.ExtraScopeVariables(extras))
+		}
+		program, diags, err := pcl.BindResourceProgram(parser.Files[0], s.snippet.Name, s.snippet.Type, bindOpts...)
+		if err != nil {
+			fail(fmt.Errorf("bind snippet: %w", err))
+			return
+		}
+		if diags.HasErrors() {
+			fail(fmt.Errorf("bind snippet: %v", diags))
+			return
+		}
+
+		// Wait on the observer for every Reference. Once they resolve, shape each entry as a Pulumi resource
+		// value (object with urn + id + outputs, wrapped in an Output so traversals work) so the interpreter
+		// sees it the same way it would see a sibling resource declared in the same program.
+		scopeVars := make(map[string]resource.PropertyValue, len(s.snippet.References))
+		if len(s.snippet.References) > 0 {
+			refURNs := make(map[string]resource.URN, len(s.snippet.References))
+			for name, raw := range s.snippet.References {
+				urn, err := resource.ParseURN(raw)
+				if err != nil {
+					fail(fmt.Errorf("invalid URN for reference %q: %w", name, err))
+					return
+				}
+				refURNs[name] = urn
+			}
+			for name, urn := range refURNs {
+				reg, err := s.observerSource.Wait(urn).Result(s.ctx)
+				if err != nil {
+					fail(fmt.Errorf("waiting for reference %q (%s): %w", name, urn, err))
+					return
+				}
+				scopeVars[name] = snippetReferenceValue(urn, reg)
+			}
+		}
+
+		// Dial the resource monitor and ask it for the deployment context the interpreter needs (project,
+		// stack, organization). The interpreter wires this into the eval context so `pulumi.project` etc.
+		// resolve to the same values the main program sees.
+		conn, err := grpc.NewClient(
+			resourceMonitorTarget,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			rpcutil.GrpcChannelOptions(),
+		)
+		if err != nil {
+			fail(fmt.Errorf("connect to resource monitor: %w", err))
+			return
+		}
+		defer contract.IgnoreClose(conn)
+		monitor := pulumirpc.NewResourceMonitorClient(conn)
+
+		infoResp, err := monitor.GetDeploymentInfo(s.ctx, &emptypb.Empty{})
+		if err != nil {
+			fail(fmt.Errorf("get deployment info: %w", err))
+			return
+		}
+
+		interp := pclruntime.NewInterpreter(
+			program, snippetRunInfo(infoResp, s.rootDir, s.workingDir, packageDescriptors))
+		if err := interp.RunEmbedded(s.ctx, monitor, s.loader, scopeVars); err != nil {
+			fail(fmt.Errorf("execute snippet: %w", err))
+			return
+		}
+		cts.Fulfill(struct{}{})
+	}()
+	return cts.Promise()
+}
+
+func snippetReferenceValue(urn resource.URN, reg URNRegistration) resource.PropertyValue {
+	obj := make(resource.PropertyMap, len(reg.Outputs)+4)
+	for k, v := range reg.Outputs {
+		obj[k] = v
+	}
+	obj["urn"] = resource.NewProperty(string(urn))
+	obj["id"] = resource.NewProperty(string(reg.ID))
+	obj["__name"] = resource.NewProperty(urn.Name())
+	obj["__type"] = resource.NewProperty(string(urn.Type()))
+	return resource.NewProperty(resource.Output{
+		Element:      resource.NewProperty(obj),
+		Dependencies: []resource.URN{urn},
+		Known:        true,
+	})
+}
+
+func snippetRunInfo(
+	info *pulumirpc.DeploymentInfo,
+	rootDir, workingDir string,
+	packageDescriptors map[string]*schema.PackageDescriptor,
+) pclruntime.RunInfo {
+	return pclruntime.RunInfo{
+		Project:            info.GetProject(),
+		Stack:              info.GetStack(),
+		Organization:       info.GetOrganization(),
+		RootDirectory:      rootDir,
+		WorkingDir:         workingDir,
+		Config:             info.GetConfig(),
+		ConfigSecrets:      info.GetConfigSecretKeys(),
+		DryRun:             info.GetDryRun(),
+		Parallel:           info.GetParallel(),
+		PackageDescriptors: packageDescriptors,
+	}
+}
+
+// NewMuxSource creates a source that runs main alongside zero or more secondary sources, returning a single
+// promise that resolves only after every source has finished. Errors from individual sources are joined with
+// [errors.Join].
+//
+// ctx scopes how long the multiplexer is willing to wait. If it is cancelled before every source has resolved,
+// the returned promise rejects with the joined errors so far (including ctx.Err()) and stops waiting. The
+// individual source goroutines must also observe cancellation through a captured context or their own channels.
+//
+// observer is optional. When non-nil, source liveness is tracked so unresolved references are rejected
+// once every remaining source is blocked waiting for another source.
+func NewMuxSource(
+	ctx context.Context,
+	observer *RegistrationObserver,
+	main func(string) *promise.Promise[struct{}],
+	sources ...func(string) *promise.Promise[struct{}],
+) func(string) *promise.Promise[struct{}] {
+	src := &muxSource{
+		ctx:     ctx,
+		main:    main,
+		sources: sources,
+	}
+	if observer != nil {
+		src.mainObserverSource = observer.NewSource()
+		observer.SourcesReady()
+	}
+	return src.run
+}
+
+type muxSource struct {
+	ctx                context.Context //nolint:containedctx // bounded to one engine update; passed by NewMuxSource
+	mainObserverSource *RegistrationObserverSource
+	main               func(string) *promise.Promise[struct{}]
+	sources            []func(string) *promise.Promise[struct{}]
+}
+
+func (m *muxSource) run(input string) *promise.Promise[struct{}] {
+	cts := &promise.CompletionSource[struct{}]{}
+
+	mainP := m.main(input)
+	sourceP := make([]*promise.Promise[struct{}], len(m.sources))
+	for i, s := range m.sources {
+		sourceP[i] = s(input)
+	}
+
+	go func() {
+		// Block until every promise resolves or our ctx is cancelled. Each waiter is independent so a slow
+		// source doesn't delay error reporting for fast ones, but we still wait for all of them to settle
+		// before fulfilling so callers don't observe a partial completion.
+		errs := make([]error, len(sourceP)+1)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if m.mainObserverSource != nil {
+				defer m.mainObserverSource.Done()
+			}
+			if _, err := mainP.Result(m.ctx); err != nil {
+				errs[0] = err
+			}
+		}()
+		for i, p := range sourceP {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if _, err := p.Result(m.ctx); err != nil {
+					errs[i+1] = err
+				}
+			}()
+		}
+		wg.Wait()
+
+		var nonNil []error
+		for _, e := range errs {
+			if e != nil {
+				nonNil = append(nonNil, e)
+			}
+		}
+		switch len(nonNil) {
+		case 0:
+			cts.Fulfill(struct{}{})
+		case 1:
+			cts.Reject(nonNil[0])
+		default:
+			cts.Reject(errors.Join(nonNil...))
+		}
+	}()
+
+	return cts.Promise()
+}

--- a/pkg/resource/deploy/snippet_source_test.go
+++ b/pkg/resource/deploy/snippet_source_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+type staticReferenceLoader struct {
+	pkg *schema.Package
+}
+
+func (l staticReferenceLoader) LoadPackage(string, *semver.Version) (*schema.Package, error) {
+	return l.pkg, nil
+}
+
+func (l staticReferenceLoader) LoadPackageV2(context.Context, *schema.PackageDescriptor) (*schema.Package, error) {
+	return l.pkg, nil
+}
+
+func (l staticReferenceLoader) LoadPackageReference(string, *semver.Version) (schema.PackageReference, error) {
+	return l.pkg.Reference(), nil
+}
+
+func (l staticReferenceLoader) LoadPackageReferenceV2(
+	context.Context, *schema.PackageDescriptor,
+) (schema.PackageReference, error) {
+	return l.pkg.Reference(), nil
+}
+
+// fakeSource turns a CompletionSource into the source-runner shape NewMuxSource expects, so tests can drive
+// completion timing precisely.
+func fakeSource(cs *promise.CompletionSource[struct{}]) func(string) *promise.Promise[struct{}] {
+	return func(string) *promise.Promise[struct{}] {
+		return cs.Promise()
+	}
+}
+
+func TestSnippetRunInfo(t *testing.T) {
+	t.Parallel()
+
+	descriptors := map[string]*schema.PackageDescriptor{
+		"pkg": {Name: "pkg"},
+	}
+	info := &pulumirpc.DeploymentInfo{
+		Project:          "project",
+		Stack:            "stack",
+		Organization:     "organization",
+		Config:           map[string]string{"project:key": "value"},
+		ConfigSecretKeys: []string{"project:secret"},
+		DryRun:           true,
+		Parallel:         42,
+	}
+
+	runInfo := snippetRunInfo(info, "/root", "/work", descriptors)
+
+	require.Equal(t, info.Project, runInfo.Project)
+	require.Equal(t, info.Stack, runInfo.Stack)
+	require.Equal(t, info.Organization, runInfo.Organization)
+	require.Equal(t, "/root", runInfo.RootDirectory)
+	require.Equal(t, "/work", runInfo.WorkingDir)
+	require.Equal(t, info.Config, runInfo.Config)
+	require.Equal(t, info.ConfigSecretKeys, runInfo.ConfigSecrets)
+	require.True(t, runInfo.DryRun)
+	require.Equal(t, info.Parallel, runInfo.Parallel)
+	require.Equal(t, descriptors, runInfo.PackageDescriptors)
+}
+
+func TestSnippetReferenceValue(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:stack::project::pkg:index:parent$pkg:index:res::name")
+	value := snippetReferenceValue(urn, URNRegistration{
+		ID: "id",
+		Outputs: resource.PropertyMap{
+			"output": resource.NewProperty("value"),
+		},
+	})
+
+	output := value.OutputValue()
+	require.True(t, output.Known)
+	require.Equal(t, []resource.URN{urn}, output.Dependencies)
+	require.Equal(t, resource.PropertyMap{
+		"output": resource.NewProperty("value"),
+		"urn":    resource.NewProperty(string(urn)),
+		"id":     resource.NewProperty("id"),
+		"__name": resource.NewProperty("name"),
+		"__type": resource.NewProperty("pkg:index:res"),
+	}, output.Element.ObjectValue())
+}
+
+func TestSnippetSourceRequiresObserver(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		NewSnippetSource(t.Context(), resource.Snippet{}, nil, "", "", nil)
+	})
+}
+
+func TestSnippetSource_CancellationStopsReferenceWait(t *testing.T) {
+	t.Parallel()
+
+	pkg, err := schema.ImportSpec(schema.PackageSpec{
+		Name: "pkg",
+		Resources: map[string]schema.ResourceSpec{
+			"pkg:index:res": {
+				InputProperties: map[string]schema.PropertySpec{
+					"message": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				RequiredInputs: []string{"message"},
+			},
+		},
+	}, nil, schema.ValidationOptions{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := NewRegistrationObserver()
+	producer := observer.NewSource()
+	source := NewSnippetSource(ctx, resource.Snippet{
+		Name:       "consumer",
+		Type:       "pkg:index:res",
+		Descriptor: resource.PackageDescriptor{Name: "pkg"},
+		References: map[string]string{
+			"producer": "urn:pulumi:stack::project::pkg:index:res::producer",
+		},
+		Code: "message = producer.message",
+	}, staticReferenceLoader{pkg: pkg}, "", "", observer)
+	observer.SourcesReady()
+
+	result := source("")
+	require.Eventually(t, func() bool {
+		observer.mu.Lock()
+		defer observer.mu.Unlock()
+		for _, waitingFor := range observer.sources {
+			if waitingFor != "" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	_, err = result.Result(t.Context())
+	require.ErrorIs(t, err, context.Canceled)
+	producer.Done()
+}
+
+func TestMuxSource_AllSucceed(t *testing.T) {
+	t.Parallel()
+
+	mainCS := &promise.CompletionSource[struct{}]{}
+	aCS := &promise.CompletionSource[struct{}]{}
+	bCS := &promise.CompletionSource[struct{}]{}
+
+	mux := NewMuxSource(t.Context(), nil, fakeSource(mainCS), fakeSource(aCS), fakeSource(bCS))
+	out := mux("ignored")
+
+	// Fulfill in arbitrary order.
+	aCS.Fulfill(struct{}{})
+	mainCS.Fulfill(struct{}{})
+	bCS.Fulfill(struct{}{})
+
+	_, err := out.Result(t.Context())
+	require.NoError(t, err)
+}
+
+func TestMuxSource_SingleErrorPropagatesAsIs(t *testing.T) {
+	t.Parallel()
+
+	mainCS := &promise.CompletionSource[struct{}]{}
+	aCS := &promise.CompletionSource[struct{}]{}
+
+	mux := NewMuxSource(t.Context(), nil, fakeSource(mainCS), fakeSource(aCS))
+	out := mux("ignored")
+
+	bang := errors.New("snippet exploded")
+	aCS.Reject(bang)
+	mainCS.Fulfill(struct{}{})
+
+	_, err := out.Result(t.Context())
+	require.ErrorIs(t, err, bang, "the single error should pass through unwrapped")
+}
+
+func TestMuxSource_MultipleErrorsJoin(t *testing.T) {
+	t.Parallel()
+
+	mainCS := &promise.CompletionSource[struct{}]{}
+	aCS := &promise.CompletionSource[struct{}]{}
+	bCS := &promise.CompletionSource[struct{}]{}
+
+	mux := NewMuxSource(t.Context(), nil, fakeSource(mainCS), fakeSource(aCS), fakeSource(bCS))
+	out := mux("ignored")
+
+	mainErr := errors.New("program failed")
+	bErr := errors.New("snippet b failed")
+	mainCS.Reject(mainErr)
+	aCS.Fulfill(struct{}{})
+	bCS.Reject(bErr)
+
+	_, err := out.Result(t.Context())
+	require.Error(t, err)
+	require.ErrorIs(t, err, mainErr)
+	require.ErrorIs(t, err, bErr)
+}
+
+// TestMuxSource_WaitsForAll asserts that even when one source finishes early the mux still blocks until
+// the others complete; the returned promise must not resolve until everything has settled.
+func TestMuxSource_WaitsForAll(t *testing.T) {
+	t.Parallel()
+
+	mainCS := &promise.CompletionSource[struct{}]{}
+	aCS := &promise.CompletionSource[struct{}]{}
+
+	mux := NewMuxSource(t.Context(), nil, fakeSource(mainCS), fakeSource(aCS))
+	out := mux("ignored")
+
+	mainCS.Fulfill(struct{}{})
+
+	// With one of two sources still pending the mux promise must not be resolved yet.
+	if _, _, ok := out.TryResult(); ok {
+		t.Fatal("mux should not be resolved while a sub-source is still pending")
+	}
+
+	aCS.Fulfill(struct{}{})
+	_, err := out.Result(t.Context())
+	require.NoError(t, err)
+}
+
+// TestMuxSource_CancelContextStopsWaiting verifies that cancelling the constructor ctx causes the mux to
+// fulfill (with the ctx error) without all sub-sources having to complete.
+func TestMuxSource_CancelContextStopsWaiting(t *testing.T) {
+	t.Parallel()
+
+	muxCtx, cancel := context.WithCancel(t.Context())
+
+	mainCS := &promise.CompletionSource[struct{}]{}
+	hangCS := &promise.CompletionSource[struct{}]{} // never resolved
+
+	mux := NewMuxSource(muxCtx, nil, fakeSource(mainCS), fakeSource(hangCS))
+	out := mux("ignored")
+
+	mainCS.Fulfill(struct{}{})
+
+	// While hangCS is pending and ctx is alive, mux should still be waiting.
+	if _, _, ok := out.TryResult(); ok {
+		t.Fatal("mux should still be waiting while a sub-source is pending and ctx is alive")
+	}
+
+	// Cancelling the ctx wakes the still-blocked waiter and the mux resolves.
+	cancel()
+
+	_, err := out.Result(t.Context())
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/resource/deploy/snippet_source_wasm.go
+++ b/pkg/resource/deploy/snippet_source_wasm.go
@@ -1,0 +1,59 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build js && wasm
+
+package deploy
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+// NewSnippetSource is unavailable in wasm display builds.
+func NewSnippetSource(
+	context.Context,
+	resource.Snippet,
+	schema.ReferenceLoader,
+	string,
+	string,
+	*RegistrationObserver,
+) func(string) *promise.Promise[struct{}] {
+	return unsupportedWasmSource("snippet sources are not supported in wasm builds")
+}
+
+// NewMuxSource is unavailable in wasm display builds when secondary sources are present.
+func NewMuxSource(
+	_ context.Context,
+	_ *RegistrationObserver,
+	main func(string) *promise.Promise[struct{}],
+	sources ...func(string) *promise.Promise[struct{}],
+) func(string) *promise.Promise[struct{}] {
+	if len(sources) == 0 {
+		return main
+	}
+	return unsupportedWasmSource("mux sources with secondary sources are not supported in wasm builds")
+}
+
+func unsupportedWasmSource(message string) func(string) *promise.Promise[struct{}] {
+	return func(string) *promise.Promise[struct{}] {
+		cts := &promise.CompletionSource[struct{}]{}
+		cts.Reject(errors.New(message))
+		return cts.Promise()
+	}
+}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -889,7 +889,7 @@ func TestRegistrationObserverResolveOnRegisterResource(t *testing.T) {
 	}
 	getterDone := make(chan result, 1)
 	go func() {
-		reg, err := observer.Get(expectedURN).Result(t.Context())
+		reg, err := observeRegistration(observer, expectedURN).Result(t.Context())
 		getterDone <- result{reg, err}
 	}()
 
@@ -1006,7 +1006,7 @@ func TestRegistrationObserverNotResolvedForUnsuccessfulRegisterResource(t *testi
 				})
 			}
 
-			if registration, _, ok := observer.Get(expectedURN).TryResult(); ok {
+			if registration, _, ok := observeRegistration(observer, expectedURN).TryResult(); ok {
 				t.Fatalf("observer should not resolve an unsuccessful registration: %+v", registration)
 			}
 		})
@@ -1097,7 +1097,7 @@ func TestRegistrationObserverNotResolvedForLocalComponentOnRegister(t *testing.T
 	getterCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	go func() {
-		reg, err := observer.Get(expectedURN).Result(getterCtx)
+		reg, err := observeRegistration(observer, expectedURN).Result(getterCtx)
 		getterDone <- result{reg, err}
 	}()
 
@@ -1193,16 +1193,16 @@ func TestRegistrationObserverComponentResolvedAtRegisterResourceOutputs(t *testi
 	driveIter(t, iter, runInfo)
 
 	// After both RegisterResource and RegisterResourceOutputs have run, the observer should resolve.
-	got, err := observer.Get(expectedURN).Result(t.Context())
+	got, err := observeRegistration(observer, expectedURN).Result(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, expectedOutputs, got.Outputs, "observer should publish ROC outputs")
 	require.Equal(t, resource.ID(""), got.ID, "component ID should be empty")
 }
 
-// TestRegistrationObserverRemoteComponentNotResolvedOnRegister verifies that a remote component is
-// treated the same as a local component for publish timing: nothing on the observer at RegisterResource
-// time, even though the Construct response carries the URN. This pins the design choice that remote
-// components publish via RegisterResourceOutputs rather than via the Construct return value.
+// TestRegistrationObserverRemoteComponentNotResolvedOnRegister verifies that a remote component is treated the same as
+// a local component for publish timing: nothing on the observer at RegisterResource time, even though the Construct
+// response carries the URN. This pins the design choice that remote components publish via RegisterResourceOutputs
+// rather than via the Construct return value. This is so the outputs match what is stored in state.
 func TestRegistrationObserverRemoteComponentNotResolvedOnRegister(t *testing.T) {
 	t.Parallel()
 
@@ -1257,7 +1257,7 @@ func TestRegistrationObserverRemoteComponentNotResolvedOnRegister(t *testing.T) 
 	defer cancel()
 	done := make(chan error, 1)
 	go func() {
-		_, err := observer.Get(expectedURN).Result(getterCtx)
+		_, err := observeRegistration(observer, expectedURN).Result(getterCtx)
 		done <- err
 	}()
 
@@ -1345,8 +1345,8 @@ func TestRegistrationObserverCustomResourceAliasesArePublished(t *testing.T) {
 	}
 
 	for _, urn := range []resource.URN{canonicalURN, aliasURN} {
-		got, err := observer.Get(urn).Result(t.Context())
-		require.NoError(t, err, "Get %s", urn)
+		got, err := observeRegistration(observer, urn).Result(t.Context())
+		require.NoError(t, err, "observe %s", urn)
 		require.Equal(t, expectedOutputs, got.Outputs, "outputs for %s", urn)
 		require.Equal(t, resource.ID("id1"), got.ID, "id for %s", urn)
 	}
@@ -1401,8 +1401,8 @@ func TestRegistrationObserverComponentAliasesArePublishedAtROC(t *testing.T) {
 	driveIter(t, iter, runInfo)
 
 	for _, urn := range []resource.URN{canonicalURN, aliasURN} {
-		got, err := observer.Get(urn).Result(t.Context())
-		require.NoError(t, err, "Get %s", urn)
+		got, err := observeRegistration(observer, urn).Result(t.Context())
+		require.NoError(t, err, "observe %s", urn)
 		require.Equal(t, expectedOutputs, got.Outputs, "outputs for %s should be the ROC outputs", urn)
 		require.Equal(t, resource.ID(""), got.ID, "component %s ID should be empty", urn)
 	}

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -266,7 +266,7 @@ func (snap *DeploymentV3) NormalizeURNReferences() (*DeploymentV3, error) {
 
 	// Rewrite References on every snippet. Each value is a URN that may have been an alias for a resource that
 	// is now stored under its canonical URN; updating in place keeps future updates resolving cleanly through
-	// the broker.
+	// the registration observer.
 	for i := range snap.Snippets {
 		for k, v := range snap.Snippets[i].References {
 			snap.Snippets[i].References[k] = string(fixURN(resource.URN(v)))


### PR DESCRIPTION
First part of supporting snippets in the engine. This allows the engine to run snippets side-by-side with user programs when they are found in the state file.

We've rejigged the URN registration observer a bit for this after finding some cases where it could race. Now each snippet registers with the observer and we can track if all snippets are waiting or finished.

This doesn't yet add support in the engine for dynamically adding or removing snippets. It's just running snippets that exist in the state files, and we manually make those state files for the tests.

We shim the support for this for WASM builds otherwise we blow the size limit.