### PR TITLE
Simplify pulumi-test-language runner's host code

### DIFF
--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -740,20 +740,6 @@ func (eng *languageTestServer) RunLanguageTest(
 		Color: colors.Never,
 	})
 
-	// Start up a plugin context. No loader factory is passed here: the test host's own loader is
-	// started on this context below, once the host exists. NewContextWithRoot requires a host, but
-	// the conformance runner installs its own test host below, so we pass a placeholder that is
-	// never used and clear it immediately.
-	pctx, err := plugin.NewContextWithRoot(
-		ctx, snk, snk, &plugin.MockHost{}, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
-		nil, convert.NewMapperServerFromContext)
-	if err != nil {
-		return nil, fmt.Errorf("setup plugin context: %w", err)
-	}
-	defer contract.IgnoreClose(pctx)
-
-	pctx.Host = nil
-
 	// Connect to the language host
 	conn, err := grpc.NewClient(token.LanguagePluginTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -763,30 +749,33 @@ func (eng *languageTestServer) RunLanguageTest(
 	languageClient := plugin.NewLanguageRuntimeClient(
 		token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
-	// And now replace the context host with our own test host
 	host := &testHost{
 		engine:      eng,
-		ctx:         pctx,
-		host:        pctx.Host,
 		runtime:     languageClient,
 		runtimeName: token.LanguagePluginName,
 		providers:   make(map[string]func() (plugin.Provider, error)),
 		connections: make(map[plugin.Provider]io.Closer),
 	}
 
-	pctx.Host = host
+	var loader *providerLoader
+	loaderServer := func(pctx *plugin.Context) codegenrpc.LoaderServer {
+		loader = &providerLoader{
+			language:     token.LanguagePluginName,
+			languageInfo: token.LanguageInfo,
+			pctx:         pctx,
+			host:         host,
+		}
+		return schema.NewLoaderServer(loader)
+	}
 
-	// Setup a schema loader for any package lookups, installs and code generation.
-	loader := &providerLoader{
-		language:     token.LanguagePluginName,
-		languageInfo: token.LanguageInfo,
-		pctx:         pctx,
-		host:         host,
+	pctx, err := plugin.NewContextWithRoot(
+		ctx, snk, snk, host, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
+		loaderServer, convert.NewMapperServerFromContext)
+	if err != nil {
+		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
-	loaderServer := schema.NewLoaderServer(loader)
-	if err := pctx.StartLoader(func(*plugin.Context) codegenrpc.LoaderServer { return loaderServer }); err != nil {
-		return nil, err
-	}
+	defer contract.IgnoreClose(pctx)
+	contract.Assertf(pctx.LoaderAddr() != "" && loader != nil, "NewContextWithRoot must invoke the loader")
 
 	// And fill that host with our test providers
 	for _, provider := range test.Providers {

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -41,8 +41,6 @@ import (
 
 type testHost struct {
 	engine      *languageTestServer
-	ctx         *plugin.Context
-	host        plugin.Host
 	runtime     plugin.LanguageRuntime
 	runtimeName string
 	providers   map[string]func() (plugin.Provider, error)
@@ -103,7 +101,7 @@ func (h *testHost) PolicyAnalyzer(
 		// This is only called for the language runtime, so we can just do a simple check.
 		return spec.Kind == apitype.LanguagePlugin && spec.Name == h.runtimeName
 	}
-	analyzer, err := plugin.NewPolicyAnalyzer(h, h.ctx, name, path, opts, hasPlugin)
+	analyzer, err := plugin.NewPolicyAnalyzer(h, ctx, name, path, opts, hasPlugin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Streamline how the language conformance test runner sets up its plugin host and
context. Previously the runner stood up a context with a placeholder
`MockHost`, cleared the host, swapped in the real test host, and then started a
schema loader on the context afterwards. It now constructs the test host first
and passes it -- together with the loader and mapper factories -- directly to
`NewContextWithRoot`, so the context owns a fully-configured host from the
start.

Pure refactor of test scaffolding; no behavior change.