### PR TITLE
fix: agent account refresh token fixes

### DIFF
--- a/changelog/pending/cli-auth-fix-agent-claim-cleanup-after-refresh-20260615.yaml
+++ b/changelog/pending/cli-auth-fix-agent-claim-cleanup-after-refresh-20260615.yaml
@@ -1,0 +1,6 @@
+component: cli/auth
+kind: fix
+body: Stop emitting the `PULUMI_EPHEMERAL_AGENT_ACCOUNT` instruction (and stale claim URL) after a claim has bound the agent's refresh token to a user
+time: 2026-06-15T00:00:00+00:00
+custom:
+  PR: ""

--- a/changelog/pending/cli-auth-fix-refresh-wrapper-explicit-home-20260615.yaml
+++ b/changelog/pending/cli-auth-fix-refresh-wrapper-explicit-home-20260615.yaml
@@ -1,0 +1,6 @@
+component: cli/auth
+kind: fix
+body: Auto-refresh now installs for agents that set `PULUMI_HOME` or `PULUMI_CREDENTIALS_PATH` for state isolation; previously the refresh wrapper silently did not install and mid-session token expiry surfaced as a "login required" error
+time: 2026-06-15T00:00:00+00:00
+custom:
+  PR: ""

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -281,8 +281,13 @@ func New(ctx context.Context, d diag.Sink,
 
 	apiClient := client.NewClient(cloudURL, apiToken, insecure, d)
 	apiClient.WithRefresh(account.RefreshToken, func(at string, expiresAt time.Time, rt string) error {
+		prev := account.AccessToken
 		account.SetCredentials(at, expiresAt, rt)
-		return account.Save(cloudURL, false)
+		if err := account.Save(cloudURL, false); err != nil {
+			return err
+		}
+		cleanupAgentClaimIfSubjectChanged(prev, at, cloudURL)
+		return nil
 	})
 	escClient := esc_client.New(client.UserAgent(), cloudURL, apiToken, insecure)
 
@@ -552,7 +557,9 @@ func validateStoredAccount(
 		fetchedUser, fetchedOrgs, fetchedTokenInfo, err := getAccountDetails(
 			ctx, cloudURL, insecure, account.AccessToken, account.RefreshToken,
 			func(at string, expiresAt time.Time, rt string) error {
+				prev := account.AccessToken
 				account.SetCredentials(at, expiresAt, rt)
+				cleanupAgentClaimIfSubjectChanged(prev, at, cloudURL)
 				return nil
 			},
 		)
@@ -2628,6 +2635,39 @@ func isExpectedTokenFormat(token string) bool {
 		return true
 	}
 	return false
+}
+
+// cleanupAgentClaimIfSubjectChanged removes the cached agent-claim file when an access-token
+// refresh returns an OBO whose subject differs from the previous one. The subject is the bound
+// user — when it changes, the agent's refresh token has been repointed onto a different identity
+// (the post-signup claim flow). Without this cleanup, MaybePrintClaimWarning keeps surfacing the
+// stale claim URL on every subsequent command.
+//
+// Best-effort: a failure here is logged but doesn't fail the refresh, since the access token is
+// already minted and persisted by the time we get here.
+func cleanupAgentClaimIfSubjectChanged(prevAccessToken, newAccessToken, cloudURL string) {
+	prevSub := jwtSubject(prevAccessToken)
+	newSub := jwtSubject(newAccessToken)
+	if prevSub == "" || newSub == "" || prevSub == newSub {
+		return
+	}
+	if err := workspace.DeleteAgentClaim(cloudURL); err != nil {
+		logging.V(7).Infof("Could not clean up agent-claim file for %q after subject change: %v", cloudURL, err)
+	}
+}
+
+// jwtSubject returns the sub claim of a JWT without verifying its signature. Returns "" when the
+// input is empty, not a parseable JWT, or carries no sub claim.
+func jwtSubject(token string) string {
+	if token == "" {
+		return ""
+	}
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(token, claims); err != nil {
+		return ""
+	}
+	sub, _ := claims["sub"].(string)
+	return sub
 }
 
 // getAccountDetails makes a request to get the authenticated user. If it returns a successful response,

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,6 +59,17 @@ import (
 //
 //nolint:lll // JWT token is long
 const testJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+// unsignedJWTWithSub builds a parseable-but-unsigned JWT carrying the given subject and a unique
+// jti. The jti keeps successive tokens distinguishable on the wire even when the subject hasn't
+// changed — that's the real-world shape (two OBOs minted minutes apart never byte-match).
+func unsignedJWTWithSub(t *testing.T, sub, jti string) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]string{"sub": sub, "jti": jti})
+	require.NoError(t, err)
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
+}
 
 //nolint:paralleltest // mutates global configuration
 func TestEnabledFullyQualifiedStackNames(t *testing.T) {
@@ -555,6 +567,162 @@ func TestCurrentRefreshesLocallyExpiredAccessTokenWhenRefreshTokenStored(t *test
 			"without this the next cold-start can't take the local-expiry refresh path")
 	assert.True(t, saved.TokenInformation.ExpiresAt.After(time.Now()),
 		"the new ExpiresAt must be in the future (roughly now + ExpiresIn)")
+}
+
+//nolint:paralleltest // mutates env vars and shared temporary agent credentials
+func TestCurrentRemovesAgentClaimWhenRefreshedAccessTokenRepointsSubject(t *testing.T) {
+	// Post-claim flow: the agent's stored OBO carries sub=<agent>; the claim repoints the refresh
+	// token onto the human, so the next refresh response carries sub=<human>. The cached agent-
+	// claim file is now stale — without cleanup, MaybePrintClaimWarning keeps surfacing the old
+	// claim URL on every command.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+	t.Setenv(workspace.PulumiCredentialsPathEnvVar, "")
+
+	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
+	require.NoError(t, err)
+	oldAgentClaim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, workspace.DeleteAgentCredentials())
+		require.NoError(t, workspace.StoreAgentCredentials(oldAgentCreds))
+		if oldAgentClaim.ClaimURL != "" {
+			require.NoError(t, workspace.StoreAgentClaim(oldAgentClaim))
+		}
+	})
+
+	staleAccessToken := unsignedJWTWithSub(t, "urn:pulumi:user:agent-c3d44c15", "jti-stale")
+	freshAccessToken := unsignedJWTWithSub(t, "urn:pulumi:user:human-3f9a8b21", "jti-fresh")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			err := json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  freshAccessToken,
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "stored-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			switch req.Header.Get("Authorization") {
+			case "token " + staleAccessToken:
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			case "token " + freshAccessToken:
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "alice",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected Authorization header: %q", req.Header.Get("Authorization"))
+				rw.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  staleAccessToken,
+		RefreshToken: "stored-refresh-token",
+	}, true))
+	require.NoError(t, workspace.StoreAgentClaim(workspace.AgentClaim{
+		CloudURL:   server.URL,
+		ClaimURL:   "https://app.example.com/claim/abc123",
+		ValidUntil: time.Now().Add(24 * time.Hour),
+	}))
+
+	account, err := NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	assert.Equal(t, freshAccessToken, account.AccessToken)
+
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	assert.Empty(t, claim.ClaimURL,
+		"agent-claim file must be removed when the refreshed OBO subject differs from the previous one")
+}
+
+//nolint:paralleltest // mutates env vars and shared temporary agent credentials
+func TestCurrentKeepsAgentClaimWhenRefreshedAccessTokenSubjectUnchanged(t *testing.T) {
+	// Refresh ahead of a claim: pre-claim refreshes return the same agent subject. The agent-claim
+	// file must survive these — premature deletion would lose the only record of the claim URL the
+	// CLI was instructed to surface.
+	pulumiHome := t.TempDir()
+	t.Setenv("PULUMI_HOME", pulumiHome)
+	t.Setenv("PULUMI_ACCESS_TOKEN", "")
+	t.Setenv(workspace.PulumiCredentialsPathEnvVar, "")
+
+	oldAgentCreds, err := workspace.GetAgentStoredCredentials()
+	require.NoError(t, err)
+	oldAgentClaim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, workspace.DeleteAgentCredentials())
+		require.NoError(t, workspace.StoreAgentCredentials(oldAgentCreds))
+		if oldAgentClaim.ClaimURL != "" {
+			require.NoError(t, workspace.StoreAgentClaim(oldAgentClaim))
+		}
+	})
+
+	staleAccessToken := unsignedJWTWithSub(t, "urn:pulumi:user:agent-c3d44c15", "jti-stale")
+	freshAccessToken := unsignedJWTWithSub(t, "urn:pulumi:user:agent-c3d44c15", "jti-fresh")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/oauth/token":
+			err := json.NewEncoder(rw).Encode(apitype.TokenExchangeGrantResponse{
+				AccessToken:  freshAccessToken,
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+				RefreshToken: "stored-refresh-token",
+			})
+			require.NoError(t, err)
+		case "/api/user":
+			switch req.Header.Get("Authorization") {
+			case "token " + staleAccessToken:
+				rw.WriteHeader(http.StatusUnauthorized)
+				err := json.NewEncoder(rw).Encode(apitype.ErrorResponse{Code: 401, Message: "Unauthorized"})
+				require.NoError(t, err)
+			case "token " + freshAccessToken:
+				err := json.NewEncoder(rw).Encode(map[string]any{
+					"githubLogin":   "agent-display",
+					"organizations": []map[string]string{},
+				})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected Authorization header: %q", req.Header.Get("Authorization"))
+				rw.WriteHeader(http.StatusUnauthorized)
+			}
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	claimURL := "https://app.example.com/claim/keep-me"
+	require.NoError(t, workspace.StoreAccount(server.URL, workspace.Account{
+		AccessToken:  staleAccessToken,
+		RefreshToken: "stored-refresh-token",
+	}, true))
+	require.NoError(t, workspace.StoreAgentClaim(workspace.AgentClaim{
+		CloudURL:   server.URL,
+		ClaimURL:   claimURL,
+		ValidUntil: time.Now().Add(24 * time.Hour),
+	}))
+
+	_, err = NewLoginManager().Current(t.Context(), server.URL, false, true)
+	require.NoError(t, err)
+
+	claim, err := workspace.GetAgentClaim()
+	require.NoError(t, err)
+	assert.Equal(t, claimURL, claim.ClaimURL,
+		"agent-claim file must be preserved when the refresh keeps the same subject (no claim event)")
 }
 
 //nolint:paralleltest // mutates env vars and shared temporary agent credentials

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -82,8 +82,11 @@ func GetAccountWithAgentFallback(key string) (Account, bool, error) {
 		return account, false, nil
 	}
 
