### PR TITLE
avoid duplicate cmd.Wait()

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1748,7 +1748,7 @@ func TestRunningViaCLIWrapper(t *testing.T) {
 		// This is the bug - process hung trying to control terminal
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
+			<-processFinished
 		}
 
 		require.Failf(t, "up hung", "pulumi up hung after %s - likely trying to set raw mode without foreground control."+


### PR DESCRIPTION
`cmd.Wait()` should only be called once per process, calling it twice can lead to a data race, as seen in
https://github.com/pulumi/pulumi/actions/runs/27743761014/job/82078495430.

We don't really need the second `cmd.Wait()` call here, we can just rely on the original one and wait for the `processFinished` channel.

It's still not quite clear to me why this times out in the first place, but hopefully fixing the data race will make that a bit easier to investigate.
