### PR TITLE
Fix RenderDocs to elide newlines if origionally missing

### DIFF
--- a/changelog/pending/sdkgen-fix-20260618-232628.yaml
+++ b/changelog/pending/sdkgen-fix-20260618-232628.yaml
@@ -1,0 +1,6 @@
+component: sdkgen
+kind: fix
+body: Fix extra trailing new lines in comments
+time: 2026-06-18T23:26:28.533711+01:00
+custom:
+    PR: "23619"

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -167,7 +167,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 		pkg := bindTestPackage(t)
 		description := "This is a reference to {{% ref #/resources/test:s3:Bucket %}} and one to the " +
 			"{{% ref #/resources/test:s3:Bucket/properties/region %}} property."
-		expected := "This is a reference to s3.Bucket and one to the region property.\n"
+		expected := "This is a reference to s3.Bucket and one to the region property."
 		result, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
 			if ref.Kind == schema.DocRefKindResource {
 				rt := ref.Type.(*schema.ResourceType)
@@ -186,7 +186,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 		pkg := bindTestPackage(t)
 		description := "This is a reference to {{% ref #/resources/test:mod:Resource/properties/myProperty %}}" +
 			" and to {{% ref #/resources/test:mod:Resource %}}."
-		expected := "This is a reference to myProperty and to test:mod:Resource.\n"
+		expected := "This is a reference to myProperty and to test:mod:Resource."
 		result, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
 			return "", false
 		})
