### PR TITLE
config env checkout / commit / discard

### DIFF
--- a/pkg/backend/state/checkout_test.go
+++ b/pkg/backend/state/checkout_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"testing"
+
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWorkspaceWithSettings returns a workspace context whose New() yields a W backed by the given shared
+// Settings pointer, so Set/Clear mutations are observable by a subsequent Get (mirroring the real
+// per-process workspace cache).
+func mockWorkspaceWithSettings(s *pkgWorkspace.Settings) *pkgWorkspace.MockContext {
+	return &pkgWorkspace.MockContext{
+		NewF: func() (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{
+				SettingsF: func() *pkgWorkspace.Settings { return s },
+			}, nil
+		},
+	}
+}
+
+func TestCheckoutMarker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get returns nil when absent", func(t *testing.T) {
+		t.Parallel()
+		ws := mockWorkspaceWithSettings(&pkgWorkspace.Settings{})
+		c, err := GetCheckout(ws, "org/proj/stack")
+		require.NoError(t, err)
+		assert.Nil(t, c)
+	})
+
+	t.Run("set then get round-trips and initializes a nil map", func(t *testing.T) {
+		t.Parallel()
+		ws := mockWorkspaceWithSettings(&pkgWorkspace.Settings{})
+		marker := pkgWorkspace.Checkout{
+			EnvRef:      "org/proj/env",
+			Etag:        "etag-1",
+			Revision:    3,
+			FilePath:    "Pulumi.stack.local.yaml",
+			ContentHash: "deadbeef",
+			Imports:     []string{"org/proj/base"},
+		}
+		require.NoError(t, SetCheckout(ws, "org/proj/stack", marker))
+
+		got, err := GetCheckout(ws, "org/proj/stack")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, marker, *got)
+	})
+
+	t.Run("clear removes the marker", func(t *testing.T) {
+		t.Parallel()
+		ws := mockWorkspaceWithSettings(&pkgWorkspace.Settings{
+			Checkouts: map[string]pkgWorkspace.Checkout{"org/proj/stack": {EnvRef: "org/proj/env"}},
+		})
+		require.NoError(t, ClearCheckout(ws, "org/proj/stack"))
+
+		got, err := GetCheckout(ws, "org/proj/stack")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("clear is a no-op when absent", func(t *testing.T) {
+		t.Parallel()
+		ws := mockWorkspaceWithSettings(&pkgWorkspace.Settings{})
+		require.NoError(t, ClearCheckout(ws, "org/proj/stack"))
+	})
+
+	t.Run("markers are independent per stack", func(t *testing.T) {
+		t.Parallel()
+		ws := mockWorkspaceWithSettings(&pkgWorkspace.Settings{})
+		require.NoError(t, SetCheckout(ws, "org/proj/a", pkgWorkspace.Checkout{EnvRef: "org/proj/env-a"}))
+		require.NoError(t, SetCheckout(ws, "org/proj/b", pkgWorkspace.Checkout{EnvRef: "org/proj/env-b"}))
+
+		require.NoError(t, ClearCheckout(ws, "org/proj/a"))
+
+		a, err := GetCheckout(ws, "org/proj/a")
+		require.NoError(t, err)
+		assert.Nil(t, a)
+
+		b, err := GetCheckout(ws, "org/proj/b")
+		require.NoError(t, err)
+		require.NotNil(t, b)
+		assert.Equal(t, "org/proj/env-b", b.EnvRef)
+	})
+}

--- a/pkg/backend/state/stacks.go
+++ b/pkg/backend/state/stacks.go
@@ -92,3 +92,49 @@ func SetCurrentStack(ws pkgWorkspace.Context, name string) error {
 	w.Settings().Stack = name
 	return w.Save()
 }
+
+// GetCheckout returns the service-backed config checkout marker for the given fully-qualified stack name,
+// or nil if the stack is not checked out.
+func GetCheckout(ws pkgWorkspace.Context, stackName string) (*pkgWorkspace.Checkout, error) {
+	w, err := ws.New()
+	if err != nil {
+		return nil, err
+	}
+
+	c, ok := w.Settings().Checkouts[stackName]
+	if !ok {
+		return nil, nil
+	}
+	return &c, nil
+}
+
+// SetCheckout records the checkout marker for the given fully-qualified stack name.
+func SetCheckout(ws pkgWorkspace.Context, stackName string, c pkgWorkspace.Checkout) error {
+	w, err := ws.New()
+	if err != nil {
+		return err
+	}
+
+	settings := w.Settings()
+	if settings.Checkouts == nil {
+		settings.Checkouts = map[string]pkgWorkspace.Checkout{}
+	}
+	settings.Checkouts[stackName] = c
+	return w.Save()
+}
+
+// ClearCheckout removes the checkout marker for the given fully-qualified stack name. It is a no-op if no
+// marker is present.
+func ClearCheckout(ws pkgWorkspace.Context, stackName string) error {
+	w, err := ws.New()
+	if err != nil {
+		return err
+	}
+
+	settings := w.Settings()
+	if _, ok := settings.Checkouts[stackName]; !ok {
+		return nil
+	}
+	delete(settings.Checkouts, stackName)
+	return w.Save()
+}

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -96,6 +97,12 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), stack, configFile, false)
+			if err != nil {
+				return err
+			}
+
 			ps, err := cmdStack.LoadProjectStack(ctx, cmdutil.Diag(), project, stack, configFile)
 			if err != nil {
 				return err
@@ -104,6 +111,17 @@ func NewConfigCmd(ws pkgWorkspace.Context) *cobra.Command {
 			// still surface environment-derived values, so treat it as empty rather than panicking.
 			if ps == nil {
 				ps = &workspace.ProjectStack{}
+			}
+
+			// Surface that a checked-out stack's listed values come from the local working copy.
+			if !jsonOut {
+				if marker, err := state.GetCheckout(ws, stack.Ref().FullyQualifiedName().String()); err == nil &&
+					marker != nil {
+					fmt.Fprintf(cmd.OutOrStdout(),
+						"Stack %s is checked out; showing the local working copy %s "+
+							"(run `pulumi config env commit` to save or `discard` to drop).\n",
+						stack.Ref().Name(), marker.FilePath)
+				}
 			}
 
 			// If --open is explicitly set, use that value. Otherwise, default to true if --show-secrets is set.
@@ -345,6 +363,12 @@ func newConfigGetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, *configFile, false)
+			if err != nil {
+				return err
+			}
+
 			key, err := ParseConfigKey(ws, args[0], path)
 			if err != nil {
 				return fmt.Errorf("invalid configuration key: %w", err)
@@ -407,6 +431,12 @@ func newConfigRmCmd(ws pkgWorkspace.Context, stack *string, configFile *string) 
 				opts,
 				*configFile,
 			)
+			if err != nil {
+				return err
+			}
+
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), stack, *configFile, false)
 			if err != nil {
 				return err
 			}
@@ -489,6 +519,12 @@ func newConfigRmAllCmd(ws pkgWorkspace.Context, stack *string, configFile *strin
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), stack, *configFile, false)
+			if err != nil {
+				return err
+			}
+
 			if err := rejectIfPinned(stack, *configFile); err != nil {
 				return err
 			}
@@ -563,6 +599,12 @@ func newConfigRefreshCmd(
 				opts,
 				*configFile,
 			)
+			if err != nil {
+				return err
+			}
+
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, *configFile, false)
 			if err != nil {
 				return err
 			}
@@ -725,6 +767,12 @@ func newConfigSetCmd(ws pkgWorkspace.Context, stack *string, configFile *string)
 				opts,
 				*configFile,
 			)
+			if err != nil {
+				return err
+			}
+
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, *configFile, false)
 			if err != nil {
 				return err
 			}
@@ -915,6 +963,12 @@ func newConfigSetAllCmd(
 				opts,
 				*configFile,
 			)
+			if err != nil {
+				return err
+			}
+
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			*configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), stack, *configFile, false)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -76,6 +77,9 @@ func newConfigEnvCmd(ws pkgWorkspace.Context, stackRef *string, configFile *stri
 	cmd.AddCommand(newConfigEnvPinCmd(&impl))
 	cmd.AddCommand(newConfigEnvRollbackCmd(&impl))
 	cmd.AddCommand(newConfigEnvConsoleCmd(ws, stackRef, configFile))
+	cmd.AddCommand(newConfigEnvCheckoutCmd(&impl))
+	cmd.AddCommand(newConfigEnvCommitCmd(&impl))
+	cmd.AddCommand(newConfigEnvDiscardCmd(&impl))
 
 	return cmd
 }
@@ -169,6 +173,13 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 		return nil, nil, nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
 	}
 
+	// Route import reads and edits to the local working copy when the stack is checked out, so
+	// `config env add`/`rm`/`ls` operate on the working copy rather than mutating the shared environment.
+	*cmd.configFile, err = cmdStack.ResolveWorkingCopy(ctx, cmd.ws, cmd.diags, stack, *cmd.configFile, false)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	projectStack, err := cmd.loadProjectStack(ctx, cmd.diags, project, stack, *cmd.configFile)
 	if err != nil {
 		return nil, nil, nil, err
@@ -177,20 +188,61 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 	return projectStack, project, &stack, nil
 }
 
