### PR TITLE
Add `--override-env` flag

### DIFF
--- a/changelog/pending/cli-config-override-env.yaml
+++ b/changelog/pending/cli-config-override-env.yaml
@@ -1,0 +1,6 @@
+component: cli/config
+kind: feat
+body: Add an `--override-env` flag to `up`, `preview`, `destroy`, and `refresh` to substitute imported environments for a single run without editing the stack config
+time: 2026-06-11T00:00:00.000000+00:00
+custom:
+    PR: "23562"

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -312,6 +312,7 @@ type EnvironmentsBackend interface {
 		org string,
 		yaml []byte,
 		duration time.Duration,
+		environmentOverrides map[string]string,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
 }
 

--- a/pkg/backend/httpstate/environments.go
+++ b/pkg/backend/httpstate/environments.go
@@ -69,8 +69,10 @@ func (b *cloudBackend) OpenYAMLEnvironment(
 	org string,
 	yaml []byte,
 	duration time.Duration,
+	environmentOverrides map[string]string,
 ) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
-	id, diags, err := b.escClient.OpenYAMLEnvironment(ctx, org, yaml, duration)
+	id, diags, err := b.escClient.OpenYAMLEnvironment(ctx, org, yaml, duration,
+		client.OpenYAMLOption{EnvironmentOverrides: environmentOverrides})
 	if err != nil || len(diags) != 0 {
 		return nil, convertESCDiags(diags), err
 	}

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -135,7 +135,7 @@ func (rp *cloudRequiredPolicy) ResolveEnvironments(ctx context.Context) (*engine
 	// This reuses the same path as stack ESC resolution.
 	yaml := workspace.NewEnvironment(rp.Environments).Definition()
 
-	env, diags, err := rp.envs.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour)
+	env, diags, err := rp.envs.OpenYAMLEnvironment(ctx, rp.orgName, yaml, 2*time.Hour, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening ESC environments for policy pack %q: %w", rp.RequiredPolicy.Name, err)
 	}
