### PR TITLE
Allow dangling snippet references in snapshots

### DIFF
--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -581,7 +581,7 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 
 	// Rewrite References on every snippet. Each value is a URN that may have been an alias for a resource that
 	// is now stored under its canonical URN; updating in place keeps future updates resolving cleanly through
-	// the broker.
+	// the registration observer.
 	if len(newSnap.Snippets) > 0 {
 		snippets := make([]resource.Snippet, len(newSnap.Snippets))
 		edited := false
@@ -788,20 +788,6 @@ func (snap *Snapshot) VerifyIntegrity() error {
 
 			if deletes != len(states)-1 && deletes != len(states) {
 				return snapshot.SnapshotIntegrityErrorf("duplicate resource %s (not marked for deletion)", urn)
-			}
-		}
-
-		// Snippets may declare References to resources outside the snippet itself; each referenced
-		// URN must exist in the snapshot. We check this after the resource loop so all URNs
-		// (including ones referenced "forward" from a snippet) have been recorded.
-		for i, snippet := range snap.Snippets {
-			for ident, ref := range snippet.References {
-				if _, has := urns[resource.URN(ref)]; !has {
-					return snapshot.SnapshotIntegrityErrorf(
-						"snippet %d (type=%q, name=%q) refers to unknown URN %s via identifier %q",
-						i, snippet.Type, snippet.Name, ref, ident,
-					)
-				}
 			}
 		}
 	}

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/snapshot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1251,57 +1250,25 @@ func TestSnapshotToposort_DetectsCycles(t *testing.T) {
 	}
 }
 
-// TestSnapshotVerifyIntegrity_SnippetReferencesKnownURN is the positive case: a snippet whose
-// References map points at a URN that exists in snap.Resources passes integrity verification.
-func TestSnapshotVerifyIntegrity_SnippetReferencesKnownURN(t *testing.T) {
+// TestSnapshotVerifyIntegrity_SnippetReferencesNeedNotExist checks that snippet references are not
+// snapshot integrity constraints. A referenced resource may be absent after a targeted delete and
+// recreated by a later update.
+func TestSnapshotVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 	t.Parallel()
 
-	target := resource.NewURN("stack", "project", "", "pkgA:index:res", "target")
+	missing := resource.NewURN("stack", "project", "", "pkgA:index:res", "missing")
 	snap := &Snapshot{
-		Resources: []*resource.State{
-			{URN: target, Type: "pkgA:index:res"},
-		},
 		Snippets: []resource.Snippet{
 			{
 				Name: "consumer",
 				Type: "pkgA:index:res",
-				Code: `propA = target.id`,
+				Code: `propA = missing.id`,
 				References: map[string]string{
-					"target": string(target),
+					"missing": string(missing),
 				},
 			},
 		},
 	}
 
 	require.NoError(t, snap.VerifyIntegrity())
-}
-
-// TestSnapshotVerifyIntegrity_SnippetReferencesUnknownURN is the negative case: a snippet that
-// references a URN absent from snap.Resources produces a snapshot integrity error naming the
-// snippet, the bad URN, and the identifier through which it was referenced.
-func TestSnapshotVerifyIntegrity_SnippetReferencesUnknownURN(t *testing.T) {
-	t.Parallel()
-
-	missing := resource.NewURN("stack", "project", "", "pkgA:index:res", "missing")
-	snap := &Snapshot{
-		// No resources at all — the snippet's reference is therefore dangling.
-		Snippets: []resource.Snippet{
-			{
-				Name: "consumer",
-				Type: "pkgA:index:res",
-				Code: `propA = ghost.id`,
-				References: map[string]string{
-					"ghost": string(missing),
-				},
-			},
-		},
-	}
-
-	err := snap.VerifyIntegrity()
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unknown URN")
-	require.ErrorContains(t, err, string(missing))
-	require.ErrorContains(t, err, `"ghost"`)
-	_, ok := snapshot.AsSnapshotIntegrityError(err)
-	require.True(t, ok, "should be a SnapshotIntegrityError")
 }

--- a/sdk/go/common/resource/resource_snippet.go
+++ b/sdk/go/common/resource/resource_snippet.go
@@ -52,6 +52,7 @@ type Snippet struct {
 	// The package descriptor for the resource
 	Descriptor PackageDescriptor `json:"descriptor" yaml:"descriptor"`
 	// References declares the external resources that this snippet's Code may refer to by HCL identifier. The map key
-	// is the identifier used inside Code; the value identifies the target resource by its URN.
+	// is the identifier used inside Code; the value identifies the target resource by its URN. The target need not be
+	// present in the snapshot, but it must be registered during an update before the snippet can run.
 	References map[string]string `json:"references,omitempty" yaml:"references,omitempty"`
 }