+// checkoutMarker returns the stack's checkout marker, or nil if it is not checked out.
+func (cmd *configEnvCmd) checkoutMarker(stack backend.Stack) (*pkgWorkspace.Checkout, error) {
+	if !stack.ConfigLocation().IsRemote {
+		return nil, nil
+	}
+	return state.GetCheckout(cmd.ws, stack.Ref().FullyQualifiedName().String())
+}
+
+// workingCopyImports returns the import names in a checked-out stack's working copy (omitting the
+// synthetic "yaml" marker a local Environment carries when it has values).
+func (cmd *configEnvCmd) workingCopyImports(
+	ctx context.Context, project *workspace.Project, stack backend.Stack, marker *pkgWorkspace.Checkout,
+) ([]string, error) {
+	ps, err := cmd.loadProjectStack(ctx, cmd.diags, project, stack, marker.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	if ps == nil || ps.Environment == nil {
+		return nil, nil
+	}
+	var imports []string
+	for _, name := range ps.Environment.Imports() {
+		if name != "yaml" {
+			imports = append(imports, name)
+		}
+	}
+	return imports, nil
+}
+
 func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool) error {
-	projectStack, _, stack, err := cmd.loadEnvPreamble(ctx)
+	projectStack, project, stack, err := cmd.loadEnvPreamble(ctx)
+	if err != nil {
+		return err
+	}
+
+	marker, err := cmd.checkoutMarker(*stack)
 	if err != nil {
 		return err
 	}
 
 	var imports []string
-	if (*stack).ConfigLocation().IsRemote {
+	switch {
+	case marker != nil:
+		// Checked out: the working copy, not the remote environment, is the source of truth.
+		imports, err = cmd.workingCopyImports(ctx, project, *stack, marker)
+		if err != nil {
+			return err
+		}
+	case (*stack).ConfigLocation().IsRemote:
 		editor, err := newESCConfigEditor(ctx, *stack)
 		if err != nil {
 			return err
 		}
 		imports = editor.Imports()
-	} else {
+	default:
 		imports = projectStack.Environment.Imports()
 	}
 
@@ -364,10 +416,55 @@ func (cmd *configEnvCmd) runStatus(cobraCmd *cobra.Command, jsonOut bool) error 
 		return cobraCmd.Help()
 	}
 
+	marker, err := cmd.checkoutMarker(stack)
+	if err != nil {
+		return err
+	}
+	if marker != nil {
+		return cmd.runCheckedOutStatus(ctx, project, stack, marker, jsonOut)
+	}
+
 	if stack.ConfigLocation().IsRemote {
 		return cmd.runRemoteStatus(ctx, stack, jsonOut)
 	}
 	return cmd.runLocalStatus(ctx, project, stack, jsonOut)
+}
+
+// runCheckedOutStatus reports that the stack is checked out, naming the source environment and revision
+// and listing the working copy's imports.
+func (cmd *configEnvCmd) runCheckedOutStatus(
+	ctx context.Context, project *workspace.Project, stack backend.Stack, marker *pkgWorkspace.Checkout,
+	jsonOut bool,
+) error {
+	imports, err := cmd.workingCopyImports(ctx, project, stack, marker)
+	if err != nil {
+		return err
+	}
+
+	if jsonOut {
+		return ui.FprintJSON(cmd.stdout, struct {
+			Source      string   `json:"source"`
+			Environment string   `json:"environment"`
+			Revision    int      `json:"revision"`
+			WorkingCopy string   `json:"workingCopy"`
+			Imports     []string `json:"imports"`
+		}{
+			Source: "checked-out", Environment: marker.EnvRef, Revision: marker.Revision,
+			WorkingCopy: marker.FilePath, Imports: imports,
+		})
+	}
+
+	ui.Fprintf(cmd.stdout,
+		"This stack is checked out: its configuration is in the local working copy %s\n"+
+			"  (materialized from environment %q at revision %d).\n"+
+			"Run `pulumi config env commit` to save changes or `pulumi config env discard` to drop them.\n",
+		marker.FilePath, marker.EnvRef, marker.Revision)
+	if len(imports) == 0 {
+		ui.Fprintf(cmd.stdout, "It imports no environments.\n")
+	} else {
+		printImportsTable(cmd.stdout, imports)
+	}
+	return nil
 }
 
 func (cmd *configEnvCmd) runRemoteStatus(ctx context.Context, stack backend.Stack, jsonOut bool) error {

--- a/pkg/cmd/pulumi/config/config_env_checkout.go
+++ b/pkg/cmd/pulumi/config/config_env_checkout.go
@@ -1,0 +1,167 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+)
+
+func newConfigEnvCheckoutCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvCheckoutCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:   "checkout",
+		Short: "Materialize a stack's remote configuration into a local working copy for editing",
+		Long: "Materializes the ESC environment backing a remote-config stack into a local\n" +
+			"Pulumi.<stack>.local.yaml working copy and marks the stack checked out. While checked out,\n" +
+			"`pulumi config` and `pulumi up`/`preview` operate on the working copy instead of the remote\n" +
+			"environment, so changes can be previewed without mutating the shared environment. Use\n" +
+			"`pulumi config env commit` to write the working copy back to the environment, or\n" +
+			"`pulumi config env discard` to drop it.",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().StringVar(&impl.secretsProvider, "secrets-provider", "",
+		"The secrets provider to use for re-encrypting secrets in the working copy "+
+			"(default, passphrase, or a cloud KMS URL such as awskms://...)")
+
+	return cmd
+}
+
+type configEnvCheckoutCmd struct {
+	parent *configEnvCmd
+
+	secretsProvider string
+}
+
+func (cmd *configEnvCheckoutCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	// resolveStack does not apply the working-copy redirect, so checkout operates on the remote
+	// environment and the marker directly.
+	_, stack, err := cmd.parent.resolveStack(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !stack.ConfigLocation().IsRemote {
+		return errors.New("this stack does not use remote configuration; there is nothing to check out")
+	}
+	loc := stack.ConfigLocation()
+	if loc.EscEnv == nil || *loc.EscEnv == "" {
+		return errors.New("this stack does not reference a backing environment")
+	}
+	// A checkout snapshots the latest revision and commit writes the latest; a pinned stack would make
+	// both ambiguous, so require unpinning first.
+	if envRefVersion(*loc.EscEnv) != "" {
+		return fmt.Errorf("the stack's configuration is pinned to %s; "+
+			"run `pulumi config env pin latest` before checking out", *loc.EscEnv)
+	}
+
+	fqn := stack.Ref().FullyQualifiedName().String()
+	if existing, err := state.GetCheckout(cmd.parent.ws, fqn); err != nil {
+		return err
+	} else if existing != nil {
+		return errors.New("this stack is already checked out; " +
+			"run `pulumi config env commit` or `pulumi config env discard` first")
+	}
+
+	path, err := cmdStack.WorkingCopyPath(stack.Ref().Name().Q())
+	if err != nil {
+		return err
+	}
+	// Refuse to overwrite a working copy we did not create (the file-without-marker matrix case).
+	if _, statErr := os.Stat(path); statErr == nil {
+		return fmt.Errorf("found %s but this stack is not checked out on this machine; "+
+			"delete it or move it aside before checking out", path)
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("checking working copy %s: %w", path, statErr)
+	}
+
+	envBackend, orgName, envProject, envName, _, err := escEnvCoordinates(stack)
+	if err != nil {
+		return err
+	}
+	def, etag, revision, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", true)
+	if err != nil {
+		return fmt.Errorf("getting environment %s/%s: %w", envProject, envName, err)
+	}
+
+	ps, imports, structured, err := materializeProjectStack(
+		ctx, cmd.parent.ssml, stack, def, envProject, envName, cmd.secretsProvider, cmd.parent.interactive, opts)
+	if err != nil {
+		return err
+	}
+	if len(structured) > 0 {
+		fmt.Fprintf(cmd.parent.stdout,
+			"Warning: import(s) %s had merge options that are not preserved in the local working copy; "+
+				"only the environment name is kept\n", strings.Join(structured, ", "))
+	}
+
+	banner := fmt.Sprintf(
+		"# Local working copy created by `pulumi config env checkout` from %s@rev%d.\n"+
+			"# This file is for temporary, local usage only; do not commit it.\n"+
+			"# Run `pulumi config env commit` to save changes, or `pulumi config env discard` to drop them.\n",
+		stripEnvVersion(*loc.EscEnv), revision)
+
+	if err := writeWorkingCopy(ps, path, banner); err != nil {
+		return err
+	}
+
+	hash, err := canonicalCheckoutHash(ps)
+	if err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+
+	marker := pkgWorkspace.Checkout{
+		EnvRef:      stripEnvVersion(*loc.EscEnv),
+		Etag:        etag,
+		Revision:    revision,
+		FilePath:    path,
+		ContentHash: hash,
+		Imports:     imports,
+	}
+	if err := state.SetCheckout(cmd.parent.ws, fqn, marker); err != nil {
+		// Keep the matrix consistent: a file without a marker is a hard error on the next config read.
+		_ = os.Remove(path)
+		return err
+	}
+
+	fmt.Fprintf(cmd.parent.stdout, "Checked out %s@rev%d to %s\n", stripEnvVersion(*loc.EscEnv), revision, path)
+
+	fmt.Fprint(cmd.parent.stdout,
+		"Edit configuration with `pulumi config set`; run `pulumi config env commit` to save changes "+
+			"or `pulumi config env discard` to drop them.\n")
+	return nil
+}

--- a/pkg/cmd/pulumi/config/config_env_checkout_test.go
+++ b/pkg/cmd/pulumi/config/config_env_checkout_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+const checkoutFQN = "org/proj/dev"
+
+// checkoutTestStack builds a remote-config MockStack named dev whose environment backend returns the
+// given definition, etag, and revision.
+func checkoutTestStack(escEnv, def, etag string, revision int) *backend.MockStack {
+	env := escEnv
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte(def), etag, revision, nil
+		},
+	}
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: tokens.QName(checkoutFQN),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+// newCheckoutCmd wires a checkout command against the given stack and a settings-backed workspace, in a
+// temp project directory. It returns the command, the shared settings, and the stdout buffer.
+func newCheckoutCmd(t *testing.T, stack backend.Stack) (*configEnvCheckoutCmd, *pkgWorkspace.Settings, *bytes.Buffer) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	settings := &pkgWorkspace.Settings{}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "proj"}, "", nil
+		},
+		NewF: func() (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{SettingsF: func() *pkgWorkspace.Settings { return settings }}, nil
+		},
+	}
+	var stdout bytes.Buffer
+	stackRef, configFile := "", ""
+	parent := &configEnvCmd{
+		stdout:     &stdout,
+		diags:      diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		ws:         ws,
+		stackRef:   &stackRef,
+		configFile: &configFile,
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return stack, nil
+		},
+		// interactive defaults to false: no secrets-provider prompt.
+	}
+	return &configEnvCheckoutCmd{parent: parent}, settings, &stdout
+}
+
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestConfigEnvCheckout(t *testing.T) {
+	ctx := t.Context()
+
+	const def = "imports:\n  - proj/base\nvalues:\n  pulumiConfig:\n    proj:foo: bar\n"
+
+	t.Run("materializes working copy and records marker", func(t *testing.T) {
+		cmd, settings, _ := newCheckoutCmd(t, checkoutTestStack("proj/env", def, "etag-1", 7))
+		require.NoError(t, cmd.run(ctx))
+
+		path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+		require.NoError(t, err)
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(contents), "Local working copy created by", "banner is written")
+		assert.Contains(t, string(contents), "proj:foo", "config is materialized")
+
+		marker, ok := settings.Checkouts[checkoutFQN]
+		require.True(t, ok, "marker is recorded")
+		assert.Equal(t, "proj/env", marker.EnvRef)
+		assert.Equal(t, "etag-1", marker.Etag)
+		assert.Equal(t, 7, marker.Revision)
+		assert.Equal(t, []string{"proj/base"}, marker.Imports)
+		assert.NotEmpty(t, marker.ContentHash)
+	})
+
+	t.Run("refuses when already checked out", func(t *testing.T) {
+		cmd, settings, _ := newCheckoutCmd(t, checkoutTestStack("proj/env", def, "etag-1", 7))
+		settings.Checkouts = map[string]pkgWorkspace.Checkout{checkoutFQN: {EnvRef: "proj/env"}}
+		err := cmd.run(ctx)
+		require.ErrorContains(t, err, "already checked out")
+	})
+
+	t.Run("refuses when pinned", func(t *testing.T) {
+		cmd, _, _ := newCheckoutCmd(t, checkoutTestStack("proj/env@5", def, "etag-1", 7))
+		err := cmd.run(ctx)
+		require.ErrorContains(t, err, "pinned")
+	})
+
+	t.Run("refuses on a local-config stack", func(t *testing.T) {
+		s := &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+			},
+			ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		}
+		cmd, _, _ := newCheckoutCmd(t, s)
+		err := cmd.run(ctx)
+		require.ErrorContains(t, err, "does not use remote configuration")
+	})
+
+	t.Run("refuses to clobber a stray working copy", func(t *testing.T) {
+		cmd, _, _ := newCheckoutCmd(t, checkoutTestStack("proj/env", def, "etag-1", 7))
+		path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, []byte("stray\n"), 0o600))
+		err = cmd.run(ctx)
+		require.ErrorContains(t, err, "not checked out on this machine")
+	})
+
+	t.Run("refuses environments with non-pulumiConfig values", func(t *testing.T) {
+		const withVars = "values:\n  pulumiConfig:\n    proj:foo: bar\n  environmentVariables:\n    FOO: bar\n"
+		cmd, _, _ := newCheckoutCmd(t, checkoutTestStack("proj/env", withVars, "etag-1", 7))
+		err := cmd.run(ctx)
+		require.ErrorContains(t, err, "cannot be represented in a local stack file")
+	})
+}

