### PR TITLE
Support updating snippets by UUID

### DIFF
--- a/pkg/backend/journal.go
+++ b/pkg/backend/journal.go
@@ -77,6 +77,13 @@ func SerializeJournalEntry(
 			return apitype.JournalEntry{}, fmt.Errorf("serializing new snapshot: %w", err)
 		}
 	}
+	var snippets []apitype.SnippetV1
+	if je.Snippets != nil {
+		snippets = make([]apitype.SnippetV1, len(je.Snippets))
+		for i, snippet := range je.Snippets {
+			snippets[i] = stack.SerializeSnippet(snippet)
+		}
+	}
 
 	serializedEntry := apitype.JournalEntry{
 		Version:               1,
@@ -96,6 +103,7 @@ func SerializeJournalEntry(
 		NewSnapshot:           snapshot,
 		ExtensionRef:          je.ExtensionRef,
 		Extension:             je.Extension,
+		Snippets:              snippets,
 	}
 
 	return serializedEntry, nil
@@ -229,6 +237,8 @@ func (r *JournalReplayer) Add(entry apitype.JournalEntry) error {
 		}
 
 		r.base.SecretsProviders = entry.SecretsProvider
+	case apitype.JournalEntryKindSnippets:
+		r.base.Snippets = entry.Snippets
 	case apitype.JournalEntryKindRebuiltBaseState:
 		// We need to build the snapshot from the current state here and discard the
 		// current journal entries. This happens after a refresh operation.
@@ -392,12 +402,17 @@ func (r *JournalReplayer) GenerateDeployment() (apitype.TypedDeployment, error) 
 	deployment.Resources = resources
 	deployment.PendingOperations = operations
 	deployment.Metadata = r.base.Metadata
+	deployment.Snippets = r.base.Snippets
 	deployment.Manifest = manifest.Serialize()
 	// Carry extensions forward from the base, plus any this plan produced.
 	extensions := maps.Clone(r.extensions)
 	maps.Copy(extensions, r.base.Extensions)
 	if len(extensions) > 0 {
 		deployment.Extensions = extensions
+	}
+
+	if len(deployment.Snippets) > 0 {
+		features["snippets-prototype"] = true
 	}
 
 	version := apitype.DeploymentSchemaVersionCurrent
@@ -621,6 +636,7 @@ func NewSnapshotJournaler(
 			Resources:         make([]*resource.State, 0),
 			PendingOperations: make([]resource.Operation, 0),
 			Metadata:          baseSnap.Metadata,
+			Snippets:          baseSnap.Snippets,
 		}
 		// Copy the resources from the base snapshot to the new snapshot.
 		for _, res := range baseSnap.Resources {

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -77,6 +77,8 @@ type SnapshotManager struct {
 	secretsManager secrets.Manager      // The default secrets manager to use
 	resources      []*resource.State    // The list of resources operated upon by this plan
 	operations     []resource.Operation // The set of operations known to be outstanding in this plan
+	snippets       []resource.Snippet   // The snippet list to persist with the next snapshot
+	hasSnippets    bool                 // Whether snippets has been set by the engine
 
 	// The set of resources that have been operated upon already by this plan. These resources could also have
 	// been added to `resources` by other operations but need to be filtered out before writing the snapshot.
@@ -220,6 +222,14 @@ func (sm *SnapshotManager) RebuiltBaseState() error {
 	// Similar to Write() we don't need to do anything here, as the snapshot manager uses the
 	// same in-memory snapshot as the engine, that is already mutated.
 	return nil
+}
+
+func (sm *SnapshotManager) SetSnippets(snippets []resource.Snippet) error {
+	return sm.mutate(func() bool {
+		sm.snippets = slices.Clone(snippets)
+		sm.hasSnippets = true
+		return true
+	})
 }
 
 // All SnapshotMutation implementations in this file follow the same basic formula:
@@ -771,6 +781,9 @@ func (sm *SnapshotManager) Snap() *deploy.Snapshot {
 	if sm.baseSnapshot != nil {
 		metadata = sm.baseSnapshot.Metadata
 		snippets = sm.baseSnapshot.Snippets
+	}
+	if sm.hasSnippets {
+		snippets = sm.snippets
 	}
 
 	manifest.Magic = manifest.NewMagic()

--- a/pkg/engine/combined_manager.go
+++ b/pkg/engine/combined_manager.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 var _ = SnapshotManager((*CombinedManager)(nil))
@@ -56,6 +57,20 @@ func (c *CombinedManager) RebuiltBaseState() error {
 	var errs []error
 	for i, m := range c.Managers {
 		if err := m.RebuiltBaseState(); err != nil {
+			if len(c.CollectErrorsOnly) > i && c.CollectErrorsOnly[i] {
+				c.appendError(err)
+			} else {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *CombinedManager) SetSnippets(snippets []resource.Snippet) error {
+	var errs []error
+	for i, m := range c.Managers {
+		if err := m.SetSnippets(snippets); err != nil {
 			if len(c.CollectErrorsOnly) > i && c.CollectErrorsOnly[i] {
 				c.appendError(err)
 			} else {

--- a/pkg/engine/combined_manager_test.go
+++ b/pkg/engine/combined_manager_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +28,7 @@ var _ = SnapshotManager(&MockSnapshotManager{})
 type MockSnapshotManager struct {
 	WriteF                   func(base *deploy.Snapshot) error
 	RebuiltBaseStateF        func() error
+	SetSnippetsF             func(snippets []resource.Snippet) error
 	BeginMutationF           func(step deploy.Step) (SnapshotMutation, error)
 	RegisterResourceOutputsF func(step deploy.Step) error
 	CloseF                   func() error
@@ -46,6 +48,13 @@ func (m *MockSnapshotManager) Write(base *deploy.Snapshot) error {
 func (m *MockSnapshotManager) RebuiltBaseState() error {
 	if m.RebuiltBaseStateF != nil {
 		return m.RebuiltBaseStateF()
+	}
+	return nil
+}
+
+func (m *MockSnapshotManager) SetSnippets(snippets []resource.Snippet) error {
+	if m.SetSnippetsF != nil {
+		return m.SetSnippetsF(snippets)
 	}
 	return nil
 }

--- a/pkg/engine/journal_snapshot.go
+++ b/pkg/engine/journal_snapshot.go
@@ -103,6 +103,7 @@ const (
 	JournalEntrySecretsManager        JournalEntryKind = 6
 	JournalEntryRebuiltBaseState      JournalEntryKind = 7
 	JournalEntryExtensionParameterize JournalEntryKind = 8
+	JournalEntrySnippets              JournalEntryKind = 9
 )
 
 func (k JournalEntryKind) String() string {
@@ -125,6 +126,8 @@ func (k JournalEntryKind) String() string {
 		return "RebuiltBaseState"
 	case JournalEntryExtensionParameterize:
 		return "ExtensionParameterize"
+	case JournalEntrySnippets:
+		return "Snippets"
 	default:
 		return "Unknown"
 	}
@@ -171,6 +174,9 @@ type JournalEntry struct {
 	// map on replay. Only set for JournalEntryExtensionParameterize entries.
 	ExtensionRef *apitype.ExtensionRef
 	Extension    *apitype.Extension
+
+	// Snippets is the complete snippet list to persist when Kind is JournalEntrySnippets.
+	Snippets []resource.Snippet
 }
 
 func hasNewResource(entry JournalEntry) bool {
@@ -228,6 +234,12 @@ func (sm *JournalSnapshotManager) RegisterSecretsManager(secretsManager secrets.
 	journalEntry := sm.newJournalEntry(JournalEntrySecretsManager, 0)
 	journalEntry.SecretsManager = secretsManager
 	journalEntry.ElideWrite = true
+	return sm.addJournalEntry(journalEntry)
+}
+
+func (sm *JournalSnapshotManager) SetSnippets(snippets []resource.Snippet) error {
+	journalEntry := sm.newJournalEntry(JournalEntrySnippets, 0)
+	journalEntry.Snippets = snippets
 	return sm.addJournalEntry(journalEntry)
 }
 
@@ -334,6 +346,7 @@ func (sm *JournalSnapshotManager) Write(base *deploy.Snapshot) error {
 		PendingOperations: make([]resource.Operation, 0, len(base.PendingOperations)),
 		Metadata:          base.Metadata,
 		Extensions:        base.Extensions,
+		Snippets:          slices.Clone(base.Snippets),
 	}
 
 	// Copy the resources from the base snapshot to the new snapshot.

--- a/pkg/engine/lifecycletest/alias_test.go
+++ b/pkg/engine/lifecycletest/alias_test.go
@@ -216,6 +216,7 @@ func createUpdateProgramWithResourceFuncForAliasTests(
 								assert.Fail(t, "unexpected failure in journal")
 							case TestJournalEntryBegin:
 							case TestJournalEntryOutputs:
+							case TestJournalEntrySnippets:
 							}
 						}
 

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -1651,3 +1651,116 @@ options {
 	}
 	require.Len(t, created, 3, "range = 3 should have produced three Create calls")
 }
+
+func TestPclSnippetAddUpdateDeleteViaOption(t *testing.T) {
+	t.Parallel()
+
+	var created, updated, deleted []resource.URN
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, &created, &updated, &deleted)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	p := &lt.TestPlan{
+		Options: lt.TestUpdateOptions{
+			SkipDisplayTests: true,
+			T:                t,
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+		},
+	}
+
+	snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
+		snippetID: {
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = true`,
+		},
+	}
+	snap, err := lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "add")
+	require.NoError(t, err)
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, snippetID.String(), snap.Snippets[0].UUID)
+	require.Equal(t, `propA = true`, snap.Snippets[0].Code)
+	require.Len(t, created, 1)
+	require.Empty(t, updated)
+	require.Empty(t, deleted)
+
+	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
+		snippetID: {
+			Name: "test-resource", Type: "pkgA:index:res",
+			Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+			Code:       `propA = false`,
+		},
+	}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "update")
+	require.NoError(t, err)
+	require.Len(t, snap.Snippets, 1)
+	require.Equal(t, snippetID.String(), snap.Snippets[0].UUID)
+	require.Equal(t, `propA = false`, snap.Snippets[0].Code)
+	require.Len(t, created, 1, "snippet update should not recreate the resource")
+	require.Len(t, updated, 1, "snippet update should update the resource")
+	require.Empty(t, deleted)
+
+	p.Options.Snippets = map[uuid.UUID]*resource.Snippet{snippetID: nil}
+	snap, err = lt.TestOp(Update).RunStep(
+		p.GetProject(), p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil, "delete")
+	require.NoError(t, err)
+	require.Empty(t, snap.Snippets)
+	require.Len(t, created, 1)
+	require.Len(t, updated, 1)
+	require.Len(t, deleted, 1, "snippet delete should delete the resource")
+}
+
+func TestPclSnippetOptionValidation(t *testing.T) {
+	t.Parallel()
+
+	loaders := pclSnippetTestProvider(pclSnippetSchemaPropA, nil, nil, nil)
+
+	programF := deploytest.NewLanguageRuntimeF(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	newPlan := func(t *testing.T) *lt.TestPlan {
+		return &lt.TestPlan{
+			Options: lt.TestUpdateOptions{
+				SkipDisplayTests: true,
+				T:                t,
+				HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			},
+		}
+	}
+
+	t.Run("mismatched UUID", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		otherID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{
+			snippetID: {
+				UUID: otherID.String(),
+				Name: "test-resource", Type: "pkgA:index:res",
+				Descriptor: resource.PackageDescriptor{Name: "pkgA"},
+				Code:       `propA = true`,
+			},
+		}
+
+		_, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "mismatched")
+		require.ErrorContains(t, err, fmt.Sprintf("snippet %q has mismatched uuid %q", snippetID, otherID))
+	})
+
+	t.Run("delete missing", func(t *testing.T) {
+		t.Parallel()
+
+		p := newPlan(t)
+		snippetID := uuid.Must(uuid.FromString(newPclSnippetUUID(t)))
+		p.Options.Snippets = map[uuid.UUID]*resource.Snippet{snippetID: nil}
+
+		_, err := lt.TestOp(Update).RunStep(
+			p.GetProject(), p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil, "delete-missing")
+		require.ErrorContains(t, err, fmt.Sprintf("cannot delete snippet %q: no such snippet in snapshot", snippetID))
+	})
+}

--- a/pkg/engine/lifecycletest/pcl_test.go
+++ b/pkg/engine/lifecycletest/pcl_test.go
@@ -1665,7 +1665,7 @@ func TestPclSnippetAddUpdateDeleteViaOption(t *testing.T) {
 		Options: lt.TestUpdateOptions{
 			SkipDisplayTests: true,
 			T:                t,
-			HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+			HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 		},
 	}
 
@@ -1727,7 +1727,7 @@ func TestPclSnippetOptionValidation(t *testing.T) {
 			Options: lt.TestUpdateOptions{
 				SkipDisplayTests: true,
 				T:                t,
-				HostF:            deploytest.NewPluginHostF(nil, nil, programF, loaders...),
+				HostF:            deploytest.NewPluginHostF(nil, nil, programF, nil, nil, loaders...),
 			},
 		}
 	}

--- a/pkg/engine/snapshot.go
+++ b/pkg/engine/snapshot.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 // SnapshotManager manages an in-memory resource graph.
@@ -31,6 +32,9 @@ type SnapshotManager interface {
 	// RebuiltBaseState is called to inform the SnapshotManager that the engine has rebuilt
 	// the base state after a refresh
 	RebuiltBaseState() error
+
+	// SetSnippets replaces the PCL snippets that should be persisted with the next snapshot.
+	SetSnippets(snippets []resource.Snippet) error
 
 	// BeginMutation signals to the SnapshotManager that the planner intends to mutate the global
 	// snapshot. It provides the step that it intends to execute. Based on that step, BeginMutation

--- a/pkg/engine/test_journal.go
+++ b/pkg/engine/test_journal.go
@@ -31,15 +31,17 @@ var _ = SnapshotManager((*TestJournal)(nil))
 type TestJournalEntryKind int
 
 const (
-	TestJournalEntryBegin   TestJournalEntryKind = 0
-	TestJournalEntrySuccess TestJournalEntryKind = 1
-	TestJournalEntryFailure TestJournalEntryKind = 2
-	TestJournalEntryOutputs TestJournalEntryKind = 4
+	TestJournalEntryBegin    TestJournalEntryKind = 0
+	TestJournalEntrySuccess  TestJournalEntryKind = 1
+	TestJournalEntryFailure  TestJournalEntryKind = 2
+	TestJournalEntryOutputs  TestJournalEntryKind = 4
+	TestJournalEntrySnippets TestJournalEntryKind = 8
 )
 
 type TestJournalEntry struct {
-	Kind TestJournalEntryKind
-	Step deploy.Step
+	Kind     TestJournalEntryKind
+	Step     deploy.Step
+	Snippets []resource.Snippet
 }
 
 type JournalEntries []TestJournalEntry
@@ -52,6 +54,10 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 	// Collect extension blobs from ExtensionParameterizeStep entries seen during this plan.
 	liveExtensions := map[apitype.ExtensionRef]apitype.Extension{}
 	for _, e := range entries {
+		if e.Kind == TestJournalEntrySnippets {
+			logging.V(7).Infof("snippets (%v)", len(e.Snippets))
+			continue
+		}
 		logging.V(7).Infof("%v %v (%v)", e.Step.Op(), e.Step.URN(), e.Kind)
 
 		if e.Kind == TestJournalEntrySuccess && e.Step.Op() == deploy.OpExtendParameterize {
@@ -63,6 +69,8 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		// Begin journal entries add pending operations to the snapshot. As we see success or failure
 		// entries, we'll record them in doneOps.
 		switch e.Kind {
+		case TestJournalEntrySnippets:
+			contract.Failf("snippet entries should be handled before step replay")
 		case TestJournalEntryBegin:
 			switch e.Step.Op() {
 			case deploy.OpCreate, deploy.OpCreateReplacement:
@@ -189,6 +197,11 @@ func (entries JournalEntries) Snap(base *deploy.Snapshot) (*deploy.Snapshot, err
 		metadata = base.Metadata
 		snippets = base.Snippets
 	}
+	for _, e := range entries {
+		if e.Kind == TestJournalEntrySnippets {
+			snippets = e.Snippets
+		}
+	}
 
 	manifest := deploy.Manifest{}
 	manifest.Magic = manifest.NewMagic()
@@ -271,6 +284,15 @@ func (j *TestJournal) Write(base *deploy.Snapshot) error {
 
 func (j *TestJournal) RebuiltBaseState() error {
 	return nil
+}
+
+func (j *TestJournal) SetSnippets(snippets []resource.Snippet) error {
+	select {
+	case j.events <- TestJournalEntry{Kind: TestJournalEntrySnippets, Snippets: snippets}:
+		return nil
+	case <-j.cancel:
+		return errors.New("journal closed")
+	}
 }
 
 // NewTestJournal creates a new TestJournal that is used in tests to record journal entries for

--- a/pkg/engine/test_journal.go
+++ b/pkg/engine/test_journal.go
@@ -35,7 +35,7 @@ const (
 	TestJournalEntrySuccess  TestJournalEntryKind = 1
 	TestJournalEntryFailure  TestJournalEntryKind = 2
 	TestJournalEntryOutputs  TestJournalEntryKind = 4
-	TestJournalEntrySnippets TestJournalEntryKind = 8
+	TestJournalEntrySnippets TestJournalEntryKind = 9
 )
 
 type TestJournalEntry struct {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -513,7 +513,7 @@ func targetWithSnippets(target *deploy.Target, snippets []resource.Snippet) *dep
 	}
 	next := *target
 	if next.Snapshot == nil {
-		next.Snapshot = deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, snippets)
+		next.Snapshot = deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, snippets, nil)
 		return &next
 	}
 	snapshot := *next.Snapshot

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/gofrs/uuid"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/display"
 	resourceanalyzer "github.com/pulumi/pulumi/pkg/v3/resource/analyzer"
@@ -436,6 +437,89 @@ type UpdateOptions struct {
 	// otherwise happens during engine setup. Missing plugins will still be installed lazily by
 	// the provider registry when they are actually requested.
 	SkipPluginPreInstall bool
+
+	// Snippets updates the PCL snippets stored in the stack snapshot as part of this deployment. Keys are snippet
+	// UUIDs. A new UUID adds a snippet, an existing UUID replaces that snippet when the value is non-nil, and an
+	// existing UUID with a nil value deletes that snippet.
+	Snippets map[uuid.UUID]*resource.Snippet
+}
+
+func applySnippetUpdates(base []resource.Snippet, updates map[uuid.UUID]*resource.Snippet) ([]resource.Snippet, error) {
+	if len(updates) == 0 {
+		return base, nil
+	}
+
+	byUUID := make(map[uuid.UUID]int, len(base))
+	result := make([]resource.Snippet, 0, len(base)+len(updates))
+	for i, snippet := range base {
+		id, err := uuid.FromString(snippet.UUID)
+		if err != nil {
+			return nil, fmt.Errorf("snippet at index %d has invalid uuid %q", i, snippet.UUID)
+		}
+		if other, ok := byUUID[id]; ok {
+			return nil, fmt.Errorf("duplicate snippet uuid %q at indexes %d and %d", snippet.UUID, other, i)
+		}
+		byUUID[id] = len(result)
+		result = append(result, snippet)
+	}
+
+	keys := make([]uuid.UUID, 0, len(updates))
+	for id := range updates {
+		if id == uuid.Nil {
+			return nil, errors.New("snippet update contains nil uuid")
+		}
+		keys = append(keys, id)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+
+	for _, id := range keys {
+		snippet := updates[id]
+		existing, exists := byUUID[id]
+		if snippet == nil {
+			if !exists {
+				return nil, fmt.Errorf("cannot delete snippet %q: no such snippet in snapshot", id)
+			}
+			result = append(result[:existing], result[existing+1:]...)
+			delete(byUUID, id)
+			for i := existing; i < len(result); i++ {
+				parsed, err := uuid.FromString(result[i].UUID)
+				contract.AssertNoErrorf(err, "validated snippet UUID changed")
+				byUUID[parsed] = i
+			}
+			continue
+		}
+
+		updated := *snippet
+		if updated.UUID != "" && updated.UUID != id.String() {
+			return nil, fmt.Errorf("snippet %q has mismatched uuid %q", id, updated.UUID)
+		}
+		updated.UUID = id.String()
+		if exists {
+			result[existing] = updated
+		} else {
+			byUUID[id] = len(result)
+			result = append(result, updated)
+		}
+	}
+
+	return result, nil
+}
+
+func targetWithSnippets(target *deploy.Target, snippets []resource.Snippet) *deploy.Target {
+	if target == nil {
+		return nil
+	}
+	next := *target
+	if next.Snapshot == nil {
+		next.Snapshot = deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil, deploy.SnapshotMetadata{}, snippets)
+		return &next
+	}
+	snapshot := *next.Snapshot
+	snapshot.Snippets = snippets
+	next.Snapshot = &snapshot
+	return &next
 }
 
 // HasChanges returns true if there are any non-same changes in the resulting summary.
@@ -458,6 +542,18 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 	contract.Requiref(ctx != nil, "ctx", "cannot be nil")
 	defer func() { ctx.Events <- NewCancelEvent() }()
 
+	var baseSnippets []resource.Snippet
+	if u.Target != nil && u.Target.Snapshot != nil {
+		baseSnippets = u.Target.Snapshot.Snippets
+	}
+	effectiveSnippets, err := applySnippetUpdates(baseSnippets, opts.Snippets)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(opts.Snippets) > 0 {
+		u.Target = targetWithSnippets(u.Target, effectiveSnippets)
+	}
+
 	info, err := newDeploymentContext(ctx.Cancel.Base(), u, "update", ctx.ParentSpan)
 	if err != nil {
 		return nil, nil, err
@@ -472,6 +568,12 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (
 
 	logging.V(7).Infof("*** Starting Update(preview=%v) ***", dryRun)
 	defer logging.V(7).Infof("*** Update(preview=%v) complete ***", dryRun)
+
+	if len(opts.Snippets) > 0 && !dryRun && ctx.SnapshotManager != nil {
+		if err := ctx.SnapshotManager.SetSnippets(effectiveSnippets); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	// We skip the target check here because the targeted resource may not exist yet.
 

--- a/sdk/go/common/apitype/journal.go
+++ b/sdk/go/common/apitype/journal.go
@@ -31,6 +31,7 @@ const (
 	JournalEntryKindSecretsManager        JournalEntryKind = 6
 	JournalEntryKindRebuiltBaseState      JournalEntryKind = 7
 	JournalEntryKindExtensionParameterize JournalEntryKind = 8
+	JournalEntryKindSnippets              JournalEntryKind = 9
 )
 
 func (k JournalEntryKind) String() string {
@@ -53,6 +54,8 @@ func (k JournalEntryKind) String() string {
 		return "rebuilt-base-state"
 	case JournalEntryKindExtensionParameterize:
 		return "extension-parameterize"
+	case JournalEntryKindSnippets:
+		return "snippets"
 	default:
 		return "invalid"
 	}
@@ -87,6 +90,8 @@ type JournalEntry struct {
 	IsRefresh bool `json:"isRefresh,omitempty"`
 	// The secrets manager associated with this journal entry, if any.
 	SecretsProvider *SecretsProvidersV1 `json:"secretsProvider,omitempty"`
+	// The complete snippet list associated with this journal entry, if any.
+	Snippets []SnippetV1 `json:"snippets,omitempty"`
 
 	// NewSnapshot is the new snapshot that this journal entry is associated with.
 	NewSnapshot *DeploymentV3 `json:"newSnapshot,omitempty"`
@@ -134,6 +139,9 @@ func (e JournalEntry) String() string {
 	}
 	if e.NewSnapshot != nil {
 		fmt.Fprintf(&sb, ", +snap")
+	}
+	if e.Snippets != nil {
+		fmt.Fprintf(&sb, ", snippets(%v)", len(e.Snippets))
 	}
 
 	return sb.String()


### PR DESCRIPTION
Adds a new engine option to change the snippets in the snapshot as part of the deployment. This lets you add/update/delete snippets before the deployment runs proper.