### PR TITLE
Move loader/mapper helper functions onto plugin.Host

### DIFF
--- a/pkg/backend/httpstate/snapshot_test.go
+++ b/pkg/backend/httpstate/snapshot_test.go
@@ -903,7 +903,7 @@ func generateSnapshots(t testing.TB, r *rand.Rand, resourceCount, resourcePayloa
 			return nil
 		})
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 
 	var journalEntries engine.JournalEntries
 	p := &lt.TestPlan{

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -36,6 +36,8 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -143,7 +145,8 @@ func getSummaryAbout(
 	} else {
 		projinfo := &engine.Projinfo{Proj: proj, Root: pwd}
 		pluginHost, hostErr := pkghost.New(
-			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if hostErr != nil {
 			addError(hostErr, "Failed to create plugin host")
 		} else if pwd, program, pluginContext, err := engine.ProjectInfoContext(

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -504,7 +504,8 @@ func runConvert(
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pluginHost, err := pkghost.New(
-			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -75,7 +75,9 @@ func NewDoCmd(
 			// uncancellable. Plugin logs route through the command's diagnostics sinks, so a
 			// provider's output reaches the command's stdout/stderr the same way it does without a
 			// pre-constructed host.
-			return pkghost.New(context.WithoutCancel(ctx), d, statusD, nil, pkgWorkspace.EnsureLanguageInstalled)
+			return pkghost.New(
+				context.WithoutCancel(ctx), d, statusD, nil, pkgWorkspace.EnsureLanguageInstalled,
+				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		}
 	}
 	if loadConverterPlugin == nil {
@@ -155,7 +157,7 @@ func NewDoCmd(
 
 		pctx, err := plugin.NewContext(
 			ctx, sink, sink, host, nil, wd, nil, false,
-			nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+			nil)
 		if err != nil {
 			contract.IgnoreClose(host)
 			return nil, nil, fmt.Errorf("create plugin context: %w", err)

--- a/pkg/cmd/pulumi/do/do_function_test.go
+++ b/pkg/cmd/pulumi/do/do_function_test.go
@@ -1817,7 +1817,13 @@ func TestDoCmdFunctionInvokeWithYAMLInputFile(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
-		return &plugin.MockHost{}, nil
+		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
+		// `do` forwards to the converter as its TargetLoader.
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
 	}
 	loadConverter := func(
 		pctx *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -1941,7 +1947,13 @@ func TestDoCmdFunctionInvokeWithYAMLInputFileParameterized(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
-		return &plugin.MockHost{}, nil
+		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
+		// `do` forwards to the converter as its TargetLoader.
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
 	}
 	subVersion := semver.MustParse("1.2.3")
 	parameterValue := []byte("opaque-parameter-blob")
@@ -2080,7 +2092,13 @@ func TestDoCmdFunctionInvokeWithYAMLProviderFile(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
-		return &plugin.MockHost{}, nil
+		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
+		// `do` forwards to the converter as its TargetLoader.
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),
@@ -2488,7 +2506,13 @@ func TestDoCmdFunctionInvokeWithYAMLFlags(t *testing.T) {
 	mlm := &cmdBackend.MockLoginManager{}
 	mws := &pkgWorkspace.MockContext{}
 	yamlHost := func(_ context.Context, d, statusD diag.Sink) (plugin.Host, error) {
-		return &plugin.MockHost{}, nil
+		// Serve the standard schema loader so the context exposes a non-empty LoaderAddr, which
+		// `do` forwards to the converter as its TargetLoader.
+		return &plugin.MockHost{
+			LoaderF: func(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+				return plugin.NewServer(ctx, schema.LoaderRegistration(schema.NewLoaderServerFromContext(ctx)))
+			},
+		}, nil
 	}
 	loadConverter := func(
 		_ *plugin.Context, name string, _ func(sev diag.Severity, msg string),

--- a/pkg/cmd/pulumi/install/install.go
+++ b/pkg/cmd/pulumi/install/install.go
@@ -38,6 +38,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
@@ -128,7 +130,8 @@ func NewInstallCmd(ws pkgWorkspace.Context) *cobra.Command {
 			span := opentracing.SpanFromContext(ctx)
 			projinfo := &engine.Projinfo{Proj: proj, Root: root}
 			pluginHost, err := pkghost.New(
-				context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+				context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/metadata/metadata.go
+++ b/pkg/cmd/pulumi/metadata/metadata.go
@@ -32,6 +32,8 @@ import (
 	git "github.com/go-git/go-git/v6"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
@@ -80,7 +82,8 @@ func GetLanguageRuntimeMetadata(
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pluginHost, err := pkghost.New(
-			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/pulumi/operations/import.go
+++ b/pkg/cmd/pulumi/operations/import.go
@@ -732,14 +732,13 @@ func NewImportCmd() *cobra.Command {
 			}
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(ctx), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return fmt.Errorf("create plugin host: %w", err)
 			}
 			// host is owned here, closed after the context
 			defer contract.IgnoreClose(pluginHost)
-			pCtx, err := plugin.NewContext(ctx, sink, sink, pluginHost, nil, cwd, nil, true, nil,
-				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+			pCtx, err := plugin.NewContext(ctx, sink, sink, pluginHost, nil, cwd, nil, true, nil)
 			if err != nil {
 				return fmt.Errorf("create plugin context: %w", err)
 			}
@@ -964,14 +963,13 @@ func NewImportCmd() *cobra.Command {
 				sink := cmdutil.Diag()
 
 				innerHost, err := pkghost.New(context.WithoutCancel(ctx), sink, sink, nil,
-					pkgWorkspace.EnsureLanguageInstalled)
+					pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 				if err != nil {
 					return nil, nil, err
 				}
 				// host is owned here, closed after the context
 				defer contract.IgnoreClose(innerHost)
-				ctx, err := plugin.NewContext(ctx, sink, sink, innerHost, nil, cwd, nil, true, nil,
-					schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+				ctx, err := plugin.NewContext(ctx, sink, sink, innerHost, nil, cwd, nil, true, nil)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -43,6 +43,8 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -439,7 +441,8 @@ func NewUpCmd() *cobra.Command {
 
 		projinfo := &engine.Projinfo{Proj: proj, Root: root}
 		pluginHost, err := pkghost.New(
-			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+			context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if err != nil {
 			return fmt.Errorf("building plugin host: %w", err)
 		}

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -129,15 +129,14 @@ from the parameters, as in:
 
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}
 			// host is owned here, closed after the context
 			defer contract.IgnoreClose(pluginHost)
 			pctx, err := plugin.NewContext(cmd.Context(),
-				sink, sink, pluginHost, nil, target.installRoot, nil, false, nil, schema.NewLoaderServerFromContext,
-				convert.NewMapperServerFromContext)
+				sink, sink, pluginHost, nil, target.installRoot, nil, false, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_mapping.go
@@ -61,7 +61,7 @@ empty string.`,
 			}
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}
@@ -69,7 +69,7 @@ empty string.`,
 			defer contract.IgnoreClose(pluginHost)
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, pluginHost, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+				nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -53,7 +53,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			defer contract.IgnoreClose(pluginHost)
 			pctx, err := plugin.NewContext(
 				cmd.Context(), sink, sink, pluginHost, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+				nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -64,14 +64,14 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}
 			// host is owned here, closed after the context
 			defer contract.IgnoreClose(pluginHost)
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, pluginHost, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+				nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -61,14 +61,14 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}
 			sink := cmdutil.Diag()
 			pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-				pkgWorkspace.EnsureLanguageInstalled)
+				pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return err
 			}
 			// host is owned here, closed after the context
 			defer contract.IgnoreClose(pluginHost)
 			pctx, err := plugin.NewContext(cmd.Context(), sink, sink, pluginHost, nil, wd, nil, false,
-				nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+				nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -165,14 +165,14 @@ func (cmd *packagePublishCmd) Run(
 		return err
 	}
 	sink := cmdutil.Diag()
-	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), sink, sink, nil, pkgWorkspace.EnsureLanguageInstalled)
+	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), sink, sink, nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}
 	// host is owned here, closed after the context
 	defer contract.IgnoreClose(pluginHost)
-	pctx, err := plugin.NewContext(ctx, sink, sink, pluginHost, nil, wd, nil, false, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+	pctx, err := plugin.NewContext(ctx, sink, sink, pluginHost, nil, wd, nil, false, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -340,12 +340,11 @@ func NewPluginContext(cwd string) (*plugin.Context, error) {
 		Color: cmdutil.GetGlobalColorization(),
 	})
 	pluginHost, err := pkghost.New(context.TODO(), sink, sink, nil,
-		pkgWorkspace.EnsureLanguageInstalled)
+		pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return nil, err
 	}
-	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, pluginHost, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+	pluginCtx, err := plugin.NewContext(context.TODO(), sink, sink, pluginHost, nil, cwd, nil, true, nil)
 	if err != nil {
 		return nil, errors.Join(err, pluginHost.Close())
 	}

--- a/pkg/cmd/pulumi/packages/packages_test.go
+++ b/pkg/cmd/pulumi/packages/packages_test.go
@@ -173,11 +173,12 @@ func TestProviderFromSource(t *testing.T) {
 		t.Helper()
 		installCtx.t = t
 
-		pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil)
+		pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil,
+			schema.NewLoaderServerFromContext, nil)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pluginHost.Close()) }()
 		pctx, err := plugin.NewContext(
-			t.Context(), nil, nil, pluginHost, nil, t.TempDir(), nil, false, nil, schema.NewLoaderServerFromContext, nil)
+			t.Context(), nil, nil, pluginHost, nil, t.TempDir(), nil, false, nil)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, pctx.Close()) }()
 

--- a/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
+++ b/pkg/cmd/pulumi/packageworkspace/packageworkspace.go
@@ -46,6 +46,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 )
 
 type Options struct {
@@ -379,10 +380,8 @@ func (w Workspace) servers(
 		refs[v.Identity()] = v
 	}
 
-	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, dir, dir, w.parentSpan)
-	err = pctx.StartLoader(func(pctx *plugin.Context) codegenrpc.LoaderServer {
-		return schema.NewLoaderServer(schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx), refs))
-	})
+	host := cachedLoaderHost{Host: w.pctx.Host, refs: refs}
+	pctx, err := plugin.NewContextWithHost(ctx, d, d, host, dir, dir, w.parentSpan)
 	if err != nil {
 		return servers{}, err
 	}
@@ -390,6 +389,21 @@ func (w Workspace) servers(
 		pctx: pctx,
 		lang: languageRuntime,
 	}, nil
+}
+
+// cachedLoaderHost overrides Loader to serve a schema loader pre-seeded with the given package
+// references, delegating every other host method to the embedded host. The seeded references let
+// SDK generation resolve packages that are not yet installed.
+type cachedLoaderHost struct {
+	plugin.Host
+	refs map[string]schema.PackageReference
+}
+
+func (h cachedLoaderHost) Loader(pctx *plugin.Context) (*plugin.GrpcServer, error) {
+	return plugin.NewServer(pctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterLoaderServer(srv,
+			schema.NewLoaderServer(schema.NewCachedLoaderWithEntries(schema.NewPluginLoader(pctx), h.refs)))
+	})
 }
 
 func (w Workspace) genSDK(ctx context.Context, language string, pkg *schema.Package) (string, error) {
@@ -443,10 +457,10 @@ func (w Workspace) RunPackage(
 		Color: diagutils.GetGlobalColorization(),
 	})
 
-	pctx := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, rootDir, rootDir, w.parentSpan)
+	pctx, err := plugin.NewContextWithHost(ctx, d, d, w.pctx.Host, rootDir, rootDir, w.parentSpan)
 	pctx.CloudCredentialEnv = w.pctx.CloudCredentialEnv
-	if err := pctx.StartLoader(schema.NewLoaderServerFromContext); err != nil {
-		return nil, fmt.Errorf("could not start loader for plugin at %q: %w", pluginPath, err)
+	if err != nil {
+		return nil, fmt.Errorf("could not start context for plugin at %q: %w", pluginPath, err)
 	}
 	p, err := plugin.NewProviderFromPath(w.pctx.Host, pctx, pluginPath)
 	if err != nil {

--- a/pkg/cmd/pulumi/plugin/plugin.go
+++ b/pkg/cmd/pulumi/plugin/plugin.go
@@ -20,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
@@ -69,7 +71,8 @@ func getProjectPlugins(ctx context.Context) ([]workspace.PluginDescriptor, error
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
 	pluginHost, err := pkghost.New(
-		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +108,8 @@ func resolvePlugins(ctx context.Context, plugins []workspace.PluginDescriptor) (
 	d := cmdutil.Diag()
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), d, d, nil, pkgWorkspace.EnsureLanguageInstalled)
+	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), d, d, nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/plugin/plugin_run.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run.go
@@ -108,14 +108,14 @@ func newPluginRunCmd() *cobra.Command {
 
 			pluginArgs := args[1:]
 
-			pluginHost, err := pkghost.New(context.WithoutCancel(ctx), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled)
+			pluginHost, err := pkghost.New(context.WithoutCancel(ctx), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled,
+				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 			if err != nil {
 				return fmt.Errorf("could not create plugin host: %w", err)
 			}
 			// host is owned here, closed after the context
 			defer contract.IgnoreClose(pluginHost)
-			pctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, ".", nil, false, nil,
-				schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+			pctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, ".", nil, false, nil)
 			if err != nil {
 				return fmt.Errorf("could not create plugin context: %w", err)
 			}

--- a/pkg/cmd/pulumi/plugin/plugin_run_test.go
+++ b/pkg/cmd/pulumi/plugin/plugin_run_test.go
@@ -35,11 +35,11 @@ func testSetup(t *testing.T) (context.Context, *plugin.Context, *plugin.GrpcServ
 	t.Helper()
 
 	ctx := t.Context()
-	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), nil, nil, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), nil, nil, nil, nil,
+		schema.NewLoaderServerFromContext, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { pluginHost.Close() })
-	pctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromContext, nil)
+	pctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, ".", nil, false, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { pctx.Close() })
 
@@ -77,11 +77,11 @@ func TestNewInstallPluginFunc_DisabledAcquisition(t *testing.T) {
 	// Set environment to disable automatic plugin acquisition
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
 
-	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil,
+		schema.NewLoaderServerFromContext, nil)
 	require.NoError(t, err)
 	defer pluginHost.Close()
-	pctx, err := plugin.NewContext(t.Context(), nil, nil, pluginHost, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromContext, nil)
+	pctx, err := plugin.NewContext(t.Context(), nil, nil, pluginHost, nil, ".", nil, false, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 
@@ -97,11 +97,11 @@ func TestNewInstallPluginFunc_PluginInstallError(t *testing.T) {
 	// Clear the environment variable to enable automatic acquisition
 	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "false")
 
-	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), nil, nil, nil, nil,
+		schema.NewLoaderServerFromContext, nil)
 	require.NoError(t, err)
 	defer pluginHost.Close()
-	pctx, err := plugin.NewContext(t.Context(), nil, nil, pluginHost, nil, ".", nil, false, nil,
-		schema.NewLoaderServerFromContext, nil)
+	pctx, err := plugin.NewContext(t.Context(), nil, nil, pluginHost, nil, ".", nil, false, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 

--- a/pkg/cmd/pulumi/policy/io.go
+++ b/pkg/cmd/pulumi/policy/io.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	pkgCmdUtil "github.com/pulumi/pulumi/pkg/v3/util/cmdutil"
@@ -63,7 +65,8 @@ func InstallPluginDependencies(
 		Runtime: projRuntime,
 	}, Root: root}
 	pluginHost, err := pkghost.New(
-		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/policy/policy_analyze.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze.go
@@ -89,13 +89,13 @@ func newPolicyAnalyzeCmd(
 						return nil, nil, fmt.Errorf("getting working directory: %w", err)
 					}
 					pluginHost, err := pkghost.New(context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(),
-						nil, pkgWorkspace.EnsureLanguageInstalled)
+						nil, pkgWorkspace.EnsureLanguageInstalled,
+						schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 					if err != nil {
 						return nil, nil, fmt.Errorf("creating plugin host: %w", err)
 					}
 					pctx, err := plugin.NewContext(ctx, cmdutil.Diag(), cmdutil.Diag(),
-						pluginHost, nil, cwd, nil, true, nil, schema.NewLoaderServerFromContext,
-						convert.NewMapperServerFromContext)
+						pluginHost, nil, cwd, nil, true, nil)
 					if err != nil {
 						contract.IgnoreClose(pluginHost)
 						return nil, nil, fmt.Errorf("creating plugin context: %w", err)

--- a/pkg/cmd/pulumi/policy/policy_install.go
+++ b/pkg/cmd/pulumi/policy/policy_install.go
@@ -127,14 +127,13 @@ func (cmd *policyInstallCmd) Run(
 	}
 
 	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), cmd.diag, cmd.diag, nil,
-		pkgWorkspace.EnsureLanguageInstalled)
+		pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return fmt.Errorf("creating plugin host: %w", err)
 	}
 	// host is owned here, closed after the context
 	defer contract.IgnoreClose(pluginHost)
-	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, pluginHost, nil, cwd, nil, true, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+	pctx, err := plugin.NewContext(ctx, cmd.diag, cmd.diag, pluginHost, nil, cwd, nil, true, nil)
 	if err != nil {
 		return fmt.Errorf("creating plugin context: %w", err)
 	}

--- a/pkg/cmd/pulumi/policy/policy_publish.go
+++ b/pkg/cmd/pulumi/policy/policy_publish.go
@@ -128,15 +128,14 @@ func (cmd *policyPublishCmd) Run(ctx context.Context, lm cmdBackend.LoginManager
 	}
 
 	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil,
-		pkgWorkspace.EnsureLanguageInstalled)
+		pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}
 	// host is owned here, closed after the context
 	defer contract.IgnoreClose(pluginHost)
 	plugctx, err := plugin.NewContextWithRoot(ctx, cmdutil.Diag(), cmdutil.Diag(), pluginHost, pwd, projinfo.Root,
-		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil, schema.NewLoaderServerFromContext,
-		convert.NewMapperServerFromContext)
+		projinfo.Proj.Runtime.Options(), false, nil, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/project/newcmd/install.go
+++ b/pkg/cmd/pulumi/project/newcmd/install.go
@@ -77,12 +77,12 @@ func InstallPackagesFromProject(
 	d := diag.DefaultSink(stdout, stderr, diag.FormatOptions{
 		Color: utilCmdutil.GetGlobalColorization(),
 	})
-	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), d, d, nil, pkgWorkspace.EnsureLanguageInstalled)
+	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), d, d, nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return packageinstallation.State{}, err
 	}