--- a/pkg/cmd/pulumi/config/config_env_commit.go
+++ b/pkg/cmd/pulumi/config/config_env_commit.go
@@ -1,0 +1,260 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newConfigEnvCommitCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvCommitCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:   "commit",
+		Short: "Write a stack's checked-out working copy back to its remote configuration",
+		Long: "Writes the local Pulumi.<stack>.local.yaml working copy back to the stack's ESC environment\n" +
+			"as a single revision, then deletes the working copy and clears the checked-out state. The\n" +
+			"environment's pulumiConfig is replaced exactly: keys removed locally are removed from the\n" +
+			"environment. If the environment changed since checkout, commit refuses unless the overwrite is\n" +
+			"confirmed (interactively, or with --force-revision).",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			impl.forced = cmd.Flags().Changed("force-revision")
+			return impl.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().IntVar(&impl.forceRevision, "force-revision", 0,
+		"Overwrite the environment that moved since checkout, asserting it is at this revision "+
+			"(force-with-lease); commit refuses if it has since moved again")
+
+	return cmd
+}
+
+type configEnvCommitCmd struct {
+	parent *configEnvCmd
+
+	forceRevision int
+	forced        bool
+}
+
+func (cmd *configEnvCommitCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	project, stack, err := cmd.parent.resolveStack(ctx)
+	if err != nil {
+		return err
+	}
+	if !stack.ConfigLocation().IsRemote {
+		return errors.New("this stack does not use remote configuration")
+	}
+
+	fqn := stack.Ref().FullyQualifiedName().String()
+	marker, err := state.GetCheckout(cmd.parent.ws, fqn)
+	if err != nil {
+		return err
+	}
+	if marker == nil {
+		return errors.New("this stack is not checked out; run `pulumi config env checkout` first")
+	}
+
+	if _, statErr := os.Stat(marker.FilePath); os.IsNotExist(statErr) {
+		_ = state.ClearCheckout(cmd.parent.ws, fqn)
+		return fmt.Errorf("the working copy %s is missing; the checkout marker has been cleared, "+
+			"run `pulumi config env checkout` to start over", marker.FilePath)
+	}
+	ps, err := cmd.parent.loadProjectStack(ctx, cmd.parent.diags, project, stack, marker.FilePath)
+	if err != nil {
+		return err
+	}
+	if ps == nil {
+		ps = &workspace.ProjectStack{}
+	}
+
+	// No-op: the working copy is unchanged from checkout, so there is nothing to write. Clean up without
+	// reading or touching the environment.
+	hash, err := canonicalCheckoutHash(ps)
+	if err != nil {
+		return err
+	}
+	if hash == marker.ContentHash {
+		return cmd.cleanup(fqn, marker.FilePath, "No changes to commit; removed working copy %s\n")
+	}
+
+	// A real commit requires the stack still linked, unpinned, and pointing at the same environment as at
+	// checkout: a pin or relink would target a different (or read-only) revision. A no-op (handled above)
+	// writes nothing, so it skips these guards.
+	loc := stack.ConfigLocation()
+	if loc.EscEnv == nil || *loc.EscEnv == "" {
+		return errors.New("this stack no longer references a backing environment")
+	}
+	if envRefVersion(*loc.EscEnv) != "" {
+		return fmt.Errorf("the stack's configuration was pinned to %s after checkout; "+
+			"run `pulumi config env pin latest` before committing", *loc.EscEnv)
+	}
+	if stripEnvVersion(*loc.EscEnv) != marker.EnvRef {
+		return fmt.Errorf("the stack was relinked to %s since checkout (was %s); "+
+			"run `pulumi config env discard` and check out again", stripEnvVersion(*loc.EscEnv), marker.EnvRef)
+	}
+
+	// Decrypt the working copy's config to plaintext-bearing values so the ESC editor can re-wrap secrets
+	// as fn::secret for server-side encryption (Copy with a Nop encrypter keeps secrets as plaintext).
+	// Non-secret config already holds plaintext, so skip the secrets-manager call when there are none.
+	plaintextConfig := ps.Config
+	if ps.Config.HasSecureValue() {
+		decrypter, _, err := cmd.parent.ssml.GetDecrypter(ctx, stack, ps)
+		if err != nil {
+			return err
+		}
+		plaintextConfig, err = ps.Config.Copy(decrypter, config.NopEncrypter)
+		if err != nil {
+			return fmt.Errorf("decrypting working copy configuration: %w", err)
+		}
+	}
+
+	// Read the environment once and write with that same etag (force-with-lease, no read-modify-write gap).
+	envBackend, orgName, envProject, envName, _, err := escEnvCoordinates(stack)
+	if err != nil {
+		return err
+	}
+	def, etag, revision, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, "", false)
+	if err != nil {
+		return fmt.Errorf("reading environment %s/%s: %w", envProject, envName, err)
+	}
+
+	if etag != marker.Etag {
+		if err := cmd.confirmOverwrite(stack, orgName, envProject, envName, marker.Revision, revision, opts); err != nil {
+			return err
+		}
+	}
+
+	editor, err := newESCConfigEditorFromDef(envBackend, orgName, envProject, envName, "", def, etag)
+	if err != nil {
+		return err
+	}
+	if err := editor.ReplaceConfig(ctx, plaintextConfig); err != nil {
+		return err
+	}
+
+	// Reconcile imports only when the working copy's list differs from the baseline, leaving structured
+	// imports (and their merge options) untouched otherwise.
+	var wcImports []string
+	if ps.Environment != nil {
+		for _, name := range ps.Environment.Imports() {
+			if name != "yaml" { // synthetic marker from a local Environment carrying values
+				wcImports = append(wcImports, name)
+			}
+		}
+	}
+	if !sameImports(marker.Imports, wcImports) {
+		if err := editor.ReplaceImports(wcImports); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.parent.stdout,
+			"Warning: imports changed; any merge options on flattened imports are not preserved\n")
+	}
+
+	if err := editor.Save(ctx); err != nil {
+		if errors.Is(err, backend.ErrConfigConflict) {
+			return fmt.Errorf("the environment changed during commit; re-run `pulumi config env commit`: %w", err)
+		}
+		return err
+	}
+
+	return cmd.cleanup(fqn, marker.FilePath,
+		fmt.Sprintf("Committed working copy to %s; removed %%s\n", marker.EnvRef))
+}
+
+// cleanup deletes the working copy and clears the checkout marker, printing msg (which must contain a
+// single %s for the working-copy path).
+func (cmd *configEnvCommitCmd) cleanup(fqn, path, msg string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := state.ClearCheckout(cmd.parent.ws, fqn); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.parent.stdout, msg, path)
+	return nil
+}
+
+// confirmOverwrite handles the drift case where the environment moved since checkout. With
+// --force-revision it asserts the environment is still at the reviewed revision (force-with-lease);
+// interactively it prompts; non-interactively without the flag it refuses.
+func (cmd *configEnvCommitCmd) confirmOverwrite(
+	stack backend.Stack, orgName, envProject, envName string, fromRev, curRev int, opts display.Options,
+) error {
+	drift := fmt.Sprintf("the environment moved from revision %d to %d since checkout", fromRev, curRev)
+	if url := envConsoleURL(stack, orgName, envProject, envName); url != "" {
+		drift += "; review it at " + url
+	}
+
+	if cmd.forced {
+		if cmd.forceRevision != curRev {
+			return fmt.Errorf("the environment is now at revision %d, not %d; re-review and retry", curRev, cmd.forceRevision)
+		}
+		return nil
+	}
+	if !cmd.parent.interactive {
+		return fmt.Errorf("%s; re-review and pass --force-revision %d to overwrite", drift, curRev)
+	}
+
+	fmt.Fprintf(cmd.parent.stdout, "Warning: %s\n", drift)
+	if !ui.ConfirmPrompt(
+		fmt.Sprintf("Overwrite the environment, discarding the changes in revision %d?", curRev), "yes", opts) {
+		return errors.New("commit canceled")
+	}
+	return nil
+}
+
+// envConsoleURL returns the Pulumi Cloud console URL for the environment, or "" if the backend does not
+// provide one.
+func envConsoleURL(stack backend.Stack, orgName, envProject, envName string) string {
+	provider, ok := stack.Backend().(consoleURLProvider)
+	if !ok {
+		return ""
+	}
+	return provider.CloudConsoleURL(orgName, "esc", envProject, envName)
+}
+
+// sameImports reports whether two import lists are identical in both contents and order. Order matters:
+// ESC resolves imports in sequence, so a reorder is a semantic change that commit must propagate.
+func sameImports(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cmd/pulumi/config/config_env_commit_test.go
+++ b/pkg/cmd/pulumi/config/config_env_commit_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// commitStack builds a remote-config MockStack named dev. getDef/getEtag/getRevision drive
+// GetEnvironment; onUpdate (if non-nil) captures the uploaded YAML.
+func commitStack(
+	escEnv, getDef, getEtag string, getRevision int,
+	onUpdate func(yaml []byte, etag string) (apitype.EnvironmentDiagnostics, error),
+) *backend.MockStack {
+	env := escEnv
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(_ context.Context, _, _, _, _ string, _ bool) ([]byte, string, int, error) {
+			return []byte(getDef), getEtag, getRevision, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, y []byte, etag string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			if onUpdate != nil {
+				return onUpdate(y, etag)
+			}
+			return nil, nil
+		},
+	}
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: tokens.QName(checkoutFQN),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+		OrgNameF: func() string { return "org" },
+		BackendF: func() backend.Backend { return be },
+	}
+}
+
+// newCommitCmd wires a commit command in a temp project dir, writing workingCopy to the working-copy
+// path and seeding the given marker. Returns the command, shared settings, the working-copy path.
+func newCommitCmd(
+	t *testing.T, stack backend.Stack, marker pkgWorkspace.Checkout, workingCopy string,
+) (*configEnvCommitCmd, *pkgWorkspace.Settings, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte(workingCopy), 0o600))
+	marker.FilePath = path
+
+	settings := &pkgWorkspace.Settings{Checkouts: map[string]pkgWorkspace.Checkout{checkoutFQN: marker}}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "proj"}, "", nil
+		},
+		NewF: func() (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{SettingsF: func() *pkgWorkspace.Settings { return settings }}, nil
+		},
+	}
+	var stdout bytes.Buffer
+	stackRef, configFile := "", ""
+	parent := &configEnvCmd{
+		stdout:           &stdout,
+		diags:            diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		ws:               ws,
+		stackRef:         &stackRef,
+		configFile:       &configFile,
+		loadProjectStack: cmdStack.LoadProjectStack,
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return stack, nil
+		},
+	}
+	return &configEnvCommitCmd{parent: parent}, settings, path
+}
+
+// hashOfWorkingCopy loads a working-copy file the way commit does and returns its canonical hash.
+func hashOfWorkingCopy(t *testing.T, path string) string {
+	t.Helper()
+	ps, err := cmdStack.LoadProjectStack(t.Context(),
+		diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		&workspace.Project{Name: "proj"}, nil, path)
+	require.NoError(t, err)
+	h, err := canonicalCheckoutHash(ps)
+	require.NoError(t, err)
+	return h
+}
+
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestConfigEnvCommit(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("refuses when not checked out", func(t *testing.T) {
+		cmd, settings, _ := newCommitCmd(t, commitStack("proj/env", "", "etag", 1, nil),
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag"}, "config:\n  proj:a: b\n")
+		delete(settings.Checkouts, checkoutFQN)
+		require.ErrorContains(t, cmd.run(ctx), "not checked out")
+	})
+
+	t.Run("refuses when pinned after checkout", func(t *testing.T) {
+		cmd, _, _ := newCommitCmd(t, commitStack("proj/env@5", "", "etag", 1, nil),
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag"}, "config:\n  proj:a: b\n")
+		require.ErrorContains(t, cmd.run(ctx), "pinned")
+	})
+
+	t.Run("refuses when relinked after checkout", func(t *testing.T) {
+		cmd, _, _ := newCommitCmd(t, commitStack("proj/other", "", "etag", 1, nil),
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag"}, "config:\n  proj:a: b\n")
+		require.ErrorContains(t, cmd.run(ctx), "relinked")
+	})
+
+	t.Run("no-op when unchanged: cleans up without writing", func(t *testing.T) {
+		var uploaded bool
+		stack := commitStack("proj/env", "values:\n  pulumiConfig:\n    proj:a: b\n", "etag", 1,
+			func([]byte, string) (apitype.EnvironmentDiagnostics, error) { uploaded = true; return nil, nil })
+		cmd, settings, path := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag"}, "config:\n  proj:a: b\n")
+		// Seed the marker hash to match the (unchanged) working copy.
+		marker := settings.Checkouts[checkoutFQN]
+		marker.ContentHash = hashOfWorkingCopy(t, path)
+		settings.Checkouts[checkoutFQN] = marker
+
+		require.NoError(t, cmd.run(ctx))
+		assert.False(t, uploaded, "no-op commit must not write the environment")
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "working copy removed")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("no-op cleans up even when relinked", func(t *testing.T) {
+		var uploaded bool
+		stack := commitStack("proj/other", "values:\n  pulumiConfig:\n    proj:a: b\n", "etag", 1,
+			func([]byte, string) (apitype.EnvironmentDiagnostics, error) { uploaded = true; return nil, nil })
+		cmd, settings, path := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag"}, "config:\n  proj:a: b\n")
+		marker := settings.Checkouts[checkoutFQN]
+		marker.ContentHash = hashOfWorkingCopy(t, path)
+		settings.Checkouts[checkoutFQN] = marker
+
+		require.NoError(t, cmd.run(ctx), "a no-op commit writes nothing, so pin/relink state is irrelevant")
+		assert.False(t, uploaded, "no-op commit must not write the environment")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("exact replacement removes env-only keys", func(t *testing.T) {
+		var uploaded []byte
+		envDef := "values:\n  pulumiConfig:\n    proj:a: original\n    proj:old: gone\n"
+		stack := commitStack("proj/env", envDef, "etag", 3,
+			func(y []byte, _ string) (apitype.EnvironmentDiagnostics, error) { uploaded = y; return nil, nil })
+		cmd, settings, path := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag", Revision: 3, ContentHash: "stale"},
+			"config:\n  proj:a: b\n")
+
+		require.NoError(t, cmd.run(ctx))
+
+		var doc map[string]any
+		require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+		pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+		assert.Equal(t, "b", pc["proj:a"], "edited key overwritten")
+		_, hasOld := pc["proj:old"]
+		assert.False(t, hasOld, "key absent from the working copy is removed")
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "working copy removed")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("changed imports are written back in order", func(t *testing.T) {
+		var uploaded []byte
+		envDef := "imports:\n  - proj/a\n  - proj/b\nvalues:\n  pulumiConfig:\n    proj:k: v\n"
+		stack := commitStack("proj/env", envDef, "etag", 2,
+			func(y []byte, _ string) (apitype.EnvironmentDiagnostics, error) { uploaded = y; return nil, nil })
+		cmd, _, _ := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "etag", Imports: []string{"proj/a", "proj/b"}, ContentHash: "stale"},
+			"environment:\n  - proj/b\n  - proj/c\nconfig:\n  proj:k: v\n")
+
+		require.NoError(t, cmd.run(ctx))
+
+		var doc struct {
+			Imports []string `yaml:"imports"`
+		}
+		require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+		assert.Equal(t, []string{"proj/b", "proj/c"}, doc.Imports, "import list rewritten to the working copy's order")
+	})
+
+	t.Run("drift refuses non-interactively without --force-revision", func(t *testing.T) {
+		stack := commitStack("proj/env", "values:\n  pulumiConfig:\n    proj:a: x\n", "new-etag", 9, nil)
+		cmd, _, _ := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "old-etag", Revision: 3, ContentHash: "stale"},
+			"config:\n  proj:a: b\n")
+		require.ErrorContains(t, cmd.run(ctx), "--force-revision 9")
+	})
+
+	t.Run("force-revision lease passes at the asserted revision", func(t *testing.T) {
+		var uploaded []byte
+		stack := commitStack("proj/env", "values:\n  pulumiConfig:\n    proj:a: x\n", "new-etag", 9,
+			func(y []byte, _ string) (apitype.EnvironmentDiagnostics, error) { uploaded = y; return nil, nil })
+		cmd, _, _ := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "old-etag", Revision: 3, ContentHash: "stale"},
+			"config:\n  proj:a: b\n")
+		cmd.forced = true
+		cmd.forceRevision = 9
+		require.NoError(t, cmd.run(ctx))
+		require.NotNil(t, uploaded, "lease satisfied, environment written")
+	})
+
+	t.Run("force-revision lease refuses at a different revision", func(t *testing.T) {
+		stack := commitStack("proj/env", "values:\n  pulumiConfig:\n    proj:a: x\n", "new-etag", 9, nil)
+		cmd, _, _ := newCommitCmd(t, stack,
+			pkgWorkspace.Checkout{EnvRef: "proj/env", Etag: "old-etag", Revision: 3, ContentHash: "stale"},
+			"config:\n  proj:a: b\n")
+		cmd.forced = true
+		cmd.forceRevision = 7
+		require.ErrorContains(t, cmd.run(ctx), "now at revision 9, not 7")
+	})
+}

