### PR TITLE
allow empty globs to be marshalled and unmarshalled

### DIFF
--- a/sdk/go/property/glob.go
+++ b/sdk/go/property/glob.go
@@ -38,9 +38,6 @@ var (
 )
 
 func (g Glob) MarshalText() (text []byte, err error) {
-	if g.len() == 0 {
-		return nil, errors.New("cannot marshal an empty glob")
-	}
 	var b strings.Builder
 segment:
 	for i, p := range g.enumerate {
@@ -76,10 +73,6 @@ segment:
 
 func (g *Glob) UnmarshalText(text []byte) error {
 	*g = Glob{}
-	if len(text) == 0 {
-		return errors.New("cannot unmarshal an empty property path")
-	}
-
 	runes := []rune(string(text))
 	for len(runes) > 0 {
 		switch {

--- a/sdk/go/property/glob_test.go
+++ b/sdk/go/property/glob_test.go
@@ -15,6 +15,7 @@
 package property
 
 import (
+	"encoding/json"
 	"math"
 	"slices"
 	"strconv"
@@ -136,6 +137,32 @@ func TestGlobEncoding(t *testing.T) {
 		assert.Equal(t, g, g2, "assert that we can round-trip the Glob")
 	})
 
+	t.Run("empty glob is marshalable", func(t *testing.T) {
+		t.Parallel()
+
+		// The empty (zero-value) glob is the root path. MarshalText must be
+		// total: it serializes to "" and "" round-trips back to it. A glob that
+		// refused to marshal made any struct embedding it un-marshalable, which
+		// is the root cause of https://github.com/pulumi/pulumi/issues/23403.
+		text, err := Glob{}.MarshalText()
+		require.NoError(t, err)
+		assert.Empty(t, text)
+
+		var g Glob
+		require.NoError(t, g.UnmarshalText([]byte("")))
+		assert.Equal(t, Glob{}, g)
+
+		// json.Marshal of a value embedding an empty glob (as the preview digest
+		// did) must not error.
+		b, err := json.Marshal(struct{ G Glob }{})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"G":""}`, string(b))
+
+		var rt struct{ G Glob }
+		require.NoError(t, json.Unmarshal(b, &rt))
+		assert.Equal(t, Glob{}, rt.G)
+	})
+
 	t.Run("unmarshal", func(t *testing.T) {
 		t.Parallel()
 
@@ -143,6 +170,7 @@ func TestGlobEncoding(t *testing.T) {
 			text     string
 			expected Glob
 		}{
+			{"", Glob{}},
 			{"x.*", GlobFromSegments(KeySegment{"x"}, Splat)},
 			{"*", GlobFromSegments(Splat)},
 			{`["x"]`, GlobFromSegments(KeySegment{"x"})},
@@ -166,7 +194,6 @@ func TestGlobEncoding(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct{ text, expectedError string }{
-			{"", "cannot unmarshal an empty property path"},
 			{".", "expected character"},
 			{"[", "unclosed '['"},
 			{"[1", "unclosed number [1"},

--- a/sdk/go/property/path_test.go
+++ b/sdk/go/property/path_test.go
@@ -15,12 +15,52 @@
 package property_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPathEncoding asserts that property.Path serialization is total, including
+// for the empty (root) path. A Path that refused to marshal made any struct
+// embedding it un-marshalable; see https://github.com/pulumi/pulumi/issues/23403.
+func TestPathEncoding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty path round-trips", func(t *testing.T) {
+		t.Parallel()
+
+		text, err := property.Path{}.MarshalText()
+		require.NoError(t, err)
+		assert.Empty(t, text)
+
+		var p property.Path
+		require.NoError(t, p.UnmarshalText([]byte("")))
+		assert.Equal(t, property.Path{}, p)
+
+		b, err := json.Marshal(struct{ P property.Path }{})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"P":""}`, string(b))
+
+		var rt struct{ P property.Path }
+		require.NoError(t, json.Unmarshal(b, &rt))
+		assert.Equal(t, property.Path{}, rt.P)
+	})
+
+	t.Run("non-empty path round-trips", func(t *testing.T) {
+		t.Parallel()
+
+		p := property.PathFromSegments(property.NewSegment("x"), property.NewSegment(0))
+		text, err := p.MarshalText()
+		require.NoError(t, err)
+
+		var p2 property.Path
+		require.NoError(t, p2.UnmarshalText(text))
+		assert.Equal(t, p, p2)
+	})
+}
 
 func TestGet(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Not allowing this to be marshalled/unmarshalled leads to panics, because we do have empty versions of these types apparently.

I don't know where these empty globs come from, but I also don't see a reason why we can't simply marshal them to empty strings/unmarshal empty strings back into empty globs.

Fixes https://github.com/pulumi/pulumi/issues/23403