### PR TITLE
Convert more commands to use the outputflag helper

### DIFF
--- a/changelog/pending/cli-improvement-20260618-143919.yaml
+++ b/changelog/pending/cli-improvement-20260618-143919.yaml
@@ -3,4 +3,4 @@ kind: improvement
 body: Add options to `pulumi stack get` for parity with bare `pulumi stack`
 time: 2026-06-18T14:39:19.458512+02:00
 custom:
-    PR: ""
+  PR: "23623"

--- a/changelog/pending/cli-improvement-20260618-143919.yaml
+++ b/changelog/pending/cli-improvement-20260618-143919.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Add options to `pulumi stack get` for parity with bare `pulumi stack`
+time: 2026-06-18T14:39:19.458512+02:00
+custom:
+    PR: ""

--- a/pkg/cmd/pulumi/deployment/deployment_list.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list.go
@@ -30,6 +30,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -57,12 +58,12 @@ const defaultPageSize = 100
 // deploymentListArgs collects the flag values for the list command, in one
 // struct so Run can be driven directly from tests.
 type deploymentListArgs struct {
-	stack  string
-	count  int
-	all    bool
-	sort   string
-	asc    bool
-	output string
+	stack        string
+	count        int
+	all          bool
+	sort         string
+	asc          bool
+	renderOutput deploymentListRenderFunc
 }
 
 // newDeploymentListCmd builds `pulumi deployment list` with the production
@@ -74,6 +75,10 @@ func newDeploymentListCmd() *cobra.Command {
 
 func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Command {
 	var args deploymentListArgs
+	output := outputflag.OutputFlag[deploymentListRenderFunc]{
+		RenderForTerminal: renderDeploymentListTable,
+		RenderJSON:        renderDeploymentListJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -103,6 +108,7 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 			if f == nil {
 				f = defaultDeploymentListClientFactory
 			}
+			args.renderOutput = output.Get()
 			return runDeploymentList(cmd.Context(), cmd.OutOrStdout(), f, args)
 		},
 	}
@@ -117,8 +123,7 @@ func newDeploymentListCmdWith(factory deploymentListClientFactory) *cobra.Comman
 		"Fetch all results (mutually exclusive with --count)")
 	cmd.Flags().StringVar(&args.sort, "sort", "", "The field to sort results by")
 	cmd.Flags().BoolVar(&args.asc, "asc", false, "Sort in ascending order (default descending)")
-	cmd.Flags().StringVar(&args.output, "output", "default",
-		"Output format. One of: default, json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -168,11 +173,6 @@ func defaultDeploymentListClientFactory(
 func runDeploymentList(
 	ctx context.Context, w io.Writer, factory deploymentListClientFactory, args deploymentListArgs,
 ) error {
-	render, err := deploymentListRenderer(args.output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, args.stack)
 	if err != nil {
 		return err
@@ -219,23 +219,12 @@ func runDeploymentList(
 		page++
 	}
 
-	return render(w, deployments, total)
+	return args.renderOutput(w, deployments, total)
 }
 
 type deploymentListRenderFunc func(
 	w io.Writer, deployments []apitype.ListDeploymentSnapshot, total int64,
 ) error
-
-func deploymentListRenderer(format string) (deploymentListRenderFunc, error) {
-	switch format {
-	case "", "default", "table":
-		return renderDeploymentListTable, nil
-	case "json":
-		return renderDeploymentListJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
-	}
-}
 
 func renderDeploymentListTable(
 	w io.Writer, deployments []apitype.ListDeploymentSnapshot, total int64,

--- a/pkg/cmd/pulumi/deployment/deployment_list_test.go
+++ b/pkg/cmd/pulumi/deployment/deployment_list_test.go
@@ -73,6 +73,16 @@ func stubListFactory(c deploymentListClient) deploymentListClientFactory {
 	}
 }
 
+func defaultDeploymentListArgs() deploymentListArgs {
+	return deploymentListArgs{renderOutput: renderDeploymentListTable}
+}
+
+func jsonDeploymentListArgs() deploymentListArgs {
+	a := defaultDeploymentListArgs()
+	a.renderOutput = renderDeploymentListJSON
+	return a
+}
+
 func sampleListResponse() apitype.ListDeploymentResponseV2 {
 	return apitype.ListDeploymentResponseV2{
 		ItemsPerPage: 10,
@@ -117,7 +127,7 @@ func TestDeploymentList_DefaultOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: sampleListResponse()}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), defaultDeploymentListArgs())
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -150,7 +160,7 @@ func TestDeploymentList_DefaultOutput_Empty(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), defaultDeploymentListArgs())
 	require.NoError(t, err)
 	assert.Equal(t, "No deployments found for this stack.\n", buf.String())
 }
@@ -175,7 +185,7 @@ func TestDeploymentList_DefaultOutput_FallsBackToNameWhenGithubLoginMissing(t *t
 
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: resp}
-	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), deploymentListArgs{})
+	err := runDeploymentList(t.Context(), &buf, stubListFactory(c), defaultDeploymentListArgs())
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Display Name")
 }
@@ -186,7 +196,7 @@ func TestDeploymentList_JSONOutput(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: sampleListResponse()}
 	err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-		deploymentListArgs{output: "json"})
+		jsonDeploymentListArgs())
 	require.NoError(t, err)
 
 	// Decode and check structural fields rather than comparing the whole
@@ -209,7 +219,7 @@ func TestDeploymentList_JSONOutput_EmptyArray(t *testing.T) {
 	var buf bytes.Buffer
 	c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}}
 	err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-		deploymentListArgs{output: "json"})