--- a/sdk/go/common/snapshot/integrity.go
+++ b/sdk/go/common/snapshot/integrity.go
@@ -162,20 +162,6 @@ func VerifyIntegrity(snap *apitype.DeploymentV3) error {
 		}
 	}
 
-	// Snippets may declare References to resources outside the snippet itself; each referenced URN
-	// must exist in the snapshot. We check this after the resource loop so all URNs (including ones
-	// referenced "forward" from a snippet) have been recorded.
-	for i, snippet := range snap.Snippets {
-		for ident, ref := range snippet.References {
-			if _, has := urns[resource.URN(ref)]; !has {
-				return SnapshotIntegrityErrorf(
-					"snippet %d (type=%q, name=%q) refers to unknown URN %s via identifier %q",
-					i, snippet.Type, snippet.Name, ref, ident,
-				)
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/sdk/go/common/snapshot/integrity_test.go
+++ b/sdk/go/common/snapshot/integrity_test.go
@@ -22,69 +22,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
-// makeValidManifest returns a ManifestV1 whose magic cookie matches Version, so VerifyIntegrity
-// passes the magic check and can get to the snippet-reference validation.
-func makeValidManifest() apitype.ManifestV1 {
-	m := apitype.ManifestV1{Version: "test"}
-	m.Magic = m.NewMagic()
-	return m
-}
-
-// TestVerifyIntegrity_SnippetReferencesKnownURN is the positive case: a snippet whose References
-// map points at a URN that exists in snap.Resources should pass integrity verification.
-func TestVerifyIntegrity_SnippetReferencesKnownURN(t *testing.T) {
+func TestVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 	t.Parallel()
 
-	const knownURN = "urn:pulumi:stack::project::pkgA:index:res::target"
+	manifest := apitype.ManifestV1{Version: "test"}
+	manifest.Magic = manifest.NewMagic()
 	snap := &apitype.DeploymentV3{
-		Manifest: makeValidManifest(),
-		Resources: []apitype.ResourceV3{
-			{URN: knownURN, Type: "pkgA:index:res"},
-		},
+		Manifest: manifest,
 		Snippets: []apitype.SnippetV1{
 			{
 				Name: "consumer",
 				Type: "pkgA:index:res",
-				Code: `propA = target.id`,
+				Code: `propA = missing.id`,
 				References: map[string]string{
-					"target": knownURN,
+					"missing": "urn:pulumi:stack::project::pkgA:index:res::missing",
 				},
 			},
 		},
 	}
 
 	require.NoError(t, VerifyIntegrity(snap))
-}
-
-// TestVerifyIntegrity_SnippetReferencesUnknownURN is the negative case: a snippet that references
-// a URN that is not present in snap.Resources should produce a snapshot integrity error naming the
-// snippet, the bad URN, and the identifier through which it was referenced.
-func TestVerifyIntegrity_SnippetReferencesUnknownURN(t *testing.T) {
-	t.Parallel()
-
-	const missingURN = "urn:pulumi:stack::project::pkgA:index:res::missing"
-	snap := &apitype.DeploymentV3{
-		Manifest: makeValidManifest(),
-		// No resources at all — the snippet's reference is therefore dangling.
-		Snippets: []apitype.SnippetV1{
-			{
-				Name: "consumer",
-				Type: "pkgA:index:res",
-				Code: `propA = ghost.id`,
-				References: map[string]string{
-					"ghost": missingURN,
-				},
-			},
-		},
-	}
-
-	err := VerifyIntegrity(snap)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "unknown URN")
-	require.ErrorContains(t, err, missingURN)
-	require.ErrorContains(t, err, `"ghost"`)
-	// Should be reported as a snapshot integrity error so callers using AsSnapshotIntegrityError
-	// can detect and react to it.
-	_, ok := AsSnapshotIntegrityError(err)
-	require.True(t, ok, "should be a SnapshotIntegrityError")
 }


### PR DESCRIPTION
First pass at adding snippets to state we also added them to VerifyIntegrity. Turns out that's not actually right, it's totally valid to have a snippet referring to a URN that is no longer in state. That could happen for example if the snippet resource and referenced resource were both target destroy'd but the snippet wasn't removed. In that case the snippet block is still going to be referring to the URN. This is fine as the next update we'll re-create the deleted resource and then resolve the snippet reference and re-create the snippet resource.