--- a/pkg/cmd/pulumi/config/config_env_discard.go
+++ b/pkg/cmd/pulumi/config/config_env_discard.go
@@ -1,0 +1,120 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func newConfigEnvDiscardCmd(parent *configEnvCmd) *cobra.Command {
+	impl := &configEnvDiscardCmd{parent: parent}
+
+	cmd := &cobra.Command{
+		Use:   "discard",
+		Short: "Discard a stack's checked-out working copy without writing it back",
+		Long: "Deletes the local Pulumi.<stack>.local.yaml working copy and clears the checked-out state\n" +
+			"without writing anything back to the stack's ESC environment. When the working copy is unchanged\n" +
+			"from checkout it is removed without confirmation; otherwise confirmation is required.",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parent.initArgs()
+			return impl.run(cmd.Context())
+		},
+	}
+
+	constrictor.AttachArguments(cmd, constrictor.NoArgs)
+
+	cmd.Flags().BoolVarP(&impl.yes, "yes", "y", false, "True to proceed without prompting")
+
+	return cmd
+}
+
+type configEnvDiscardCmd struct {
+	parent *configEnvCmd
+
+	yes bool
+}
+
+func (cmd *configEnvDiscardCmd) run(ctx context.Context) error {
+	opts := display.Options{Color: cmd.parent.color}
+
+	project, stack, err := cmd.parent.resolveStack(ctx)
+	if err != nil {
+		return err
+	}
+
+	fqn := stack.Ref().FullyQualifiedName().String()
+	marker, err := state.GetCheckout(cmd.parent.ws, fqn)
+	if err != nil {
+		return err
+	}
+	if marker == nil {
+		return errors.New("this stack is not checked out; there is nothing to discard")
+	}
+
+	// A missing working copy means there is nothing to drop; just clear the marker.
+	if _, statErr := os.Stat(marker.FilePath); os.IsNotExist(statErr) {
+		if err := state.ClearCheckout(cmd.parent.ws, fqn); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.parent.stdout, "Working copy already gone; cleared checked-out state for %s\n", marker.EnvRef)
+		return nil
+	}
+
+	// Unchanged working copies have nothing to lose, so skip confirmation. A working copy that no longer
+	// parses (the user hand-edited it into invalid YAML) is treated as changed so discard can still drop
+	// it — discard must never be blocked by the file it is removing.
+	changed := true
+	if ps, err := cmd.parent.loadProjectStack(ctx, cmd.parent.diags, project, stack, marker.FilePath); err == nil {
+		if ps == nil {
+			ps = &workspace.ProjectStack{}
+		}
+		if hash, herr := canonicalCheckoutHash(ps); herr == nil {
+			changed = hash != marker.ContentHash
+		}
+	}
+
+	if changed && !cmd.yes {
+		if !cmd.parent.interactive {
+			return backenderr.ErrNonInteractiveRequiresYes
+		}
+		if !ui.ConfirmPrompt(
+			fmt.Sprintf("Discard local changes to %s and revert to remote configuration?", marker.EnvRef),
+			"yes", opts) {
+			return errors.New("discard canceled")
+		}
+	}
+
+	if err := os.Remove(marker.FilePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := state.ClearCheckout(cmd.parent.ws, fqn); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.parent.stdout, "Discarded working copy %s\n", marker.FilePath)
+	return nil
+}

