### PR TITLE
Update GetPackageConfig to return property.Map

### DIFF
--- a/pkg/resource/deploy/default_providers.go
+++ b/pkg/resource/deploy/default_providers.go
@@ -138,10 +138,11 @@ func (d *defaultProviders) newRegisterDefaultProviderEvent(
 	req providers.ProviderRequest,
 ) (*registerResourceEvent, <-chan *RegisterResult, error) {
 	// Attempt to get the config for the package.
-	inputs, err := d.config.GetPackageConfig(req.Package())
+	minputs, err := d.config.GetPackageConfig(req.Package())
 	if err != nil {
 		return nil, nil, err
 	}
+	inputs := resource.ToResourcePropertyMap(minputs)
 	if req.Version() != nil {
 		providers.SetProviderVersion(inputs, req.Version())
 	}
@@ -270,19 +271,19 @@ func (d *defaultProviders) shouldDenyRequest(req providers.ProviderRequest) (boo
 	}
 
 	denyCreation := false
-	if value, ok := pConfig["disable-default-providers"]; ok {
+	if value, ok := pConfig.GetOk("disable-default-providers"); ok {
 		array := []any{}
 		if !value.IsString() {
 			return true, errors.New("Unexpected encoding of pulumi:disable-default-providers")
 		}
-		if value.StringValue() == "" {
+		if value.AsString() == "" {
 			// If the list is provided but empty, we don't encode a empty json
 			// list, we just encode the empty string. Check to ensure we don't
 			// get parse errors.
 			return false, nil
 		}
-		if err := json.Unmarshal([]byte(value.StringValue()), &array); err != nil {
-			return true, fmt.Errorf("Failed to parse %s: %w", value.StringValue(), err)
+		if err := json.Unmarshal([]byte(value.AsString()), &array); err != nil {
+			return true, fmt.Errorf("Failed to parse %s: %w", value.AsString(), err)
 		}
 		for i, v := range array {
 			s, ok := v.(string)

--- a/pkg/resource/deploy/default_providers_test.go
+++ b/pkg/resource/deploy/default_providers_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 func TestDefaultProviders(t *testing.T) {
@@ -46,11 +46,7 @@ func TestDefaultProviders(t *testing.T) {
 						},
 					},
 				},
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return resource.PropertyMap{}, nil
-					},
-				},
+				config: &configSourceMock{},
 			}
 			req := d.normalizeProviderRequest(providers.NewProviderRequest(tokens.Package("pkg"), nil, "", nil, nil))
 			require.NotNil(t, req)
@@ -66,8 +62,8 @@ func TestDefaultProviders(t *testing.T) {
 			expectedErr := errors.New("expected error")
 			d := &defaultProviders{
 				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, expectedErr
+					GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+						return property.Map{}, expectedErr
 					},
 				},
 			}
@@ -82,8 +78,8 @@ func TestDefaultProviders(t *testing.T) {
 			expectedErr := errors.New("expected error")
 			d := &defaultProviders{
 				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, expectedErr
+					GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+						return property.Map{}, expectedErr
 					},
 				},
 			}
@@ -95,13 +91,13 @@ func TestDefaultProviders(t *testing.T) {
 			expectedErr := errors.New("expected error")
 			d := &defaultProviders{
 				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
+					GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
 						if pkg == "pulumi" {
 							// Enables shouldDenyRequest(req) to succeed as it always calls using
 							// "pulumi".
-							return nil, nil
+							return property.Map{}, nil
 						}
-						return nil, expectedErr
+						return property.Map{}, expectedErr
 					},
 				},
 			}
