### PR TITLE
Add --skip-config-validation flag to preview, up, refresh, and destroy

### DIFF
--- a/changelog/pending/cli-feat-skip-config-validation.yaml
+++ b/changelog/pending/cli-feat-skip-config-validation.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Add `--skip-config-validation` flag to preview, up, refresh, and destroy to skip validation of stack config against the project config schema
+time: 2026-06-24T12:45:00.000000-04:00

--- a/changelog/pending/cli-feat-skip-config-validation.yaml
+++ b/changelog/pending/cli-feat-skip-config-validation.yaml
@@ -2,3 +2,5 @@ component: cli
 kind: feat
 body: Add `--skip-config-validation` flag to preview, up, refresh, and destroy to skip validation of stack config against the project config schema
 time: 2026-06-24T12:45:00.000000-04:00
+custom:
+  PR: "23691"

--- a/pkg/cmd/pulumi/config/config.go
+++ b/pkg/cmd/pulumi/config/config.go
@@ -1115,7 +1115,7 @@ func listConfig(
 
 	// when listing configuration values
 	// also show values coming from the project and environment
-	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter)
+	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter, nil)
 	if err != nil {
 		return err
 	}
@@ -1296,7 +1296,7 @@ func getConfig(
 	}
 
 	// when asking for a configuration value, include values from the project and environment