+		jsonDeploymentListArgs())
 	require.NoError(t, err)
 
 	assert.JSONEq(t,
@@ -253,6 +263,7 @@ func TestDeploymentList_PropagatesFlagsToClient(t *testing.T) {
 			var captured []capturedListCall
 			c := &mockDeploymentListClient{resp: apitype.ListDeploymentResponseV2{}, captured: &captured}
 			var buf bytes.Buffer
+			tt.args.renderOutput = renderDeploymentListTable
 			err := runDeploymentList(t.Context(), &buf, stubListFactory(c), tt.args)
 			require.NoError(t, err)
 			require.NotEmpty(t, captured, "expected at least one client call")
@@ -286,8 +297,9 @@ func TestDeploymentList_AutoPaginates(t *testing.T) {
 		var captured []capturedListCall
 		c := &mockDeploymentListClient{pages: pages, captured: &captured}
 		var buf bytes.Buffer
-		err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-			deploymentListArgs{all: true, output: "json"})
+		args := jsonDeploymentListArgs()
+		args.all = true
+		err := runDeploymentList(t.Context(), &buf, stubListFactory(c), args)
 		require.NoError(t, err)
 
 		var env deploymentListEnvelope
@@ -304,8 +316,9 @@ func TestDeploymentList_AutoPaginates(t *testing.T) {
 		var captured []capturedListCall
 		c := &mockDeploymentListClient{pages: pages, captured: &captured}
 		var buf bytes.Buffer
-		err := runDeploymentList(t.Context(), &buf, stubListFactory(c),
-			deploymentListArgs{count: 150, output: "json"})
+		args := jsonDeploymentListArgs()
+		args.count = 150
+		err := runDeploymentList(t.Context(), &buf, stubListFactory(c), args)
 		require.NoError(t, err)
 
 		var env deploymentListEnvelope

--- a/pkg/cmd/pulumi/insights/insights_resource_get.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_get.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -47,10 +48,12 @@ type clientFactory func(
 	ctx context.Context, orgOverride string,
 ) (insightsResourceClient, string, error)
 
+type insightsResourceGetRenderFunc func(w io.Writer, r apitype.InsightsResourceWithVersion) error
+
 type insightsResourceGetArgs struct {
-	org     string
-	account string
-	output  string
+	org          string
+	account      string
+	renderOutput insightsResourceGetRenderFunc
 }
 
 type insightsResourceGetCmd struct {
@@ -67,6 +70,10 @@ func newInsightsResourceGetCmd(factory clientFactory) *cobra.Command {
 
 	get := &insightsResourceGetCmd{clientFactory: factory}
 	var args insightsResourceGetArgs
+	output := outputflag.OutputFlag[insightsResourceGetRenderFunc]{
+		RenderForTerminal: renderResourceText,
+		RenderJSON:        renderResourceJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -89,6 +96,7 @@ func newInsightsResourceGetCmd(factory clientFactory) *cobra.Command {
 			"  pulumi insights resource get --account prod-aws \\\n" +
 			"      'aws:s3/bucket:Bucket::my-bucket' --output json",
 		RunE: func(cmd *cobra.Command, posArgs []string) error {
+			args.renderOutput = output.Get()
 			return get.Run(cmd.Context(), cmd.OutOrStdout(), posArgs[0], args)
 		},
 	}
@@ -102,8 +110,7 @@ func newInsightsResourceGetCmd(factory clientFactory) *cobra.Command {
 		"Organization that owns the Insights account (defaults to the current default org)")
 	cmd.Flags().StringVar(&args.account, "account", "",
 		"Insights account containing the resource")
-	cmd.Flags().StringVar(&args.output, "output", "default",
-		"Output format. One of: default, json")
+	outputflag.VarP(cmd.Flags(), &output)
 	// MarkFlagRequired only errors when the flag isn't defined, which is a
 	// programming bug — the immediate StringVar above guarantees it exists.
 	_ = cmd.MarkFlagRequired("account")
@@ -122,13 +129,6 @@ func (c *insightsResourceGetCmd) Run(
 		return errors.New("--account is required")
 	}
 
-	// Validate --output before talking to the network so a typo doesn't burn an
-	// API call.
-	render, err := renderer(args.output)
-	if err != nil {
-		return err
-	}
-
 	client, org, err := c.clientFactory(ctx, args.org)
 	if err != nil {
 		return err
@@ -139,20 +139,7 @@ func (c *insightsResourceGetCmd) Run(
 		return fmt.Errorf("reading insights resource: %w", err)
 	}
 
-	return render(out, resource)
-}
-
-// renderer maps --output to the corresponding render function. Returns a
-// caller-actionable error for unknown values.
-func renderer(format string) (func(io.Writer, apitype.InsightsResourceWithVersion) error, error) {
-	switch format {
-	case "", "default":
-		return renderResourceText, nil
-	case "json":
-		return renderResourceJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", format)
-	}
+	return args.renderOutput(out, resource)
 }
 
 // renderResourceText writes a human-readable key/value view of the resource to w.

--- a/pkg/cmd/pulumi/insights/insights_resource_get_test.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_get_test.go
@@ -91,6 +91,16 @@ func sampleResource() apitype.InsightsResourceWithVersion {
 	}
 }
 
+func defaultGetArgs() insightsResourceGetArgs {
+	return insightsResourceGetArgs{account: "prod-aws", renderOutput: renderResourceText}
+}
+
+func jsonGetArgs() insightsResourceGetArgs {
+	a := defaultGetArgs()
+	a.renderOutput = renderResourceJSON
+	return a
+}
+
 func TestInsightsResourceGetCmd_DefaultOutput(t *testing.T) {
 	t.Parallel()
 
@@ -98,8 +108,7 @@ func TestInsightsResourceGetCmd_DefaultOutput(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", defaultGetArgs())
 	require.NoError(t, err)
 
 	output := out.String()
@@ -125,8 +134,7 @@ func TestInsightsResourceGetCmd_DefaultOutput_WithPolicyState(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", defaultGetArgs())
 	require.NoError(t, err)
 
 	assert.Contains(t, out.String(), "Policy state: violation")
@@ -141,8 +149,7 @@ func TestInsightsResourceGetCmd_DefaultOutput_NoState(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", defaultGetArgs())
 	require.NoError(t, err)
 
 	// Header fields are present, but no "State:" section when state is empty.
@@ -174,8 +181,7 @@ func TestInsightsResourceGetCmd_JSONOutput(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws", output: "json"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", jsonGetArgs())
 	require.NoError(t, err)
 
 	var got apitype.InsightsResourceWithVersion
@@ -222,8 +228,10 @@ func TestInsightsResourceGetCmd_OrgOverride(t *testing.T) {
 			}
 			c := &insightsResourceGetCmd{clientFactory: stubFactory(client, tt.defaultOrg)}
 
+			args := tt.args
+			args.renderOutput = renderResourceText
 			var out bytes.Buffer
-			err := c.Run(t.Context(), &out, tt.wantTypeID, tt.args)
+			err := c.Run(t.Context(), &out, tt.wantTypeID, args)
 			require.NoError(t, err)
 			assert.Equal(t, capturedCall{
 				org:               tt.wantOrg,
@@ -247,19 +255,6 @@ func TestInsightsResourceGetCmd_MissingAccount(t *testing.T) {
 	assert.Contains(t, err.Error(), "--account is required")
 }
 
-func TestInsightsResourceGetCmd_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	client := &mockInsightsClient{resource: sampleResource()}
-	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
-
-	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws", output: "yaml"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
-}
-
 func TestInsightsResourceGetCmd_ClientError(t *testing.T) {
 	t.Parallel()
 
@@ -267,8 +262,7 @@ func TestInsightsResourceGetCmd_ClientError(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: stubFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::missing",
-		insightsResourceGetArgs{account: "prod-aws"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::missing", defaultGetArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reading insights resource")
 	assert.Contains(t, err.Error(), "404 not found")
@@ -280,8 +274,7 @@ func TestInsightsResourceGetCmd_FactoryError(t *testing.T) {
 	c := &insightsResourceGetCmd{clientFactory: failingFactory(errors.New("not logged in"))}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket",
-		insightsResourceGetArgs{account: "prod-aws"})
+	err := c.Run(t.Context(), &out, "aws:s3/bucket:Bucket::my-bucket", defaultGetArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }

--- a/pkg/cmd/pulumi/insights/insights_resource_search.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_search.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cloud"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -75,17 +76,19 @@ type searchClientFactory func(
 	ctx context.Context, orgOverride string,
 ) (insightsResourceSearchClient, string, error)
 
+type insightsResourceSearchRenderFunc func(w io.Writer, r apitype.InsightsResourceSearchResponse) error
+
 type insightsResourceSearchArgs struct {
-	org        string
-	query      string
-	sort       []string
-	asc        bool
-	page       int
-	size       int
-	cursor     string
-	properties bool
-	collapse   bool
-	output     string
+	org          string
+	query        string
+	sort         []string
+	asc          bool
+	page         int
+	size         int
+	cursor       string
+	properties   bool
+	collapse     bool
+	renderOutput insightsResourceSearchRenderFunc
 }
 
 type insightsResourceSearchCmd struct {
@@ -102,6 +105,10 @@ func newInsightsResourceSearchCmd(factory searchClientFactory) *cobra.Command {
 
 	search := &insightsResourceSearchCmd{clientFactory: factory}
 	var args insightsResourceSearchArgs
+	output := outputflag.OutputFlag[insightsResourceSearchRenderFunc]{
+		RenderForTerminal: renderSearchTable,
+		RenderJSON:        renderSearchJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "search",
@@ -127,6 +134,7 @@ func newInsightsResourceSearchCmd(factory searchClientFactory) *cobra.Command {
 			"  # JSON output for scripting.\n" +
 			"  pulumi insights resource search --query 'aws:s3' --output json",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			args.renderOutput = output.Get()
 			return search.Run(cmd.Context(), cmd.OutOrStdout(), args)
 		},
 	}
@@ -152,8 +160,7 @@ func newInsightsResourceSearchCmd(factory searchClientFactory) *cobra.Command {
 		"Include resource input/output values (requires a supported subscription)")
 	cmd.Flags().BoolVar(&args.collapse, "collapse", false,
 		"Consolidate resources that exist in multiple sources into a single result")
-	cmd.Flags().StringVar(&args.output, "output", "default",
-		"Output format. One of: default, table, json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -163,12 +170,8 @@ func newInsightsResourceSearchCmd(factory searchClientFactory) *cobra.Command {
 func (c *insightsResourceSearchCmd) Run(
 	ctx context.Context, out io.Writer, args insightsResourceSearchArgs,
 ) error {
-	// Validate --output and --sort before talking to the network so a typo
-	// doesn't burn an API call.
-	render, err := searchRenderer(args.output)
-	if err != nil {
-		return err
-	}
+	// --output is validated at flag-parse time by outputflag; validate --sort here
+	// before talking to the network so a typo doesn't burn an API call.
 	if err := validateSortFields(args.sort); err != nil {
 		return err
 	}
@@ -192,7 +195,7 @@ func (c *insightsResourceSearchCmd) Run(
 	if err != nil {
 		return fmt.Errorf("searching insights resources: %w", err)
 	}
-	return render(out, resp)
+	return args.renderOutput(out, resp)
 }
 
 // sortedSortFields returns the valid sort fields in deterministic order, so
@@ -216,24 +219,6 @@ func validateSortFields(sorts []string) error {
 		}
 	}
 	return nil
-}
-
-// searchRenderer maps --output to the corresponding render function.
-// `default` and `table` are aliases — they both render the box-drawn table
-// produced by go-pretty, matching other cli/cloud list/search commands such
-// as `pulumi stack webhook list` and `pulumi org search`.
-func searchRenderer(format string) (
-	func(io.Writer, apitype.InsightsResourceSearchResponse) error, error,
-) {
-	switch format {
-	case "", "default", "table":
-		return renderSearchTable, nil
-	case "json":
-		return renderSearchJSON, nil
-	default:
-		return nil, fmt.Errorf(
-			"invalid --output value %q (must be 'default', 'table', or 'json')", format)
-	}
 }
 
 // searchTableFallbackCols is the column count used when stdout isn't a TTY

--- a/pkg/cmd/pulumi/insights/insights_resource_search_test.go
+++ b/pkg/cmd/pulumi/insights/insights_resource_search_test.go
@@ -98,14 +98,26 @@ func sampleSearchResponse() apitype.InsightsResourceSearchResponse {
 	}
 }
 
+func defaultSearchArgs() insightsResourceSearchArgs {
+	return insightsResourceSearchArgs{renderOutput: renderSearchTable}
+}
+
+func jsonSearchArgs() insightsResourceSearchArgs {
+	a := defaultSearchArgs()
+	a.renderOutput = renderSearchJSON
+	return a
+}
+
 func TestInsightsResourceSearchCmd_DefaultOutput(t *testing.T) {
 	t.Parallel()
 
 	client := &mockSearchClient{response: sampleSearchResponse()}
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
+	args := defaultSearchArgs()
+	args.query = "type:aws:s3"
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{query: "type:aws:s3"})
+	err := c.Run(t.Context(), &out, args)
 	require.NoError(t, err)
 
 	output := out.String()
@@ -132,7 +144,7 @@ func TestInsightsResourceSearchCmd_DefaultOutput_Empty(t *testing.T) {
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{})
+	err := c.Run(t.Context(), &out, defaultSearchArgs())
 	require.NoError(t, err)
 	assert.Equal(t, "No resources found.\n", out.String())
 }
@@ -151,7 +163,7 @@ func TestInsightsResourceSearchCmd_DefaultOutput_PageBasedHint(t *testing.T) {
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{})
+	err := c.Run(t.Context(), &out, defaultSearchArgs())
 	require.NoError(t, err)
 
 	output := out.String()
@@ -169,7 +181,7 @@ func TestInsightsResourceSearchCmd_DefaultOutput_LastPage(t *testing.T) {
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{})
+	err := c.Run(t.Context(), &out, defaultSearchArgs())
 	require.NoError(t, err)
 	assert.NotContains(t, out.String(), "More results available")
 }
@@ -181,7 +193,7 @@ func TestInsightsResourceSearchCmd_JSONOutput(t *testing.T) {
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{output: "json"})
+	err := c.Run(t.Context(), &out, jsonSearchArgs())
 	require.NoError(t, err)
 
 	var got apitype.InsightsResourceSearchResponse
@@ -244,8 +256,10 @@ func TestInsightsResourceSearchCmd_OrgAndParamsPropagate(t *testing.T) {
 			}
 			c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, tt.defaultOrg)}
 
+			args := tt.args
+			args.renderOutput = renderSearchTable
 			var out bytes.Buffer
-			err := c.Run(t.Context(), &out, tt.args)
+			err := c.Run(t.Context(), &out, args)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantOrg, captured.org)
 			assert.Equal(t, tt.wantParams, captured.params)
@@ -259,37 +273,12 @@ func TestInsightsResourceSearchCmd_InvalidSort(t *testing.T) {
 	client := &mockSearchClient{response: sampleSearchResponse()}
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
+	args := defaultSearchArgs()
+	args.sort = []string{"bogus"}
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{sort: []string{"bogus"}})
+	err := c.Run(t.Context(), &out, args)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid --sort value "bogus"`)
-}
-
-func TestInsightsResourceSearchCmd_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	client := &mockSearchClient{response: sampleSearchResponse()}
-	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
-
-	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{output: "yaml"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
-}
-
-func TestInsightsResourceSearchCmd_TableAliasMatchesDefault(t *testing.T) {
-	t.Parallel()
-
-	// `--output table` and `--output default` must produce byte-identical
-	// output — they're aliases. Verifying once here keeps the rest of the
-	// table-shape assertions in one place (TestInsightsResourceSearchCmd_DefaultOutput).
-	client := &mockSearchClient{response: sampleSearchResponse()}
-	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
-
-	var defaultBuf, tableBuf bytes.Buffer
-	require.NoError(t, c.Run(t.Context(), &defaultBuf, insightsResourceSearchArgs{}))
-	require.NoError(t, c.Run(t.Context(), &tableBuf, insightsResourceSearchArgs{output: "table"}))
-	assert.Equal(t, defaultBuf.String(), tableBuf.String())
 }
 
 func TestInsightsResourceSearchCmd_ClientError(t *testing.T) {
@@ -298,8 +287,10 @@ func TestInsightsResourceSearchCmd_ClientError(t *testing.T) {
 	client := &mockSearchClient{err: errors.New("402 payment required")}
 	c := &insightsResourceSearchCmd{clientFactory: stubSearchFactory(client, "acme")}
 
+	args := defaultSearchArgs()
+	args.properties = true
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{properties: true})
+	err := c.Run(t.Context(), &out, args)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "searching insights resources")
 	assert.Contains(t, err.Error(), "402 payment required")
@@ -311,7 +302,7 @@ func TestInsightsResourceSearchCmd_FactoryError(t *testing.T) {
 	c := &insightsResourceSearchCmd{clientFactory: failingSearchFactory(errors.New("not logged in"))}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, insightsResourceSearchArgs{})
+	err := c.Run(t.Context(), &out, defaultSearchArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }

--- a/pkg/cmd/pulumi/stack/stack.go
+++ b/pkg/cmd/pulumi/stack/stack.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -48,12 +49,16 @@ type stackArgs struct {
 	startTime              string
 	showStackName          bool
 	fullyQualifyStackNames bool
-	output                 string
 }
 
 func NewStackCmd() *cobra.Command {
 	var stackName string
 	args := stackArgs{}
+
+	output := outputflag.OutputFlag[stackRenderFunc]{
+		RenderForTerminal: runStackText,
+		RenderJSON:        runStackJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "stack",
@@ -86,7 +91,11 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
-			return runStack(ctx, s, cmd.OutOrStdout(), args)
+			if args.showStackName {
+				writeStackName(cmd.OutOrStdout(), s, args.fullyQualifyStackNames)
+				return nil
+			}
+			return output.Get()(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
 
@@ -103,9 +112,7 @@ func NewStackCmd() *cobra.Command {
 		&args.showSecrets, "show-secrets", false, "Display stack outputs which are marked as secret in plaintext")
 	cmd.Flags().BoolVar(
 		&args.showStackName, "show-name", false, "Display only the stack name")
-	cmd.Flags().StringVar(
-		&args.output, "output", "default",
-		"The output format: default (human-readable) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	cmd.AddCommand(newStackExportCmd())
 	cmd.AddCommand(newStackGraphCmd())
@@ -128,25 +135,17 @@ func NewStackCmd() *cobra.Command {
 	return cmd
 }
 
-func runStack(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
-	if args.showStackName {
-		if args.fullyQualifyStackNames {
-			fmt.Fprintln(out, s.Ref().String())
-		} else {
-			fmt.Fprintln(out, s.Ref().Name())
-		}
-		return nil
+func writeStackName(out io.Writer, s backend.Stack, fullyQualify bool) {
+	if fullyQualify {
+		fmt.Fprintln(out, s.Ref().String())
+	} else {
+		fmt.Fprintln(out, s.Ref().Name())
 	}
+}
 
-	switch args.output {
-	case "", "default":
-		// Fall through to the human-readable rendering below.
-	case "json":
-		return runStackJSON(ctx, s, out, args)
-	default:
-		return fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", args.output)
-	}
+type stackRenderFunc func(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error
 
+func runStackText(ctx context.Context, s backend.Stack, out io.Writer, args stackArgs) error {
 	snap, err := s.Snapshot(ctx, secrets.DefaultProvider)
 	if err != nil {
 		return err

--- a/pkg/cmd/pulumi/stack/stack_get.go
+++ b/pkg/cmd/pulumi/stack/stack_get.go
@@ -20,44 +20,45 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
-// newStackGetCmd registers `pulumi stack get`, a thin convenience alias
-// for `pulumi stack`. It behaves identically to `pulumi stack` on both
-// the Pulumi Cloud and DIY backends, including the default value of
-// `--output` (human-readable text). Pass `--output=json` for the
-// stable, machine-readable envelope built by stack_json.go.
+// `pulumi stack get` shows the same information as `pulumi stack` (same flags and output), but only reads an existing
+// stack, it does not offer to create one. This command exists for verb-noun consistency with the other `get` commands.
 func newStackGetCmd() *cobra.Command {
-	var (
-		stackName   string
-		output      string
-		showSecrets bool
-	)
+	var stackName string
+	args := stackArgs{}
+
+	output := outputflag.OutputFlag[stackRenderFunc]{
+		RenderForTerminal: runStackText,
+		RenderJSON:        runStackJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "[EXPERIMENTAL] Retrieve detailed information about a stack",
 		Long: "[EXPERIMENTAL] Retrieve detailed information about a stack.\n" +
 			"\n" +
-			"`pulumi stack get` is a convenience alias for `pulumi stack --output=json`.\n" +
-			"On the Pulumi Cloud backend it surfaces the organization, project, and\n" +
-			"stack name, the current version, all associated tags, any active update\n" +
-			"operation (with its kind, author, and start time), the active update\n" +
-			"UUID, and (when available) the local resource snapshot. On DIY backends\n" +
-			"the cloud-only fields are omitted; everything else is rendered.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+			"Shows the current stack's state: the owning organization, the resources in\n" +
+			"the stack, stack outputs, the last update, and (on the Pulumi Cloud backend)\n" +
+			"any in-progress operation. This is the same information shown by `pulumi\n" +
+			"stack`",
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			s, err := RequireStack(ctx, cmdutil.Diag(), pkgWorkspace.Instance, cmdBackend.DefaultLoginManager,
 				stackName, LoadOnly, display.Options{Color: cmdutil.GetGlobalColorization()}, "")
 			if err != nil {
 				return err
 			}
-			return runStack(ctx, s, cmd.OutOrStdout(), stackArgs{
-				output:      output,
-				showSecrets: showSecrets,
-			})
+
+			args.fullyQualifyStackNames = cmdutil.FullyQualifyStackNames
+			if args.showStackName {
+				writeStackName(cmd.OutOrStdout(), s, args.fullyQualifyStackNames)
+				return nil
+			}
+			return output.Get()(ctx, s, cmd.OutOrStdout(), args)
 		},
 	}
 
@@ -65,10 +66,15 @@ func newStackGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stackName, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable) or json")
-	cmd.Flags().BoolVar(&showSecrets, "show-secrets", false,
+	cmd.Flags().BoolVarP(&args.showIDs, "show-ids", "i", false,
+		"Display each resource's provider-assigned unique ID")
+	cmd.Flags().BoolVarP(&args.showURNs, "show-urns", "u", false,
+		"Display each resource's Pulumi-assigned globally unique URN")
+	cmd.Flags().BoolVar(&args.showSecrets, "show-secrets", false,
 		"Display stack outputs which are marked as secret in plaintext")
+	cmd.Flags().BoolVar(&args.showStackName, "show-name", false,
+		"Display only the stack name")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack/stack_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_get_test.go
@@ -377,7 +377,7 @@ func TestRunStackJSON_NonCloud_NilSnapshot(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := runStackJSON(t.Context(), newMockStack(nil, nil), &buf, stackArgs{output: "json"})
+	err := runStackJSON(t.Context(), newMockStack(nil, nil), &buf, stackArgs{})
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{

--- a/pkg/cmd/pulumi/stack/stack_test.go
+++ b/pkg/cmd/pulumi/stack/stack_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShowStackName(t *testing.T) {
@@ -40,7 +39,6 @@ func TestShowStackName(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 
-			args := stackArgs{showStackName: true, fullyQualifyStackNames: tt.full}
 			var output bytes.Buffer
 			s := backend.MockStack{
 				RefF: func() backend.StackReference {
@@ -51,8 +49,7 @@ func TestShowStackName(t *testing.T) {
 				},
 			}
 
-			err := runStack(t.Context(), &s, &output, args)
-			require.NoError(t, err)
+			writeStackName(&output, &s, tt.full)
 			assert.Equal(t, tt.expected+"\n", output.String())
 		})
 	}

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -51,10 +52,11 @@ func newStackWebhookDeliveryRedeliverCmd() *cobra.Command {
 func newStackWebhookDeliveryRedeliverCmdWith(
 	factory stackWebhookRedeliverClientFactory,
 ) *cobra.Command {
-	var (
-		stack  string
-		output string
-	)
+	var stack string
+	output := outputflag.OutputFlag[redeliverRenderFunc]{
+		RenderForTerminal: renderRedeliverText,
+		RenderJSON:        renderRedeliverJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "redeliver",
@@ -77,7 +79,7 @@ func newStackWebhookDeliveryRedeliverCmdWith(
 			}
 			return runRedeliver(
 				cmd.Context(), cmd.OutOrStdout(), factory,
-				stack, args[0], args[1], output,
+				stack, args[0], args[1], output.Get(),
 			)
 		},
 	}
@@ -92,8 +94,7 @@ func newStackWebhookDeliveryRedeliverCmdWith(
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVarP(&output, "output", "o", "default",
-		"The output format: default (human-readable text) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -112,13 +113,8 @@ func runRedeliver(
 	factory stackWebhookRedeliverClientFactory,
 	stackFlag string,
 	webhookName, eventID string,
-	output string,
+	render redeliverRenderFunc,
 ) error {
-	renderer, err := redeliverRenderer(output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, stackFlag)
 	if err != nil {
 		return err
@@ -129,22 +125,10 @@ func runRedeliver(
 		return fmt.Errorf("redelivering webhook event: %w", err)
 	}
 
-	return renderer(w, delivery)
+	return render(w, delivery)
 }
 
 type redeliverRenderFunc func(w io.Writer, d apitype.WebhookDelivery) error
-
-func redeliverRenderer(output string) (redeliverRenderFunc, error) {
-	switch output {
-	case "", "default":
-		return renderRedeliverText, nil
-	case "json":
-		return renderRedeliverJSON, nil
-	default:
-		return nil, fmt.Errorf(
-			"invalid --output value %q: expected \"default\" or \"json\"", output)
-	}
-}
 
 func renderRedeliverJSON(w io.Writer, d apitype.WebhookDelivery) error {
 	enc := json.NewEncoder(w)

--- a/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_delivery_redeliver_test.go
@@ -68,7 +68,7 @@ func TestRedeliver_TextOutput(t *testing.T) {
 
 	c := &mockRedeliverClient{delivery: redeliverSample()}
 	var buf bytes.Buffer
-	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "my-hook", "evt-1", "default")
+	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "my-hook", "evt-1", renderRedeliverText)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -87,7 +87,7 @@ func TestRedeliver_JSONOutput(t *testing.T) {
 
 	c := &mockRedeliverClient{delivery: redeliverSample()}
 	var buf bytes.Buffer
-	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "hook", "evt-1", "json")
+	err := runRedeliver(t.Context(), &buf, stubRedeliverFactory(c), "", "hook", "evt-1", renderRedeliverJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{

--- a/pkg/cmd/pulumi/stack/stack_webhook_edit.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_edit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -60,8 +61,11 @@ func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Co
 		active       bool
 		secret       string
 		displayName  string
-		output       string
 	)
+	output := outputflag.OutputFlag[webhookGetRenderFunc]{
+		RenderForTerminal: renderWebhookGetText,
+		RenderJSON:        renderWebhookGetJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "edit",
@@ -103,7 +107,7 @@ func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Co
 					active:       active,
 					secret:       secret,
 					displayName:  displayName,
-				}, output,
+				}, output.Get(),
 			)
 		},
 	}
@@ -130,8 +134,7 @@ func newStackWebhookEditCmdWith(factory stackWebhookEditClientFactory) *cobra.Co
 		"The HMAC key for signature verification (empty string removes the secret)")
 	cmd.Flags().StringVar(&displayName, "display-name", "",
 		"The webhook display name")
-	cmd.Flags().StringVarP(&output, "output", "o", "default",
-		"The output format: default (human-readable text) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -164,13 +167,8 @@ func runEdit(
 	stackFlag string,
 	webhookName string,
 	flags editFlags,
-	output string,
+	render webhookGetRenderFunc,
 ) error {
-	renderer, err := webhookGetRenderer(output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, stackFlag)
 	if err != nil {
 		return err
@@ -192,7 +190,7 @@ func runEdit(
 		return fmt.Errorf("updating webhook %q: %w", webhookName, err)
 	}
 
-	return renderer(w, updated)
+	return render(w, updated)
 }
 
 // removeSecretSentinel is the value the Pulumi Service recognises as

--- a/pkg/cmd/pulumi/stack/stack_webhook_get.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -40,14 +41,15 @@ type stackWebhookGetClient interface {
 type stackWebhookGetCmd struct {
 	client  stackWebhookGetClient
 	stackID client.StackIdentifier
-	output  string
+	render  webhookGetRenderFunc
 }
 
 func newStackWebhookGetCmd() *cobra.Command {
-	var (
-		stack  string
-		output string
-	)
+	var stack string
+	output := outputflag.OutputFlag[webhookGetRenderFunc]{
+		RenderForTerminal: renderWebhookGetText,
+		RenderJSON:        renderWebhookGetJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -66,7 +68,7 @@ func newStackWebhookGetCmd() *cobra.Command {
 			get := &stackWebhookGetCmd{
 				client:  c,
 				stackID: stackID,
-				output:  output,
+				render:  output.Get(),
 			}
 			return get.run(ctx, cmd.OutOrStdout(), args[0])
 		},
@@ -76,38 +78,21 @@ func newStackWebhookGetCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable text) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
 
 func (c *stackWebhookGetCmd) run(ctx context.Context, w io.Writer, webhookName string) error {
-	renderer, err := webhookGetRenderer(c.output)
-	if err != nil {
-		return err
-	}
-
 	webhook, err := c.client.GetStackWebhook(ctx, c.stackID, webhookName)
 	if err != nil {
 		return fmt.Errorf("reading stack webhook: %w", err)
 	}
 
-	return renderer(w, webhook)
+	return c.render(w, webhook)
 }
 
 type webhookGetRenderFunc func(w io.Writer, webhook apitype.Webhook) error
-
-func webhookGetRenderer(output string) (webhookGetRenderFunc, error) {
-	switch output {
-	case "", "default":
-		return renderWebhookGetText, nil
-	case "json":
-		return renderWebhookGetJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
-	}
-}
 
 // webhookGetJSON is the full JSON shape for `pulumi stack webhook get --output=json`.
 // It includes all fields returned by the API, unlike the list command's summary.

--- a/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_get_test.go
@@ -57,11 +57,11 @@ func sampleWebhook() apitype.Webhook {
 	}
 }
 
-func newTestGetCmd(c *mockWebhookGetClient, output string) *stackWebhookGetCmd {
+func newTestGetCmd(c *mockWebhookGetClient, render webhookGetRenderFunc) *stackWebhookGetCmd {
 	return &stackWebhookGetCmd{
 		client:  c,
 		stackID: testStackID,
-		output:  output,
+		render:  render,
 	}
 }
 
@@ -70,7 +70,7 @@ func TestStackWebhookGet_TextOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookGetClient{webhook: sampleWebhook()}
-	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "deploy-hook")
+	err := newTestGetCmd(c, renderWebhookGetText).run(t.Context(), &buf, "deploy-hook")
 	require.NoError(t, err)
 
 	assert.Equal(t, `ID:                deploy-hook
@@ -101,7 +101,7 @@ func TestStackWebhookGet_TextOutput_Minimal(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookGetClient{webhook: wh}
-	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "bare-hook")
+	err := newTestGetCmd(c, renderWebhookGetText).run(t.Context(), &buf, "bare-hook")
 	require.NoError(t, err)
 
 	assert.Equal(t, `ID:                bare-hook
@@ -117,7 +117,7 @@ func TestStackWebhookGet_JSONOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookGetClient{webhook: sampleWebhook()}
-	err := newTestGetCmd(c, "json").run(t.Context(), &buf, "deploy-hook")
+	err := newTestGetCmd(c, renderWebhookGetJSON).run(t.Context(), &buf, "deploy-hook")
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -149,7 +149,7 @@ func TestStackWebhookGet_JSONOutput_NilFields(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookGetClient{webhook: wh}
-	err := newTestGetCmd(c, "json").run(t.Context(), &buf, "bare-hook")
+	err := newTestGetCmd(c, renderWebhookGetJSON).run(t.Context(), &buf, "bare-hook")
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -169,22 +169,12 @@ func TestStackWebhookGet_JSONOutput_NilFields(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestStackWebhookGet_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockWebhookGetClient{webhook: sampleWebhook()}
-	err := newTestGetCmd(c, "yaml").run(t.Context(), &buf, "deploy-hook")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
-}
-
 func TestStackWebhookGet_ClientError(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	c := &mockWebhookGetClient{err: errors.New("not found")}
-	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "no-such")
+	err := newTestGetCmd(c, renderWebhookGetText).run(t.Context(), &buf, "no-such")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reading stack webhook")
 	assert.Contains(t, err.Error(), "not found")
@@ -195,7 +185,7 @@ func TestStackWebhookGet_WebhookNamePropagation(t *testing.T) {
 
 	c := &mockWebhookGetClient{webhook: sampleWebhook()}
 	var buf bytes.Buffer
-	err := newTestGetCmd(c, "default").run(t.Context(), &buf, "my-hook-name")
+	err := newTestGetCmd(c, renderWebhookGetText).run(t.Context(), &buf, "my-hook-name")
 	require.NoError(t, err)
 	assert.Equal(t, "my-hook-name", c.gotName)
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_list.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list.go
@@ -29,6 +29,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -50,10 +51,11 @@ func newStackWebhookListCmd() *cobra.Command {
 }
 
 func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Command {
-	var (
-		stack  string
-		output string
-	)
+	var stack string
+	output := outputflag.OutputFlag[webhookListRenderFunc]{
+		RenderForTerminal: renderWebhookListTable,
+		RenderJSON:        renderWebhookListJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -67,7 +69,7 @@ func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Co
 			if factory == nil {
 				factory = defaultStackWebhookListClientFactory
 			}
-			return runStackWebhookList(cmd.Context(), cmd.OutOrStdout(), factory, stack, output)
+			return runStackWebhookList(cmd.Context(), cmd.OutOrStdout(), factory, stack, output.Get())
 		},
 	}
 
@@ -75,8 +77,7 @@ func newStackWebhookListCmdWith(factory stackWebhookListClientFactory) *cobra.Co
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable table) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -94,13 +95,8 @@ func runStackWebhookList(
 	w io.Writer,
 	factory stackWebhookListClientFactory,
 	stackFlag string,
-	output string,
+	render webhookListRenderFunc,
 ) error {
-	renderer, err := webhookListRenderer(output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, stackFlag)
 	if err != nil {
 		return err
@@ -111,21 +107,10 @@ func runStackWebhookList(
 		return fmt.Errorf("listing stack webhooks: %w", err)
 	}
 
-	return renderer(w, webhooks)
+	return render(w, webhooks)
 }
 
 type webhookListRenderFunc func(w io.Writer, webhooks []apitype.Webhook) error
-
-func webhookListRenderer(output string) (webhookListRenderFunc, error) {
-	switch output {
-	case "", "default", "table":
-		return renderWebhookListTable, nil
-	case "json":
-		return renderWebhookListJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q: expected \"default\", \"table\", or \"json\"", output)
-	}
-}
 
 // webhookListEnvelope is the JSON shape emitted by `pulumi stack webhook list --output=json`.
 type webhookListEnvelope struct {

--- a/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_list_test.go
@@ -87,7 +87,7 @@ func TestStackWebhookList_TableOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: sampleWebhooks()}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "default")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListTable)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -140,7 +140,7 @@ func TestStackWebhookList_TableOutput_DropsEmptyColumns(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: webhooks}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListTable)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -182,7 +182,7 @@ func TestStackWebhookList_TableOutput_PartialColumns(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: webhooks}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListTable)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -197,7 +197,7 @@ func TestStackWebhookList_TableOutput_Empty(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: []apitype.Webhook{}}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "table")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListTable)
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), "No webhooks configured for this stack.")
@@ -208,7 +208,7 @@ func TestStackWebhookList_JSONOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: sampleWebhooks()}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListJSON)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -242,7 +242,7 @@ func TestStackWebhookList_JSONOutput_Empty(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: []apitype.Webhook{}}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{"webhooks": [], "count": 0}`, buf.String())
@@ -264,7 +264,7 @@ func TestStackWebhookList_JSONOutput_NilFormat(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{webhooks: webhooks}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "json")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -283,23 +283,12 @@ func TestStackWebhookList_JSONOutput_NilFormat(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestStackWebhookList_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockWebhookClient{webhooks: sampleWebhooks()}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "xml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
-	assert.Contains(t, err.Error(), "xml")
-}
-
 func TestStackWebhookList_ClientError(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	c := &mockWebhookClient{err: errors.New("server error")}
-	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", "default")
+	err := runStackWebhookList(t.Context(), &buf, stubFactory(c), "", renderWebhookListTable)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing stack webhooks")
 	assert.Contains(t, err.Error(), "server error")
@@ -309,7 +298,7 @@ func TestStackWebhookList_FactoryError(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	err := runStackWebhookList(t.Context(), &buf, failingFactory(errors.New("not logged in")), "", "default")
+	err := runStackWebhookList(t.Context(), &buf, failingFactory(errors.New("not logged in")), "", renderWebhookListTable)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
@@ -324,7 +313,7 @@ func TestStackWebhookList_StackFlagPropagation(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookList(t.Context(), &buf, factory, "org/proj/my-stack", "default")
+	err := runStackWebhookList(t.Context(), &buf, factory, "org/proj/my-stack", renderWebhookListTable)
 	require.NoError(t, err)
 	assert.Equal(t, "org/proj/my-stack", capturedStack)
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_new.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new.go
@@ -28,6 +28,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -71,8 +72,11 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 		active  bool
 		secret  string
 		yes     bool
-		output  string
 	)
+	output := outputflag.OutputFlag[webhookNewRenderFunc]{
+		RenderForTerminal: renderWebhookGetText,
+		RenderJSON:        renderWebhookGetJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "new",
@@ -120,7 +124,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 
 			return runStackWebhookNew(
 				cmd.Context(), cmd.OutOrStdout(), factory,
-				stack, webhookArgs, output,
+				stack, webhookArgs, output.Get(),
 			)
 		},
 	}
@@ -145,8 +149,7 @@ func newStackWebhookNewCmdWith(factory stackWebhookNewClientFactory) *cobra.Comm
 		"The HMAC key for signature verification")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
 		"Skip prompts and proceed with default values")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable text) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -366,13 +369,8 @@ func runStackWebhookNew(
 	factory stackWebhookNewClientFactory,
 	stackFlag string,
 	args stackWebhookNewArgs,
-	output string,
+	render webhookNewRenderFunc,
 ) error {
-	renderer, err := webhookNewRenderer(output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, stackFlag)
 	if err != nil {
 		return err
@@ -405,20 +403,7 @@ func runStackWebhookNew(
 		return fmt.Errorf("creating stack webhook: %w", err)
 	}
 
-	return renderer(w, created)
+	return render(w, created)
 }
 
 type webhookNewRenderFunc func(w io.Writer, wh apitype.Webhook) error
-
-func webhookNewRenderer(output string) (webhookNewRenderFunc, error) {
-	switch output {
-	case "", "default":
-		return renderWebhookGetText, nil
-	case "json":
-		return renderWebhookGetJSON, nil
-	default:
-		return nil, fmt.Errorf(
-			"invalid --output value %q: expected \"default\" or \"json\"",
-			output)
-	}
-}

--- a/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_new_test.go
@@ -80,7 +80,7 @@ func TestStackWebhookNew_TextOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, renderWebhookGetText)
 	require.NoError(t, err)
 
 	expected := "ID:                my-hook\n" +
@@ -107,7 +107,7 @@ func TestStackWebhookNew_JSONOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "json")
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, renderWebhookGetJSON)
 	require.NoError(t, err)
 
 	assert.Contains(t, buf.String(), `"id": "my-hook"`)
@@ -129,7 +129,7 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, renderWebhookGetText)
 	require.NoError(t, err)
 
 	assert.Equal(t, "", c.gotReq.Name)
@@ -143,20 +143,6 @@ func TestStackWebhookNew_RequestFields(t *testing.T) {
 	assert.Equal(t, "s3cret", c.gotReq.Secret)
 }
 
-func TestStackWebhookNew_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	c := &mockWebhookNewClient{created: createdWebhook()}
-	args := stackWebhookNewArgs{
-		Name: "hook", URL: "https://example.com", Format: "raw", Active: true,
-	}
-
-	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "yaml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
-}
-
 func TestStackWebhookNew_ClientError(t *testing.T) {
 	t.Parallel()
 
@@ -166,7 +152,7 @@ func TestStackWebhookNew_ClientError(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, "default")
+	err := runStackWebhookNew(t.Context(), &buf, stubNewFactory(c), "", args, renderWebhookGetText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating stack webhook")
 	assert.Contains(t, err.Error(), "409 conflict")
@@ -182,7 +168,7 @@ func TestStackWebhookNew_FactoryError(t *testing.T) {
 	var buf bytes.Buffer
 	err := runStackWebhookNew(
 		t.Context(), &buf, failingNewFactory(errors.New("not logged in")),
-		"", args, "default")
+		"", args, renderWebhookGetText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
@@ -201,7 +187,7 @@ func TestStackWebhookNew_StackFlagPropagation(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := runStackWebhookNew(t.Context(), &buf, factory, "org/proj/my-stack", args, "default")
+	err := runStackWebhookNew(t.Context(), &buf, factory, "org/proj/my-stack", args, renderWebhookGetText)
 	require.NoError(t, err)
 	assert.Equal(t, "org/proj/my-stack", capturedStack)
 }

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -49,10 +50,11 @@ func newStackWebhookPingCmd() *cobra.Command {
 }
 
 func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Command {
-	var (
-		stack  string
-		output string
-	)
+	var stack string
+	output := outputflag.OutputFlag[webhookPingRenderFunc]{
+		RenderForTerminal: renderWebhookPingText,
+		RenderJSON:        renderWebhookPingJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "ping",
@@ -76,7 +78,7 @@ func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Co
 			if factory == nil {
 				factory = defaultStackWebhookPingClientFactory
 			}
-			return runStackWebhookPing(cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], output)
+			return runStackWebhookPing(cmd.Context(), cmd.OutOrStdout(), factory, stack, args[0], output.Get())
 		},
 	}
 
@@ -84,8 +86,7 @@ func newStackWebhookPingCmdWith(factory stackWebhookPingClientFactory) *cobra.Co
 
 	cmd.Flags().StringVarP(&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
-	cmd.Flags().StringVar(&output, "output", "default",
-		"The output format: default (human-readable text) or json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -105,13 +106,8 @@ func runStackWebhookPing(
 	factory stackWebhookPingClientFactory,
 	stackFlag string,
 	webhookName string,
-	output string,
+	render webhookPingRenderFunc,
 ) error {
-	renderer, err := webhookPingRenderer(output)
-	if err != nil {
-		return err
-	}
-
 	c, stackID, err := factory(ctx, stackFlag)
 	if err != nil {
 		return err
@@ -122,21 +118,10 @@ func runStackWebhookPing(
 		return fmt.Errorf("pinging stack webhook: %w", err)
 	}
 
-	return renderer(w, delivery)
+	return render(w, delivery)
 }
 
 type webhookPingRenderFunc func(w io.Writer, d apitype.WebhookDelivery) error
-
-func webhookPingRenderer(output string) (webhookPingRenderFunc, error) {
-	switch output {
-	case "", "default":
-		return renderWebhookPingText, nil
-	case "json":
-		return renderWebhookPingJSON, nil
-	default:
-		return nil, fmt.Errorf("invalid --output value %q: expected \"default\" or \"json\"", output)
-	}
-}
 
 func renderWebhookPingJSON(w io.Writer, d apitype.WebhookDelivery) error {
 	enc := json.NewEncoder(w)

--- a/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
+++ b/pkg/cmd/pulumi/stack/stack_webhook_ping_test.go
@@ -65,7 +65,7 @@ func TestStackWebhookPing_TextOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookPingClient{delivery: sampleDelivery()}
-	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", "default")
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", renderWebhookPingText)
 	require.NoError(t, err)
 
 	assert.Equal(t, `ID:                delivery-abc