@@ -114,11 +110,7 @@ func TestDefaultProviders(t *testing.T) {
 			cancel <- true
 			d := &defaultProviders{
 				cancel: cancel,
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			}
 			_, err := d.handleRequest(providers.ProviderRequest{})
 			assert.ErrorIs(t, err, context.Canceled)
@@ -131,11 +123,7 @@ func TestDefaultProviders(t *testing.T) {
 			d := &defaultProviders{
 				cancel:          cancel,
 				providerRegChan: providerRegChan,
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config:          &configSourceMock{},
 			}
 			go func() {
 				// Cancel after reading the registration.
@@ -154,8 +142,8 @@ func TestDefaultProviders(t *testing.T) {
 			expectedErr := errors.New("expected error")
 			d := &defaultProviders{
 				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, expectedErr
+					GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+						return property.Map{}, expectedErr
 					},
 				},
 			}
@@ -168,10 +156,10 @@ func TestDefaultProviders(t *testing.T) {
 				t.Parallel()
 				d := &defaultProviders{
 					config: &configSourceMock{
-						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-							return resource.PropertyMap{
-								"disable-default-providers": resource.NewProperty(100.0),
-							}, nil
+						GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+							return property.NewMap(map[string]property.Value{
+								"disable-default-providers": property.New(100.0),
+							}), nil
 						},
 					},
 				}
@@ -182,10 +170,10 @@ func TestDefaultProviders(t *testing.T) {
 				t.Parallel()
 				d := &defaultProviders{
 					config: &configSourceMock{
-						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-							return resource.PropertyMap{
-								"disable-default-providers": resource.NewProperty(""),
-							}, nil
+						GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+							return property.NewMap(map[string]property.Value{
+								"disable-default-providers": property.New(""),
+							}), nil
 						},
 					},
 				}
@@ -198,10 +186,10 @@ func TestDefaultProviders(t *testing.T) {
 					t.Parallel()
 					d := &defaultProviders{
 						config: &configSourceMock{
-							GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-								return resource.PropertyMap{
-									"disable-default-providers": resource.NewProperty("[[["),
-								}, nil
+							GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+								return property.NewMap(map[string]property.Value{
+									"disable-default-providers": property.New("[[["),
+								}), nil
 							},
 						},
 					}
@@ -213,10 +201,10 @@ func TestDefaultProviders(t *testing.T) {
 					t.Parallel()
 					d := &defaultProviders{
 						config: &configSourceMock{
-							GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-								return resource.PropertyMap{
-									"disable-default-providers": resource.NewProperty(`["foo", 2, 3]`),
-								}, nil
+							GetPackageConfigF: func(pkg tokens.Package) (property.Map, error) {
+								return property.NewMap(map[string]property.Value{
+									"disable-default-providers": property.New(`["foo", 2, 3]`),
+								}), nil
 							},
 						},
 					}

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -411,10 +411,11 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) (bool, e
 		pkg := res.URN.Type().Package()
 		ref, ok := defaultProviderRefs[pkg]
 		if !ok {
-			inputs, err := target.GetPackageConfig(pkg)
+			minputs, err := target.GetPackageConfig(pkg)
 			if err != nil {
 				return false, fmt.Errorf("could not fetch configuration for default provider '%v'", pkg)
 			}
+			inputs := resource.ToResourcePropertyMap(minputs)
 			if pkgInfo, ok := defaultProviderInfo[pkg]; ok {
 				providers.SetProviderVersion(inputs, pkgInfo.Version)
 				providers.SetProviderURL(inputs, pkgInfo.PluginDownloadURL)

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -364,10 +364,11 @@ func (i *importer) registerProviders(ctx context.Context) (map[resource.URN]stri
 		urn := i.deployment.generateURN("", typ, name)
 
 		// Fetch, prepare, and check the configuration for this provider.
-		inputs, err := i.deployment.target.GetPackageConfig(req.Package())
+		minputs, err := i.deployment.target.GetPackageConfig(req.Package())
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch provider config: %w", err)
 		}
+		inputs := resource.ToResourcePropertyMap(minputs)
 
 		// Calculate the inputs for the provider using the ambient config.
 		if v := req.Version(); v != nil {

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -2907,16 +2908,16 @@ func TestParseSourcePosition(t *testing.T) {
 }
 
 type configSourceMock struct {
-	GetPackageConfigF func(pkg tokens.Package) (resource.PropertyMap, error)
+	GetPackageConfigF func(pkg tokens.Package) (property.Map, error)
 }
 
 var _ plugin.ConfigSource = (*configSourceMock)(nil)
 
-func (c *configSourceMock) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, error) {
+func (c *configSourceMock) GetPackageConfig(pkg tokens.Package) (property.Map, error) {
 	if c.GetPackageConfigF != nil {
 		return c.GetPackageConfigF(pkg)
 	}
-	panic("unimplemented")
+	return property.Map{}, nil
 }
 
 func TestInvoke(t *testing.T) {
@@ -3429,11 +3430,7 @@ func TestReadResource(t *testing.T) {
 		rm := &resmon{
 			defaultProviders: &defaultProviders{
 				cancel: cancel,
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		_, err := rm.ReadResource(t.Context(), &pulumirpc.ReadResourceRequest{
@@ -3446,11 +3443,7 @@ func TestReadResource(t *testing.T) {
 		t.Parallel()
 		rm := &resmon{
 			defaultProviders: &defaultProviders{
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		_, err := rm.ReadResource(t.Context(), &pulumirpc.ReadResourceRequest{
@@ -3468,11 +3461,7 @@ func TestReadResource(t *testing.T) {
 		t.Parallel()
 		rm := &resmon{
 			defaultProviders: &defaultProviders{
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		_, err := rm.ReadResource(t.Context(), &pulumirpc.ReadResourceRequest{
@@ -3492,11 +3481,7 @@ func TestReadResource(t *testing.T) {
 		rm := &resmon{
 			regReadChan: regReadChan,
 			defaultProviders: &defaultProviders{
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		wg := &sync.WaitGroup{}
@@ -3523,11 +3508,7 @@ func TestReadResource(t *testing.T) {
 		rm := &resmon{
 			cancel: cancel,
 			defaultProviders: &defaultProviders{
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		wg := &sync.WaitGroup{}
@@ -3552,11 +3533,7 @@ func TestReadResource(t *testing.T) {
 			regReadChan: regReadChan,
 			cancel:      cancel,
 			defaultProviders: &defaultProviders{
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config: &configSourceMock{},
 			},
 		}
 		wg := &sync.WaitGroup{}
@@ -3727,11 +3704,7 @@ func TestRegisterResource(t *testing.T) {
 			rm := &resmon{
 				defaultProviders: &defaultProviders{
 					requests: requests,
-					config: &configSourceMock{
-						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-							return nil, nil
-						},
-					},
+					config:   &configSourceMock{},
 				},
 			}
 			req := &pulumirpc.RegisterResourceRequest{
@@ -3761,11 +3734,7 @@ func TestRegisterResource(t *testing.T) {
 			rm := &resmon{
 				defaultProviders: &defaultProviders{
 					requests: requests,
-					config: &configSourceMock{
-						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-							return nil, nil
-						},
-					},
+					config:   &configSourceMock{},
 				},
 				providers: &providerSourceMock{
 					Provider: &deploytest.Provider{},
@@ -3799,11 +3768,7 @@ func TestRegisterResource(t *testing.T) {
 			rm := &resmon{
 				defaultProviders: &defaultProviders{
 					requests: requests,
-					config: &configSourceMock{
-						GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-							return nil, nil
-						},
-					},
+					config:   &configSourceMock{},
 				},
 				providers: &providerSourceMock{},
 			}
@@ -3835,11 +3800,7 @@ func TestRegisterResource(t *testing.T) {
 		rm := &resmon{
 			defaultProviders: &defaultProviders{
 				requests: requests,
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config:   &configSourceMock{},
 			},
 			providers: &providerSourceMock{
 				Provider: &deploytest.Provider{
@@ -4053,11 +4014,7 @@ func TestValidationFailures(t *testing.T) {
 			abortChan:   abortChan,
 			defaultProviders: &defaultProviders{
 				requests: requests,
-				config: &configSourceMock{
-					GetPackageConfigF: func(pkg tokens.Package) (resource.PropertyMap, error) {
-						return nil, nil
-					},
-				},
+				config:   &configSourceMock{},
 			},
 			providers: &providerSourceMock{
 				Provider: &deploytest.Provider{

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -15,9 +15,9 @@
 package deploy
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // Target represents information about a deployment target.
@@ -43,12 +43,12 @@ func isDynamicProvider(pkg tokens.Package) bool {
 }
 
 // GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
-func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, error) {
-	result := resource.PropertyMap{}
+func (t *Target) GetPackageConfig(pkg tokens.Package) (property.Map, error) {
 	if t == nil {
-		return result, nil
+		return property.Map{}, nil
 	}
 
+	result := make(map[string]property.Value)
 	for k, c := range t.Config {
 		// For dynamic providers, we always pass the full configuration.
 		if !isDynamicProvider(pkg) && tokens.Package(k.Namespace()) != pkg {
@@ -57,19 +57,16 @@ func (t *Target) GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, err
 
 		v, err := c.Value(t.Decrypter)
 		if err != nil {
-			return nil, err
+			return property.Map{}, err
 		}
 
-		propertyValue := resource.NewProperty(v)
-		if c.Secure() {
-			propertyValue = resource.MakeSecret(propertyValue)
-		}
+		propertyValue := property.New(v).WithSecret(c.Secure())
 		if isDynamicProvider(pkg) {
 			// For dynamic providers, we want to maintain the namespace.
-			result[resource.PropertyKey(k.String())] = propertyValue
+			result[k.String()] = propertyValue
 		} else {
-			result[resource.PropertyKey(k.Name())] = propertyValue
+			result[k.Name()] = propertyValue
 		}
 	}
-	return result, nil
+	return property.NewMap(result), nil
 }

--- a/pkg/resource/deploy/target_test.go
+++ b/pkg/resource/deploy/target_test.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,16 +82,15 @@ func TestTarget(t *testing.T) {
 					},
 				},
 			}
-			res, err := target.GetPackageConfig("test")
+			cfg, err := target.GetPackageConfig("test")
 			require.NoError(t, err, expectedErr)
 
-			cfg := res.Mappable()
-			assert.Equal(t, "regular-value", cfg["regular"])
-			secret, ok := cfg["secret"].(*resource.Secret)
+			assert.Equal(t, property.New("regular-value"), cfg.Get("regular"))
+			secret, ok := cfg.GetOk("secret")
 			assert.True(t, ok)
-			assert.Equal(t, "secret-value", secret.Element.V)
+			assert.Equal(t, property.New("secret-value").WithSecret(true), secret)
 
-			_, ok = cfg["a"].(*resource.Secret)
+			_, ok = cfg.GetOk("a")
 			assert.False(t, ok)
 		})
 	})

--- a/sdk/go/common/resource/plugin/config_source.go
+++ b/sdk/go/common/resource/plugin/config_source.go
@@ -15,13 +15,13 @@
 package plugin
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // ConfigSource is an interface that allows a plugin context to fetch configuration data for a plugin named by
 // package.
 type ConfigSource interface {
 	// GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
-	GetPackageConfig(pkg tokens.Package) (resource.PropertyMap, error)
+	GetPackageConfig(pkg tokens.Package) (property.Map, error)
 }


### PR DESCRIPTION
Continuing trying to move to `property.Value` and its ilk. This updates one small method in the engine `ConfigSource.GetPackageConfig` to return a `property.Map` instead of a `resource.PropertyMap`.