### PR TITLE
Modernize TypeScript examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ const sg = new aws.ec2.SecurityGroup("web-sg", {
 
 for (const i of [0, 1, 2]) {
     new aws.ec2.Instance(`web-${i}`, {
-        ami: "ami-7172b611",
-        instanceType: "t2.micro",
+        instanceType: "t3.micro",
         vpcSecurityGroupIds: [sg.id],
         userData: `#!/bin/bash
             echo "Hello, World!" > index.html

--- a/README.md
+++ b/README.md
@@ -37,12 +37,19 @@ For example, create three web servers:
 ```typescript
 import * as aws from "@pulumi/aws";
 
+const ami = aws.ec2.getAmiOutput({
+    mostRecent: true,
+    owners: ["amazon"],
+    filters: [{ name: "name", values: ["al2023-ami-*-x86_64"] }],
+});
+
 const sg = new aws.ec2.SecurityGroup("web-sg", {
     ingress: [{ protocol: "tcp", fromPort: 80, toPort: 80, cidrBlocks: ["0.0.0.0/0"] }],
 });
 
 for (const i of [0, 1, 2]) {
     new aws.ec2.Instance(`web-${i}`, {
+        ami: ami.id,
         instanceType: "t3.micro",
         vpcSecurityGroupIds: [sg.id],
         userData: `#!/bin/bash

--- a/README.md
+++ b/README.md
@@ -35,18 +35,20 @@ and package management that you already know and love.
 For example, create three web servers:
 
 ```typescript
-const aws = require("@pulumi/aws");
+import * as aws from "@pulumi/aws";
+
 const sg = new aws.ec2.SecurityGroup("web-sg", {
     ingress: [{ protocol: "tcp", fromPort: 80, toPort: 80, cidrBlocks: ["0.0.0.0/0"] }],
 });
-for (let i = 0; i < 3; i++) {
+
+for (const i of [0, 1, 2]) {
     new aws.ec2.Instance(`web-${i}`, {
         ami: "ami-7172b611",
         instanceType: "t2.micro",
         vpcSecurityGroupIds: [sg.id],
         userData: `#!/bin/bash
             echo "Hello, World!" > index.html
-            nohup python -m SimpleHTTPServer 80 &`,
+            nohup python3 -m http.server 80 &`,
     });
 }
 ```
@@ -54,23 +56,25 @@ for (let i = 0; i < 3; i++) {
 Or a simple serverless timer that archives Hacker News every day at 8:30AM:
 
 ```typescript
-const aws = require("@pulumi/aws");
+import * as aws from "@pulumi/aws";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 
 const snapshots = new aws.dynamodb.Table("snapshots", {
-    attributes: [{ name: "id", type: "S", }],
-    hashKey: "id", billingMode: "PAY_PER_REQUEST",
+    attributes: [{ name: "id", type: "S" }],
+    hashKey: "id",
+    billingMode: "PAY_PER_REQUEST",
 });
 
-aws.cloudwatch.onSchedule("daily-yc-snapshot", "cron(30 8 * * ? *)", () => {
-    require("https").get("https://news.ycombinator.com", res => {
-        let content = "";
-        res.setEncoding("utf8");
-        res.on("data", chunk => content += chunk);
-        res.on("end", () => new aws.sdk.DynamoDB.DocumentClient().put({
-            TableName: snapshots.name.get(),
-            Item: { date: Date.now(), content },
-        }).promise());
-    }).end();
+aws.cloudwatch.onSchedule("daily-yc-snapshot", "cron(30 8 * * ? *)", async () => {
+    const res = await fetch("https://news.ycombinator.com");
+    const content = await res.text();
+
+    const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+    await client.send(new PutCommand({
+        TableName: snapshots.name.get(),
+        Item: { id: `${Date.now()}`, content },
+    }));
 });
 ```
 


### PR DESCRIPTION
## Description

The two TypeScript snippets in the README were written in a dated JavaScript style — CommonJS `require`, callback/event-stream HTTP, and the end-of-life AWS SDK v2. This modernizes both to current idiom:

- Use ES module `import` instead of `require()`
- Replace the C-style index loop with `for...of`
- Replace the callback/event-stream HTTP request (`https.get` + `res.on(...)`) with `await fetch()`
- Replace AWS SDK v2 (`aws.sdk` + `.promise()`, maintenance ended 2025) with the modular AWS SDK v3 (`@aws-sdk/client-dynamodb` + `@aws-sdk/lib-dynamodb`)
- Use an `async` schedule handler
- Update the `userData` snippet from the Python 2 `SimpleHTTPServer` to `python3 -m http.server`

It also sets the DynamoDB item's `id` attribute, which the table declares as its `hashKey` but the previous example omitted (the old snippet would have failed at runtime with a missing-key error).

## Notes

Docs-only change, so no changelog entry.

The second example's `fetch` and v3-SDK imports were checked against this repo's Node.js closure serializer (`sdk/nodejs/runtime/closure/createClosure.ts`): globals like `fetch` are emitted as `global.fetch` runtime references, and node_modules packages are emitted as `require(...)` by name — so both serialize cleanly into the Lambda. This requires an `nodejs18.x`+ Lambda runtime (for global `fetch` and the bundled v3 SDK) and the `@aws-sdk/*` packages as project dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)