### PR TITLE
Require snippet UUIDs in snapshots

### DIFF
--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -95,6 +95,13 @@ const pclSnippetSchemaPropA = `{
   }
 }`
 
+func newPclSnippetUUID(t *testing.T) string {
+	t.Helper()
+	id, err := uuid.NewV4()
+	require.NoError(t, err)
+	return id.String()
+}
+
 // TestPclSnippet checks that we can run a PCL snippet via an engine update.
 func TestPclSnippet(t *testing.T) {
 	t.Parallel()
@@ -136,6 +143,7 @@ func TestPclSnippet(t *testing.T) {
 
 	snippets := []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
@@ -222,6 +230,7 @@ func TestPclInvalidSnippet(t *testing.T) {
 	snippets := []resource.Snippet{
 		// Only set one property.
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
@@ -281,6 +290,7 @@ func TestPclSnippetUpdate(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
@@ -329,6 +339,7 @@ func TestPclSnippetDelete(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
@@ -377,11 +388,13 @@ func TestPclMultipleSnippets(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "r1", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
 		},
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "r2", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = false`,
@@ -489,6 +502,7 @@ func TestPclSnippetBuiltins(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code: `projectName = project()
@@ -582,6 +596,7 @@ func TestPclSnippetDirectories(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code: `workingDir = cwd()
@@ -690,6 +705,7 @@ func TestPclSnippetInvoke(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `message = invoke("pkgA:index:echo", { input = "hi" }).result`,
@@ -791,6 +807,7 @@ func TestPclSnippetResourceReference(t *testing.T) {
 	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
 	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{
@@ -915,6 +932,7 @@ func TestPclSnippetReferenceLocalComponent(t *testing.T) {
 	const compURN = "urn:pulumi:test::test::pkgA:index:Comp::comp"
 	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{
@@ -1028,6 +1046,7 @@ func TestPclSnippetMissingProgramReference(t *testing.T) {
 	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
 	snap := deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{
@@ -1132,17 +1151,20 @@ func TestPclSnippetMissingSnippetReference(t *testing.T) {
 	const producerURN = "urn:pulumi:test::test::pkgA:index:producer::producer"
 	const middleURN = "urn:pulumi:test::test::pkgA:index:producer::middle"
 	producerSnippet := resource.Snippet{
+		UUID: newPclSnippetUUID(t),
 		Name: "producer", Type: "pkgA:index:producer",
 		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 		Code:       `seed = "abc"`,
 	}
 	middleSnippet := resource.Snippet{
+		UUID: newPclSnippetUUID(t),
 		Name: "middle", Type: "pkgA:index:producer",
 		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 		References: map[string]string{"producer": producerURN},
 		Code:       `seed = producer.value`,
 	}
 	consumerSnippet := resource.Snippet{
+		UUID: newPclSnippetUUID(t),
 		Name: "consumer", Type: "pkgA:index:res",
 		Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 		References: map[string]string{"middle": middleURN},
@@ -1269,6 +1291,7 @@ func TestPclSnippetReferenceFollowsAlias(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "consumer", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{"comp": aURN},
@@ -1338,6 +1361,7 @@ func TestPclSnippetResourceOptions(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "test-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code: `propA = true
@@ -1416,6 +1440,7 @@ func TestPclSnippetResourceOptionsResourceRefs(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "snippet-resource", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{
@@ -1481,6 +1506,7 @@ func TestPclSnippetResourceOptionsParent(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "child", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			References: map[string]string{
@@ -1533,9 +1559,12 @@ func TestPclSnippetResourceOptionsAlias(t *testing.T) {
 		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "0")
 	require.NoError(t, err)
 
+	snippetUUID := newPclSnippetUUID(t)
+
 	// First update creates a resource at "old-name".
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: snippetUUID,
 			Name: "old-name", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code:       `propA = true`,
@@ -1552,6 +1581,7 @@ func TestPclSnippetResourceOptionsAlias(t *testing.T) {
 	// Second update renames to "new-name" but declares the old URN as an alias, so no delete should occur.
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: snippetUUID,
 			Name: "new-name", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code: fmt.Sprintf(`propA = true
@@ -1592,6 +1622,7 @@ func TestPclSnippetResourceOptionsRange(t *testing.T) {
 
 	snap.Snippets = []resource.Snippet{
 		{
+			UUID: newPclSnippetUUID(t),
 			Name: "fan", Type: "pkgA:index:res",
 			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 			Code: `propA = true

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -619,7 +619,8 @@ func (snap *Snapshot) NormalizeURNReferences() (*Snapshot, error) {
 //  3. Parents must precede children in the resource list
 //  4. Dependents must precede their dependencies in the resource list
 //  5. For every URN in the snapshot, there must be at most one resource with that URN that is not pending deletion
-//  6. The magic manifest number should change every time the snapshot is mutated
+//  6. Every snippet must have a non-empty, unique UUID
+//  7. The magic manifest number should change every time the snapshot is mutated
 //
 // N.B. Constraints 2 does NOT apply for resources that are pending deletion. This is because they may have
 // had their provider replaced but not yet be replaced themselves yet (due to a partial update). Pending
@@ -789,6 +790,18 @@ func (snap *Snapshot) VerifyIntegrity() error {
 			if deletes != len(states)-1 && deletes != len(states) {
 				return snapshot.SnapshotIntegrityErrorf("duplicate resource %s (not marked for deletion)", urn)
 			}
+		}
+
+		snippetUUIDs := make(map[string]int, len(snap.Snippets))
+		for i, snippet := range snap.Snippets {
+			if snippet.UUID == "" {
+				return snapshot.SnapshotIntegrityErrorf("snippet at index %d missing required 'uuid' field", i)
+			}
+			if other, has := snippetUUIDs[snippet.UUID]; has {
+				return snapshot.SnapshotIntegrityErrorf(
+					"duplicate snippet uuid %q at indexes %d and %d", snippet.UUID, other, i)
+			}
+			snippetUUIDs[snippet.UUID] = i
 		}
 	}
 

--- a/pkg/resource/deploy/snapshot_test.go
+++ b/pkg/resource/deploy/snapshot_test.go
@@ -1260,6 +1260,7 @@ func TestSnapshotVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 	snap := &Snapshot{
 		Snippets: []resource.Snippet{
 			{
+				UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
 				Name: "consumer",
 				Type: "pkgA:index:res",
 				Code: `propA = missing.id`,
@@ -1271,4 +1272,48 @@ func TestSnapshotVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 	}
 
 	require.NoError(t, snap.VerifyIntegrity())
+}
+
+func TestSnapshotVerifyIntegrity_SnippetUUID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+
+		snap := &Snapshot{
+			Snippets: []resource.Snippet{
+				{
+					Name: "consumer",
+					Type: "pkgA:index:res",
+					Code: `propA = true`,
+				},
+			},
+		}
+
+		require.ErrorContains(t, snap.VerifyIntegrity(), "snippet at index 0 missing required 'uuid' field")
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		snap := &Snapshot{
+			Snippets: []resource.Snippet{
+				{
+					UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
+					Name: "consumer-a",
+					Type: "pkgA:index:res",
+					Code: `propA = true`,
+				},
+				{
+					UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
+					Name: "consumer-b",
+					Type: "pkgA:index:res",
+					Code: `propA = false`,
+				},
+			},
+		}
+
+		require.ErrorContains(t, snap.VerifyIntegrity(),
+			`duplicate snippet uuid "e970a91d-4f4c-5793-8d27-dd27a0d96cf7" at indexes 0 and 1`)
+	})
 }

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -293,6 +293,7 @@ func SerializeSnippet(s resource.Snippet) apitype.SnippetV1 {
 		}
 	}
 	return apitype.SnippetV1{
+		UUID:       s.UUID,
 		Name:       s.Name,
 		Type:       s.Type,
 		Code:       s.Code,
@@ -327,6 +328,7 @@ func DeserializeSnippet(s apitype.SnippetV1) resource.Snippet {
 		}
 	}
 	return resource.Snippet{
+		UUID:       s.UUID,
 		Name:       s.Name,
 		Type:       s.Type,
 		Code:       s.Code,

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -246,6 +246,7 @@ func TestSerializeDeploymentWithMetadata(t *testing.T) {
 			},
 			snippets: []resource.Snippet{
 				{
+					UUID: "f32e0379-9985-5781-b5cb-9c053a8bb890",
 					Name: "r", Type: "pkgA:index:res",
 					Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 					Code:       `propA = true`,
@@ -395,11 +396,13 @@ func TestSnippetRoundTrip(t *testing.T) {
 	snap := &deploy.Snapshot{
 		Snippets: []resource.Snippet{
 			{
+				UUID: "89ed2ff3-1139-54c2-b53b-c3d9fb860da6",
 				Name: "r1", Type: "pkgA:index:res",
 				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
 				Code:       `propA = true`,
 			},
 			{
+				UUID: "02c76a6b-a0d6-52bd-888e-ebdc7e44ce99",
 				Name: "r2", Type: "pkgB:index:res",
 				Descriptor: resource.PackageDescriptor{
 					Name:        "pkgB",

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -290,6 +290,8 @@ type SnapshotMetadataV1 struct {
 // SnippetV1 is the serialized form of a PCL snippet stored alongside a snapshot. Snippets are evaluated by the
 // engine on every update to produce additional resource registrations.
 type SnippetV1 struct {
+	// UUID is the stable identity of this snippet within the snapshot.
+	UUID string `json:"uuid" yaml:"uuid"`
 	// Name is the logical name of the resource this snippet registers.
 	Name string `json:"name" yaml:"name"`
 	// Type is the type token of the resource this snippet registers.

--- a/sdk/go/common/apitype/deployments.json
+++ b/sdk/go/common/apitype/deployments.json
@@ -192,6 +192,10 @@
             "description": "A PCL snippet stored alongside a snapshot. The engine evaluates these on every update.",
             "type": "object",
             "properties": {
+                "uuid": {
+                    "description": "The stable identity of this snippet within the snapshot.",
+                    "type": "string"
+                },
                 "name": {
                     "description": "The logical name of the resource this snippet registers.",
                     "type": "string"
@@ -216,7 +220,7 @@
                     }
                 }
             },
-            "required": ["name", "type", "code", "descriptor"],
+            "required": ["uuid", "name", "type", "code", "descriptor"],
             "additionalProperties": false
         },
         "packageDescriptorV1": {

--- a/sdk/go/common/resource/resource_snippet.go
+++ b/sdk/go/common/resource/resource_snippet.go
@@ -43,6 +43,8 @@ type PackageDescriptor struct {
 //
 //nolint:lll
 type Snippet struct {
+	// UUID is the stable identity of this snippet within the snapshot.
+	UUID string `json:"uuid" yaml:"uuid"`
 	// The logical name of the resource this snippet is for.
 	Name string `json:"name" yaml:"name"`
 	// The type of the resource this snippet is for.

--- a/sdk/go/common/snapshot/integrity.go
+++ b/sdk/go/common/snapshot/integrity.go
@@ -162,6 +162,17 @@ func VerifyIntegrity(snap *apitype.DeploymentV3) error {
 		}
 	}
 
+	snippetUUIDs := make(map[string]int, len(snap.Snippets))
+	for i, snippet := range snap.Snippets {
+		if snippet.UUID == "" {
+			return SnapshotIntegrityErrorf("snippet at index %d missing required 'uuid' field", i)
+		}
+		if other, has := snippetUUIDs[snippet.UUID]; has {
+			return SnapshotIntegrityErrorf("duplicate snippet uuid %q at indexes %d and %d", snippet.UUID, other, i)
+		}
+		snippetUUIDs[snippet.UUID] = i
+	}
+
 	return nil
 }
 

--- a/sdk/go/common/snapshot/integrity_test.go
+++ b/sdk/go/common/snapshot/integrity_test.go
@@ -31,6 +31,7 @@ func TestVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 		Manifest: manifest,
 		Snippets: []apitype.SnippetV1{
 			{
+				UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
 				Name: "consumer",
 				Type: "pkgA:index:res",
 				Code: `propA = missing.id`,
@@ -42,4 +43,54 @@ func TestVerifyIntegrity_SnippetReferencesNeedNotExist(t *testing.T) {
 	}
 
 	require.NoError(t, VerifyIntegrity(snap))
+}
+
+func TestVerifyIntegrity_SnippetUUID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := apitype.ManifestV1{Version: "test"}
+		manifest.Magic = manifest.NewMagic()
+		snap := &apitype.DeploymentV3{
+			Manifest: manifest,
+			Snippets: []apitype.SnippetV1{
+				{
+					Name: "consumer",
+					Type: "pkgA:index:res",
+					Code: `propA = true`,
+				},
+			},
+		}
+
+		require.ErrorContains(t, VerifyIntegrity(snap), "snippet at index 0 missing required 'uuid' field")
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		manifest := apitype.ManifestV1{Version: "test"}
+		manifest.Magic = manifest.NewMagic()
+		snap := &apitype.DeploymentV3{
+			Manifest: manifest,
+			Snippets: []apitype.SnippetV1{
+				{
+					UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
+					Name: "consumer-a",
+					Type: "pkgA:index:res",
+					Code: `propA = true`,
+				},
+				{
+					UUID: "e970a91d-4f4c-5793-8d27-dd27a0d96cf7",
+					Name: "consumer-b",
+					Type: "pkgA:index:res",
+					Code: `propA = false`,
+				},
+			},
+		}
+
+		require.ErrorContains(t, VerifyIntegrity(snap),
+			`duplicate snippet uuid "e970a91d-4f4c-5793-8d27-dd27a0d96cf7" at indexes 0 and 1`)
+	})
 }

--- a/tests/stack/stack_test.go
+++ b/tests/stack/stack_test.go
@@ -962,6 +962,7 @@ func TestStackImportExportSnippetsAcrossBackends(t *testing.T) {
 
 		typed.Snippets = []apitype.SnippetV1{
 			{
+				UUID: "b2b3b67c-1c46-487a-924b-b181d19d2e48",
 				Name: "fromSnippet",
 				Type: "pulumi:pulumi:Stack",
 				Code: "name = \"fromSnippet\"",


### PR DESCRIPTION
Next part for snippets. Turns out to do accurate targeting we need some link between resources and snippets, more than just the name, and we can't calculate URNs up front. So we add a uuid to every snippet, snapshot verification checks these are non-empty and unique (it doesn't actually really matter if they're really uuids or just unique strings).