### PR TITLE
Generate redirects for command aliases

### DIFF
--- a/changelog/pending/docs-improvement-20260617-131432.yaml
+++ b/changelog/pending/docs-improvement-20260617-131432.yaml
@@ -1,0 +1,6 @@
+component: docs
+kind: improvement
+body: Generate redirects for command aliases
+time: 2026-06-17T13:14:32.111468+02:00
+custom:
+  PR: "23610"

--- a/pkg/cmd/pulumi/markdown/gen.go
+++ b/pkg/cmd/pulumi/markdown/gen.go
@@ -60,6 +60,30 @@ func generateMetaDescription(title, commandName string) string {
 	return baseDesc
 }
 
+// aliasRedirectPaths returns the docs-site paths that should redirect to the given command's page, one per cobra alias.
+// For example `pulumi stack remove` yields redirect paths for `pulumi_stack_rm` under both the current
+// (`/docs/iac/cli/commands/`) and legacy (`/docs/reference/cli/`) CLI docs prefixes.
+func aliasRedirectPaths(cmd *cobra.Command) []string {
+	if cmd == nil || len(cmd.Aliases) == 0 {
+		return nil
+	}
+
+	var prefix string
+	if cmd.HasParent() {
+		prefix = strings.ReplaceAll(cmd.Parent().CommandPath(), " ", "_") + "_"
+	}
+
+	paths := make([]string, 0, len(cmd.Aliases)*2)
+	for _, alias := range cmd.Aliases {
+		slug := prefix + alias
+		paths = append(paths,
+			fmt.Sprintf("/docs/iac/cli/commands/%s/", slug),
+			fmt.Sprintf("/docs/reference/cli/%s/", slug),
+		)
+	}
+	return paths
+}
+
 // NewGenMarkdownCmd returns a new command that, when run, generates CLI documentation as Markdown files.
 // It is hidden by default since it's not commonly used outside of our own build processes.
 func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
@@ -69,6 +93,16 @@ func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var files []string
+
+			commandsBySlug := map[string]*cobra.Command{}
+			var indexCommands func(c *cobra.Command)
+			indexCommands = func(c *cobra.Command) {
+				commandsBySlug[strings.ReplaceAll(c.CommandPath(), " ", "_")] = c
+				for _, child := range c.Commands() {
+					indexCommands(child)
+				}
+			}
+			indexCommands(root)
 
 			// filePrepender is used to add front matter to each file, and to keep track of all
 			// generated files.
@@ -87,6 +121,10 @@ func NewGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// Add redirect aliases to the front matter.
 				fmt.Fprint(buf, "aliases:\n")
 				fmt.Fprintf(buf, "%s- /docs/reference/cli/%s/\n", ymlIndent, fileNameWithoutExtension)
+				// Add a redirect for each of the command's cobra aliases
+				for _, aliasPath := range aliasRedirectPaths(commandsBySlug[fileNameWithoutExtension]) {
+					fmt.Fprintf(buf, "%s- %s\n", ymlIndent, aliasPath)
+				}
 				// Add meta description for SEO
 				metaDesc := generateMetaDescription(title, fileNameWithoutExtension)
 				fmt.Fprintf(buf, "meta_desc: %q\n", metaDesc)

--- a/pkg/cmd/pulumi/markdown/gen_test.go
+++ b/pkg/cmd/pulumi/markdown/gen_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package markdown
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAliasRedirectPaths(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "pulumi"}
+	stack := &cobra.Command{Use: "stack"}
+	remove := &cobra.Command{Use: "remove", Aliases: []string{"rm"}}
+	noAlias := &cobra.Command{Use: "get"}
+	multi := &cobra.Command{Use: "destroy", Aliases: []string{"down", "dn"}}
+	root.AddCommand(stack)
+	stack.AddCommand(remove, noAlias)
+	root.AddCommand(multi)
+
+	// A command emits redirects for its aliases under both prefixes
+	assert.Equal(t, []string{
+		"/docs/iac/cli/commands/pulumi_stack_rm/",
+		"/docs/reference/cli/pulumi_stack_rm/",
+	}, aliasRedirectPaths(remove))
+
+	// Multiple aliases each get a pair of redirects
+	assert.Equal(t, []string{
+		"/docs/iac/cli/commands/pulumi_down/",
+		"/docs/reference/cli/pulumi_down/",
+		"/docs/iac/cli/commands/pulumi_dn/",
+		"/docs/reference/cli/pulumi_dn/",
+	}, aliasRedirectPaths(multi))
+
+	// Commands without aliases (and nil) produce nothing.
+	assert.Nil(t, aliasRedirectPaths(noAlias))
+	assert.Nil(t, aliasRedirectPaths(nil))
+}


### PR DESCRIPTION
`gen-markdown` is used to generate the markdown files for the CLI docs at https://www.pulumi.com/docs/iac/cli/commands/. We now generate a redirect for each of a command's cobra aliases.

For example for `/docs/iac/cli/commands/pulumi_stack_remove/` we get:

```
 aliases:
   - /docs/reference/cli/pulumi_stack_remove/
   - /docs/iac/cli/commands/pulumi_stack_rm/
   - /docs/reference/cli/pulumi_stack_rm/
```

Ref https://github.com/pulumi/pulumi/issues/22959