-	pctx, err := plugin.NewContext(ctx, d, d, pluginHost, nil, root, nil, false, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+	pctx, err := plugin.NewContext(ctx, d, d, pluginHost, nil, root, nil, false, nil)
 	if err != nil {
 		return packageinstallation.State{}, errors.Join(err, pluginHost.Close())
 	}

--- a/pkg/cmd/pulumi/project/newcmd/new.go
+++ b/pkg/cmd/pulumi/project/newcmd/new.go
@@ -40,6 +40,8 @@ import (
 	cmdStack "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/stack"
 	cmdTemplates "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/templates"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -401,7 +403,8 @@ func runNew(ctx context.Context, args newArgs) error {
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
 	pluginHost, err := pkghost.New(
-		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled)
+		context.WithoutCancel(ctx), cmdutil.Diag(), cmdutil.Diag(), nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -112,14 +112,14 @@ func schemaFromSourceOrStdin(cmd *cobra.Command, source string, extraArgs []stri
 	}
 	sink := cmdutil.Diag()
 	pluginHost, err := pkghost.New(context.WithoutCancel(cmd.Context()), sink, sink, nil,
-		pkgWorkspace.EnsureLanguageInstalled)
+		pkgWorkspace.EnsureLanguageInstalled, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return nil, err
 	}
 	// host is owned here, closed after the context
 	defer contract.IgnoreClose(pluginHost)
 	pctx, err := plugin.NewContext(cmd.Context(), sink, sink, pluginHost, nil, wd, nil, false,
-		nil, schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+		nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/convert/mapper_server_test.go
+++ b/pkg/codegen/convert/mapper_server_test.go
@@ -62,11 +62,11 @@ func TestMapperServerFromHost_RealProvider(t *testing.T) {
 	t.Setenv("PULUMI_HOME", home)
 
 	sink := diagtest.LogSink(t)
-	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), sink, sink, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), sink, sink, nil, nil,
+		nil, NewMapperServerFromContext)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, pluginHost.Close()) }()
-	pctx, err := plugin.NewContext(t.Context(), sink, sink, pluginHost, nil, t.TempDir(), nil, false, nil,
-		nil, NewMapperServerFromContext)
+	pctx, err := plugin.NewContext(t.Context(), sink, sink, pluginHost, nil, t.TempDir(), nil, false, nil)
 	require.NoError(t, err)
 	defer pctx.Close()
 

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -82,7 +82,7 @@ resource "app" "scaleway:iam/application:Application" {}
 	parser := syntax.NewParser()
 	err = parser.ParseFile(bytes.NewReader([]byte(hcl)), "infra.tf")
 	require.NoError(t, err, "parse failed")
-	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(plugin.NewContextWithHost(
+	pctx, err := plugin.NewContextWithHost(
 		t.Context(), nil, nil, &plugin.MockHost{
 			ResolvePluginF: func(_ *plugin.Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error) {
 				return &workspace.PluginInfo{Name: spec.Name}, nil
@@ -97,7 +97,9 @@ resource "app" "scaleway:iam/application:Application" {}
 					},
 				}, nil
 			},
-		}, "", "", nil)))
+		}, "", "", nil)
+	require.NoError(t, err)
+	program, diags, err := pcl.BindProgram(parser.Files, pcl.PluginHost(pctx))
 	if err != nil || diags.HasErrors() {
 		for _, d := range diags {
 			t.Logf("%s: %s", d.Summary, d.Detail)

--- a/pkg/codegen/pcl/binder.go
+++ b/pkg/codegen/pcl/binder.go
@@ -460,14 +460,14 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 			return nil, nil, err
 		}
 		pluginHost, err := pkghost.New(
-			context.WithoutCancel(ctx), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled)
+			context.WithoutCancel(ctx), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled,
+			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if err != nil {
 			return nil, nil, err
 		}
 		// The host is owned here, not by the context; the deferred closes run host-last.
 		defer contract.IgnoreClose(pluginHost)
-		ctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, cwd, nil, false, nil,
-			schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+		ctx, err := plugin.NewContext(ctx, nil, nil, pluginHost, nil, cwd, nil, false, nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -361,12 +361,12 @@ func newBinder(info PackageInfoSpec, spec specSource, loader Loader,
 		if err != nil {
 			return nil, nil, err
 		}
-		pluginHost, err := pkghost.New(context.TODO(), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled)
+		pluginHost, err := pkghost.New(context.TODO(), nil, nil, nil, pkgWorkspace.EnsureLanguageInstalled,
+			NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 		if err != nil {
 			return nil, nil, err
 		}
-		ctx, err := plugin.NewContext(context.TODO(), nil, nil, pluginHost, nil, cwd, nil, false, nil,
-			NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+		ctx, err := plugin.NewContext(context.TODO(), nil, nil, pluginHost, nil, cwd, nil, false, nil)
 		if err != nil {
 			return nil, nil, errors.Join(err, pluginHost.Close())
 		}

--- a/pkg/codegen/schema/loader_caching_test.go
+++ b/pkg/codegen/schema/loader_caching_test.go
@@ -56,8 +56,9 @@ func newCachingHost(provider plugin.Provider, pluginInfo *workspace.PluginInfo) 
 
 // fileCacheLoader creates a loader with the in-memory caches disabled so that
 // only the file-based cache is exercised.
-func fileCacheLoader(host plugin.Host) ReferenceLoader {
-	pctx := plugin.NewContextWithHost(context.Background(), nil, nil, host, "", "", nil)
+func fileCacheLoader(tb testing.TB, host plugin.Host) ReferenceLoader {
+	pctx, err := plugin.NewContextWithHost(tb.Context(), nil, nil, host, "", "", nil)
+	require.NoError(tb, err)
 	return newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
@@ -146,7 +147,7 @@ func TestSchemaCacheMissWritesFile(t *testing.T) {
 		Path:    pluginDir,
 	}
 
-	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
+	loader := fileCacheLoader(t, newCachingHost(provider, pluginInfo))
 
 	ref, err := loader.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{
 		Name:    "aws",
@@ -199,7 +200,7 @@ func TestSchemaCacheHitSkipsPlugin(t *testing.T) {
 		Path:    pluginDir,
 	}
 
-	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
+	loader := fileCacheLoader(t, newCachingHost(provider, pluginInfo))
 
 	ref, err := loader.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{
 		Name:    "aws",
@@ -246,7 +247,7 @@ func TestSchemaCacheStaleOnReinstall(t *testing.T) {
 		Path:    pluginDir, // ctime is newer than the backdated cache file
 	}
 
-	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
+	loader := fileCacheLoader(t, newCachingHost(provider, pluginInfo))
 
 	ref, err := loader.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{
 		Name:    "aws",
@@ -283,7 +284,7 @@ func TestSchemaCacheNoVersionSkipsCache(t *testing.T) {
 		Kind: apitype.ResourcePlugin,
 	}
 
-	loader := fileCacheLoader(newCachingHost(provider, pluginInfo))
+	loader := fileCacheLoader(t, newCachingHost(provider, pluginInfo))
 
 	for range 2 {
 		_, err := loader.LoadPackageReferenceV2(t.Context(), &PackageDescriptor{Name: "aws"})
@@ -348,7 +349,7 @@ func TestSchemaCacheParameterized(t *testing.T) {
 				return plugin.GetSchemaResponse{Schema: schema}, nil
 			},
 		}
-		return fileCacheLoader(newCachingHost(p, pluginInfo))
+		return fileCacheLoader(t, newCachingHost(p, pluginInfo))
 	}
 
 	awsSchema := minimalSchemaJSON("terraform-aws", "5.0.0")
@@ -382,7 +383,7 @@ func TestSchemaCacheParameterized(t *testing.T) {
 			return plugin.GetSchemaResponse{}, nil
 		},
 	}
-	cachedLoader := fileCacheLoader(newCachingHost(neverCallProvider, pluginInfo))
+	cachedLoader := fileCacheLoader(t, newCachingHost(neverCallProvider, pluginInfo))
 
 	awsRef, err := cachedLoader.LoadPackageReferenceV2(t.Context(), awsDescriptor)
 	require.NoError(t, err)

--- a/pkg/codegen/schema/loader_server_test.go
+++ b/pkg/codegen/schema/loader_server_test.go
@@ -51,7 +51,9 @@ func mockSchemaHost(
 			}, nil
 		},
 	}
-	return plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
+	return pctx
 }
 
 func schemaProvider(schemaBytes []byte) *plugin.MockProvider {
@@ -217,7 +219,8 @@ func TestLoaderServerCachedEntryBypassesRawPath(t *testing.T) {
 			return nil, workspace.NewMissingError(spec, false)
 		},
 	}
-	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
 	loader := NewCachedLoaderWithEntries(
 		NewPluginLoader(pctx),
 		map[string]PackageReference{pkg.Reference().Identity(): pkg.Reference()},

--- a/pkg/codegen/schema/loader_test.go
+++ b/pkg/codegen/schema/loader_test.go
@@ -36,11 +36,12 @@ func initLoader(b testing.TB, options pluginLoaderCacheOptions) ReferenceLoader 
 	require.NoError(b, err)
 	sink := diagtest.LogSink(b)
 	//nolint:usetesting // plugin.NewContext manages gRPC providers; b.Context cancels too early
-	pluginHost, err := pkghost.New(context.WithoutCancel(b.Context()), sink, sink, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(b.Context()), sink, sink, nil, nil,
+		NewLoaderServerFromContext, nil)
 	require.NoError(b, err)
 	b.Cleanup(func() { require.NoError(b, pluginHost.Close()) })
 	ctx, err := plugin.NewContext(
-		b.Context(), sink, sink, pluginHost, nil, cwd, nil, true, nil, NewLoaderServerFromContext, nil)
+		b.Context(), sink, sink, pluginHost, nil, cwd, nil, true, nil)
 	require.NoError(b, err)
 	loader := newPluginLoaderWithOptions(ctx, options)
 
@@ -184,7 +185,8 @@ func TestLoadParameterized(t *testing.T) {
 		},
 	}
 
-	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
 	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
@@ -247,7 +249,8 @@ func TestLoadNameMismatch(t *testing.T) {
 		},
 	}
 
-	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
 	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,
@@ -319,7 +322,8 @@ func TestLoadVersionMismatch(t *testing.T) {
 		},
 	}
 
-	pctx := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
 	loader := newPluginLoaderWithOptions(pctx, pluginLoaderCacheOptions{
 		disableEntryCache: true,
 		disableMmap:       true,

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -2658,11 +2658,12 @@ func debugProvidersHelperContext(t *testing.T) *plugin.Context {
 	sink := diag.DefaultSink(os.Stderr, os.Stderr, diag.FormatOptions{
 		Color: cmdutil.GetGlobalColorization(),
 	})
-	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), sink, sink, nil, nil)
+	pluginHost, err := pkghost.New(context.WithoutCancel(t.Context()), sink, sink, nil, nil,
+		NewLoaderServerFromContext, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, pluginHost.Close()) })
 	pluginCtx, err := plugin.NewContext(
-		t.Context(), sink, sink, pluginHost, nil, cwd, nil, true, nil, NewLoaderServerFromContext, nil)
+		t.Context(), sink, sink, pluginHost, nil, cwd, nil, true, nil)
 	require.NoError(t, err)
 	return pluginCtx
 }

