### PR TITLE
Share InterpretPulumiRefs logic with private helper

### DIFF
--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -234,7 +234,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 	diags = diags.Extend(checkDuplicates(spec.Resources, spec.Functions, types.pkg.TokenToModule))
 
 	// Now we've bound everything we can do a pass over the Descriptions and Comments to check they have valid doc refs.
-	diags = diags.Extend(checkDocRefs(types, spec, options))
+	diags = diags.Extend(checkDocRefs(types, spec))
 
 	pkg := types.pkg
 	pkg.Config = config
@@ -253,13 +253,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 		return nil, nil, err
 	}
 	pkg.interpretPulumiRefs = func(description string, resolver PulumiRefResolver) (string, error) {
-		source := []byte(description)
-		parsed := ParseDocs(source)
-		err := interpretPulumiRefs("", types, ValidationOptions{}, parsed, resolver)
-		if err != nil {
-			return "", err
-		}
-		return RenderDocsToString(source, parsed), nil
+		return interpretPulumiRefsInDescription(description, types, resolver)
 	}
 	return pkg, diags, nil
 }
@@ -407,7 +401,7 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 	return types, diags, nil
 }
 
-// Options that affect the validation of the packgae schema.
+// Options that affect the validation of the package schema.
 type ValidationOptions struct {
 	// Internal flag set to allow the builtin pulumi package to bind.
 	AllowPulumiPackage      bool
@@ -1724,7 +1718,7 @@ func (t *types) finishTypes(tokens []string, options ValidationOptions) ([]Type,
 	return typeList, diags, nil
 }
 
-func checkDocRefs(types *types, spec PackageSpec, options ValidationOptions) hcl.Diagnostics {
+func checkDocRefs(types *types, spec PackageSpec) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 	resolver := func(ref DocRef) (string, bool) { return "", false }
 
@@ -1733,7 +1727,7 @@ func checkDocRefs(types *types, spec PackageSpec, options ValidationOptions) hcl
 			return
 		}
 		parsed := ParseDocs([]byte(text))
-		diags = diags.Extend(interpretPulumiRefs(path, types, options, parsed, resolver))
+		diags = diags.Extend(interpretPulumiRefs(path, types, parsed, resolver))
 	}
 
 	checkProperties := func(basePath string, props map[string]PropertySpec) {

--- a/pkg/codegen/schema/docs.go
+++ b/pkg/codegen/schema/docs.go
@@ -31,17 +31,36 @@ import (
 // resolved; if false, the caller falls back to a default rendering of the ref.
 type PulumiRefResolver func(ref DocRef) (string, bool)
 
+// interpretPulumiRefsInDescription interprets Pulumi refs in a documentation string,
+// then renders the result back to text.
+func interpretPulumiRefsInDescription(
+	description string, types *types, resolver PulumiRefResolver,
+) (string, error) {
+	if description == "" {
+		return "", nil
+	}
+
+	source := []byte(description)
+	parsed := ParseDocs(source)
+	err := interpretPulumiRefs("", types, parsed, resolver)
+	if err != nil {
+		return "", err
+	}
+
+	return RenderDocsToString(source, parsed), nil
+}
+
 // interpretPulumiRefs parses all {{% ref %}} shortcodes that descend from the given node. Each ref is passed to the
 // `resolveRefToName` callback to replace the shortcode with literal text.
 func interpretPulumiRefs(
-	path string, types *types, options ValidationOptions,
+	path string, types *types,
 	node ast.Node, resolveRefToName PulumiRefResolver,
 ) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
 	var c, next ast.Node
 	for c = node.FirstChild(); c != nil; c = next {
-		subdiags := interpretPulumiRefs(path, types, options, c, resolveRefToName)
+		subdiags := interpretPulumiRefs(path, types, c, resolveRefToName)
 		diags = append(diags, subdiags...)
 
 		next = c.NextSibling()

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -835,17 +835,7 @@ func (p *PartialPackage) InterpretPulumiRefs(description string, resolver Pulumi
 		return p.def.InterpretPulumiRefs(description, resolver)
 	}
 
-	if description == "" {
-		return "", nil
-	}
-
-	source := []byte(description)
-	parsed := ParseDocs(source)
-	err := interpretPulumiRefs("", p.types, ValidationOptions{}, parsed, resolver)
-	if err != nil {
-		return "", err
-	}
-	return RenderDocsToString(source, parsed), nil
+	return interpretPulumiRefsInDescription(description, p.types, resolver)
 }
 
 type partialPackageTypes struct {


### PR DESCRIPTION
Little cleanup to share some logic between bound and partial packages, also cleanup an unused parameter while at it.