### PR TITLE
[pcl] Fix data race in the interpreter's parallel resource registration

### DIFF
--- a/pkg/pcl/runtime/evalContext.go
+++ b/pkg/pcl/runtime/evalContext.go
@@ -43,8 +43,9 @@ type EvalContext struct {
 	call        func(context.Context, *pulumirpc.ResourceCallRequest) (*pulumirpc.CallResponse, error)
 	getResource func(context.Context, resource.ResourceReference) (resource.PropertyMap, error)
 
-	// we write variables to the hcl.EvalContext in parallel during execution, so we need to synchronize access to it
-	evalLock    sync.Mutex
+	// We read and write variables to the hcl.EvalContext + children in parallel during
+	// execution, so we synchronize access to it.
+	evalLock    *sync.Mutex
 	evalContext *hcl.EvalContext
 }
 
@@ -67,6 +68,7 @@ func NewEvalContext(
 		getResource:      getResource,
 		invoke:           invoke,
 		call:             call,
+		evalLock:         new(sync.Mutex),
 	}
 
 	ctx.evalContext = &hcl.EvalContext{
@@ -91,6 +93,7 @@ func (ectx *EvalContext) NewChild() *EvalContext {
 		getResource:      ectx.getResource,
 		invoke:           ectx.invoke,
 		call:             ectx.call,
+		evalLock:         ectx.evalLock,
 		evalContext:      child,
 	}
 }

--- a/pkg/pcl/runtime/evalContext_test.go
+++ b/pkg/pcl/runtime/evalContext_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+)
+
+func TestEvalContextConcurrentParentChildAccess(t *testing.T) {
+	t.Parallel()
+
+	root := NewEvalContext("", "", "", "", "", nil, nil, nil, nil, nil)
+	root.SetVariable("shared", cty.StringVal("value"))
+
+	child := root.NewChild()
+	child.SetVariable("private", cty.StringVal("ignored"))
+	ref := model.VariableReference(&model.Variable{Name: "shared", VariableType: model.StringType})
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader: the child evaluates an expression that reads the parent's map.
+	// Assertions stay out of the goroutine (require's FailNow is unsafe there);
+	// the race detector is what this test relies on.
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			_, _, _ = child.Evaluate(ref)
+		}
+	}()
+
+	// Writer: the parent keeps publishing new variables onto the same map.
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			root.SetVariable(fmt.Sprintf("k%d", i), cty.NumberIntVal(int64(i)))
+		}
+	}()
+
+	wg.Wait()
+
+	// Sanity check that the reference actually resolves the parent variable, so
+	// the test is exercising the lookup path and not silently no-op'ing.
+	value, poison, diags := child.Evaluate(ref)
+	require.False(t, diags.HasErrors(), "diagnostics: %v", diags)
+	require.Nil(t, poison)
+	require.Equal(t, "value", value.StringValue())
+}


### PR DESCRIPTION
## Description

The PCL interpreter registers resources concurrently (a `pdag.DAG` walk over an `errgroup`). When the `-race` build runs the PCL conformance suite (`sdk/pcl/cmd/pulumi-language-pcl` `TestLanguage`), it intermittently trips a data race, failing many tests at once.

**Root cause.** A resource's result is published with `EvalContext.SetVariable` on the **root** context, while a ranged resource evaluates its inputs against a **child** context from `EvalContext.NewChild` (`interpreter.go:1031`). hcl resolves a variable name by walking up the parent chain (`hcl2.LookupVariable`), so the child's evaluation reads the *root's* variable map. But `NewChild` returned a child with a **fresh, independent mutex**, so:

- child `Evaluate` (holds child lock) reads `root.Variables` via the parent-walk, while
- root `SetVariable` (holds root lock) writes `root.Variables`

— the same map under two different locks. The `-race` detector catches it intermittently (`SetVariable` write vs `LookupVariable` read), which is why the `pcl 2/2` integration job flickered red.

**Fix.** Share one lock across the whole parent/child chain (`evalLock` becomes a shared `*sync.Mutex`, propagated in `NewChild`). Any evaluation now serializes against writes to any ancestor's variables. The lock only guards the fast cty expression evaluation — the gRPC `RegisterResource` call is outside it — so parallel registration is preserved.