### PR TITLE
Change ReplacementTrigger to a property.Value

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -2546,7 +2546,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			ReplaceWith:             replaceWith,
 			IgnoreChanges:           ignoreChanges,
 			ReplaceOnChanges:        replaceOnChanges,
-			ReplacementTrigger:      replacementTrigger,
+			ReplacementTrigger:      resource.FromResourcePropertyValue(replacementTrigger),
 			RetainOnDelete:          retainOnDelete,
 			ResourceHooks:           resourceHooks,
 		}

--- a/sdk/go/common/resource/plugin/provider.go
+++ b/sdk/go/common/resource/plugin/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 type GetSchemaRequest struct {
@@ -926,7 +927,7 @@ type ConstructOptions struct {
 
 	// ReplacementTrigger specifies that if set, the engine will diff this with
 	// the last recorded value, and trigger a replace if they are not equal.
-	ReplacementTrigger resource.PropertyValue
+	ReplacementTrigger property.Value
 
 	// RetainOnDelete is true if deletion of the resource should not
 	// delete the resource in the provider.

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -2012,7 +2012,8 @@ func (p *provider) Construct(ctx context.Context, req ConstructRequest) (Constru
 	// Marshal the replacement trigger.
 	var replacementTrigger *structpb.Value
 	if !req.Options.ReplacementTrigger.IsNull() {
-		trigger, err := MarshalPropertyValue("replacementTrigger", req.Options.ReplacementTrigger, MarshalOptions{
+		value := resource.ToResourcePropertyValue(req.Options.ReplacementTrigger)
+		trigger, err := MarshalPropertyValue("replacementTrigger", value, MarshalOptions{
 			Label:            label + ".replacementTrigger",
 			KeepUnknowns:     req.Info.DryRun,
 			KeepSecrets:      true,

--- a/sdk/go/common/resource/plugin/provider_plugin_test.go
+++ b/sdk/go/common/resource/plugin/provider_plugin_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/testing/diagtest"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -641,7 +642,7 @@ func TestProvider_ConstructOptions(t *testing.T) {
 		{
 			desc: "replacement trigger",
 			give: ConstructOptions{
-				ReplacementTrigger: resource.NewProperty("trigger-value"),
+				ReplacementTrigger: property.New("trigger-value"),
 			},
 			want: &pulumirpc.ConstructRequest{
 				ReplacementTrigger: structpb.NewStringValue("trigger-value"),

--- a/sdk/go/common/resource/plugin/provider_server.go
+++ b/sdk/go/common/resource/plugin/provider_server.go
@@ -936,7 +936,7 @@ func (p *providerServer) Construct(ctx context.Context,
 		ResourceHooks:        hooks,
 		DeletedWith:          resource.URN(req.DeletedWith),
 		ReplaceWith:          replaceWith,
-		ReplacementTrigger:   replacementTrigger,
+		ReplacementTrigger:   resource.FromResourcePropertyValue(replacementTrigger),
 		IgnoreChanges:        req.GetIgnoreChanges(),
 		ReplaceOnChanges:     req.GetReplaceOnChanges(),
 	}


### PR DESCRIPTION
We want to eventually move all `resource.PropertyValue`s to use `property.Value` instead. This is a little chip away at that, changing the `ReplacementTrigger` value in construct.
