### PR TITLE
Invoke multi-argument-input functions positionally in PCL

### DIFF
--- a/changelog/pending/programgen-pcl-multiarg-positional.yaml
+++ b/changelog/pending/programgen-pcl-multiarg-positional.yaml
@@ -1,0 +1,6 @@
+component: programgen/pcl
+kind: feat
+body: Invoke functions declared with multi-argument inputs using positional arguments in PCL
+time: 2026-06-15T00:00:00+00:00
+custom:
+    PR: ""

--- a/changelog/pending/programgen-pcl-multiarg-positional.yaml
+++ b/changelog/pending/programgen-pcl-multiarg-positional.yaml
@@ -3,4 +3,4 @@ kind: feat
 body: Invoke functions declared with multi-argument inputs using positional arguments in PCL
 time: 2026-06-15T00:00:00+00:00
 custom:
-    PR: ""
+    PR: "23571"

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/fs"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -482,14 +483,10 @@ func BindProgram(files []*syntax.File, loader schema.Loader, opts ...BindOption)
 	// Load package descriptors from the files
 	descriptorMap, descriptorDiags := ReadAllPackageDescriptors(files)
 	diagnostics = append(diagnostics, descriptorDiags...)
-	for packageName, descriptor := range descriptorMap {
-		b.packageDescriptors[packageName] = descriptor
-	}
+	maps.Copy(b.packageDescriptors, descriptorMap)
 	// Caller-supplied descriptors (snippet bindings carry these structurally rather than as PCL syntax)
 	// take precedence over any file-declared block for the same package.
-	for packageName, descriptor := range options.extraPackageDescriptors {
-		b.packageDescriptors[packageName] = descriptor
-	}
+	maps.Copy(b.packageDescriptors, options.extraPackageDescriptors)
 
 	// Sort files in source order, then declare all top-level nodes in each.
 	sort.Slice(files, func(i, j int) bool {
@@ -511,6 +508,10 @@ func BindProgram(files []*syntax.File, loader schema.Loader, opts ...BindOption)
 	if diagnostics.HasErrors() {
 		return nil, diagnostics, diagnostics
 	}
+
+	// Normalize positional multi-argument invokes into their object-argument form so that downstream
+	// code only ever observes the object form. See invoke_positional.go.
+	diagnostics = diagnostics.Extend(b.rewritePositionalInvokes())
 
 	return &Program{
 		Nodes:  b.nodes,

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -46,6 +46,38 @@ func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) 
 	return literal.Val.AsString(), call.Args[0].Range(), true
 }
 
+// invokeTokenArgument extracts the literal function token from a bound invoke call's first argument.
+// It returns the token, the literal expression holding it (so callers may canonicalize the token in
+// place), and the token's source range. ok is false if the first argument is not a single string
+// literal.
+func invokeTokenArgument(args []model.Expression) (
+	token string, lit *model.LiteralValueExpression, tokenRange hcl.Range, ok bool,
+) {
+	if len(args) < 1 {
+		return "", nil, hcl.Range{}, false
+	}
+	template, isTemplate := args[0].(*model.TemplateExpression)
+	if !isTemplate || len(template.Parts) != 1 {
+		return "", nil, hcl.Range{}, false
+	}
+	literal, isLiteral := template.Parts[0].(*model.LiteralValueExpression)
+	if !isLiteral || model.StringType.ConversionFrom(literal.Type()) == model.NoConversion {
+		return "", nil, hcl.Range{}, false
+	}
+	return literal.Value.AsString(), literal, args[0].SyntaxNode().Range(), true
+}
+
+// loadPackageSchema loads the schema for the named package, honoring a registered package descriptor
+// when present and otherwise loading the package's default version. The default version is loaded
+// (rather than failing) because the concrete version may not yet be known; see the note in
+// binder_resource.go.
+func (b *binder) loadPackageSchema(pkg string) (*packageSchema, error) {
+	if descriptor, ok := b.packageDescriptors[pkg]; ok {
+		return b.options.packageCache.loadPackageSchemaFromDescriptor(b.options.loader, descriptor)
+	}
+	return b.options.packageCache.loadPackageSchema(context.TODO(), b.options.loader, pkg, "", "")
+}
+
 // annotateObjectProperties annotates the properties of an object expression with the
 // types of the corresponding properties in the schema. This is used to provide type
 // information for invoke calls that didn't have type annotations.
@@ -107,16 +139,11 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), nil
 	}
 