+	// PULUMI_HOME / PULUMI_CREDENTIALS_PATH select where regular credentials live (often for state
+	// isolation in CI, sandboxes, or dev containers) — they don't mean "don't use agent credentials."
+	// Only an outright read error at an explicit path counts as a signal to stop and surface it.
 	agent := agentdetect.Detect(os.Getenv)
-	if agent == "" || hasExplicitPulumiPathEnv() {
+	if agent == "" || (err != nil && hasExplicitPulumiPathEnv()) {
 		return account, false, err
 	}
 

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -733,6 +733,12 @@ func DeleteAgentAccount(key string) error {
 	return result
 }
 
+// DeleteAgentClaim removes the singleton shared temporary agent claim file when the stored claim
+// belongs to the given cloud URL. No-op when the claim file is missing or points elsewhere.
+func DeleteAgentClaim(key string) error {
+	return deleteAgentClaim(key)
+}
+
 // deleteAgentClaim removes the singleton shared temporary agent claim file when
 // the stored claim belongs to the given cloud URL.
 func deleteAgentClaim(key string) error {

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -474,8 +474,12 @@ func TestGetAccountWithAgentFallbackDisabledOutsideAgentMode(t *testing.T) {
 	assert.Empty(t, account.AccessToken)
 }
 
+// PULUMI_HOME is for state isolation (sandboxes, CI runners, dev containers) — it doesn't mean
+// "don't use agent credentials." An empty default credentials file at the explicit path falls
+// through to the shared agent cache just like a missing default file does.
+//
 //nolint:paralleltest // mutates environment and package global
-func TestGetAccountWithAgentFallbackDisabledWithExplicitHome(t *testing.T) {
+func TestGetAccountWithAgentFallbackUsesAgentCredentialsWithExplicitHome(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir
 	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
 	t.Cleanup(func() {
@@ -492,12 +496,12 @@ func TestGetAccountWithAgentFallbackDisabledWithExplicitHome(t *testing.T) {
 
 	account, fromAgent, err := GetAccountWithAgentFallback(cloudURL)
 	require.NoError(t, err)
-	assert.False(t, fromAgent)
-	assert.Empty(t, account.AccessToken)
+	assert.True(t, fromAgent)
+	assert.Equal(t, "agent-token", account.AccessToken)
 }
 
 //nolint:paralleltest // mutates environment and package global
-func TestGetAccountWithAgentFallbackDisabledWithExplicitCredentialsPath(t *testing.T) {
+func TestGetAccountWithAgentFallbackUsesAgentCredentialsWithExplicitCredentialsPath(t *testing.T) {
 	oldAgentPulumiDir := agentPulumiDir
 	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
 	t.Cleanup(func() {
@@ -514,6 +518,33 @@ func TestGetAccountWithAgentFallbackDisabledWithExplicitCredentialsPath(t *testi
 
 	account, fromAgent, err := GetAccountWithAgentFallback(cloudURL)
 	require.NoError(t, err)
+	assert.True(t, fromAgent)
+	assert.Equal(t, "agent-token", account.AccessToken)
+}
+
+// An explicit credentials path that errors out (malformed file) is a misconfiguration the user
+// intended; surface it instead of silently falling through to agent credentials.
+//
+//nolint:paralleltest // mutates environment and package global
+func TestGetAccountWithAgentFallbackPropagatesDefaultReadErrorWithExplicitPath(t *testing.T) {
+	oldAgentPulumiDir := agentPulumiDir
+	agentPulumiDir = filepath.Join(t.TempDir(), ".pulumi")
+	t.Cleanup(func() {
+		require.NoError(t, DeleteAgentCredentials())
+		agentPulumiDir = oldAgentPulumiDir
+	})
+
+	setAgentEnv(t)
+	credsDir := t.TempDir()
+	t.Setenv(PulumiCredentialsPathEnvVar, credsDir)
+	t.Setenv("PULUMI_HOME", "")
+	require.NoError(t, os.WriteFile(filepath.Join(credsDir, "credentials.json"), []byte("{not json"), 0o600))
+
+	cloudURL := "https://api.malformed-default.example.com"
+	require.NoError(t, StoreAgentAccount(cloudURL, Account{AccessToken: "agent-token"}, true))
+
+	account, fromAgent, err := GetAccountWithAgentFallback(cloudURL)
+	require.Error(t, err)
 	assert.False(t, fromAgent)
 	assert.Empty(t, account.AccessToken)
 }


### PR DESCRIPTION
This fixes two issues that would have happened when the server started issuing refresh tokens for new agent accounts:

1. Agents that set `PULUMI_HOME` or `PULUMI_CREDENTIALS_PATH` (CI runners, sandboxes, dev containers) would return "login required" after the access token expires, instead of silently auto-refreshing like other agents.

2. After a user claims their agent account, the token would refresh and the CLI would keep working, but the CLI would continue to spam the `PULUMI_EPHEMERAL_AGENT_ACCOUNT` message anyway.

## Test plan

```
go test ./pkg/backend/httpstate/... ./sdk/go/common/workspace/...
```

- [x] `PULUMI_HOME` with empty default → agent-credentials fallback fires
- [x] `PULUMI_CREDENTIALS_PATH` with empty default → agent-credentials fallback fires
- [x] Explicit path + malformed `credentials.json` → error surfaces, no silent fallback
- [x] Refresh whose new access token carries a different `sub` → cached `agent-claim.json` removed
- [x] Refresh whose new access token carries the same `sub` → cached `agent-claim.json` preserved
- [x] End-to-end on a review stack with `PULUMI_HOME` set: agent signs up, refresh fires, human claims via API, the next refresh removes the cached claim and the `PULUMI_EPHEMERAL_AGENT_ACCOUNT` message stops

## Out of scope

Other CLI paths still don't auto-refresh — ESC client, raw HTTP in `pkg/backend/httpstate`, private-template downloads. They were waiting on pulumi-service #44200 (which landed today), and will come in their own PRs.
