### PR TITLE
Fix ci-info when changelogs are backfilled

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Backfill PR numbers in pending changelog entries
         run: |
           python3 scripts/changie-pr-lookup.py
+          git add changelog/pending
+          # Commit changes made so `git status` in "Check version" doesn't always fire
+          git commit -m "Backfill PR numbers in pending changelog entries" || echo "No changes to commit"
       - name: Extract release notes
         id: notes
         run: |


### PR DESCRIPTION
When `scripts/changie-pr-lookup.py` fills in PR numbers it causes the later `git status` check after calling `./.github/scripts/update-versions` to always fail. This commits the changelog changes so the later git status only triggers if update-versions changed something.