### PR TITLE
Ignore `--logtostderr` when logs are exported over OTel

### DIFF
--- a/changelog/pending/cli-display-fix-20260618-125217.yaml
+++ b/changelog/pending/cli-display-fix-20260618-125217.yaml
@@ -1,0 +1,7 @@
+component: cli/display
+kind: fix
+body: Prevent plugin debug logs from appearing as raw JSON in the CLI's output when
+    logging with `--logtostderr`
+time: 2026-06-18T12:52:17.600518-07:00
+custom:
+    PR: "23633"

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -227,13 +227,21 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 		fmt.Sscan(f.Value.String(), &Verbose) //nolint:errcheck
 	}
 
+	initExportHandler(filepath.Base(os.Args[0]))
+
 	handlerMu.Lock()
 
-	if LogToStderr {
+	switch {
+	case LogToStderr && exportHandler != nil:
+		// Logs already flow to the engine over OTel, so ignore --logtostderr:
+		// writing JSON records to stderr would only leak them into the
+		// engine's display of our output.
+		primary = discardHandler{}
+	case LogToStderr:
 		primary = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: verbosityLevel(Verbose),
 		})
-	} else if Verbose > 0 {
+	case Verbose > 0:
 		f, err := os.Create(logFileName())
 		if err == nil {
 			logFilePath = f.Name()
@@ -245,8 +253,6 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	}
 	rebuildLogger()
 	handlerMu.Unlock()
-
-	initExportHandler(filepath.Base(os.Args[0]))
 }
 
 // logFileName returns a log file path matching the glog naming convention:

--- a/sdk/go/common/util/logging/log_test.go
+++ b/sdk/go/common/util/logging/log_test.go
@@ -38,6 +38,31 @@ func TestInitLogging(t *testing.T) {
 	assert.Equal(t, prevFlow, LogFlow)
 }
 
+// TestInitLoggingIgnoresLogToStderrWithOTel verifies that --logtostderr is
+// ignored when logs are exported over OTel: records already reach the engine
+// through the OTLP export handler, so writing JSON to stderr would only leak
+// them into the engine's display of our output.
+func TestInitLoggingIgnoresLogToStderrWithOTel(t *testing.T) {
+	t.Setenv("PULUMI_LOG_OTLP_ENDPOINT", "127.0.0.1:1")
+
+	prevLog, prevV, prevFlow := LogToStderr, Verbose, LogFlow
+	t.Cleanup(func() {
+		shutdownExportHandler()
+		handlerMu.Lock()
+		primary = discardHandler{}
+		rebuildLogger()
+		handlerMu.Unlock()
+		LogToStderr, Verbose, LogFlow = prevLog, prevV, prevFlow
+	})
+
+	InitLogging(true, 0, false)
+
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
+	require.NotNil(t, exportHandler)
+	assert.Equal(t, discardHandler{}, primary)
+}
+
 func TestFilter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When the engine launches a plugin it passes `PULUMI_LOG_OTLP_ENDPOINT`, so the plugin's slog records already reach the engine over OTLP and land in the stack's log file. Writing them to stderr as well only leaks raw JSON records into the engine's display of the plugin's output, so ignore `--logtostderr` whenever the OTLP export handler is active.

Partially addresses https://github.com/pulumi/home/issues/4819