### PR TITLE
Add `--output $format` flag to `pulumi stack {list,history,tag list}`

### DIFF
--- a/changelog/pending/cli-improvement-20260624-153612.yaml
+++ b/changelog/pending/cli-improvement-20260624-153612.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Add `--output $format` flag to `pulumi stack {list,history,tag list}`
+time: 2026-06-24T15:36:12.642705+02:00

--- a/pkg/cmd/pulumi/stack/stack_history.go
+++ b/pkg/cmd/pulumi/stack/stack_history.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -40,13 +41,22 @@ import (
 
 const errorDecryptingValue = "ERROR_UNABLE_TO_DECRYPT"
 
+type stackHistoryRenderFunc func(w io.Writer, updates []backend.UpdateInfo, decrypter config.Decrypter) error
+
 func newStackHistoryCmd() *cobra.Command {
 	var stack string
-	var jsonOut bool
 	var showSecrets bool
 	var pageSize int
 	var page int
 	var showFullDates bool
+
+	output := outputflag.OutputFlag[stackHistoryRenderFunc]{
+		RenderForTerminal: func(w io.Writer, updates []backend.UpdateInfo, _ config.Decrypter) error {
+			return displayUpdatesConsole(w, updates, page,
+				display.Options{Color: cmdutil.GetGlobalColorization()}, showFullDates)
+		},
+		RenderJSON: displayUpdatesJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:        "history",
@@ -107,11 +117,7 @@ This command displays data about previous updates for a stack.`,
 				Log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack history")
 			}
 
-			if jsonOut {
-				return displayUpdatesJSON(cmd.OutOrStdout(), updates, decrypter)
-			}
-
-			return displayUpdatesConsole(cmd.OutOrStdout(), updates, page, opts, showFullDates)
+			return output.Get()(cmd.OutOrStdout(), updates, decrypter)
 		},
 	}
 
@@ -123,8 +129,7 @@ This command displays data about previous updates for a stack.`,
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false,
 		"Show secret values when listing config instead of displaying blinded values")
-	cmd.Flags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.Flags(), &output)
 	cmd.Flags().BoolVar(
 		&showFullDates, "full-dates", false, "Show full dates, instead of relative dates")
 	cmd.Flags().IntVar(

--- a/pkg/cmd/pulumi/stack/stack_list.go
+++ b/pkg/cmd/pulumi/stack/stack_list.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -42,12 +43,24 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type stackSummariesRenderFunc func(
+	w io.Writer, b backend.Backend, currentStack string, stackSummaries []backend.StackSummary,
+) error
+
 func newStackListCmd() *cobra.Command {
-	var jsonOut bool
 	var allStacks bool
 	var orgFilter string
 	var projFilter string
 	var tagFilter string
+
+	output := outputflag.OutputFlag[stackSummariesRenderFunc]{
+		RenderForTerminal: formatStackSummariesConsole,
+		RenderJSON: func(
+			w io.Writer, b backend.Backend, currentStack string, stackSummaries []backend.StackSummary,
+		) error {
+			return formatStackSummariesJSON(b, currentStack, stackSummaries, w)
+		},
+	}
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -65,12 +78,12 @@ func newStackListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			cmdArgs := stackLSArgs{
-				jsonOut:    jsonOut,
-				allStacks:  allStacks,
-				orgFilter:  orgFilter,
-				projFilter: projFilter,
-				tagFilter:  tagFilter,
-				stdout:     cmd.OutOrStdout(),
+				renderOutput: output.Get(),
+				allStacks:    allStacks,
+				orgFilter:    orgFilter,
+				projFilter:   projFilter,
+				tagFilter:    tagFilter,
+				stdout:       cmd.OutOrStdout(),
 			}
 			return runStackLS(ctx, cmdArgs)
 		},
@@ -78,8 +91,7 @@ func newStackListCmd() *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 
 	cmd.PersistentFlags().BoolVarP(
 		&allStacks, "all", "a", false, "List all stacks instead of just stacks for the current project")
@@ -95,17 +107,20 @@ func newStackListCmd() *cobra.Command {
 }
 
 type stackLSArgs struct {
-	jsonOut    bool
-	allStacks  bool
-	orgFilter  string
-	projFilter string
-	tagFilter  string
-	stdout     io.Writer
+	renderOutput stackSummariesRenderFunc
+	allStacks    bool
+	orgFilter    string
+	projFilter   string
+	tagFilter    string
+	stdout       io.Writer
 }
 
 func runStackLS(ctx context.Context, args stackLSArgs) error {
 	if args.stdout == nil {
 		args.stdout = io.Discard
+	}
+	if args.renderOutput == nil {
+		args.renderOutput = formatStackSummariesConsole
 	}
 	// Build up the stack filters. We do not support accepting empty strings as filters
 	// from command-line arguments, though the API technically supports it.
@@ -195,11 +210,7 @@ func runStackLS(ctx context.Context, args stackLSArgs) error {
 		return allStackSummaries[i].Name().String() < allStackSummaries[j].Name().String()
 	})
 
-	if args.jsonOut {
-		return formatStackSummariesJSON(b, current, allStackSummaries, args.stdout)
-	}
-
-	return formatStackSummariesConsole(args.stdout, b, current, allStackSummaries)
+	return args.renderOutput(args.stdout, b, current, allStackSummaries)
 }
 
 // parseTagFilter parses a tag filter into its separate name and value parts, separatedby an equal sign.

--- a/pkg/cmd/pulumi/stack/stack_list_test.go
+++ b/pkg/cmd/pulumi/stack/stack_list_test.go
@@ -17,6 +17,7 @@ package stack
 import (
 	"bytes"
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -230,7 +231,11 @@ func TestListStacksJsonProgress(t *testing.T) {
 	var buff bytes.Buffer
 	ctx := t.Context()
 	args := stackLSArgs{
-		jsonOut:   true,
+		renderOutput: func(
+			w io.Writer, b backend.Backend, currentStack string, stackSummaries []backend.StackSummary,
+		) error {
+			return formatStackSummariesJSON(b, currentStack, stackSummaries, w)
+		},
 		allStacks: true,
 		stdout:    &buff,
 	}
@@ -288,7 +293,11 @@ func TestListStacksJsonNoProgress(t *testing.T) {
 	var buff bytes.Buffer
 	ctx := t.Context()
 	args := stackLSArgs{
-		jsonOut:   true,
+		renderOutput: func(
+			w io.Writer, b backend.Backend, currentStack string, stackSummaries []backend.StackSummary,
+		) error {
+			return formatStackSummariesJSON(b, currentStack, stackSummaries, w)
+		},
 		allStacks: true,
 		stdout:    &buff,
 	}

--- a/pkg/cmd/pulumi/stack/stack_tag.go
+++ b/pkg/cmd/pulumi/stack/stack_tag.go
@@ -26,11 +26,14 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 )
+
+type stackTagsRenderFunc func(w io.Writer, tags map[apitype.StackTagName]string) error
 
 func newStackTagCmd() *cobra.Command {
 	var stack string
@@ -107,7 +110,15 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 }
 
 func newStackTagListCmd(stack *string) *cobra.Command {
-	var jsonOut bool
+	output := outputflag.OutputFlag[stackTagsRenderFunc]{
+		RenderForTerminal: func(w io.Writer, tags map[apitype.StackTagName]string) error {
+			printStackTags(w, tags)
+			return nil
+		},
+		RenderJSON: func(w io.Writer, tags map[apitype.StackTagName]string) error {
+			return ui.FprintJSON(w, tags)
+		},
+	}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -136,19 +147,13 @@ func newStackTagListCmd(stack *string) *cobra.Command {
 
 			tags := s.Tags()
 
-			if jsonOut {
-				return ui.FprintJSON(cmd.OutOrStdout(), tags)
-			}
-
-			printStackTags(cmd.OutOrStdout(), tags)
-			return nil
+			return output.Get()(cmd.OutOrStdout(), tags)
 		},
 	}
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 
 	return cmd
 }


### PR DESCRIPTION
Another set of commands now take `--output $format`, with `--json` as a hidden flag for backwards comatibility.

Ref https://github.com/pulumi/pulumi/issues/22959