### PR TITLE
add l2-docs to list of bun tests that are flaky

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/language_test.go
@@ -210,7 +210,7 @@ func testLanguage(t *testing.T, runtime string, forceTsc bool) {
 
 					if runtime == "bun" {
 						if tt == "l2-external-enum" || tt == "l2-namespaced-provider" ||
-							tt == "provider-replacement-trigger-component" {
+							tt == "provider-replacement-trigger-component" || tt == "l2-docs" {
 							t.Skip(
 								"On linux bun has trouble resolving indirect dependencies that point to a local file" +
 									"https://github.com/pulumi/pulumi/issues/22100")


### PR DESCRIPTION
These are flaky because they rely on a local dependency, namely @pulumi/docs for this one, which has a dependency on @pulumi/enum, which is the same dependency that's causeing issues for the other tests.  Exclude this test to avoid the flakyness.

Fixes https://github.com/pulumi/pulumi/issues/23631
