### PR TITLE
fix typos in CLI help strings

### DIFF
--- a/pkg/cmd/pulumi/cmd/cmd.go
+++ b/pkg/cmd/pulumi/cmd/cmd.go
@@ -167,7 +167,7 @@ We would appreciate a report: https://github.com/pulumi/pulumi/issues/
 
 	if sie.Op == snapshot.SnapshotIntegrityRead && sie.Metadata == nil {
 		message.WriteString(`
-NOTE: This error occurred while reading a snaphot. This error was introduced by
+NOTE: This error occurred while reading a snapshot. This error was introduced by
 a previous operation when it wrote the snapshot. If you have details about that
 operation, please include them in your report as well.
 `)

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -219,7 +219,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd.Flags().IntVar(&parallel,
 		"parallel", 4, "The max number of concurrent installs to perform. "+
-			"Parallelism of less then 1 implies unbounded parallelism")
+			"Parallelism of less than 1 implies unbounded parallelism")
 	cmd.PersistentFlags().BoolVar(&reinstall,
 		"reinstall", false, "Reinstall a plugin even if it already exists")
 	cmd.PersistentFlags().BoolVar(&noPlugins,
@@ -227,7 +227,7 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&noDependencies,
 		"no-dependencies", false, "Skip installing dependencies")
 	cmd.PersistentFlags().BoolVar(&useLanguageVersionTools,
-		"use-language-version-tools", false, "Use language version tools to setup and install the language runtime")
+		"use-language-version-tools", false, "Use language version tools to set up and install the language runtime")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/logs/logs.go
+++ b/pkg/cmd/pulumi/logs/logs.go
@@ -138,7 +138,7 @@ func NewLogsCmd(ws pkgWorkspace.Context) *cobra.Command {
 					return fmt.Errorf("failed to get logs: %w", err)
 				}
 
-				// When we are emitting a fixed number of log entries, and outputing JSON, wrap them in an array.
+				// When we are emitting a fixed number of log entries, and outputting JSON, wrap them in an array.
 				if !follow && jsonOut {
 					entries := slice.Prealloc[logEntryJSON](len(logs))
 

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -664,7 +664,7 @@ func NewImportCmd() *cobra.Command {
 			"The type token and property used for resource lookup are available in the Import section of\n" +
 			"the resource's API documentation in the Pulumi Registry (https://www.pulumi.com/registry/)." +
 			"\n" +
-			"To fully specify parent and/or provider, subsitute the <urn> for each into the following:\n" +
+			"To fully specify parent and/or provider, substitute the <urn> for each into the following:\n" +
 			"\n" +
 			"     pulumi import 'aws:iam/user:User' name id --parent 'parent=<urn>' --provider 'admin=<urn>'\n" +
 			"\n" +

--- a/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
+++ b/pkg/cmd/pulumi/packageinstallation/packageinstallation.go
@@ -118,7 +118,7 @@ type Options struct {
 	packageresolution.Options
 	// The maximum number of concurrent operations.
 	//
-	// If Concurrency is less then 1, the number of concurrent operations is unbounded.
+	// If Concurrency is less than 1, the number of concurrent operations is unbounded.
 	Concurrency int
 
 	// A [PriorState] representing existing work done that won't be repeated.

--- a/pkg/cmd/pulumi/policy/policy_group_ls.go
+++ b/pkg/cmd/pulumi/policy/policy_group_ls.go
@@ -144,7 +144,7 @@ func formatPolicyGroupsConsole(w io.Writer, policyGroups []apitype.PolicyGroupSu
 		// Number of enabled Policy Packs column
 		numPolicyPacks := strconv.Itoa(group.NumEnabledPolicyPacks)
 
-		// Number of stacks colum
+		// Number of stacks column
 		numStacks := strconv.Itoa(group.NumStacks)
 
 		// Render the columns.

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -588,7 +588,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 	return cmd, cleanup
 }
 
-// haveNewerDevVersion checks whethere we have a newer dev version available.
+// haveNewerDevVersion checks whether we have a newer dev version available.
 func haveNewerDevVersion(devVersion semver.Version, curVersion semver.Version) bool {
 	if devVersion.Major != curVersion.Major {
 		return devVersion.Major > curVersion.Major

--- a/pkg/cmd/pulumi/trace/convert.go
+++ b/pkg/cmd/pulumi/trace/convert.go
@@ -669,7 +669,7 @@ func exportTraceToOtel(w io.Writer, querier appdash.Queryer, ignoreLogSpans bool
 		return err
 	}
 
-	// Conver the trace roots.
+	// Convert the trace roots.
 	for _, r := range roots {
 		if err = t.newSpan(r, nil); err != nil {
 			return err

--- a/pkg/testing/pulumi-test-language/program_overrides_test.go
+++ b/pkg/testing/pulumi-test-language/program_overrides_test.go
@@ -134,7 +134,7 @@ func (h *ProgramOverridesLanguageHost) Run(
 }
 
 // Tests that a conformance test which specifies program overrides does not ask the language host to generate a project,
-// but otherwise behaves as expected (validating snaphots, checking assertions, etc.).
+// but otherwise behaves as expected (validating snapshots, checking assertions, etc.).
 func TestProgramOverrides_DontGenerateProgram(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Noticed a few typos that are also replicated in the docs. This PR fixes some of those (along with some typos in the comments). Should be a safe, easy, and boring change.