@@ -210,7 +210,7 @@ func TestInterpretPulumiRefs(t *testing.T) {
 
 		pkg := bindTestPackage(t)
 		description := "This description has no Pulumi references."
-		expected := "This description has no Pulumi references.\n"
+		expected := "This description has no Pulumi references."
 		result, err := pkg.InterpretPulumiRefs(description, func(ref schema.DocRef) (string, bool) {
 			return "ResolvedName", true
 		})

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2662,6 +2662,7 @@ func (mod *modContext) genTypeDocstring(w io.Writer, comment string, properties 
 	// If this type has documentation, write it at the top of the docstring.
 	if comment != "" {
 		fmt.Fprintln(b, comment)
+		fmt.Fprintln(b, "")
 	}
 
 	for _, prop := range properties {

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -104,7 +104,19 @@ func RenderDocs(w io.Writer, source []byte, node ast.Node, options ...RendererOp
 		util.Prioritized(md, 200),
 	}
 	r := renderer.NewRenderer(renderer.WithNodeRenderers(nodeRenderers...))
-	return r.Render(w, source, node)
+
+	var buf bytes.Buffer
+	if err := r.Render(&buf, source, node); err != nil {
+		return err
+	}
+
+	rendered := buf.Bytes()
+	if !bytes.HasSuffix(source, []byte("\n")) {
+		rendered = bytes.TrimSuffix(rendered, []byte("\n"))
+	}
+
+	_, err := w.Write(rendered)
+	return err
 }
 
 // RenderDocsToString is like RenderDocs, but renders to a string instead of a Writer.

--- a/pkg/codegen/schema/docs_renderer_test.go
+++ b/pkg/codegen/schema/docs_renderer_test.go
@@ -33,7 +33,6 @@ func TestRenderDocsToString_PreservesTrailingNewlineBehavior(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/codegen/schema/docs_renderer_test.go
+++ b/pkg/codegen/schema/docs_renderer_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderDocsToString_PreservesTrailingNewlineBehavior(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "no trailing newline", source: "plain text"},
+		{name: "with trailing newline", source: "plain text\n"},
+		{name: "empty source", source: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := []byte(tt.source)
+			parsed := ParseDocs(source)
+			rendered := RenderDocsToString(source, parsed)
+
+			assert.Equal(t, tt.source, rendered)
+		})
+	}
+}

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/call-15.7.9/pulumi_call/provider.py
@@ -41,7 +41,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -41,7 +41,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -42,7 +42,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -42,7 +42,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-13.3.7/pulumi_component/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -66,7 +66,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -78,7 +77,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -42,7 +42,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -41,7 +41,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -46,7 +46,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -60,7 +59,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/local/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -64,7 +64,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -78,7 +77,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/call-15.7.9/pulumi_call/provider.py
@@ -41,7 +41,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -41,7 +41,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -42,7 +42,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -42,7 +42,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-13.3.7/pulumi_component/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -66,7 +66,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -78,7 +77,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -42,7 +42,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -54,7 +53,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -41,7 +41,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -41,7 +41,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -53,7 +52,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -46,7 +46,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -60,7 +59,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/classes/published/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -64,7 +64,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -78,7 +77,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/call-15.7.9/pulumi_call/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -46,7 +46,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-13.3.7/pulumi_component/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -71,7 +71,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -83,7 +82,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -47,7 +47,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -51,7 +51,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -65,7 +64,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/local/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -69,7 +69,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -83,7 +82,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/call-15.7.9/pulumi_call/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -46,7 +46,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-13.3.7/pulumi_component/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -71,7 +71,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -83,7 +82,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -47,7 +47,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -51,7 +51,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -65,7 +64,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/setuppy/published/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -69,7 +69,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -83,7 +82,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/call-15.7.9/pulumi_call/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -46,7 +46,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-13.3.7/pulumi_component/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -71,7 +71,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -83,7 +82,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -47,7 +47,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -51,7 +51,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -65,7 +64,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/local/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -69,7 +69,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -83,7 +82,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource that supports method calls
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource that supports method calls
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/call-15.7.9/pulumi_call/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The `call` package's provider resource
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `call` package's provider resource
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_callable.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_callable.py
@@ -46,7 +46,6 @@ class ComponentCallable(pulumi.ComponentResource):
         """
         A component resource that has callable methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class ComponentCallable(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that has callable methods.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCallableArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_input_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefInputOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a reference to a custom resource. The input resource's `value` is used to create a child custom resource inside the component, before a reference to this child is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefInputOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/component_custom_ref_output.py
@@ -47,7 +47,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class ComponentCustomRefOutput(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts an input that is used to create a child custom resource. A reference to this child custom resource is returned.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentCustomRefOutputArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-13.3.7/pulumi_component/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/component.py
@@ -71,7 +71,6 @@ class Component(pulumi.ComponentResource):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -83,7 +82,6 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component resource that accepts a list of resources. The construct request's property dependencies are returned as an output.
-
 
         :param str resource_name: The name of the resource.
         :param ComponentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/component-property-deps-1.33.7/pulumi_component_property_deps/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource with a single string input and output
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource with a single string input and output
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/configurer.py
@@ -47,7 +47,6 @@ class Configurer(pulumi.ComponentResource):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -59,7 +58,6 @@ class Configurer(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A component that internally constructs a Provider configured with `providerConfig` and exposes it via methods.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigurerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/custom.py
@@ -46,7 +46,6 @@ class Custom(pulumi.CustomResource):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Custom(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A custom resource whose outputs echo its configured provider's `config` setting.
-
 
         :param str resource_name: The name of the resource.
         :param CustomArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/configurer-38.0.0/pulumi_configurer/provider.py
@@ -46,7 +46,6 @@ class Provider(pulumi.ProviderResource):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -58,7 +57,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The configurer provider. Its `config` setting is echoed onto each Custom resource it creates.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/fun.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/fun.py
@@ -51,7 +51,6 @@ def fun(in_: Optional[_builtins.bool] = None,
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
 
-
     :param _builtins.bool in_: Will be used to set out.
     """
     __args__ = dict()
@@ -65,7 +64,6 @@ def fun_output(in_: pulumi.Input[Optional[_builtins.bool]] = None,
                opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FunResult]:
     """
     fun is a basic function for setting ResourceArgs.in_ on Resource.
-
 
     :param _builtins.bool in_: Will be used to set out.
     """