--- a/pkg/cmd/pulumi/config/config_env_discard_test.go
+++ b/pkg/cmd/pulumi/config/config_env_discard_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+func discardStack() *backend.MockStack {
+	env := "proj/env"
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName("dev"),
+				FullyQualifiedNameV: tokens.QName(checkoutFQN),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+}
+
+// newDiscardCmd wires a discard command in a temp project dir. If writeFile is true it writes workingCopy
+// to the working-copy path. Returns the command, shared settings, and the path.
+func newDiscardCmd(
+	t *testing.T, marker pkgWorkspace.Checkout, workingCopy string, writeFile, interactive bool,
+) (*configEnvDiscardCmd, *pkgWorkspace.Settings, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+	require.NoError(t, err)
+	if writeFile {
+		require.NoError(t, os.WriteFile(path, []byte(workingCopy), 0o600))
+	}
+	marker.FilePath = path
+
+	settings := &pkgWorkspace.Settings{Checkouts: map[string]pkgWorkspace.Checkout{checkoutFQN: marker}}
+	ws := &pkgWorkspace.MockContext{
+		ReadProjectF: func() (*workspace.Project, string, error) {
+			return &workspace.Project{Name: "proj"}, "", nil
+		},
+		NewF: func() (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{SettingsF: func() *pkgWorkspace.Settings { return settings }}, nil
+		},
+	}
+	var stdout bytes.Buffer
+	stackRef, configFile := "", ""
+	stack := discardStack()
+	parent := &configEnvCmd{
+		stdout:           &stdout,
+		diags:            diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		ws:               ws,
+		stackRef:         &stackRef,
+		configFile:       &configFile,
+		interactive:      interactive,
+		loadProjectStack: cmdStack.LoadProjectStack,
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return stack, nil
+		},
+	}
+	return &configEnvDiscardCmd{parent: parent}, settings, path
+}
+
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestConfigEnvDiscard(t *testing.T) {
+	ctx := t.Context()
+	const wc = "config:\n  proj:a: b\n"
+
+	t.Run("refuses when not checked out", func(t *testing.T) {
+		cmd, settings, _ := newDiscardCmd(t, pkgWorkspace.Checkout{EnvRef: "proj/env"}, wc, true, false)
+		delete(settings.Checkouts, checkoutFQN)
+		require.ErrorContains(t, cmd.run(ctx), "not checked out")
+	})
+
+	t.Run("unchanged working copy is removed without confirmation", func(t *testing.T) {
+		cmd, settings, path := newDiscardCmd(t, pkgWorkspace.Checkout{EnvRef: "proj/env"}, wc, true, false)
+		marker := settings.Checkouts[checkoutFQN]
+		marker.ContentHash = hashOfWorkingCopy(t, path)
+		settings.Checkouts[checkoutFQN] = marker
+
+		require.NoError(t, cmd.run(ctx)) // non-interactive, no --yes, but no-op needs no confirmation
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "working copy removed")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("changed working copy refuses non-interactively without --yes", func(t *testing.T) {
+		cmd, _, path := newDiscardCmd(t, pkgWorkspace.Checkout{EnvRef: "proj/env", ContentHash: "stale"}, wc, true, false)
+		require.Error(t, cmd.run(ctx))
+		_, statErr := os.Stat(path)
+		assert.False(t, os.IsNotExist(statErr), "working copy preserved on refusal")
+	})
+
+	t.Run("changed working copy is discarded with --yes", func(t *testing.T) {
+		marker := pkgWorkspace.Checkout{EnvRef: "proj/env", ContentHash: "stale"}
+		cmd, settings, path := newDiscardCmd(t, marker, wc, true, false)
+		cmd.yes = true
+		require.NoError(t, cmd.run(ctx))
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "working copy removed")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("corrupt working copy is still discardable with --yes", func(t *testing.T) {
+		marker := pkgWorkspace.Checkout{EnvRef: "proj/env", ContentHash: "stale"}
+		cmd, settings, path := newDiscardCmd(t, marker, "\tnot: [valid yaml", true, false)
+		cmd.yes = true
+		require.NoError(t, cmd.run(ctx))
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr), "corrupt working copy removed")
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+
+	t.Run("missing working copy clears the dangling marker", func(t *testing.T) {
+		marker := pkgWorkspace.Checkout{EnvRef: "proj/env", ContentHash: "stale"}
+		cmd, settings, _ := newDiscardCmd(t, marker, wc, false, false)
+		require.NoError(t, cmd.run(ctx))
+		_, ok := settings.Checkouts[checkoutFQN]
+		assert.False(t, ok, "marker cleared")
+	})
+}

--- a/pkg/cmd/pulumi/config/config_env_eject.go
+++ b/pkg/cmd/pulumi/config/config_env_eject.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/backend/state"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
@@ -104,6 +105,15 @@ func (cmd *configEnvEjectCmd) run(ctx context.Context) error {
 		return errors.New("this stack does not use remote configuration; there is nothing to eject")
 	}
 
+	// Ejecting a checked-out stack would silently drop the working copy's uncommitted edits and leave a
+	// dangling marker; require the user to resolve the checkout first.
+	if marker, err := state.GetCheckout(cmd.parent.ws, stack.Ref().FullyQualifiedName().String()); err != nil {
+		return err
+	} else if marker != nil {
+		return errors.New("this stack is checked out; run `pulumi config env commit` or " +
+			"`pulumi config env discard` before ejecting")
+	}
+
 	// Eject's local write, unlink, and default delete are irreversible; require --yes when no TTY can confirm.
 	if !cmd.yes && !cmd.parent.interactive {
 		return backenderr.ErrNonInteractiveRequiresYes
@@ -141,52 +151,18 @@ func (cmd *configEnvEjectCmd) run(ctx context.Context) error {
 	}
 
 	ps := &workspace.ProjectStack{}
-	hasSecret := false
 	if !envMissing {
-		pulumiConfig, imports, structured, otherValues, err := parseEjectedEnvironment(def)
+		var structured []string
+		ps, _, structured, err = materializeProjectStack(
+			ctx, cmd.parent.ssml, stack, def, envProject, envName, cmd.secretsProvider,
+			!cmd.yes && cmd.parent.interactive, opts)
 		if err != nil {
 			return err
-		}
-		// A local stack file holds only config and imports. If the env carries other values
-		// (environmentVariables, files, ...), refuse before mutating: ejecting drops them and the default
-		// delete would destroy the only copy.
-		if len(otherValues) > 0 {
-			return fmt.Errorf(
-				"environment %s/%s defines values eject cannot preserve in a local stack file (values.%s); "+
-					"eject supports environments whose values contain only pulumiConfig. Inspect them with "+
-					"`pulumi config edit` or keep the stack on remote configuration",
-				envProject, envName, strings.Join(otherValues, ", values."))
 		}
 		if len(structured) > 0 {
 			fmt.Fprintf(cmd.parent.stdout,
 				"Warning: import(s) %s had merge options that are not preserved in the local stack "+
 					"file; only the environment name is kept\n", strings.Join(structured, ", "))
-		}
-
-		plaintextMap, err := buildPlaintextMap(pulumiConfig)
-		if err != nil {
-			return err
-		}
-		for _, pt := range plaintextMap {
-			if pt.Secure() {
-				hasSecret = true
-				break
-			}
-		}
-
-		encrypter, err := cmd.resolveEncrypter(ctx, stack, ps, hasSecret, opts)
-		if err != nil {
-			return err
-		}
-
-		cfg, err := config.EncryptMap(ctx, plaintextMap, encrypter)
-		if err != nil {
-			return fmt.Errorf("re-encrypting configuration: %w", err)
-		}
-
-		ps.Config = config.Map(cfg)
-		if len(imports) > 0 {
-			ps.Environment = workspace.NewEnvironment(imports)
 		}
 	}
 
@@ -243,50 +219,6 @@ func (cmd *configEnvEjectCmd) run(ctx context.Context) error {
 		fmt.Fprintf(cmd.parent.stdout, "Kept environment %s/%s\n", envProject, envName)
 	}
 	return nil
-}
-
-// resolveEncrypter builds an Encrypter for local re-encryption: NopEncrypter when there are no
-// secrets, otherwise --secrets-provider or "default".
-func (cmd *configEnvEjectCmd) resolveEncrypter(
-	ctx context.Context,
-	stack backend.Stack,
-	ps *workspace.ProjectStack,
-	hasSecret bool,
-	opts display.Options,
-) (config.Encrypter, error) {
-	if !hasSecret {
-		return config.NopEncrypter, nil
-	}
-
-	provider := cmd.secretsProvider
-	if provider == "" {
-		if !cmd.yes && cmd.parent.interactive {
-			value, err := ui.PromptForValue(
-				false, "secrets provider", "default", false,
-				func(string) error { return nil }, opts)
-			if err != nil {
-				return nil, err
-			}
-			provider = value
-		}
-		// Fall back to "default" when non-interactive or the prompt is empty.
-		if provider == "" {
-			provider = "default"
-		}
-	}
-
-	if err := cmdStack.ValidateSecretsProvider(provider); err != nil {
-		return nil, err
-	}
-	if provider != "default" {
-		ps.SecretsProvider = provider
-	}
-
-	encrypter, _, err := cmd.parent.ssml.GetEncrypter(ctx, stack, ps)
-	if err != nil {
-		return nil, fmt.Errorf("setting up secrets provider %q: %w", provider, err)
-	}
-	return encrypter, nil
 }
 
 // deleteEnvironment removes the backing environment unless --keep-env is set; an already-deleted env
@@ -459,21 +391,35 @@ func secretInnerString(v any) (string, error) {
 // atomicWriteProjectStack writes ps to path atomically (temp file in the same dir, then rename) so a
 // failed write never leaves a half-written (plaintext) file.
 func atomicWriteProjectStack(ps *workspace.ProjectStack, path string) error {
+	b, err := marshalProjectStack(ps, path)
+	if err != nil {
+		return err
+	}
+	return atomicWriteBytes(path, b)
+}
+
+// marshalProjectStack serializes ps using the marshaler for path's file extension.
+func marshalProjectStack(ps *workspace.ProjectStack, path string) ([]byte, error) {
 	ext := filepath.Ext(path)
 	marshaler, ok := encoding.Marshalers[ext]
 	if !ok {
-		return fmt.Errorf("no marshaler found for file format %q", ext)
+		return nil, fmt.Errorf("no marshaler found for file format %q", ext)
 	}
 	b, err := marshaler.Marshal(ps)
 	if err != nil {
-		return fmt.Errorf("serializing stack configuration: %w", err)
+		return nil, fmt.Errorf("serializing stack configuration: %w", err)
 	}
+	return b, nil
+}
 
+// atomicWriteBytes writes b to path atomically (temp file in the same dir, then rename).
+func atomicWriteBytes(path string, b []byte) error {
+	ext := filepath.Ext(path)
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, ".pulumi-eject-*"+ext)
+	tmp, err := os.CreateTemp(dir, ".pulumi-stack-*"+ext)
 	if err != nil {
 		return fmt.Errorf("creating temporary stack configuration file: %w", err)
 	}

--- a/pkg/cmd/pulumi/config/config_env_eject_test.go
+++ b/pkg/cmd/pulumi/config/config_env_eject_test.go
@@ -110,6 +110,9 @@ func newEjectCmdForTest(
 				}
 				return p, "", nil
 			},
+			NewF: func() (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{}, nil
+			},
 		},
 		requireStack: func(
 			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,

--- a/pkg/cmd/pulumi/config/config_env_materialize.go
+++ b/pkg/cmd/pulumi/config/config_env_materialize.go
@@ -1,0 +1,180 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/encoding"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// materializeProjectStack converts a decrypted environment definition into a ProjectStack with config
+// re-encrypted under a local secrets provider and the environment's imports flattened to a name list. It
+// refuses environments that carry values other than pulumiConfig, which a local stack file cannot
+// represent. The returned structured slice names imports whose merge options were dropped, so the caller
+// can warn. promptAllowed enables the interactive secrets-provider prompt; when false it defaults to
+// "default". This is the shared materialization core of `config env eject` and `config env checkout`.
+func materializeProjectStack(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	stack backend.Stack,
+	def []byte,
+	envProject, envName, secretsProvider string,
+	promptAllowed bool,
+	opts display.Options,
+) (ps *workspace.ProjectStack, imports, structured []string, err error) {
+	pulumiConfig, imports, structured, otherValues, err := parseEjectedEnvironment(def)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// A local stack file holds only config and imports. If the env carries other values
+	// (environmentVariables, files, ...), refuse: materializing would silently drop them.
+	if len(otherValues) > 0 {
+		return nil, nil, nil, fmt.Errorf(
+			"environment %s/%s defines values that cannot be represented in a local stack file (values.%s); "+
+				"only environments whose values contain solely pulumiConfig are supported. Inspect them with "+
+				"`pulumi config edit` or keep the stack on remote configuration",
+			envProject, envName, strings.Join(otherValues, ", values."))
+	}
+
+	plaintextMap, err := buildPlaintextMap(pulumiConfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	hasSecret := false
+	for _, pt := range plaintextMap {
+		if pt.Secure() {
+			hasSecret = true
+			break
+		}
+	}
+
+	ps = &workspace.ProjectStack{}
+	encrypter, err := resolveEncrypter(ctx, ssml, stack, ps, secretsProvider, hasSecret, promptAllowed, opts)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cfg, err := config.EncryptMap(ctx, plaintextMap, encrypter)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("re-encrypting configuration: %w", err)
+	}
+
+	ps.Config = config.Map(cfg)
+	if len(imports) > 0 {
+		ps.Environment = workspace.NewEnvironment(imports)
+	}
+	return ps, imports, structured, nil
+}
+
+// resolveEncrypter builds an Encrypter for local re-encryption: NopEncrypter when there are no secrets,
+// otherwise the requested secretsProvider or "default". When promptAllowed is true and no provider is set,
+// it prompts (defaulting to "default").
+func resolveEncrypter(
+	ctx context.Context,
+	ssml cmdStack.SecretsManagerLoader,
+	stack backend.Stack,
+	ps *workspace.ProjectStack,
+	secretsProvider string,
+	hasSecret bool,
+	promptAllowed bool,
+	opts display.Options,
+) (config.Encrypter, error) {
+	if !hasSecret {
+		return config.NopEncrypter, nil
+	}
+
+	provider := secretsProvider
+	if provider == "" {
+		if promptAllowed {
+			value, err := ui.PromptForValue(
+				false, "secrets provider", "default", false,
+				func(string) error { return nil }, opts)
+			if err != nil {
+				return nil, err
+			}
+			provider = value
+		}
+		// Fall back to "default" when non-interactive or the prompt is empty.
+		if provider == "" {
+			provider = "default"
+		}
+	}
+
+	if err := cmdStack.ValidateSecretsProvider(provider); err != nil {
+		return nil, err
+	}
+	if provider != "default" {
+		ps.SecretsProvider = provider
+	}
+
+	encrypter, _, err := ssml.GetEncrypter(ctx, stack, ps)
+	if err != nil {
+		return nil, fmt.Errorf("setting up secrets provider %q: %w", provider, err)
+	}
+	return encrypter, nil
+}
+
+// writeWorkingCopy marshals ps and writes it atomically to path with the given banner prepended as
+// leading comment lines. The banner is plain YAML trivia: it is ignored on load and excluded from the
+// canonical hash, so it does not affect no-op detection.
+func writeWorkingCopy(ps *workspace.ProjectStack, path, banner string) error {
+	b, err := marshalProjectStack(ps, path)
+	if err != nil {
+		return err
+	}
+	if banner != "" {
+		b = append([]byte(banner), b...)
+	}
+	return atomicWriteBytes(path, b)
+}
+
+// canonicalCheckoutHash hashes a ProjectStack's canonical content rather than its file bytes. It
+// marshals a fresh copy that carries only the semantic fields, deliberately dropping the loaded file's
+// trivia (the banner and original formatting a ProjectStack retains for comment-preserving saves). A raw
+// byte hash would not survive even a no-op edit, since a later save reflows the file; this canonical hash
+// is stable across that round trip and changes only when config values, imports, or secrets settings do.
+func canonicalCheckoutHash(ps *workspace.ProjectStack) (string, error) {
+	marshaler, ok := encoding.Marshalers[".yaml"]
+	if !ok {
+		return "", errors.New("no marshaler found for yaml")
+	}
+	// Copy only the exported (semantic) fields so the unexported raw byte cache does not leak the banner
+	// and formatting into the hash.
+	canonical := &workspace.ProjectStack{
+		SecretsProvider: ps.SecretsProvider,
+		EncryptedKey:    ps.EncryptedKey,
+		EncryptionSalt:  ps.EncryptionSalt,
+		Config:          ps.Config,
+		Environment:     ps.Environment,
+	}
+	b, err := marshaler.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("hashing stack configuration: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/pkg/cmd/pulumi/config/config_env_materialize_test.go
+++ b/pkg/cmd/pulumi/config/config_env_materialize_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestCanonicalCheckoutHashStableAcrossLoad locks in the no-op detection guarantee: the hash computed at
+// checkout (from the in-memory ProjectStack, no banner) must equal the hash computed by commit/discard
+// after writing the banner-prefixed file and loading it back. A raw byte hash would diverge here because
+// a loaded ProjectStack retains the file's trivia for comment-preserving saves.
+//
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestCanonicalCheckoutHashStableAcrossLoad(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	ps := &workspace.ProjectStack{Config: config.Map{}}
+	require.NoError(t, ps.Config.Set(config.MustMakeKey("proj", "a"), config.NewValue("b"), false))
+	ps.Environment = workspace.NewEnvironment([]string{"proj/base"})
+
+	checkoutHash, err := canonicalCheckoutHash(ps)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "Pulumi.dev.local.yaml")
+	banner := "# created by checkout\n# do not commit\n"
+	require.NoError(t, writeWorkingCopy(ps, path, banner))
+
+	loaded, err := cmdStack.LoadProjectStack(t.Context(),
+		diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		&workspace.Project{Name: "proj"}, nil, path)
+	require.NoError(t, err)
+
+	loadedHash, err := canonicalCheckoutHash(loaded)
+	require.NoError(t, err)
+
+	require.Equal(t, checkoutHash, loadedHash,
+		"hash must survive checkout-write (with banner) then load, or no-op detection breaks")
+}

--- a/pkg/cmd/pulumi/config/config_env_preamble_test.go
+++ b/pkg/cmd/pulumi/config/config_env_preamble_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestLoadEnvPreambleRoutesToWorkingCopy verifies the C1 fix: when a stack is checked out, loadEnvPreamble
+// resolves the effective config file to the working copy, so config env add/rm/ls operate on it rather
+// than mutating the shared remote environment.
+//
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestLoadEnvPreambleRoutesToWorkingCopy(t *testing.T) {
+	ctx := t.Context()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("environment:\n  - proj/base\nconfig:\n  proj:a: b\n"), 0o600))
+
+	settings := &pkgWorkspace.Settings{
+		Checkouts: map[string]pkgWorkspace.Checkout{checkoutFQN: {EnvRef: "proj/env", FilePath: path}},
+	}
+	stackRef, configFile := "", ""
+	parent := &configEnvCmd{
+		diags:            diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		stackRef:         &stackRef,
+		configFile:       &configFile,
+		loadProjectStack: cmdStack.LoadProjectStack,
+		ws: &pkgWorkspace.MockContext{
+			ReadProjectF: func() (*workspace.Project, string, error) {
+				return &workspace.Project{Name: "proj"}, "", nil
+			},
+			NewF: func() (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{SettingsF: func() *pkgWorkspace.Settings { return settings }}, nil
+			},
+		},
+		requireStack: func(
+			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,
+			_ string, _ cmdStack.LoadOption, _ display.Options, _ string,
+		) (backend.Stack, error) {
+			return checkoutTestStack("proj/env", "", "etag", 1), nil
+		},
+	}
+
+	ps, _, _, err := parent.loadEnvPreamble(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, path, configFile, "configFile is resolved to the working copy")
+	require.NotNil(t, ps.Environment)
+	assert.Equal(t, []string{"proj/base"}, ps.Environment.Imports(), "imports loaded from the working copy")
+}

--- a/pkg/cmd/pulumi/config/config_env_remote_test.go
+++ b/pkg/cmd/pulumi/config/config_env_remote_test.go
@@ -80,6 +80,9 @@ func newRemoteConfigEnvCmdForTest(
 				}
 				return p, "", nil
 			},
