### PR TITLE
Fix ci-info when changelogs are backfilled (take 2)

### DIFF
--- a/.github/workflows/ci-info.yml
+++ b/.github/workflows/ci-info.yml
@@ -67,9 +67,12 @@ jobs:
       - name: Backfill PR numbers in pending changelog entries
         run: |
           python3 scripts/changie-pr-lookup.py
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add changelog/pending
-          # Commit changes made so `git status` in "Check version" doesn't always fire
-          git commit -m "Backfill PR numbers in pending changelog entries" || echo "No changes to commit"
+          # Commit changes made so `git status` in "Check version" doesn't always fire.
+          # Allow an empty commit so the step succeeds even when there is nothing to backfill.
+          git commit --allow-empty -m "Backfill PR numbers in pending changelog entries"
       - name: Extract release notes
         id: notes
         run: |


### PR DESCRIPTION
Follow-up on https://github.com/pulumi/pulumi/pull/23674, this should enable the commit to actually take.