--- a/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/resource.py
+++ b/sdk/python/cmd/pulumi-language-python/testdata/toml/published/sdks/docs-28.0.0/pulumi_docs/resource.py
@@ -69,7 +69,6 @@ class Resource(pulumi.CustomResource):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_enum.StringEnum'] external_enum: External enum value from StringEnum.
@@ -83,7 +82,6 @@ class Resource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource is a basic resource. Use fun to set {{% ref#/resources/docs:index:Resource/inputProperties/in %}} using FunResult.out.
-
 
         :param str resource_name: The name of the resource.
         :param ResourceArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -138,7 +138,6 @@ class ConfigMap(pulumi.CustomResource):
         """
         A non-overlay, non-component, Kubernetes resource.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -156,7 +155,6 @@ class ConfigMap(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A non-overlay, non-component, Kubernetes resource.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigMapInitArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -105,7 +105,6 @@ class ConfigMapList(pulumi.CustomResource):
         """
         A Kubernetes list resource.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -121,7 +120,6 @@ class ConfigMapList(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A Kubernetes list resource.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigMapListArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/helm/v3/Release.py
@@ -85,7 +85,6 @@ class Release(pulumi.CustomResource):
         """
         A non-overlay, non-component, non-Kubernetes resource.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] chart: Chart name to be installed. A path may be used.
@@ -100,7 +99,6 @@ class Release(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A non-overlay, non-component, non-Kubernetes resource.
-
 
         :param str resource_name: The name of the resource.
         :param ReleaseArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/provider.py
@@ -99,7 +99,6 @@ class Provider(pulumi.ProviderResource):
         """
         The provider type for the kubernetes package.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
@@ -119,7 +118,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The provider type for the kubernetes package.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/tests/testdata/codegen/kubernetes20/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -103,7 +103,6 @@ class ConfigGroup(pulumi.ComponentResource):
         """
         A non-overlay component resource.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union[_builtins.str, Sequence[pulumi.Input[_builtins.str]]]] files: Set of paths or a URLs that uniquely identify files.
@@ -119,7 +118,6 @@ class ConfigGroup(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A non-overlay component resource.
-
 
         :param str resource_name: The name of the resource.
         :param ConfigGroupArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_configurations.py
@@ -72,7 +72,6 @@ def list_configurations(configuration_filters: Optional[Sequence[Union['Configur
     The list of configurations.
     API Version: 2020-12-01-preview.
 
-
     :param Sequence[Union['ConfigurationFilters', 'ConfigurationFiltersDict']] configuration_filters: Holds details about product hierarchy information and filterable property.
     :param Union['CustomerSubscriptionDetails', 'CustomerSubscriptionDetailsDict'] customer_subscription_details: Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
     :param _builtins.str skip_token: $skipToken is supported on list of configurations, which provides the next page in the list of configurations.
@@ -94,7 +93,6 @@ def list_configurations_output(configuration_filters: pulumi.Input[Optional[Sequ
     """
     The list of configurations.
     API Version: 2020-12-01-preview.
-
 
     :param Sequence[Union['ConfigurationFilters', 'ConfigurationFiltersDict']] configuration_filters: Holds details about product hierarchy information and filterable property.
     :param Union['CustomerSubscriptionDetails', 'CustomerSubscriptionDetailsDict'] customer_subscription_details: Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details

--- a/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
+++ b/tests/testdata/codegen/output-funcs-edgeorder/python/pulumi_myedgeorder/list_product_families.py
@@ -73,7 +73,6 @@ def list_product_families(customer_subscription_details: Optional[Union['Custome
     The list of product families.
     API Version: 2020-12-01-preview.
 
-
     :param Union['CustomerSubscriptionDetails', 'CustomerSubscriptionDetailsDict'] customer_subscription_details: Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
     :param _builtins.str expand: $expand is supported on configurations parameter for product, which provides details on the configurations for the product.
     :param Mapping[str, Sequence[Union['FilterableProperty', 'FilterablePropertyDict']]] filterable_properties: Dictionary of filterable properties on product family.
@@ -98,7 +97,6 @@ def list_product_families_output(customer_subscription_details: pulumi.Input[Opt
     """
     The list of product families.
     API Version: 2020-12-01-preview.
-
 
     :param Union['CustomerSubscriptionDetails', 'CustomerSubscriptionDetailsDict'] customer_subscription_details: Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
     :param _builtins.str expand: $expand is supported on configurations parameter for product, which provides details on the configurations for the product.

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/get_ami_ids.py
@@ -116,7 +116,6 @@ def get_ami_ids(executable_users: Optional[Sequence[_builtins.str]] = None,
     """
     Taken from pulumi-AWS to regress an issue
 
-
     :param Sequence[_builtins.str] executable_users: Limit search to users with *explicit* launch
            permission on  the image. Valid items are the numeric account ID or `self`.
     :param Sequence[Union['GetAmiIdsFilterArgs', 'GetAmiIdsFilterArgsDict']] filters: One or more name/value pairs to filter off of. There
@@ -156,7 +155,6 @@ def get_ami_ids_output(executable_users: pulumi.Input[Optional[Optional[Sequence
                        opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetAmiIdsResult]:
     """
     Taken from pulumi-AWS to regress an issue
-
 
     :param Sequence[_builtins.str] executable_users: Limit search to users with *explicit* launch
            permission on  the image. Valid items are the numeric account ID or `self`.

--- a/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/tests/testdata/codegen/output-funcs-tfbridge20/python/pulumi_mypkg/list_storage_account_keys.py
@@ -58,7 +58,6 @@ def list_storage_account_keys(account_name: Optional[_builtins.str] = None,
     The response from the ListKeys operation.
     API Version: 2021-02-01.
 
-
     :param _builtins.str account_name: The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     :param _builtins.str expand: Specifies type of the key to be listed. Possible value is kerb.
     :param _builtins.str resource_group_name: The name of the resource group within the user's subscription. The name is case insensitive.
@@ -79,7 +78,6 @@ def list_storage_account_keys_output(account_name: pulumi.Input[Optional[_builti
     """
     The response from the ListKeys operation.
     API Version: 2021-02-01.
-
 
     :param _builtins.str account_name: The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     :param _builtins.str expand: Specifies type of the key to be listed. Possible value is kerb.

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_all_optional_inputs.py
@@ -49,7 +49,6 @@ def func_with_all_optional_inputs(a: Optional[_builtins.str] = None,
     """
     Check codegen of functions with all optional inputs.
 
-
     :param _builtins.str a: Property A
     :param _builtins.str b: Property B
     """
@@ -66,7 +65,6 @@ def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[Optional[_buil
                                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.
-
 
     :param _builtins.str a: Property A
     :param _builtins.str b: Property B

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/func_with_empty_outputs.py
@@ -23,7 +23,6 @@ def func_with_empty_outputs(name: Optional[_builtins.str] = None,
     """
     n/a
 
-
     :param _builtins.str name: The Name of the FeatureGroup.
     """
     __args__ = dict()

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_bastion_shareable_link.py
@@ -58,7 +58,6 @@ def get_bastion_shareable_link(bastion_host_name: Optional[_builtins.str] = None
     Response for all the Bastion Shareable Link endpoints.
     API Version: 2020-11-01.
 
-
     :param _builtins.str bastion_host_name: The name of the Bastion Host.
     :param _builtins.str resource_group_name: The name of the resource group.
     :param Sequence[Union['BastionShareableLink', 'BastionShareableLinkDict']] vms: List of VM references.
@@ -79,7 +78,6 @@ def get_bastion_shareable_link_output(bastion_host_name: pulumi.Input[Optional[_
     """
     Response for all the Bastion Shareable Link endpoints.
     API Version: 2020-11-01.
-
 
     :param _builtins.str bastion_host_name: The name of the Bastion Host.
     :param _builtins.str resource_group_name: The name of the resource group.

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/get_integration_runtime_object_metadatum.py
@@ -71,7 +71,6 @@ def get_integration_runtime_object_metadatum(factory_name: Optional[_builtins.st
     Another failing example. A list of SSIS object metadata.
     API Version: 2018-06-01.
 
-
     :param _builtins.str factory_name: The factory name.
     :param _builtins.str integration_runtime_name: The integration runtime name.
     :param _builtins.str metadata_path: Metadata path.
@@ -96,7 +95,6 @@ def get_integration_runtime_object_metadatum_output(factory_name: pulumi.Input[O
     """
     Another failing example. A list of SSIS object metadata.
     API Version: 2018-06-01.
-
 
     :param _builtins.str factory_name: The factory name.
     :param _builtins.str integration_runtime_name: The integration runtime name.

--- a/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
+++ b/tests/testdata/codegen/output-funcs/python/pulumi_mypkg/list_storage_account_keys.py
@@ -58,7 +58,6 @@ def list_storage_account_keys(account_name: Optional[_builtins.str] = None,
     The response from the ListKeys operation.
     API Version: 2021-02-01.
 
-
     :param _builtins.str account_name: The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     :param _builtins.str expand: Specifies type of the key to be listed. Possible value is kerb.
     :param _builtins.str resource_group_name: The name of the resource group within the user's subscription. The name is case insensitive.
@@ -79,7 +78,6 @@ def list_storage_account_keys_output(account_name: pulumi.Input[Optional[_builti
     """
     The response from the ListKeys operation.
     API Version: 2021-02-01.
-
 
     :param _builtins.str account_name: The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.
     :param _builtins.str expand: Specifies type of the key to be listed. Possible value is kerb.

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/foo.py
@@ -100,7 +100,6 @@ class Foo(pulumi.CustomResource):
         """
         test new feature with resoruces
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
@@ -115,7 +114,6 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         test new feature with resoruces
-
 
         :param str resource_name: The name of the resource.
         :param FooArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -50,7 +50,6 @@ def func_with_all_optional_inputs(a: Optional[Union['HelmReleaseSettings', 'Helm
     """
     Check codegen of functions with all optional inputs.
 
-
     :param Union['HelmReleaseSettings', 'HelmReleaseSettingsDict'] a: Property A
     :param _builtins.str b: Property B
     """
@@ -67,7 +66,6 @@ def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[Optional[Union
                                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.
-
 
     :param Union['HelmReleaseSettings', 'HelmReleaseSettingsDict'] a: Property A
     :param _builtins.str b: Property B

--- a/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-defaults/python/pulumi_example/provider.py
@@ -53,7 +53,6 @@ class Provider(pulumi.ProviderResource):
         """
         The provider type for the kubernetes package.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
@@ -66,7 +65,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The provider type for the kubernetes package.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/foo.py
@@ -100,7 +100,6 @@ class Foo(pulumi.CustomResource):
         """
         test new feature with resoruces
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']] backup_kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
@@ -115,7 +114,6 @@ class Foo(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         test new feature with resoruces
-
 
         :param str resource_name: The name of the resource.
         :param FooArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/func_with_all_optional_inputs.py
@@ -50,7 +50,6 @@ def func_with_all_optional_inputs(a: Optional[Union['HelmReleaseSettings', 'Helm
     """
     Check codegen of functions with all optional inputs.
 
-
     :param Union['HelmReleaseSettings', 'HelmReleaseSettingsDict'] a: Property A
     :param _builtins.str b: Property B
     """
@@ -67,7 +66,6 @@ def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[Optional[Union
                                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.
-
 
     :param Union['HelmReleaseSettings', 'HelmReleaseSettingsDict'] a: Property A
     :param _builtins.str b: Property B

--- a/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
+++ b/tests/testdata/codegen/plain-object-disable-defaults/python/pulumi_example/provider.py
@@ -53,7 +53,6 @@ class Provider(pulumi.ProviderResource):
         """
         The provider type for the kubernetes package.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']] helm_release_settings: BETA FEATURE - Options to configure the Helm Release resource.
@@ -66,7 +65,6 @@ class Provider(pulumi.ProviderResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The provider type for the kubernetes package.
-
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
+++ b/tests/testdata/codegen/provider-config-schema/python/pulumi_configstation/func_with_all_optional_inputs.py
@@ -49,7 +49,6 @@ def func_with_all_optional_inputs(a: Optional[_builtins.str] = None,
     """
     Check codegen of functions with all optional inputs.
 
-
     :param _builtins.str a: Property A
     :param _builtins.str b: Property B
     """
@@ -66,7 +65,6 @@ def func_with_all_optional_inputs_output(a: pulumi.Input[Optional[Optional[_buil
                                          opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[FuncWithAllOptionalInputsResult]:
     """
     Check codegen of functions with all optional inputs.
-
 
     :param _builtins.str a: Property A
     :param _builtins.str b: Property B

--- a/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
+++ b/tests/testdata/codegen/regress-py-14539/python/pulumi_gcp/compute/instance/instance.py
@@ -81,7 +81,6 @@ class Instance(pulumi.CustomResource):
         """
         A mock of an instance.
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['_compute.instancebootdisk.InstanceBootDiskArgs', '_compute.instancebootdisk.InstanceBootDiskArgsDict']] boot_disk: The boot disk for the instance.
@@ -95,7 +94,6 @@ class Instance(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A mock of an instance.
-
 
         :param str resource_name: The name of the resource.
         :param InstanceArgs args: The arguments to use to populate this resource's properties.

--- a/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
+++ b/tests/testdata/codegen/urn-id-properties/python/pulumi_urnid/res.py
@@ -61,7 +61,6 @@ class Res(pulumi.CustomResource):
         """
         It's fine to use urn and id as input properties
 
-
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         """
@@ -73,7 +72,6 @@ class Res(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         It's fine to use urn and id as input properties
-
 
         :param str resource_name: The name of the resource.
         :param ResArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
This fixes `RenderDocs` to elide a trailing new line if the original text had no trailing new line.

This flagged up that a lot of python comments were both relying on this, and had extra new lines that were unneeded.

This makes it easier to work with functions built on top of RenderDocs to do partial string fixes (like handling refs, examples etc) without having to worry about newlines being added all the time.