### PR TITLE
Use plugin.MockHost in the providers registry tests

### DIFF
--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -16,7 +16,6 @@ package providers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -39,75 +38,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-type testPluginHost struct {
-	t             *testing.T
-	provider      func(descriptor workspace.PluginDescriptor) (plugin.Provider, error)
-	closeProvider func(provider plugin.Provider) error
-}
-
-func (host *testPluginHost) ReleaseContext(ctx *plugin.Context) error {
-	return nil
-}
-
-func (host *testPluginHost) SignalCancellation() error {
-	return nil
-}
-
-func (host *testPluginHost) Close() error {
-	return nil
-}
-
-func (host *testPluginHost) ServerAddr() string {
-	host.t.Fatalf("Host RPC address not available")
-	return ""
-}
-
-func (host *testPluginHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.t.Logf("[%v] %v@%v: %v", sev, urn, streamID, msg)
-}
-
-func (host *testPluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.t.Logf("[%v] %v@%v: %v", sev, urn, streamID, msg)
-}
-
-func (host *testPluginHost) Analyzer(ctx *plugin.Context, nm tokens.QName) (plugin.Analyzer, error) {
-	return nil, errors.New("unsupported")
-}
-
-func (host *testPluginHost) PolicyAnalyzer(ctx *plugin.Context, name tokens.QName, path string,
-	opts *plugin.PolicyAnalyzerOptions,
-) (plugin.Analyzer, error) {
-	return nil, errors.New("unsupported")
-}
-
-func (host *testPluginHost) Provider(
-	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
-) (plugin.Provider, error) {
-	return host.provider(descriptor)
-}
-
-func (host *testPluginHost) LanguageRuntime(ctx *plugin.Context, runtime string) (plugin.LanguageRuntime, error) {
-	return nil, errors.New("unsupported")
-}
-
-func (host *testPluginHost) ResolvePlugin(
-	ctx *plugin.Context, spec workspace.PluginDescriptor,
-) (*workspace.PluginInfo, error) {
-	return nil, nil
-}
-
-func (host *testPluginHost) GetRequiredPlugins(project string, info plugin.ProgramInfo,
-	kinds plugin.Flags,
-) ([]workspace.PluginInfo, error) {
-	return nil, nil
-}
-
-func (host *testPluginHost) StartDebugging(info plugin.DebuggingInfo) error {
-	return nil
-}
-
-func (host *testPluginHost) AttachDebugger(_ plugin.DebugSpec) bool {
-	return false
+// testLogF routes a host's log lines to the test's log, matching the behavior the registry tests
+// relied on before they used plugin.MockHost.
+func testLogF(t *testing.T) func(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
+	return func(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
+		t.Logf("[%v] %v@%v: %v", sev, urn, streamID, msg)
+	}
 }
 
 type testProvider struct {
@@ -181,9 +117,10 @@ func newTestContext(host plugin.Host) *plugin.Context {
 }
 
 func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
-	return &testPluginHost{
-		t: t,
-		provider: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
+	return &plugin.MockHost{
+		LogF:       testLogF(t),
+		LogStatusF: testLogF(t),
+		ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, _ env.Env) (plugin.Provider, error) {
 			var best *providerLoader
 			for _, l := range loaders {
 				if string(l.pkg) != descriptor.Name {
@@ -201,9 +138,6 @@ func newPluginHost(t *testing.T, loaders []*providerLoader) plugin.Host {
 				return nil, nil
 			}
 			return best.load()
-		},
-		closeProvider: func(provider plugin.Provider) error {
-			return nil
 		},
 	}
 }
@@ -270,10 +204,10 @@ func newProviderState(pkg, name, id string, del bool, inputs resource.PropertyMa
 func TestNewRegistryNoOldState(t *testing.T) {
 	t.Parallel()
 
-	r := NewRegistry(newTestContext(&testPluginHost{}), false, nil)
+	r := NewRegistry(newTestContext(&plugin.MockHost{}), false, nil)
 	require.NotNil(t, r)
 
-	r = NewRegistry(newTestContext(&testPluginHost{}), true, nil)
+	r = NewRegistry(newTestContext(&plugin.MockHost{}), true, nil)
 	require.NotNil(t, r)
 }
 
@@ -1181,45 +1115,33 @@ func TestEnvironmentVariableMappings(t *testing.T) {
 	})
 }
 
-// testPluginHostWithEnvCapture is a test host that captures the env passed to Provider()
-type testPluginHostWithEnvCapture struct {
-	testPluginHost
-	capturedEnv env.Env
-}
-
-//nolint:lll
-func (host *testPluginHostWithEnvCapture) Provider(
-	ctx *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env,
-) (plugin.Provider, error) {
-	host.capturedEnv = e
-	return host.provider(descriptor)
-}
-
 func TestEnvMappingsPassedToHost(t *testing.T) {
 	// Set SOURCE_VAR in the environment so the mapping can be tested
 	t.Setenv("CUSTOM_VAR", "use-this-value")
 
 	// Create a host that captures the environment passed to Provider()
-	customHost := &testPluginHostWithEnvCapture{
-		testPluginHost: testPluginHost{
-			t: t,
-			provider: func(descriptor workspace.PluginDescriptor) (plugin.Provider, error) {
-				return &testProvider{
-					pkg:     tokens.Package(descriptor.Name),
-					version: semver.MustParse("1.0.0"),
-					//nolint:lll
-					checkConfig: func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
-						return news, nil, nil
-					},
-					//nolint:lll
-					diffConfig: func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
-						return plugin.DiffResult{}, nil
-					},
-					config: func(inputs resource.PropertyMap) error {
-						return nil
-					},
-				}, nil
-			},
+	var capturedEnv env.Env
+	customHost := &plugin.MockHost{
+		LogF:       testLogF(t),
+		LogStatusF: testLogF(t),
+		//nolint:lll
+		ProviderF: func(_ *plugin.Context, descriptor workspace.PluginDescriptor, e env.Env) (plugin.Provider, error) {
+			capturedEnv = e
+			return &testProvider{
+				pkg:     tokens.Package(descriptor.Name),
+				version: semver.MustParse("1.0.0"),
+				//nolint:lll
+				checkConfig: func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					return news, nil, nil
+				},
+				//nolint:lll
+				diffConfig: func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error) {
+					return plugin.DiffResult{}, nil
+				},
+				config: func(inputs resource.PropertyMap) error {
+					return nil
+				},
+			}, nil
 		},
 	}
 
@@ -1241,9 +1163,9 @@ func TestEnvMappingsPassedToHost(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that an env was passed to the host
-	require.NotNil(t, customHost.capturedEnv, "Environment should be passed to host.Provider()")
+	require.NotNil(t, capturedEnv, "Environment should be passed to host.Provider()")
 
-	store := customHost.capturedEnv.GetStore()
+	store := capturedEnv.GetStore()
 	require.NotNil(t, store, "Environment should have a store")
 
 	targetValue, ok := store.Raw("PROVIDER_VAR")


### PR DESCRIPTION
Replace the bespoke `testPluginHost` (and its `testPluginHostWithEnvCapture`
subtype) in the providers registry tests with `plugin.MockHost`, which already
implements the full `Host` interface. The registry only calls `Host.Provider`
and `Host.Log`, so the mock's `ProviderF` and a small logging closure cover
everything the tests need; the env-capture test captures the env directly in
`ProviderF` instead of a dedicated host type.