+			NewF: func() (pkgWorkspace.W, error) {
+				return &pkgWorkspace.MockW{}, nil
+			},
 		},
 		requireStack: func(
 			_ context.Context, _ diag.Sink, _ pkgWorkspace.Context, _ cmdBackend.LoginManager,

--- a/pkg/cmd/pulumi/config/config_env_status_test.go
+++ b/pkg/cmd/pulumi/config/config_env_status_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// TestConfigEnvCheckedOutStatus verifies the bare `config env` status of a checked-out stack reports the
+// source environment/revision and the working copy's imports, not the remote environment.
+//
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestConfigEnvCheckedOutStatus(t *testing.T) {
+	ctx := t.Context()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+
+	path, err := cmdStack.WorkingCopyPath(tokens.QName("dev"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("environment:\n  - proj/base\nconfig:\n  proj:a: b\n"), 0o600))
+
+	var stdout bytes.Buffer
+	cmd := &configEnvCmd{
+		stdout:           &stdout,
+		diags:            diag.DefaultSink(&bytes.Buffer{}, &bytes.Buffer{}, diag.FormatOptions{Color: colors.Never}),
+		loadProjectStack: cmdStack.LoadProjectStack,
+	}
+	marker := &pkgWorkspace.Checkout{EnvRef: "proj/env", Revision: 4, FilePath: path}
+
+	require.NoError(t, cmd.runCheckedOutStatus(ctx, &workspace.Project{Name: "proj"}, discardStack(), marker, false))
+
+	out := stdout.String()
+	assert.Contains(t, out, "checked out")
+	assert.Contains(t, out, "proj/env")
+	assert.Contains(t, out, "revision 4")
+	assert.Contains(t, out, "proj/base", "imports come from the working copy")
+}

--- a/pkg/cmd/pulumi/config/editor.go
+++ b/pkg/cmd/pulumi/config/editor.go
@@ -144,35 +144,59 @@ type escConfigEditor struct {
 	version string
 }
 
-func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEditor, error) {
-	envBackend, ok := stack.Backend().(backend.EnvironmentsBackend)
+// escEnvCoordinates resolves the environment backend and the org/project/name/version addressing the
+// stack's linked ESC environment. version is the pinned revision/tag carried by the ref (empty for
+// latest).
+func escEnvCoordinates(stack backend.Stack) (
+	envBackend backend.EnvironmentsBackend, orgName, envProject, envName, version string, err error,
+) {
+	eb, ok := stack.Backend().(backend.EnvironmentsBackend)
 	if !ok {
-		return nil, fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
+		return nil, "", "", "", "", fmt.Errorf("backend %v does not support environments", stack.Backend().Name())
 	}
 
 	orgNamer, ok := stack.(interface{ OrgName() string })
 	if !ok {
-		return nil, errors.New("internal error: stack does not provide an organization name")
+		return nil, "", "", "", "", errors.New("internal error: stack does not provide an organization name")
 	}
-	orgName := orgNamer.OrgName()
 
 	ref := stack.ConfigLocation().EscEnv
 	if ref == nil {
-		return nil, errors.New("stack is configured for remote config but has no linked environment")
+		return nil, "", "", "", "", errors.New("stack is configured for remote config but has no linked environment")
 	}
-	envProject, envName, err := splitEnvRef(*ref)
+	project, name, err := splitEnvRef(*ref)
+	if err != nil {
+		return nil, "", "", "", "", err
+	}
+	return eb, orgNamer.OrgName(), project, name, envRefVersion(*ref), nil
+}
+
+func newESCConfigEditor(ctx context.Context, stack backend.Stack) (*escConfigEditor, error) {
+	envBackend, orgName, envProject, envName, version, err := escEnvCoordinates(stack)
 	if err != nil {
 		return nil, err
 	}
+
 	// Read at the pinned revision/tag when the ref carries one, else latest. Save still guards against
 	// writing to a pinned version regardless.
-	version := envRefVersion(*ref)
-
 	def, etag, _, err := envBackend.GetEnvironment(ctx, orgName, envProject, envName, version, false)
 	if err != nil {
 		return nil, fmt.Errorf("getting environment definition: %w", err)
 	}
 
+	return newESCConfigEditorFromDef(envBackend, orgName, envProject, envName, version, def, etag)
+}
+
+// newESCConfigEditorFromDef builds an editor from an already-read environment definition and its etag,
+// rather than reading inside the constructor. Commit uses this so its drift-check read and its write
+// share one etag (force-with-lease with no read-modify-write gap). version must be empty for a writable
+// (unpinned) editor; a non-empty version makes Save refuse.
+func newESCConfigEditorFromDef(
+	envBackend backend.EnvironmentsBackend,
+	orgName, envProject, envName, version string,
+	def []byte,
+	etag string,
+) (*escConfigEditor, error) {
 	var doc yaml.Node
 	if len(def) != 0 {
 		if err := yaml.Unmarshal(def, &doc); err != nil {
@@ -258,6 +282,60 @@ func (e *escConfigEditor) Save(ctx context.Context) error {
 	return nil
 }
 
+// ConfigKeys returns the keys currently under values.pulumiConfig (empty if absent). Used by
+// ReplaceConfig to find keys to delete.
+func (e *escConfigEditor) ConfigKeys() ([]config.Key, error) {
+	node, ok := escEncoding.YAMLSyntax{Node: &e.doc}.Get(resource.PropertyPath{"values", "pulumiConfig"})
+	if !ok || node.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	keys := make([]config.Key, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k, err := config.ParseKey(node.Content[i].Value)
+		if err != nil {
+			return nil, fmt.Errorf("parsing config key %q: %w", node.Content[i].Value, err)
+		}
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// ReplaceConfig makes values.pulumiConfig exactly match c: keys present in the environment but absent
+// from c are removed, and keys in c are set (added or overwritten). Imports and any other values are
+// left untouched. Unlike SaveRemoteConfigValues, which only overwrites, this applies deletions — the
+// exact-replacement semantics `config env commit` needs. It buffers edits without saving so the caller
+// can reconcile imports on the same editor before a single Save.
+func (e *escConfigEditor) ReplaceConfig(ctx context.Context, c config.Map) error {
+	current, err := e.ConfigKeys()
+	if err != nil {
+		return err
+	}
+
+	target := make(map[string]bool, len(c))
+	for k := range c {
+		target[k.String()] = true
+	}
+	for _, k := range current {
+		if !target[k.String()] {
+			if err := e.Remove(ctx, k, false /*path*/); err != nil {
+				return err
+			}
+		}
+	}
+
+	keys := make(config.KeyArray, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	sort.Sort(keys)
+	for _, k := range keys {
+		if err := e.Set(ctx, k, c[k], false /*path*/); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Imports returns the names of the top-level `imports` entries (empty if absent). Unlike
 // workspace.Environment.Imports it omits the synthetic "yaml" marker, a local-Environment artifact
 // meaningless for the backing env's real imports.
@@ -323,6 +401,18 @@ func (e *escConfigEditor) RemoveImport(env string) error {
 		}
 	}
 	return nil
+}
+
+// ReplaceImports rewrites the `imports` sequence to exactly envs, in order, as plain scalar entries.
+// Used by commit to propagate an edited import list (including reordering); any structured/merge options
+// on the previous entries are dropped, so callers should only invoke it when the list actually changed.
+func (e *escConfigEditor) ReplaceImports(envs []string) error {
+	seq, err := e.ensureImportsNode()
+	if err != nil {
+		return err
+	}
+	seq.Content = nil
+	return e.AddImports(envs...)
 }
 
 func (e *escConfigEditor) ensureImportsNode() (*yaml.Node, error) {

--- a/pkg/cmd/pulumi/config/editor_test.go
+++ b/pkg/cmd/pulumi/config/editor_test.go
@@ -524,6 +524,92 @@ func pulumiConfigScalar(t *testing.T, doc []byte, key string) *yaml.Node {
 	return n
 }
 
+func TestESCConfigEditorConfigKeys(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const initial = `values:
+  pulumiConfig:
+    testProject:a: 1
+    testProject:b: 2
+`
+	s := remoteStackForEditor(t, []byte(initial), "etag", nil)
+	editor, err := newConfigEditor(ctx, s, &workspace.ProjectStack{}, config.NopEncrypter, "")
+	require.NoError(t, err)
+	esc, ok := editor.(*escConfigEditor)
+	require.True(t, ok)
+
+	keys, err := esc.ConfigKeys()
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, k := range keys {
+		got[k.String()] = true
+	}
+	require.Equal(t, map[string]bool{"testProject:a": true, "testProject:b": true}, got)
+}
+
+// TestESCConfigEditorReplaceConfig verifies exact replacement: keys absent from the new set are removed
+// (not merely left in place as SaveRemoteConfigValues does), surviving keys are overwritten, and new
+// keys are added.
+func TestESCConfigEditorReplaceConfig(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const initial = `values:
+  pulumiConfig:
+    testProject:a: 1
+    testProject:b: 2
+    testProject:c: 3
+`
+	uploaded := editForRemote(t, initial, func(t *testing.T, e *escConfigEditor) {
+		c := config.Map{
+			config.MustMakeKey("testProject", "a"): config.NewValue("updated"),
+			config.MustMakeKey("testProject", "d"): config.NewValue("new"),
+		}
+		require.NoError(t, e.ReplaceConfig(ctx, c))
+	})
+
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal(uploaded, &doc))
+	pc := doc["values"].(map[string]any)["pulumiConfig"].(map[string]any)
+	require.Equal(t, "updated", pc["testProject:a"], "surviving key overwritten")
+	require.Equal(t, "new", pc["testProject:d"], "new key added")
+	_, hasB := pc["testProject:b"]
+	_, hasC := pc["testProject:c"]
+	require.False(t, hasB, "key absent from the new set is removed")
+	require.False(t, hasC, "key absent from the new set is removed")
+}
+
+// TestNewESCConfigEditorFromDefUsesSeededEtag verifies the seeded constructor writes with the supplied
+// etag and never re-reads the environment, giving commit a no-gap force-with-lease write.
+func TestNewESCConfigEditorFromDefUsesSeededEtag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	var gotEtag string
+	be := &backend.MockEnvironmentsBackend{
+		GetEnvironmentF: func(
+			_ context.Context, _, _, _, _ string, _ bool,
+		) ([]byte, string, int, error) {
+			t.Fatal("a seeded editor must not read the environment")
+			return nil, "", 0, nil
+		},
+		UpdateEnvironmentWithProjectF: func(
+			_ context.Context, _, _, _ string, _ []byte, etag string,
+		) (apitype.EnvironmentDiagnostics, error) {
+			gotEtag = etag
+			return nil, nil
+		},
+	}
+
+	editor, err := newESCConfigEditorFromDef(
+		be, "org", "testProject", "testStack", "", []byte("values:\n  pulumiConfig: {}\n"), "lease-etag")
+	require.NoError(t, err)
+	require.NoError(t, editor.Set(ctx, config.MustMakeKey("testProject", "k"), config.NewValue("v"), false))
+	require.NoError(t, editor.Save(ctx))
+	require.Equal(t, "lease-etag", gotEtag)
+}
+
 // TestConfigSetSecretRemoteCommand exercises the full `config set --secret` command path against a
 // remote stack, verifying the plaintext is passed through to the editor (not encrypted locally) and
 // uploaded as fn::secret.

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -223,6 +223,12 @@ func NewDestroyCmd() *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, configFile, true)
+			if err != nil {
+				return err
+			}
+
 			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -931,6 +931,12 @@ func NewImportCmd() *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, sink, s, configFile, true)
+			if err != nil {
+				return err
+			}
+
 			cfg, sm, err := config.GetStackConfiguration(ctx, sink, ssml, s, proj, configFile)
 			if err != nil {
 				return fmt.Errorf("getting stack configuration: %w", err)

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -464,6 +464,12 @@ func NewPreviewCmd() *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, configFile, true)
+			if err != nil {
+				return err
+			}
+
 			// Save any config values passed via flags.
 			if err = parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath, configFile); err != nil {
 				return err

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -225,6 +225,12 @@ func NewRefreshCmd() *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, configFile, true)
+			if err != nil {
+				return err
+			}
+
 			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -162,6 +162,12 @@ func NewUpCmd() *cobra.Command {
 			return err
 		}
 
+		// Route config to the local working copy if this stack is checked out (service-backed config).
+		configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, configFile, true)
+		if err != nil {
+			return err
+		}
+
 		// Save any config values passed via flags.
 		if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, path, configFile); err != nil {
 			return err

--- a/pkg/cmd/pulumi/operations/watch.go
+++ b/pkg/cmd/pulumi/operations/watch.go
@@ -113,6 +113,12 @@ func NewWatchCmd() *cobra.Command {
 				return err
 			}
 
+			// Route config to the local working copy if this stack is checked out (service-backed config).
+			configFile, err = cmdStack.ResolveWorkingCopy(ctx, ws, cmdutil.Diag(), s, configFile, true)
+			if err != nil {
+				return err
+			}
+
 			// Save any config values passed via flags.
 			if err := parseAndSaveConfigArray(ctx, cmdutil.Diag(), ws, s, configArray, configPath, configFile); err != nil {
 				return err

--- a/pkg/cmd/pulumi/stack/checkout_resolve_test.go
+++ b/pkg/cmd/pulumi/stack/checkout_resolve_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+func discardSink() diag.Sink {
+	return diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+}
+
+func wsWithSettings(s *pkgWorkspace.Settings) pkgWorkspace.Context {
+	return &pkgWorkspace.MockContext{
+		NewF: func() (pkgWorkspace.W, error) {
+			return &pkgWorkspace.MockW{SettingsF: func() *pkgWorkspace.Settings { return s }}, nil
+		},
+	}
+}
+
+func remoteCheckoutStack(name string) *backend.MockStack {
+	env := "proj/env"
+	return &backend.MockStack{
+		RefF: func() backend.StackReference {
+			return &backend.MockStackReference{
+				NameV:               tokens.MustParseStackName(name),
+				FullyQualifiedNameV: tokens.QName("org/proj/" + name),
+			}
+		},
+		ConfigLocationF: func() backend.StackConfigLocation {
+			return backend.StackConfigLocation{IsRemote: true, EscEnv: &env}
+		},
+	}
+}
+
+// setupProjectDir chdirs into a temp dir holding a Pulumi.yaml so DetectProjectStackPath resolves.
+func setupProjectDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte("name: proj\nruntime: nodejs\n"), 0o600))
+	t.Chdir(dir)
+}
+
+//nolint:paralleltest // mutates the working directory via t.Chdir
+func TestResolveWorkingCopy(t *testing.T) {
+	ctx := t.Context()
+	sink := discardSink()
+	const fqn = "org/proj/dev"
+
+	t.Run("explicit config file wins without touching markers", func(t *testing.T) {
+		s := remoteCheckoutStack("dev")
+		ws := wsWithSettings(&pkgWorkspace.Settings{})
+		got, err := ResolveWorkingCopy(ctx, ws, sink, s, "Pulumi.custom.yaml", false)
+		require.NoError(t, err)
+		assert.Equal(t, "Pulumi.custom.yaml", got)
+	})
+
+	t.Run("local-config stack returns empty", func(t *testing.T) {
+		s := &backend.MockStack{
+			RefF: func() backend.StackReference {
+				return &backend.MockStackReference{NameV: tokens.MustParseStackName("dev")}
+			},
+			ConfigLocationF: func() backend.StackConfigLocation { return backend.StackConfigLocation{} },
+		}
+		ws := wsWithSettings(&pkgWorkspace.Settings{})
+		got, err := ResolveWorkingCopy(ctx, ws, sink, s, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("file present and marker present routes to the working copy", func(t *testing.T) {
+		setupProjectDir(t)
+		s := remoteCheckoutStack("dev")
+		path, err := WorkingCopyPath(s.Ref().Name().Q())
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, []byte("config: {}\n"), 0o600))
+		ws := wsWithSettings(&pkgWorkspace.Settings{
+			Checkouts: map[string]pkgWorkspace.Checkout{fqn: {EnvRef: "proj/env"}},
+		})
+		got, err := ResolveWorkingCopy(ctx, ws, sink, s, "", false)
+		require.NoError(t, err)
+		assert.Equal(t, path, got)
+	})
+
+	t.Run("deploying makes the checked-out warning more prominent", func(t *testing.T) {
+		setupProjectDir(t)
+		s := remoteCheckoutStack("dev")
+		path, err := WorkingCopyPath(s.Ref().Name().Q())
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, []byte("config: {}\n"), 0o600))
+
+		warn := func(deploying bool) string {
+			var stderr bytes.Buffer
+			capturing := diag.DefaultSink(io.Discard, &stderr, diag.FormatOptions{Color: colors.Never})
+			ws := wsWithSettings(&pkgWorkspace.Settings{
+				Checkouts: map[string]pkgWorkspace.Checkout{fqn: {EnvRef: "proj/env"}},
+			})
+			_, err := ResolveWorkingCopy(ctx, ws, capturing, s, "", deploying)
+			require.NoError(t, err)
+			return stderr.String()
+		}
+
+		read := warn(false)
+		assert.Contains(t, read, "using local stack config")
+		assert.NotContains(t, read, "this operation uses")
+
+		deploy := warn(true)
+		assert.Contains(t, deploy, "this operation uses the uncommitted local stack config")
+	})
+
+	t.Run("file present and marker absent is a hard error", func(t *testing.T) {
+		setupProjectDir(t)
+		s := remoteCheckoutStack("dev")
+		path, err := WorkingCopyPath(s.Ref().Name().Q())
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, []byte("config: {}\n"), 0o600))
+		ws := wsWithSettings(&pkgWorkspace.Settings{})
+		_, err = ResolveWorkingCopy(ctx, ws, sink, s, "", false)
+		require.ErrorContains(t, err, "not checked out on this machine")
+	})
+
+	t.Run("file absent and marker present clears the dangling marker", func(t *testing.T) {
+		setupProjectDir(t)
+		s := remoteCheckoutStack("dev")
+		settings := &pkgWorkspace.Settings{
+			Checkouts: map[string]pkgWorkspace.Checkout{fqn: {EnvRef: "proj/env"}},
+		}
+		ws := wsWithSettings(settings)
+		got, err := ResolveWorkingCopy(ctx, ws, sink, s, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+		_, ok := settings.Checkouts[fqn]
+		assert.False(t, ok, "dangling marker should be cleared")
+	})
+
+	t.Run("file absent and marker absent uses remote", func(t *testing.T) {
+		setupProjectDir(t)
+		s := remoteCheckoutStack("dev")
+		ws := wsWithSettings(&pkgWorkspace.Settings{})
+		got, err := ResolveWorkingCopy(ctx, ws, sink, s, "", false)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/cmd/pulumi/stack/io.go
+++ b/pkg/cmd/pulumi/stack/io.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	survey "github.com/AlecAivazis/survey/v2"
@@ -43,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
@@ -89,6 +92,145 @@ func SaveProjectStack(
 		return stack.SaveRemoteConfig(ctx, ps)
 	}
 	return workspace.SaveProjectStack(stack.Ref().Name().Q(), ps)
+}
+
+// WorkingCopyPath returns the path of a stack's service-backed config working copy,
+// Pulumi.<stack>.local.yaml. The `.local` infix distinguishes it from the standard Pulumi.<stack>.yaml
+// so it does not collide with the local+remote conflict detection on that path.
+func WorkingCopyPath(stackName tokens.QName) (string, error) {
+	_, configFilePath, err := workspace.DetectProjectStackPath(stackName)
+	if err != nil {
+		return "", fmt.Errorf("could not detect project stack path: %w", err)
+	}
+	ext := filepath.Ext(configFilePath)
+	return strings.TrimSuffix(configFilePath, ext) + ".local" + ext, nil
+}
+
+// ResolveWorkingCopy computes the effective config file for a command, routing a checked-out
+// remote-config stack to its local working copy. It implements the working-copy/marker state matrix:
+//
+//	file present, marker present -> route to the working copy (warn)
+//	file present, marker absent  -> hard error (file not created by a checkout on this machine)
+//	file absent,  marker present -> dangling marker: warn, clear it, use remote
+//	file absent,  marker absent  -> normal remote operation
+//
+// An explicit --config-file always wins and never touches markers. Callers shadow their configFile
+// variable with the returned value before loading, saving, or editing config, so every consumer
+// (LoadProjectStack, SaveProjectStack, the config editor) routes consistently. deploying makes the
+// checked-out warning more prominent, since a deploy against an uncommitted working copy is higher-stakes
+// than a config read.
+func ResolveWorkingCopy(
+	ctx context.Context,
+	ws pkgWorkspace.Context,
+	sink diag.Sink,
+	stack backend.Stack,
+	configFile string,
+	deploying bool,
+) (string, error) {
+	if configFile != "" {
+		return configFile, nil
+	}
+	if !stack.ConfigLocation().IsRemote {
+		return "", nil
+	}
+
+	fqn := stack.Ref().FullyQualifiedName().String()
+	marker, err := state.GetCheckout(ws, fqn)
+	if err != nil {
+		return "", err
+	}
+
+	if marker != nil {
+		// Trust the path recorded at checkout rather than recomputing, so a moved cwd or changed stack
+		// config dir cannot point at a different same-named file.
+		path := marker.FilePath
+		if path == "" {
+			if path, err = WorkingCopyPath(stack.Ref().Name().Q()); err != nil {
+				return "", err
+			}
+		}
+		_, statErr := os.Stat(path)
+		if statErr != nil && !os.IsNotExist(statErr) {
+			return "", fmt.Errorf("checking working copy %s: %w", path, statErr)
+		}
+		if os.IsNotExist(statErr) {
+			// Dangling marker: the working copy was deleted externally. Clear it and use remote config.
+			sink.Warningf(diag.Message("",
+				"stack %s working copy %s is missing; clearing the checkout marker and using remote configuration"),
+				stack.Ref().Name(), path)
+			if err := state.ClearCheckout(ws, fqn); err != nil {
+				return "", err
+			}
+			return "", nil
+		}
+
+		// Warn early if the stack was relinked since checkout so the working copy is no longer a faithful
+		// snapshot; commit re-checks pin/relink authoritatively.
+		if loc := stack.ConfigLocation(); loc.EscEnv != nil && stripRefVersion(*loc.EscEnv) != marker.EnvRef {
+			sink.Warningf(diag.Message("",
+				"stack %s is now linked to %s but its working copy was checked out from %s; "+
+					"`pulumi config env commit` will refuse until you discard and check out again"),
+				stack.Ref().Name(), stripRefVersion(*loc.EscEnv), marker.EnvRef)
+		}
+		const hint = "Run `pulumi config env commit` to save changes or " +
+			"`pulumi config env discard` to drop them"
+		if deploying {
+			sink.Warningf(diag.Message("",
+				"remote-config for stack %s is checked out; this operation uses the uncommitted local stack "+
+					"config %s, not the remote environment. "+hint),
+				stack.Ref().Name(), filepath.Base(path))
+		} else {
+			sink.Warningf(diag.Message("",
+				"remote-config for stack %s is checked out; using local stack config %s. "+hint),
+				stack.Ref().Name(), filepath.Base(path))
+		}
+		// Routing to a non-empty configFile bypasses LoadProjectStack's stray-Pulumi.<stack>.yaml warning,
+		// so re-emit it here to preserve the signal.
+		warnIfStrayConfigFile(sink, stack)
+		return path, nil
+	}
+
+	// No marker: detect a stray working-copy file. If the path cannot be computed (no project on disk),
+	// there can be no stray file, so use remote.
+	path, err := WorkingCopyPath(stack.Ref().Name().Q())
+	if err != nil {
+		//nolint:nilerr // no project means no working copy; fall back to remote config
+		return "", nil
+	}
+	if _, statErr := os.Stat(path); statErr == nil {
+		return "", fmt.Errorf(
+			"found %s but this stack is not checked out on this machine; it was likely committed to "+
+				"source control or its checkout marker was lost. Delete %s to use remote configuration, "+
+				"or run `pulumi config env checkout` for a fresh working copy",
+			path, path)
+	} else if !os.IsNotExist(statErr) {
+		return "", fmt.Errorf("checking working copy %s: %w", path, statErr)
+	}
+	return "", nil
+}
+
+// stripRefVersion removes an "@version" or ":version" suffix from an environment reference, returning the
+// bare project/name. It mirrors the config package's stripEnvVersion, duplicated here to avoid an import.
+func stripRefVersion(ref string) string {
+	if base, _, found := strings.Cut(ref, "@"); found {
+		return base
+	}
+	base, _, _ := strings.Cut(ref, ":")
+	return base
+}
+
+// warnIfStrayConfigFile warns when a remote-config stack also has a standard Pulumi.<stack>.yaml on disk,
+// mirroring the warning LoadProjectStack emits when it is not routed to an explicit config file.
+func warnIfStrayConfigFile(sink diag.Sink, stack backend.Stack) {
+	_, configFilePath, err := workspace.DetectProjectStackPath(stack.Ref().Name().Q())
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(configFilePath); err == nil {
+		sink.Warningf(
+			diag.Message("", "config file %s exists but will be ignored because this stack uses remote config"),
+			configFilePath)
+	}
 }
 
 type LoadOption int

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -116,6 +116,14 @@ func newStackRmCmd() *cobra.Command {
 						if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
 							return err
 						}
+						// Drop any service-backed config working copy and clear its checkout marker so a
+						// later stack with the same name does not inherit stale checked-out state.
+						if wc, werr := WorkingCopyPath(s.Ref().Name().Q()); werr == nil {
+							if err = os.Remove(wc); err != nil && !os.IsNotExist(err) {
+								return err
+							}
+						}
+						contract.IgnoreError(state.ClearCheckout(ws, s.Ref().FullyQualifiedName().String()))
 					}
 				}
 			}

