### PR TITLE
Add `Output.recover` to python sdk

### DIFF
--- a/changelog/pending/sdk-python-feat-20260616-142432.yaml
+++ b/changelog/pending/sdk-python-feat-20260616-142432.yaml
@@ -1,0 +1,6 @@
+component: sdk/python
+kind: feat
+body: Add `Output.recover` to catch and recover from exceptions in outputs
+time: 2026-06-16T14:24:32.929399+01:00
+custom:
+    PR: 23591

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -341,6 +341,34 @@ class Output(Generic[T_co]):
 
         return Output._from_data(run())
 
+    def recover(self, func: Callable[[Exception], Input[T_co]]) -> "Output[T_co]":
+        """
+        Returns an Output that yields this Output's value, or — if this Output
+        faulted with an exception — the value produced by calling ``func``.
+
+        When recovery happens, the original faulted Output is removed from the
+        runtime's tracking set so it no longer causes the program to error at
+        exit. ``func`` is only invoked if this Output failed.
+
+        :param Callable[[Exception],Input[T_co]] func: A thunk producing a replacement value
+               (which may itself be an Input/Output) when this Output has faulted.
+        :return: An Output that never propagates the original failure.
+        :rtype: Output[T_co]
+        """
+
+        original = self._data
+
+        async def run() -> "_OutputData[T_co]":
+            try:
+                return await original
+            except Exception as exc:
+                with SETTINGS.lock:
+                    SETTINGS.outputs.discard(original)
+                recovered = Output.from_input(func(exc))
+                return await recovered._data
+
+        return Output._from_data(run())
+
     def __getattr__(self, item: str) -> "Output[Any]":  # type: ignore
         """
         Syntactic sugar for retrieving attributes off of outputs.

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -361,7 +361,7 @@ class Output(Generic[T_co]):
         async def run() -> "_OutputData[T_co]":
             try:
                 return await original
-            except Exception as exc: # noqa: BLE001 catch blind exception
+            except Exception as exc:  # noqa: BLE001 catch blind exception
                 with SETTINGS.lock:
                     SETTINGS.outputs.discard(original)
                 recovered = Output.from_input(func(exc))

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -361,7 +361,7 @@ class Output(Generic[T_co]):
         async def run() -> "_OutputData[T_co]":
             try:
                 return await original
-            except Exception as exc:
+            except Exception as exc: # noqa: BLE001 catch blind exception
                 with SETTINGS.lock:
                     SETTINGS.outputs.discard(original)
                 recovered = Output.from_input(func(exc))

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -411,6 +411,86 @@ class OutputApplyTests(unittest.TestCase):
             test()
 
 
+class OutputRecoverTests(unittest.TestCase):
+    def _faulted_output(self, exc: Exception) -> Output:
+        bad = asyncio.Future()
+        bad.set_exception(exc)
+        ok_res: asyncio.Future = asyncio.Future()
+        ok_res.set_result(set())
+        ok_known: asyncio.Future = asyncio.Future()
+        ok_known.set_result(True)
+        return Output(resources=ok_res, future=bad, is_known=ok_known)
+
+    def test_faulted_output_raises_at_program_exit(self):
+        """Baseline: a faulted Output causes pulumi_test to raise."""
+
+        @pulumi_test
+        async def test():
+            self._faulted_output(Exception("boom"))
+
+        with self.assertRaises(Exception) as cm:
+            test()
+        self.assertIn("boom", str(cm.exception))
+
+    def test_recover_returns_value_on_failure(self):
+        @pulumi_test
+        async def test():
+            recovered = self._faulted_output(Exception("boom")).recover(lambda _: 42)
+            self.assertEqual(await recovered.future(), 42)
+
+        test()
+
+    def test_recover_receives_exception(self):
+        seen: list[Exception] = []
+        exc = ValueError("boom")
+
+        @pulumi_test
+        async def test():
+            def handler(e: Exception) -> str:
+                seen.append(e)
+                return "fallback"
+
+            recovered = self._faulted_output(exc).recover(handler)
+            self.assertEqual(await recovered.future(), "fallback")
+
+        test()
+        self.assertEqual(len(seen), 1)
+        self.assertIs(seen[0], exc)
+
+    def test_recover_passes_through_value_on_success(self):
+        called = []
+
+        @pulumi_test
+        async def test():
+            ok = Output.from_input("hello")
+            recovered = ok.recover(lambda _: called.append("x") or "fallback")
+            self.assertEqual(await recovered.future(), "hello")
+
+        test()
+        self.assertEqual(called, [])
+
+    def test_recover_accepts_output_returning_func(self):
+        @pulumi_test
+        async def test():
+            recovered = self._faulted_output(Exception("boom")).recover(
+                lambda _: Output.from_input("recovered")
+            )
+            self.assertEqual(await recovered.future(), "recovered")
+
+        test()
+
+    def test_recovered_failure_does_not_raise_at_program_exit(self):
+        """The whole point: a recovered failure must not raise at exit."""
+
+        @pulumi_test
+        async def test():
+            recovered = self._faulted_output(Exception("boom")).recover(lambda _: 1)
+            self.assertEqual(await recovered.future(), 1)
+
+        # Should not raise.
+        test()
+
+
 class OutputAllTests(unittest.IsolatedAsyncioTestCase):
     @pulumi_test
     async def test_args(self):

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -479,17 +479,6 @@ class OutputRecoverTests(unittest.TestCase):
 
         test()
 
-    def test_recovered_failure_does_not_raise_at_program_exit(self):
-        """The whole point: a recovered failure must not raise at exit."""
-
-        @pulumi_test
-        async def test():
-            recovered = self._faulted_output(Exception("boom")).recover(lambda _: 1)
-            self.assertEqual(await recovered.future(), 1)
-
-        # Should not raise.
-        test()
-
 
 class OutputAllTests(unittest.IsolatedAsyncioTestCase):
     @pulumi_test


### PR DESCRIPTION
Adds a new `recover` method to outputs in the Python SDK. This allows a user to "catch" exceptions in outputs and recover from them.

If an output is recovered it no longer contributes to the waiting loop at the end of the program where we would normally re-throw the error.