### PR TITLE
config set: add flag to avoid stripping trailing newline

### DIFF
--- a/changelog/pending/cli-config-feat-20260616-173343.yaml
+++ b/changelog/pending/cli-config-feat-20260616-173343.yaml
@@ -1,0 +1,6 @@
+component: cli/config
+kind: feat
+body: Add --raw flag to `pulumi config set` to avoid stripping newlines when input is piped through stdin
+time: 2026-06-16T17:33:43.884914275+02:00
+custom:
+    PR: "23593"

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -660,6 +660,7 @@ type configSetCmd struct {
 	Plaintext bool
 	Secret    bool
 	Path      bool
+	Raw       bool
 	Type      string
 }
 
@@ -671,7 +672,8 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 		Short: "Set configuration value",
 		Long: "Configuration values can be accessed when a stack is being deployed and used to configure behavior. \n" +
 			"If a value is not present on the command line, pulumi will prompt for the value. Multi-line values\n" +
-			"may be set by piping a file to standard in.\n\n" +
+			"may be set by piping a file to standard in. Note that in that case, trailing newlines are stripped,\n" +
+			"unless `--raw` is passed.\n\n" +
 			"The `--path` flag can be used to set a value inside a map or list:\n\n" +
 			"  - `pulumi config set --path 'names[0]' a` " +
 			"will set the value to a list with the first item `a`.\n" +
@@ -734,6 +736,9 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 	setCmd.PersistentFlags().StringVar(
 		&configSetCmd.Type, "type", "", "Save the value as the given type.  Allowed values are string, bool, int, and float")
 	setCmd.MarkFlagsMutuallyExclusive("secret", "plaintext", "type")
+	setCmd.PersistentFlags().BoolVar(
+		&configSetCmd.Raw, "raw", false,
+		"When setting the value through stdin, do not trim trailing newlines from the value")
 	setCmd.DisableFlagsInUseLine = true
 
 	return setCmd
@@ -762,7 +767,11 @@ func (c *configSetCmd) Run(
 		if readerr != nil {
 			return readerr
 		}
-		value = cmdutil.RemoveTrailingNewline(string(b))
+		if !c.Raw {
+			value = cmdutil.RemoveTrailingNewline(string(b))
+		} else {
+			value = string(b)
+		}
 	case !cmdutil.Interactive():
 		return backenderr.NonInteractiveInputRequiredError{Detail: "config value must be specified in non-interactive mode"}
 	case c.Secret:


### PR DESCRIPTION
In `pulumi config set`, the config can be passed through `stdin`.  In that case, we currently strip the trailing newline.  This can be convenient, e.g. when users do "echo xyz | pulumi config set", as `echo` always adds a trailing newline.

However it's also somewhat surprising that this is happening, and there's currently no opt-out for this behaviour.  Add a `--raw` flag to opt out, and a few words to the docs explaining this behaviour.

Fixes https://github.com/pulumi/pulumi/issues/23462