### PR TITLE
Add `--output $format` to `pulumi plugin list`

### DIFF
--- a/changelog/pending/cli-plugin-improvement-20260624-163155.yaml
+++ b/changelog/pending/cli-plugin-improvement-20260624-163155.yaml
@@ -1,0 +1,4 @@
+component: cli/plugin
+kind: improvement
+body: Add `--output $format` to `pulumi plugin list`
+time: 2026-06-24T16:31:55.615492+02:00

--- a/pkg/cmd/pulumi/plugin/plugin_list.go
+++ b/pkg/cmd/pulumi/plugin/plugin_list.go
@@ -27,14 +27,20 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
 	"github.com/pulumi/pulumi/pkg/v3/pluginstorage"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type pluginListRenderFunc func(w io.Writer, plugins []workspace.PluginInfo) error
+
 func newPluginListCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	var projectOnly bool
-	var jsonOut bool
+	output := outputflag.OutputFlag[pluginListRenderFunc]{
+		RenderForTerminal: formatPluginConsole,
+		RenderJSON:        formatPluginsJSON,
+	}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -72,10 +78,7 @@ func newPluginListCmd(pluginContext pluginstorage.Context) *cobra.Command {
 				return false
 			})
 
-			if jsonOut {
-				return formatPluginsJSON(cmd.OutOrStdout(), plugins)
-			}
-			return formatPluginConsole(cmd.OutOrStdout(), plugins)
+			return output.Get()(cmd.OutOrStdout(), plugins)
 		},
 	}
 
@@ -84,9 +87,7 @@ func newPluginListCmd(pluginContext pluginstorage.Context) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&projectOnly, "project", "p", false,
 		"List only the plugins used by the current project")
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false,
-		"Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 
 	return cmd
 }


### PR DESCRIPTION
Use the standard `--output $format` flag to handle different formats. `--json` remains as a hidden flag for backwards compatibility.

Ref https://github.com/pulumi/pulumi/issues/22959