### PR TITLE
Add ResolveDocRef to DocLanguageHelper

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -82,6 +82,20 @@ type DocLanguageHelper interface {
 	GetMethodName(m *schema.Method) string
 	GetMethodResultName(pkg schema.PackageReference, modName string, r *schema.Resource, m *schema.Method) string
 
+	// ResolveDocRef renders a single `{{% ref %}}` shortcode target as a name in the target
+	// language (e.g. PascalCase types in Go, snake_case properties in Python). Callers typically
+	// use this as the resolver callback passed to schema.PackageReference.InterpretPulumiRefs.
+	//
+	// selfRef identifies the entity whose documentation is being rendered. Property refs that
+	// belong to that entity are emitted unqualified (e.g. `prop` rather than `Self.prop`). Pass
+	// the zero `schema.DocRef{}` if there is no enclosing entity.
+	//
+	// The boolean return mirrors `schema.PulumiRefResolver`: false means the ref could not be
+	// resolved and the caller should fall back to a default rendering. The error return is for
+	// setup failures (e.g. Go's package-context map cannot be built); successful resolution to
+	// "ref not found" returns `("", false, nil)`.
+	ResolveDocRef(pkg schema.PackageReference, selfRef, ref schema.DocRef) (string, bool, error)
+
 	// Doc links
 	GetDocLinkForResourceType(pkg *schema.Package, moduleName, typeName string) string
 	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -158,6 +158,47 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 	return funcName + "Result"
 }
 
+// ResolveDocRef renders a single doc ref as a Go name. It honours package-level renames and
+// import aliases by consulting the package context map (built and cached on d by
+// GeneratePackagesMap; rebuilt on the fly for pkgs the helper has not seen).
+func (d DocLanguageHelper) ResolveDocRef(pkg schema.PackageReference, selfRef, ref schema.DocRef) (string, bool, error) {
+	packages := d.packages
+	goInfo := d.goPkgInfo
+	if packages == nil || d.topLevelPkg == nil || d.topLevelPkg.Name() != pkg.Name() {
+		if i, err := pkg.Language("go"); err == nil {
+			goInfo, _ = i.(GoPackageInfo)
+		}
+		var err error
+		packages, err = generatePackageContextMap("", pkg, goInfo, nil)
+		if err != nil {
+			return "", false, err
+		}
+	}
+
+	// Pick a representative context for non-resolver fields and synthesise a pkgContext whose
+	// module is set to a sentinel that cannot match any real module. This guarantees that every
+	// ref resolves to a fully-qualified cross-module name, while still routing through the
+	// shared packages map for rename/alias handling.
+	var template *pkgContext
+	for _, c := range packages {
+		template = c
+		break
+	}
+	if template == nil {
+		return "", false, nil
+	}
+	ctx := &pkgContext{
+		pkg:              pkg,
+		mod:              "\x00docrefresolver",
+		packages:         packages,
+		modToPkg:         goInfo.ModuleToPackage,
+		pkgImportAliases: goInfo.PackageImportAliases,
+		importBasePath:   template.importBasePath,
+	}
+	name, ok := ctx.docRefResolver(selfRef)(ref)
+	return name, ok, nil
+}
+
 func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return Title(m.Name)
 }

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -20,12 +20,30 @@ package gen
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// renderWithResolver is a test helper that obtains a DocRefResolver and uses it to substitute the
+// ref shortcodes in description, mirroring what a doc-generating caller would do (modulo its own
+// AST walking / code-block handling).
+func renderWithResolver(
+	t *testing.T, d DocLanguageHelper, pkg schema.PackageReference,
+	selfRef schema.DocRef, description string,
+) string {
+	t.Helper()
+	rendered, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
+		name, ok, err := d.ResolveDocRef(pkg, selfRef, ref)
+		require.NoError(t, err)
+		return name, ok
+	})
+	require.NoError(t, err)
+	return strings.TrimSuffix(rendered, "\n")
+}
 
 var testPackageSpec = schema.PackageSpec{
 	Name:        "aws",
@@ -151,6 +169,256 @@ func TestGetFunctionName(t *testing.T) {
 		// (NewResource).
 		"pkg:conflict:newResource": "CreateResource",
 	}, names)
