### PR TITLE
fix daily CI job

### DIFF
--- a/.github/scripts/set-output
+++ b/.github/scripts/set-output
@@ -3,14 +3,21 @@
 # Sets an output value in GitHub Actions, escaping quotes, newlines, and special characters by JSON
 # stringifying it.
 #
-# To use this, invoke the script with an output variable name and quoted value, and then declare the
-# output like so:
+# The value may be passed either as the second argument or, when omitted, on stdin. Prefer stdin for
+# large values: command-line arguments are capped at 128 KiB per argument (MAX_ARG_STRLEN), so
+# passing a big value as an argument fails with "Argument list too long" (exit code 126). stdin has
+# no such limit.
+#
+# To use this, invoke the script with an output variable name and either a quoted value or piped
+# input, and then declare the output like so:
 #
 # ```github-action.yaml
 #  job:
 #    steps:
 #    - run: |
 #        .github/scripts/set-output my-output "$(some-shell-command ...)"
+#        # or, for large values:
+#        some-shell-command ... | .github/scripts/set-output my-output
 #    outputs:
 #       my-output: "${{ fromJSON(steps.job.outputs.my-output) }}"
 # ```
@@ -19,7 +26,10 @@
 set -euo pipefail
 
 OUTPUT_NAME="$1"
-VALUE="$2"
 
-ESCAPED="$(echo -n "${VALUE}" | jq -Rsc ".")" # JSON encode
+if [ "$#" -ge 2 ]; then
+  ESCAPED="$(printf '%s' "$2" | jq -Rsc ".")" # JSON encode the argument
+else
+  ESCAPED="$(jq -Rsc ".")" # JSON encode stdin
+fi
 echo "${OUTPUT_NAME}=${ESCAPED}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/ci-performance-gate.yml
+++ b/.github/workflows/ci-performance-gate.yml
@@ -123,9 +123,11 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Set outputs"
-          ./.github/scripts/set-output performance-test-matrix "${PERFORMANCE_TEST_MATRIX}"
-          ./.github/scripts/set-output version-set "${VERSION_SET}"
-          ./.github/scripts/set-output build-targets "${BUILD_TARGETS}"
+          # Pipe matrix values via stdin: they can exceed the 128 KiB per-argument limit
+          # (MAX_ARG_STRLEN), which would otherwise fail the exec with "Argument list too long".
+          printf '%s' "${PERFORMANCE_TEST_MATRIX}" | ./.github/scripts/set-output performance-test-matrix
+          printf '%s' "${VERSION_SET}" | ./.github/scripts/set-output version-set
+          printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
           echo "::endgroup::"
     outputs:
       performance-test-matrix: "${{ fromJson(steps.matrix.outputs.performance-test-matrix) }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,12 +271,14 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Set outputs"
-          ./.github/scripts/set-output unit-test-matrix "${UNIT_TEST_MATRIX}"
-          ./.github/scripts/set-output integration-test-matrix "${INTEGRATION_TEST_MATRIX}"
-          ./.github/scripts/set-output acceptance-test-matrix-win "${ACCEPTANCE_TEST_MATRIX_WIN}"
-          ./.github/scripts/set-output acceptance-test-matrix-macos "${ACCEPTANCE_TEST_MATRIX_MACOS}"
-          ./.github/scripts/set-output version-set "${VERSION_SET}"
-          ./.github/scripts/set-output build-targets "${BUILD_TARGETS}"
+          # Pipe matrix values via stdin: they can exceed the 128 KiB per-argument limit
+          # (MAX_ARG_STRLEN), which would otherwise fail the exec with "Argument list too long".
+          printf '%s' "${UNIT_TEST_MATRIX}" | ./.github/scripts/set-output unit-test-matrix
+          printf '%s' "${INTEGRATION_TEST_MATRIX}" | ./.github/scripts/set-output integration-test-matrix
+          printf '%s' "${ACCEPTANCE_TEST_MATRIX_WIN}" | ./.github/scripts/set-output acceptance-test-matrix-win
+          printf '%s' "${ACCEPTANCE_TEST_MATRIX_MACOS}" | ./.github/scripts/set-output acceptance-test-matrix-macos
+          printf '%s' "${VERSION_SET}" | ./.github/scripts/set-output version-set
+          printf '%s' "${BUILD_TARGETS}" | ./.github/scripts/set-output build-targets
           echo "::endgroup::"
     outputs:
       unit-test-matrix: "${{ fromJson(steps.matrix.outputs.unit-test-matrix) }}"


### PR DESCRIPTION
Currently our daily CI job is broken, consistently failing the "matrix" step.  Claude claims this is because the argument list to `set-output` is too long, which is possible, since we're fanning out quite a few jobs.  Pass the argument list via stdin instead, to work around this issue.

Fixes #23388