### PR TITLE
Add `--output` flag to about and whoami commands

### DIFF
--- a/changelog/pending/cli-improvement-20260622-093056.yaml
+++ b/changelog/pending/cli-improvement-20260622-093056.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: improvement
+body: Add `--output` flag to about and whoami commands
+time: 2026-06-22T09:30:56.093672+02:00
+custom:
+  PR: "23651"

--- a/pkg/cmd/pulumi/about/about.go
+++ b/pkg/cmd/pulumi/about/about.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	pkghost "github.com/pulumi/pulumi/pkg/v3/host"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -54,10 +55,20 @@ import (
 )
 
 func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
-	var jsonOut bool
 	var transitiveDependencies bool
 	var stack string
 	short := "Print information about the Pulumi environment."
+
+	output := outputflag.OutputFlag[aboutRenderFunc]{
+		RenderForTerminal: func(w io.Writer, summary summaryAbout) error {
+			summary.Print(w)
+			return nil
+		},
+		RenderJSON: func(w io.Writer, summary summaryAbout) error {
+			return ui.FprintJSON(w, summary)
+		},
+	}
+
 	cmd := &cobra.Command{
 		Use:   "about",
 		Short: short,
@@ -74,11 +85,7 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			summary := getSummaryAbout(ctx, ws, cmdBackend.DefaultLoginManager, transitiveDependencies, stack)
-			if jsonOut {
-				return ui.FprintJSON(cmd.OutOrStdout(), summary)
-			}
-			summary.Print(cmd.OutOrStdout())
-			return nil
+			return output.Get()(cmd.OutOrStdout(), summary)
 		},
 	}
 
@@ -86,8 +93,7 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	cmd.AddCommand(newAboutEnvCmd())
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to get info on. Defaults to the current stack")
@@ -96,6 +102,8 @@ func NewAboutCmd(ws pkgWorkspace.Context) *cobra.Command {
 
 	return cmd
 }