-	template, ok := args[0].(*model.TemplateExpression)
-	if !ok || len(template.Parts) != 1 {
-		return b.zeroSignature(), hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
-	}
-	lit, ok := template.Parts[0].(*model.LiteralValueExpression)
-	if !ok || model.StringType.ConversionFrom(lit.Type()) == model.NoConversion {
+	token, lit, tokenRange, ok := invokeTokenArgument(args)
+	if !ok {
 		return b.zeroSignature(), hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
 	}
 
-	token, tokenRange := lit.Value.AsString(), args[0].SyntaxNode().Range()
 	pkg, _, _, diagnostics := DecomposeToken(token, tokenRange)
 	if diagnostics.HasErrors() {
 		return b.zeroSignature(), diagnostics
@@ -168,6 +195,20 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 	if len(args) < 2 {
 		return b.zeroSignature(), hcl.Diagnostics{errorf(tokenRange, "missing second arg")}
 	}
+
+	// A function declared with multiArgumentInputs must be invoked positionally, e.g.
+	// invoke(token, a, b) rather than invoke(token, { p1 = a, p2 = b }). Reject the object-argument
+	// form and bind positional calls against a per-input signature; rewritePositionalInvokes later
+	// normalizes them to the object form. See invoke_positional.go.
+	if fn.MultiArgumentInputs {
+		if b.invokeUsesObjectArgument(fn, args) {
+			return b.zeroSignature(), hcl.Diagnostics{errorf(tokenRange,
+				"function %q is declared with multi-argument inputs and must be invoked with positional "+
+					"arguments, e.g. invoke(%q, arg1, arg2), not a single object argument", token, token)}
+		}
+		return b.positionalInvokeSignature(fn), nil
+	}
+
 	sig, err := b.signatureForArgs(fn, args[1].Type())
 	if err != nil {
 		diag := hcl.Diagnostics{errorf(tokenRange, "Invoke binding error: %v", err)}

--- a/pkg/codegen/pcl/invoke_positional.go
+++ b/pkg/codegen/pcl/invoke_positional.go
@@ -1,0 +1,192 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// A function declared with multiArgumentInputs must be invoked positionally, passing one argument
+// per input rather than wrapping them in a single object argument:
+//
+//	invoke("pkg:index:fn", arg1, arg2)            // required
+//	invoke("pkg:index:fn", { p1 = arg1, p2 = arg2 }) // rejected by the binder
+//
+// The optional invokeOptions object is passed as a final positional argument, after one argument
+// per input. To supply invokeOptions while omitting an optional input, pass null for that input:
+//
+//	invoke("pkg:index:fn", arg1, null, { provider = p })
+//
+// Positional invokes are bound against a per-input signature (see positionalInvokeSignature) and
+// then normalized to the object form by rewritePositionalInvokes, so that the rest of PCL and every
+// program generator only ever observe the object form.
+
+// invokeUsesObjectArgument reports whether an invoke's second argument is a single object assignable
+// to the function's input object (in either its plain or its inputy shape), i.e. the object-argument
+// form rather than the positional form.
+func (b *binder) invokeUsesObjectArgument(fn *schema.Function, args []model.Expression) bool {
+	if fn.Inputs == nil || len(args) < 2 {
+		return false
+	}
+	plain := b.schemaTypeToType(fn.Inputs)
+	inputy := b.schemaTypeToType(fn.Inputs.InputShape)
+	argType := args[1].Type()
+	return plain.ConversionFrom(argType) != model.NoConversion ||
+		inputy.ConversionFrom(argType) != model.NoConversion
+}
+
+// positionalInvokeSignature builds the signature for a positional multi-argument invoke:
+// (token, <input 1>, <input 2>, ..., invokeOptions?). The parameters follow the order declared by
+// the function's multiArgumentInputs. Optional inputs accept null, allowing a caller to skip them
+// while still supplying the trailing invokeOptions argument.
+func (b *binder) positionalInvokeSignature(fn *schema.Function) model.StaticFunctionSignature {
+	params := make([]model.Parameter, 0, len(fn.Inputs.Properties)+2)
+	params = append(params, model.Parameter{Name: "token", Type: model.StringType})
+	for _, prop := range fn.Inputs.Properties {
+		t := b.schemaTypeToType(prop.Type)
+		if !prop.IsRequired() && !model.IsOptionalType(t) {
+			t = model.NewOptionalType(t)
+		}
+		params = append(params, model.Parameter{Name: prop.Name, Type: t})
+	}
+	params = append(params, model.Parameter{
+		Name: "invokeOptions",
+		Type: model.NewOptionalType(invokeOptionsType()),
+	})
+
+	var returnType model.Type
+	if fn.ReturnType == nil {
+		returnType = model.NewObjectType(map[string]model.Type{})
+	} else {
+		returnType = b.schemaTypeToType(fn.ReturnType)
+	}
+
+	return model.StaticFunctionSignature{
+		Parameters:          params,
+		ReturnType:          model.NewPromiseType(returnType),
+		MultiArgumentInputs: fn.MultiArgumentInputs,
+	}
+}
+
+// invokeFunction re-resolves the schema function referenced by an invoke call's arguments. It
+// mirrors the lookup performed during signature binding (sharing invokeTokenArgument and
+// loadPackageSchema) and relies on the package cache, so it is cheap to call again after binding.
+func (b *binder) invokeFunction(args []model.Expression) (*schema.Function, bool) {
+	token, _, _, ok := invokeTokenArgument(args)
+	if !ok {
+		return nil, false
+	}
+	pkg, _, _, diags := DecomposeToken(token, hcl.Range{})
+	if diags.HasErrors() {
+		return nil, false
+	}
+	pkgSchema, err := b.loadPackageSchema(pkg)
+	if err != nil {
+		return nil, false
+	}
+	fn, _, found, err := pkgSchema.LookupFunction(token)
+	if err != nil || !found {
+		return nil, false
+	}
+	return fn, true
+}
+
+// rewritePositionalInvokes normalizes every positional multi-argument invoke in the program into the
+// object-argument form, so that program generators only need to handle the object form.
+func (b *binder) rewritePositionalInvokes() hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	for _, n := range b.nodes {
+		diags = diags.Extend(n.VisitExpressions(nil, b.rewritePositionalInvoke))
+	}
+	return diags
+}
+
+// rewritePositionalInvoke rewrites a single positional multi-argument invoke call into the object
+// form: invoke(token, v1, v2) becomes invoke(token, { p1 = v1, p2 = v2 }), preserving any trailing
+// invokeOptions argument. Non-invoke expressions and invokes already in object form are returned
+// unchanged.
+func (b *binder) rewritePositionalInvoke(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	call, ok := expr.(*model.FunctionCallExpression)
+	if !ok || call.Name != Invoke || !call.Signature.MultiArgumentInputs {
+		return expr, nil
+	}
+	fn, ok := b.invokeFunction(call.Args)
+	if !ok || fn.Inputs == nil {
+		return expr, nil
+	}
+	// A successfully-bound multi-argument invoke is always positional; guard against re-processing a
+	// call that is already in object form.
+	if b.invokeUsesObjectArgument(fn, call.Args) {
+		return expr, nil
+	}
+
+	// The positional signature is (token, input₁ … inputₙ, invokeOptions?), and the binder rejects
+	// any further arguments. So the arguments after the token are one value per input (with optional
+	// inputs possibly null), optionally followed by a single invokeOptions object.
+	numInputs := len(fn.Inputs.Properties)
+	inputArgs := call.Args[1:]
+	var optionsArg model.Expression
+	if len(inputArgs) > numInputs {
+		contract.Assertf(len(inputArgs) == numInputs+1,
+			"positional invoke of %q bound with %d arguments for %d inputs", fn.Token, len(inputArgs), numInputs)
+		optionsArg, inputArgs = inputArgs[numInputs], inputArgs[:numInputs]
+	}
+
+	// Build the object argument, keyed by the input property names in declaration order.
+	items := make([]model.ObjectConsItem, len(inputArgs))
+	for i, value := range inputArgs {
+		items[i] = model.ObjectConsItem{
+			Key:   &model.LiteralValueExpression{Value: cty.StringVal(fn.Inputs.Properties[i].Name)},
+			Value: value,
+		}
+	}
+	args := &model.ObjectConsExpression{
+		Tokens: syntax.NewObjectConsTokens(len(items)),
+		Items:  items,
+	}
+	// Typecheck computes and caches the object's type from its items. The constructed object has
+	// string-literal keys and already-bound values, so it cannot produce diagnostics.
+	typecheckDiags := args.Typecheck(false)
+	contract.Assertf(len(typecheckDiags) == 0,
+		"constructing the invoke argument object for %q produced diagnostics: %v", fn.Token, typecheckDiags)
+	annotateObjectProperties(args.Type(), fn.Inputs)
+
+	newArgs := []model.Expression{call.Args[0], args}
+	if optionsArg != nil {
+		newArgs = append(newArgs, optionsArg)
+	}
+
+	sig, err := b.signatureForArgs(fn, args.Type())
+	if err != nil {
+		// Binding already succeeded against the positional signature; leave the call as-is.
+		return expr, nil
+	}
+	sig.MultiArgumentInputs = fn.MultiArgumentInputs
+
+	return &model.FunctionCallExpression{
+		Syntax:      call.Syntax,
+		Tokens:      syntax.NewFunctionCallTokens(call.Name, len(newArgs)),
+		Name:        call.Name,
+		Signature:   sig,
+		Args:        newArgs,
+		ExpandFinal: call.ExpandFinal,
+	}, nil
+}

--- a/pkg/codegen/pcl/invoke_positional_test.go
+++ b/pkg/codegen/pcl/invoke_positional_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pcl_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
+)
+
+// multiArgInvoke binds a program containing a single local variable `result` whose value is an
+// invoke of the multiArgumentInputs function `multiarg:index:funcWithMultiArgs`, and returns the
+// bound invoke call expression along with the binding diagnostics.
+func multiArgInvoke(t *testing.T, invokeExpr string) (*model.FunctionCallExpression, hcl.Diagnostics) {
+	t.Helper()
+	source := "result = " + invokeExpr + "\n"
+	program, diags, err := ParseAndBindProgram(t, source, "program.pp")
+	if diags.HasErrors() {
+		// On binding errors BindProgram returns the diagnostics as the error too; surface the
+		// diagnostics to the caller rather than failing here.
+		return nil, diags
+	}
+	require.NoError(t, err)
+
+	require.Len(t, program.Nodes, 1, "expected a single node")
+	local, ok := program.Nodes[0].(*pcl.LocalVariable)
+	require.True(t, ok, "expected a local variable, got %T", program.Nodes[0])
+	call, ok := local.Definition.Value.(*model.FunctionCallExpression)
+	require.True(t, ok, "expected the local's value to be a function call, got %T", local.Definition.Value)
+	return call, diags
+}
+
+// The object-argument form is rejected for multiArgumentInputs functions.
+func TestMultiArgumentInvokeRejectsObjectArgument(t *testing.T) {
+	t.Parallel()
+
+	_, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", { a = "hello", b = "world" })`)
+
+	require.True(t, diags.HasErrors(), "expected the object-argument form to be rejected")
+	require.Contains(t, diags.Error(), "must be invoked with positional arguments")
+}
+
+// The positional form binds and is normalized to the object-argument form.
+func TestMultiArgumentInvokePositional(t *testing.T) {
+	t.Parallel()
+
+	call, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", "hello", "world")`)
+	require.False(t, diags.HasErrors(), "unexpected diagnostics: %v", diags)
+
+	// After normalization the call is invoke(token, { a = ..., b = ... }) with no options argument.
+	require.Len(t, call.Args, 2)
+	requireObjectKeys(t, call.Args[1], []string{"a", "b"})
+}
+
+// Only the required input is supplied; the optional input is omitted.
+func TestMultiArgumentInvokeOmitsOptionalInput(t *testing.T) {
+	t.Parallel()
+
+	call, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", "hello")`)
+	require.False(t, diags.HasErrors(), "unexpected diagnostics: %v", diags)
+
+	require.Len(t, call.Args, 2)
+	requireObjectKeys(t, call.Args[1], []string{"a"})
+}
+
+// invokeOptions may be passed as a trailing positional argument.
+func TestMultiArgumentInvokeWithOptions(t *testing.T) {
+	t.Parallel()
+
+	call, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", "hello", "world", { version = "1.2.3" })`)
+	require.False(t, diags.HasErrors(), "unexpected diagnostics: %v", diags)
+
+	// The inputs are collapsed into the object argument and the options object is preserved as the
+	// trailing argument.
+	require.Len(t, call.Args, 3)
+	requireObjectKeys(t, call.Args[1], []string{"a", "b"})
+	requireObjectKeys(t, call.Args[2], []string{"version"})
+}
+
+// An optional input can be skipped with null in order to supply trailing invokeOptions.
+func TestMultiArgumentInvokeWithOptionsAndNullInput(t *testing.T) {
+	t.Parallel()
+
+	call, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", "hello", null, { version = "1.2.3" })`)
+	require.False(t, diags.HasErrors(), "unexpected diagnostics: %v", diags)
+
+	require.Len(t, call.Args, 3)
+	requireObjectKeys(t, call.Args[1], []string{"a", "b"})
+	requireObjectKeys(t, call.Args[2], []string{"version"})
+}
+
+// An argument after invokeOptions (i.e. more arguments than inputs plus options) is rejected.
+func TestMultiArgumentInvokeRejectsTooManyArguments(t *testing.T) {
+	t.Parallel()
+
+	_, diags := multiArgInvoke(t,
+		`invoke("multiarg:index:funcWithMultiArgs", "hello", "world", { version = "1.2.3" }, "extra")`)
+
+	require.True(t, diags.HasErrors(), "expected an argument after invokeOptions to be rejected")
+}
+
+// requireObjectKeys asserts that the expression is an object construction with exactly the given
+// literal keys, in order.
+func requireObjectKeys(t *testing.T, expr model.Expression, keys []string) {
+	t.Helper()
+	obj, ok := expr.(*model.ObjectConsExpression)
+	require.True(t, ok, "expected an object construction expression, got %T", expr)
+	actual := make([]string, 0, len(obj.Items))
+	for _, item := range obj.Items {
+		lit, ok := item.Key.(*model.LiteralValueExpression)
+		require.True(t, ok, "expected a literal key, got %T", item.Key)
+		actual = append(actual, lit.Value.AsString())
+	}
+	require.Equal(t, keys, actual)
+}

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -107,6 +107,7 @@ func NewContext(schemaDirectoryPath string) *plugin.Context {
 		SchemaProvider{"tls", "4.10.0"},
 		SchemaProvider{"random", "4.11.2"},
 		SchemaProvider{"std", "1.0.0"},
+		SchemaProvider{"multiarg", "1.0.0"},
 
 		SchemaProvider{"component", "13.3.7"},
 		SchemaProvider{"importer", "1.0.0"},

--- a/pkg/testing/pulumi-test-language/tests/testdata/l2-invoke-multi-argument/main.pp
+++ b/pkg/testing/pulumi-test-language/tests/testdata/l2-invoke-multi-argument/main.pp
@@ -1,7 +1,7 @@
 output "both" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello", second = "world"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", "world").result
 }
 
 output "onlyRequired" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello").result
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-invoke-multi-argument/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/eject-pcl/l2-invoke-multi-argument/main.pp
@@ -1,7 +1,7 @@
 output "both" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello", second = "world"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", "world").result
 }
 
 output "onlyRequired" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello").result
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-invoke-multi-argument/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/projects/l2-invoke-multi-argument/main.pp
@@ -1,7 +1,7 @@
 output "both" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello", second = "world"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", "world").result
 }
 
 output "onlyRequired" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello").result
 }

