### PR TITLE
Precompose filenames to NFC on macOS when matching archive ignore patterns

### DIFF
--- a/changelog/pending/sdk-fix-gitignore-unicode-nfc.yaml
+++ b/changelog/pending/sdk-fix-gitignore-unicode-nfc.yaml
@@ -1,0 +1,6 @@
+component: sdk
+kind: fix
+body: Precompose filenames to NFC on macOS when matching ignore patterns during archive creation, mirroring git's core.precomposeunicode so composed patterns match decomposed filenames
+time: 2026-06-12T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/changelog/pending/sdk-fix-gitignore-unicode-nfc.yaml
+++ b/changelog/pending/sdk-fix-gitignore-unicode-nfc.yaml
@@ -3,4 +3,4 @@ kind: fix
 body: Precompose filenames to NFC on macOS when matching ignore patterns during archive creation, mirroring git's core.precomposeunicode so composed patterns match decomposed filenames
 time: 2026-06-12T00:00:00.000000+00:00
 custom:
-    PR: ""
+    PR: "23566"

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.37.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 )

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -230,7 +230,10 @@ func addDirectoryToTar(writer *tar.Writer, root, dir, prefixPathInsideTar string
 	}
 
 	for _, info := range infos {
-		fullName := filepath.Join(dir, info.Name())
+		// Precompose the entry name to NFC on filesystems that decompose Unicode
+		// (macOS), mirroring git's core.precomposeunicode, so NFC-authored ignore
+		// patterns match files the filesystem hands back in decomposed form.
+		fullName := filepath.Join(dir, precomposeUnicode(info.Name()))
 
 		if !info.IsDir() && ignores.IsIgnored(fullName) {
 			logging.V(9).Infof("skip archiving of %v due to ignore file", fullName)

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -119,24 +119,22 @@ func TestIgnoreNestedGitignore(t *testing.T) {
 		fileContents{name: "pkg/node_modules/pulumi/excluded/excluded.txt", shouldRetain: false})
 }
 
-// TestIgnorePrecomposesUnicode verifies that, on a filesystem that decomposes
-// Unicode, a .gitignore pattern authored in composed (NFC) form still matches a
-// file whose name the filesystem hands back decomposed (NFD) — mirroring git's
-// core.precomposeunicode. The package-level flag is forced on so the behavior is
-// exercised regardless of the host OS.
-//
-//nolint:paralleltest // mutates package-level precomposeUnicodeFS
+// TestIgnorePrecomposesUnicode verifies that a .gitignore pattern authored in
+// composed (NFC) form matches a directory whose name is stored decomposed (NFD)
+// on disk — mirroring git's core.precomposeunicode. This is macOS-only behavior:
+// precomposeUnicode normalizes readdir output to NFC there and is a no-op
+// elsewhere, so the test only runs on darwin.
 func TestIgnorePrecomposesUnicode(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipped on Windows: filesystem Unicode normalization is ambiguous there")
+	t.Parallel()
+
+	if runtime.GOOS != "darwin" {
+		t.Skip("precomposeUnicode only normalizes on macOS")
 	}
 
-	saved := precomposeUnicodeFS
-	precomposeUnicodeFS = true
-	t.Cleanup(func() { precomposeUnicodeFS = saved })
-
-	// "café" — the directory is created on disk in NFD form (decomposed "e" +
-	// combining acute), while the .gitignore pattern uses NFC (precomposed "é").
+	// The directory is created on disk in NFD (decomposed) form while the
+	// .gitignore pattern uses NFC (precomposed). APFS preserves the exact bytes
+	// we write, so readdir hands the name back in NFD; the match then succeeds
+	// only because precomposeUnicode brings it back to NFC before matching.
 	nfc := norm.NFC.String("café")
 	nfd := norm.NFD.String("café")
 	require.NotEqual(t, nfc, nfd, "expected NFC and NFD forms to differ")

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestIgnoreSimple(t *testing.T) {
@@ -116,6 +117,34 @@ func TestIgnoreNestedGitignore(t *testing.T) {
 		fileContents{name: "pkg/node_modules/included.txt", shouldRetain: true},
 		fileContents{name: "pkg/node_modules/pulumi/excluded.txt", shouldRetain: false},
 		fileContents{name: "pkg/node_modules/pulumi/excluded/excluded.txt", shouldRetain: false})
+}
+
+// TestIgnorePrecomposesUnicode verifies that, on a filesystem that decomposes
+// Unicode, a .gitignore pattern authored in composed (NFC) form still matches a
+// file whose name the filesystem hands back decomposed (NFD) — mirroring git's
+// core.precomposeunicode. The package-level flag is forced on so the behavior is
+// exercised regardless of the host OS.
+//
+//nolint:paralleltest // mutates package-level precomposeUnicodeFS
+func TestIgnorePrecomposesUnicode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipped on Windows: filesystem Unicode normalization is ambiguous there")
+	}
+
+	saved := precomposeUnicodeFS
+	precomposeUnicodeFS = true
+	t.Cleanup(func() { precomposeUnicodeFS = saved })
+
+	// "café" — the directory is created on disk in NFD form (decomposed "e" +
+	// combining acute), while the .gitignore pattern uses NFC (precomposed "é").
+	nfc := norm.NFC.String("café")
+	nfd := norm.NFD.String("café")
+	require.NotEqual(t, nfc, nfd, "expected NFC and NFD forms to differ")
+
+	doArchiveTest(t, ".",
+		fileContents{name: ".gitignore", contents: []byte(nfc + "/"), shouldRetain: true},
+		fileContents{name: "included.txt", shouldRetain: true},
+		fileContents{name: nfd + "/excluded.txt", shouldRetain: false})
 }
 
 func doArchiveTest(t *testing.T, path string, files ...fileContents) {

--- a/sdk/go/common/util/archive/precompose.go
+++ b/sdk/go/common/util/archive/precompose.go
@@ -20,28 +20,21 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// precomposeUnicodeFS reports whether directory-entry names read from the
-// filesystem should be precomposed to NFC before we match them against ignore
-// patterns. macOS stores filenames in a decomposed (roughly NFD) form, so the
-// name "café" read back from readdir is a different byte sequence than the
-// composed (NFC) "café" a user typically types into a .gitignore — and our
-// pattern matching is byte/rune-exact. Git solves this with
-// core.precomposeunicode, which precomposes readdir output to NFC and defaults
-// to on for macOS; we mirror that gating so our ignore matching agrees with
-// git's on the same filesystem.
-//
-// It is a var rather than a const so tests can exercise the precompose path on
-// hosts that don't decompose.
-var precomposeUnicodeFS = runtime.GOOS == "darwin"
-
 // precomposeUnicode returns name in NFC form on filesystems that decompose
-// Unicode (see [precomposeUnicodeFS]), and otherwise returns it unchanged.
-// Normalizing only there mirrors git: on a decomposing filesystem the NFC name
-// still resolves to the same file (lookup is normalization-insensitive), while
-// on a byte-preserving filesystem rewriting the name could point at a file that
-// doesn't exist.
+// Unicode (macOS), and otherwise returns it unchanged. macOS stores filenames
+// in a decomposed (roughly NFD) form, so the name "café" read back from readdir
+// is a different byte sequence than the composed (NFC) "café" a user typically
+// types into a .gitignore — and our pattern matching is byte/rune-exact. Git
+// solves this with core.precomposeunicode, which precomposes readdir output to
+// NFC and defaults to on for macOS; we mirror that gating so our ignore matching
+// agrees with git's on the same filesystem.
+//
+// Normalizing only on macOS also mirrors git for correctness: on a decomposing
+// filesystem the NFC name still resolves to the same file (lookup is
+// normalization-insensitive), while on a byte-preserving filesystem rewriting
+// the name could point at a file that doesn't exist.
 func precomposeUnicode(name string) string {
-	if !precomposeUnicodeFS {
+	if runtime.GOOS != "darwin" {
 		return name
 	}
 	return norm.NFC.String(name)

--- a/sdk/go/common/util/archive/precompose.go
+++ b/sdk/go/common/util/archive/precompose.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"runtime"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// precomposeUnicodeFS reports whether directory-entry names read from the
+// filesystem should be precomposed to NFC before we match them against ignore
+// patterns. macOS stores filenames in a decomposed (roughly NFD) form, so the
+// name "café" read back from readdir is a different byte sequence than the
+// composed (NFC) "café" a user typically types into a .gitignore — and our
+// pattern matching is byte/rune-exact. Git solves this with
+// core.precomposeunicode, which precomposes readdir output to NFC and defaults
+// to on for macOS; we mirror that gating so our ignore matching agrees with
+// git's on the same filesystem.
+//
+// It is a var rather than a const so tests can exercise the precompose path on
+// hosts that don't decompose.
+var precomposeUnicodeFS = runtime.GOOS == "darwin"
+
+// precomposeUnicode returns name in NFC form on filesystems that decompose
+// Unicode (see [precomposeUnicodeFS]), and otherwise returns it unchanged.
+// Normalizing only there mirrors git: on a decomposing filesystem the NFC name
+// still resolves to the same file (lookup is normalization-insensitive), while
+// on a byte-preserving filesystem rewriting the name could point at a file that
+// doesn't exist.
+func precomposeUnicode(name string) string {
+	if !precomposeUnicodeFS {
+		return name
+	}
+	return norm.NFC.String(name)
+}


### PR DESCRIPTION
## Description

When archiving a directory for upload (`pulumi template publish` and policy-pack publish), we honor `.gitignore` files plus a set of default excludes. The matcher compared filesystem entry names against ignore patterns byte/rune-exact, with no Unicode normalization.

macOS stores filenames in a decomposed (roughly NFD) form, so a name like `café` read back from `readdir` is a different rune sequence than the composed (NFC) `café` a user typically types into a `.gitignore`. The pattern then fails to match, and the file is included in the archive even though the user intended to exclude it.

This mirrors git's own `core.precomposeunicode` behavior (default-on for macOS): precompose directory-entry names to NFC before matching. Since we read and honor `.gitignore` files, matching git here is the correct behavior. The normalization is gated to macOS for the same reason git gates it — on a decomposing filesystem the NFC name still resolves to the same file, whereas on a byte-preserving filesystem (Linux) rewriting the name could point at a file that doesn't exist.

## Changes

- New `precompose.go`: `precomposeUnicode(name)` returns the NFC form on filesystems that decompose Unicode (macOS), and the name unchanged elsewhere.
- `archive.go`: precompose each directory-entry name at the single point where it enters the path used for matching, the tar header, and file open.
- New test `TestIgnorePrecomposesUnicode`: an NFD-on-disk directory with an NFC `.gitignore` pattern is correctly excluded. Verified it fails without the fix.
- Promote `golang.org/x/text` from indirect to direct in `sdk/go.mod` (effective version unchanged).

## Test plan

- `cd sdk && go test ./go/common/util/archive/ -count=1` passes, including the new test.
- Manually on macOS: create a dir whose name is stored in NFD with an NFC pattern in `.gitignore` that should match it; confirm the file is now excluded from the archive (was previously included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Internal tracking: pulumi/home#4807
