### PR TITLE
 Add options to `pulumi stack get` for parity with bare `pulumi stack`

### DIFF
--- a/changelog/pending/cli-improvement-20260618-143919.yaml
+++ b/changelog/pending/cli-improvement-20260618-143919.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Add options to `pulumi stack get` for parity with bare `pulumi stack`
 time: 2026-06-18T14:39:19.458512+02:00
 custom:
-    PR: ""
+  PR: "23623"

--- a/changelog/pending/cli-improvement-20260618-143919.yaml
+++ b/changelog/pending/cli-improvement-20260618-143919.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Add options to `pulumi stack get` for parity with bare `pulumi stack`
+time: 2026-06-18T14:39:19.458512+02:00
+custom:
+    PR: ""

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -48,12 +49,16 @@ type stackArgs struct {
 	startTime              string
 	showStackName          bool
 	fullyQualifyStackNames bool
-	output                 string
 }
 
 func NewStackCmd() *cobra.Command {
 	var stackName string
 	args := stackArgs{}
+
+	output := outputflag.OutputFlag[stackRenderFunc]{
+		RenderForTerminal: runStackText,
+		RenderJSON:        runStackJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "stack",
@@ -86,7 +91,11 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
-			return runStack(ctx, s, cmd.OutOrStdout(), args)
+			if args.showStackName {
+				writeStackName(cmd.OutOrStdout(), s, args.fullyQualifyStackNames)
+				return nil
+			}
+			return output.Get()(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
 
@@ -103,9 +112,7 @@ func NewStackCmd() *cobra.Command {
 		&args.showSecrets, "show-secrets", false, "Display stack outputs which are marked as secret in plaintext")
 	cmd.Flags().BoolVar(
 		&args.showStackName, "show-name", false, "Display only the stack name")
-	cmd.Flags().StringVar(
-		&args.output, "output", "default",
-		"The output format: default (human-readable) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	cmd.AddCommand(newStackExportCmd())
 	cmd.AddCommand(newStackGraphCmd())
@@ -128,25 +135,17 @@ func NewStackCmd() *cobra.Command {
 	return cmd
 }
 
-func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
-	if args.showStackName {
-		if args.fullyQualifyStackNames {
-			fmt.Fprintln(out, s.Ref().String())
-		} else {
-			fmt.Fprintln(out, s.Ref().Name())
-		}
-		return nil
+func writeStackName(out io.Writer, s backend.Stack, fullyQualify bool) {
+	if fullyQualify {
+		fmt.Fprintln(out, s.Ref().String())
+	} else {
+		fmt.Fprintln(out, s.Ref().Name())
 	}
+}
 
-	switch args.output {
-	case "", "default":
-		// Fall through to the human-readable rendering below.
-	case "json":
-		return runStackJSON(ctx, s, out, args)
-	default:
-		return fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", args.output)
-	}
+type stackRenderFunc func(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error
 
+func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
 	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -20,44 +20,45 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// newStackGetCmd registers `pulumi stack get`, a thin convenience alias
-// for `pulumi stack`. It behaves identically to `pulumi stack` on both
-// the Pulumi Cloud and DIY backends, including the default value of
-// `--output` (human-readable text). Pass `--output=json` for the
-// stable, machine-readable envelope built by stack_json.go.
+// `pulumi stack get` shows the same information as `pulumi stack` (same flags and output), but only reads an existing
+// stack, it does not offer to create one. This command exists for verb-noun consistency with the other `get` commands.
 func newStackGetCmd() *cobra.Command {
-	var (
-		stackName   string
-		output      string
-		showSecrets bool
-	)
+	var stackName string
+	args := stackArgs{}
+
+	output := outputflag.OutputFlag[stackRenderFunc]{
+		RenderForTerminal: runStackText,
+		RenderJSON:        runStackJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "[EXPERIMENTAL] Retrieve detailed information about a stack",
 		Long: "[EXPERIMENTAL] Retrieve detailed information about a stack.\n" +
 			"\n" +
-			"`pulumi stack get` is a convenience alias for `pulumi stack --output=json`.\n" +
-			"On the Pulumi Cloud backend it surfaces the organization, project, and\n" +
-			"stack name, the current version, all associated tags, any active update\n" +
-			"operation (with its kind, author, and start time), the active update\n" +
-			"UUID, and (when available) the local resource snapshot. On DIY backends\n" +
-			"the cloud-only fields are omitted; everything else is rendered.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+			"Shows the current stack's state: the owning organization, the resources in\n" +
+			"the stack, stack outputs, the last update, and (on the Pulumi Cloud backend)\n" +
+			"any in-progress operation. This is the same information shown by `pulumi\n" +
+			"stack`",
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			s, err := RequireStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager,
 				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()}, "")
 			if err != nil {
 				return err
 			}
-			return runStack(ctx, s, cmd.OutOrStdout(), stackArgs{
-				output:      output,
-				showSecrets: showSecrets,
-			})
+
+			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
+			if args.showStackName {
+				writeStackName(cmd.OutOrStdout(), s, args.fullyQualifyStackNames)
+				return nil
+			}
+			return output.Get()(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
 
@@ -65,10 +66,15 @@ func newStackGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable) or json")
-	cmd.Flags().BoolVar(&showSecrets, "show-secrets", false,
+	cmd.Flags().BoolVarP(&args.showIDs, "show-ids", "i", false,
+		"Display each resource's provider-assigned unique ID")
+	cmd.Flags().BoolVarP(&args.showURNs, "show-urns", "u", false,
+		"Display each resource's Pulumi-assigned globally unique URN")
+	cmd.Flags().BoolVar(&args.showSecrets, "show-secrets", false,
 		"Display stack outputs which are marked as secret in plaintext")
+	cmd.Flags().BoolVar(&args.showStackName, "show-name", false,
+		"Display only the stack name")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -377,7 +377,7 @@ func TestRunStackJSON_NonCloud_NilSnapshot(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := runStackJSON(t.Context(), newMockStack(nil, nil), &buf, stackArgs{output: "json"})
+	err := runStackJSON(t.Context(), newMockStack(nil, nil), &buf, stackArgs{})
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{

--- a/pkg/cmd/pulumi/stack/stack_test.go
+++ b/pkg/cmd/pulumi/stack/stack_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShowStackName(t *testing.T) {
@@ -40,7 +39,6 @@ func TestShowStackName(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
-			args := stackArgs{showStackName: true, fullyQualifyStackNames: tt.full}
 			var output bytes.Buffer
 			s := backend.MockStack{
 				RefF: func() backend.StackReference {
@@ -51,8 +49,7 @@ func TestShowStackName(t *testing.T) {
 				},
 			}
 
-			err := runStack(t.Context(), &s, &output, args)
-			require.NoError(t, err)
+			writeStackName(&output, &s, tt.full)
 			assert.Equal(t, tt.expected+"\n", output.String())
 		})
 	}


### PR DESCRIPTION
Refactor `pulumi stack` to use `outputflag` and make `pulumi stack get` a (read only) alias of `pulumi stack.

Ref https://github.com/pulumi/pulumi/issues/22959