--- a/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-invoke-multi-argument/main.pp
+++ b/sdk/pcl/cmd/pulumi-language-pcl/testdata/round-tripped-project/l2-invoke-multi-argument/main.pp
@@ -1,7 +1,7 @@
 output "both" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello", second = "world"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", "world").result
 }
 
 output "onlyRequired" {
-    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", {first = "hello"}).result
+    value = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello").result
 }

--- a/tests/testdata/codegen/multiarg-1.0.0.json
+++ b/tests/testdata/codegen/multiarg-1.0.0.json
@@ -1,0 +1,38 @@
+{
+  "name": "multiarg",
+  "version": "1.0.0",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "provider": {
+    "type": "object"
+  },
+  "functions": {
+    "multiarg:index:funcWithMultiArgs": {
+      "description": "A function whose inputs are passed positionally.",
+      "multiArgumentInputs": ["a", "b"],
+      "inputs": {
+        "type": "object",
+        "properties": {
+          "a": {
+            "type": "string"
+          },
+          "b": {
+            "type": "string"
+          }
+        },
+        "required": ["a"]
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "string"
+          }
+        },
+        "required": ["result"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

A function declared with `multiArgumentInputs` is now invoked in PCL by passing its inputs **positionally** rather than as a single object argument:

```hcl
# before
invoke("pkg:index:fn", { p1 = arg1, p2 = arg2 })
# now
invoke("pkg:index:fn", arg1, arg2)
```

The binder **rejects the object-argument form** for such functions with a clear diagnostic (*"function … is declared with multi-argument inputs and must be invoked with positional arguments…"*).

The optional `invokeOptions` object is passed as a final positional argument, after one argument per input. To supply options while omitting an optional input, pass `null` for that input:

```hcl
invoke("pkg:index:fn", arg1, null, { provider = p })
```

Anything beyond one argument per input plus the options object is rejected.

## How it works

Positional invokes bind against a per-input signature `(token, input₁, …, inputₙ, invokeOptions?)`, and a post-bind pass normalizes the call back into the object-argument form. As a result the rest of PCL and **every program generator continue to observe only the object form** — no generator changes are needed, and PCL itself round-trips the positional source.

The `l2-invoke-multi-argument` conformance program is updated to the positional form (its PCL snapshots regenerate accordingly; TypeScript output is unchanged because the normalized object form is identical).

The schema lookup shared by signature binding and the post-bind normalization is factored into `invokeTokenArgument` and the binder's `loadPackageSchema` helper.

## Testing

- New unit tests in `pkg/codegen/pcl/invoke_positional_test.go`: object-argument form rejected, positional happy paths, optional-input omission, `invokeOptions` as a trailing argument (with and without a `null` placeholder), and too-many-arguments rejection. A `multiarg` test schema fixture is added.
- `l2-invoke-multi-argument` conformance passes for PCL and TypeScript (Go and Python remain expected failures, unchanged).
- `make lint_golang` is clean.

## Checklist

- [x] I have run `make lint` to verify my code passes the lint check
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make changelog` and committed the `changelog/pending/<file>` documenting my change
