### PR TITLE
run uv commands with retries

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1120,6 +1120,26 @@ func (pt *ProgramTester) runCommand(name string, args []string, wd string) error
 	return RunCommandPulumiHome(pt.t, name, args, wd, pt.opts, pt.pulumiHome)
 }
 
+// runCommandWithRetries runs a command, retrying up to maxTries on failure to absorb transient
+// errors such as network blips and shared-cache races.
+func (pt *ProgramTester) runCommandWithRetries(name string, args []string, wd string) error {
+	maxTries := 3
+	_, _, err := retry.Until(context.Background(), retry.Acceptor{
+		Accept: func(try int, _ time.Duration) (bool, any, error) {
+			runerr := pt.runCommand(name, args, wd)
+			if runerr == nil {
+				return true, nil, nil
+			}
+			if try+1 >= maxTries {
+				return false, nil, runerr
+			}
+			pt.t.Logf("%v failed: %v; retrying...", strings.Join(args, " "), runerr)
+			return false, nil, nil
+		},
+	})
+	return err
+}
+
 // RunPulumiCommand runs a Pulumi command in the project directory.
 // For example:
 //
@@ -2728,7 +2748,7 @@ func (pt *ProgramTester) preparePythonProjectWithUv(projinfo *engine.Projinfo, c
 	if pt.opts.InstallDevReleases {
 		syncArgs = append(syncArgs, "--prerelease=allow")
 	}
-	if err := pt.runCommand("uv-sync", syncArgs, cwd); err != nil {
+	if err := pt.runCommandWithRetries("uv-sync", syncArgs, cwd); err != nil {
 		return err
 	}
 
@@ -2751,7 +2771,7 @@ func (pt *ProgramTester) preparePythonProjectWithUv(projinfo *engine.Projinfo, c
 			}
 			dep = abs
 		}
-		if err := pt.runCommand("uv-add", []string{uvBin, "add", "--editable", dep}, cwd); err != nil {
+		if err := pt.runCommandWithRetries("uv-add", []string{uvBin, "add", "--editable", dep}, cwd); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
uv sometimes flakes on windows because of busy cache directories, see for example https://github.com/pulumi/pulumi/actions/runs/27964127588/job/82756236134.

Add some retries in testing, where we run many uv commands concurrently, to try and avoid this flake.