+}
+
+// buildSelfRefFixture builds a small package containing a resource, an object type and a function
+// (each with input/output properties) so that selfRef behaviour can be exercised against every
+// kind of `IsWithin` pairing.
+func buildSelfRefFixture(t *testing.T) (*schema.Package, *schema.Resource, *schema.ObjectType, *schema.Function) {
+	t.Helper()
+	pkg, err := schema.ImportSpec(schema.PackageSpec{
+		Name:    "demo",
+		Version: "0.0.1",
+		Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+		Resources: map[string]schema.ResourceSpec{
+			"demo:mod/widget:Widget": {
+				InputProperties: map[string]schema.PropertySpec{
+					"size": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"size":  {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"color": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+		Types: map[string]schema.ComplexTypeSpec{
+			"demo:mod/Settings:Settings": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"verbose": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+					},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"demo:mod:getWidget": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"id": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+	require.NoError(t, err)
+
+	var widget *schema.Resource
+	for _, r := range pkg.Resources {
+		if r.Token == "demo:mod/widget:Widget" {
+			widget = r
+		}
+	}
+	require.NotNil(t, widget)
+	var settings *schema.ObjectType
+	for _, typ := range pkg.Types {
+		if obj, ok := typ.(*schema.ObjectType); ok && obj.Token == "demo:mod/Settings:Settings" {
+			settings = obj
+		}
+	}
+	require.NotNil(t, settings)
+	var getWidget *schema.Function
+	for _, f := range pkg.Functions {
+		if f.Token == "demo:mod:getWidget" {
+			getWidget = f
+		}
+	}
+	require.NotNil(t, getWidget)
+	return pkg, widget, settings, getWidget
+}
+
+func TestResolveDocRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic refs", func(t *testing.T) {
+		t.Parallel()
+
+		pkg := getTestPackage(t)
+		d := DocLanguageHelper{}
+
+		cases := []struct {
+			name        string
+			description string
+			expected    string
+		}{
+			{
+				name:        "resource",
+				description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket %}}.",
+				// "s3" is the module; Go qualifies cross-module refs with the package alias.
+				expected: "See s3.Bucket.",
+			},
+			{
+				name:        "resource input property",
+				description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket/inputProperties/corsRules %}}.",
+				expected:    "See s3.BucketArgs.CorsRules.",
+			},
+			{
+				name:        "type",
+				description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule %}}.",
+				expected:    "See s3.BucketCorsRule.",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{}, tc.description)
+				assert.Equal(t, tc.expected, got)
+			})
+		}
+	})
+
+	t.Run("function/resource rename conflict", func(t *testing.T) {
+		t.Parallel()
+
+		// `pkg:conflict:newResource` collides with the generated `New<Resource>` constructor
+		// for `pkg:conflict:Resource`, so Go codegen renames the function to `CreateResource`.
+		// DocRefResolver must honour that rename.
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "pkg",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"pkg:conflict:Resource": {},
+			},
+			Functions: map[string]schema.FunctionSpec{
+				"pkg:conflict:newResource": {},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+
+		d := DocLanguageHelper{}
+		got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{},
+			"See {{% ref #/functions/pkg:conflict:newResource %}}.")
+		assert.Equal(t, "See CreateResource.", got)
+	})
+
+	t.Run("duplicate type/resource token suffix", func(t *testing.T) {
+		t.Parallel()
+
+		// An object type that shares a token (case-insensitively) with a resource gets a
+		// `Type` suffix during Go codegen. Doc refs must resolve to the suffixed name.
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "dup",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"dup:idx:Thing": {},
+			},
+			Types: map[string]schema.ComplexTypeSpec{
+				"dup:idx:Thing": {
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Type: "object",
+						Properties: map[string]schema.PropertySpec{
+							"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+
+		d := DocLanguageHelper{}
+		got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{},
+			"See {{% ref #/types/dup:idx:Thing %}}.")
+		assert.Contains(t, got, "ThingType")
+	})
+
+	t.Run("selfRef", func(t *testing.T) {
+		t.Parallel()
+		fixture, widget, settings, getWidget := buildSelfRefFixture(t)
+		d := DocLanguageHelper{}
+		cases := []struct {
+			name        string
+			selfRef     schema.DocRef
+			description string
+			expected    string
+		}{
+			{
+				name:        "resource self-property unqualified",
+				selfRef:     schema.DocRefForResource(widget),
+				description: "See {{% ref #/resources/demo:mod%2Fwidget:Widget/properties/color %}}.",
+				expected:    "See Color.",
+			},
+			{
+				name:        "resource self-input-property unqualified",
+				selfRef:     schema.DocRefForResource(widget),
+				description: "See {{% ref #/resources/demo:mod%2Fwidget:Widget/inputProperties/size %}}.",
+				expected:    "See Size.",
+			},
+			{
+				name:        "resource ref to other entity stays qualified",
+				selfRef:     schema.DocRefForResource(widget),
+				description: "See {{% ref #/types/demo:mod%2FSettings:Settings/properties/verbose %}}.",
+				expected:    "See mod.Settings.Verbose.",
+			},
+			{
+				name:        "type self-property unqualified",
+				selfRef:     schema.DocRefForType(settings),
+				description: "See {{% ref #/types/demo:mod%2FSettings:Settings/properties/verbose %}}.",
+				expected:    "See Verbose.",
+			},
+			{
+				name:        "function self-input-property unqualified",
+				selfRef:     schema.DocRefForFunction(getWidget),
+				description: "See {{% ref #/functions/demo:mod:getWidget/inputs/properties/name %}}.",
+				expected:    "See Name.",
+			},
+			{
+				name:        "function self-output-property unqualified",
+				selfRef:     schema.DocRefForFunction(getWidget),
+				description: "See {{% ref #/functions/demo:mod:getWidget/outputs/properties/id %}}.",
+				expected:    "See Id.",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				got := renderWithResolver(t, d, fixture.Reference(), tc.selfRef, tc.description)
+				assert.Equal(t, tc.expected, got)
+			})
+		}
+	})
+
+	t.Run("ModuleToPackage override applied", func(t *testing.T) {
+		t.Parallel()
+
+		// Verify that GoPackageInfo.ModuleToPackage remappings (which change the import
+		// alias used in cross-module refs) flow through to DocRefResolver.
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "pkg",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"pkg:original/widget:Widget": {},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		pkg.Language["go"] = GoPackageInfo{
+			ModuleToPackage: map[string]string{"original": "renamed"},
+		}
+
+		d := DocLanguageHelper{}
+		got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{},
+			"See {{% ref #/resources/pkg:original%2Fwidget:Widget %}}.")
+		assert.Equal(t, "See renamed.Widget.", got)
+	})
 }
 
 // Calling GetFunctionName may return the wrong result when

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1134,13 +1134,10 @@ func (pkg *pkgContext) toOutputMethod(t schema.Type) string {
 // printComment filters examples for the Go languages and prepends double forward slash to each line in the given
 // comment. If indent is true, each line is indented with tab character. It returns the number of lines in the
 // resulting comment. It guarantees that each line is terminated with newline character.
-func (pkg *pkgContext) printComment(w io.Writer, comment string, selfRef schema.DocRef, indent bool) (int, error) {
-	if comment == "" {
-		return 0, nil
-	}
-	comment = codegen.FilterExamples(comment, "go")
-
-	comment, err := pkg.pkg.InterpretPulumiRefs(comment, func(ref schema.DocRef) (string, bool) {
+// docRefResolver returns a resolver for `{{% ref %}}` shortcodes that produces Go names. If
+// selfRef is set, refs within the same scope are returned unqualified.
+func (pkg *pkgContext) docRefResolver(selfRef schema.DocRef) func(schema.DocRef) (string, bool) {
+	return func(ref schema.DocRef) (string, bool) {
 		var base string
 		switch ref.Kind {
 		case schema.DocRefKindResource, schema.DocRefKindResourceProperty:
@@ -1148,11 +1145,11 @@ func (pkg *pkgContext) printComment(w io.Writer, comment string, selfRef schema.
 		case schema.DocRefKindResourceInputProperty:
 			base = pkg.tokenToResource(ref.ResourceToken()) + "Args"
 		case schema.DocRefKindFunction:
-			base = tokenToName(ref.Function.Token)
+			base = pkg.docRefFunctionName(ref.Function)
 		case schema.DocRefKindFunctionInputProperty:
-			base = tokenToName(ref.Function.Token) + "Args"
+			base = pkg.docRefFunctionName(ref.Function) + "Args"
 		case schema.DocRefKindFunctionOutputProperty:
-			base = tokenToName(ref.Function.Token)
+			base = pkg.docRefFunctionName(ref.Function)
 		case schema.DocRefKindType, schema.DocRefKindTypeProperty:
 			base = pkg.tokenToType(ref.Type.String())
 		case schema.DocRefKindUnknown:
@@ -1180,7 +1177,16 @@ func (pkg *pkgContext) printComment(w io.Writer, comment string, selfRef schema.
 		}
 
 		return fmt.Sprintf("%s.%s", base, property), true
-	})
+	}
+}
+
+func (pkg *pkgContext) printComment(w io.Writer, comment string, selfRef schema.DocRef, indent bool) (int, error) {
+	if comment == "" {
+		return 0, nil
+	}
+	comment = codegen.FilterExamples(comment, "go")
+
+	comment, err := pkg.pkg.InterpretPulumiRefs(comment, pkg.docRefResolver(selfRef))
 	if err != nil {
 		return 0, fmt.Errorf("error interpreting Pulumi references in comment %q: %w", comment, err)
 	}
@@ -3221,6 +3227,21 @@ func (pkg *pkgContext) functionName(f *schema.Function) string {
 		panic(fmt.Sprintf("No function name found for %v", f))
 	}
 
+	return name
+}
+
+func (pkg *pkgContext) docRefFunctionName(f *schema.Function) string {
+	if f == nil {
+		return ""
+	}
+
+	name := tokenToName(f.Token)
+	mod := pkg.tokenToPackage(f.Token)
+	if modPkg, ok := pkg.packages[mod]; ok {
+		if override, ok := modPkg.functionNames[f]; ok {
+			name = override
+		}
+	}
 	return name
 }
 

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -119,6 +119,21 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 	return cgstrings.UppercaseFirst(funcName) + "Result"
 }
 
+// ResolveDocRef renders a single doc ref as a NodeJS name.
+func (d DocLanguageHelper) ResolveDocRef(pkg schema.PackageReference, selfRef, ref schema.DocRef) (string, bool, error) {
+	var info NodePackageInfo
+	if a, err := pkg.Language("nodejs"); err == nil {
+		info, _ = a.(NodePackageInfo)
+	}
+	mod := &modContext{
+		pkg:      pkg,
+		modToPkg: info.ModuleToPackage,
+		mod:      "\x00docrefresolver",
+	}
+	name, ok := mod.docRefResolver(selfRef)(ref)
+	return name, ok, nil
+}
+
 func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return cgstrings.Camel(m.Name)
 }

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -19,12 +19,30 @@
 package nodejs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// renderWithResolver is a test helper that obtains a DocRefResolver and uses it to substitute the
+// ref shortcodes in description, mirroring what a doc-generating caller would do (modulo its own
+// AST walking / code-block handling).
+func renderWithResolver(
+	t *testing.T, d DocLanguageHelper, pkg schema.PackageReference,
+	selfRef schema.DocRef, description string,
+) string {
+	t.Helper()
+	rendered, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
+		name, ok, err := d.ResolveDocRef(pkg, selfRef, ref)
+		require.NoError(t, err)
+		return name, ok
+	})
+	require.NoError(t, err)
+	return strings.TrimSuffix(rendered, "\n")
+}
 
 var testPackageSpec = schema.PackageSpec{
 	Name:        "aws",
@@ -101,6 +119,92 @@ func TestGetDocLinkForResourceType(t *testing.T) {
 	expected := "/docs/reference/pkg/nodejs/pulumi/aws/s3/#Bucket"
 	link := d.GetDocLinkForResourceType(pkg, "s3", "Bucket")
 	assert.Equal(t, expected, link)
+}
+
+func TestResolveDocRef(t *testing.T) {
+	t.Parallel()
+
+	pkg := getTestPackage(t)
+	d := DocLanguageHelper{}
+
+	cases := []struct {
+		name        string
+		description string
+		expected    string
+	}{
+		{
+			name:        "resource",
+			description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket %}}.",
+			expected:    "See Bucket.",
+		},
+		{
+			name:        "resource input property",
+			description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket/inputProperties/corsRules %}}.",
+			expected:    "See BucketArgs.corsRules.",
+		},
+		{
+			name:        "type",
+			description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule %}}.",
+			expected:    "See BucketCorsRule.",
+		},
+		{
+			name:        "type property",
+			description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule/properties/stringProp %}}.",
+			expected:    "See BucketCorsRule.stringProp.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{}, tc.description)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+
+	t.Run("selfRef", func(t *testing.T) {
+		t.Parallel()
+		var bucket *schema.Resource
+		for _, r := range pkg.Resources {
+			if r.Token == "aws:s3/bucket:Bucket" {
+				bucket = r
+			}
+		}
+		require.NotNil(t, bucket)
+		var corsRule schema.Type
+		for _, typ := range pkg.Types {
+			if obj, ok := typ.(*schema.ObjectType); ok && obj.Token == "aws:s3/BucketCorsRule:BucketCorsRule" {
+				corsRule = obj
+			}
+		}
+		require.NotNil(t, corsRule)
+
+		cases := []struct {
+			name        string
+			selfRef     schema.DocRef
+			description string
+			expected    string
+		}{
+			{
+				name:        "resource self-input-property unqualified",
+				selfRef:     schema.DocRefForResource(bucket),
+				description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket/inputProperties/corsRules %}}.",
+				expected:    "See corsRules.",
+			},
+			{
+				name:        "type self-property unqualified",
+				selfRef:     schema.DocRefForType(corsRule),
+				description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule/properties/stringProp %}}.",
+				expected:    "See stringProp.",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				got := renderWithResolver(t, d, pkg.Reference(), tc.selfRef, tc.description)
+				assert.Equal(t, tc.expected, got)
+			})
+		}
+	})
 }
 
 func TestGetDocLinkForResourceInputOrOutputType(t *testing.T) {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -366,12 +366,10 @@ func sanitizeComment(str string) string {
 	return strings.ReplaceAll(str, "*/", "*&#47;")
 }
 
-func (mod *modContext) printComment(w io.Writer, comment, deprecationMessage, indent string, selfRef schema.DocRef) error {
-	if comment == "" && deprecationMessage == "" {
-		return nil
-	}
-
-	comment, err := mod.pkg.InterpretPulumiRefs(comment, func(ref schema.DocRef) (string, bool) {
+// docRefResolver returns a resolver for `{{% ref %}}` shortcodes that produces NodeJS names. If
+// selfRef is set, refs within the same scope are returned unqualified.
+func (mod *modContext) docRefResolver(selfRef schema.DocRef) func(schema.DocRef) (string, bool) {
+	return func(ref schema.DocRef) (string, bool) {
 		var base string
 		switch ref.Kind {
 		case schema.DocRefKindResource, schema.DocRefKindResourceProperty:
@@ -411,7 +409,15 @@ func (mod *modContext) printComment(w io.Writer, comment, deprecationMessage, in
 		}
 
 		return fmt.Sprintf("%s.%s", base, property), true
-	})
+	}
+}
+
+func (mod *modContext) printComment(w io.Writer, comment, deprecationMessage, indent string, selfRef schema.DocRef) error {
+	if comment == "" && deprecationMessage == "" {
+		return nil
+	}
+
+	comment, err := mod.pkg.InterpretPulumiRefs(comment, mod.docRefResolver(selfRef))
 	if err != nil {
 		return fmt.Errorf("error interpreting Pulumi references in comment %q: %w", comment, err)
 	}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -123,6 +123,24 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 	return cgstrings.UppercaseFirst(tokenToName(f.Token)) + "Result"
 }
 
+// ResolveDocRef renders a single doc ref as a Python name. It honours per-package
+// ModuleNameOverrides and resource→args class naming (including the `InitArgs` fallback used when
+// an object type collides with a resource token).
+func (d DocLanguageHelper) ResolveDocRef(pkg schema.PackageReference, selfRef, ref schema.DocRef) (string, bool, error) {
+	var info PackageInfo
+	if a, err := pkg.Language("python"); err == nil {
+		info, _ = a.(PackageInfo)
+	}
+	mod := &modContext{
+		pkg:              pkg,
+		mod:              "\x00docrefresolver",
+		modNameOverrides: info.ModuleNameOverrides,
+		typeDetails:      map[*schema.ObjectType]*typeDetails{},
+	}
+	name, ok := mod.docRefResolver(selfRef)(ref)
+	return name, ok, nil
+}
+
 func (d DocLanguageHelper) GetMethodName(m *schema.Method) string {
 	return PyName(m.Name)
 }

--- a/pkg/codegen/python/doc_test.go
+++ b/pkg/codegen/python/doc_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderWithResolver is a test helper that obtains a DocRefResolver and uses it to substitute the
+// ref shortcodes in description, mirroring what a doc-generating caller would do (modulo its own
+// AST walking / code-block handling).
+func renderWithResolver(
+	t *testing.T, d DocLanguageHelper, pkg schema.PackageReference,
+	selfRef schema.DocRef, description string,
+) string {
+	t.Helper()
+	rendered, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
+		name, ok, err := d.ResolveDocRef(pkg, selfRef, ref)
+		require.NoError(t, err)
+		return name, ok
+	})
+	require.NoError(t, err)
+	return strings.TrimSuffix(rendered, "\n")
+}
+
+func TestResolveDocRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic refs", func(t *testing.T) {
+		t.Parallel()
+
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "aws",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Types: map[string]schema.ComplexTypeSpec{
+				"aws:s3/BucketCorsRule:BucketCorsRule": {
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Type: "object",
+						Properties: map[string]schema.PropertySpec{
+							"stringProp": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"aws:s3/bucket:Bucket": {
+					InputProperties: map[string]schema.PropertySpec{
+						"corsRules": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		d := DocLanguageHelper{}
+
+		cases := []struct {
+			name        string
+			description string
+			expected    string
+		}{
+			{
+				name:        "resource",
+				description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket %}}.",
+				expected:    "See _s3.Bucket.",
+			},
+			{
+				name:        "resource input property",
+				description: "See {{% ref #/resources/aws:s3%2Fbucket:Bucket/inputProperties/corsRules %}}.",
+				expected:    "See _s3.BucketArgs.cors_rules.",
+			},
+			{
+				name:        "type",
+				description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule %}}.",
+				expected:    "See BucketCorsRuleArgs.",
+			},
+			{
+				name:        "type property",
+				description: "See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule/properties/stringProp %}}.",
+				expected:    "See BucketCorsRuleArgs.string_prop.",
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{}, tc.description)
+				assert.Equal(t, tc.expected, got)
+			})
+		}
+
+		t.Run("selfRef", func(t *testing.T) {
+			t.Parallel()
+			var bucket *schema.Resource
+			for _, r := range pkg.Resources {
+				if r.Token == "aws:s3/bucket:Bucket" {
+					bucket = r
+				}
+			}
+			require.NotNil(t, bucket)
+			var corsRule *schema.ObjectType
+			for _, typ := range pkg.Types {
+				if obj, ok := typ.(*schema.ObjectType); ok && obj.Token == "aws:s3/BucketCorsRule:BucketCorsRule" {
+					corsRule = obj
+				}
+			}
+			require.NotNil(t, corsRule)
+
+			got := renderWithResolver(t, d, pkg.Reference(), schema.DocRefForResource(bucket),
+				"See {{% ref #/resources/aws:s3%2Fbucket:Bucket/inputProperties/corsRules %}}.")
+			assert.Equal(t, "See cors_rules.", got)
+
+			got = renderWithResolver(t, d, pkg.Reference(), schema.DocRefForType(corsRule),
+				"See {{% ref #/types/aws:s3%2FBucketCorsRule:BucketCorsRule/properties/stringProp %}}.")
+			assert.Equal(t, "See string_prop.", got)
+		})
+	})
+
+	t.Run("InitArgs fallback for resource/object token collision", func(t *testing.T) {
+		t.Parallel()
+
+		// When an object type shares a token with a resource, genResource emits the args class
+		// as `<Resource>InitArgs` instead of `<Resource>Args`. DocRefResolver must agree.
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "dup",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"dup:idx:Thing": {
+					InputProperties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+			Types: map[string]schema.ComplexTypeSpec{
+				"dup:idx:Thing": {
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Type: "object",
+						Properties: map[string]schema.PropertySpec{
+							"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+
+		d := DocLanguageHelper{}
+		got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{},
+			"See {{% ref #/resources/dup:idx:Thing/inputProperties/name %}}.")
+		assert.Equal(t, "See ThingInitArgs.name.", got)
+	})
+
+	t.Run("ModuleNameOverrides applied", func(t *testing.T) {
+		t.Parallel()
+
+		pkg, err := schema.ImportSpec(schema.PackageSpec{
+			Name:    "pkg",
+			Version: "0.0.1",
+			Meta:    &schema.MetadataSpec{ModuleFormat: "(.*)(?:/[^/]*)"},
+			Resources: map[string]schema.ResourceSpec{
+				"pkg:original/widget:Widget": {},
+			},
+		}, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+		require.NoError(t, err)
+		pkg.Language["python"] = PackageInfo{
+			ModuleNameOverrides: map[string]string{"original": "renamed"},
+		}
+
+		d := DocLanguageHelper{}
+		got := renderWithResolver(t, d, pkg.Reference(), schema.DocRef{},
+			"See {{% ref #/resources/pkg:original%2Fwidget:Widget %}}.")
+		// The module override should turn the schema module "original" into the python module
+		// "renamed" in the qualified reference.
+		assert.Equal(t, "See _renamed.Widget.", got)
+	})
+}

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2570,14 +2570,10 @@ func (mod *modContext) genInitDocstring(w io.Writer, res *schema.Resource, resou
 	return nil
 }
 
-func (mod *modContext) genComment(comment string, selfRef schema.DocRef, filterExamples bool) (string, error) {
-	if comment == "" {
-		return "", nil
-	}
-	if filterExamples {
-		comment = codegen.FilterExamples(comment, "python")
-	}
-	comment, err := mod.pkg.InterpretPulumiRefs(comment, func(ref schema.DocRef) (string, bool) {
+// docRefResolver returns a resolver for `{{% ref %}}` shortcodes that produces Python names. If
+// selfRef is set, refs within the same scope are returned unqualified.
+func (mod *modContext) docRefResolver(selfRef schema.DocRef) func(schema.DocRef) (string, bool) {
+	return func(ref schema.DocRef) (string, bool) {
 		var base string
 		switch ref.Kind {
 		case schema.DocRefKindResource, schema.DocRefKindResourceProperty:
@@ -2622,7 +2618,17 @@ func (mod *modContext) genComment(comment string, selfRef schema.DocRef, filterE
 		}
 
 		return fmt.Sprintf("%s.%s", base, property), true
-	})
+	}
+}
+
+func (mod *modContext) genComment(comment string, selfRef schema.DocRef, filterExamples bool) (string, error) {
+	if comment == "" {
+		return "", nil
+	}
+	if filterExamples {
+		comment = codegen.FilterExamples(comment, "python")
+	}
+	comment, err := mod.pkg.InterpretPulumiRefs(comment, mod.docRefResolver(selfRef))
 	if err != nil {
 		return "", fmt.Errorf("error interpreting Pulumi references in comment %q: %w", comment, err)
 	}


### PR DESCRIPTION
Add a `ResolveDocRef` function to `DocLanguageHelper` to allow docs to translate doc refs in comments based on the language they are targeting. 