### PR TITLE
get latest version from API rather than from GitHub

### DIFF
--- a/npm/lib/download.js
+++ b/npm/lib/download.js
@@ -56,9 +56,9 @@ async function installCLI(
 
 // fetchLatestVersion returns the latest stable Pulumi release version string.
 async function fetchLatestVersion(fetchText = defaultFetchText) {
-    const text = await fetchText("https://api.github.com/repos/pulumi/pulumi/releases/latest");
-    const { tag_name } = JSON.parse(text);
-    return tag_name.replace(/^v/, "");
+    const text = await fetchText("https://api.pulumi.com/api/cli/version");
+    const { latestVersion } = JSON.parse(text);
+    return latestVersion.replace(/^v/, "");
 }
 
 module.exports = { installCLI, fetchLatestVersion };

--- a/npm/test/download.test.js
+++ b/npm/test/download.test.js
@@ -10,13 +10,14 @@ const path = require("path");
 const { installCLI, fetchLatestVersion } = require("../lib/download");
 
 describe("fetchLatestVersion()", () => {
-    it("parses tag_name from GitHub releases API response", async () => {
-        const fakeFetch = async () => JSON.stringify({ tag_name: "v3.99.0", name: "v3.99.0" });
+    it("parses latestVersion from the Pulumi API response", async () => {
+        const fakeFetch = async () =>
+            JSON.stringify({ latestVersion: "3.99.0", oldestWithoutWarning: "3.99.0" });
         assert.equal(await fetchLatestVersion(fakeFetch), "3.99.0");
     });
 
-    it("strips leading v from tag_name", async () => {
-        const fakeFetch = async () => JSON.stringify({ tag_name: "v3.1.0" });
+    it("strips a leading v from the version", async () => {
+        const fakeFetch = async () => JSON.stringify({ latestVersion: "v3.1.0" });
         assert.equal(await fetchLatestVersion(fakeFetch), "3.1.0");
     });
 });


### PR DESCRIPTION
Currently we fetch the latest version for the CLI installed via `npm` from GitHub. This is flaky in our CI tests, and probably also flaky for our users.  Instead, get the version directly from the Pulumi API, which is more in our control, and hopefully more reliable.

Fixes https://github.com/pulumi/pulumi/issues/23621

cc @blampe 