--- a/pkg/workspace/settings.go
+++ b/pkg/workspace/settings.go
@@ -18,10 +18,26 @@ package workspace
 type Settings struct {
 	// Stack is an optional default stack to use.
 	Stack string `json:"stack,omitempty" yaml:"env,omitempty"`
+	// Checkouts records the active service-backed config checkouts, keyed by fully-qualified stack name.
+	Checkouts map[string]Checkout `json:"checkouts,omitempty" yaml:"checkouts,omitempty"`
+}
+
+// Checkout records a service-backed config working copy that materialized a stack's linked ESC environment
+// into a local file. Its presence marks the stack as checked out: config reads and writes route to FilePath
+// until the working copy is committed or discarded. Etag is the conflict token captured at checkout;
+// Revision is display-only; ContentHash is over canonical config content (not file bytes) so the no-op
+// detection survives a YAML re-marshal; Imports is the baseline import list for the commit reconcile.
+type Checkout struct {
+	EnvRef      string   `json:"envRef"`
+	Etag        string   `json:"etag"`
+	Revision    int      `json:"revision"`
+	FilePath    string   `json:"filePath"`
+	ContentHash string   `json:"contentHash"`
+	Imports     []string `json:"imports,omitempty"`
 }
 
 // IsEmpty returns true when the settings object is logically empty (no selected stack and nothing in the deprecated
 // configuration bag).
 func (s *Settings) IsEmpty() bool {
-	return s.Stack == ""
+	return s.Stack == "" && len(s.Checkouts) == 0
 }

