### PR TITLE
[fix] neo explain-failure links for custom console urls

### DIFF
--- a/changelog/pending/cli-neo-fix-explain-failure-console-url.yaml
+++ b/changelog/pending/cli-neo-fix-explain-failure-console-url.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Use backend-provided Console URLs for Neo explain-failure links
+component: cli/neo

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1747,7 +1747,7 @@ func (b *cloudBackend) renderAndSummarizeOutput(
 		}
 
 		if op.Opts.Display.ShowNeoFeatures {
-			permalink := b.getPermalink(update, updateMeta.version, dryRun)
+			permalink := b.getPermalink(ctx, update, updateMeta.version, dryRun)
 			summary, err := b.summarizeErrorWithNeo(ctx, renderer.Output(), stack.Ref(), op.Opts.Display)
 			// Pass the error into the renderer to ensure it's displayed. We don't want to fail the update/preview
 			// if we can't generate a summary.
@@ -1981,19 +1981,39 @@ func (b *cloudBackend) apply(
 	// Display messages from the backend if present.
 	displayBackendMessages(updateMeta.messages)
 
-	permalink := b.getPermalink(update, updateMeta.version, opts.DryRun)
+	permalink := b.getPermalink(ctx, update, updateMeta.version, opts.DryRun)
 	return b.runEngineAction(
 		ctx, kind, stack.Ref(), op, update, updateMeta.leaseToken,
 		permalink, events, opts.DryRun, updateMeta.journalVersion)
 }
 
 // getPermalink returns a link to the update in the Pulumi Console.
-func (b *cloudBackend) getPermalink(update client.UpdateIdentifier, version int, preview bool) string {
-	base := b.cloudConsoleStackPath(update.StackIdentifier)
+func (b *cloudBackend) getPermalink(
+	ctx context.Context, update client.UpdateIdentifier, version int, preview bool,
+) string {
+	paths := []string{b.cloudConsoleStackPath(update.StackIdentifier)}
 	if !preview {
-		return b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
+		paths = append(paths, "updates", strconv.Itoa(version))
+	} else {
+		paths = append(paths, "previews", update.UpdateID)
 	}
-	return b.CloudConsoleURL(base, "previews", update.UpdateID)
+
+	if consoleURL := consoleURLWithPath(b.Capabilities(ctx).CopilotSummarizeErrorConsoleURL, paths...); consoleURL != "" {
+		return consoleURL
+	}
+	return b.CloudConsoleURL(paths...)
+}
+
+func consoleURLWithPath(consoleURL string, paths ...string) string {
+	if strings.TrimSpace(consoleURL) == "" {
+		return ""
+	}
+	u, err := url.Parse(consoleURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	u.Path = path.Join(append([]string{u.Path}, paths...)...)
+	return u.String()
 }
 
 func (b *cloudBackend) runEngineAction(
@@ -2805,7 +2825,7 @@ func (b *cloudBackend) showDeploymentEvents(ctx context.Context, stackID client.
 	// Timings do not display correctly when rendering remote events, so suppress showing them.
 	opts.SuppressTimings = true
 
-	permalink := b.getPermalink(update, version, dryRun)
+	permalink := b.getPermalink(ctx, update, version, dryRun)
 	go display.ShowEvents(
 		backend.ActionLabel(kind, dryRun), kind, stackID.Stack, tokens.PackageName(stackID.Project),
 		permalink, events, done, opts, dryRun)

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -919,6 +919,63 @@ func TestCloudBackend_GetCloudRegistry(t *testing.T) {
 	assert.True(t, ok, "expected registry to be a cloudRegistry")
 }
 
+func TestCloudBackendGetPermalinkUsesCapabilityConsoleURL(t *testing.T) {
+	t.Parallel()
+
+	capabilities := &promise.CompletionSource[apitype.Capabilities]{}
+	capabilities.MustFulfill(apitype.Capabilities{
+		CopilotSummarizeErrorConsoleURL: "https://app-review.review-stacks.pulumi-dev.io",
+	})
+	b := &cloudBackend{
+		url:          "https://api-review.review-stacks.pulumi-dev.io",
+		capabilities: capabilities.Promise(),
+	}
+	update := client.UpdateIdentifier{
+		StackIdentifier: client.StackIdentifier{
+			Owner:   "pulumi",
+			Project: "project",
+			Stack:   tokens.MustParseStackName("dev"),
+		},
+		UpdateID: "preview-id",
+	}
+
+	assert.Equal(
+		t,
+		"https://app-review.review-stacks.pulumi-dev.io/pulumi/project/dev/previews/preview-id",
+		b.getPermalink(t.Context(), update, 42, true),
+	)
+	assert.Equal(
+		t,
+		"https://app-review.review-stacks.pulumi-dev.io/pulumi/project/dev/updates/42",
+		b.getPermalink(t.Context(), update, 42, false),
+	)
+}
+
+func TestCloudBackendGetPermalinkFallsBackWithoutCapabilityConsoleURL(t *testing.T) {
+	t.Parallel()
+
+	capabilities := &promise.CompletionSource[apitype.Capabilities]{}
+	capabilities.MustFulfill(apitype.Capabilities{})
+	b := &cloudBackend{
+		url:          client.PulumiCloudURL,
+		capabilities: capabilities.Promise(),
+	}
+	update := client.UpdateIdentifier{
+		StackIdentifier: client.StackIdentifier{
+			Owner:   "pulumi",
+			Project: "project",
+			Stack:   tokens.MustParseStackName("dev"),
+		},
+		UpdateID: "preview-id",
+	}
+
+	assert.Equal(
+		t,
+		"https://app.pulumi.com/pulumi/project/dev/previews/preview-id",
+		b.getPermalink(t.Context(), update, 42, true),
+	)
+}
+
 // Bit of an integration test.
 // That we can render engine events, send them to the backend, and get a summary back.
 func TestCopilotExplainer(t *testing.T) {

--- a/sdk/go/common/apitype/service.go
+++ b/sdk/go/common/apitype/service.go
@@ -63,6 +63,12 @@ type DeltaCheckpointUploadsConfigV2 struct {
 	CheckpointCutoffSizeBytes int `json:"checkpointCutoffSizeBytes"`
 }
 
+// CopilotSummarizeErrorConfig is the configuration for the copilot-summarize-error capability.
+type CopilotSummarizeErrorConfig struct {
+	// ConsoleURL is the base Pulumi Console URL for this backend.
+	ConsoleURL string `json:"consoleUrl,omitempty"`
+}
+
 // DeploymentSchemaVersionConfig is the configuration for the deployment-schema-version capability.
 type DeploymentSchemaVersionConfig struct {
 	// Version is the maximum version of the deployment schema that the service supports.
@@ -135,6 +141,9 @@ type Capabilities struct {
 	// Indicates whether the service supports summarizing errors via Copilot.
 	CopilotSummarizeErrorV1 bool
 
+	// The backend-provided base Pulumi Console URL for Copilot summarize error links.
+	CopilotSummarizeErrorConsoleURL string
+
 	// Indicates whether the service supports the Copilot explainer.
 	CopilotExplainPreviewV1 bool
 
@@ -177,6 +186,13 @@ func (r CapabilitiesResponse) Parse() (Capabilities, error) {
 		case CopilotSummarizeError:
 			if entry.Version == 1 {
 				parsed.CopilotSummarizeErrorV1 = true
+				if len(entry.Configuration) > 0 {
+					var cfg CopilotSummarizeErrorConfig
+					if err := json.Unmarshal(entry.Configuration, &cfg); err != nil {
+						return Capabilities{}, fmt.Errorf("decoding CopilotSummarizeErrorConfig returned %w", err)
+					}
+					parsed.CopilotSummarizeErrorConsoleURL = cfg.ConsoleURL
+				}
 			}
 		case CopilotExplainPreview:
 			if entry.Version == 1 {

--- a/sdk/go/common/apitype/service_test.go
+++ b/sdk/go/common/apitype/service_test.go
@@ -129,6 +129,25 @@ func TestCapabilities(t *testing.T) {
 		}, actual)
 	})
 
+	t.Run("parse copilot summarize error v1 with console url", func(t *testing.T) {
+		t.Parallel()
+		response := CapabilitiesResponse{
+			Capabilities: []APICapabilityConfig{
+				{
+					Capability:    CopilotSummarizeError,
+					Version:       1,
+					Configuration: json.RawMessage(`{"consoleUrl":"https://app.example.com"}`),
+				},
+			},
+		}
+		actual, err := response.Parse()
+		require.NoError(t, err)
+		assert.Equal(t, Capabilities{
+			CopilotSummarizeErrorV1:         true,
+			CopilotSummarizeErrorConsoleURL: "https://app.example.com",
+		}, actual)
+	})
+
 	t.Run("parse copilot summarize error with newer version", func(t *testing.T) {
 		t.Parallel()
 		response := CapabilitiesResponse{


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->
<!-- Remember: we squash-merge, so this description becomes the commit message. -->
Use a backend-provided Console URL when rendering Neo explain-failure links.

The CLI now parses the optional `consoleUrl` field from the `copilot-summarize-error` capability config and prefers it when building update/preview permalinks. If the field is absent, empty, or invalid, the existing Console URL inference remains the fallback.

Neo explain-failure links currently rely on deriving the Console URL from the API URL. That works for standard `api.` → `app.` domains, but breaks for review stacks and some self-hosted/custom backends with different hostname patterns.

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test in `pkg/engine/lifecycletest` - For all engine/protocol changes
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - For language protocol changes
- [ ] Added a golden test in `pkg/backend/display` - For changes to the output renderers

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [ ] `make test_fast` — all pass
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] Relevant SDK tests pass (if SDK changes)
- [ ] `make check_proto` — clean (if proto changes)

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added. If you do not believe this PR requires a changelog, ask a maintainer to apply
  the `impact/no-changelog-required` label.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->

The main risk is a bad or malicious consoleUrl from the backend causing the CLI to print an incorrect Neo explain-failure link. The CLI patch mitigates malformed values by requiring a parseable absolute URL with scheme and host, then falls back to the old heuristic if invalid. It does not validate that the URL is a Pulumi-owned host, which is probably fine because custom/self-hosted backends legitimately need custom console domains.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->