@@ -296,7 +296,7 @@ func (r *localPolicyEnvironmentResolver) ResolveEnvironments(
 
 	yaml := workspace.NewEnvironment(environments).Definition()
 
-	env, diags, err := r.envs.OpenYAMLEnvironment(ctx, r.orgName, yaml, 2*time.Hour)
+	env, diags, err := r.envs.OpenYAMLEnvironment(ctx, r.orgName, yaml, 2*time.Hour, nil)
 	if err != nil {
 		return nil, fmt.Errorf("opening ESC environments: %w", err)
 	}

--- a/pkg/backend/httpstate/policypack_test.go
+++ b/pkg/backend/httpstate/policypack_test.go
@@ -136,6 +136,7 @@ func TestEscValueToConfigMap(t *testing.T) {
 type mockEnvironmentsBackend struct {
 	openYAMLEnvironmentF func(
 		ctx context.Context, org string, yaml []byte, duration time.Duration,
+		environmentOverrides map[string]string,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
 }
 
@@ -153,8 +154,9 @@ func (m *mockEnvironmentsBackend) CheckYAMLEnvironment(
 
 func (m *mockEnvironmentsBackend) OpenYAMLEnvironment(
 	ctx context.Context, org string, yaml []byte, duration time.Duration,
+	environmentOverrides map[string]string,
 ) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
-	return m.openYAMLEnvironmentF(ctx, org, yaml, duration)
+	return m.openYAMLEnvironmentF(ctx, org, yaml, duration, environmentOverrides)
 }
 
 func TestResolveEnvironments(t *testing.T) {
@@ -178,6 +180,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				_ context.Context, org string, yaml []byte, _ time.Duration,
+				_ map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				assert.Equal(t, "test-org", org)
 				assert.Contains(t, string(yaml), "prod/policy-config")
@@ -225,6 +228,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return nil, nil, errors.New("connection refused")
 			},
@@ -250,6 +254,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return nil, apitype.EnvironmentDiagnostics{
 					{Summary: "unknown environment 'prod/missing'"},
@@ -276,6 +281,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -308,6 +314,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -340,6 +347,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				_ context.Context, org string, yaml []byte, _ time.Duration,
+				_ map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				assert.Equal(t, "test-org", org)
 				yamlStr := string(yaml)
@@ -377,6 +385,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -415,6 +424,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -468,6 +478,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -512,6 +523,7 @@ func TestResolveEnvironments(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{
@@ -569,6 +581,7 @@ func TestLocalPolicyEnvironmentResolver(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				_ context.Context, org string, yaml []byte, _ time.Duration,
+				_ map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				assert.Equal(t, "test-org", org)
 				assert.Contains(t, string(yaml), "org/policy-secrets")
@@ -615,6 +628,7 @@ func TestLocalPolicyEnvironmentResolver(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return nil, nil, errors.New("connection refused")
 			},
@@ -632,6 +646,7 @@ func TestLocalPolicyEnvironmentResolver(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return nil, apitype.EnvironmentDiagnostics{
 					{Summary: "unknown environment 'env/missing'"},
@@ -650,6 +665,7 @@ func TestLocalPolicyEnvironmentResolver(t *testing.T) {
 		mock := &mockEnvironmentsBackend{
 			openYAMLEnvironmentF: func(
 				context.Context, string, []byte, time.Duration,
+				map[string]string,
 			) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 				return &esc.Environment{
 					Properties: map[string]esc.Value{

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -521,6 +521,7 @@ type MockEnvironmentsBackend struct {
 		org string,
 		yaml []byte,
 		duration time.Duration,
+		environmentOverrides map[string]string,
 	) (*esc.Environment, apitype.EnvironmentDiagnostics, error)
 }
 
@@ -553,9 +554,10 @@ func (be *MockEnvironmentsBackend) OpenYAMLEnvironment(
 	org string,
 	yaml []byte,
 	duration time.Duration,
+	environmentOverrides map[string]string,
 ) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 	if be.OpenYAMLEnvironmentF != nil {
-		return be.OpenYAMLEnvironmentF(ctx, org, yaml, duration)
+		return be.OpenYAMLEnvironmentF(ctx, org, yaml, duration, environmentOverrides)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/esc/analysis/common_test.go
+++ b/pkg/cmd/esc/analysis/common_test.go
@@ -89,6 +89,10 @@ func (testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]byt
 	return []byte(`{"values": {}}`), nil, nil
 }
 
+func (testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
 const def = `imports:
   - a
 values:

--- a/pkg/cmd/esc/cli/cli_test.go
+++ b/pkg/cmd/esc/cli/cli_test.go
@@ -218,6 +218,10 @@ func (e *testEnvironments) LoadEnvironment(ctx context.Context, ref string) ([]b
 	return env.latest().yaml, rot128{}, nil
 }
 
+func (e *testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
 type testEnvironmentRetract struct {
 	replacement int
 	reason      string
@@ -828,6 +832,7 @@ func (c *testPulumiClient) OpenYAMLEnvironment(
 	orgName string,
 	yaml []byte,
 	duration time.Duration,
+	opts ...client.OpenYAMLOption,
 ) (string, []client.EnvironmentDiagnostic, error) {
 	return c.openEnvironment(ctx, orgName, "<yaml>", yaml)
 }

--- a/pkg/cmd/esc/cli/client/client.go
+++ b/pkg/cmd/esc/cli/client/client.go
@@ -19,6 +19,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -47,6 +48,10 @@ const (
 
 type CheckYAMLOption struct {
 	ShowSecrets bool
+}
+
+type OpenYAMLOption struct {
+	EnvironmentOverrides map[string]string
 }
 
 // Client provides a slim wrapper around the Pulumi HTTP/REST API.
@@ -248,6 +253,7 @@ type Client interface {
 		orgName string,
 		yaml []byte,
 		duration time.Duration,
+		opts ...OpenYAMLOption,
 	) (string, []EnvironmentDiagnostic, error)
 
 	// GetOpenEnvironment returns the AST, values, and schema for the open environment with ID openEnvID in
@@ -1020,11 +1026,22 @@ func (pc *client) OpenYAMLEnvironment(
 	orgName string,
 	yaml []byte,
 	duration time.Duration,
+	opts ...OpenYAMLOption,
 ) (string, []EnvironmentDiagnostic, error) {
 	queryObj := struct {
-		Duration string `url:"duration"`
+		Duration             string `url:"duration"`
+		EnvironmentOverrides string `url:"environmentOverrides,omitempty"`
 	}{
 		Duration: duration.String(),
+	}
+
+	overrides := firstOrDefault(opts).EnvironmentOverrides
+	if len(overrides) > 0 {
+		encoded, err := json.Marshal(overrides)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshaling environment overrides: %w", err)
+		}
+		queryObj.EnvironmentOverrides = base64.RawURLEncoding.EncodeToString(encoded)
 	}
 
 	var resp struct {

--- a/pkg/cmd/esc/cli/client/client_test.go
+++ b/pkg/cmd/esc/cli/client/client_test.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -1154,6 +1155,68 @@ func TestOpenYAMLEnvironment(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedID, id)
 		assert.Empty(t, diags)
+	})
+
+	t.Run("EnvironmentOverrides", func(t *testing.T) {
+		t.Parallel()
+		yaml := []byte(`{"values":{"foo":"bar"}}`)
+
+		const expectedID = "open-id"
+		duration := 2 * time.Hour
+		overrides := map[string]string{"default/env@6": "team/replacement"}
+
+		client := newTestClient(
+			t,
+			http.MethodPost,
+			"/api/esc/environments/test-org/yaml/open",
+			func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, duration.String(), r.URL.Query().Get("duration"))
+
+				decoded, err := base64.RawURLEncoding.DecodeString(r.URL.Query().Get("environmentOverrides"))
+				require.NoError(t, err)
+				var got map[string]string
+				require.NoError(t, json.Unmarshal(decoded, &got))
+				assert.Equal(t, overrides, got)
+
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				assert.Equal(t, yaml, body)
+
+				err = json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
+				require.NoError(t, err)
+			},
+		)
+
+		id, diags, err := client.OpenYAMLEnvironment(t.Context(), "test-org", yaml, duration,
+			OpenYAMLOption{EnvironmentOverrides: overrides})
+		require.NoError(t, err)
+		assert.Equal(t, expectedID, id)
+		assert.Empty(t, diags)
+	})
+
+	t.Run("NoEnvironmentOverrides", func(t *testing.T) {
+		t.Parallel()
+		yaml := []byte(`{"values":{"foo":"bar"}}`)
+
+		const expectedID = "open-id"
+		duration := 2 * time.Hour
+
+		client := newTestClient(
+			t,
+			http.MethodPost,
+			"/api/esc/environments/test-org/yaml/open",
+			func(w http.ResponseWriter, r *http.Request) {
+				// The query parameter must be omitted entirely when there are no overrides.
+				assert.False(t, r.URL.Query().Has("environmentOverrides"))
+
+				err := json.NewEncoder(w).Encode(map[string]any{"id": expectedID})
+				require.NoError(t, err)
+			},
+		)
+
+		id, _, err := client.OpenYAMLEnvironment(t.Context(), "test-org", yaml, duration)
+		require.NoError(t, err)
+		assert.Equal(t, expectedID, id)
 	})
 
 	t.Run("Diags", func(t *testing.T) {

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -1133,7 +1133,7 @@ func listConfig(
 	var diags []apitype.EnvironmentDiagnostic
 	var err error
 	if openEnvironment {
-		env, diags, err = openStackEnv(ctx, stack, ps)
+		env, diags, err = openStackEnv(ctx, stack, ps, nil)
 	} else {
 		env, diags, err = checkStackEnv(ctx, stack, ps)
 	}
@@ -1321,7 +1321,7 @@ func getConfig(
 	var env *esc.Environment
 	var diags []apitype.EnvironmentDiagnostic
 	if openEnvironment {
-		env, diags, err = openStackEnv(ctx, stack, ps)
+		env, diags, err = openStackEnv(ctx, stack, ps, nil)
 	} else {
 		env, diags, err = checkStackEnv(ctx, stack, ps)
 	}

--- a/pkg/cmd/pulumi/config/config_env_test.go
+++ b/pkg/cmd/pulumi/config/config_env_test.go
@@ -205,6 +205,10 @@ func (m envDefMap) LoadEnvironment(ctx context.Context, name string) ([]byte, ev
 	return []byte(def), nil, nil
 }
 
+func (m envDefMap) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
 func newConfigEnvCmdForInitTest(
 	stdin io.Reader,
 	stdout io.Writer,

--- a/pkg/cmd/pulumi/config/config_test.go
+++ b/pkg/cmd/pulumi/config/config_test.go
@@ -448,6 +448,7 @@ func prepareConfig(
 					org string,
 					yaml []byte,
 					duration time.Duration,
+					_ map[string]string,
 				) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 					return env, apitype.EnvironmentDiagnostics{}, nil
 				},

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -35,10 +35,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/spf13/cobra"
 )
 
-const OverrideEnvFlagUsage = "Override an imported environment for this run only, as <env>=<replacement>; " +
-	"repeatable. Sent to ESC and never written to the stack config"
+// OverrideEnvFlag registers the --override-env flag on cmd, binding it to overrides.
+func OverrideEnvFlag(cmd *cobra.Command, overrides *[]string) {
+	cmd.PersistentFlags().StringArrayVar(
+		overrides, "override-env", nil,
+		"Override an imported environment for this run only, as <env>=<replacement>; repeatable")
+}
 
 // Attempts to load configuration for the given stack.
 func GetStackConfiguration(

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -37,6 +37,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+const OverrideEnvFlagUsage = "Override an imported environment for this run only, as <env>=<replacement>; " +
+	"repeatable. Sent to ESC and never written to the stack config"
+
 // Attempts to load configuration for the given stack.
 func GetStackConfiguration(
 	ctx context.Context,
@@ -45,8 +48,9 @@ func GetStackConfiguration(
 	stack backend.Stack,
 	project *workspace.Project,
 	configFile string,
+	envOverrides []string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
-	return getStackConfigurationWithFallback(ctx, sink, ssml, stack, project, nil, configFile)
+	return getStackConfigurationWithFallback(ctx, sink, ssml, stack, project, nil, configFile, envOverrides)
 }
 
 // GetStackConfigurationOrLatest attempts to load a current stack configuration
@@ -62,6 +66,7 @@ func GetStackConfigurationOrLatest(
 	stack backend.Stack,
 	project *workspace.Project,
 	configFile string,
+	envOverrides []string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
 	return getStackConfigurationWithFallback(
 		ctx, sink, ssml, stack, project,
@@ -74,8 +79,7 @@ func GetStackConfigurationOrLatest(
 			}
 			return nil, err
 		},
-		configFile,
-	)
+		configFile, envOverrides)
 }
 
 func getStackConfigurationWithFallback(
@@ -86,6 +90,7 @@ func getStackConfigurationWithFallback(
 	project *workspace.Project,
 	fallbackGetConfig func(err error) (config.Map, error), // optional
 	configFile string,
+	envOverrides []string,
 ) (backend.StackConfiguration, secrets.Manager, error) {
 	workspaceStack, err := cmdStack.LoadProjectStack(ctx, sink, project, s, configFile)
 	if err != nil || workspaceStack == nil {
@@ -109,7 +114,7 @@ func getStackConfigurationWithFallback(
 		return backend.StackConfiguration{}, nil, err
 	}
 
-	config, err := getStackConfigurationFromProjectStack(ctx, s, project, sm, workspaceStack)
+	config, err := getStackConfigurationFromProjectStack(ctx, s, project, sm, workspaceStack, envOverrides)
 	if err != nil {
 		return backend.StackConfiguration{}, nil, err
 	}
@@ -122,8 +127,9 @@ func getStackConfigurationFromProjectStack(
 	project *workspace.Project,
 	sm secrets.Manager,
 	workspaceStack *workspace.ProjectStack,
+	envOverrides []string,
 ) (backend.StackConfiguration, error) {
-	env, diags, err := openStackEnv(ctx, stack, workspaceStack)
+	env, diags, err := openStackEnv(ctx, stack, workspaceStack, envOverrides)
 	if err != nil {
 		return backend.StackConfiguration{}, fmt.Errorf("opening environment: %w", err)
 	}
@@ -229,10 +235,16 @@ func openStackEnv(
 	ctx context.Context,
 	stack backend.Stack,
 	workspaceStack *workspace.ProjectStack,
+	envOverrides []string,
 ) (*esc.Environment, []apitype.EnvironmentDiagnostic, error) {
 	yaml := workspaceStack.EnvironmentBytes()
 	if len(yaml) == 0 {
 		return nil, nil, nil
+	}
+
+	overrides, err := parseEnvironmentOverrides(envOverrides)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	envs, ok := stack.Backend().(backend.EnvironmentsBackend)
@@ -245,7 +257,24 @@ func openStackEnv(
 	}
 	orgName := orgNamer.OrgName()
 
-	return envs.OpenYAMLEnvironment(ctx, orgName, yaml, 2*time.Hour)
+	return envs.OpenYAMLEnvironment(ctx, orgName, yaml, 2*time.Hour, overrides)
+}
+
+// parseEnvironmentOverrides converts <env>=<replacement> pairs into a map sent to ESC,
+// which substitutes the matching imports while resolving the environment import graph.
+func parseEnvironmentOverrides(envOverrides []string) (map[string]string, error) {
+	if len(envOverrides) == 0 {
+		return nil, nil
+	}
+	overrides := make(map[string]string, len(envOverrides))
+	for _, o := range envOverrides {
+		match, replacement, ok := strings.Cut(o, "=")
+		if !ok || match == "" || replacement == "" {
+			return nil, fmt.Errorf("invalid --override-env value %q: expected format <env>=<replacement>", o)
+		}
+		overrides[match] = replacement
+	}
+	return overrides, nil
 }
 
 func copySingleConfigKey(

--- a/pkg/cmd/pulumi/config/io.go
+++ b/pkg/cmd/pulumi/config/io.go
@@ -42,7 +42,7 @@ import (
 func OverrideEnvFlag(cmd *cobra.Command, overrides *[]string) {
 	cmd.PersistentFlags().StringArrayVar(
 		overrides, "override-env", nil,
-		"Override an imported environment for this run only, as <env>=<replacement>; repeatable")
+		"[EXPERIMENTAL] Override an imported environment for this run only, as <env>=<replacement>; repeatable")
 }
 
 // Attempts to load configuration for the given stack.

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -92,6 +92,7 @@ func TestGetStackConfigurationDoesNotGetLatestConfiguration(t *testing.T) {
 		},
 		nil,
 		"",
+		nil,
 	)
 }
 
@@ -129,6 +130,7 @@ func TestGetStackConfigurationOrLatest(t *testing.T) {
 		},
 		nil,
 		"",
+		nil,
 	)
 	if !called {
 		t.Fatalf("GetLatestConfiguration should be called in getStackConfigurationOrLatest.")
@@ -189,7 +191,7 @@ func TestOpenStackEnvNoEnv(t *testing.T) {
 	err := yaml.Unmarshal([]byte(""), &projectStack)
 	require.NoError(t, err)
 
-	_, _, err = openStackEnv(t.Context(), stack, &projectStack)
+	_, _, err = openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 }
 
@@ -203,7 +205,7 @@ func TestOpenStackEnvUnsupportedBackend(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  - test"), &projectStack)
 	require.NoError(t, err)
 
-	_, _, err = openStackEnv(t.Context(), stack, &projectStack)
+	_, _, err = openStackEnv(t.Context(), stack, &projectStack, nil)
 	assert.Error(t, err)
 }
 
@@ -219,6 +221,7 @@ func getMockStackWithEnv(t *testing.T, env map[string]esc.Value) *backend.MockSt
 			org string,
 			yaml []byte,
 			duration time.Duration,
+			_ map[string]string,
 		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 			assert.Equal(t, "test-org", org)
 			assert.NotEmpty(t, yaml)
@@ -255,7 +258,7 @@ func TestOpenStackEnv(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  - test"), &projectStack)
 	require.NoError(t, err)
 
-	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
@@ -282,7 +285,7 @@ func TestOpenStackEnvLiteral(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  imports:\n    - test"), &projectStack)
 	require.NoError(t, err)
 
-	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
@@ -306,6 +309,7 @@ func TestOpenStackEnvVersionPinned(t *testing.T) {
 			org string,
 			yamlBody []byte,
 			duration time.Duration,
+			_ map[string]string,
 		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 			assert.Equal(t, "test-org", org)
 			assert.Contains(t, string(yamlBody), "project/env@3")
@@ -322,10 +326,65 @@ func TestOpenStackEnvVersionPinned(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  - project/env@3\n  - project/other@stable"), &projectStack)
 	require.NoError(t, err)
 
-	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
+}
+
+func TestOpenStackEnvOverrides(t *testing.T) {
+	t.Parallel()
+
+	var gotOverrides map[string]string
+	be := &backend.MockEnvironmentsBackend{
+		MockBackend: backend.MockBackend{
+			NameF: func() string { return "test" },
+		},
+		OpenYAMLEnvironmentF: func(
+			ctx context.Context,
+			org string,
+			yamlBody []byte,
+			duration time.Duration,
+			environmentOverrides map[string]string,
+		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
+			gotOverrides = environmentOverrides
+			return &esc.Environment{Properties: map[string]esc.Value{}}, nil, nil
+		},
+	}
+	stack := &backend.MockStack{
+		OrgNameF: func() string { return "test-org" },
+		BackendF: func() backend.Backend { return be },
+	}
+
+	var projectStack workspace.ProjectStack
+	err := yaml.Unmarshal([]byte("environment:\n  - proj/env"), &projectStack)
+	require.NoError(t, err)
+
+	_, diags, err := openStackEnv(t.Context(), stack, &projectStack,
+		[]string{"proj/env=proj/other@tag", "proj/env2=proj/other2"})
+	require.NoError(t, err)
+	require.Len(t, diags, 0)
+	assert.Equal(t, map[string]string{
+		"proj/env":  "proj/other@tag",
+		"proj/env2": "proj/other2",
+	}, gotOverrides)
+}
+
+func TestParseEnvironmentOverrides(t *testing.T) {
+	t.Parallel()
+
+	overrides, err := parseEnvironmentOverrides(nil)
+	require.NoError(t, err)
+	assert.Nil(t, overrides)
+
+	overrides, err = parseEnvironmentOverrides([]string{"proj/env=proj/other@tag", "a=b"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"proj/env": "proj/other@tag", "a": "b"}, overrides)
+
+	for _, bad := range []string{"noequals", "=replacement", "match="} {
+		_, err := parseEnvironmentOverrides([]string{bad})
+		assert.ErrorContains(t, err, "invalid --override-env value")
+	}
 }
 
 func TestOpenStackEnvVersionPinnedLiteral(t *testing.T) {
@@ -346,6 +405,7 @@ func TestOpenStackEnvVersionPinnedLiteral(t *testing.T) {
 			org string,
 			yamlBody []byte,
 			duration time.Duration,
+			_ map[string]string,
 		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 			assert.Equal(t, "test-org", org)
 			assert.Contains(t, string(yamlBody), "project/env@3")
@@ -363,7 +423,7 @@ func TestOpenStackEnvVersionPinnedLiteral(t *testing.T) {
 	err := yaml.Unmarshal([]byte(stackYAML), &projectStack)
 	require.NoError(t, err)
 
-	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	openEnv, diags, err := openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 	require.Len(t, diags, 0)
 	assert.Equal(t, env, openEnv.Properties)
@@ -440,6 +500,7 @@ func TestStackEnvConfig(t *testing.T) {
 		&project,
 		mockSecretsManager,
 		&projectStack,
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -556,6 +617,7 @@ func TestOpenStackEnvDiags(t *testing.T) {
 			org string,
 			yaml []byte,
 			duration time.Duration,
+			_ map[string]string,
 		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 			return nil, []apitype.EnvironmentDiagnostic{{Summary: "diag"}}, nil
 		},
@@ -569,7 +631,7 @@ func TestOpenStackEnvDiags(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  - test"), &projectStack)
 	require.NoError(t, err)
 
-	_, diags, err := openStackEnv(t.Context(), stack, &projectStack)
+	_, diags, err := openStackEnv(t.Context(), stack, &projectStack, nil)
 	require.NoError(t, err)
 	require.Len(t, diags, 1)
 }
@@ -586,6 +648,7 @@ func TestOpenStackEnvError(t *testing.T) {
 			org string,
 			yaml []byte,
 			duration time.Duration,
+			_ map[string]string,
 		) (*esc.Environment, apitype.EnvironmentDiagnostics, error) {
 			return nil, nil, errors.New("error")
 		},
@@ -599,7 +662,7 @@ func TestOpenStackEnvError(t *testing.T) {
 	err := yaml.Unmarshal([]byte("environment:\n  - test"), &projectStack)
 	require.NoError(t, err)
 
-	_, _, err = openStackEnv(t.Context(), stack, &projectStack)
+	_, _, err = openStackEnv(t.Context(), stack, &projectStack, nil)
 	assert.Error(t, err)
 }
 

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -81,7 +81,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile, nil)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/neo/tools/pulumi.go
+++ b/pkg/cmd/pulumi/neo/tools/pulumi.go
@@ -262,7 +262,7 @@ func (p *Pulumi) run(ctx context.Context, a pulumiArgs, isPreview bool) (pulumiR
 	}
 
 	ssml := cmdStack.NewStackSecretsManagerLoaderFromEnv()
-	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, "")
+	cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, "", nil)
 	if err != nil {
 		return failedResult(a, "", fmt.Errorf("getting stack configuration: %w", err))
 	}

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -430,9 +430,7 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
-	cmd.PersistentFlags().StringArrayVar(
-		&envOverrides, "override-env", nil,
-		config.OverrideEnvFlagUsage)
+	config.OverrideEnvFlag(cmd, &envOverrides)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the destroy and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -61,6 +61,7 @@ func NewDestroyCmd() *cobra.Command {
 	var execAgent string
 	var configArray []string
 	var configFile string
+	var envOverrides []string
 	var path bool
 	var client string
 
@@ -256,7 +257,7 @@ func NewDestroyCmd() *cobra.Command {
 				// The config may be missing, fallback on the latest configuration in the backend.
 				getConfig = config.GetStackConfigurationOrLatest
 			}
-			cfg, sm, err := getConfig(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+			cfg, sm, err := getConfig(ctx, cmdutil.Diag(), ssml, s, proj, configFile, envOverrides)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -429,6 +430,9 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
+	cmd.PersistentFlags().StringArrayVar(
+		&envOverrides, "override-env", nil,
+		config.OverrideEnvFlagUsage)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the destroy and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -1010,7 +1010,7 @@ func NewImportCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj, configFile)
+			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj, configFile, nil)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -286,6 +286,7 @@ func NewPreviewCmd() *cobra.Command {
 	var stackName string
 	var configArray []string
 	var configFile string
+	var envOverrides []string
 	var configPath bool
 	var client string
 	var planFilePath string
@@ -470,7 +471,7 @@ func NewPreviewCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile, envOverrides)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -659,6 +660,9 @@ func NewPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
+	cmd.PersistentFlags().StringArrayVar(
+		&envOverrides, "override-env", nil,
+		config.OverrideEnvFlagUsage)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the preview and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -660,9 +660,7 @@ func NewPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
-	cmd.PersistentFlags().StringArrayVar(
-		&envOverrides, "override-env", nil,
-		config.OverrideEnvFlagUsage)
+	config.OverrideEnvFlag(cmd, &envOverrides)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the preview and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -400,9 +400,7 @@ func NewRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
-	cmd.PersistentFlags().StringArrayVar(
-		&envOverrides, "override-env", nil,
-		config.OverrideEnvFlagUsage)
+	config.OverrideEnvFlag(cmd, &envOverrides)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the refresh and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -61,6 +61,7 @@ func NewRefreshCmd() *cobra.Command {
 	var stackName string
 	var configArray []string
 	var configFile string
+	var envOverrides []string
 	var path bool
 	var client string
 
@@ -231,7 +232,7 @@ func NewRefreshCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile, envOverrides)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}
@@ -399,6 +400,9 @@ func NewRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
+	cmd.PersistentFlags().StringArrayVar(
+		&envOverrides, "override-env", nil,
+		config.OverrideEnvFlagUsage)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the refresh and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -97,6 +97,7 @@ func NewUpCmd() *cobra.Command {
 	var stackName string
 	var configArray []string
 	var configFile string
+	var envOverrides []string
 	var path bool
 	var client string
 
@@ -178,7 +179,7 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
-		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile, envOverrides)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -473,7 +474,7 @@ func NewUpCmd() *cobra.Command {
 			}
 		}
 
-		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, pctx.Diag, ssml, s, proj, configFile)
+		cfg, sm, err := cmdConfig.GetStackConfiguration(ctx, pctx.Diag, ssml, s, proj, configFile, envOverrides)
 		if err != nil {
 			return fmt.Errorf("getting stack configuration: %w", err)
 		}
@@ -750,6 +751,9 @@ func NewUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
+	cmd.PersistentFlags().StringArrayVar(
+		&envOverrides, "override-env", nil,
+		cmdConfig.OverrideEnvFlagUsage)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the update and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -751,9 +751,7 @@ func NewUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&configFile, "config-file", "",
 		"Use the configuration values in the specified file rather than detecting the file name")
-	cmd.PersistentFlags().StringArrayVar(
-		&envOverrides, "override-env", nil,
-		cmdConfig.OverrideEnvFlagUsage)
+	cmdConfig.OverrideEnvFlag(cmd, &envOverrides)
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the update and save to the stack config file")

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -123,7 +123,7 @@ func NewWatchCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile)
+			cfg, sm, err := config.GetStackConfiguration(ctx, cmdutil.Diag(), ssml, s, proj, configFile, nil)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)
 			}

--- a/sdk/go/common/esc/eval/eval.go
+++ b/sdk/go/common/esc/eval/eval.go
@@ -50,6 +50,9 @@ type ProviderLoader interface {
 type EnvironmentLoader interface {
 	// LoadEnvironment loads the definition for the environment with the given name.
 	LoadEnvironment(ctx context.Context, name string) ([]byte, Decrypter, error)
+
+	// AuthorizeImport reports whether the environment named by importer may import the environment named by imported.
+	AuthorizeImport(ctx context.Context, importer string, imported string, importerIsRoot bool) error
 }
 
 // LoadYAML decodes a YAML template from an io.Reader.
@@ -597,6 +600,12 @@ func (e *evalContext) evaluateImports() {
 //
 // Each environment in the import closure is only evaluated once.
 func (e *evalContext) evaluateImport(expr ast.Expr, name string) (*value, bool) {
+	// Authorize the import edge before consulting the cache, so authorization runs once per (importer, imported)
+	if err := e.environments.AuthorizeImport(e.ctx, e.name, name, e.isRootEnv); err != nil {
+		e.errorf(expr, "%s", err.Error())
+		return nil, false
+	}
+
 	var val *value
 	if imported, ok := e.imports[name]; ok {
 		if imported.evaluating {

--- a/sdk/go/common/esc/eval/eval_options_test.go
+++ b/sdk/go/common/esc/eval/eval_options_test.go
@@ -45,6 +45,10 @@ func (e inlineEnvironments) LoadEnvironment(_ context.Context, name string) ([]b
 	return src, rot128{}, nil
 }
 
+func (e inlineEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
 // deepImportChain is a 5-environment stack all merging the same key, so the
 // Trace.Base chain is deep enough (>2) for Full and None to diverge observably.
 var deepImportChain = inlineEnvironments{

--- a/sdk/go/common/esc/eval/eval_test.go
+++ b/sdk/go/common/esc/eval/eval_test.go
@@ -304,6 +304,10 @@ func (e *testEnvironments) LoadEnvironment(ctx context.Context, name string) ([]
 	return bytes, rot128{}, nil
 }
 
+func (e *testEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
+}
+
 type benchEnvironments struct {
 	defs  map[string][]byte
 	delay time.Duration
@@ -344,6 +348,10 @@ func (e *benchEnvironments) LoadEnvironment(ctx context.Context, name string) ([
 		return nil, nil, os.ErrNotExist
 	}
 	return bytes, rot128{}, nil
+}
+
+func (e *benchEnvironments) AuthorizeImport(_ context.Context, _ string, _ string, _ bool) error {
+	return nil
 }
 
 func sortEnvironmentDiagnostics(diags syntax.Diagnostics) {


### PR DESCRIPTION
~depends on https://github.com/pulumi/esc/pull/665~

## Summary
Add --override-env flag to override esc environments used for a stack operation

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [x] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
