### PR TITLE
Remove outdated  `AI Generated - needs human review` markers

### DIFF
--- a/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_settings_get_test.go
@@ -14,8 +14,6 @@
 
 package deployment
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/org/org_audit_log_export.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_export.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/org/org_audit_log_export_test.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_export_test.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/org/org_audit_log_list.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_list.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/org/org_audit_log_list_test.go
+++ b/pkg/cmd/pulumi/org/org_audit_log_list_test.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/org/org_member_edit.go
+++ b/pkg/cmd/pulumi/org/org_member_edit.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"errors"

--- a/pkg/cmd/pulumi/org/org_member_edit_test.go
+++ b/pkg/cmd/pulumi/org/org_member_edit_test.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/org/org_member_remove.go
+++ b/pkg/cmd/pulumi/org/org_member_remove.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/org/org_member_remove_test.go
+++ b/pkg/cmd/pulumi/org/org_member_remove_test.go
@@ -14,8 +14,6 @@
 
 package org
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_group_edit.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"errors"

--- a/pkg/cmd/pulumi/policy/policy_group_edit_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_edit_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_group_get.go
+++ b/pkg/cmd/pulumi/policy/policy_group_get.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/policy/policy_group_get_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_get_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_group_new_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_new_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_group_remove.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/policy/policy_group_remove_test.go
+++ b/pkg/cmd/pulumi/policy/policy_group_remove_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_issue_get.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_get.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/policy/policy_issue_get_test.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_get_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"

--- a/pkg/cmd/pulumi/policy/policy_issue_list.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_list.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/cmd/pulumi/policy/policy_issue_list_test.go
+++ b/pkg/cmd/pulumi/policy/policy_issue_list_test.go
@@ -14,8 +14,6 @@
 
 package policy
 
-// AI Generated - needs human review
-
 import (
 	"bytes"
 	"context"


### PR DESCRIPTION
The Cloud-Ready CLI commands were initially landed as an AI-generated batch in #23183, each carrying a `AI Generated - needs human review` marker as a TODO. Every one of those commands has since been individually reviewed, fixed, and unhidden by a human in a dedicated follow-up PR. This removes the now-satisfied markers.

- deployment settings get — #23229, #23236
- org audit-log list — #23211
- org audit-log export — #23211, #23212
- org member edit — #23235
- org member remove — #23237
- policy group new — #23202
- policy group get — #23203, #23206
- policy group edit — #23187, #23206
- policy group remove — #23208
- policy issue get — #23200
- policy issue list — #23198, #23200

Ref https://github.com/pulumi/pulumi/issues/22959
