### PR TITLE
upgrade Go to latest patch version in `go.mod`

### DIFF
--- a/docs/utils/go.mod
+++ b/docs/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/docs
 
-go 1.25.8
+go 1.25.11
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../sdk
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/pkg/v3
 
-go 1.25.8
+go 1.25.11
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../sdk
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/v3
 
-go 1.25.8
+go 1.25.11
 
 replace golang.org/x/text => golang.org/x/text v0.3.8
 

--- a/sdk/go/pulumi-language-go/go.mod
+++ b/sdk/go/pulumi-language-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/go/pulumi-language-go/v3
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/go/tools/automation/tests/runtime/go.mod
+++ b/sdk/go/tools/automation/tests/runtime/go.mod
@@ -6,7 +6,7 @@
 
 module github.com/pulumi/pulumi/sdk/v3/go/tools/automation/tests/runtime
 
-go 1.25.8
+go 1.25.11
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../..
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs/v3
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/pcl/go.mod
+++ b/sdk/pcl/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/pcl/v3
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/sdk/python/cmd/pulumi-language-python/go.mod
+++ b/sdk/python/cmd/pulumi-language-python/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python/v3
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.8.3

--- a/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
+++ b/tests/integration/construct_component_configure_provider/testcomponent-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/integration/construct_component_configure_provider/testcomponent-go
 
-go 1.25.8
+go 1.25.11
 
 replace (
 	github.com/atotto/clipboard => github.com/tgummerer/clipboard v0.0.0-20241001131231-d02d263e614e

--- a/tests/integration/construct_component_provider_propagation/go/go.mod
+++ b/tests/integration/construct_component_provider_propagation/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_component_provider_propagation
 
-go 1.25.8
+go 1.25.11
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_component_resource_options/go/go.mod
+++ b/tests/integration/construct_component_resource_options/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_component_resource_options
 
-go 1.25.8
+go 1.25.11
 
 replace github.com/pulumi/pulumi/sdk/v3 => ../../../../sdk
 

--- a/tests/integration/construct_nested_component/go/go.mod
+++ b/tests/integration/construct_nested_component/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi/tests/construct_nested_component
 
-go 1.25.8
+go 1.25.11
 
 require github.com/pulumi/pulumi/sdk/v3 v3.225.1
 

--- a/tests/integration/signal_cancellation/go/go.mod
+++ b/tests/integration/signal_cancellation/go/go.mod
@@ -1,6 +1,6 @@
 module signal-cancellation-go
 
-go 1.25.8
+go 1.25.11
 
 require github.com/pulumi/pulumi/sdk/v3 v3.228.0
 

--- a/tests/integration/signal_cancellation/go_ignore/go.mod
+++ b/tests/integration/signal_cancellation/go_ignore/go.mod
@@ -1,6 +1,6 @@
 module signal-cancellation-go
 
-go 1.25.8
+go 1.25.11
 
 require github.com/pulumi/pulumi/sdk/v3 v3.228.0
 

--- a/tests/integration/signal_cancellation/plugin_go/provider/go.mod
+++ b/tests/integration/signal_cancellation/plugin_go/provider/go.mod
@@ -1,6 +1,6 @@
 module signal-cancellation-plugin-go/provider
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/tests/integration/signal_cancellation/plugin_go_ignore/provider/go.mod
+++ b/tests/integration/signal_cancellation/plugin_go_ignore/provider/go.mod
@@ -1,6 +1,6 @@
 module signal-cancellation-plugin-go-ignore/provider
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
This doesn't really have an impact on anything, but it makes security scanners happier, so let's just bump this to the latest patch release.

This does force everyone still on Go 1.25 to the latest patch release, but being on the latest patch release is generally good, so I don't really see a downside to that.

 Fixes https://github.com/pulumi/pulumi/issues/23373