### PR TITLE
Pull host construction out of the engine

### DIFF
--- a/pkg/backend/diy/backend.go
+++ b/pkg/backend/diy/backend.go
@@ -1306,6 +1306,10 @@ func (b *diyBackend) apply(
 		engineCtx.SnapshotManager = manager
 	}
 
+	if op.Opts.Engine.HostFactory == nil {
+		op.Opts.Engine.HostFactory = backend.DefaultHostFactory
+	}
+
 	// Perform the update
 	start := time.Now().Unix()
 	var plan *deploy.Plan

--- a/pkg/backend/host.go
+++ b/pkg/backend/host.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/engine"
+	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
+	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+)
+
+// DefaultHostFactory is the production engine.HostFactory: it builds the standard plugin host
+// with language installation and the schema-loader and conversion-mapper services. The engine
+// supplies the diagnostic sinks and debug context so plugin logs surface in the UI as events.
+func DefaultHostFactory(
+	ctx context.Context, d, statusD diag.Sink, debug plugin.DebugContext,
+) (plugin.Host, error) {
+	return pkghost.New(ctx, d, statusD, debug,
+		pkgWorkspace.EnsureLanguageInstalled,
+		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+}
+
+// Assert DefaultHostFactory satisfies the engine's factory type.
+var _ engine.HostFactory = DefaultHostFactory

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2133,6 +2133,10 @@ func (b *cloudBackend) runEngineAction(
 		engineCtx.ParentSpan = parentSpan.Context()
 	}
 
+	if op.Opts.Engine.HostFactory == nil {
+		op.Opts.Engine.HostFactory = backend.DefaultHostFactory
+	}
+
 	var plan *deploy.Plan
 	var changes sdkDisplay.ResourceChanges
 	var updateErr error

--- a/pkg/backend/httpstate/snapshot_benchmark_test.go
+++ b/pkg/backend/httpstate/snapshot_benchmark_test.go
@@ -220,7 +220,11 @@ func update(
 			PluginManager:   framework.NopPluginManager{},
 			BackendClient:   snapshotBackendClient{},
 		},
-		engine.UpdateOptions{Host: host},
+		engine.UpdateOptions{
+			HostFactory: func(context.Context, diag.Sink, diag.Sink, plugin.DebugContext) (plugin.Host, error) {
+				return host, nil
+			},
+		},
 		false,
 	)
 	require.NoError(t, err)

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -25,12 +25,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
-	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
-	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/providers"
@@ -145,10 +141,9 @@ func (ctx *deploymentContext) Close() {
 type deploymentOptions struct {
 	UpdateOptions
 
-	// ownsHost is true when the engine constructed UpdateOptions.Host itself (via ensureHost) and
-	// is therefore responsible for closing it. A host injected through UpdateOptions.Host (e.g. by
-	// tests) is owned by its injector and is left open.
-	ownsHost bool
+	// host is the plugin host for this deployment, built from UpdateOptions.HostFactory by
+	// ensureHost. The engine owns it and closes it when the deployment context terminates.
+	host plugin.Host
 
 	// SourceFunc is a factory that returns an EvalSource to use during deployment.  This is the thing that
 	// creates resources to compare against the current checkpoint state (e.g., by evaluating a program, etc).
@@ -192,26 +187,21 @@ type deploymentSourceFunc func(
 	target *deploy.Target, plugctx *plugin.Context, resourceHooks *deploy.ResourceHooks, panicErrs chan<- error,
 ) (deploy.Source, error)
 
-// ensureHost makes sure opts has a non-nil plugin host. A host injected via UpdateOptions.Host
-// (e.g. by tests) is left as-is and owned by its injector; otherwise one is constructed here and
-// flagged so the engine closes it when the deployment finishes. The host's diag sinks are the
-// engine's event sinks so that plugin logs are routed to the UI, which is why the host is built
-// here rather than threaded in from the backend. The lifetime context strips cancellation so a
-// cancelled operation still gets the graceful shutdown budget; ensureHost's caller closes it.
+// ensureHost builds the deployment's plugin host from opts.HostFactory and stores it on opts.
+// The factory is given the engine's event-routed diag sinks and debug context so that plugin
+// logs reach the UI; this is why the engine supplies those rather than receiving a fully-built
+// host. The lifetime context strips cancellation so a cancelled operation still gets the
+// graceful shutdown budget. The engine owns the resulting host and closes it (see newDeployment).
 func ensureHost(ctx context.Context, opts *deploymentOptions, span opentracing.Span) error {
-	if opts.Host != nil {
-		return nil
-	}
+	contract.Assertf(opts.HostFactory != nil, "a plugin host factory must be provided")
 	debugging := newDebugContext(opts.Events, opts.AttachDebugger)
-	h, err := pkghost.New(
+	h, err := opts.HostFactory(
 		opentracing.ContextWithSpan(context.WithoutCancel(ctx), span),
-		opts.Diag, opts.StatusDiag, debugging, pkgWorkspace.EnsureLanguageInstalled,
-		schema.NewLoaderServerFromContext, convert.NewMapperServerFromContext)
+		opts.Diag, opts.StatusDiag, debugging)
 	if err != nil {
 		return err
 	}
-	opts.Host = h
-	opts.ownsHost = true
+	opts.host = h
 	return nil
 }
 
@@ -240,12 +230,9 @@ func newDeployment(
 
 	panicErrsChannel := make(chan error)
 
-	// Create a context for plugins. opts.Host is constructed by update() (or injected by a test);
-	// it is closed once the deployment context is terminated, after the plugin context, since the
-	// context does not own the host. A test-injected host (opts.ownsHost false) is left for its
-	// owner to close.
+	// Create a context for plugins.
 	baseCtx := trace.ContextWithSpan(ctx.Cancel.Base(), info.otelSpan)
-	pwd, main, plugctx, err := ProjectInfoContext(baseCtx, projinfo, opts.Host,
+	pwd, main, plugctx, err := ProjectInfoContext(baseCtx, projinfo, opts.host,
 		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan, config)
 	if err != nil {
 		return nil, err
@@ -255,9 +242,7 @@ func newDeployment(
 	go func() {
 		<-ctx.Cancel.Terminated()
 		contract.IgnoreClose(plugctx)
-		if opts.ownsHost {
-			contract.IgnoreClose(opts.Host)
-		}
+		contract.IgnoreClose(opts.host)
 	}()
 
 	// Set up a goroutine that will signal cancellation to the source if the caller context

--- a/pkg/engine/deployment_test.go
+++ b/pkg/engine/deployment_test.go
@@ -137,14 +137,13 @@ func TestSourceFuncCancellation(t *testing.T) {
 	defer host.Close()
 
 	opts := &deploymentOptions{
-		UpdateOptions: UpdateOptions{
-			Host: host,
-		},
-		SourceFunc: sourceF,
-		Events:     ctx.makeEventEmitter(t),
-		Diag:       diagtest.LogSink(t),
-		StatusDiag: diagtest.LogSink(t),
-		DryRun:     false,
+		UpdateOptions: UpdateOptions{},
+		host:          host,
+		SourceFunc:    sourceF,
+		Events:        ctx.makeEventEmitter(t),
+		Diag:          diagtest.LogSink(t),
+		StatusDiag:    diagtest.LogSink(t),
+		DryRun:        false,
 	}
 
 	_, err = newDeployment(&ctx.Context, info, nil, opts)

--- a/pkg/engine/lifecycletest/framework/framework.go
+++ b/pkg/engine/lifecycletest/framework/framework.go
@@ -295,11 +295,18 @@ func (op TestOp) runWithContext(
 	// We want to always run with plan generation to ensure that plans _can_ be generated.
 	// This is to prevent regressions such as https://github.com/pulumi/pulumi/pull/19750.
 	updateOpts.GeneratePlan = true
-	defer func() {
-		if updateOpts.Host != nil {
-			contract.IgnoreClose(updateOpts.Host)
+	// The engine builds the host from HostFactory and closes it when its cancel source terminates.
+	// This harness roots that source at context.Background() (it never terminates), so the engine's
+	// close never fires here -- build the host up front and close it ourselves.
+	if opts.HostF != nil {
+		host := opts.HostF()
+		defer contract.IgnoreClose(host)
+		updateOpts.HostFactory = func(
+			context.Context, diag.Sink, diag.Sink, plugin.DebugContext,
+		) (plugin.Host, error) {
+			return host, nil
 		}
-	}()
+	}
 
 	// Begin draining events.
 	firedEventsPromise := promise.Run(func() ([]engine.Event, error) {
@@ -789,9 +796,6 @@ type TestUpdateOptions struct {
 // Options produces UpdateOptions for an update operation.
 func (o TestUpdateOptions) Options() engine.UpdateOptions {
 	opts := o.UpdateOptions
-	if o.HostF != nil {
-		opts.Host = o.HostF()
-	}
 	// Set a sensible parallel count because most tests leave this zero.
 	if opts.Parallel == 0 {
 		opts.Parallel = int32(runtime.NumCPU()) //nolint:gosec // NumCPU isn't going to overflow int32

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -328,6 +328,11 @@ func LoadLocalPolicyPackAnalyzers(
 	return analyzers, nil
 }
 
+// HostFactory constructs the plugin host for a deployment.
+type HostFactory func(
+	ctx context.Context, d, statusD diag.Sink, debug plugin.DebugContext,
+) (plugin.Host, error)
+
 // UpdateOptions contains all the settings for customizing how an update (deploy, preview, or destroy) is performed.
 //
 // This structure is embedded in another which uses some of the unexported fields, which trips up the `structcheck`
@@ -395,8 +400,8 @@ type UpdateOptions struct {
 	// true if the engine should disable output value support.
 	DisableOutputValues bool
 
-	// the plugin host to use for this update
-	Host plugin.Host
+	// HostFactory builds the plugin host for this operation.
+	HostFactory HostFactory
 
 	// The plan to use for the update, if any.
 	Plan *deploy.Plan

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -1537,7 +1537,11 @@ func runLanguageTests(
 		}
 
 		updateOptions := run.UpdateOptions
-		updateOptions.Host = pctx.Host
+		updateOptions.HostFactory = func(
+			ctx context.Context, d, statusD diag.Sink, debug plugin.DebugContext,
+		) (plugin.Host, error) {
+			return pctx.Host, nil
+		}
 
 		// Translate the policy pack option on the test to point to the paths given by the testdata
 		if len(run.PolicyPacks) > 0 && token.PolicyPackDirectory == "" {


### PR DESCRIPTION
Move construction of the plugin host out of the deployment engine and into the
backend.

The engine previously either accepted a host injected through
`UpdateOptions.Host` or built the standard host itself, tracking whether it
owned the host via an `ownsHost` flag. It now always builds its host from a
required `UpdateOptions.HostFactory` and owns its teardown, removing the
inject-or-build branching and the ownership bookkeeping.

`backend.DefaultHostFactory` becomes the production factory: it builds the host
with language installation and the schema-loader and conversion-mapper
services, wired to the engine's diagnostic sinks so plugin logs surface as
events. Tests and the conformance runner supply their own factory.