--- a/pkg/codegen/testing/utils/host.go
+++ b/pkg/codegen/testing/utils/host.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type SchemaProvider struct {
@@ -82,7 +83,9 @@ func NewContextWithProviders(schemaDirectoryPath string, providers ...SchemaProv
 	host := deploytest.NewPluginHost(nil, nil, nil,
 		pluginLoaders...,
 	)
-	return plugin.NewContextWithHost(context.Background(), nil, nil, host, "", "", nil)
+	pctx, err := plugin.NewContextWithHost(context.Background(), nil, nil, host, "", "", nil)
+	contract.AssertNoErrorf(err, "failed to create schema-only plugin context")
+	return pctx
 }
 
 // NewContext creates a plugin context with a schema-only plugin host, supporting multiple package

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -71,8 +71,7 @@ func ProjectInfoContext(ctx context.Context, projinfo *Projinfo, host plugin.Hos
 
 	pctx, err := plugin.NewContextWithRoot(pluginCtx, diag, statusDiag, host, pwd, projinfo.Root,
 		projinfo.Proj.Runtime.Options(), disableProviderPreview, tracingSpan, projinfo.Proj.Plugins,
-		projinfo.Proj.GetPackageSpecs(), config,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+		projinfo.Proj.GetPackageSpecs(), config)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -206,7 +205,8 @@ func ensureHost(ctx context.Context, opts *deploymentOptions, span opentracing.S
 	debugging := newDebugContext(opts.Events, opts.AttachDebugger)
 	h, err := pkghost.New(
 		opentracing.ContextWithSpan(context.WithoutCancel(ctx), span),
-		opts.Diag, opts.StatusDiag, debugging, pkgWorkspace.EnsureLanguageInstalled)
+		opts.Diag, opts.StatusDiag, debugging, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -184,7 +184,7 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 			err := registerResources(t, monitor, resources)
 			return err
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -1293,7 +1293,7 @@ func TestDuplicatesDueToAliases(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1396,7 +1396,7 @@ func TestCorrectResourceChosen(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1471,7 +1471,7 @@ func TestComponentToCustomUpdate(t *testing.T) {
 		createA(monitor)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1583,7 +1583,7 @@ func TestParentAlias(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1659,7 +1659,7 @@ func TestEmptyParentAlias(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1781,7 +1781,7 @@ func TestSplitUpdateComponentAliases(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1913,7 +1913,7 @@ func TestFailDeleteDuplicateAliases(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1999,7 +1999,7 @@ func TestAliasesInProvidersAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, loaders...)
+	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, loaders...)
 	setupOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF,
@@ -2057,7 +2057,7 @@ func TestAliasesInProvidersAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, loaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, loaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,
@@ -2114,7 +2114,7 @@ func TestAliasesInDependenciesAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, loaders...)
+	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, loaders...)
 	setupOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF,
@@ -2170,7 +2170,7 @@ func TestAliasesInDependenciesAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, loaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, loaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,
@@ -2227,7 +2227,7 @@ func TestAliasesInPropertyDependenciesAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, loaders...)
+	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, loaders...)
 	setupOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF,
@@ -2283,7 +2283,7 @@ func TestAliasesInPropertyDependenciesAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, loaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, loaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,
@@ -2340,7 +2340,7 @@ func TestAliasesInDeletedWithAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, loaders...)
+	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, loaders...)
 	setupOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF,
@@ -2396,7 +2396,7 @@ func TestAliasesInDeletedWithAreNormalized(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, loaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, loaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -118,7 +118,7 @@ func TestSimpleAnalyzer(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	proj := "test-proj"
 	p := &lt.TestPlan{
@@ -190,7 +190,7 @@ func TestSimpleAnalyzeResourceFailure(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -291,7 +291,7 @@ func TestSimpleAnalyzeStackFailure(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -412,7 +412,7 @@ func TestResourceRemediation(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -538,7 +538,7 @@ func TestRemediationDiagnostic(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -582,7 +582,7 @@ func TestRemediateFailure(t *testing.T) {
 		assert.ErrorContains(t, err, "context canceled")
 		return nil
 	})
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -629,7 +629,7 @@ func TestSimpleAnalyzeResourceFailureRemediateDowngradedToMandatory(t *testing.T
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -694,7 +694,7 @@ func TestSimpleAnalyzeStackFailureRemediateDowngradedToMandatory(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -771,7 +771,7 @@ func TestAnalyzerCancellation(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -911,7 +911,7 @@ func TestSimpleAnalyzeResourceMultipleViolations(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -980,7 +980,7 @@ func TestSimpleAnalyzeResourceFailureSeverityOverride(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1089,7 +1089,7 @@ func TestAnalyzeRunsInParallel(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1169,7 +1169,7 @@ func TestAnalyzeStackRunsInParallel(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1270,7 +1270,7 @@ func TestPolicyPackDownloadFailureReturnsError(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1302,7 +1302,7 @@ func TestPolicyPackInstallFailureReturnsError(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{

--- a/pkg/engine/lifecycletest/autonaming_test.go
+++ b/pkg/engine/lifecycletest/autonaming_test.go
@@ -64,7 +64,7 @@ func TestAutonaming(t *testing.T) {
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
-			HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 			T:     t,
 			UpdateOptions: UpdateOptions{
 				GeneratePlan: true,

--- a/pkg/engine/lifecycletest/components_test.go
+++ b/pkg/engine/lifecycletest/components_test.go
@@ -82,7 +82,7 @@ func TestSingleComponentDefaultProviderLifecycle(t *testing.T) {
 		}, resp.Outputs)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -125,7 +125,7 @@ func TestRemoteComponentConstructInfoIncludesOrganization(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Project: "project-name",
@@ -240,7 +240,7 @@ func TestComponentDeleteDependencies(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	p.Steps = []lt.TestStep{
@@ -373,7 +373,7 @@ func TestConstructCallSecretsUnknowns(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -509,7 +509,7 @@ func TestConstructCallReturnDependencies(t *testing.T) {
 
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -663,7 +663,7 @@ func TestConstructCallReturnOutputs(t *testing.T) {
 
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -827,7 +827,7 @@ func TestConstructCallSendDependencies(t *testing.T) {
 
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -997,7 +997,7 @@ func TestConstructCallDependencyDedeuplication(t *testing.T) {
 
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1087,7 +1087,7 @@ func TestSingleComponentMethodResourceDefaultProviderLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -1186,7 +1186,7 @@ func TestSingleComponentMethodDefaultProviderLifecycle(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -1298,7 +1298,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options = lt.TestUpdateOptions{
 		T:     t,
@@ -1431,7 +1431,7 @@ func TestComponentRegisteredResourceOutputCanBeHydratedByComponent(t *testing.T)
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options = lt.TestUpdateOptions{
 		T:     t,
@@ -1555,7 +1555,7 @@ func TestComponentReadResourceOutputCanBeHydratedByProgram(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options = lt.TestUpdateOptions{
 		T:     t,
@@ -1700,7 +1700,7 @@ func TestComponentReadResourceOutputCanBeHydratedByComponent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options = lt.TestUpdateOptions{
 		T:     t,
@@ -1778,7 +1778,7 @@ func TestCallSelfProvider(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/continue_on_error_test.go
+++ b/pkg/engine/lifecycletest/continue_on_error_test.go
@@ -73,7 +73,7 @@ func TestDestroyContinueOnError(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -195,7 +195,7 @@ func TestUpContinueOnErrorCreate(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -327,7 +327,7 @@ func TestUpContinueOnErrorUpdate(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -453,7 +453,7 @@ func TestUpContinueOnErrorUpdateWithRefresh(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -538,7 +538,7 @@ func TestUpContinueOnErrorNoSDKSupport(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -623,7 +623,7 @@ func TestUpContinueOnErrorUpdateNoSDKSupport(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -692,7 +692,7 @@ func TestDestroyContinueOnErrorDeleteAfterFailedUp(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -752,7 +752,7 @@ func TestContinueOnErrorImport(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -837,7 +837,7 @@ func TestUpContinueOnErrorFailedDependencies(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -900,7 +900,7 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{
 		T: t, HostF: upHostF, UpdateOptions: UpdateOptions{
 			ContinueOnError: true,
@@ -947,7 +947,7 @@ func TestContinueOnErrorWithChangingProviderOnCreate(t *testing.T) {
 
 		return nil
 	})
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{
 		T: t, HostF: replaceHostF,
 		UpdateOptions: UpdateOptions{

--- a/pkg/engine/lifecycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifecycletest/delete_before_replace_test.go
@@ -190,7 +190,7 @@ func TestDeleteBeforeReplace(t *testing.T) {
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	p.Steps = []lt.TestStep{{
 		Op:            Update,
@@ -270,7 +270,7 @@ func TestPropertyDependenciesAdapter(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps:   []lt.TestStep{{Op: Update}},
@@ -354,7 +354,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
@@ -564,7 +564,7 @@ func TestDependencyChangeDBR(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
@@ -586,7 +586,7 @@ func TestDependencyChangeDBR(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Steps = []lt.TestStep{
 		{
 			Op: Update,
@@ -677,7 +677,7 @@ func TestDBRProtect(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	options := lt.TestUpdateOptions{T: t, HostF: hostF}
 	p := &lt.TestPlan{}
 
@@ -754,7 +754,7 @@ func TestDBRReplaceOnChanges(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	options := lt.TestUpdateOptions{T: t, HostF: hostF}
 	p := &lt.TestPlan{}
 
@@ -876,7 +876,7 @@ func TestDBRParallel(t *testing.T) {
 				return program(monitor)
 			})
 
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 			options := lt.TestUpdateOptions{
 				UpdateOptions: UpdateOptions{
 					ParallelDiff: true,
@@ -1062,7 +1062,7 @@ func TestDBRProviderUpgrade(t *testing.T) {
 		_, err := resAPromise.Result(t.Context())
 		return err
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{

--- a/pkg/engine/lifecycletest/destroy_test.go
+++ b/pkg/engine/lifecycletest/destroy_test.go
@@ -112,7 +112,7 @@ func TestDestroyWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -220,7 +220,7 @@ func TestTargetedDestroyWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -351,7 +351,7 @@ func TestProviderUpdateDestroyWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -477,7 +477,7 @@ func TestExplicitProviderUpdateDestroyWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -580,7 +580,7 @@ func TestDestroyWithProgramWithComponents(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -695,7 +695,7 @@ func TestDestroyWithProgramWithSkippedComponents(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -814,7 +814,7 @@ func TestDestroyWithProgramWithSkippedAlias(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -942,7 +942,7 @@ func TestDestroyWithProgramResourceRead(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1049,7 +1049,7 @@ func TestTargetedAliasDestroyV2(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1107,7 +1107,7 @@ func TestDestroyV2ProtectedWithProviderDependencies(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1164,7 +1164,7 @@ func TestDestroyWithProgramProtectedResourceWithProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
 			T:     t,
@@ -1235,7 +1235,7 @@ func TestDestroyV2TargetChildWithNewParent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1328,7 +1328,7 @@ func TestDestroyV2TargetProviderWithAliasedParent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
 			T:     t,
@@ -1418,7 +1418,7 @@ func TestDestroyV2ResourceWithDependencyOnDeleted(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options = lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1493,7 +1493,7 @@ func TestDestroyV2ResourceReferencesAliasedProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -1583,7 +1583,7 @@ func TestDestroyV2RefreshWithTargetedProviderParentChange(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,

--- a/pkg/engine/lifecycletest/env_var_mappings_test.go
+++ b/pkg/engine/lifecycletest/env_var_mappings_test.go
@@ -66,7 +66,7 @@ func TestEnvVarMappingsOnProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -123,7 +123,7 @@ func TestEnvVarMappingsOnNonProviderFails(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -164,7 +164,7 @@ func TestEmptyEnvVarMappingsNotStoredInState(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -248,7 +248,7 @@ func TestEnvVarMappingsRemovedFromStateOnUpdate(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}

--- a/pkg/engine/lifecycletest/error_hooks_test.go
+++ b/pkg/engine/lifecycletest/error_hooks_test.go
@@ -114,7 +114,7 @@ func TestErrorHooks_OperationIdentifierAndMultipleHooks_Create(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -210,7 +210,7 @@ func TestErrorHooks_OperationIdentifierAndMultipleHooks_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -303,7 +303,7 @@ func TestErrorHooks_OldAndNewOptionsAreSentOnUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -398,7 +398,7 @@ func TestErrorHooks_OperationIdentifierAndMultipleHooks_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -479,7 +479,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Create_RetryIfAnyHookRet
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -537,7 +537,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Create_NoRetryWhenNoHook
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -609,7 +609,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Update_RetryIfAnyHookRet
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -680,7 +680,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Update_NoRetryWhenNoHook
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -752,7 +752,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Delete_RetryIfAnyHookRet
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -816,7 +816,7 @@ func TestErrorHooks_RetrySemanticsAndNoRetryWhenNoHooks_Delete_NoRetryWhenNoHook
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}
@@ -882,7 +882,7 @@ func TestErrorHooks_NoRetryIfAllHooksReturnFalse_Create(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -952,7 +952,7 @@ func TestErrorHooks_NoRetryIfAllHooksReturnFalse_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1016,7 +1016,7 @@ func TestErrorHooks_NoRetryIfAllHooksReturnFalse_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1085,7 +1085,7 @@ func TestErrorHooks_NotCalledOnSuccess_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1151,7 +1151,7 @@ func TestErrorHooks_NotCalledOnSuccess_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1221,7 +1221,7 @@ func TestErrorHooks_RetryLimitWarningAt100_Create(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1313,7 +1313,7 @@ func TestErrorHooks_RetryLimitWarningAt100_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1416,7 +1416,7 @@ func TestErrorHooks_RetryLimitWarningAt100_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1532,7 +1532,7 @@ func TestErrorHooks_RetryThenNoRetry_OperationFails_Create(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1609,7 +1609,7 @@ func TestErrorHooks_RetryThenNoRetry_OperationFails_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1684,7 +1684,7 @@ func TestErrorHooks_RetryThenNoRetry_OperationFails_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1789,7 +1789,7 @@ func TestErrorHooks_IndependentPerResource_Create(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1895,7 +1895,7 @@ func TestErrorHooks_IndependentPerResource_Update(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -1993,7 +1993,7 @@ func TestErrorHooks_IndependentPerResource_Delete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -2062,7 +2062,7 @@ func TestErrorHooks_PlainCreateErrorRunsOnErrorHook(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
 	}

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -1084,7 +1084,7 @@ func (b *TestBuilder) RunUpdate(
 	program func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error, skipDisplayTests bool,
 ) *Result {
 	programF := deploytest.NewLanguageRuntimeF(program)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, b.loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, b.loaders...)
 
 	p := &TestPlan{
 		Options: TestUpdateOptions{T: b.t, HostF: hostF, SkipDisplayTests: skipDisplayTests},

--- a/pkg/engine/lifecycletest/fuzzing/fixture.go
+++ b/pkg/engine/lifecycletest/fuzzing/fixture.go
@@ -107,7 +107,8 @@ func GeneratedFixture(fo FixtureOptions) func(t *rapid.T) {
 		inSnap := snapSpec.AsSnapshot()
 		require.NoError(t, inSnap.VerifyIntegrity(), "initial snapshot is not valid")
 
-		hostF := deploytest.NewPluginHostF(nil, nil, progSpec.AsLanguageRuntimeF(t), provSpec.AsProviderLoaders()...)
+		hostF := deploytest.NewPluginHostF(
+			nil, nil, progSpec.AsLanguageRuntimeF(t), nil, nil, provSpec.AsProviderLoaders()...)
 
 		opOpts, op := planSpec.Executors(t, hostF)
 		opOpts.SkipDisplayTests = true

--- a/pkg/engine/lifecycletest/fuzzing/reprogen.go
+++ b/pkg/engine/lifecycletest/fuzzing/reprogen.go
@@ -236,7 +236,7 @@ func writeSnapshotTestFunction(
 			)
 
 			g.writeLine("")
-			g.writeLine("reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)")
+			g.writeLine("reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, reproLoaders...)")
 			g.writeBlock(
 				"reproOpts := lt.TestUpdateOptions{",
 				func(g *generator) {
@@ -342,7 +342,7 @@ func writeFrameworkTestFunction(
 			)
 
 			g.writeLine("")
-			g.writeLine("setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, setupLoaders...)")
+			g.writeLine("setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, setupLoaders...)")
 			g.writeBlock(
 				"setupOpts := lt.TestUpdateOptions{",
 				func(g *generator) {
@@ -400,7 +400,7 @@ func writeFrameworkTestFunction(
 			)
 
 			g.writeLine("")
-			g.writeLine("reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)")
+			g.writeLine("reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, reproLoaders...)")
 			g.writeBlock(
 				"reproOpts := lt.TestUpdateOptions{",
 				func(g *generator) {

--- a/pkg/engine/lifecycletest/golang_sdk_test.go
+++ b/pkg/engine/lifecycletest/golang_sdk_test.go
@@ -115,7 +115,7 @@ func TestSingleResourceDefaultProviderGolangLifecycle(t *testing.T) {
 			return nil
 		})
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -184,7 +184,7 @@ func TestIgnoreChangesGolangLifecycle(t *testing.T) {
 			})
 		})
 
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -286,7 +286,7 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 		})
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	p.Steps = []lt.TestStep{{Op: Update}}
 	snap := p.Run(t, nil)
@@ -382,7 +382,7 @@ func TestReadResourceGolangLifecycle(t *testing.T) {
 			})
 		})
 
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -589,7 +589,7 @@ func TestProviderInheritanceGolangLifecycle(t *testing.T) {
 			return nil
 		})
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -643,7 +643,7 @@ func TestReplaceOnChangesGolangLifecycle(t *testing.T) {
 
 	expectedOps := []display.StepOp{deploy.OpCreate}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{
@@ -774,7 +774,7 @@ func TestRemoteComponentGolang(t *testing.T) {
 		})
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/hide_diffs_test.go
+++ b/pkg/engine/lifecycletest/hide_diffs_test.go
@@ -139,7 +139,7 @@ func testHideDiffs(t *testing.T, detailedDiff bool) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{

--- a/pkg/engine/lifecycletest/import_test.go
+++ b/pkg/engine/lifecycletest/import_test.go
@@ -121,7 +121,7 @@ func TestImportOption(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, UpdateOptions: engine.UpdateOptions{GeneratePlan: true}},
@@ -426,7 +426,7 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -504,7 +504,7 @@ func TestImportUpdatedID(t *testing.T) {
 		assert.Equal(t, actualID, resp.ID)
 		return nil
 	})
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 
 	p.Steps = []lt.TestStep{{Op: Refresh, SkipPreview: true}}
@@ -631,7 +631,7 @@ func TestImportPlan(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -709,7 +709,7 @@ func TestImportIgnoreChanges(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -777,7 +777,7 @@ func TestImportPlanExistingImport(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -849,7 +849,7 @@ func TestImportPlanEmptyState(t *testing.T) {
 		}),
 	}
 	programF := deploytest.NewLanguageRuntimeF(nil)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -908,7 +908,7 @@ func TestImportPlanSpecificProvider(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -989,7 +989,7 @@ func TestImportPlanSpecificProperties(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1053,7 +1053,7 @@ func TestImportIntoParent(t *testing.T) {
 		}),
 	}
 	programF := deploytest.NewLanguageRuntimeF(nil)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1111,7 +1111,7 @@ func TestImportComponent(t *testing.T) {
 		}),
 	}
 	programF := deploytest.NewLanguageRuntimeF(nil)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1184,7 +1184,7 @@ func TestImportRemoteComponent(t *testing.T) {
 		}),
 	}
 	programF := deploytest.NewLanguageRuntimeF(nil)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1274,7 +1274,7 @@ func TestImportInputDiff(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1367,7 +1367,7 @@ func TestImportDefaultProvider(t *testing.T) {
 			Version: &pkgAVersion,
 		},
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1410,7 +1410,7 @@ func TestImportStackReference(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return errors.New("unexpected program execution")
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1490,7 +1490,7 @@ func TestImportWithFailedUpdate(t *testing.T) {
 		require.Fail(t, "RegisterResource should not return")
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1548,7 +1548,7 @@ func TestImportFailedCreate(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return errors.New("unexpected program execution")
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1609,7 +1609,7 @@ func TestImportDeleteBeforeReplace(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/invoke_test.go
+++ b/pkg/engine/lifecycletest/invoke_test.go
@@ -60,7 +60,7 @@ func TestPreviewInvoke(t *testing.T) {
 		assert.Equal(t, resource.NewProperty("invoked"), resp["result"])
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -105,7 +105,7 @@ func TestSecretsInvoke(t *testing.T) {
 		assert.Equalf(t, resource.MakeSecret(resource.NewProperty("invoked")), resp["result"], "Returned: %#v", resp)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/loader_test.go
+++ b/pkg/engine/lifecycletest/loader_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	. "github.com/pulumi/pulumi/pkg/v3/engine" //nolint:revive
 	lt "github.com/pulumi/pulumi/pkg/v3/engine/lifecycletest/framework"
@@ -105,7 +106,10 @@ func TestLoader(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostFWithServices(
+		nil, nil, programF,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
+		loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -125,7 +129,9 @@ func TestMapperAddressIsPassed(t *testing.T) {
 		observedMapperAddress = info.MapperAddress
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostFWithServices(
+		nil, nil, programF,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/loader_test.go
+++ b/pkg/engine/lifecycletest/loader_test.go
@@ -106,7 +106,7 @@ func TestLoader(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostFWithServices(
+	hostF := deploytest.NewPluginHostF(
 		nil, nil, programF,
 		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext,
 		loaders...)
@@ -129,7 +129,7 @@ func TestMapperAddressIsPassed(t *testing.T) {
 		observedMapperAddress = info.MapperAddress
 		return nil
 	})
-	hostF := deploytest.NewPluginHostFWithServices(
+	hostF := deploytest.NewPluginHostF(
 		nil, nil, programF,
 		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 

--- a/pkg/engine/lifecycletest/parameterized_test.go
+++ b/pkg/engine/lifecycletest/parameterized_test.go
@@ -108,7 +108,7 @@ func TestPackageRef(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -348,7 +348,7 @@ func TestReplacementParameterizedProvider(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -472,7 +472,7 @@ func TestReplacementParameterizedProviderConfig(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Config: config.Map{
@@ -617,7 +617,7 @@ func TestReplacementParameterizedProviderImport(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -154,7 +154,7 @@ func TestPclSnippet(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
@@ -241,7 +241,7 @@ func TestPclInvalidSnippet(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
@@ -280,7 +280,7 @@ func TestPclSnippetUpdate(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -329,7 +329,7 @@ func TestPclSnippetDelete(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -378,7 +378,7 @@ func TestPclMultipleSnippets(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -492,7 +492,7 @@ func TestPclSnippetBuiltins(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -586,7 +586,7 @@ func TestPclSnippetDirectories(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -695,7 +695,7 @@ func TestPclSnippetInvoke(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -800,7 +800,7 @@ func TestPclSnippetResourceReference(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -925,7 +925,7 @@ func TestPclSnippetReferenceLocalComponent(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1039,7 +1039,7 @@ func TestPclSnippetMissingProgramReference(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1144,7 +1144,7 @@ func TestPclSnippetMissingSnippetReference(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1281,7 +1281,7 @@ func TestPclSnippetReferenceFollowsAlias(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1351,7 +1351,7 @@ func TestPclSnippetResourceOptions(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1429,7 +1429,7 @@ func TestPclSnippetResourceOptionsResourceRefs(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1495,7 +1495,7 @@ func TestPclSnippetResourceOptionsParent(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1551,7 +1551,7 @@ func TestPclSnippetResourceOptionsAlias(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1612,7 +1612,7 @@ func TestPclSnippetResourceOptionsRange(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 

--- a/pkg/engine/lifecycletest/pending_delete_test.go
+++ b/pkg/engine/lifecycletest/pending_delete_test.go
@@ -42,7 +42,7 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -119,7 +119,7 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -196,7 +196,7 @@ func TestDestroyWithUntargetedPendingDelete(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{

--- a/pkg/engine/lifecycletest/pending_replace_test.go
+++ b/pkg/engine/lifecycletest/pending_replace_test.go
@@ -129,7 +129,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).
@@ -152,7 +152,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		}),
 	}
 
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
 	replaceSnap, err := lt.TestOp(Update).
@@ -189,7 +189,7 @@ func TestPendingReplaceFailureDoesNotViolateSnapshotIntegrity(t *testing.T) {
 		}),
 	}
 
-	retryHostF := deploytest.NewPluginHostF(nil, nil, programF, retryLoaders...)
+	retryHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, retryLoaders...)
 	retryOptions := lt.TestUpdateOptions{T: t, HostF: retryHostF}
 
 	retrySnap, err := lt.TestOp(Update).
@@ -294,7 +294,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).
@@ -318,7 +318,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 		}),
 	}
 
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
 	replaceSnap, err := lt.TestOp(Update).
@@ -346,7 +346,7 @@ func TestPendingReplaceResumeWithSameGoals(t *testing.T) {
 		}),
 	}
 
-	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, removeLoaders...)
+	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, removeLoaders...)
 	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
 	removeSnap, err := lt.TestOp(Update).
@@ -444,7 +444,7 @@ func TestPendingReplaceResumeWithSameGoalsRefreshRunProgram(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).
@@ -468,7 +468,7 @@ func TestPendingReplaceResumeWithSameGoalsRefreshRunProgram(t *testing.T) {
 		}),
 	}
 
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
 	replaceSnap, err := lt.TestOp(Update).
@@ -496,7 +496,7 @@ func TestPendingReplaceResumeWithSameGoalsRefreshRunProgram(t *testing.T) {
 		}),
 	}
 
-	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, removeLoaders...)
+	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, removeLoaders...)
 	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
 	removeOptions.Refresh = true
@@ -599,7 +599,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).
@@ -623,7 +623,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 		}),
 	}
 
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
 	replaceSnap, err := lt.TestOp(Update).
@@ -658,7 +658,7 @@ func TestPendingReplaceResumeWithDeletedGoals(t *testing.T) {
 		return nil
 	})
 
-	removeHostF := deploytest.NewPluginHostF(nil, nil, removeProgramF, removeLoaders...)
+	removeHostF := deploytest.NewPluginHostF(nil, nil, removeProgramF, nil, nil, removeLoaders...)
 	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
 	removeSnap, err := lt.TestOp(Update).
@@ -775,7 +775,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, upLoaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, upLoaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).
@@ -799,7 +799,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 		}),
 	}
 
-	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, replaceLoaders...)
+	replaceHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, replaceLoaders...)
 	replaceOptions := lt.TestUpdateOptions{T: t, HostF: replaceHostF}
 
 	replaceSnap, err := lt.TestOp(Update).
@@ -830,7 +830,7 @@ func TestPendingReplaceResumeWithUpdatedGoals(t *testing.T) {
 		}),
 	}
 
-	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, removeLoaders...)
+	removeHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, removeLoaders...)
 	removeOptions := lt.TestUpdateOptions{T: t, HostF: removeHostF}
 
 	removeSnap, err := lt.TestOp(Update).
@@ -882,7 +882,7 @@ func TestInteruptedPendingReplace(t *testing.T) {
 		return nil
 	})
 
-	upHostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	upHostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	upOptions := lt.TestUpdateOptions{T: t, HostF: upHostF}
 
 	upSnap, err := lt.TestOp(Update).

--- a/pkg/engine/lifecycletest/preview_test.go
+++ b/pkg/engine/lifecycletest/preview_test.go
@@ -132,7 +132,7 @@ func TestPreviewRefreshWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -211,7 +211,7 @@ func TestPreviewStackOutputs(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}

--- a/pkg/engine/lifecycletest/protect_test.go
+++ b/pkg/engine/lifecycletest/protect_test.go
@@ -69,7 +69,7 @@ func TestMultipleProtectedDeletes(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -154,7 +154,7 @@ func TestProtectInheritance(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -228,7 +228,7 @@ func TestProtectedDeleteChainsWithDuplicateDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	setupHostF1 := deploytest.NewPluginHostF(nil, nil, setupProgramF1, setupLoaders1...)
+	setupHostF1 := deploytest.NewPluginHostF(nil, nil, setupProgramF1, nil, nil, setupLoaders1...)
 	setupOpts1 := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF1,
@@ -276,7 +276,7 @@ func TestProtectedDeleteChainsWithDuplicateDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	setupHostF2 := deploytest.NewPluginHostF(nil, nil, setupProgramF2, setupLoaders2...)
+	setupHostF2 := deploytest.NewPluginHostF(nil, nil, setupProgramF2, nil, nil, setupLoaders2...)
 	setupOpts2 := lt.TestUpdateOptions{
 		T:     t,
 		HostF: setupHostF2,
@@ -300,7 +300,7 @@ func TestProtectedDeleteChainsWithDuplicateDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,

--- a/pkg/engine/lifecycletest/provider_test.go
+++ b/pkg/engine/lifecycletest/provider_test.go
@@ -59,7 +59,7 @@ func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -95,7 +95,7 @@ func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -118,7 +118,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -235,7 +235,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -330,7 +330,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -476,7 +476,7 @@ func TestSingleResourceExplicitProviderAliasUpdateDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -564,7 +564,7 @@ func TestSingleResourceExplicitProviderAliasReplace(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -703,7 +703,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -812,7 +812,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -940,7 +940,7 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -1059,7 +1059,7 @@ func TestExplicitProviderDiffReplacement(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			Steps: []lt.TestStep{
@@ -1145,7 +1145,7 @@ func TestProviderVersionDefault(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1188,7 +1188,7 @@ func TestProviderVersionOption(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1233,7 +1233,7 @@ func TestProviderVersionInput(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1279,7 +1279,7 @@ func TestProviderVersionInputAndOption(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1318,7 +1318,7 @@ func TestPluginDownloadURLPassthrough(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	steps := lt.MakeBasicLifecycleSteps(t, 2)
 	steps[0].ValidateAnd(func(project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -1362,7 +1362,7 @@ func TestPluginDownloadURLDefaultProvider(t *testing.T) {
 	})
 
 	snapshot := (&lt.TestPlan{
-		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)},
+		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)},
 		// The first step is the update. We don't want the full lifecycle because we want to see the
 		// created resources.
 		Steps: lt.MakeBasicLifecycleSteps(t, 2)[:1],
@@ -1457,7 +1457,7 @@ func TestMultipleResourceDenyDefaultProviderLifecycle(t *testing.T) {
 			}
 
 			programF := deploytest.NewLanguageRuntimeF(tt.f)
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 			c := config.Map{}
 			k := config.MustMakeKey("pulumi", "disable-default-providers")
@@ -1590,7 +1590,7 @@ func TestProviderVersionAssignment(t *testing.T) {
 						return &deploytest.Provider{}, nil
 					}))
 			}
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 			update := []lt.TestStep{{Op: Update, Validate: func(
 				project workspace.Project, target deploy.Target, entries JournalEntries,
@@ -1651,7 +1651,7 @@ func TestDeletedWithOptionInheritance(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1723,7 +1723,7 @@ func TestDeletedWithOptionInheritanceMLC(t *testing.T) {
 		}, deploytest.WithGrpc),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1774,7 +1774,7 @@ func TestProviderOptionInheritance(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -1845,7 +1845,7 @@ func TestProvidersOptionInheritance(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -1946,7 +1946,7 @@ func TestProvidersOptionInheritanceRemote(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -2071,7 +2071,7 @@ func TestComponentProvidersInheritance(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2101,7 +2101,7 @@ func TestRefreshLegacyState(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2212,7 +2212,7 @@ func TestInternalFiltered(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests as the delete events seem unstable
@@ -2264,7 +2264,7 @@ func TestProviderSameStep(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2318,7 +2318,7 @@ func TestMalformedProvider(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2373,7 +2373,7 @@ func TestMissingIDRefresh(t *testing.T) {
 		assert.Equal(t, expectedID, resp.ID)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2437,7 +2437,7 @@ func TestDroppedVersion(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2484,7 +2484,7 @@ func TestChangedVersion(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2530,7 +2530,7 @@ func TestInternalKey(t *testing.T) {
 	})
 
 	sink := &diag.MockSink{}
-	hostF := deploytest.NewPluginHostF(sink, sink, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(sink, sink, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2615,7 +2615,7 @@ func TestDefaultProviderInheritance(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/pulumi_test.go
+++ b/pkg/engine/lifecycletest/pulumi_test.go
@@ -169,7 +169,7 @@ func TestEmptyProgramLifecycle(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -184,7 +184,7 @@ func TestNoRuntimeLifecycle(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return errors.New("program should not run")
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 
 	p := &lt.TestPlan{
 		NoRuntime: true,
@@ -223,7 +223,7 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -285,7 +285,7 @@ func TestCheckFailureRecord(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{{
@@ -341,7 +341,7 @@ func TestCheckFailureInvalidPropertyRecord(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{{
@@ -388,7 +388,7 @@ func TestLanguageHostDiagnostics(t *testing.T) {
 		return errors.New(errorText)
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{{
@@ -445,7 +445,7 @@ func TestBrokenDecrypter(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	key := config.MustMakeKey("foo", "bar")
 	msg := "decryption failed"
 	configMap := make(config.Map)
@@ -519,7 +519,7 @@ func TestBadResourceType(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{{
@@ -599,7 +599,7 @@ func TestProviderCancellation(t *testing.T) {
 	options := lt.TestUpdateOptions{
 		T: t,
 
-		HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		UpdateOptions: UpdateOptions{
 			Parallel: resourceCount,
 		},
@@ -637,7 +637,7 @@ func TestLanguageRuntimeCancellation(t *testing.T) {
 		})
 	}
 
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil)}
 
 	p := &lt.TestPlan{}
 	project, target := p.GetProject(), p.GetTarget(t, nil)
@@ -696,7 +696,7 @@ func TestPreviewWithPendingOperations(t *testing.T) {
 
 	op := lt.TestOp(Update)
 
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	project, target := p.GetProject(), p.GetTarget(t, old)
 
 	// A preview should succeed despite the pending operations.
@@ -749,7 +749,7 @@ func TestRefreshWithPendingOperations(t *testing.T) {
 	})
 
 	op := lt.TestOp(Update)
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	project, target := p.GetProject(), p.GetTarget(t, old)
 
 	// With a refresh, the update should succeed.
@@ -827,7 +827,7 @@ func TestRefreshPreservesPendingCreateOperations(t *testing.T) {
 	})
 
 	op := lt.TestOp(Update)
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	project, target := p.GetProject(), p.GetTarget(t, old)
 
 	// With a refresh, the update should succeed.
@@ -903,7 +903,7 @@ func TestUpdateShowsWarningWithPendingOperations(t *testing.T) {
 	})
 
 	op := lt.TestOp(Update)
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	project, target := p.GetProject(), p.GetTarget(t, old)
 
 	// The update should succeed but give a warning
@@ -973,7 +973,7 @@ func TestUpdatePartialFailure(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	resURN := p.NewURN("pkgA:m:typA", "resA", "")
@@ -1063,7 +1063,7 @@ func TestStackReference(t *testing.T) {
 				}
 			},
 		},
-		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)},
+		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)},
 		Steps:   lt.MakeBasicLifecycleSteps(t, 2),
 	}
 	p.Run(t, nil)
@@ -1121,7 +1121,7 @@ func TestStackReference(t *testing.T) {
 		assert.Error(t, err)
 		return err
 	})
-	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	p.Steps = []lt.TestStep{{
 		Op:            Update,
 		ExpectFailure: true,
@@ -1139,7 +1139,7 @@ func TestStackReference(t *testing.T) {
 		assert.Error(t, err)
 		return err
 	})
-	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	p.Run(t, nil)
 }
 
@@ -1219,7 +1219,7 @@ func TestStackReferenceRegister(t *testing.T) {
 				}
 			},
 		},
-		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)},
+		Options: lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)},
 		Steps:   steps,
 	}
 	p.Run(t, nil)
@@ -1277,7 +1277,7 @@ func TestStackReferenceRegister(t *testing.T) {
 		assert.Error(t, err)
 		return err
 	})
-	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	p.Steps = []lt.TestStep{{
 		Op:            Update,
 		ExpectFailure: true,
@@ -1296,7 +1296,7 @@ func TestStackReferenceRegister(t *testing.T) {
 		assert.Error(t, err)
 		return err
 	})
-	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, loaders...)}
+	p.Options = lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)}
 	p.Run(t, nil)
 }
 
@@ -1379,7 +1379,7 @@ func TestLoadFailureShutdown(t *testing.T) {
 
 	op := lt.TestOp(Update)
 	sink := diag.DefaultSink(sinkWriter, sinkWriter, diag.FormatOptions{Color: colors.Raw})
-	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(sink, sink, programF, loaders...)}
+	options := lt.TestUpdateOptions{T: t, HostF: deploytest.NewPluginHostF(sink, sink, programF, nil, nil, loaders...)}
 	p := &lt.TestPlan{}
 	project, target := p.GetProject(), p.GetTarget(t, nil)
 
@@ -1423,7 +1423,7 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 			require.NoError(t, err)
 			return nil
 		})
-		hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+		hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 		p := &lt.TestPlan{
 			// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
 			Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -1585,7 +1585,7 @@ func TestIgnoreChangesInvalidPaths(t *testing.T) {
 	runtimeF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return program(monitor)
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, runtimeF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, runtimeF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1694,7 +1694,7 @@ func replaceOnChangesTest(t *testing.T, name string, diffFunc DiffFunc) {
 				require.NoError(t, err)
 				return nil
 			})
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 			p := &lt.TestPlan{
 				Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 				Steps: []lt.TestStep{
@@ -1830,7 +1830,7 @@ func TestPersistentDiff(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1911,7 +1911,7 @@ func TestDetailedDiffReplace(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1962,7 +1962,7 @@ func TestCustomTimeouts(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2010,7 +2010,7 @@ func TestProviderDiffMissingOldOutputs(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2108,7 +2108,7 @@ func TestMissingRead(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps:   []lt.TestStep{{Op: Update, ExpectFailure: true}},
@@ -2179,7 +2179,7 @@ func TestProviderPreview(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2269,7 +2269,7 @@ func TestProviderPreviewGrpc(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2494,7 +2494,7 @@ func TestProviderPreviewUnknowns(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2633,7 +2633,7 @@ func TestLanguageClient(t *testing.T) {
 		}),
 	}
 
-	update, err := startUpdate(t, deploytest.NewPluginHostF(nil, nil, nil, loaders...))
+	update, err := startUpdate(t, deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...))
 	if err != nil {
 		t.Fatalf("failed to start update: %v", err)
 	}
@@ -2661,7 +2661,7 @@ func TestConfigSecrets(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	crypter := config.NewSymmetricCrypter(make([]byte, 32))
 	//nolint:usetesting // outlives t.Context inside the engine
@@ -2705,7 +2705,7 @@ func TestComponentOutputs(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2773,7 +2773,7 @@ func TestProtect(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2928,7 +2928,7 @@ func TestImportDiff(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3047,7 +3047,7 @@ func TestDeletedWith(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3149,7 +3149,7 @@ func TestReplaceWithAndPropertyChange(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3197,7 +3197,7 @@ func TestInvalidGetIDReportsUserError(t *testing.T) {
 		assert.Error(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3254,7 +3254,7 @@ func TestEventSecrets(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
@@ -3340,7 +3340,7 @@ func TestAdditionalSecretOutputs(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3423,7 +3423,7 @@ func TestDefaultParents(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3570,7 +3570,7 @@ func TestPendingDeleteOrder(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3731,7 +3731,7 @@ func TestPendingDeleteReplacement(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -3824,7 +3824,7 @@ func TestTimestampTracking(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	// Run an update to create the resource -- created and updated should be set and equal.
 	p.Steps = []lt.TestStep{{Op: Update, SkipPreview: true}}
@@ -4032,7 +4032,7 @@ func TestOldCheckedInputsAreSent(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4148,7 +4148,7 @@ func TestResourceNames(t *testing.T) {
 
 				return nil
 			})
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 			p := &lt.TestPlan{
 				Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 			}
@@ -4313,7 +4313,7 @@ func TestSourcePositions(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4459,7 +4459,7 @@ func TestBadResourceOptionURNs(t *testing.T) {
 				tt.assertFn(err)
 				return nil
 			})
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 			p := &lt.TestPlan{
 				Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4500,7 +4500,7 @@ func TestProviderChecksums(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4547,7 +4547,7 @@ func TestAutomaticDiff(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4641,7 +4641,7 @@ func TestStackOutputsProgramError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -4746,7 +4746,7 @@ func TestStackOutputsResourceError(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -4841,7 +4841,7 @@ func TestParallelDiff(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -4921,7 +4921,7 @@ func TestConstructHangsAfterRegisterResourceFailure(t *testing.T) {
 		require.ErrorContains(t, err, "resource monitor shut down while waiting for construct to complete")
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -4965,7 +4965,7 @@ func TestProgramError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -5015,7 +5015,7 @@ func TestResourceError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}

--- a/pkg/engine/lifecycletest/refresh_before_update_test.go
+++ b/pkg/engine/lifecycletest/refresh_before_update_test.go
@@ -110,7 +110,7 @@ func TestRefreshBeforeUpdate(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -293,7 +293,7 @@ func TestRefreshBeforeUpdateDeletedResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{

--- a/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
+++ b/pkg/engine/lifecycletest/refresh_legacy_diff_test.go
@@ -141,7 +141,7 @@ func validateRefreshBasicsWithLegacyDiffCombination(
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 	p.Options.T = t
 
 	p.Steps = []lt.TestStep{{

--- a/pkg/engine/lifecycletest/refresh_test.go
+++ b/pkg/engine/lifecycletest/refresh_test.go
@@ -76,7 +76,7 @@ func TestParallelRefresh(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -137,7 +137,7 @@ func TestExternalRefresh(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps:   []lt.TestStep{{Op: Update}},
@@ -215,7 +215,7 @@ func TestExternalRefreshDoesNotCallDiff(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps:   []lt.TestStep{{Op: Update}},
@@ -294,7 +294,7 @@ func TestRefreshInitFailure(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options.HostF = hostF
 	p.Options.T = t
@@ -402,7 +402,7 @@ func TestRefreshWithDelete(t *testing.T) {
 				return err
 			})
 
-			hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+			hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 			p := &lt.TestPlan{
 				Options: lt.TestUpdateOptions{
 					T: t,
@@ -482,7 +482,7 @@ func TestRefreshDeletePropertyDependencies(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
@@ -545,7 +545,7 @@ func TestRefreshDeleteDeletedWith(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
@@ -655,7 +655,7 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 	p.Options.T = t
 
 	p.Steps = []lt.TestStep{
@@ -840,7 +840,7 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...)
 	p.Options.T = t
 
 	p.Steps = []lt.TestStep{{
@@ -1030,7 +1030,7 @@ func TestCanceledRefresh(t *testing.T) {
 	op := lt.TestOp(Refresh)
 	options := lt.TestUpdateOptions{
 		T:     t,
-		HostF: deploytest.NewPluginHostF(nil, nil, nil, loaders...),
+		HostF: deploytest.NewPluginHostF(nil, nil, nil, nil, nil, loaders...),
 		UpdateOptions: UpdateOptions{
 			Parallel: 1,
 		},
@@ -1159,7 +1159,7 @@ func TestRefreshStepWillPersistUpdatedIDs(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options.HostF = hostF
 	p.Options.T = t
@@ -1217,7 +1217,7 @@ func TestRefreshUpdateWithDeletedResource(t *testing.T) {
 	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Options.HostF = hostF
 	p.Options.Refresh = true
@@ -1320,7 +1320,7 @@ func TestRefreshWithProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1430,7 +1430,7 @@ func TestRefreshWithProviderThatHasDependencies(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1562,7 +1562,7 @@ func TestRefreshWithProgramUpdateExplicitProvider(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1691,7 +1691,7 @@ func TestRefreshWithProgramUpdateDefaultProvider(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1825,7 +1825,7 @@ func TestRefreshWithProgramUpdateDefaultProviderWithoutRegistration(t *testing.T
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1967,7 +1967,7 @@ func TestRefreshWithProgramWithDeletedResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2080,7 +2080,7 @@ func TestRefreshWithBigProgram(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2206,7 +2206,7 @@ func TestRefreshWithAlias(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2305,7 +2305,7 @@ func TestRefreshRunProgramDeletedResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2428,7 +2428,7 @@ func TestRefreshRunProgramDBRReplacedResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2542,7 +2542,7 @@ func TestRefreshRunProgramReplacedResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2614,7 +2614,7 @@ func TestRefreshDeleteParent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
 			T:     t,
@@ -2744,7 +2744,7 @@ func TestRefreshV2Targeted(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -2830,7 +2830,7 @@ func TestRefreshV2FailedRead(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -2927,7 +2927,7 @@ func TestRefreshDeletedResourceWithChild(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:             t,
 		HostF:         hostF,
@@ -3033,7 +3033,7 @@ func TestRefreshPreservesInputsWhenReadReturnsNoInputs(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p.Steps = []lt.TestStep{
 		{Op: Update},
@@ -3141,7 +3141,7 @@ func TestRefreshV2TargetedWithPropertyDependencies(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -3237,7 +3237,7 @@ func TestRefreshV2TargetNotInProgram(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -3329,7 +3329,7 @@ func TestRefreshV2ParentChildOrdering(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, reproLoaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,
@@ -3393,7 +3393,7 @@ func TestRefreshV2DependencyNotInOriginalSnapshot(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, reproLoaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:             t,
 		HostF:         reproHostF,
@@ -3468,7 +3468,7 @@ func TestRefreshV2ExcludesChildWithExcludedParent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loader)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loader)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	_, err = lt.TestOp(engine.RefreshV2).
@@ -3517,7 +3517,7 @@ func TestRefreshV2ExcludeTarget(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	// First, create all resources with a normal update.
@@ -3598,7 +3598,7 @@ func TestRefreshV2IncludeTarget(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	// First, create all resources with a normal update.
@@ -3693,7 +3693,7 @@ func TestRefreshV2DeletedWithOrdering(t *testing.T) {
 		return nil
 	})
 
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, reproLoaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, reproLoaders...)
 	reproOpts := lt.TestUpdateOptions{
 		T:                t,
 		HostF:            reproHostF,
@@ -3755,7 +3755,7 @@ func TestRefreshV2PropertyDependencyOrdering(t *testing.T) {
 		}),
 	}
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	_, err := lt.TestOp(engine.RefreshV2).RunStep(
 		p.GetProject(), p.GetTarget(t, snap), lt.TestUpdateOptions{T: t, HostF: hostF}, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)

--- a/pkg/engine/lifecycletest/replace_with_test.go
+++ b/pkg/engine/lifecycletest/replace_with_test.go
@@ -83,7 +83,7 @@ func TestReplaceWith(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -201,7 +201,7 @@ func TestReplaceWithAndDeletedWith(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -300,7 +300,7 @@ func TestReplaceWithDeleteBeforeReplace(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/replacement_trigger_test.go
+++ b/pkg/engine/lifecycletest/replacement_trigger_test.go
@@ -62,7 +62,7 @@ func TestReplacementTrigger(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
@@ -139,7 +139,7 @@ func TestReplacementTriggerWithSecret(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
@@ -197,7 +197,7 @@ func TestReplacementTriggerWithDeepSecret(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
@@ -261,7 +261,7 @@ func TestReplacementTriggerWithOutput(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
@@ -359,7 +359,7 @@ func TestReplacementTriggerWithComputed(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()
@@ -442,7 +442,7 @@ func TestReplacementTriggerOutputWrappedPlainValue(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 
 	project := p.GetProject()

--- a/pkg/engine/lifecycletest/resource_hooks_test.go
+++ b/pkg/engine/lifecycletest/resource_hooks_test.go
@@ -101,7 +101,7 @@ func TestResourceHookDryRun(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -185,7 +185,7 @@ func TestResourceHooksAfterCreate(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -280,7 +280,7 @@ func TestResourceHooks_OptionsAreSent(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -347,7 +347,7 @@ func TestResourceHooks_OldAndNewOptionsAreSentOnUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -410,7 +410,7 @@ func TestResourceHookBeforeCreateError(t *testing.T) {
 		require.Fail(t, "RegisterResource should not return")
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -505,7 +505,7 @@ func TestResourceHookAfterDelete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -621,7 +621,7 @@ func TestResourceHookComponentAfterDelete(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -709,7 +709,7 @@ func TestResourceHookBeforeDeleteError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -853,7 +853,7 @@ func TestResourceHookBeforeUpdate(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -958,7 +958,7 @@ func TestResourceHookBeforeUpdateError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1032,7 +1032,7 @@ func TestResourceHookDeleteCalledOnDestroyRunProgram(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1098,7 +1098,7 @@ func TestResourceHookDeleteErrorWhenNoRunProgram(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1205,7 +1205,7 @@ func TestResourceHookComponent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1270,7 +1270,7 @@ func TestResourceHookTransform(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1342,7 +1342,7 @@ func TestResourceHookAfterCreateError(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1437,7 +1437,7 @@ func TestResourceHookAfterCreateErrorFailsFast(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -1527,7 +1527,7 @@ func TestResourceHookAfterDeleteError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1608,7 +1608,7 @@ func TestResourceHookAfterCreateErrorContinueOnError(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1679,7 +1679,7 @@ func TestResourceHookAfterCreateErrorIgnoreErrors(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1761,7 +1761,7 @@ func TestResourceHookBeforeCreateErrorIgnoreErrors(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/resource_reference_test.go
+++ b/pkg/engine/lifecycletest/resource_reference_test.go
@@ -102,7 +102,7 @@ func TestResourceReferences(t *testing.T) {
 		}))
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -184,7 +184,7 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -268,7 +268,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -345,7 +345,7 @@ func TestResourceReferences_GetResource(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because different ordering makes the colouring different.
@@ -444,7 +444,7 @@ func TestResourceReferences_NameAndTypeFilledByEngine(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},

--- a/pkg/engine/lifecycletest/retain_on_delete_test.go
+++ b/pkg/engine/lifecycletest/retain_on_delete_test.go
@@ -83,7 +83,7 @@ func TestRetainOnDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{Options: lt.TestUpdateOptions{T: t, HostF: hostF}}
 

--- a/pkg/engine/lifecycletest/signal_and_wait_for_shutdown_test.go
+++ b/pkg/engine/lifecycletest/signal_and_wait_for_shutdown_test.go
@@ -50,7 +50,7 @@ func TestSignalAndWaitForShutdown(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -95,7 +95,7 @@ func TestSignalAndWaitForShutdownError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -136,7 +136,7 @@ func TestSignalAndWaitForShutdownContinueOnError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, UpdateOptions: UpdateOptions{
@@ -178,7 +178,7 @@ func TestSignalAndWaitForShutdownErrorAfterWait(t *testing.T) {
 		return errors.New("error in program without signal")
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/lifecycletest/skip_plugin_pre_install_test.go
+++ b/pkg/engine/lifecycletest/skip_plugin_pre_install_test.go
@@ -109,7 +109,7 @@ func TestSkipPluginPreInstallSkipsUnusedLanguagePackages(t *testing.T) {
 	// The language host advertises both pkgA and pkgB as required, even though the program only
 	// ever registers a resource of pkgA.
 	programF := deploytest.NewLanguageRuntimeF(program, pkgA, pkgB)
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	runUpdate := func(skip bool) *countingPluginManager {
 		// Reset counters

--- a/pkg/engine/lifecycletest/stash_test.go
+++ b/pkg/engine/lifecycletest/stash_test.go
@@ -40,7 +40,7 @@ func TestStashImportError(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -69,7 +69,7 @@ func TestStash(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}

--- a/pkg/engine/lifecycletest/step_generator_test.go
+++ b/pkg/engine/lifecycletest/step_generator_test.go
@@ -54,7 +54,7 @@ func TestDuplicateURN(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -84,7 +84,7 @@ func TestDuplicateAlias(t *testing.T) {
 	runtimeF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		return program(monitor)
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, runtimeF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, runtimeF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -142,7 +142,7 @@ func TestSecretMasked(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
@@ -488,7 +488,7 @@ func TestExternalEventMetadata(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},

--- a/pkg/engine/lifecycletest/taint_test.go
+++ b/pkg/engine/lifecycletest/taint_test.go
@@ -68,7 +68,7 @@ func TestTaintReplacement(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -154,7 +154,7 @@ func TestTaintMultipleResources(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -228,7 +228,7 @@ func TestTaintWithPendingDelete(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},
@@ -336,7 +336,7 @@ func TestTaintNoChanges(t *testing.T) {
 		return err
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, SkipDisplayTests: true},

--- a/pkg/engine/lifecycletest/target_test.go
+++ b/pkg/engine/lifecycletest/target_test.go
@@ -88,7 +88,7 @@ func TestRefreshTargetChildren(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -203,7 +203,7 @@ func TestExcludeTarget(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 	opts.Excludes = deploy.NewUrnTargetsFromUrns([]resource.URN{
@@ -249,7 +249,7 @@ func TestExcludeChildren(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 	opts.ExcludeDependents = true
@@ -294,7 +294,7 @@ func TestDestroyExcludeTarget(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -358,7 +358,7 @@ func TestDestroyExcludeChildren(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -409,7 +409,7 @@ func TestExcludeProviderImplicitly(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "1")
@@ -459,7 +459,7 @@ func TestGlobExcludes(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -528,7 +528,7 @@ func TestRefreshExcludeTarget(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -608,7 +608,7 @@ func TestRefreshExcludeChildren(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -683,7 +683,7 @@ func destroySpecificTargets(
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.TargetDependents = targetDependents
 
 	destroyTargets := slice.Prealloc[resource.URN](len(targets))
@@ -804,7 +804,7 @@ func updateSpecificTargets(t *testing.T, targets, globTargets []string, targetDe
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.TargetDependents = targetDependents
 	p.Options.T = t
 	updateTargets := globTargets
@@ -912,7 +912,7 @@ func updateInvalidTarget(t *testing.T) {
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{"foo"})
@@ -940,7 +940,7 @@ func TestCreateDuringTargetedUpdate_CreateMentionedAsTarget(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	host1F := deploytest.NewPluginHostF(nil, nil, program1F, loaders...)
+	host1F := deploytest.NewPluginHostF(nil, nil, program1F, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: host1F},
@@ -959,7 +959,7 @@ func TestCreateDuringTargetedUpdate_CreateMentionedAsTarget(t *testing.T) {
 
 		return nil
 	})
-	host2F := deploytest.NewPluginHostF(nil, nil, program2F, loaders...)
+	host2F := deploytest.NewPluginHostF(nil, nil, program2F, nil, nil, loaders...)
 
 	resA := p.NewURN("pkgA:m:typA", "resA", "")
 	resB := p.NewURN("pkgA:m:typA", "resB", "")
@@ -1002,7 +1002,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateNotReferenced(t *testing.T) 
 		require.NoError(t, err)
 		return nil
 	})
-	host1F := deploytest.NewPluginHostF(nil, nil, program1F, loaders...)
+	host1F := deploytest.NewPluginHostF(nil, nil, program1F, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: host1F},
@@ -1021,7 +1021,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateNotReferenced(t *testing.T) 
 
 		return nil
 	})
-	host2F := deploytest.NewPluginHostF(nil, nil, program2F, loaders...)
+	host2F := deploytest.NewPluginHostF(nil, nil, program2F, nil, nil, loaders...)
 
 	resA := p.NewURN("pkgA:m:typA", "resA", "")
 
@@ -1084,7 +1084,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByChangedTarget(t 
 		return nil
 	})
 
-	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, beforeLoaders...)
+	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, beforeLoaders...)
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
@@ -1116,7 +1116,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByChangedTarget(t 
 		return nil
 	})
 
-	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, afterLoaders...)
+	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, afterLoaders...)
 
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -1159,7 +1159,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUnchangedTarget(
 		return nil
 	})
 
-	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
@@ -1185,7 +1185,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUnchangedTarget(
 		return nil
 	})
 
-	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -1235,7 +1235,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetPropertyDe
 		return nil
 	})
 
-	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, beforeLoaders...)
+	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, beforeLoaders...)
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
@@ -1269,7 +1269,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetPropertyDe
 		return nil
 	})
 
-	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, afterLoaders...)
+	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, afterLoaders...)
 
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -1319,7 +1319,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetDeletedWit
 		return nil
 	})
 
-	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, beforeLoaders...)
+	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, beforeLoaders...)
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
@@ -1351,7 +1351,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetDeletedWit
 		return nil
 	})
 
-	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, afterLoaders...)
+	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, afterLoaders...)
 
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -1403,7 +1403,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetParent(t *
 		return nil
 	})
 
-	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, beforeLoaders...)
+	beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, beforeLoaders...)
 
 	snap, err := lt.TestOp(Update).RunStep(project, p.GetTarget(t, nil), lt.TestUpdateOptions{
 		T:     t,
@@ -1436,7 +1436,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByTargetParent(t *
 		return nil
 	})
 
-	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, afterLoaders...)
+	afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, afterLoaders...)
 
 	_, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
 		T:     t,
@@ -1472,7 +1472,7 @@ func TestCreateDuringTargetedUpdate_UntargetedProviderReferencedByTarget(t *test
 		require.NoError(t, err)
 		return nil
 	})
-	host1F := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	host1F := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: host1F},
@@ -1501,7 +1501,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUntargetedCreate
 		require.NoError(t, err)
 		return nil
 	})
-	host1F := deploytest.NewPluginHostF(nil, nil, program1F, loaders...)
+	host1F := deploytest.NewPluginHostF(nil, nil, program1F, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: host1F},
@@ -1530,7 +1530,7 @@ func TestCreateDuringTargetedUpdate_UntargetedCreateReferencedByUntargetedCreate
 
 		return nil
 	})
-	host2F := deploytest.NewPluginHostF(nil, nil, program2F, loaders...)
+	host2F := deploytest.NewPluginHostF(nil, nil, program2F, nil, nil, loaders...)
 
 	p.Options.HostF = host2F
 	p.Options.Targets = deploy.NewUrnTargetsFromUrns([]resource.URN{resA})
@@ -1587,7 +1587,7 @@ func TestReplaceSpecificTargets(t *testing.T) {
 		}),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.T = t
 	getURN := func(name string) resource.URN {
 		return pickURN(t, urns, complexTestDependencyGraphNames, name)
@@ -1826,7 +1826,7 @@ func destroySpecificTargetsWithChildren(
 		}, deploytest.WithGrpc),
 	}
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p.Options.TargetDependents = targetDependents
 
 	destroyTargets := slice.Prealloc[resource.URN](len(targets))
@@ -1914,7 +1914,7 @@ func TestTargetedCreateDefaultProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{}
 
@@ -1996,7 +1996,7 @@ func TestEnsureUntargetedSame(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -2081,7 +2081,7 @@ func TestReplaceSpecificTargetsPlan(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	project := p.GetProject()
 
@@ -2258,7 +2258,7 @@ func TestTargetDependents(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -2326,7 +2326,7 @@ func TestTargetDependentsExplicitProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -2418,7 +2418,7 @@ func TestTargetDependentsSiblingResources(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -2492,7 +2492,7 @@ func TestTargetUntargetedParent(t *testing.T) {
 	}
 
 	hostFF := func(expectError bool) deploytest.PluginHostFactory {
-		return deploytest.NewPluginHostF(nil, nil, programFF(expectError), loaders...)
+		return deploytest.NewPluginHostF(nil, nil, programFF(expectError), nil, nil, loaders...)
 	}
 	p := &lt.TestPlan{}
 
@@ -2580,7 +2580,7 @@ func TestTargetDestroyDependencyErrors(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2643,7 +2643,7 @@ func TestTargetDestroyChildErrors(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2704,7 +2704,7 @@ func TestTargetDestroyDeleteFails(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2773,7 +2773,7 @@ func TestTargetDestroyDependencyDeleteFails(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2862,7 +2862,7 @@ func TestTargetDestroyChildDeleteFails(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2966,8 +2966,8 @@ func TestDependencyUnreleatedToTargetUpdatedSucceeds(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
-	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
+	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -3061,9 +3061,9 @@ func TestTargetUntargetedParentWithUpdatedDependency(t *testing.T) {
 	})
 
 	hostFF := func(expectError bool) deploytest.PluginHostFactory {
-		return deploytest.NewPluginHostF(nil, nil, programFF(expectError), loaders...)
+		return deploytest.NewPluginHostF(nil, nil, programFF(expectError), nil, nil, loaders...)
 	}
-	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, loaders...)
+	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, nil, nil, loaders...)
 	p := &lt.TestPlan{}
 
 	project := p.GetProject()
@@ -3165,7 +3165,7 @@ func TestTargetChangeProviderVersion(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	options := lt.TestUpdateOptions{T: t, HostF: hostF}
 	p := &lt.TestPlan{}
 
@@ -3237,7 +3237,7 @@ func TestTargetChangeAndSameProviderVersion(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	options := lt.TestUpdateOptions{T: t, HostF: hostF}
 	p := &lt.TestPlan{}
 
@@ -3331,7 +3331,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		p := &lt.TestPlan{}
 		project := p.GetProject()
@@ -3368,7 +3368,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+		afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 		// Act.
 		snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3420,7 +3420,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		// Actions:
 		//
@@ -3456,7 +3456,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3504,7 +3504,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3550,7 +3550,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3606,7 +3606,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		// Actions:
 		//
@@ -3651,7 +3651,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3708,7 +3708,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3763,7 +3763,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3813,7 +3813,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		// Actions:
 		//
@@ -3850,7 +3850,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3899,7 +3899,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -3946,7 +3946,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4000,7 +4000,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		// Actions:
 		//
@@ -4039,7 +4039,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4088,7 +4088,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4135,7 +4135,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4185,7 +4185,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 			return nil
 		})
 
-		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, loaders...)
+		beforeHostF := deploytest.NewPluginHostF(nil, nil, beforeF, nil, nil, loaders...)
 
 		// Actions:
 		//
@@ -4222,7 +4222,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4271,7 +4271,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4318,7 +4318,7 @@ func TestUntargetedDependencyChainsArePreserved(t *testing.T) {
 				return nil
 			})
 
-			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, loaders...)
+			afterHostF := deploytest.NewPluginHostF(nil, nil, afterF, nil, nil, loaders...)
 
 			// Act.
 			snap, err = lt.TestOp(Update).RunStep(project, p.GetTarget(t, snap), lt.TestUpdateOptions{
@@ -4391,7 +4391,7 @@ func TestUntargetedProviderChange(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	options := lt.TestUpdateOptions{T: t, HostF: hostF}
 	p := &lt.TestPlan{}
 
@@ -4476,7 +4476,7 @@ func TestUntargetedAliasedProviderChanges(t *testing.T) {
 		return nil
 	})
 
-	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, loaders...)
+	setupHostF := deploytest.NewPluginHostF(nil, nil, setupProgramF, nil, nil, loaders...)
 	setupOptions := lt.TestUpdateOptions{T: t, HostF: setupHostF}
 
 	setupSnap, err := lt.TestOp(Update).
@@ -4511,7 +4511,7 @@ func TestUntargetedAliasedProviderChanges(t *testing.T) {
 	// Run a targeted update that does not target any resources. Since providers are implicitly targeted, and since we
 	// gave Prov an alias, it should be renamed to its new URN (and subsequently, the set of resources that we didn't
 	// target should have their provider references updated to reflect the new URN).
-	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, loaders...)
+	reproHostF := deploytest.NewPluginHostF(nil, nil, reproProgramF, nil, nil, loaders...)
 	reproOptions := lt.TestUpdateOptions{
 		T:     t,
 		HostF: reproHostF,
@@ -4579,7 +4579,7 @@ func TestUntargetedSameStepsAcceptDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	hostF1 := deploytest.NewPluginHostF(nil, nil, programF1, loaders1...)
+	hostF1 := deploytest.NewPluginHostF(nil, nil, programF1, nil, nil, loaders1...)
 	opts1 := lt.TestUpdateOptions{T: t, HostF: hostF1}
 
 	snap1, err := lt.TestOp(Update).
@@ -4665,7 +4665,7 @@ func TestUntargetedSameStepsAcceptDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, loaders2...)
+	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, nil, nil, loaders2...)
 	opts2 := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF2,
@@ -4713,7 +4713,7 @@ func TestUntargetedSameStepsAcceptDeletedResources(t *testing.T) {
 		return nil
 	})
 
-	hostF3 := deploytest.NewPluginHostF(nil, nil, programF3, loaders3...)
+	hostF3 := deploytest.NewPluginHostF(nil, nil, programF3, nil, nil, loaders3...)
 	opts3 := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF3,
@@ -4785,7 +4785,7 @@ func TestUntargetedResourceAnalyzer(t *testing.T) {
 		return nil
 	})
 
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: host,
@@ -4884,7 +4884,7 @@ func TestUntargetedRefreshedProviderUpdate(t *testing.T) {
 		return nil
 	})
 
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: host,

--- a/pkg/engine/lifecycletest/transformation_test.go
+++ b/pkg/engine/lifecycletest/transformation_test.go
@@ -230,7 +230,7 @@ func TestRemoteTransforms(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored
@@ -298,7 +298,7 @@ func TestRemoteTransformBadResponse(t *testing.T) {
 		assert.ErrorContains(t, err, "cannot parse invalid wire-format data")
 		return err
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -342,7 +342,7 @@ func TestRemoteTransformErrorResponse(t *testing.T) {
 		assert.ErrorContains(t, err, "Unknown desc = bad transform")
 		return err
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -416,7 +416,7 @@ func TestRemoteTransformationsConstruct(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -534,7 +534,7 @@ func TestRemoteTransformsOptions(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -634,7 +634,7 @@ func TestRemoteTransformsDependencies(t *testing.T) {
 		assert.Empty(t, respC.Dependencies)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -723,7 +723,7 @@ func TestRemoteComponentTransforms(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -822,7 +822,7 @@ func TestTransformsProviderOpt(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{
@@ -901,7 +901,7 @@ func TestTransformInvoke(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{
@@ -958,7 +958,7 @@ func TestTransformInvokeTransformProvider(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{
@@ -1029,7 +1029,7 @@ func TestTransformOrdering(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 		Steps: []lt.TestStep{
@@ -1127,7 +1127,7 @@ func TestAssetArchiveRoundtrip(t *testing.T) {
 			respB.Outputs["archive"].ArchiveValue().Hash)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		// Skip display tests because secrets are serialized with the blinding crypter and can't be restored

--- a/pkg/engine/lifecycletest/update_plan_test.go
+++ b/pkg/engine/lifecycletest/update_plan_test.go
@@ -65,7 +65,7 @@ func TestPlannedUpdate(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -182,7 +182,7 @@ func TestUnplannedCreate(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -250,7 +250,7 @@ func TestUnplannedDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -328,7 +328,7 @@ func TestExpectedDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -403,7 +403,7 @@ func TestExpectedCreate(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -475,7 +475,7 @@ func TestPropertySetChange(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -534,7 +534,7 @@ func TestExpectedUnneededCreate(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -600,7 +600,7 @@ func TestExpectedUnneededDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -678,7 +678,7 @@ func TestResoucesWithSames(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -773,7 +773,7 @@ func TestPlannedPreviews(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -868,7 +868,7 @@ func TestPlannedUpdateChangedStack(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -956,7 +956,7 @@ func TestPlannedOutputChanges(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1038,7 +1038,7 @@ func TestPlannedInputOutputDifferences(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1131,7 +1131,7 @@ func TestAliasWithPlans(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1199,7 +1199,7 @@ func TestComputedCanBeDropped(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1355,7 +1355,7 @@ func TestPlannedUpdateWithNondeterministicCheck(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1441,7 +1441,7 @@ func TestPlannedUpdateWithCheckFailure(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1508,7 +1508,7 @@ func TestPluginsAreDownloaded(t *testing.T) {
 	},
 		workspace.PackageDescriptor{PluginDescriptor: workspace.PluginDescriptor{Name: "pkgA"}},
 		workspace.PackageDescriptor{PluginDescriptor: workspace.PluginDescriptor{Name: "pkgB", Version: &semver10}})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1584,7 +1584,7 @@ func TestProviderDeterministicPreview(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1672,7 +1672,7 @@ func TestPlannedUpdateWithDependentDelete(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF, UpdateOptions: UpdateOptions{GeneratePlan: true}},
@@ -1754,7 +1754,7 @@ func TestResourcesTargeted(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{}
 
@@ -1836,7 +1836,7 @@ func TestStackOutputsWithTargetedPlan(t *testing.T) {
 		return nil
 	})
 
-	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	p.Options.HostF = deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	project := p.GetProject()
 

--- a/pkg/engine/lifecycletest/update_test.go
+++ b/pkg/engine/lifecycletest/update_test.go
@@ -77,7 +77,7 @@ func TestComponentResourceTypeAliasWithReadResource(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
 	}
@@ -125,7 +125,7 @@ func TestComponentResourceTypeAliasWithReadResource(t *testing.T) {
 		return nil
 	})
 
-	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, loaders...)
+	hostF2 := deploytest.NewPluginHostF(nil, nil, programF2, nil, nil, loaders...)
 	p2 := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF2},
 	}
@@ -179,7 +179,7 @@ func TestUpdateWithTargetedParentChildMarkedAsDelete(t *testing.T) {
 		return nil
 	})
 
-	host := deploytest.NewPluginHostF(nil, nil, program, loaders...)
+	host := deploytest.NewPluginHostF(nil, nil, program, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: host,
@@ -287,7 +287,7 @@ func TestUpdateWithTargetedResourceChangingParent(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	opts := lt.TestUpdateOptions{
 		T:     t,
@@ -402,7 +402,7 @@ func TestTargetedUpdateWithProviderDependencyOnAliasedResource(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:             t,
 		HostF:         hostF,
@@ -485,7 +485,7 @@ func TestUpdateDeletedWithResourceDependedsOnDeleteResource(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -553,7 +553,7 @@ func TestPendingReplacementUpdateSnapshotIntegrity(t *testing.T) {
 		return nil
 	})
 
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -615,7 +615,7 @@ func TestUntargetedComponentResource(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	opts := lt.TestUpdateOptions{T: t, HostF: hostF}
 	snap, err := lt.TestOp(Update).RunStep(p.GetProject(), p.GetTarget(t, nil), opts, false, p.BackendClient, nil, "0")
@@ -720,7 +720,7 @@ func TestTargetedUpdateRefreshUnknownChildProvider(t *testing.T) {
 
 	targetURN := "urn:pulumi:test-stack::test-project::" +
 		"pkgA:index:Component$pkgB:index:ResA::resA"
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:     t,
 		HostF: hostF,
@@ -853,7 +853,7 @@ func TestTargetedUpdateRefreshWithDeletedParent(t *testing.T) {
 	})
 
 	targetURN := "urn:pulumi:test-stack::test-project::pkgA:m:TypeA$pkgA:m:TypeB::res-target"
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 	opts := lt.TestUpdateOptions{
 		T:                t,
 		HostF:            hostF,

--- a/pkg/engine/lifecycletest/views_test.go
+++ b/pkg/engine/lifecycletest/views_test.go
@@ -186,7 +186,7 @@ func TestViewsBasic(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -391,7 +391,7 @@ func TestViewsUpdateError(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -544,7 +544,7 @@ func TestViewsUpdateDelete(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -695,7 +695,7 @@ func TestViewsRefreshSame(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -830,7 +830,7 @@ func TestViews_RefreshBeforeUpdate_Same(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -967,7 +967,7 @@ func TestViewsRefreshUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1107,7 +1107,7 @@ func TestViews_RefreshBeforeUpdate_Update(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1234,7 +1234,7 @@ func TestViewsRefreshDelete(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1355,7 +1355,7 @@ func TestViews_RefreshBeforeUpdate_Delete(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1434,7 +1434,7 @@ func TestViewsImport(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -1616,7 +1616,7 @@ func TestViewsDeleteBeforeReplace(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -1824,7 +1824,7 @@ func TestViewsCreateBeforeReplace(t *testing.T) {
 		}
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},
@@ -2013,7 +2013,7 @@ func TestViewsRefreshDriftDeleteCreate_UpdateRefresh(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2181,7 +2181,7 @@ func TestViewsRefreshDriftDeleteCreate_RefreshBeforeUpdate(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2349,7 +2349,7 @@ func TestViewsRefreshDriftDeleteCreate_RefreshProgram(t *testing.T) {
 		require.NoError(t, err)
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{
@@ -2446,7 +2446,7 @@ func TestViewsDestroyPreview(t *testing.T) {
 
 		return nil
 	})
-	hostF := deploytest.NewPluginHostF(nil, nil, programF, loaders...)
+	hostF := deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...)
 
 	p := &lt.TestPlan{
 		Options: lt.TestUpdateOptions{T: t, HostF: hostF},

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -130,7 +130,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -151,7 +151,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -173,7 +173,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -217,7 +217,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -250,7 +250,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 
@@ -286,7 +286,7 @@ func TestLoadPolicyAnalyzer(t *testing.T) {
 			},
 		}
 		plugctx, err := plugin.NewContextWithRoot(
-			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil, nil, nil)
+			t.Context(), nil, nil, host, "", "", nil, false, nil, nil, nil, nil)
 		require.NoError(t, err)
 		defer plugctx.Close()
 

--- a/pkg/host/analyzer_test.go
+++ b/pkg/host/analyzer_test.go
@@ -28,10 +28,11 @@ import (
 
 func TestAnalyzerSpawn(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	// Sanity test that from config.Map to envvars we see what we expect to see
 	proj := "test-project"
@@ -74,10 +75,11 @@ func TestAnalyzerSpawn(t *testing.T) {
 
 func TestAnalyzerSpawnNoConfig(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/analyzer-no-config")
 	require.NoError(t, err)
@@ -96,10 +98,11 @@ func TestAnalyzerSpawnNoConfig(t *testing.T) {
 
 func TestAnalyzerSpawnViaLanguage(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	// Sanity test that from config.Map to property values we see what we expect to see
 	proj := "test-project"

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
@@ -34,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 // the host is independent of any workspace, and ctx is its lifetime context — cancelling it is the hard stop that
@@ -41,6 +43,7 @@ import (
 // RPC server parents its tracing interceptors on the span carried by ctx, if any.
 func New(
 	ctx context.Context, d, statusD diag.Sink, debugging plugin.DebugContext, installLang plugin.LanguageInstaller,
+	newLoader plugin.NewLoaderFunc, newMapper plugin.NewMapperFunc,
 ) (plugin.Host, error) {
 	// d and statusD may be nil; default them to a discarding sink so that logging through the host
 	// (e.g. from a plugin download-progress callback) never dereferences a nil sink.
@@ -66,6 +69,8 @@ func New(
 		closer:                  new(sync.Once),
 		debugContext:            debugging,
 		installLang:             installLang,
+		newLoader:               newLoader,
+		newMapper:               newMapper,
 	}
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
@@ -123,9 +128,40 @@ type defaultHost struct {
 	closer *sync.Once
 
 	installLang plugin.LanguageInstaller // installs unbundled language runtimes on demand; may be nil.
+
+	// newLoader and newMapper build the schema loader and conversion mapper services bound to a
+	// given context's workspace view. They live on the host so callers no longer thread them
+	// through every context constructor; each is workspace-independent and may be nil, in which
+	// case the host serves no loader / no mapper.
+	newLoader plugin.NewLoaderFunc
+	newMapper plugin.NewMapperFunc
 }
 
 var _ plugin.Host = (*defaultHost)(nil)
+
+// Loader returns a schema loader service bound to ctx's workspace view, built from the loader
+// factory the host was constructed with. It returns nil if the host has no loader factory. The
+// returned server is owned by ctx and shut down when ctx is closed.
+func (host *defaultHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	if host.newLoader == nil {
+		return nil, nil
+	}
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterLoaderServer(srv, host.newLoader(ctx))
+	})
+}
+
+// Mapper returns a conversion mapper service bound to ctx's workspace view, built from the
+// mapper factory the host was constructed with. It returns nil if the host has no mapper
+// factory. The returned server is owned by ctx and shut down when ctx is closed.
+func (host *defaultHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	if host.newMapper == nil {
+		return nil, nil
+	}
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterMapperServer(srv, host.newMapper(ctx))
+	})
+}
 
 // analyzerPluginKey identifies a booted analyzer plugin. Analyzers are spawned in the
 // workspace's working directory and resolved against its project plugins; policy analyzers are

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -71,6 +71,7 @@ func New(
 		installLang:             installLang,
 		newLoader:               newLoader,
 		newMapper:               newMapper,
+		contextServers:          map[*plugin.Context][]*plugin.GrpcServer{},
 	}
 
 	// Fire up a gRPC server to listen for requests.  This acts as a RPC interface that plugins can use
@@ -135,32 +136,73 @@ type defaultHost struct {
 	// case the host serves no loader / no mapper.
 	newLoader plugin.NewLoaderFunc
 	newMapper plugin.NewMapperFunc
+
+	// contextServers holds the loader and mapper gRPC servers the host hosts on behalf of a
+	// context. The host creates them in Loader/Mapper and shuts them down in ReleaseContext --
+	// after that context's plugins, since the servers boot plugins through the host -- or in
+	// Close for any context never released.
+	contextServers   map[*plugin.Context][]*plugin.GrpcServer
+	contextServersMu sync.Mutex
 }
 
 var _ plugin.Host = (*defaultHost)(nil)
 
 // Loader returns a schema loader service bound to ctx's workspace view, built from the loader
 // factory the host was constructed with. It returns nil if the host has no loader factory. The
-// returned server is owned by ctx and shut down when ctx is closed.
+// server is hosted by the host and shut down when ctx is released.
 func (host *defaultHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
 	if host.newLoader == nil {
 		return nil, nil
 	}
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterLoaderServer(srv, host.newLoader(ctx))
 	})
+	if err != nil {
+		return nil, err
+	}
+	host.trackContextServer(ctx, srv)
+	return srv, nil
 }
 
 // Mapper returns a conversion mapper service bound to ctx's workspace view, built from the
 // mapper factory the host was constructed with. It returns nil if the host has no mapper
-// factory. The returned server is owned by ctx and shut down when ctx is closed.
+// factory. The server is hosted by the host and shut down when ctx is released.
 func (host *defaultHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
 	if host.newMapper == nil {
 		return nil, nil
 	}
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterMapperServer(srv, host.newMapper(ctx))
 	})
+	if err != nil {
+		return nil, err
+	}
+	host.trackContextServer(ctx, srv)
+	return srv, nil
+}
+
+// trackContextServer records a gRPC server the host hosts on behalf of ctx, so that releasing or
+// closing the context (or the host) shuts it down.
+func (host *defaultHost) trackContextServer(ctx *plugin.Context, srv *plugin.GrpcServer) {
+	host.contextServersMu.Lock()
+	defer host.contextServersMu.Unlock()
+	host.contextServers[ctx] = append(host.contextServers[ctx], srv)
+}
+
+// releaseContextServers shuts down and forgets the gRPC servers hosted on behalf of ctx.
+func (host *defaultHost) releaseContextServers(ctx *plugin.Context) error {
+	host.contextServersMu.Lock()
+	servers := host.contextServers[ctx]
+	delete(host.contextServers, ctx)
+	host.contextServersMu.Unlock()
+
+	var errs []error
+	for _, srv := range servers {
+		if err := srv.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // analyzerPluginKey identifies a booted analyzer plugin. Analyzers are spawned in the
@@ -551,6 +593,10 @@ func (host *defaultHost) ReleaseContext(ctx *plugin.Context) error {
 		return nil //nolint:nilerr
 	}
 
+	// Shut down the loader and mapper gRPC servers hosted for ctx, after the plugins they may have
+	// booted have been released.
+	errs = append(errs, host.releaseContextServers(ctx))
+
 	return errors.Join(errs...)
 }
 
@@ -656,6 +702,17 @@ func (host *defaultHost) Close() (err error) {
 		host.analyzerPlugins = map[analyzerPluginKey]*analyzerPlugin{}
 		host.languagePlugins = map[languagePluginKey]*languagePlugin{}
 		host.resourcePlugins = map[plugin.Provider]*resourcePlugin{}
+
+		// Shut down the loader/mapper gRPC servers hosted for any context never released, after
+		// the plugins they may have booted.
+		host.contextServersMu.Lock()
+		for _, servers := range host.contextServers {
+			for _, srv := range servers {
+				contract.IgnoreClose(srv)
+			}
+		}
+		host.contextServers = map[*plugin.Context][]*plugin.GrpcServer{}
+		host.contextServersMu.Unlock()
 
 		// Shut down the plugin loader.
 		close(host.languageLoadRequests)

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -33,7 +33,7 @@ import (
 // internals. The host is closed when the test finishes.
 func newHost(t *testing.T, installLang plugin.LanguageInstaller) *defaultHost {
 	sink := diagtest.LogSink(t)
-	h, err := New(t.Context(), sink, sink, nil, installLang)
+	h, err := New(t.Context(), sink, sink, nil, installLang, nil, nil)
 	require.NoError(t, err)
 	host, ok := h.(*defaultHost)
 	require.True(t, ok)
@@ -103,8 +103,10 @@ func TestContextCloseReleasesProviders(t *testing.T) {
 	sink := diagtest.LogSink(t)
 	host := newHost(t, nil)
 
-	ctxA := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
-	ctxB := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	ctxA, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
+	ctxB, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ctxA.Close()) })
 
 	var mu sync.Mutex
@@ -157,7 +159,8 @@ func TestContextCloseGracefulShutdownBudget(t *testing.T) {
 	sink := diagtest.LogSink(t)
 	host := newHost(t, nil)
 
-	ctxB := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	ctxB, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
 
 	var mu sync.Mutex
 	var gotErr error
@@ -180,7 +183,7 @@ func TestContextCloseGracefulShutdownBudget(t *testing.T) {
 
 	require.NoError(t, ctxB.Close())
 	var has bool
-	_, err := host.loadPlugin(host.loadRequests, func() (any, error) {
+	_, err = host.loadPlugin(host.loadRequests, func() (any, error) {
 		_, has = host.resourcePlugins[plugin.Provider(prov)]
 		return nil, nil
 	})
@@ -223,8 +226,10 @@ func TestContextCloseRefcountsSharedPlugins(t *testing.T) {
 	sink := diagtest.LogSink(t)
 	host := newHost(t, nil)
 
-	ctxB := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
-	ctxC := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	ctxB, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
+	ctxC, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
 
 	runtime := &stubLanguageRuntime{}
 	langKey := languagePluginKey{runtime: "test", workingDirectory: ""}
@@ -317,7 +322,6 @@ func TestContextLoaderAddr(t *testing.T) {
 	t.Parallel()
 
 	sink := diagtest.LogSink(t)
-	host := newHost(t, nil)
 
 	var captureCtx *plugin.Context
 	mockLoader := func(ctx *plugin.Context) codegenrpc.LoaderServer {
@@ -325,7 +329,11 @@ func TestContextLoaderAddr(t *testing.T) {
 		return codegenrpc.UnimplementedLoaderServer{}
 	}
 
-	ctx, err := plugin.NewContext(t.Context(), sink, sink, host, nil, "", nil, false, nil, mockLoader, nil)
+	host, err := New(t.Context(), sink, sink, nil, nil, mockLoader, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	ctx, err := plugin.NewContext(t.Context(), sink, sink, host, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, ctx, captureCtx, "the loader is bound to the context it was constructed with")
@@ -339,7 +347,6 @@ func TestContextMapperAddr(t *testing.T) {
 	t.Parallel()
 
 	sink := diagtest.LogSink(t)
-	host := newHost(t, nil)
 
 	var captureCtx *plugin.Context
 	mockMapper := func(ctx *plugin.Context) codegenrpc.MapperServer {
@@ -347,7 +354,11 @@ func TestContextMapperAddr(t *testing.T) {
 		return codegenrpc.UnimplementedMapperServer{}
 	}
 
-	ctx, err := plugin.NewContext(t.Context(), sink, sink, host, nil, "", nil, false, nil, nil, mockMapper)
+	host, err := New(t.Context(), sink, sink, nil, nil, nil, mockMapper)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	ctx, err := plugin.NewContext(t.Context(), sink, sink, host, nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, ctx, captureCtx, "the mapper is bound to the context it was constructed with")
@@ -374,7 +385,8 @@ func TestDefaultHostLanguageRuntimeInstallsOnDemand(t *testing.T) {
 	}
 
 	host := newHost(t, installLang)
-	ctx := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), sink, sink, host, "", "", nil)
+	require.NoError(t, err)
 
 	lang, err := host.LanguageRuntime(ctx, "test-lang")
 

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -50,7 +50,7 @@ func newHost(t *testing.T, installLang plugin.LanguageInstaller) *defaultHost {
 func TestLogWithNilSink(t *testing.T) {
 	t.Parallel()
 
-	h, err := New(t.Context(), nil, nil, nil, nil)
+	h, err := New(t.Context(), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	host, ok := h.(*defaultHost)
 	require.True(t, ok)

--- a/pkg/host/provider_test.go
+++ b/pkg/host/provider_test.go
@@ -29,10 +29,11 @@ import (
 
 func TestStartupFailure(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
 	require.NoError(t, err)
@@ -52,10 +53,11 @@ func TestStartupFailure(t *testing.T) {
 
 func TestNonZeroExitcode(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
 	require.NoError(t, err)
@@ -112,10 +114,11 @@ func TestNonZeroExitcode(t *testing.T) {
 // Similar to TestNonZeroExitcode but with a zero exit code, but no port written so it's still an error.
 func TestZeroExitcode(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, h.Close()) }()
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 
 	pluginPath, err := filepath.Abs("./testdata/provider-language")
 	require.NoError(t, err)
@@ -174,10 +177,11 @@ func TestZeroExitcode(t *testing.T) {
 //nolint:paralleltest // Modifying the global version.Version
 func TestPulumiVersionRangeYaml(t *testing.T) {
 	d := diagtest.LogSink(t)
-	h, err := New(t.Context(), d, d, nil, nil)
+	h, err := New(t.Context(), d, d, nil, nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, h.Close()) })
-	ctx := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	ctx, err := plugin.NewContextWithHost(t.Context(), d, d, h, "", "", nil)
+	require.NoError(t, err)
 	t.Cleanup(func() { ctx.Close() })
 
 	oldVersion := version.Version

--- a/pkg/importer/hcl2_test.go
+++ b/pkg/importer/hcl2_test.go
@@ -503,7 +503,9 @@ func TestGenerateHCL2DefinitionsWithVersionMismatches(t *testing.T) {
 	})
 
 	host := deploytest.NewPluginHost(nil /*sink*/, nil /*statusSink*/, nil /*languageRuntime*/, pluginLoader)
-	schemaLoader := schema.NewPluginLoader(plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil))
+	pctx, err := plugin.NewContextWithHost(t.Context(), nil, nil, host, "", "", nil)
+	require.NoError(t, err)
+	schemaLoader := schema.NewPluginLoader(pctx)
 
 	state := &resource.State{
 		Type:     "aws:cloudformation/stack:Stack",
@@ -532,7 +534,7 @@ func TestGenerateHCL2DefinitionsWithVersionMismatches(t *testing.T) {
 	}
 
 	// Act.
-	_, _, err := GenerateHCL2Definition(schemaLoader, state, importState)
+	_, _, err = GenerateHCL2Definition(schemaLoader, state, importState)
 
 	// Assert.
 	require.NoError(t, err)

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 var ErrHostIsClosed = errors.New("plugin host is shutting down")
@@ -297,6 +298,13 @@ type pluginHost struct {
 	sink            diag.Sink
 	statusSink      diag.Sink
 
+	// loaderFactory and mapperFactory build the schema loader and conversion mapper this host
+	// serves to its contexts. They are injected (rather than imported) because deploytest cannot
+	// import the codegen packages that define them without creating an import cycle; both are nil
+	// unless a caller needs the host to serve those services.
+	loaderFactory plugin.NewLoaderFunc
+	mapperFactory plugin.NewMapperFunc
+
 	engine *hostEngine
 
 	providers []plugin.Provider
@@ -319,9 +327,37 @@ func NewPluginHostF(sink, statusSink diag.Sink, languageRuntimeF LanguageRuntime
 	}
 }
 
+// NewPluginHostFWithServices is like [NewPluginHostF] but the produced host also serves a schema
+// loader and conversion mapper built from the given factories. deploytest cannot import the
+// codegen packages that define [schema.NewLoaderServerFromContext] and
+// [convert.NewMapperServerFromContext] (it would create an import cycle), so callers that need a
+// host serving those services inject the factories here.
+func NewPluginHostFWithServices(
+	sink, statusSink diag.Sink, languageRuntimeF LanguageRuntimeFactory,
+	newLoader plugin.NewLoaderFunc, newMapper plugin.NewMapperFunc,
+	pluginLoaders ...*ProviderLoader,
+) PluginHostFactory {
+	return func() plugin.Host {
+		var lr plugin.LanguageRuntime
+		if languageRuntimeF != nil {
+			lr = languageRuntimeF()
+		}
+		host := newPluginHost(sink, statusSink, lr, pluginLoaders...)
+		host.loaderFactory = newLoader
+		host.mapperFactory = newMapper
+		return host
+	}
+}
+
 func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRuntime,
 	pluginLoaders ...*ProviderLoader,
 ) plugin.Host {
+	return newPluginHost(sink, statusSink, languageRuntime, pluginLoaders...)
+}
+
+func newPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRuntime,
+	pluginLoaders ...*ProviderLoader,
+) *pluginHost {
 	engine := &hostEngine{
 		sink:       sink,
 		statusSink: statusSink,
@@ -546,6 +582,24 @@ func (host *pluginHost) AttachDebugger(_ plugin.DebugSpec) bool {
 
 func (host *pluginHost) Analyzer(ctx *plugin.Context, nm tokens.QName) (plugin.Analyzer, error) {
 	return host.PolicyAnalyzer(ctx, nm, "", nil)
+}
+
+func (host *pluginHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	if host.loaderFactory == nil {
+		return nil, nil
+	}
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterLoaderServer(srv, host.loaderFactory(ctx))
+	})
+}
+
+func (host *pluginHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	if host.mapperFactory == nil {
+		return nil, nil
+	}
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterMapperServer(srv, host.mapperFactory(ctx))
+	})
 }
 
 func (host *pluginHost) ResolvePlugin(

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -310,8 +310,11 @@ type pluginHost struct {
 	providers []plugin.Provider
 	analyzers []plugin.Analyzer
 	plugins   map[any]io.Closer
-	closed    bool
-	m         sync.Mutex
+	// contextServers holds the loader/mapper gRPC servers this host hosts on behalf of a context,
+	// shut down in ReleaseContext. Guarded by m.
+	contextServers map[*plugin.Context][]*plugin.GrpcServer
+	closed         bool
+	m              sync.Mutex
 }
 
 // NewPluginHostF returns a factory that produces a plugin host for an operation.
@@ -384,6 +387,7 @@ func newPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 		statusSink:      statusSink,
 		engine:          engine,
 		plugins:         map[any]io.Closer{},
+		contextServers:  map[*plugin.Context][]*plugin.GrpcServer{},
 	}
 }
 
@@ -502,10 +506,27 @@ func (host *pluginHost) LanguageRuntime(ctx *plugin.Context, runtime string) (pl
 	return host.languageRuntime, nil
 }
 
-// ReleaseContext is a no-op: this test host does not scope plugins to a context, so the plugins
-// it booted are torn down when the host itself closes rather than per-context.
+// ReleaseContext shuts down the loader and mapper gRPC servers this host hosts for the context.
+// This host does not scope its plugins to a context, so those are torn down when it closes.
 func (host *pluginHost) ReleaseContext(ctx *plugin.Context) error {
-	return nil
+	host.m.Lock()
+	servers := host.contextServers[ctx]
+	delete(host.contextServers, ctx)
+	host.m.Unlock()
+
+	var errs []error
+	for _, srv := range servers {
+		if err := srv.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (host *pluginHost) trackContextServer(ctx *plugin.Context, srv *plugin.GrpcServer) {
+	host.m.Lock()
+	defer host.m.Unlock()
+	host.contextServers[ctx] = append(host.contextServers[ctx], srv)
 }
 
 func (host *pluginHost) SignalCancellation() error {
@@ -588,18 +609,28 @@ func (host *pluginHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) 
 	if host.loaderFactory == nil {
 		return nil, nil
 	}
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterLoaderServer(srv, host.loaderFactory(ctx))
 	})
+	if err != nil {
+		return nil, err
+	}
+	host.trackContextServer(ctx, srv)
+	return srv, nil
 }
 
 func (host *pluginHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
 	if host.mapperFactory == nil {
 		return nil, nil
 	}
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterMapperServer(srv, host.mapperFactory(ctx))
 	})
+	if err != nil {
+		return nil, err
+	}
+	host.trackContextServer(ctx, srv)
+	return srv, nil
 }
 
 func (host *pluginHost) ResolvePlugin(

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -317,26 +317,13 @@ type pluginHost struct {
 	m              sync.Mutex
 }
 
-// NewPluginHostF returns a factory that produces a plugin host for an operation.
+// NewPluginHostF returns a factory that produces a plugin host for an operation. The produced
+// host serves a schema loader and conversion mapper built from newLoader and newMapper; callers
+// that do not need those services pass nil for both. deploytest cannot import the codegen packages
+// that define [schema.NewLoaderServerFromContext] and [convert.NewMapperServerFromContext] (it
+// would create an import cycle), so callers that need a host serving those services inject the
+// factories here.
 func NewPluginHostF(sink, statusSink diag.Sink, languageRuntimeF LanguageRuntimeFactory,
-	pluginLoaders ...*ProviderLoader,
-) PluginHostFactory {
-	return func() plugin.Host {
-		var lr plugin.LanguageRuntime
-		if languageRuntimeF != nil {
-			lr = languageRuntimeF()
-		}
-		return NewPluginHost(sink, statusSink, lr, pluginLoaders...)
-	}
-}
-
-// NewPluginHostFWithServices is like [NewPluginHostF] but the produced host also serves a schema
-// loader and conversion mapper built from the given factories. deploytest cannot import the
-// codegen packages that define [schema.NewLoaderServerFromContext] and
-// [convert.NewMapperServerFromContext] (it would create an import cycle), so callers that need a
-// host serving those services inject the factories here.
-func NewPluginHostFWithServices(
-	sink, statusSink diag.Sink, languageRuntimeF LanguageRuntimeFactory,
 	newLoader plugin.NewLoaderFunc, newMapper plugin.NewMapperFunc,
 	pluginLoaders ...*ProviderLoader,
 ) PluginHostFactory {

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/promise"
 	sdkproviders "github.com/pulumi/pulumi/sdk/v3/go/common/providers"
@@ -232,7 +231,7 @@ func newTestPluginContext(t testing.TB, program deploytest.ProgramFunc) (*plugin
 	lang := deploytest.NewLanguageRuntime(program)
 	host := deploytest.NewPluginHost(sink, statusSink, lang)
 	return plugin.NewContext(t.Context(), sink, statusSink, host, nil, "", nil, false,
-		nil, schema.NewLoaderServerFromContext, nil)
+		nil)
 }
 
 type testProviderSource struct {
@@ -2710,7 +2709,7 @@ func TestGetDeploymentInfo(t *testing.T) {
 	plugctx, err := plugin.NewContext(t.Context(),
 		&deploytest.NoopSink{}, &deploytest.NoopSink{},
 		deploytest.NewPluginHostF(nil, nil, nil)(),
-		nil, "", nil, false, nil, nil, nil)
+		nil, "", nil, false, nil)
 	require.NoError(t, err)
 
 	plainKey := config.MustMakeKey("test", "region")
@@ -2937,7 +2936,7 @@ func TestInvoke(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -2997,7 +2996,7 @@ func TestInvoke(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -3078,7 +3077,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -3152,7 +3151,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -3257,7 +3256,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)
@@ -3325,7 +3324,7 @@ func TestCall(t *testing.T) {
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
 			deploytest.NewPluginHostF(nil, nil, nil)(),
-			nil, "", nil, false, nil, nil, nil)
+			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
 		providerRegChan := make(chan *registerResourceEvent, 1)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -2708,7 +2708,7 @@ func TestGetDeploymentInfo(t *testing.T) {
 
 	plugctx, err := plugin.NewContext(t.Context(),
 		&deploytest.NoopSink{}, &deploytest.NoopSink{},
-		deploytest.NewPluginHostF(nil, nil, nil)(),
+		deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 		nil, "", nil, false, nil)
 	require.NoError(t, err)
 
@@ -2935,7 +2935,7 @@ func TestInvoke(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
@@ -2995,7 +2995,7 @@ func TestInvoke(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
@@ -3076,7 +3076,7 @@ func TestCall(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
@@ -3150,7 +3150,7 @@ func TestCall(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
@@ -3255,7 +3255,7 @@ func TestCall(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 
@@ -3323,7 +3323,7 @@ func TestCall(t *testing.T) {
 
 		plugctx, err := plugin.NewContext(t.Context(),
 			&deploytest.NoopSink{}, &deploytest.NoopSink{},
-			deploytest.NewPluginHostF(nil, nil, nil)(),
+			deploytest.NewPluginHostF(nil, nil, nil, nil, nil)(),
 			nil, "", nil, false, nil)
 		require.NoError(t, err)
 

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -60,7 +60,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/gsync"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 	testingrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/testing"
 	"github.com/segmentio/encoding/json"
 	"github.com/stretchr/testify/require"
@@ -548,13 +547,13 @@ func (eng *languageTestServer) PrepareLanguageTests(
 	})
 
 	// Start up a plugin host and context. The host is owned here and closed after the context.
-	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), snk, snk, nil, pkgWorkspace.EnsureLanguageInstalled)
+	pluginHost, err := pkghost.New(context.WithoutCancel(ctx), snk, snk, nil, pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin host: %w", err)
 	}
 	defer contract.IgnoreClose(pluginHost)
-	pctx, err := plugin.NewContextWithRoot(ctx, snk, snk, pluginHost, "", "", nil, false, nil, nil, nil, nil,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+	pctx, err := plugin.NewContextWithRoot(ctx, snk, snk, pluginHost, "", "", nil, false, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
@@ -750,32 +749,22 @@ func (eng *languageTestServer) RunLanguageTest(
 		token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	host := &testHost{
-		engine:      eng,
-		runtime:     languageClient,
-		runtimeName: token.LanguagePluginName,
-		providers:   make(map[string]func() (plugin.Provider, error)),
-		connections: make(map[plugin.Provider]io.Closer),
-	}
-
-	var loader *providerLoader
-	loaderServer := func(pctx *plugin.Context) codegenrpc.LoaderServer {
-		loader = &providerLoader{
-			language:     token.LanguagePluginName,
-			languageInfo: token.LanguageInfo,
-			pctx:         pctx,
-			host:         host,
-		}
-		return schema.NewLoaderServer(loader)
+		engine:       eng,
+		runtime:      languageClient,
+		runtimeName:  token.LanguagePluginName,
+		languageInfo: token.LanguageInfo,
+		providers:    make(map[string]func() (plugin.Provider, error)),
+		connections:  make(map[plugin.Provider]io.Closer),
 	}
 
 	pctx, err := plugin.NewContextWithRoot(
-		ctx, snk, snk, host, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil,
-		loaderServer, convert.NewMapperServerFromContext)
+		ctx, snk, snk, host, token.TemporaryDirectory, token.TemporaryDirectory, nil, false, nil, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("setup plugin context: %w", err)
 	}
 	defer contract.IgnoreClose(pctx)
-	contract.Assertf(pctx.LoaderAddr() != "" && loader != nil, "NewContextWithRoot must invoke the loader")
+	contract.Assertf(pctx.LoaderAddr() != "" && host.loader != nil, "NewContextWithRoot must invoke the host's loader")
+	loader := host.loader
 
 	// And fill that host with our test providers
 	for _, provider := range test.Providers {

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -749,12 +749,13 @@ func (eng *languageTestServer) RunLanguageTest(
 		token.LanguagePluginName, pulumirpc.NewLanguageRuntimeClient(conn))
 
 	host := &testHost{
-		engine:       eng,
-		runtime:      languageClient,
-		runtimeName:  token.LanguagePluginName,
-		languageInfo: token.LanguageInfo,
-		providers:    make(map[string]func() (plugin.Provider, error)),
-		connections:  make(map[plugin.Provider]io.Closer),
+		engine:          eng,
+		runtime:         languageClient,
+		runtimeName:     token.LanguagePluginName,
+		languageInfo:    token.LanguageInfo,
+		providers:       make(map[string]func() (plugin.Provider, error)),
+		connections:     make(map[plugin.Provider]io.Closer),
+		contextServices: make(map[*plugin.Context][]*plugin.GrpcServer),
 	}
 
 	pctx, err := plugin.NewContextWithRoot(

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -53,6 +53,10 @@ type testHost struct {
 	// here when Loader runs so the conformance runner can reuse it to bind PCL programs.
 	loader *providerLoader
 
+	// services are the loader/mapper gRPC servers this host hosts; they are shut down in
+	// ReleaseContext.
+	services []*plugin.GrpcServer
+
 	connectionsMutex sync.Mutex
 	connections      map[plugin.Provider]io.Closer
 
@@ -219,10 +223,17 @@ func (h *testHost) ResolvePlugin(
 	}, nil
 }
 
-// ReleaseContext is a no-op: the conformance test host tears its providers down when it closes
-// rather than scoping them to a context.
+// ReleaseContext shuts down the loader and mapper gRPC servers this host hosts for the context.
+// The test host's providers are not scoped to a context and are torn down when it closes.
 func (h *testHost) ReleaseContext(ctx *plugin.Context) error {
-	return nil
+	var errs []error
+	for _, srv := range h.services {
+		if err := srv.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	h.services = nil
+	return errors.Join(errs...)
 }
 
 // Loader serves the conformance runner's provider-backed schema loader, bound to ctx. The loader
@@ -234,17 +245,27 @@ func (h *testHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
 		pctx:         ctx,
 		host:         h,
 	}
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterLoaderServer(srv, schema.NewLoaderServer(h.loader))
 	})
+	if err != nil {
+		return nil, err
+	}
+	h.services = append(h.services, srv)
+	return srv, nil
 }
 
 // Mapper serves the standard conversion mapper bound to ctx, sourcing mappings from the plugins
 // installed in the global plugin storage.
 func (h *testHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
-	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
 		codegenrpc.RegisterMapperServer(srv, convert.NewMapperServerFromContext(ctx))
 	})
+	if err != nil {
+		return nil, err
+	}
+	h.services = append(h.services, srv)
+	return srv, nil
 }
 
 func (h *testHost) SignalCancellation() error {

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -49,13 +49,17 @@ type testHost struct {
 	languageInfo string
 	providers    map[string]func() (plugin.Provider, error)
 
+	// servicesMu guards loader and contextServices, which are written from Loader/Mapper as the
+	// engine boots contexts concurrently.
+	servicesMu sync.Mutex
+
 	// loader is the provider-backed schema loader this host binds onto a context. It is captured
 	// here when Loader runs so the conformance runner can reuse it to bind PCL programs.
 	loader *providerLoader
 
-	// services are the loader/mapper gRPC servers this host hosts; they are shut down in
-	// ReleaseContext.
-	services []*plugin.GrpcServer
+	// contextServices holds the loader/mapper gRPC servers this host hosts for each context; they
+	// are shut down in that context's ReleaseContext.
+	contextServices map[*plugin.Context][]*plugin.GrpcServer
 
 	connectionsMutex sync.Mutex
 	connections      map[plugin.Provider]io.Closer
@@ -226,32 +230,39 @@ func (h *testHost) ResolvePlugin(
 // ReleaseContext shuts down the loader and mapper gRPC servers this host hosts for the context.
 // The test host's providers are not scoped to a context and are torn down when it closes.
 func (h *testHost) ReleaseContext(ctx *plugin.Context) error {
+	h.servicesMu.Lock()
+	servers := h.contextServices[ctx]
+	delete(h.contextServices, ctx)
+	h.servicesMu.Unlock()
+
 	var errs []error
-	for _, srv := range h.services {
+	for _, srv := range servers {
 		if err := srv.Close(); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	h.services = nil
 	return errors.Join(errs...)
 }
 
 // Loader serves the conformance runner's provider-backed schema loader, bound to ctx. The loader
 // resolves schemas from the test's own providers via this host.
 func (h *testHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
-	h.loader = &providerLoader{
+	loader := &providerLoader{
 		language:     h.runtimeName,
 		languageInfo: h.languageInfo,
 		pctx:         ctx,
 		host:         h,
 	}
 	srv, err := plugin.NewServer(ctx, func(srv *grpc.Server) {
-		codegenrpc.RegisterLoaderServer(srv, schema.NewLoaderServer(h.loader))
+		codegenrpc.RegisterLoaderServer(srv, schema.NewLoaderServer(loader))
 	})
 	if err != nil {
 		return nil, err
 	}
-	h.services = append(h.services, srv)
+	h.servicesMu.Lock()
+	h.loader = loader
+	h.contextServices[ctx] = append(h.contextServices[ctx], srv)
+	h.servicesMu.Unlock()
 	return srv, nil
 }
 
@@ -264,7 +275,9 @@ func (h *testHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	h.services = append(h.services, srv)
+	h.servicesMu.Lock()
+	h.contextServices[ctx] = append(h.contextServices[ctx], srv)
+	h.servicesMu.Unlock()
 	return srv, nil
 }
 

--- a/pkg/testing/pulumi-test-language/runner/test_host.go
+++ b/pkg/testing/pulumi-test-language/runner/test_host.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/testing/pulumi-test-language/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -37,13 +39,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 type testHost struct {
-	engine      *languageTestServer
-	runtime     plugin.LanguageRuntime
-	runtimeName string
-	providers   map[string]func() (plugin.Provider, error)
+	engine       *languageTestServer
+	runtime      plugin.LanguageRuntime
+	runtimeName  string
+	languageInfo string
+	providers    map[string]func() (plugin.Provider, error)
+
+	// loader is the provider-backed schema loader this host binds onto a context. It is captured
+	// here when Loader runs so the conformance runner can reuse it to bind PCL programs.
+	loader *providerLoader
 
 	connectionsMutex sync.Mutex
 	connections      map[plugin.Provider]io.Closer
@@ -215,6 +223,28 @@ func (h *testHost) ResolvePlugin(
 // rather than scoping them to a context.
 func (h *testHost) ReleaseContext(ctx *plugin.Context) error {
 	return nil
+}
+
+// Loader serves the conformance runner's provider-backed schema loader, bound to ctx. The loader
+// resolves schemas from the test's own providers via this host.
+func (h *testHost) Loader(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	h.loader = &providerLoader{
+		language:     h.runtimeName,
+		languageInfo: h.languageInfo,
+		pctx:         ctx,
+		host:         h,
+	}
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterLoaderServer(srv, schema.NewLoaderServer(h.loader))
+	})
+}
+
+// Mapper serves the standard conversion mapper bound to ctx, sourcing mappings from the plugins
+// installed in the global plugin storage.
+func (h *testHost) Mapper(ctx *plugin.Context) (*plugin.GrpcServer, error) {
+	return plugin.NewServer(ctx, func(srv *grpc.Server) {
+		codegenrpc.RegisterMapperServer(srv, convert.NewMapperServerFromContext(ctx))
+	})
 }
 
 func (h *testHost) SignalCancellation() error {

--- a/pkg/workspace/plugin.go
+++ b/pkg/workspace/plugin.go
@@ -222,7 +222,8 @@ func installDependenciesForPluginSpec(
 	}
 
 	pluginHost, err := pkghost.New(
-		context.WithoutCancel(ctx), diagutil.Diag(), diagutil.Diag(), nil, EnsureLanguageInstalled)
+		context.WithoutCancel(ctx), diagutil.Diag(), diagutil.Diag(), nil, EnsureLanguageInstalled,
+		newLoader, convert.NewMapperServerFromContext)
 	if err != nil {
 		return err
 	}
@@ -239,8 +240,6 @@ func installDependenciesForPluginSpec(
 		nil,   // Plugins
 		proj.GetPackageSpecs(),
 		nil, // config
-		newLoader,
-		convert.NewMapperServerFromContext,
 	)
 	if err != nil {
 		return errors.Join(err, pluginHost.Close())

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -28,8 +28,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	interceptors "github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/rpcdebug"
 )
@@ -324,24 +322,15 @@ func (ctx *Context) Request() context.Context {
 func (ctx *Context) Close() error {
 	defer ctx.cancel()
 
-	// Release the plugins this context booted before tearing down the context's own services and
-	// cancelling it. ReleaseContext is synchronous, so when it returns the providers have shut
-	// down and any diagnostics they emitted have been delivered through this context's sinks --
-	// before the caller that owns those sinks tears them down.
+	// Release everything the host booted on behalf of this context: its plugins and the loader and
+	// mapper gRPC servers the host hosts for it (those are shut down after the plugins, since they
+	// boot plugins through the host). ReleaseContext is synchronous, so when it returns those have
+	// shut down and any diagnostics they emitted have been delivered through this context's sinks
+	// -- before the caller that owns those sinks tears them down.
 	err := ctx.Host.ReleaseContext(ctx)
 
 	if ctx.tracingSpan != nil {
 		ctx.tracingSpan.Finish()
-	}
-	if ctx.loaderServer != nil {
-		if err := ctx.loaderServer.Close(); err != nil && !rpcutil.IsBenignCloseErr(err) {
-			logging.V(5).Infof("Error closing the context's loader service; ignoring: %v", err)
-		}
-	}
-	if ctx.mapperServer != nil {
-		if err := ctx.mapperServer.Close(); err != nil && !rpcutil.IsBenignCloseErr(err) {
-			logging.V(5).Infof("Error closing the context's mapper service; ignoring: %v", err)
-		}
 	}
 	return err
 }

--- a/sdk/go/common/resource/plugin/context.go
+++ b/sdk/go/common/resource/plugin/context.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	interceptors "github.com/pulumi/pulumi/sdk/v3/go/pulumi-internal/rpcdebug"
-	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
 )
 
 // Context is used to group related operations together so that
@@ -90,21 +89,6 @@ func (ctx *Context) LoaderAddr() string {
 	return ctx.loaderServer.Addr()
 }
 
-// StartLoader starts a schema loader service bound to this context's workspace view. The
-// service is shut down when the context is closed. A context may have at most one loader;
-// contexts constructed with a non-nil NewLoaderFunc already have one.
-func (ctx *Context) StartLoader(newLoader NewLoaderFunc) error {
-	contract.Assertf(ctx.loaderServer == nil, "context already has a loader")
-	server, err := NewServer(ctx, func(srv *grpc.Server) {
-		codegenrpc.RegisterLoaderServer(srv, newLoader(ctx))
-	})
-	if err != nil {
-		return err
-	}
-	ctx.loaderServer = server
-	return nil
-}
-
 // MapperAddr returns the address of the conversion mapper service bound to this context, or
 // the empty string if the context has none.
 func (ctx *Context) MapperAddr() string {
@@ -114,18 +98,22 @@ func (ctx *Context) MapperAddr() string {
 	return ctx.mapperServer.Addr()
 }
 
-// StartMapper starts a conversion mapper service bound to this context's workspace view. The
-// service is shut down when the context is closed. A context may have at most one mapper;
-// contexts constructed with a non-nil NewMapperFunc already have one.
-func (ctx *Context) StartMapper(newMapper NewMapperFunc) error {
-	contract.Assertf(ctx.mapperServer == nil, "context already has a mapper")
-	server, err := NewServer(ctx, func(srv *grpc.Server) {
-		codegenrpc.RegisterMapperServer(srv, newMapper(ctx))
-	})
+// startServices binds this context's loader and mapper services, sourced from host. Each
+// service is workspace-scoped: it boots plugins against this context's view and is shut down
+// when the context is closed. A host may serve no loader and/or no mapper, in which case the
+// corresponding service is left unset.
+func (ctx *Context) startServices(host Host) error {
+	loader, err := host.Loader(ctx)
 	if err != nil {
 		return err
 	}
-	ctx.mapperServer = server
+	ctx.loaderServer = loader
+
+	mapper, err := host.Mapper(ctx)
+	if err != nil {
+		return err
+	}
+	ctx.mapperServer = mapper
 	return nil
 }
 
@@ -183,7 +171,7 @@ func (ctx *Context) ProjectPlugins() []workspace.ProjectPlugin {
 // shared by several contexts.
 func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSource,
 	pwd string, runtimeOptions map[string]any, disableProviderPreview bool,
-	parentSpan opentracing.Span, newLoader NewLoaderFunc, newMapper NewMapperFunc,
+	parentSpan opentracing.Span,
 ) (*Context, error) {
 	// TODO: really this ought to just take plugins *workspace.Plugins and packages map[string]workspace.PackageSpec
 	// as args, but yaml depends on this function so *sigh*. For now just see if there's a project we should be using,
@@ -200,14 +188,14 @@ func NewContext(ctx context.Context, d, statusD diag.Sink, host Host, _ ConfigSo
 	}
 
 	return NewContextWithRoot(ctx, d, statusD, host, pwd, pwd, runtimeOptions,
-		disableProviderPreview, parentSpan, plugins, packages, nil, newLoader, newMapper)
+		disableProviderPreview, parentSpan, plugins, packages, nil)
 }
 
 // NewContextWithRoot is a variation of NewContext that also sets known project Root. Additionally accepts Plugins
 func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	pwd, root string, runtimeOptions map[string]any, disableProviderPreview bool,
 	parentSpan opentracing.Span, plugins *workspace.Plugins, packages map[string]workspace.PackageSpec,
-	config map[config.Key]string, newLoader NewLoaderFunc, newMapper NewMapperFunc,
+	config map[config.Key]string,
 ) (*Context, error) {
 	contract.Assertf(host != nil, "host cannot be nil")
 	if d == nil {
@@ -253,18 +241,9 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 	}
 	pctx.projectPlugins = projectPlugins
 
-	if newLoader != nil {
-		if err := pctx.StartLoader(newLoader); err != nil {
-			contract.IgnoreClose(pctx)
-			return nil, err
-		}
-	}
-
-	if newMapper != nil {
-		if err := pctx.StartMapper(newMapper); err != nil {
-			contract.IgnoreClose(pctx)
-			return nil, err
-		}
+	if err := pctx.startServices(host); err != nil {
+		contract.IgnoreClose(pctx)
+		return nil, err
 	}
 
 	if logFile := env.DebugGRPC.Value(); logFile != "" {
@@ -297,7 +276,7 @@ func NewContextWithHost(
 	host Host,
 	pwd, root string,
 	parentSpan opentracing.Span,
-) *Context {
+) (*Context, error) {
 	contract.Assertf(host != nil, "NewContextWithHost requires a non-nil host")
 	if d == nil {
 		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
@@ -308,7 +287,7 @@ func NewContextWithHost(
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	return &Context{
+	pctx := &Context{
 		Diag:            d,
 		StatusDiag:      statusD,
 		Host:            host,
@@ -319,6 +298,13 @@ func NewContextWithHost(
 		cancel:          cancel,
 		baseContext:     ctx,
 	}
+
+	if err := pctx.startServices(host); err != nil {
+		contract.IgnoreClose(pctx)
+		return nil, err
+	}
+
+	return pctx, nil
 }
 
 // Base returns this plugin context's base context; this is useful for things like cancellation.

--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -65,8 +65,6 @@ func TestWithoutProviderDebugging(t *testing.T) {
 		nil,
 		false,
 		mocktracer.New().StartSpan("root"),
-		nil,
-		nil,
 	)
 	require.NoError(t, err)
 

--- a/sdk/go/common/resource/plugin/context_test.go
+++ b/sdk/go/common/resource/plugin/context_test.go
@@ -36,8 +36,6 @@ func TestContextRequest_race(t *testing.T) {
 		nil,                 // runtimeOptions
 		false,               // disableProviderPreview
 		mocktracer.New().StartSpan("root"),
-		nil,
-		nil,
 	)
 	require.NoError(t, err)
 

--- a/sdk/go/common/resource/plugin/host.go
+++ b/sdk/go/common/resource/plugin/host.go
@@ -85,6 +85,18 @@ type Host interface {
 	// across contexts uses it to reclaim a finished context's plugins without closing the host.
 	ReleaseContext(ctx *Context) error
 
+	// Loader returns a schema loader gRPC server bound to ctx's workspace view, or nil if this
+	// host serves no loader. The loader boots plugins to load schemas, and which plugins resolve
+	// depends on ctx, so the server is workspace-scoped: it is owned by ctx and closed when ctx is
+	// closed. Override this method on a custom Host to serve a bespoke loader.
+	Loader(ctx *Context) (*GrpcServer, error)
+
+	// Mapper returns a conversion mapper gRPC server bound to ctx's workspace view, or nil if this
+	// host serves no mapper. Like the loader, the mapper boots plugins to source mappings against
+	// ctx's workspace view, so the server is workspace-scoped: it is owned by ctx and closed when
+	// ctx is closed. Override this method on a custom Host to serve a bespoke mapper.
+	Mapper(ctx *Context) (*GrpcServer, error)
+
 	// SignalCancellation asks all resource providers to gracefully shut down and abort any ongoing
 	// operations. Operation aborted in this way will return an error (e.g., `Update` and `Create`
 	// will either a creation error or an initialization error. SignalCancellation is advisory and

--- a/sdk/go/common/resource/plugin/mock.go
+++ b/sdk/go/common/resource/plugin/mock.go
@@ -37,6 +37,8 @@ type MockHost struct {
 	LanguageRuntimeF    func(ctx *Context, runtime string) (LanguageRuntime, error)
 	ResolvePluginF      func(ctx *Context, spec workspace.PluginDescriptor) (*workspace.PluginInfo, error)
 	ReleaseContextF     func(ctx *Context) error
+	LoaderF             func(ctx *Context) (*GrpcServer, error)
+	MapperF             func(ctx *Context) (*GrpcServer, error)
 	SignalCancellationF func() error
 	CloseF              func() error
 	StartDebuggingF     func(info DebuggingInfo) error
@@ -108,6 +110,20 @@ func (m *MockHost) ReleaseContext(ctx *Context) error {
 		return m.ReleaseContextF(ctx)
 	}
 	return nil
+}
+
+func (m *MockHost) Loader(ctx *Context) (*GrpcServer, error) {
+	if m.LoaderF != nil {
+		return m.LoaderF(ctx)
+	}
+	return nil, nil
+}
+
+func (m *MockHost) Mapper(ctx *Context) (*GrpcServer, error) {
+	if m.MapperF != nil {
+		return m.MapperF(ctx)
+	}
+	return nil, nil
 }
 
 func (m *MockHost) SignalCancellation() error {

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -804,7 +804,7 @@ func newTestContext(t testing.TB) *Context {
 		t.Context(),
 		sink, sink,
 		// The tests using this context wire up in-process stub clients, so the host is never used.
-		&MockHost{}, nil /* source */, cwd, nil /* options */, false, nil /* span */, nil, nil)
+		&MockHost{}, nil /* source */, cwd, nil /* options */, false, nil /* span */)
 	require.NoError(t, err, "build context")
 
 	return ctx

--- a/tests/integration/run_plugin/go/main.go
+++ b/tests/integration/run_plugin/go/main.go
@@ -63,12 +63,12 @@ func main() {
 		}
 
 		sink := cmdutil.Diag()
-		pluginHost, err := pkghost.New(context.WithoutCancel(ctx.Context()), sink, sink, nil, nil)
+		pluginHost, err := pkghost.New(context.WithoutCancel(ctx.Context()), sink, sink, nil, nil, nil, nil)
 		if err != nil {
 			return err
 		}
 		defer contract.IgnoreClose(pluginHost)
-		pCtx, err := plugin.NewContext(ctx.Context(), sink, sink, pluginHost, nil, wd, nil, false, nil, nil, nil)
+		pCtx, err := plugin.NewContext(ctx.Context(), sink, sink, pluginHost, nil, wd, nil, false, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Moves ownership of the schema-loader and conversion-mapper gRPC services off
`plugin.Context` and onto `plugin.Host`.

Previously every `NewContext*` call threaded loader/mapper factories through the
engine. This PR introduces `Loader(*Context) (*GrpcServer, error)` and
`Mapper(*Context) (*GrpcServer, error)` on `plugin.Host`: the factories are
passed once to `host.New` and stored, and each context sources its loader and
mapper from its host at construction time. As a result:

- `NewContext`, `NewContextWithRoot`, and `NewContextWithHost` no longer take
  loader/mapper parameters. `NewContextWithHost` now returns an error because it
  may start those services.
- `StartLoader`/`StartMapper` are removed. To serve a bespoke loader or mapper,
  pass a `Host` that overrides the method (see `cachedLoaderHost` in
  packageworkspace and the conformance runner's `testHost`).
- The host owns teardown: it tracks the servers it hosts for a context and shuts
  them down in `ReleaseContext`, after that context's plugins (the servers boot
  plugins through the host). `Context` no longer closes them directly.
- `deploytest`'s plugin host gains injectable loader/mapper factories rather than
  importing the codegen packages directly, which would create an import cycle.

## Notes for reviewers

This PR is intentionally self-contained: it introduces `NewPluginHostFWithServices`
as an intermediate step and then folds it back into `NewPluginHostF` (which now
takes the loader and mapper factories directly). Both happen here so no other PR
ever sees a function that is added and then removed. Callers that do not want the
host to serve a loader or mapper pass `nil` for both factories.

The commits are kept separate and tell the story in order:

1. Move loader/mapper helper functions onto `plugin.Host`
2. Shut down loader and mapper servers in `ReleaseContext`
3. Scope the test host's loader/mapper servers per context (fixes a data race the
   race detector flagged in the language conformance tests, since contexts boot
   and release concurrently)
4. Fold `NewPluginHostFWithServices` into `NewPluginHostF`
5. Update the `run_plugin` integration test program for the new signatures