### PR TITLE
Simplify `TestInlineConcurrentUpdateError` & `TestConcurrentUpdateError`

### DIFF
--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -19,12 +19,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/python/toolchain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConcurrentUpdateError(t *testing.T) {
@@ -105,16 +105,15 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
+	block := make(chan struct{})
+
 	// initialize
 	s, err := NewStackInlineSource(ctx, stackName, pName, func(ctx *pulumi.Context) error {
-		time.Sleep(5 * time.Second)
+		<-block
 		ctx.Export("exp_static", pulumi.String("foo"))
 		return nil
 	})
-	if err != nil {
-		t.Errorf("failed to initialize stack, err: %v", err)
-		t.FailNow()
-	}
+	require.NoErrorf(t, err, "failed to initialize stack")
 
 	defer func() {
 		// -- pulumi stack rm --
@@ -125,32 +124,22 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 	c := make(chan error)
 
 	// parallel updates to cause conflict
-	for i := 0; i < 50; i++ {
-		go func() {
-			_, err := s.Up(ctx)
-			c <- err
-		}()
+	for range 2 {
+		go func() { _, err := s.Up(ctx); c <- err }()
 	}
 
-	conflicts := 0
+	// One stack successfully entered the program and is waiting on block to close. The only way for a stack
+	// to return is to error before the program, so we assert that's the concurrent update.
+	err = <-c
+	assert.Truef(t, IsConcurrentUpdateError(err), "found %s", err)
 
-	for i := 0; i < 50; i++ {
-		err := <-c
-		if IsConcurrentUpdateError(err) {
-			conflicts++
-		}
-	}
+	// Release the remaining stack to complete, then block until it does.
+	close(block)
+	assert.Nil(t, <-c)
 
 	// -- pulumi destroy --
-
 	_, err = s.Destroy(ctx)
-	if err != nil {
-		t.Errorf("destroy failed, err: %v", err)
-		t.FailNow()
-	}
-
-	// should have at least one conflict
-	assert.Greater(t, conflicts, 0)
+	require.NoError(t, err, "destroy failed")
 }
 
 const compilationErrProj = "compilation_error"

--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -30,22 +30,22 @@ import (
 func TestConcurrentUpdateError(t *testing.T) {
 	t.Parallel()
 
-	// TODO[pulumi/pulumi#8122] - investigate underlying sporadic 404 error
-	t.Skip("disabled as flaky and resource-intensive")
-
-	n := 50
 	ctx := t.Context()
 	pName := "conflict_error"
 	sName := ptesting.RandomStackName()
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
 
+	// The program blocks until this file is removed, letting us hold one update inside the program while a
+	// second update races to produce a concurrent update error.
+	block := filepath.Join(t.TempDir(), "block")
+	require.NoError(t, os.WriteFile(block, nil, 0o600))
+
 	// initialize
 	pDir := filepath.Join(".", "test", "errors", "conflict_error")
 	s, err := NewStackLocalSource(ctx, stackName, pDir)
-	if err != nil {
-		t.Errorf("failed to initialize stack, err: %v", err)
-		t.FailNow()
-	}
+	require.NoErrorf(t, err, "failed to initialize stack")
+
+	s.Workspace().SetEnvVar("PULUMI_TEST_BLOCK_FILE", block)
 
 	defer func() {
 		// -- pulumi stack rm --
@@ -56,45 +56,22 @@ func TestConcurrentUpdateError(t *testing.T) {
 	c := make(chan error)
 
 	// parallel updates to cause conflict
-	for i := 0; i < n; i++ {
-		go func() {
-			_, err := s.Up(ctx)
-			c <- err
-		}()
+	for range 2 {
+		go func() { _, err := s.Up(ctx); c <- err }()
 	}
 
-	conflicts := 0
-	var otherErrors []error
+	// One stack successfully entered the program and is waiting on the block file to be removed. The only way
+	// for a stack to return is to error before the program, so we assert that's the concurrent update.
+	err = <-c
+	assert.Truef(t, IsConcurrentUpdateError(err), "found %s", err)
 
-	for i := 0; i < n; i++ {
-		err := <-c
-		if err != nil {
-			if IsConcurrentUpdateError(err) {
-				conflicts++
-			} else {
-				otherErrors = append(otherErrors, err)
-			}
-		}
-	}
+	// Release the remaining stack to complete, then block until it does.
+	require.NoError(t, os.Remove(block))
+	assert.Nil(t, <-c)
 
 	// -- pulumi destroy --
-
 	_, err = s.Destroy(ctx)
-	if err != nil {
-		t.Errorf("destroy failed, err: %v", err)
-		t.FailNow()
-	}
-
-	if len(otherErrors) > 0 {
-		t.Logf("Concurrent updates incurred %d non-conflict errors, including:", len(otherErrors))
-		for _, err := range otherErrors {
-			t.Error(err)
-		}
-	}
-
-	if conflicts == 0 {
-		t.Errorf("Expected at least one conflict error from the %d concurrent updates, but got none", n)
-	}
+	require.NoError(t, err, "destroy failed")
 }
 
 func TestInlineConcurrentUpdateError(t *testing.T) {

--- a/sdk/go/auto/test/errors/conflict_error/main.go
+++ b/sdk/go/auto/test/errors/conflict_error/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"os"
 	"time"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -11,7 +12,17 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		time.Sleep(5 * time.Second)
+		// Block until the test removes the file named by PULUMI_TEST_BLOCK_FILE. This lets the test
+		// deterministically hold one update inside the program while a second update races to produce a
+		// concurrent update error, instead of relying on a timing-sensitive sleep.
+		if block := os.Getenv("PULUMI_TEST_BLOCK_FILE"); block != "" {
+			for {
+				if _, err := os.Stat(block); os.IsNotExist(err) {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+		}
 		ctx.Export("exp_static", pulumi.String("foo"))
 		return nil
 	})


### PR DESCRIPTION
`TestInlineConcurrentUpdateError` deliberately races 50 concurrent inline updates and then tears the stack down. `TestConcurrentUpdateError` does the same. After fixing the service bug that made this necessary & fixing the logging bug that caused the teardown to sporadically fail, this PR makes the test deterministic, since we no longer need 50 tries to approximate success. 

The resulting test is easier to understand and much faster to run.