+
+type aboutRenderFunc func(w io.Writer, summary summaryAbout) error
 
 type summaryAbout struct {
 	// We use pointers here to allow the field to be nullable. When

--- a/pkg/cmd/pulumi/whoami/whoami.go
+++ b/pkg/cmd/pulumi/whoami/whoami.go
@@ -17,12 +17,15 @@ package whoami
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
+	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -30,8 +33,25 @@ import (
 )
 
 func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Command {
-	var jsonOut bool
 	var verbose bool
+
+	output := outputflag.OutputFlag[whoAmIRenderFunc]{
+		RenderForTerminal: func(
+			w io.Writer, b backend.Backend, name string, orgs []string, tokenInfo *workspace.TokenInformation,
+		) error {
+			return renderWhoAmIText(w, b, name, orgs, tokenInfo, verbose)
+		},
+		RenderJSON: func(
+			w io.Writer, b backend.Backend, name string, orgs []string, tokenInfo *workspace.TokenInformation,
+		) error {
+			return ui.FprintJSON(w, whoAmIJSON{
+				User:             name,
+				Organizations:    orgs,
+				URL:              b.URL(),
+				TokenInformation: tokenInfo,
+			})
+		},
+	}
 
 	cmd := &cobra.Command{
 		Use:   "whoami",
@@ -67,49 +87,50 @@ func NewWhoAmICmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Co
 				return err
 			}
 
-			if jsonOut {
-				return ui.FprintJSON(stdout, whoAmIJSON{
-					User:             name,
-					Organizations:    orgs,
-					URL:              b.URL(),
-					TokenInformation: tokenInfo,
-				})
-			}
-
-			if verbose {
-				fmt.Fprintf(stdout, "User: %s\n", name)
-				fmt.Fprintf(stdout, "Organizations: %s\n", strings.Join(orgs, ", "))
-				fmt.Fprintf(stdout, "Backend URL: %s\n", b.URL())
-				if tokenInfo != nil {
-					tokenType := "unknown"
-					if tokenInfo.Team != "" {
-						tokenType = "team: " + tokenInfo.Team
-					} else if tokenInfo.Organization != "" {
-						tokenType = "organization: " + tokenInfo.Organization
-					}
-					fmt.Fprintf(stdout, "Token type: %s\n", tokenType)
-					fmt.Fprintf(stdout, "Token name: %s\n", tokenInfo.Name)
-				} else {
-					fmt.Fprintf(stdout, "Token type: personal\n")
-				}
-			} else {
-				fmt.Fprintf(stdout, "%s\n", name)
-			}
-
-			return nil
+			return output.Get()(stdout, b, name, orgs, tokenInfo)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 
 	cmd.PersistentFlags().BoolVarP(
 		&verbose, "verbose", "v", false,
 		"Print detailed whoami information")
 
 	return cmd
+}
+
+type whoAmIRenderFunc func(
+	w io.Writer, b backend.Backend, name string, orgs []string, tokenInfo *workspace.TokenInformation,
+) error
+
+func renderWhoAmIText(
+	w io.Writer, b backend.Backend, name string, orgs []string,
+	tokenInfo *workspace.TokenInformation, verbose bool,
+) error {
+	if !verbose {
+		fmt.Fprintf(w, "%s\n", name)
+		return nil
+	}
+
+	fmt.Fprintf(w, "User: %s\n", name)
+	fmt.Fprintf(w, "Organizations: %s\n", strings.Join(orgs, ", "))
+	fmt.Fprintf(w, "Backend URL: %s\n", b.URL())
+	if tokenInfo == nil {
+		fmt.Fprintf(w, "Token type: personal\n")
+		return nil
+	}
+	tokenType := "unknown"
+	if tokenInfo.Team != "" {
+		tokenType = "team: " + tokenInfo.Team
+	} else if tokenInfo.Organization != "" {
+		tokenType = "organization: " + tokenInfo.Organization
+	}
+	fmt.Fprintf(w, "Token type: %s\n", tokenType)
+	fmt.Fprintf(w, "Token name: %s\n", tokenInfo.Name)
+	return nil
 }
 
 // whoAmIJSON is the shape of the --json output of this command.

--- a/pkg/util/outputflag/outputflag.go
+++ b/pkg/util/outputflag/outputflag.go
@@ -17,8 +17,10 @@ package outputflag
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -31,6 +33,45 @@ func Var[R any](flags *pflag.FlagSet, output *OutputFlag[R]) {
 // -o shorthand.
 func VarP[R any](flags *pflag.FlagSet, output *OutputFlag[R]) {
 	flags.VarP(output, "output", "", usage(*output))
+}
+
+// VarWithJSONAlias registers the OutputFlag on flags as --output and a hidden
+// bool --json/-j alias equivalent to --output=json, and marks the two mutually
+// exclusive.
+// This is used to add the standard `--output $format` flag while preserving
+// the `--json` alias for backwards compatibility.
+func VarWithJSONAlias[R any](cmd *cobra.Command, flags *pflag.FlagSet, output *OutputFlag[R]) {
+	Var(flags, output)
+	f := flags.VarPF(jsonAlias[R]{output: output}, "json", "j",
+		"Emit output as JSON (alias for --output=json)")
+	f.NoOptDefVal = "true" // allow a bare `--json`
+	f.Hidden = true
+	cmd.MarkFlagsMutuallyExclusive("output", "json")
+}
+
+// jsonAlias is a bool-style flag that flips an OutputFlag to "json" when set,
+// backing the --json alias registered by VarWithJSONAlias.
+type jsonAlias[R any] struct{ output *OutputFlag[R] }
+
+func (jsonAlias[R]) Type() string     { return "bool" }
+func (jsonAlias[R]) IsBoolFlag() bool { return true }
+
+func (j jsonAlias[R]) String() string {
+	if j.output != nil && j.output.value == "json" {
+		return "true"
+	}
+	return "false"
+}
+
+func (j jsonAlias[R]) Set(s string) error {
+	on, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	if !on {
+		return nil
+	}
+	return j.output.Set("json")
 }
 
 func usage[R any](output OutputFlag[R]) string {

--- a/pkg/util/outputflag/outputflag_test.go
+++ b/pkg/util/outputflag/outputflag_test.go
@@ -15,8 +15,11 @@
 package outputflag
 
 import (
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +35,73 @@ func allFormats() OutputFlag[string] {
 		RenderYAML:        "yaml",
 		RenderCSV:         "csv",
 	}
+}
+
+func newAliasCmd() (*cobra.Command, *OutputFlag[string]) {
+	f := allFormats()
+	cmd := &cobra.Command{
+		Use:           "test",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          func(*cobra.Command, []string) error { return nil },
+	}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	VarWithJSONAlias(cmd, cmd.Flags(), &f)
+	return cmd, &f
+}
+
+func TestVarWithJSONAlias(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"no flags", nil, "terminal"},
+		{"bare --json", []string{"--json"}, "json"},
+		{"-j shorthand", []string{"-j"}, "json"},
+		{"--json=false stays default", []string{"--json=false"}, "terminal"},
+		{"--output json", []string{"--output", "json"}, "json"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cmd, f := newAliasCmd()
+			cmd.SetArgs(tc.args)
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, tc.want, f.Get())
+		})
+	}
+
+	// --json and --output are mutually exclusive: passing both is an error,
+	// even when they agree (--json --output=json).
+	conflicts := [][]string{
+		{"--json", "--output", "default"},
+		{"--output", "default", "--json"},
+		{"--json", "--output", "json"},
+		{"--json=false", "--output", "json"},
+	}
+	for _, args := range conflicts {
+		t.Run("conflict "+strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+			cmd, _ := newAliasCmd()
+			cmd.SetArgs(args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "none of the others can be")
+		})
+	}
+
+	t.Run("--json flag is hidden", func(t *testing.T) {
+		t.Parallel()
+		cmd, _ := newAliasCmd()
+		require.NotNil(t, cmd.Flags().Lookup("json"))
+		assert.True(t, cmd.Flags().Lookup("json").Hidden)
+		require.NotNil(t, cmd.Flags().Lookup("output"))
+	})
 }
 
 func TestOutputFlag_DefaultUnset(t *testing.T) {


### PR DESCRIPTION
The `VarWithJSONAlias` flag adds our now standard `--output $format` flag along with a hidden `--json` flag for backwards compatibility.

Passing `--json` is equivalent to `--output json`. `--json` and `--output` are mutually exclusive.

Ref https://github.com/pulumi/pulumi/issues/22959