### PR TITLE
allow symlinks to be extracted

### DIFF
--- a/changelog/pending/cli-plugin-fix-20260616-114840.yaml
+++ b/changelog/pending/cli-plugin-fix-20260616-114840.yaml
@@ -1,0 +1,6 @@
+component: cli/plugin
+kind: fix
+body: Allow plugin tarballs containing symlinks
+time: 2026-06-16T11:48:40.178206401+02:00
+custom:
+    PR: "23587"

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -105,6 +105,33 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 		if _, err = io.Copy(dst, r); err != nil {
 			return fmt.Errorf("untarring file %s: %w", path, err)
 		}
+	case tar.TypeSymlink:
+		// Guard against symlinks that point outside the extraction directory.
+		target := header.Linkname
+		if !filepath.IsAbs(target) {
+			//nolint:gosec // This is only for checking for symlinks outside of the extraction directory.
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		rel, err := filepath.Rel(dir, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("symlink %s points outside the extraction directory", header.Name)
+		}
+
+		linkDir := filepath.Dir(path)
+		if _, err := os.Stat(linkDir); err != nil {
+			if err = os.MkdirAll(linkDir, 0o0700); err != nil {
+				return fmt.Errorf("extracting dir %s: %w", linkDir, err)
+			}
+		}
+
+		if _, err := os.Lstat(path); err == nil {
+			if err = os.Remove(path); err != nil {
+				return fmt.Errorf("removing existing file %s before creating symlink: %w", path, err)
+			}
+		}
+		if err := os.Symlink(header.Linkname, path); err != nil {
+			return fmt.Errorf("extracting symlink %s: %w", path, err)
+		}
 	default:
 		return fmt.Errorf("unexpected plugin file type %s (%v)", header.Name, header.Typeflag)
 	}

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -109,11 +109,11 @@ func extractFile(r *tar.Reader, header *tar.Header, dir string) error {
 		// Guard against symlinks that point outside the extraction directory.
 		target := header.Linkname
 		if !filepath.IsAbs(target) {
-			//nolint:gosec // This is only for checking for symlinks outside of the extraction directory.
+			//nolint:gosec // The resolved target is checked against the destination directory below.
 			target = filepath.Join(filepath.Dir(path), target)
 		}
-		rel, err := filepath.Rel(dir, target)
-		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		target = filepath.Clean(target)
+		if target != cleanDir && !strings.HasPrefix(target, cleanDir+string(os.PathSeparator)) {
 			return fmt.Errorf("symlink %s points outside the extraction directory", header.Name)
 		}
 

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -317,3 +317,106 @@ func TestExtractTGZRelativePathWithEscape(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, escaped, "file escaped destination directory using relative path")
 }
+
+func TestExtractTGZSymlink(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipped on Windows: symlink creation requires elevated privileges")
+	}
+
+	buffer := &bytes.Buffer{}
+	gw := gzip.NewWriter(buffer)
+	tw := tar.NewWriter(gw)
+
+	contents := []byte("hello")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "target.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o600,
+		Size:     int64(len(contents)),
+	}))
+	_, err := tw.Write(contents)
+	require.NoError(t, err)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "link.txt",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "target.txt",
+		Mode:     0o777,
+	}))
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+
+	dir := t.TempDir()
+	require.NoError(t, ExtractTGZ(buffer, dir))
+
+	linkPath := filepath.Join(dir, "link.txt")
+	target, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, "target.txt", target)
+
+	got, err := os.ReadFile(linkPath)
+	require.NoError(t, err)
+	assert.Equal(t, contents, got)
+}
+
+func TestExtractTGZSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipped on Windows: symlink creation requires elevated privileges")
+	}
+
+	tgzWithSymlink := func(t *testing.T, name, linkname string) io.Reader {
+		buffer := &bytes.Buffer{}
+		gw := gzip.NewWriter(buffer)
+		tw := tar.NewWriter(gw)
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Typeflag: tar.TypeSymlink,
+			Linkname: linkname,
+			Mode:     0o777,
+		}))
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+		return buffer
+	}
+
+	cases := []struct {
+		name     string
+		linkname string
+		linkpath string
+	}{
+		{name: "relative parent escape", linkname: "../escape.txt", linkpath: "link.txt"},
+		{name: "nested relative escape", linkname: "../../escape.txt", linkpath: "sub/link.txt"},
+		{name: "absolute escape", linkname: "/etc/passwd", linkpath: "link.txt"},
+		{name: "relative within escape", linkname: "sub/../../../escape.txt", linkpath: "link.txt"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			err := ExtractTGZ(tgzWithSymlink(t, tc.linkpath, tc.linkname), dir)
+			require.ErrorContains(t, err, "points outside the extraction directory")
+
+			// Nothing should have been created.
+			_, statErr := os.Lstat(filepath.Join(dir, tc.linkpath))
+			assert.ErrorIs(t, statErr, os.ErrNotExist)
+		})
+	}
+
+	t.Run("relative within is allowed", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		err := ExtractTGZ(tgzWithSymlink(t, "link.txt", "sub/../target.txt"), dir)
+		require.NoError(t, err)
+		target, err := os.Readlink(filepath.Join(dir, "link.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "sub/../target.txt", target)
+	})
+}


### PR DESCRIPTION
Archives can contain symlinks, but we currently do not allow extracting them.  This makes commands such as `pulumi package publish` fail, if there is a symlink in the repo for the plugin that's supposed to be published.

Fix this by making sure we can extract symlinks in addition to regular files.  We also make sure that symlinks can't point outside of the extraction directory.

Fixes https://github.com/pulumi/pulumi/issues/22943