@@ -90,7 +90,7 @@ func TestStackWebhookPing_TextOutput_NoBody(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookPingClient{delivery: d}
-	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "default")
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", renderWebhookPingText)
 	require.NoError(t, err)
 
 	assert.Equal(t, `ID:                delivery-abc
@@ -110,7 +110,7 @@ func TestStackWebhookPing_JSONOutput(t *testing.T) {
 
 	var buf bytes.Buffer
 	c := &mockWebhookPingClient{delivery: sampleDelivery()}
-	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", "json")
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "deploy-hook", renderWebhookPingJSON)
 	require.NoError(t, err)
 
 	assert.JSONEq(t, `{
@@ -127,22 +127,12 @@ func TestStackWebhookPing_JSONOutput(t *testing.T) {
 	}`, buf.String())
 }
 
-func TestStackWebhookPing_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	var buf bytes.Buffer
-	c := &mockWebhookPingClient{delivery: sampleDelivery()}
-	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "xml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --output value")
-}
-
 func TestStackWebhookPing_ClientError(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	c := &mockWebhookPingClient{err: errors.New("connection refused")}
-	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", "default")
+	err := runStackWebhookPing(t.Context(), &buf, stubPingFactory(c), "", "hook", renderWebhookPingText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pinging stack webhook")
 	assert.Contains(t, err.Error(), "connection refused")

--- a/pkg/cmd/pulumi/templatecmd/template_list.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list.go
@@ -28,6 +28,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	cmdCmd "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -35,11 +36,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
 
+type templateListRenderFunc func(w io.Writer, templates []apitype.TemplateMetadata) error
+
 type templateListArgs struct {
-	name   string
-	org    string
-	search string
-	output string
+	name         string
+	org          string
+	search       string
+	renderOutput templateListRenderFunc
 }
 
 type templateListCmd struct {
@@ -58,6 +61,10 @@ func newTemplateListCmd(
 
 	listCmd := &templateListCmd{registryFactory: registryFactory}
 	var args templateListArgs
+	output := outputflag.OutputFlag[templateListRenderFunc]{
+		RenderForTerminal: renderTemplatesTable,
+		RenderJSON:        renderTemplatesJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -81,6 +88,7 @@ func newTemplateListCmd(
 			"  # Emit JSON for scripting.\n" +
 			"  pulumi template list --output json",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			args.renderOutput = output.Get()
 			return listCmd.Run(cmd.Context(), cmd.OutOrStdout(), args)
 		},
 	}
@@ -93,8 +101,7 @@ func newTemplateListCmd(
 		"Filter to templates owned by the given organization")
 	cmd.Flags().StringVar(&args.search, "search", "",
 		"Free-text search across name, display name, description, metadata values, and runtime")
-	cmd.Flags().StringVar(&args.output, "output", "default",
-		"Output format. One of: default, json")
+	outputflag.VarP(cmd.Flags(), &output)
 
 	return cmd
 }
@@ -118,14 +125,7 @@ func (c *templateListCmd) Run(ctx context.Context, out io.Writer, args templateL
 		templates = append(templates, tmpl)
 	}
 
-	switch args.output {
-	case "", "default":
-		return renderTemplatesTable(out, templates)
-	case "json":
-		return renderTemplatesJSON(out, templates)
-	default:
-		return fmt.Errorf("invalid --output value %q (must be 'default' or 'json')", args.output)
-	}
+	return args.renderOutput(out, templates)
 }
 
 func renderTemplatesTable(w io.Writer, templates []apitype.TemplateMetadata) error {

--- a/pkg/cmd/pulumi/templatecmd/template_list_test.go
+++ b/pkg/cmd/pulumi/templatecmd/template_list_test.go
@@ -71,6 +71,16 @@ func registryFactory(r registry.Registry) func(ctx context.Context) registry.Reg
 	return func(_ context.Context) registry.Registry { return r }
 }
 
+func defaultTemplateListArgs() templateListArgs {
+	return templateListArgs{renderOutput: renderTemplatesTable}
+}
+
+func jsonTemplateListArgs() templateListArgs {
+	a := defaultTemplateListArgs()
+	a.renderOutput = renderTemplatesJSON
+	return a
+}
+
 func sampleTemplates() []apitype.TemplateMetadata {
 	desc := "An example template"
 	return []apitype.TemplateMetadata{
@@ -102,7 +112,7 @@ func TestTemplateListCmd_DefaultOutput_WithResults(t *testing.T) {
 	c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{})
+	err := c.Run(t.Context(), &out, defaultTemplateListArgs())
 	require.NoError(t, err)
 
 	output := out.String()
@@ -120,7 +130,7 @@ func TestTemplateListCmd_DefaultOutput_NoResults(t *testing.T) {
 	c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{})
+	err := c.Run(t.Context(), &out, defaultTemplateListArgs())
 	require.NoError(t, err)
 
 	assert.Equal(t, "No templates found.\n", out.String())
@@ -133,7 +143,7 @@ func TestTemplateListCmd_JSONOutput(t *testing.T) {
 	c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{output: "json"})
+	err := c.Run(t.Context(), &out, jsonTemplateListArgs())
 	require.NoError(t, err)
 
 	var got struct {
@@ -166,7 +176,7 @@ func TestTemplateListCmd_ZeroUpdatedAt(t *testing.T) {
 		c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 		var out bytes.Buffer
-		require.NoError(t, c.Run(t.Context(), &out, templateListArgs{}))
+		require.NoError(t, c.Run(t.Context(), &out, defaultTemplateListArgs()))
 		assert.NotContains(t, out.String(), "0001-01-01")
 	})
 
@@ -177,7 +187,7 @@ func TestTemplateListCmd_ZeroUpdatedAt(t *testing.T) {
 		c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 		var out bytes.Buffer
-		require.NoError(t, c.Run(t.Context(), &out, templateListArgs{output: "json"}))
+		require.NoError(t, c.Run(t.Context(), &out, jsonTemplateListArgs()))
 
 		var raw map[string]any
 		require.NoError(t, json.Unmarshal(out.Bytes(), &raw))
@@ -196,7 +206,7 @@ func TestTemplateListCmd_JSONOutput_NoResults(t *testing.T) {
 	c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{output: "json"})
+	err := c.Run(t.Context(), &out, jsonTemplateListArgs())
 	require.NoError(t, err)
 
 	// Empty list, not null — keeps the contract stable for scripts.
@@ -247,23 +257,12 @@ func TestTemplateListCmd_FiltersPassedThrough(t *testing.T) {
 			c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 			var out bytes.Buffer
+			tt.args.renderOutput = renderTemplatesTable
 			err := c.Run(t.Context(), &out, tt.args)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, captured)
 		})
 	}
-}
-
-func TestTemplateListCmd_InvalidOutput(t *testing.T) {
-	t.Parallel()
-
-	reg := newMockListRegistry(t, nil, sampleTemplates(), nil)
-	c := &templateListCmd{registryFactory: registryFactory(reg)}
-
-	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{output: "yaml"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid --output value "yaml"`)
 }
 
 func TestTemplateListCmd_RegistryError(t *testing.T) {
@@ -273,7 +272,7 @@ func TestTemplateListCmd_RegistryError(t *testing.T) {
 	c := &templateListCmd{registryFactory: registryFactory(reg)}
 
 	var out bytes.Buffer
-	err := c.Run(t.Context(), &out, templateListArgs{})
+	err := c.Run(t.Context(), &out, defaultTemplateListArgs())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "listing templates")
 	assert.Contains(t, err.Error(), "connection refused")


### PR DESCRIPTION
No functional changes, convert a bunch of the commands from https://github.com/pulumi/pulumi/issues/22959 to use `outputflag`.

Ref https://github.com/pulumi/pulumi/issues/22959