### PR TITLE
Fix nil-sink panic in host.New when binding referenced plugins

### DIFF
--- a/changelog/pending/cli-fix-20260618-173403.yaml
+++ b/changelog/pending/cli-fix-20260618-173403.yaml
@@ -1,6 +1,6 @@
-component: engine
-kind: bug
+component: cli
+kind: fix
 body: Fix a panic in `pulumi package get-schema` when binding a schema that references an uninstalled plugin
-time: 2026-06-18T00:00:00.000000+00:00
+time: 2026-06-18T17:34:03.832187-07:00
 custom:
-    PR: ""
+    PR: "23647"

--- a/changelog/pending/engine-bug-20260618-000000.yaml
+++ b/changelog/pending/engine-bug-20260618-000000.yaml
@@ -1,0 +1,6 @@
+component: engine
+kind: bug
+body: Fix a panic in `pulumi package get-schema` when binding a schema that references an uninstalled plugin
+time: 2026-06-18T00:00:00.000000+00:00
+custom:
+    PR: ""

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -19,12 +19,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -40,6 +42,15 @@ import (
 func New(
 	ctx context.Context, d, statusD diag.Sink, debugging plugin.DebugContext, installLang plugin.LanguageInstaller,
 ) (plugin.Host, error) {
+	// d and statusD may be nil; default them to a discarding sink so that logging through the host
+	// (e.g. from a plugin download-progress callback) never dereferences a nil sink.
+	if d == nil {
+		d = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	}
+	if statusD == nil {
+		statusD = diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	}
+
 	hostCtx, hostCancel := context.WithCancel(ctx)
 	host := &defaultHost{
 		diag:                    d,

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
@@ -38,6 +39,27 @@ func newHost(t *testing.T, installLang plugin.LanguageInstaller) *defaultHost {
 	require.True(t, ok)
 	t.Cleanup(func() { require.NoError(t, host.Close()) })
 	return host
+}
+
+// TestLogWithNilSink is a regression test for https://github.com/pulumi/pulumi/issues/23646.
+//
+// Schema binding instantiates a throwaway host with nil diagnostic sinks (see newBinder in
+// pkg/codegen/schema/bind.go) when it needs to load a referenced package. If that reference is to
+// an uninstalled plugin, the plugin download-progress callback logs through the host. A host with a
+// nil diag sink must not panic when logged to.
+func TestLogWithNilSink(t *testing.T) {
+	t.Parallel()
+
+	h, err := New(t.Context(), nil, nil, nil, nil)
+	require.NoError(t, err)
+	host, ok := h.(*defaultHost)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+	require.NotPanics(t, func() {
+		host.Log(diag.Info, "", "downloading plugin", 0)
+		host.LogStatus(diag.Info, "", "downloading plugin", 0)
+	})
 }
 
 // TestHostManagedProviderCloseSignalsCancellation locks in the contract that hostManagedProvider.Close sends


### PR DESCRIPTION
Fixes #23646

### Problem

`pulumi package get-schema` (and `pulumi package add`, `pulumi plugin run`) panics with a nil pointer dereference when binding a schema that `$ref`s a package whose plugin is not yet installed locally. Binding the reference triggers a plugin download, and the download-progress callback logs through a host whose diagnostic sink is `nil`:

```
github.com/pulumi/pulumi/pkg/v3/host.(*defaultHost).Log(...)
	pkg/host/host.go:170
```

This is a regression in v3.247.0: v3.246.0 downloads the referenced plugin cleanly.

### Root cause

Schema binding instantiates a throwaway host with `nil` diagnostic sinks when it needs to load a referenced package (`newBinder` in `pkg/codegen/schema/bind.go`). The regression is #23573, which moved the default host into `pkg/host`. The previous code routed host construction through `plugin.NewContext`, which defaults `nil` sinks to a discarding sink before building the host. `pkghost.New` did not, leaving `host.diag` nil — so `host.Log` panicked once the download callback fired.

### Fix

Default `nil` sinks to a discarding sink in `host.New`, matching the documented contract of `plugin.NewContextWithHost` ("d, statusD ... may all be nil"). This also covers the other nil-sink call site in `pkg/cmd/pulumi/plugin/plugin_run.go`.

### Test

`TestLogWithNilSink` in `pkg/host/host_test.go` constructs a host with nil sinks and asserts that `Log`/`LogStatus` do not panic. It reproduces the exact panic (`host.go:170`) without the fix and passes with it.