### PR TITLE
Document the pulumi plugin run command

### DIFF
--- a/changelog/pending/plugin-run-documented-20260612.yaml
+++ b/changelog/pending/plugin-run-documented-20260612.yaml
@@ -3,4 +3,4 @@ kind: chore
 body: Document the `pulumi plugin run` command by including it in the generated CLI docs
 time: 2026-06-12T00:00:00+00:00
 custom:
-    PR: ""
+    PR: "23559"

--- a/changelog/pending/plugin-run-documented-20260612.yaml
+++ b/changelog/pending/plugin-run-documented-20260612.yaml
@@ -1,0 +1,6 @@
+component: cli/plugin
+kind: chore
+body: Document the `pulumi plugin run` command by including it in the generated CLI docs
+time: 2026-06-12T00:00:00+00:00
+custom:
+    PR: ""

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -71,9 +71,8 @@ func newPluginRunCmd(ws pkgWorkspace.Context) *cobra.Command {
 	var kind string
 
 	cmd := &cobra.Command{
-		Use:    "run",
-		Hidden: !env.Dev.Value(),
-		Short:  "Run a command on a plugin binary",
+		Use:   "run",
+		Short: "Run a command on a plugin binary",
 		Long: "[EXPERIMENTAL] Run a command on a plugin binary.\n" +
 			"\n" +
 			"Directly executes a plugin binary, if VERSION is not specified " +


### PR DESCRIPTION
### Description

`pulumi plugin run` was hidden from the CLI (and therefore absent from the generated CLI docs) unless the `PULUMI_DEV` env var was set:

```go
Hidden: !env.Dev.Value(),
```

This removes the `Hidden` gate so the command is always visible and gets picked up by docs generation. The `[EXPERIMENTAL]` marker in the command's long description is retained.

Fixes #23558

### Checklist

- [x] I have run `make tidy` to update any new dependencies
- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have added a changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)