--- a/pkg/workspace/settings_test.go
+++ b/pkg/workspace/settings_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&Settings{}).IsEmpty())
+	assert.True(t, (&Settings{Checkouts: map[string]Checkout{}}).IsEmpty())
+	assert.False(t, (&Settings{Stack: "dev"}).IsEmpty())
+	assert.False(t, (&Settings{Checkouts: map[string]Checkout{"org/proj/dev": {}}}).IsEmpty())
+}
+
+func TestSettingsCheckoutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := &Settings{
+		Stack: "org/proj/dev",
+		Checkouts: map[string]Checkout{
+			"org/proj/dev": {
+				EnvRef:      "org/proj/env",
+				Etag:        "etag-1",
+				Revision:    7,
+				FilePath:    "Pulumi.dev.local.yaml",
+				ContentHash: "abc123",
+				Imports:     []string{"org/proj/base"},
+			},
+		},
+	}
+
+	b, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	var got Settings
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, *s, got)
+}
+
+func TestSettingsOmitsEmptyCheckouts(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(&Settings{Stack: "dev"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "checkouts")
+}


### PR DESCRIPTION
## Summary

Adds a hidden `pulumi config env checkout` / `commit` / `discard` workflow that materializes a remote-config stack's backing ESC environment into a local `Pulumi.<stack>.local.yaml` working copy, lets you edit it with the normal `pulumi config` commands, and writes it back as a single environment revision (or drops it). Hidden behind the service-backed-config (SBC) preview.

## Changes

- **Checkout marker** — per-stack `Checkout` state in `workspace.Settings` (env ref, etag, revision, working-copy path, canonical content hash, baseline imports), with `state.{Get,Set,Clear}Checkout` persistence. The marker's presence is what distinguishes a checked-out stack from a normal remote-config one.
- **`config env checkout`** — materializes the ESC environment into `Pulumi.<stack>.local.yaml`, records the marker, and refuses on local-config, pinned, already-checked-out, or stray-working-copy stacks.
- **`config env commit`** — writes the working copy back as one revision and clears checked-out state. No-ops (just removes the working copy) when the canonical hash is unchanged; a writing commit additionally requires the stack still be linked, unpinned, and pointing at the same env, then replaces `pulumiConfig` exactly (deletes locally-removed keys) and rewrites imports when changed. Secrets are re-sent as `fn::secret` for server-side encryption — no plaintext reaches ESC. On drift it refuses unless confirmed interactively or asserted with `--force-revision` (force-with-lease).
- **`config env discard`** — deletes the working copy and clears state without writing back. Unchanged copies drop without confirmation; changed ones need `--yes` or interactive confirmation; an unparseable or missing copy is still droppable.
- **Routing** — `cmdStack.ResolveWorkingCopy` implements the working-copy/marker state matrix and is wired into the config subcommands and the deploy commands (up, preview, destroy, refresh, watch, import) so every consumer routes to the working copy consistently while checked out. Deploy commands warn more prominently that the operation uses the uncommitted local config. `--config-file` always wins and never touches markers.
- **Shared materialization** — factored the parse/re-encrypt core out of `config env eject` into `materializeProjectStack` (plus `writeWorkingCopy` and `canonicalCheckoutHash`); eject's observable behavior is unchanged but now refuses on a checked-out stack.
- **`stack rm`** (without `--preserve-config`) now removes the working copy and clears the marker so a same-named recreated stack doesn't inherit stale checked-out state.

## Notes

- Stacked on `rgharris/sbc-08-pin-restore`; review that first.
- `canonicalCheckoutHash` hashes canonical config content, not file bytes, so no-op detection survives a YAML re-marshal round trip.
