### PR TITLE
Respect PULUMI_SKIP_CONFIRMATIONS whenever we ask for confirmation

### DIFF
--- a/changelog/pending/cli-improvement-20260617-114824.yaml
+++ b/changelog/pending/cli-improvement-20260617-114824.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Respect PULUMI_SKIP_CONFIRMATIONS whenever we ask for confirmation
+time: 2026-06-17T11:48:24.192746+02:00
+custom:
+  PR: "23607"

--- a/pkg/cmd/pulumi/deployment/deployment_cancel.go
+++ b/pkg/cmd/pulumi/deployment/deployment_cancel.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -33,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
@@ -86,6 +86,7 @@ func newDeploymentCancelCmdWith(factory deploymentCancelClientFactory) *cobra.Co
 			"  # Emit JSON for scripting.\n" +
 			"  pulumi deployment cancel dep-abc123 --yes --output json",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			args.yes = args.yes || env.SkipConfirmations.Value()
 			return runDeploymentCancel(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
 	}
@@ -120,17 +121,12 @@ func runDeploymentCancel(
 		return err
 	}
 
-	if !args.yes {
-		if !cmdutil.Interactive() {
-			return backenderr.ErrNonInteractiveRequiresYes
-		}
-		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-		prompt := fmt.Sprintf(
-			"This will cancel deployment '%s' for stack '%s'!",
-			deploymentID, stackName)
-		if !ui.ConfirmPrompt(prompt, "cancel", opts) {
-			return errors.New("confirmation declined")
-		}
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	prompt := fmt.Sprintf(
+		"This will cancel deployment '%s' for stack '%s'!",
+		deploymentID, stackName)
+	if err := ui.ConfirmDeletion(args.yes, cmdutil.Interactive(), prompt, "cancel", w, opts); err != nil {
+		return err
 	}
 
 	if err := c.CancelStackDeployment(ctx, stackID, deploymentID); err != nil {

--- a/pkg/cmd/pulumi/logs/rm.go
+++ b/pkg/cmd/pulumi/logs/rm.go
@@ -25,7 +25,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
@@ -78,11 +77,8 @@ func newRmCmd() *cobra.Command {
 			}
 
 			out := cobraCmd.OutOrStdout()
-			if !yes {
-				if !cmdutil.Interactive() {
-					return backenderr.ErrNonInteractiveRequiresYes
-				}
-
+			// Show what will be removed before asking the user to confirm.
+			if !yes && cmdutil.Interactive() {
 				suffix := "s"
 				if len(targets) == 1 {
 					suffix = ""
@@ -91,10 +87,11 @@ func newRmCmd() *cobra.Command {
 					fmt.Sprintf("%sThis will permanently remove %d log file%s:%s",
 						colors.SpecAttention, len(targets), suffix, colors.Reset)))
 				printRemovalTable(out, targets)
-
-				if !ui.ConfirmPrompt("", confirmToken(targets), opts) {
-					return errors.New("confirmation declined")
-				}
+			}
+			if err := ui.ConfirmDeletion(
+				yes, cmdutil.Interactive(), "", confirmToken(targets), out, opts,
+			); err != nil {
+				return err
 			}
 
 			for _, t := range targets {

--- a/pkg/cmd/pulumi/org/org_member_remove.go
+++ b/pkg/cmd/pulumi/org/org_member_remove.go
@@ -33,9 +33,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // orgMemberRemoveClient is the narrow subset of cloud-API operations the
@@ -92,6 +92,7 @@ func newOrgMemberRemoveCmdWith(factory orgMemberRemoveClientFactory) *cobra.Comm
 			"  # Remove without confirmation\n" +
 			"  pulumi org member remove alice --yes",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			args.yes = args.yes || env.SkipConfirmations.Value()
 			return runOrgMemberRemove(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
 	}
@@ -159,17 +160,11 @@ func runOrgMemberRemove(
 	ctx context.Context, w io.Writer,
 	factory orgMemberRemoveClientFactory, userLogin string, args orgMemberRemoveArgs,
 ) error {
-	if !args.yes {
-		if !cmdutil.Interactive() {
-			return errors.New(
-				"confirmation required; pass --yes (-y) to confirm in non-interactive mode")
-		}
-		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-		prompt := fmt.Sprintf(
-			"This will permanently remove member '%s' from the organization!", userLogin)
-		if !ui.ConfirmPrompt(prompt, userLogin, opts) {
-			return result.FprintBailf(w, "confirmation declined")
-		}
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	prompt := fmt.Sprintf(
+		"This will permanently remove member '%s' from the organization!", userLogin)
+	if err := ui.ConfirmDeletion(args.yes, cmdutil.Interactive(), prompt, userLogin, w, opts); err != nil {
+		return err
 	}
 
 	c, org, err := factory(ctx, args.org)

--- a/pkg/cmd/pulumi/org/org_role_remove.go
+++ b/pkg/cmd/pulumi/org/org_role_remove.go
@@ -17,7 +17,6 @@ package org
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
@@ -27,28 +26,13 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 func newOrgRoleRemoveCmd() *cobra.Command {
-	return newOrgRoleRemoveCmdWith(defaultOrgRoleClientFactory, defaultConfirmFunc)
-}
-
-// confirmFunc abstracts the interactive confirmation prompt so tests can stub
-// it out without standing up a TTY. It is expected to also reject non-interactive
-// sessions by returning (false, an error explaining --yes is required).
-type confirmFunc func(prompt, name string) (bool, error)
-
-// defaultConfirmFunc uses cmdutil.Interactive + ui.ConfirmPrompt and returns an
-// error when the session is non-interactive (so callers must pass --yes).
-func defaultConfirmFunc(prompt, name string) (bool, error) {
-	if !cmdutil.Interactive() {
-		return false, errors.New(
-			"--yes is required when not running in a terminal (non-interactive)")
-	}
-	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-	return ui.ConfirmPrompt(prompt, name, opts), nil
+	return newOrgRoleRemoveCmdWith(defaultOrgRoleClientFactory)
 }
 
 // roleRemoveRender renders the outcome of a remove operation.
@@ -61,9 +45,8 @@ func defaultRoleRemoveOutput() outputflag.OutputFlag[roleRemoveRender] {
 	}
 }
 
-func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory, confirm confirmFunc) *cobra.Command {
+func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory) *cobra.Command {
 	contract.Assertf(factory != nil, "factory must not be nil")
-	contract.Assertf(confirm != nil, "confirm must not be nil")
 
 	var (
 		org   string
@@ -90,8 +73,9 @@ func newOrgRoleRemoveCmdWith(factory orgRoleClientFactory, confirm confirmFunc) 
 			"  # Delete a role non-interactively, even if it is assigned\n" +
 			"  pulumi org role remove role-123 --force --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			yes = yes || env.SkipConfirmations.Value()
 			return runOrgRoleRemove(
-				cmd.Context(), cmd.OutOrStdout(), factory, confirm,
+				cmd.Context(), cmd.OutOrStdout(), factory,
 				org, args[0], force, yes, output.Get())
 		},
 	}
@@ -118,7 +102,6 @@ func runOrgRoleRemove(
 	ctx context.Context,
 	w io.Writer,
 	factory orgRoleClientFactory,
-	confirm confirmFunc,
 	orgFlag, roleID string,
 	force, yes bool,
 	render roleRemoveRender,
@@ -128,16 +111,11 @@ func runOrgRoleRemove(
 		return err
 	}
 
-	if !yes {
-		prompt := fmt.Sprintf(
-			"This will permanently delete role %q from organization %q.", roleID, orgName)
-		ok, err := confirm(prompt, roleID)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return errors.New("confirmation declined")
-		}
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	prompt := fmt.Sprintf(
+		"This will permanently delete role %q from organization %q.", roleID, orgName)
+	if err := ui.ConfirmDeletion(yes, cmdutil.Interactive(), prompt, roleID, w, opts); err != nil {
+		return err
 	}
 
 	if err := c.DeleteOrgRole(ctx, orgName, roleID, force); err != nil {

--- a/pkg/cmd/pulumi/org/org_role_remove_test.go
+++ b/pkg/cmd/pulumi/org/org_role_remove_test.go
@@ -21,19 +21,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-)
 
-func acceptAllConfirm(_ string, _ string) (bool, error) { return true, nil }
-func denyAllConfirm(_ string, _ string) (bool, error)   { return false, nil }
-func nonInteractiveConfirm(_ string, _ string) (bool, error) {
-	return false, errors.New("--yes is required when not running in a terminal (non-interactive)")
-}
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+)
 
 func TestOrgRoleRemove_Yes_NoConfirm(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -50,7 +46,7 @@ func TestOrgRoleRemove_ForceFlagPassesThrough(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 	cmd.SetArgs([]string{"role-1", "--yes", "--force"})
 
 	err := cmd.ExecuteContext(t.Context())
@@ -58,48 +54,24 @@ func TestOrgRoleRemove_ForceFlagPassesThrough(t *testing.T) {
 	assert.True(t, c.deleteForce)
 }
 
-func TestOrgRoleRemove_ConfirmAccepted(t *testing.T) {
-	t.Parallel()
-
-	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), acceptAllConfirm)
-	cmd.SetArgs([]string{"role-1"})
-
-	err := cmd.ExecuteContext(t.Context())
-	require.NoError(t, err)
-	assert.Equal(t, "role-1", c.deleteID)
-}
-
-func TestOrgRoleRemove_ConfirmDeclined(t *testing.T) {
-	t.Parallel()
-
-	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
-	cmd.SetArgs([]string{"role-1"})
-
-	err := cmd.ExecuteContext(t.Context())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "confirmation declined")
-	assert.Empty(t, c.deleteID)
-}
-
 func TestOrgRoleRemove_NonInteractiveWithoutYes(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), nonInteractiveConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 	cmd.SetArgs([]string{"role-1"})
 
 	err := cmd.ExecuteContext(t.Context())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--yes is required")
+	assert.ErrorIs(t, err, backenderr.ErrNonInteractiveRequiresYes)
+	assert.Empty(t, c.deleteID, "client must not be called without confirmation")
 }
 
 func TestOrgRoleRemove_JSONOutput(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
@@ -116,7 +88,7 @@ func TestOrgRoleRemove_InvalidOutput(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 	cmd.SetArgs([]string{"role-1", "--yes", "--output", "xml"})
 
 	err := cmd.ExecuteContext(t.Context())
@@ -128,7 +100,7 @@ func TestOrgRoleRemove_DeleteError(t *testing.T) {
 	t.Parallel()
 
 	c := &mockOrgRoleClient{deleteErr: errors.New("conflict")}
-	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(stubRoleFactory(c, "my-org"))
 	cmd.SetArgs([]string{"role-1", "--yes"})
 
 	err := cmd.ExecuteContext(t.Context())
@@ -139,7 +111,7 @@ func TestOrgRoleRemove_DeleteError(t *testing.T) {
 func TestOrgRoleRemove_FactoryError(t *testing.T) {
 	t.Parallel()
 
-	cmd := newOrgRoleRemoveCmdWith(failingRoleFactory(errors.New("not logged in")), denyAllConfirm)
+	cmd := newOrgRoleRemoveCmdWith(failingRoleFactory(errors.New("not logged in")))
 	cmd.SetArgs([]string{"role-1", "--yes"})
 	err := cmd.ExecuteContext(t.Context())
 	require.Error(t, err)

--- a/pkg/cmd/pulumi/org/org_webhook_remove.go
+++ b/pkg/cmd/pulumi/org/org_webhook_remove.go
@@ -23,15 +23,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -64,6 +63,7 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 			"  # Remove without confirmation\n" +
 			"  pulumi org webhook remove 1a2b3c4d --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			orcmd.yes = orcmd.yes || env.SkipConfirmations.Value()
 			orcmd.w = cmd.OutOrStdout()
 			return orcmd.run(cmd.Context(), args[0])
 		},
@@ -85,15 +85,9 @@ func newOrgWebhookRemoveCmd() *cobra.Command {
 func (c *orgWebhookRemoveCmd) run(ctx context.Context, webhookName string) error {
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	if !c.yes {
-		if !cmdutil.Interactive() {
-			return backenderr.ErrNonInteractiveRequiresYes
-		}
-		prompt := fmt.Sprintf(
-			"This will permanently remove the webhook '%s'!", webhookName)
-		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
-			return result.FprintBailf(c.w, "confirmation declined")
-		}
+	prompt := fmt.Sprintf("This will permanently remove the webhook '%s'!", webhookName)
+	if err := ui.ConfirmDeletion(c.yes, cmdutil.Interactive(), prompt, webhookName, c.w, opts); err != nil {
+		return err
 	}
 
 	currentBackend := c.currentBackend

--- a/pkg/cmd/pulumi/packagecmd/package_delete.go
+++ b/pkg/cmd/pulumi/packagecmd/package_delete.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/registry"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -126,8 +125,10 @@ You must have publish permissions for the package to delete it.`,
 			prompt := opts.Color.Colorize(fmt.Sprintf("This will permanently delete package version %s%s%s!",
 				colors.SpecAttention, formatPkg(pkg), colors.Reset,
 			))
-			if !yes && !ui.ConfirmPrompt(prompt, packageVersion.String(), opts) {
-				return result.FprintBailf(cmd.ErrOrStderr(), "confirmation declined")
+			if err := ui.ConfirmDeletion(
+				yes, cmdutil.Interactive(), prompt, packageVersion.String(), cmd.ErrOrStderr(), opts,
+			); err != nil {
+				return err
 			}
 
 			if err := r.DeletePackageVersion(ctx,

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
@@ -34,9 +33,9 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // policyGroupRemoveClient is the narrow subset of cloud-API operations the
@@ -97,6 +96,7 @@ func newPolicyGroupRemoveCmdWith(factory policyGroupRemoveClientFactory) *cobra.
 			"  # Remove from a specific organization\n" +
 			"  pulumi policy group remove prod-policies --org acme --yes",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			args.yes = args.yes || env.SkipConfirmations.Value()
 			return runPolicyGroupRemove(cmd.Context(), cmd.OutOrStdout(), factory, posArgs[0], args)
 		},
 	}
@@ -164,16 +164,10 @@ func runPolicyGroupRemove(
 	ctx context.Context, w io.Writer,
 	factory policyGroupRemoveClientFactory, name string, args policyGroupRemoveArgs,
 ) error {
-	if !cmdutil.Interactive() && !args.yes {
-		return backenderr.ErrNonInteractiveRequiresYes
-	}
-
-	if !args.yes {
-		opts := display.Options{Color: cmdutil.GetGlobalColorization()}
-		prompt := fmt.Sprintf("This will permanently remove the policy group '%s'!", name)
-		if !ui.ConfirmPrompt(prompt, name, opts) {
-			return result.FprintBailf(w, "confirmation declined")
-		}
+	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
+	prompt := fmt.Sprintf("This will permanently remove the policy group '%s'!", name)
+	if err := ui.ConfirmDeletion(args.yes, cmdutil.Interactive(), prompt, name, w, opts); err != nil {
+		return err
 	}
 
 	c, org, err := factory(ctx, args.org)

--- a/pkg/cmd/pulumi/policy/policy_rm.go
+++ b/pkg/cmd/pulumi/policy/policy_rm.go
@@ -18,14 +18,12 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/spf13/cobra"
 )
 
@@ -56,13 +54,11 @@ func newPolicyRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			if !cmdutil.Interactive() && !yes {
-				return backenderr.ErrNonInteractiveRequiresYes
-			}
-
 			prompt := fmt.Sprintf("This will permanently remove the '%s' policy!", args[0])
-			if !yes && !ui.ConfirmPrompt(prompt, args[0], opts) {
-				return result.FprintBailf(cmd.OutOrStdout(), "confirmation declined")
+			if err := ui.ConfirmDeletion(
+				yes, cmdutil.Interactive(), prompt, args[0], cmd.OutOrStdout(), opts,
+			); err != nil {
+				return err
 			}
 
 			// Attempt to remove the Policy Pack.

--- a/pkg/cmd/pulumi/stack/stack_rm.go
+++ b/pkg/cmd/pulumi/stack/stack_rm.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
@@ -35,7 +34,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
@@ -84,14 +82,12 @@ func newStackRmCmd() *cobra.Command {
 				return err
 			}
 
-			if !cmdutil.Interactive() && !yes {
-				return backenderr.ErrNonInteractiveRequiresYes
-			}
-
 			// Ensure the user really wants to do this.
 			prompt := fmt.Sprintf("This will permanently remove the '%s' stack!", s.Ref())
-			if !yes && !ui.ConfirmPrompt(prompt, s.Ref().String(), opts) {
-				return result.FprintBailf(cmd.OutOrStdout(), "confirmation declined")
+			if err := ui.ConfirmDeletion(
+				yes, cmdutil.Interactive(), prompt, s.Ref().String(), cmd.OutOrStdout(), opts,
+			); err != nil {
+				return err
 			}
 
 			hasResources, err := backend.RemoveStack(ctx, s, force, removeBackups)

--- a/pkg/cmd/pulumi/stack/stack_schedule_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_schedule_remove.go
@@ -21,15 +21,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 type stackScheduleRemoveClient interface {
@@ -61,6 +60,7 @@ func newStackScheduleRemoveCmdWith(factory stackScheduleRemoveClientFactory) *co
 			"  # Remove without confirmation\n" +
 			"  pulumi stack schedule remove bb61b60a-a313-46cb-b4ab-9d42dce46de8 --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			yes = yes || env.SkipConfirmations.Value()
 			if factory == nil {
 				factory = defaultStackScheduleRemoveClientFactory
 			}
@@ -101,14 +101,9 @@ func runStackScheduleRemove(
 ) error {
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	if !yes {
-		if !cmdutil.Interactive() {
-			return backenderr.ErrNonInteractiveRequiresYes
-		}
-		prompt := fmt.Sprintf("This will remove the schedule '%s'!", scheduleID)
-		if !ui.ConfirmPrompt(prompt, "remove", opts) {
-			return result.FprintBailf(w, "confirmation declined")
-		}
+	prompt := fmt.Sprintf("This will remove the schedule '%s'!", scheduleID)
+	if err := ui.ConfirmDeletion(yes, cmdutil.Interactive(), prompt, "remove", w, opts); err != nil {
+		return err
 	}
 
 	c, stackID, err := factory(ctx, stackFlag)

--- a/pkg/cmd/pulumi/stack/stack_webhook_remove.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_remove.go
@@ -21,15 +21,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // stackWebhookRemoveClient is the interface the remove command needs.
@@ -68,6 +67,7 @@ func newStackWebhookRemoveCmdWith(factory stackWebhookRemoveClientFactory) *cobr
 			"  # Remove without confirmation\n" +
 			"  pulumi stack webhook remove 1a2b3c4d --yes",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			yes = yes || env.SkipConfirmations.Value()
 			if factory == nil {
 				factory = defaultStackWebhookRemoveClientFactory
 			}
@@ -105,16 +105,9 @@ func runStackWebhookRemove(
 ) error {
 	opts := display.Options{Color: cmdutil.GetGlobalColorization()}
 
-	if !yes {
-		if !cmdutil.Interactive() {
-			return backenderr.ErrNonInteractiveRequiresYes
-		}
-		prompt := fmt.Sprintf(
-			"This will permanently remove the webhook '%s'!",
-			webhookName)
-		if !ui.ConfirmPrompt(prompt, webhookName, opts) {
-			return result.FprintBailf(w, "confirmation declined")
-		}
+	prompt := fmt.Sprintf("This will permanently remove the webhook '%s'!", webhookName)
+	if err := ui.ConfirmDeletion(yes, cmdutil.Interactive(), prompt, webhookName, w, opts); err != nil {
+		return err
 	}
 
 	c, stackID, err := factory(ctx, stackFlag)

--- a/pkg/cmd/pulumi/ui/survey.go
+++ b/pkg/cmd/pulumi/ui/survey.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
 // Make sure we set `surveycore.DisableColor` to true exactly once, to avoid data races.
@@ -264,4 +266,34 @@ func ConfirmPrompt(prompt string, name string, opts display.Options) bool {
 	reader := bufio.NewReader(in)
 	line, _ := reader.ReadString('\n')
 	return strings.TrimSpace(line) == name
+}
+
+// ConfirmDeletion runs the standard confirmation flow shared by destructive
+// commands (delete/remove/cancel). It returns nil when the caller should
+// proceed, and a non-nil error to return directly from RunE otherwise.
+//
+// The flow is:
+//   - if yes is true (the --yes flag), proceed without prompting;
+//   - if the session is non-interactive, return ErrNonInteractiveRequiresYes so
+//     callers must pass --yes in scripts and CI;
+//   - otherwise prompt and require the user to type confirmText, bailing (via
+//     result.FprintBailf) if they decline.
+//
+// confirmText is what the user must type to confirm. Pass the entity's name or
+// id so the user reaffirms exactly what they are deleting. For values that are
+// cumbersome to retype (for example UUIDs) pass a short word such as the command
+// verb ("remove", "cancel") instead.
+func ConfirmDeletion(
+	yes, interactive bool, prompt, confirmText string, w io.Writer, opts display.Options,
+) error {
+	if yes {
+		return nil
+	}
+	if !interactive {
+		return backenderr.ErrNonInteractiveRequiresYes
+	}
+	if !ConfirmPrompt(prompt, confirmText, opts) {
+		return result.FprintBailf(w, "confirmation declined")
+	}
+	return nil
 }

--- a/pkg/cmd/pulumi/ui/survey_test.go
+++ b/pkg/cmd/pulumi/ui/survey_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/backend/backenderr"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
+)
+
+func TestConfirmDeletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("yes skips the prompt even when interactive", func(t *testing.T) {
+		t.Parallel()
+		var w bytes.Buffer
+		err := ConfirmDeletion(true /*yes*/, true /*interactive*/, "prompt", "my-thing", &w,
+			display.Options{Stdin: failingReader{t}})
+		require.NoError(t, err)
+		assert.Empty(t, w.String())
+	})
+
+	t.Run("non-interactive without yes requires yes", func(t *testing.T) {
+		t.Parallel()
+		var w bytes.Buffer
+		err := ConfirmDeletion(false /*yes*/, false /*interactive*/, "prompt", "my-thing", &w,
+			display.Options{Stdin: failingReader{t}})
+		assert.ErrorIs(t, err, backenderr.ErrNonInteractiveRequiresYes)
+		assert.Empty(t, w.String())
+	})
+
+	t.Run("interactive proceeds when the user retypes the value", func(t *testing.T) {
+		t.Parallel()
+		var w, out bytes.Buffer
+		err := ConfirmDeletion(false /*yes*/, true /*interactive*/, "prompt", "my-thing", &w,
+			display.Options{Color: colors.Never, Stdin: strings.NewReader("my-thing\n"), Stdout: &out})
+		require.NoError(t, err)
+		assert.Empty(t, w.String())
+	})
+
+	t.Run("interactive bails when the value does not match", func(t *testing.T) {
+		t.Parallel()
+		var w, out bytes.Buffer
+		err := ConfirmDeletion(false /*yes*/, true /*interactive*/, "prompt", "my-thing", &w,
+			display.Options{Color: colors.Never, Stdin: strings.NewReader("nope\n"), Stdout: &out})
+		require.Error(t, err)
+		assert.True(t, result.IsBail(err), "declining must return a bail error")
+		assert.Contains(t, w.String(), "confirmation declined")
+	})
+}
+
+// failingReader fails the test if anything tries to read from it
+type failingReader struct{ t *testing.T }
+
+func (r failingReader) Read([]byte) (int, error) {
+	r.t.Helper()
+	r.t.Fatal("stdin should not be read")
+	return 0, nil
+}


### PR DESCRIPTION
The desired behaviour is that destructive commands ask for confirmation before proceeding, unless the `--yes` flag is set. The user has to type the concerned entity’s id or name to confirm. If the id is too cumbersome to type, for example an UUID, we ask the user to type `remove` or `delete` or a similar action instead. When running non-interactively, `--yes` is required for these commands.

This behaviour was already place, but there were a couple inconsistencies:

- We didn’t always respect`PULUMI_SKIP_CONFIRMATIONS`
- We didn’t always return a BailError on decline

Ref https://github.com/pulumi/pulumi/issues/22959