-	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter)
+	err = workspace.ApplyProjectConfig(ctx, stackName, project, pulumiEnv, cfg, envCrypter, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/config/io_test.go
+++ b/pkg/cmd/pulumi/config/io_test.go
@@ -446,7 +446,8 @@ func TestStackEnvConfig(t *testing.T) {
 	assert.Nil(t, cfg.Config)
 	cfg.Config = config.Map{}
 
-	err = workspace.ApplyProjectConfig(ctx, "mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter)
+	err = workspace.ApplyProjectConfig(
+		ctx, "mystack", &project, cfg.Environment, cfg.Config, config.NopEncrypter, config.NopDecrypter)
 	require.NoError(t, err)
 
 	assert.Equal(t, config.Map{

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -275,17 +275,25 @@ func NewDestroyCmd() *cobra.Command {
 			// or when explicitly requested via --skip-config-validation. This allows stacks with
 			// missing or invalid config to be destroyed in scenarios such as ephemeral PR environments
 			// where config may diverge between branches.
-			if runProgram && !skipConfigValidation {
-				configError := workspace.ValidateStackConfigAndApplyProjectConfig(
-					ctx,
-					stackName,
-					proj,
-					cfg.Environment,
-					cfg.Config,
-					encrypter,
-					decrypter)
-				if configError != nil {
-					return fmt.Errorf("validating stack config: %w", configError)
+			if runProgram {
+				if skipConfigValidation {
+					// Still apply project config defaults onto the stack config, but skip validation.
+					if configError := workspace.ApplyProjectConfigWithoutValidation(
+						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configError != nil {
+						return fmt.Errorf("applying stack config: %w", configError)
+					}
+				} else {
+					configError := workspace.ValidateStackConfigAndApplyProjectConfig(
+						ctx,
+						stackName,
+						proj,
+						cfg.Environment,
+						cfg.Config,
+						encrypter,
+						decrypter)
+					if configError != nil {
+						return fmt.Errorf("validating stack config: %w", configError)
+					}
 				}
 			}
 

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -275,25 +275,25 @@ func NewDestroyCmd() *cobra.Command {
 			// or when explicitly requested via --skip-config-validation. This allows stacks with
 			// missing or invalid config to be destroyed in scenarios such as ephemeral PR environments
 			// where config may diverge between branches.
-			if runProgram {
-				if skipConfigValidation {
-					// Still apply project config defaults onto the stack config, but skip validation.
-					if configError := workspace.ApplyProjectConfig(
-						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configError != nil {
-						return fmt.Errorf("applying stack config: %w", configError)
-					}
-				} else {
-					configError := workspace.ValidateStackConfigAndApplyProjectConfig(
-						ctx,
-						stackName,
-						proj,
-						cfg.Environment,
-						cfg.Config,
-						encrypter,
-						decrypter)
-					if configError != nil {
-						return fmt.Errorf("validating stack config: %w", configError)
-					}
+			if runProgram && !skipConfigValidation {
+				// Running the program: validate the stack config (and apply project defaults).
+				configError := workspace.ValidateStackConfigAndApplyProjectConfig(
+					ctx,
+					stackName,
+					proj,
+					cfg.Environment,
+					cfg.Config,
+					encrypter,
+					decrypter)
+				if configError != nil {
+					return fmt.Errorf("validating stack config: %w", configError)
+				}
+			} else {
+				// The program isn't run, or validation was explicitly skipped: still apply
+				// project config defaults onto the stack config, but skip validation.
+				if configError := workspace.ApplyProjectConfig(
+					ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configError != nil {
+					return fmt.Errorf("applying stack config: %w", configError)
 				}
 			}
 

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -405,7 +405,7 @@ func NewDestroyCmd() *cobra.Command {
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to destroy resources")
 	cmd.PersistentFlags().BoolVar(
-		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		&skipConfigValidation, "skip-config-validation", false,
 		"Skip validation of stack config values against the project config schema. "+
 			"Config validation is skipped automatically when --run-program is not set.")
 

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -278,7 +278,7 @@ func NewDestroyCmd() *cobra.Command {
 			if runProgram {
 				if skipConfigValidation {
 					// Still apply project config defaults onto the stack config, but skip validation.
-					if configError := workspace.ApplyProjectConfigWithoutValidation(
+					if configError := workspace.ApplyProjectConfig(
 						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configError != nil {
 						return fmt.Errorf("applying stack config: %w", configError)
 					}

--- a/pkg/cmd/pulumi/operations/destroy.go
+++ b/pkg/cmd/pulumi/operations/destroy.go
@@ -51,6 +51,7 @@ import (
 
 func NewDestroyCmd() *cobra.Command {
 	var runProgram bool
+	var skipConfigValidation bool
 	var debug bool
 	var remove bool
 	var stackName string
@@ -270,16 +271,22 @@ func NewDestroyCmd() *cobra.Command {
 			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
-			configError := workspace.ValidateStackConfigAndApplyProjectConfig(
-				ctx,
-				stackName,
-				proj,
-				cfg.Environment,
-				cfg.Config,
-				encrypter,
-				decrypter)
-			if configError != nil {
-				return fmt.Errorf("validating stack config: %w", configError)
+			// Skip config validation when the program is not being run (the default for destroy),
+			// or when explicitly requested via --skip-config-validation. This allows stacks with
+			// missing or invalid config to be destroyed in scenarios such as ephemeral PR environments
+			// where config may diverge between branches.
+			if runProgram && !skipConfigValidation {
+				configError := workspace.ValidateStackConfigAndApplyProjectConfig(
+					ctx,
+					stackName,
+					proj,
+					cfg.Environment,
+					cfg.Config,
+					encrypter,
+					decrypter)
+				if configError != nil {
+					return fmt.Errorf("validating stack config: %w", configError)
+				}
 			}
 
 			refreshOption, err := getRefreshOption(proj, refresh)
@@ -397,6 +404,10 @@ func NewDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to destroy resources")
+	cmd.PersistentFlags().BoolVar(
+		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		"Skip validation of stack config values against the project config schema. "+
+			"Config validation is skipped automatically when --run-program is not set.")
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -485,7 +485,13 @@ func NewPreviewCmd() *cobra.Command {
 			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
-			if !skipConfigValidation {
+			if skipConfigValidation {
+				// Still apply project config defaults onto the stack config, but skip validation.
+				if configErr := workspace.ApplyProjectConfigWithoutValidation(
+					ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+					return fmt.Errorf("applying stack config: %w", configErr)
+				}
+			} else {
 				configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
 					ctx,
 					stackName,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -737,7 +737,7 @@ func NewPreviewCmd() *cobra.Command {
 		"Run the program to determine up-to-date state for providers to refresh resources,"+
 			" this only applies if --refresh is set")
 	cmd.PersistentFlags().BoolVar(
-		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		&skipConfigValidation, "skip-config-validation", false,
 		"Skip validation of stack config values against the project config schema")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -487,7 +487,7 @@ func NewPreviewCmd() *cobra.Command {
 			stackName := s.Ref().Name().String()
 			if skipConfigValidation {
 				// Still apply project config defaults onto the stack config, but skip validation.
-				if configErr := workspace.ApplyProjectConfigWithoutValidation(
+				if configErr := workspace.ApplyProjectConfig(
 					ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
 					return fmt.Errorf("applying stack config: %w", configErr)
 				}

--- a/pkg/cmd/pulumi/operations/preview.go
+++ b/pkg/cmd/pulumi/operations/preview.go
@@ -306,6 +306,7 @@ func NewPreviewCmd() *cobra.Command {
 	var parallel int32
 	var refresh string
 	var runProgram bool
+	var skipConfigValidation bool
 	var showConfig bool
 	var showPolicyRemediations bool
 	var showReplacementSteps bool
@@ -484,16 +485,18 @@ func NewPreviewCmd() *cobra.Command {
 			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
-			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-				ctx,
-				stackName,
-				proj,
-				cfg.Environment,
-				cfg.Config,
-				encrypter,
-				decrypter)
-			if configErr != nil {
-				return fmt.Errorf("validating stack config: %w", configErr)
+			if !skipConfigValidation {
+				configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+					ctx,
+					stackName,
+					proj,
+					cfg.Environment,
+					cfg.Config,
+					encrypter,
+					decrypter)
+				if configErr != nil {
+					return fmt.Errorf("validating stack config: %w", configErr)
+				}
 			}
 
 			targetURNs := slice.Prealloc[string](len(targets))
@@ -733,6 +736,9 @@ func NewPreviewCmd() *cobra.Command {
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to refresh resources,"+
 			" this only applies if --refresh is set")
+	cmd.PersistentFlags().BoolVar(
+		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		"Skip validation of stack config values against the project config schema")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -249,17 +249,25 @@ func NewRefreshCmd() *cobra.Command {
 			// or when explicitly requested via --skip-config-validation. This allows stacks with
 			// missing or invalid config to be refreshed in scenarios such as ephemeral PR environments
 			// where config may diverge between branches.
-			if runProgram && !skipConfigValidation {
-				configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-					ctx,
-					stackName,
-					proj,
-					cfg.Environment,
-					cfg.Config,
-					encrypter,
-					decrypter)
-				if configErr != nil {
-					return fmt.Errorf("validating stack config: %w", configErr)
+			if runProgram {
+				if skipConfigValidation {
+					// Still apply project config defaults onto the stack config, but skip validation.
+					if configErr := workspace.ApplyProjectConfigWithoutValidation(
+						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+						return fmt.Errorf("applying stack config: %w", configErr)
+					}
+				} else {
+					configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+						ctx,
+						stackName,
+						proj,
+						cfg.Environment,
+						cfg.Config,
+						encrypter,
+						decrypter)
+					if configErr != nil {
+						return fmt.Errorf("validating stack config: %w", configErr)
+					}
 				}
 			}
 

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -374,7 +374,7 @@ func NewRefreshCmd() *cobra.Command {
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to refresh resources")
 	cmd.PersistentFlags().BoolVar(
-		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		&skipConfigValidation, "skip-config-validation", false,
 		"Skip validation of stack config values against the project config schema. "+
 			"Config validation is skipped automatically when --run-program is not set.")
 

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -252,7 +252,7 @@ func NewRefreshCmd() *cobra.Command {
 			if runProgram {
 				if skipConfigValidation {
 					// Still apply project config defaults onto the stack config, but skip validation.
-					if configErr := workspace.ApplyProjectConfigWithoutValidation(
+					if configErr := workspace.ApplyProjectConfig(
 						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
 						return fmt.Errorf("applying stack config: %w", configErr)
 					}

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -249,25 +249,25 @@ func NewRefreshCmd() *cobra.Command {
 			// or when explicitly requested via --skip-config-validation. This allows stacks with
 			// missing or invalid config to be refreshed in scenarios such as ephemeral PR environments
 			// where config may diverge between branches.
-			if runProgram {
-				if skipConfigValidation {
-					// Still apply project config defaults onto the stack config, but skip validation.
-					if configErr := workspace.ApplyProjectConfig(
-						ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
-						return fmt.Errorf("applying stack config: %w", configErr)
-					}
-				} else {
-					configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-						ctx,
-						stackName,
-						proj,
-						cfg.Environment,
-						cfg.Config,
-						encrypter,
-						decrypter)
-					if configErr != nil {
-						return fmt.Errorf("validating stack config: %w", configErr)
-					}
+			if runProgram && !skipConfigValidation {
+				// Running the program: validate the stack config (and apply project defaults).
+				configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+					ctx,
+					stackName,
+					proj,
+					cfg.Environment,
+					cfg.Config,
+					encrypter,
+					decrypter)
+				if configErr != nil {
+					return fmt.Errorf("validating stack config: %w", configErr)
+				}
+			} else {
+				// The program isn't run, or validation was explicitly skipped: still apply
+				// project config defaults onto the stack config, but skip validation.
+				if configErr := workspace.ApplyProjectConfig(
+					ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+					return fmt.Errorf("applying stack config: %w", configErr)
 				}
 			}
 

--- a/pkg/cmd/pulumi/operations/refresh.go
+++ b/pkg/cmd/pulumi/operations/refresh.go
@@ -51,6 +51,7 @@ import (
 
 func NewRefreshCmd() *cobra.Command {
 	var runProgram bool
+	var skipConfigValidation bool
 	var debug bool
 	var expectNop bool
 	var message string
@@ -244,16 +245,22 @@ func NewRefreshCmd() *cobra.Command {
 			encrypter := sm.Encrypter()
 
 			stackName := s.Ref().Name().String()
-			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-				ctx,
-				stackName,
-				proj,
-				cfg.Environment,
-				cfg.Config,
-				encrypter,
-				decrypter)
-			if configErr != nil {
-				return fmt.Errorf("validating stack config: %w", configErr)
+			// Skip config validation when the program is not being run (the default for refresh),
+			// or when explicitly requested via --skip-config-validation. This allows stacks with
+			// missing or invalid config to be refreshed in scenarios such as ephemeral PR environments
+			// where config may diverge between branches.
+			if runProgram && !skipConfigValidation {
+				configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+					ctx,
+					stackName,
+					proj,
+					cfg.Environment,
+					cfg.Config,
+					encrypter,
+					decrypter)
+				if configErr != nil {
+					return fmt.Errorf("validating stack config: %w", configErr)
+				}
 			}
 
 			if skipPendingCreates && clearPendingCreates {
@@ -366,6 +373,10 @@ func NewRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to refresh resources")
+	cmd.PersistentFlags().BoolVar(
+		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		"Skip validation of stack config values against the project config schema. "+
+			"Config validation is skipped automatically when --run-program is not set.")
 
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -193,7 +193,13 @@ func NewUpCmd() *cobra.Command {
 		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().Name().String()
-		if !skipConfigValidation {
+		if skipConfigValidation {
+			// Still apply project config defaults onto the stack config, but skip validation.
+			if configErr := workspace.ApplyProjectConfigWithoutValidation(
+				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+				return fmt.Errorf("applying stack config: %w", configErr)
+			}
+		} else {
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
 				ctx,
 				stackName,
@@ -482,7 +488,13 @@ func NewUpCmd() *cobra.Command {
 		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().String()
-		if !skipConfigValidation {
+		if skipConfigValidation {
+			// Still apply project config defaults onto the stack config, but skip validation.
+			if configErr := workspace.ApplyProjectConfigWithoutValidation(
+				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
+				return fmt.Errorf("applying stack config: %w", configErr)
+			}
+		} else {
 			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
 				ctx,
 				stackName,

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -113,6 +113,7 @@ func NewUpCmd() *cobra.Command {
 	var parallel int32
 	var refresh string
 	var runProgram bool
+	var skipConfigValidation bool
 	var showConfig bool
 	var showPolicyRemediations bool
 	var showReplacementSteps bool
@@ -192,16 +193,18 @@ func NewUpCmd() *cobra.Command {
 		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().Name().String()
-		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-			ctx,
-			stackName,
-			proj,
-			cfg.Environment,
-			cfg.Config,
-			encrypter,
-			decrypter)
-		if configErr != nil {
-			return fmt.Errorf("validating stack config: %w", configErr)
+		if !skipConfigValidation {
+			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
+				stackName,
+				proj,
+				cfg.Environment,
+				cfg.Config,
+				encrypter,
+				decrypter)
+			if configErr != nil {
+				return fmt.Errorf("validating stack config: %w", configErr)
+			}
 		}
 
 		targetURNs := slice.Prealloc[string](len(targets) + len(targetReplaces))
@@ -479,16 +482,18 @@ func NewUpCmd() *cobra.Command {
 		encrypter := sm.Encrypter()
 
 		stackName := s.Ref().String()
-		configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
-			ctx,
-			stackName,
-			proj,
-			cfg.Environment,
-			cfg.Config,
-			encrypter,
-			decrypter)
-		if configErr != nil {
-			return fmt.Errorf("validating stack config: %w", configErr)
+		if !skipConfigValidation {
+			configErr := workspace.ValidateStackConfigAndApplyProjectConfig(
+				ctx,
+				stackName,
+				proj,
+				cfg.Environment,
+				cfg.Config,
+				encrypter,
+				decrypter)
+			if configErr != nil {
+				return fmt.Errorf("validating stack config: %w", configErr)
+			}
 		}
 
 		refreshOption, err := getRefreshOption(proj, refresh)
@@ -808,6 +813,9 @@ func NewUpCmd() *cobra.Command {
 		&runProgram, "run-program", env.RunProgram.Value(),
 		"Run the program to determine up-to-date state for providers to refresh resources,"+
 			" this only applies if --refresh is set")
+	cmd.PersistentFlags().BoolVar(
+		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		"Skip validation of stack config values against the project config schema")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -195,7 +195,7 @@ func NewUpCmd() *cobra.Command {
 		stackName := s.Ref().Name().String()
 		if skipConfigValidation {
 			// Still apply project config defaults onto the stack config, but skip validation.
-			if configErr := workspace.ApplyProjectConfigWithoutValidation(
+			if configErr := workspace.ApplyProjectConfig(
 				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
 				return fmt.Errorf("applying stack config: %w", configErr)
 			}
@@ -490,7 +490,7 @@ func NewUpCmd() *cobra.Command {
 		stackName := s.Ref().String()
 		if skipConfigValidation {
 			// Still apply project config defaults onto the stack config, but skip validation.
-			if configErr := workspace.ApplyProjectConfigWithoutValidation(
+			if configErr := workspace.ApplyProjectConfig(
 				ctx, stackName, proj, cfg.Environment, cfg.Config, encrypter, decrypter); configErr != nil {
 				return fmt.Errorf("applying stack config: %w", configErr)
 			}

--- a/pkg/cmd/pulumi/operations/up.go
+++ b/pkg/cmd/pulumi/operations/up.go
@@ -814,7 +814,7 @@ func NewUpCmd() *cobra.Command {
 		"Run the program to determine up-to-date state for providers to refresh resources,"+
 			" this only applies if --refresh is set")
 	cmd.PersistentFlags().BoolVar(
-		&skipConfigValidation, "skip-config-validation", env.SkipConfigValidation.Value(),
+		&skipConfigValidation, "skip-config-validation", false,
 		"Skip validation of stack config values against the project config schema")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -144,6 +144,10 @@ var ParallelDiff = env.Bool("PARALLEL_DIFF",
 var RunProgram = env.Bool("RUN_PROGRAM",
 	"Run the Pulumi program for refresh and destroy operations. This is the same as passing --run-program=true.")
 
+var SkipConfigValidation = env.Bool("SKIP_CONFIG_VALIDATION",
+	"Skip validation of stack config values against the project config schema. "+
+		"This is the same as passing --skip-config-validation=true.")
+
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
 //

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -144,10 +144,6 @@ var ParallelDiff = env.Bool("PARALLEL_DIFF",
 var RunProgram = env.Bool("RUN_PROGRAM",
 	"Run the Pulumi program for refresh and destroy operations. This is the same as passing --run-program=true.")
 
-var SkipConfigValidation = env.Bool("SKIP_CONFIG_VALIDATION",
-	"Skip validation of stack config values against the project config schema. "+
-		"This is the same as passing --skip-config-validation=true.")
-
 // List of overrides for Plugin Download URLs. The expected format is `regexp=URL`, and multiple pairs can
 // be specified separated by commas, e.g. `regexp1=URL1,regexp2=URL2`
 //

--- a/sdk/go/common/workspace/config.go
+++ b/sdk/go/common/workspace/config.go
@@ -255,7 +255,6 @@ func mergeConfig(
 	stackConfig config.Map,
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
-	requireKeys bool,
 	validate bool,
 ) error {
 	projectName := project.Name.String()
@@ -344,7 +343,7 @@ func mergeConfig(
 		}
 	}
 
-	if requireKeys && len(missingConfigurationKeys) > 0 {
+	if validate && len(missingConfigurationKeys) > 0 {
 		// there are missing configuration keys in the stack
 		// return them as a single error.
 		return missingStackConfigurationKeysError(missingConfigurationKeys, stackName)
@@ -370,15 +369,18 @@ func ValidateStackConfigAndApplyProjectConfig(
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
 ) error {
-	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, true, true)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, true)
 }
 
-// ApplyProjectConfigWithoutValidation applies the project configuration onto the stack configuration
-// exactly like ValidateStackConfigAndApplyProjectConfig, but without validating the merged config:
-// it neither errors on missing required keys nor type-checks stack values against the project schema.
-// This is used by operations run with --skip-config-validation, where project defaults still need to
-// be applied even though config validation is intentionally skipped.
-func ApplyProjectConfigWithoutValidation(
+// ApplyProjectConfig applies the project configuration onto the stack configuration without validating
+// the merged config: it neither errors on missing required keys nor type-checks stack values against the
+// project schema. Project-level defaults and values are still merged onto the stack config.
+//
+// This is used both during pulumi config ls and pulumi config get (where, if users are using
+// PassphraseDecrypter, we don't want to always prompt for values when not necessary, and where a single
+// missing key should not block reading the others), and by operations run with --skip-config-validation,
+// where project defaults still need to be applied even though validation is intentionally skipped.
+func ApplyProjectConfig(
 	ctx context.Context,
 	stackName string,
 	project *Project,
@@ -387,20 +389,5 @@ func ApplyProjectConfigWithoutValidation(
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
 ) error {
-	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, false, false)
-}
-
-// ApplyConfigDefaults applies the default values for the project configuration onto the stack configuration
-// without validating the contents of stack config values.
-// This is because sometimes during pulumi config ls and pulumi config get, if users are
-// using PassphraseDecrypter, we don't want to always prompt for the values when not necessary
-func ApplyProjectConfig(
-	ctx context.Context,
-	stackName string,
-	project *Project,
-	stackEnv esc.Value,
-	stackConfig config.Map,
-	encrypter config.Encrypter,
-) error {
-	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, nil, true, false)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, false)
 }

--- a/sdk/go/common/workspace/config.go
+++ b/sdk/go/common/workspace/config.go
@@ -255,6 +255,7 @@ func mergeConfig(
 	stackConfig config.Map,
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
+	requireKeys bool,
 	validate bool,
 ) error {
 	projectName := project.Name.String()
@@ -343,7 +344,7 @@ func mergeConfig(
 		}
 	}
 
-	if len(missingConfigurationKeys) > 0 {
+	if requireKeys && len(missingConfigurationKeys) > 0 {
 		// there are missing configuration keys in the stack
 		// return them as a single error.
 		return missingStackConfigurationKeysError(missingConfigurationKeys, stackName)
@@ -369,7 +370,24 @@ func ValidateStackConfigAndApplyProjectConfig(
 	encrypter config.Encrypter,
 	decrypter config.Decrypter,
 ) error {
-	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, true)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, true, true)
+}
+
+// ApplyProjectConfigWithoutValidation applies the project configuration onto the stack configuration
+// exactly like ValidateStackConfigAndApplyProjectConfig, but without validating the merged config:
+// it neither errors on missing required keys nor type-checks stack values against the project schema.
+// This is used by operations run with --skip-config-validation, where project defaults still need to
+// be applied even though config validation is intentionally skipped.
+func ApplyProjectConfigWithoutValidation(
+	ctx context.Context,
+	stackName string,
+	project *Project,
+	stackEnv esc.Value,
+	stackConfig config.Map,
+	encrypter config.Encrypter,
+	decrypter config.Decrypter,
+) error {
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, decrypter, false, false)
 }
 
 // ApplyConfigDefaults applies the default values for the project configuration onto the stack configuration
@@ -384,5 +402,5 @@ func ApplyProjectConfig(
 	stackConfig config.Map,
 	encrypter config.Encrypter,
 ) error {
-	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, nil, false)
+	return mergeConfig(ctx, stackName, project, stackEnv, stackConfig, encrypter, nil, true, false)
 }

--- a/tests/integration/config_skip_validation/Pulumi.yaml
+++ b/tests/integration/config_skip_validation/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: config-skip-validation
+description: A project with a required config schema key that the program does not read
+runtime:
+  name: nodejs
+config:
+  config-skip-validation:example:
+    description: A required configuration parameter the program never reads
+    type: string

--- a/tests/integration/config_skip_validation/index.ts
+++ b/tests/integration/config_skip_validation/index.ts
@@ -1,0 +1,7 @@
+import * as pulumi from '@pulumi/pulumi';
+
+// Intentionally does not read the required `example` config key. The project
+// config schema declares it as required, so config validation fails when it is
+// unset, but the program itself runs fine. This lets us exercise
+// --skip-config-validation end to end without the program failing at runtime.
+console.log("config-skip-validation program ran");

--- a/tests/integration/config_skip_validation/package.json
+++ b/tests/integration/config_skip_validation/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pulumi-test-ts",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^22.15.17",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.207.0"
+    }
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1865,8 +1865,8 @@ func TestSkipConfigValidation(t *testing.T) {
 	// run for refresh and destroy. The program runs but does not read the missing key.
 	e.RunCommand("pulumi", "refresh", "--run-program", "--skip-config-validation", "--yes")
 
-	// The PULUMI_SKIP_CONFIG_VALIDATION env var is equivalent to the flag.
-	e.Env = append(e.Env, "PULUMI_SKIP_CONFIG_VALIDATION=true")
+	// The flag is also exposed automatically as an env var (PULUMI_OPTION_<FLAG>).
+	e.Env = append(e.Env, "PULUMI_OPTION_SKIP_CONFIG_VALIDATION=true")
 	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
 	e.Env = e.Env[:len(e.Env)-1]
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1134,7 +1134,8 @@ func TestAdvisoryPolicyPack(t *testing.T) {
 	e.InstallDependencies()
 
 	stdout, _, err := e.GetCommandResults(
-		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "advisory_policy_pack")
+		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "advisory_policy_pack",
+	)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Failing advisory policy pack for testing\n          foobar")
 }
@@ -1160,7 +1161,8 @@ func TestMandatoryPolicyPack(t *testing.T) {
 	e.InstallDependencies()
 
 	stdout, _, err := e.GetCommandResults(
-		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "mandatory_policy_pack")
+		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "mandatory_policy_pack",
+	)
 	assert.Error(t, err)
 	assert.Contains(t, stdout, "error: update failed")
 	assert.Contains(t, stdout, "❌ typescript@v0.0.1 (local: mandatory_policy_pack)")
@@ -1187,7 +1189,8 @@ func TestBunMandatoryPolicyPack(t *testing.T) {
 	e.InstallDependencies()
 
 	stdout, _, err := e.GetCommandResults(
-		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "bun_mandatory_policy_pack")
+		"pulumi", "up", "--skip-preview", "--yes", "--policy-pack", "bun_mandatory_policy_pack",
+	)
 	assert.Error(t, err)
 	assert.Contains(t, stdout, "error: update failed")
 	assert.Contains(t, stdout, "❌ bun@v0.0.1 (local: bun_mandatory_policy_pack)")
@@ -1776,7 +1779,8 @@ func TestConfigFlag(t *testing.T) {
 
 	e.RunCommand("pulumi", "stack", "init", "config-flag-test")
 	stdout, _ := e.RunCommand(
-		"pulumi", "up", "--skip-preview", "--yes", "--config", "config-flag:example=an-example")
+		"pulumi", "up", "--skip-preview", "--yes", "--config", "config-flag:example=an-example",
+	)
 	require.Contains(t, stdout, "an-example")
 
 	configPath := filepath.Join(e.CWD, "Pulumi.config-flag-test.yaml")
@@ -1803,6 +1807,71 @@ func TestConfigFlag(t *testing.T) {
 	configContent, err = os.ReadFile(configPath)
 	require.NoError(t, err)
 	require.Contains(t, string(configContent), "config-flag:example: an-example")
+}
+
+// TestRefreshDestroySkipConfigValidationByDefault verifies that refresh and destroy no longer
+// validate stack config against the project config schema unless the program is being run.
+// This allows stacks with missing or invalid config to be refreshed and destroyed, e.g. in
+// ephemeral PR environments where config may diverge between branches.
+func TestRefreshDestroySkipConfigValidationByDefault(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("config_flag")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "install")
+
+	e.RunCommand("pulumi", "stack", "init", "config-flag-test")
+	e.RunCommand("pulumi", "up", "--skip-preview", "--yes", "--config", "config-flag:example=an-example")
+
+	// Remove the stack config so the required `config-flag:example` key is missing.
+	e.RunCommand("rm", "Pulumi.config-flag-test.yaml")
+
+	// Without --run-program, refresh and destroy must not validate config and should succeed.
+	e.RunCommand("pulumi", "refresh", "--yes")
+	e.RunCommand("pulumi", "destroy", "--yes")
+
+	// With --run-program, config validation runs again and the missing key is reported.
+	e.RunCommandExpectError("pulumi", "refresh", "--run-program", "--yes")
+}
+
+// TestSkipConfigValidation verifies the --skip-config-validation flag (and its
+// PULUMI_SKIP_CONFIG_VALIDATION env var equivalent) on preview, up, refresh, and destroy.
+// It uses a project whose config schema declares a required key that the program never reads,
+// so config validation fails when the key is unset, but the program itself runs successfully
+// once validation is skipped.
+func TestSkipConfigValidation(t *testing.T) {
+	t.Parallel()
+	e := ptesting.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+	e.ImportDirectory("config_skip_validation")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "install")
+
+	e.RunCommand("pulumi", "stack", "init", "skip-validation-test")
+
+	// The required `config-skip-validation:example` key is unset, so the default behavior
+	// is to fail config validation for preview and up.
+	_, stderr := e.RunCommandExpectError("pulumi", "preview")
+	require.Contains(t, stderr, "validating stack config")
+	_, stderr = e.RunCommandExpectError("pulumi", "up", "--skip-preview", "--yes")
+	require.Contains(t, stderr, "validating stack config")
+
+	// --skip-config-validation lets both proceed; the program does not read the key.
+	e.RunCommand("pulumi", "preview", "--skip-config-validation")
+	e.RunCommand("pulumi", "up", "--skip-preview", "--yes", "--skip-config-validation")
+
+	// --skip-config-validation also overrides --run-program, where validation would otherwise
+	// run for refresh and destroy. The program runs but does not read the missing key.
+	e.RunCommand("pulumi", "refresh", "--run-program", "--skip-config-validation", "--yes")
+
+	// The PULUMI_SKIP_CONFIG_VALIDATION env var is equivalent to the flag.
+	e.Env = append(e.Env, "PULUMI_SKIP_CONFIG_VALIDATION=true")
+	e.RunCommand("pulumi", "up", "--skip-preview", "--yes")
+	e.Env = e.Env[:len(e.Env)-1]
+
+	// Tear the stack down, skipping validation so the missing key does not block destroy.
+	e.RunCommand("pulumi", "destroy", "--run-program", "--yes", "--skip-config-validation")
 }
 
 func TestValidatePulumiVersionRange(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a `--skip-config-validation` flag to preview, up, refresh, and destroy to bypass validation of stack config against the project's config schema.

Before an operation runs, the CLI validates a stack's config against the project config schema (required keys present, values match declared types). This is the right default, but it blocks legitimate workflows where config intentionally diverges from the schema (most notably ephemeral PR environments, where a stack created on one branch needs to be refreshed or destroyed using a different branch's project definition.) There was previously no way to opt out.

In addition, refresh and destroy now skip config validation by default when `--run-program` is not set. Since these commands don't run the program by default, the program never consumes config, so validating it served no purpose and only blocked otherwise-valid operations. When `--run-program` is set, validation runs as before unless `--skip-config-validation` is passed. preview and up are unchanged by default; the flag is purely opt-in for them.

Validation and project-config application were previously coupled in one call, which also merges project-level defaults into the config sent to the engine — so skipping validation also skipped applying defaults. This splits them: the skip path now still applies project config (via the new workspace.ApplyProjectConfigWithoutValidation) and only the validation step is skipped. pulumi config ls/get behavior is unchanged.

Fixes #23670

## Test plan
<!-- How did you test this change? -->
- [x] Added appropriate unit tests - For all changes
- [ ] Added a test `in pkg/engine/lifecycletechanges` - **No engine/protocol changes**
- [ ] Added a conformance test in `pkg/testing/pulumi-test-language` - **No language protocol changes**
- [ ] Added a golden test in `pkg/backend/display` - **No changes to the output renderers**

Added two integration tests in `tests/integration/integration_test.go`:
- `TestRefreshDestroySkipConfigValidationByDefault`: refresh/destroy succeed with missing config when `--run-program` is absent, and still error when it's set.
- `TestSkipConfigValidation`: exercises the flag and the auto-gen `PULUMI_OPTION_SKIP_CONFIG_VALIDATION` env var across preview/up/refresh/destroy, using a new fixture (`tests/integration/config_skip_validation`) whose config schema requires a key the program never reads.

Both pass against a locally rebuilt CLI.

## Validation
<!-- Commands you ran. Do not include output, but make sure that you've run these and checked the results. -->
- [x] `make lint` — clean
- [x] `make tidy_fix` — clean
- [x] `make format` — clean
- [ ] make test_fast — ran locally; passes except two pre-existing, environment-dependent tests unrelated to this CLI-only change: `backend/diy::TestS3LegacyURLCopy` (needs a local AWS profile) and `codegen/testing/test::TestTranspiledExampleTestsCovered` (needs codegen example tooling). Both fail identically on master in this environment; CI runs them with the proper setup.
- [ ] Relevant SDK tests pass (if SDK changes) — N/A, no SDK changes
- [ ] make check_proto — clean (if proto changes) — N/A, no proto changes

## Changelog
<!-- Does this PR need a changelog entry? If so, did you run `make changelog`? -->
- [x] Changelog entry added.

## Risk
<!-- What could go wrong? What's the blast radius? Does this affect public API? -->
Low blast radius. The flag is opt-in and defaults to off for preview/up, so their behavior is unchanged. The one behavioral change is that refresh/destroy no longer validate config when `--run-program` is absent — config the program never reads is no longer checked, which can surface previously-blocked operations rather than break working ones. The only public surface change is a new exported helper, `workspace.ApplyProjectConfigWithoutValidation`, in `sdk/go/common/workspace`; existing config functions keep their behavior. Otherwise CLI-only (new cobra flag + env var). No proto or state-serialization changes. import and watch intentionally keep validating config and are out of scope for this change.

<!--

NOTE: maintainer time is a limited resource. Pull requests that do not follow this template can create
avoidable work and may be closed without review. Repeatedly ignoring these guidelines may result in
temporary or permanent restrictions to your ability to contribute to this project.

-->