### PR TITLE
Allow running the postinstall script for local SDKs under npm

### DIFF
--- a/changelog/pending/sdk-nodejs-improvement-20260615-132945.yaml
+++ b/changelog/pending/sdk-nodejs-improvement-20260615-132945.yaml
@@ -1,0 +1,6 @@
+component: sdk/nodejs
+kind: improvement
+body: Allow running the postinstall script for local SDKs under npm 12
+time: 2026-06-15T13:29:45.095155+02:00
+custom:
+    PR: "23568"

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -98,6 +98,19 @@ func (node *npmManager) Link(ctx context.Context, dir, packageName, path string)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("error executing npm command %s: %w, output: %s", cmd.String(), err, out)
 	}
+
+	// Local SDKs have a postinstall script that needs to run to compile the SDK from TypeScript. Starting with
+	// npm 11.16.0, npm warns about packages whose install scripts are not covered by the `allowScripts` field in
+	// package.json, and npm 12 will skip those scripts unless they are allowlisted. Add the local SDK to
+	// `allowScripts` so its postinstall script keeps running.
+	// https://docs.npmjs.com/cli/configuring-npm/package-json#allowscripts
+	allowScripts := fmt.Sprintf("allowScripts[file:%s]=true", path)
+	//nolint:gosec
+	cmd = exec.CommandContext(ctx, "npm", "pkg", "set", allowScripts, "--json")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error executing npm command %s: %w, output: %s", cmd.String(), err, out)
+	}
 	return nil
 }
 

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -17,6 +17,7 @@ package npm
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -101,15 +102,32 @@ func (node *npmManager) Link(ctx context.Context, dir, packageName, path string)
 
 	// Local SDKs have a postinstall script that needs to run to compile the SDK from TypeScript. Starting with
 	// npm 11.16.0, npm warns about packages whose install scripts are not covered by the `allowScripts` field in
-	// package.json, and npm 12 will skip those scripts unless they are allowlisted. Add the local SDK to
-	// `allowScripts` so its postinstall script keeps running.
+	// package.json, and npm 12 will skip those scripts unless they are allowlisted. Add the package to
+	// `allowScripts`, keyed by its `file:` dependency spec, so its install scripts keep running.
 	// https://docs.npmjs.com/cli/configuring-npm/package-json#allowscripts
-	allowScripts := fmt.Sprintf("allowScripts[file:%s]=true", path)
+	cmd = exec.CommandContext(ctx, "npm", "pkg", "get", "allowScripts")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running %s: %w, output: %s", cmd.String(), err, out)
+	}
+	out = bytes.TrimSpace(out)
+	allowScripts := map[string]bool{}
+	if len(out) > 0 && string(out) != "undefined" {
+		if err := json.Unmarshal(out, &allowScripts); err != nil {
+			allowScripts = map[string]bool{}
+		}
+	}
+	allowScripts["file:"+path] = true
+	jsonData, err := json.Marshal(allowScripts)
+	if err != nil {
+		return fmt.Errorf("error marshaling allowScripts to JSON: %w", err)
+	}
 	//nolint:gosec
-	cmd = exec.CommandContext(ctx, "npm", "pkg", "set", allowScripts, "--json")
+	cmd = exec.CommandContext(ctx, "npm", "pkg", "set", "--json", "allowScripts="+string(jsonData))
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("error executing npm command %s: %w, output: %s", cmd.String(), err, out)
+		return fmt.Errorf("error running %s: %w, output: %s", cmd.String(), err, out)
 	}
 	return nil
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2549,7 +2549,11 @@ func TestPackageAddNode(t *testing.T) {
 			case "npm":
 				allowScripts, ok := packagesJSON["allowScripts"].(map[string]any)
 				require.True(t, ok, "expected allowScripts in package.json")
-				assert.Equal(t, true, allowScripts["file:sdks/random"])
+				normalized := make(map[string]any, len(allowScripts))
+				for k, v := range allowScripts {
+					normalized[filepath.ToSlash(k)] = v
+				}
+				assert.Equal(t, true, normalized["file:sdks/random"])
 			case "bun":
 				trusted, ok := packagesJSON["trustedDependencies"].([]any)
 				require.True(t, ok, "expected trustedDependencies in package.json")

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -2543,6 +2543,23 @@ func TestPackageAddNode(t *testing.T) {
 
 			require.Equal(t, "file:sdks/random", filepath.ToSlash(cf.(string)))
 
+			// The local SDK has a postinstall script that compiles it from TypeScript. Each package manager requires
+			// the package to be allowlisted so the script runs (npm 12 and pnpm/bun skip install scripts by default).
+			switch packageManager {
+			case "npm":
+				allowScripts, ok := packagesJSON["allowScripts"].(map[string]any)
+				require.True(t, ok, "expected allowScripts in package.json")
+				assert.Equal(t, true, allowScripts["file:sdks/random"])
+			case "bun":
+				trusted, ok := packagesJSON["trustedDependencies"].([]any)
+				require.True(t, ok, "expected trustedDependencies in package.json")
+				assert.Contains(t, trusted, "@pulumi/random")
+			case "pnpm":
+				b, err := os.ReadFile(filepath.Join(e.CWD, "pnpm-workspace.yaml"))
+				require.NoError(t, err, "expected pnpm-workspace.yaml")
+				assert.Contains(t, string(b), "@pulumi/random")
+			}
+
 			require.FileExists(t, filepath.Join(e.CWD, "sdks", "random", ".gitignore"))
 			b, err := os.ReadFile(filepath.Join(e.CWD, "sdks", "random", ".gitignore"))
 			require.NoError(t, err)


### PR DESCRIPTION
Similar to pnpm and bun, in version 12 npm will no longer run `preinstall`, `install`, or `postinstall` scripts, and requires explicit approval to run them. See
https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/.

We add the local SDK to `allowScripts` in `package.json` to make it work.

Fixes https://github.com/pulumi/pulumi/issues/23568
