### PR TITLE
display: fix panic rendering a stack-level policy violation

### DIFF
--- a/changelog/pending/cli-fix-policy-stack-violation-panic.yaml
+++ b/changelog/pending/cli-fix-policy-stack-violation-panic.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: fix
+body: Fix a panic when displaying a stack-level policy violation
+time: 2026-06-24T13:39:15.001560-06:00
+custom:
+    PR: "23692"

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -176,6 +176,16 @@ func resourceText(urn resource.URN, opts Options) string {
 	return urn.Name()
 }
 
+// policyResourceClause renders the "  (type: name)" suffix for a policy event's target
+// resource, or "" for an invalid URN — URN.Type/URN.Name panic on the empty URN a
+// stack-level violation may carry.
+func policyResourceClause(urn resource.URN, opts Options) string {
+	if !urn.IsValid() {
+		return ""
+	}
+	return fmt.Sprintf("  (%s: %s)", urn.Type().DisplayName(), resourceText(urn, opts))
+}
+
 func renderDiffPolicyRemediationEvent(payload engine.PolicyRemediationEventPayload,
 	prefix string, detailed bool, opts Options,
 ) string {
@@ -185,10 +195,10 @@ func renderDiffPolicyRemediationEvent(payload engine.PolicyRemediationEventPaylo
 		return ""
 	}
 
-	// Print the individual remediation's name and target resource type/name.
-	resText := resourceText(payload.ResourceURN, opts)
-	remediationLine := fmt.Sprintf("%s[remediate]  %s%s  (%s: %s)",
-		colors.SpecInfo, payload.PolicyName, colors.Reset, payload.ResourceURN.Type(), resText)
+	// Print the individual remediation's name and its target resource type and name.
+	remediationLine := fmt.Sprintf("%s[remediate]  %s%s%s",
+		colors.SpecInfo, payload.PolicyName, colors.Reset,
+		policyResourceClause(payload.ResourceURN, opts))
 
 	// If there is already a prefix string requested, use it, otherwise fall back to a default.
 	if prefix == "" {
@@ -228,10 +238,11 @@ func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 		severity = fmt.Sprintf(" [severity: %s]", payload.Severity)
 	}
 
-	// Print the individual policy's name and target resource type/name.
-	policyLine := fmt.Sprintf("%s[%s]%s  %s%s  (%s: %s)",
+	// Print the individual policy's name and, for resource-scoped violations, the
+	// target resource type and name. Stack-level violations carry no resource URN.
+	policyLine := fmt.Sprintf("%s[%s]%s  %s%s%s",
 		c, payload.EnforcementLevel, severity, payload.PolicyName, colors.Reset,
-		payload.ResourceURN.Type().DisplayName(), resourceText(payload.ResourceURN, opts))
+		policyResourceClause(payload.ResourceURN, opts))
 
 	// If there is already a prefix string requested, use it, otherwise fall back to a default.
 	if prefix == "" {

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -438,3 +438,66 @@ func TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs(t *te
 		"(aws:s3:Bucket: urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket)",
 	)
 }
+
+func TestRenderDiffPolicyRemediationEventUsesDisplayResourceTypeName(t *testing.T) {
+	t.Parallel()
+
+	payload := engine.PolicyRemediationEventPayload{
+		ResourceURN:       "urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket",
+		PolicyName:        "tag-policy",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		Before:            resource.PropertyMap{"tag": resource.NewProperty("before")},
+		After:             resource.PropertyMap{"tag": resource.NewProperty("after")},
+	}
+
+	output := renderDiffPolicyRemediationEvent(payload, "", false, Options{Color: colors.Never})
+
+	assert.Contains(t, output, "(aws:s3:Bucket: my-bucket)")
+	assert.NotContains(t, output, "aws:s3/bucket:Bucket")
+}
+
+func TestPolicyResourceClause(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{Color: colors.Never}
+
+	// A stack-level violation carries an empty URN; an empty or otherwise malformed URN
+	// must produce no clause and must not panic (URN.Type/URN.Name assert the urn:pulumi:
+	// prefix).
+	assert.Empty(t, policyResourceClause("", opts))
+	assert.Empty(t, policyResourceClause("not-a-pulumi-urn", opts))
+
+	// Resource types render as display names (the module path is truncated).
+	assert.Equal(t,
+		"  (aws:s3:Bucket: my-bucket)",
+		policyResourceClause("urn:pulumi:stack::project::aws:s3/bucket:Bucket::my-bucket", opts))
+}
+
+func TestRenderDiffPolicyViolationEvent_StackLevel(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{Color: colors.Never}
+	base := engine.PolicyViolationEventPayload{
+		PolicyName:        "resource-inventory",
+		PolicyPackName:    "my-pack",
+		PolicyPackVersion: "1.0.0",
+		EnforcementLevel:  apitype.Advisory,
+		Message:           "analyzed 6209 resources",
+	}
+
+	// A stack-level violation has no resource URN; rendering must not panic and
+	// must omit the "(type: name)" clause.
+	var stackOut string
+	require.NotPanics(t, func() {
+		stackOut = renderDiffPolicyViolationEvent(base, "", "", opts)
+	})
+	assert.Contains(t, stackOut, "resource-inventory")
+	assert.Contains(t, stackOut, "analyzed 6209 resources")
+	assert.NotContains(t, stackOut, "(")
+
+	resourceLevel := base
+	resourceLevel.ResourceURN = "urn:pulumi:stack::project::aws:s3/bucket:Bucket::my-bucket"
+	resourceOut := renderDiffPolicyViolationEvent(resourceLevel, "", "", opts)
+	assert.Contains(t, resourceOut, "(aws:s3:Bucket: my-bucket)")
+}

--- a/pkg/resource/deploy/analyze_snapshot.go
+++ b/pkg/resource/deploy/analyze_snapshot.go
@@ -95,6 +95,42 @@ func analyzeResource(
 	return invalidAtomic.Load(), sawErrorAtomic.Load(), nil
 }
 
+// snapshotRootStackURN returns the URN to attribute stack-level policy violations to:
+// the snapshot's root stack resource, or a default root stack URN synthesized from any
+// resource. Only valid URNs are considered, so a malformed URN never reaches consumers
+// that dereference it. Returns an empty URN for a resourceless snapshot; the display
+// layer's policyResourceClause guard tolerates that.
+func snapshotRootStackURN(snap *Snapshot) resource.URN {
+	var fallback resource.URN
+	for _, res := range snap.Resources {
+		if !res.URN.IsValid() {
+			continue
+		}
+		if res.Type == resource.RootStackType && res.Parent == "" {
+			return res.URN
+		}
+		if fallback == "" {
+			fallback = resource.DefaultRootStackURN(res.URN.Stack(), res.URN.Project())
+		}
+	}
+	return fallback
+}
+
+// resolveStackPolicyViolationURN returns the URN to attribute a stack-level policy
+// diagnostic to: the diagnostic's own URN when it names a resource currently in the
+// stack, otherwise the root stack URN, since stack-level violations are not tied to a
+// resource. Shared by the deployment path (step_generator.go) and the offline snapshot
+// analyzer so their attribution stays consistent.
+func resolveStackPolicyViolationURN(
+	diagURN, rootStackURN resource.URN,
+	inStack func(resource.URN) bool,
+) resource.URN {
+	if inStack(diagURN) {
+		return diagURN
+	}
+	return rootStackURN
+}
+
 // buildSnapshotProviderMap builds a map of provider URN -> provider state from a snapshot.
 func buildSnapshotProviderMap(snap *Snapshot) map[resource.URN]*resource.State {
 	providers := make(map[resource.URN]*resource.State)
@@ -235,6 +271,18 @@ func AnalyzeSnapshot(
 		})
 	}
 
+	// Inputs for resolveStackPolicyViolationURN: only non-deleted resources are sent to
+	// AnalyzeStack, so only those are valid violation targets; anything else (including a
+	// stack-level violation's empty URN) attributes to the root stack.
+	rootStackURN := snapshotRootStackURN(snap)
+	snapshotURNs := make(map[resource.URN]struct{}, len(snap.Resources))
+	for _, res := range snap.Resources {
+		if res.Delete {
+			continue
+		}
+		snapshotURNs[res.URN] = struct{}{}
+	}
+
 	var sawStackError atomic.Bool
 	var g errgroup.Group
 	if parallelism := env.ParallelAnalyze.Value(); parallelism > 0 {
@@ -261,7 +309,9 @@ func AnalyzeSnapshot(
 				if d.EnforcementLevel == apitype.Mandatory {
 					sawStackError.Store(true)
 				}
-				events.OnPolicyViolation(d.URN, d)
+				urn := resolveStackPolicyViolationURN(d.URN, rootStackURN,
+					func(u resource.URN) bool { _, ok := snapshotURNs[u]; return ok })
+				events.OnPolicyViolation(urn, d)
 			}
 
 			summary := resourceanalyzer.NewAnalyzeStackPolicySummary(response, info)

--- a/pkg/resource/deploy/analyze_snapshot.go
+++ b/pkg/resource/deploy/analyze_snapshot.go
@@ -95,11 +95,9 @@ func analyzeResource(
 	return invalidAtomic.Load(), sawErrorAtomic.Load(), nil
 }
 
-// snapshotRootStackURN returns the URN to attribute stack-level policy violations to:
-// the snapshot's root stack resource, or a default root stack URN synthesized from any
-// resource. Only valid URNs are considered, so a malformed URN never reaches consumers
-// that dereference it. Returns an empty URN for a resourceless snapshot; the display
-// layer's policyResourceClause guard tolerates that.
+// snapshotRootStackURN returns the URN that stack-level policy violations are attributed
+// to: the snapshot's root stack resource, or a default synthesized from another resource.
+// Invalid URNs are skipped; a resourceless snapshot yields the empty URN.
 func snapshotRootStackURN(snap *Snapshot) resource.URN {
 	var fallback resource.URN
 	for _, res := range snap.Resources {
@@ -116,11 +114,9 @@ func snapshotRootStackURN(snap *Snapshot) resource.URN {
 	return fallback
 }
 
-// resolveStackPolicyViolationURN returns the URN to attribute a stack-level policy
-// diagnostic to: the diagnostic's own URN when it names a resource currently in the
-// stack, otherwise the root stack URN, since stack-level violations are not tied to a
-// resource. Shared by the deployment path (step_generator.go) and the offline snapshot
-// analyzer so their attribution stays consistent.
+// resolveStackPolicyViolationURN attributes a stack-level policy diagnostic to its own URN
+// when that names a resource in the stack, otherwise to the root stack URN. Shared with the
+// deployment path (step_generator.go) to keep attribution consistent.
 func resolveStackPolicyViolationURN(
 	diagURN, rootStackURN resource.URN,
 	inStack func(resource.URN) bool,
@@ -271,8 +267,7 @@ func AnalyzeSnapshot(
 		})
 	}
 
-	// Inputs for resolveStackPolicyViolationURN: only non-deleted resources are sent to
-	// AnalyzeStack, so only those are valid violation targets; anything else (including a
+	// Only non-deleted resources are valid violation targets; anything else (including a
 	// stack-level violation's empty URN) attributes to the root stack.
 	rootStackURN := snapshotRootStackURN(snap)
 	snapshotURNs := make(map[resource.URN]struct{}, len(snap.Resources))

--- a/pkg/resource/deploy/analyze_snapshot_test.go
+++ b/pkg/resource/deploy/analyze_snapshot_test.go
@@ -33,6 +33,7 @@ import (
 // recordingPolicyEvents records all policy events for later inspection.
 type recordingPolicyEvents struct {
 	violations    []plugin.AnalyzeDiagnostic
+	violationURNs []resource.URN
 	remediations  []remediationRecord
 	analyzeSumm   []plugin.PolicySummary
 	remediateSumm []plugin.PolicySummary
@@ -47,6 +48,7 @@ type remediationRecord struct {
 
 func (r *recordingPolicyEvents) OnPolicyViolation(urn resource.URN, d plugin.AnalyzeDiagnostic) {
 	r.violations = append(r.violations, d)
+	r.violationURNs = append(r.violationURNs, urn)
 }
 
 func (r *recordingPolicyEvents) OnPolicyRemediation(
@@ -304,6 +306,172 @@ func TestAnalyzeSnapshot_StackLevelViolation(t *testing.T) {
 	require.Len(t, events.violations, 1)
 	assert.Equal(t, "stack violates policy", events.violations[0].Message)
 	require.Len(t, events.stackSumm, 1)
+
+	// The violation is not tied to a resource, so it must be attributed to a valid root
+	// stack URN rather than forwarded as the empty URN the analyzer reported.
+	require.Len(t, events.violationURNs, 1)
+	assert.True(t, events.violationURNs[0].IsValid())
+	assert.Equal(t, resource.RootStackType, events.violationURNs[0].QualifiedType())
+}
+
+func TestAnalyzeSnapshot_StackLevelViolationUsesRootStackResource(t *testing.T) {
+	t.Parallel()
+
+	rootStack := &resource.State{
+		Type: resource.RootStackType,
+		URN:  "urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack",
+	}
+	res := makeTestResource("urn:pulumi:stack::project::pkg:index:MyResource::res")
+	snap := &deploy.Snapshot{Resources: []*resource.State{rootStack, res}}
+	events := &recordingPolicyEvents{}
+
+	analyzer := &deploytest.Analyzer{
+		Info: plugin.AnalyzerInfo{Name: "test-pack"},
+		AnalyzeStackF: func(resources []plugin.AnalyzerStackResource) (plugin.AnalyzeResponse, error) {
+			return plugin.AnalyzeResponse{
+				Diagnostics: []plugin.AnalyzeDiagnostic{{
+					PolicyName:       "stack-policy",
+					PolicyPackName:   "test-pack",
+					EnforcementLevel: apitype.Advisory,
+					Message:          "stack violates policy",
+				}},
+			}, nil
+		},
+	}
+
+	_, err := deploy.AnalyzeSnapshot(t.Context(), snap, []plugin.Analyzer{analyzer}, events)
+	require.NoError(t, err)
+	require.Len(t, events.violationURNs, 1)
+	assert.Equal(t, rootStack.URN, events.violationURNs[0])
+}
+
+func TestAnalyzeSnapshot_StackLevelViolationResourcelessSnapshot(t *testing.T) {
+	t.Parallel()
+
+	// A resourceless snapshot has no root stack to attribute a stack-level violation to;
+	// AnalyzeSnapshot forwards the empty URN (the display guard tolerates it) instead of
+	// panicking. The CLI rejects resourceless snapshots upstream, so this guards other callers.
+	snap := &deploy.Snapshot{}
+	events := &recordingPolicyEvents{}
+
+	analyzer := &deploytest.Analyzer{
+		Info: plugin.AnalyzerInfo{Name: "test-pack"},
+		AnalyzeStackF: func(resources []plugin.AnalyzerStackResource) (plugin.AnalyzeResponse, error) {
+			return plugin.AnalyzeResponse{
+				Diagnostics: []plugin.AnalyzeDiagnostic{{
+					PolicyName:       "stack-policy",
+					PolicyPackName:   "test-pack",
+					EnforcementLevel: apitype.Advisory,
+					Message:          "stack violates policy",
+				}},
+			}, nil
+		},
+	}
+
+	_, err := deploy.AnalyzeSnapshot(t.Context(), snap, []plugin.Analyzer{analyzer}, events)
+	require.NoError(t, err)
+	require.Len(t, events.violationURNs, 1)
+	assert.Empty(t, events.violationURNs[0])
+}
+
+func TestAnalyzeSnapshot_StackLevelViolationDeletedTargetFallsBackToRoot(t *testing.T) {
+	t.Parallel()
+
+	// Deleted resources are not sent to AnalyzeStack, so a stack diagnostic naming one is
+	// not a valid target and must fall back to the root stack rather than be trusted.
+	rootStack := &resource.State{
+		Type: resource.RootStackType,
+		URN:  "urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack",
+	}
+	deleted := makeTestResource("urn:pulumi:stack::project::pkg:index:MyResource::gone")
+	deleted.Delete = true
+	snap := &deploy.Snapshot{Resources: []*resource.State{rootStack, deleted}}
+	events := &recordingPolicyEvents{}
+
+	analyzer := &deploytest.Analyzer{
+		Info: plugin.AnalyzerInfo{Name: "test-pack"},
+		AnalyzeStackF: func(resources []plugin.AnalyzerStackResource) (plugin.AnalyzeResponse, error) {
+			return plugin.AnalyzeResponse{
+				Diagnostics: []plugin.AnalyzeDiagnostic{{
+					PolicyName:       "stack-policy",
+					PolicyPackName:   "test-pack",
+					EnforcementLevel: apitype.Advisory,
+					Message:          "stack violates policy",
+					URN:              deleted.URN,
+				}},
+			}, nil
+		},
+	}
+
+	_, err := deploy.AnalyzeSnapshot(t.Context(), snap, []plugin.Analyzer{analyzer}, events)
+	require.NoError(t, err)
+	require.Len(t, events.violationURNs, 1)
+	assert.Equal(t, rootStack.URN, events.violationURNs[0])
+}
+
+func TestAnalyzeSnapshot_StackLevelViolationResourceScopedURNPreserved(t *testing.T) {
+	t.Parallel()
+
+	// A stack-level analyzer may attribute a violation to a specific live resource; that
+	// URN names a current resource, so it is preserved rather than replaced by the root stack.
+	res := makeTestResource("urn:pulumi:stack::project::pkg:index:MyResource::res")
+	snap := &deploy.Snapshot{Resources: []*resource.State{res}}
+	events := &recordingPolicyEvents{}
+
+	analyzer := &deploytest.Analyzer{
+		Info: plugin.AnalyzerInfo{Name: "test-pack"},
+		AnalyzeStackF: func(resources []plugin.AnalyzerStackResource) (plugin.AnalyzeResponse, error) {
+			return plugin.AnalyzeResponse{
+				Diagnostics: []plugin.AnalyzeDiagnostic{{
+					PolicyName:       "stack-policy",
+					PolicyPackName:   "test-pack",
+					EnforcementLevel: apitype.Advisory,
+					Message:          "resource violates stack policy",
+					URN:              res.URN,
+				}},
+			}, nil
+		},
+	}
+
+	_, err := deploy.AnalyzeSnapshot(t.Context(), snap, []plugin.Analyzer{analyzer}, events)
+	require.NoError(t, err)
+	require.Len(t, events.violationURNs, 1)
+	assert.Equal(t, res.URN, events.violationURNs[0])
+}
+
+func TestAnalyzeSnapshot_StackLevelViolationSkipsInvalidRootStackURN(t *testing.T) {
+	t.Parallel()
+
+	// A root stack resource with a malformed URN must not be used as the attribution
+	// target; it is skipped and a valid URN is synthesized from another resource instead.
+	badRootStack := &resource.State{
+		Type:   resource.RootStackType,
+		URN:    "not-a-valid-urn",
+		Delete: true, // deleted so the per-resource pass skips it (URN.Name would panic)
+	}
+	res := makeTestResource("urn:pulumi:stack::project::pkg:index:MyResource::res")
+	snap := &deploy.Snapshot{Resources: []*resource.State{badRootStack, res}}
+	events := &recordingPolicyEvents{}
+
+	analyzer := &deploytest.Analyzer{
+		Info: plugin.AnalyzerInfo{Name: "test-pack"},
+		AnalyzeStackF: func(resources []plugin.AnalyzerStackResource) (plugin.AnalyzeResponse, error) {
+			return plugin.AnalyzeResponse{
+				Diagnostics: []plugin.AnalyzeDiagnostic{{
+					PolicyName:       "stack-policy",
+					PolicyPackName:   "test-pack",
+					EnforcementLevel: apitype.Advisory,
+					Message:          "stack violates policy",
+				}},
+			}, nil
+		},
+	}
+
+	_, err := deploy.AnalyzeSnapshot(t.Context(), snap, []plugin.Analyzer{analyzer}, events)
+	require.NoError(t, err)
+	require.Len(t, events.violationURNs, 1)
+	assert.True(t, events.violationURNs[0].IsValid())
+	assert.Equal(t, resource.RootStackType, events.violationURNs[0].QualifiedType())
 }
 
 func TestAnalyzeSnapshot_AnalyzeErrorPropagated(t *testing.T) {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -3412,18 +3412,9 @@ func (sg *stepGenerator) AnalyzeResources(ctx context.Context) error {
 				if d.EnforcementLevel == apitype.Mandatory {
 					sawError.Store(true)
 				}
-				// If a URN was provided and it is a URN associated with a resource in the stack, use it.
-				// Otherwise, if the URN is empty or is not associated with a resource in the stack, use
-				// the default root stack URN.
-				var urn resource.URN
-				if d.URN != "" {
-					if _, ok := sg.deployment.news.Load(d.URN); ok {
-						urn = d.URN
-					}
-				}
-				if urn == "" {
-					urn = resource.DefaultRootStackURN(sg.deployment.Target().Name.Q(), sg.deployment.source.Project())
-				}
+				urn := resolveStackPolicyViolationURN(d.URN,
+					resource.DefaultRootStackURN(sg.deployment.Target().Name.Q(), sg.deployment.source.Project()),
+					func(u resource.URN) bool { _, ok := sg.deployment.news.Load(u); return ok })
 				sg.deployment.events.OnPolicyViolation(urn, d)
 			}
 


### PR DESCRIPTION
## Why

`pulumi policy analyze` panics with `Urn is: ''` when a `validateStack` policy reports a **stack-level** violation in the non-JSON display. Stack-level violations are not tied to a resource, so they arrive with an empty `ResourceURN`. The diff renderer called `URN.Type()`/`URN.Name()` directly on that URN, and both assert the `urn:pulumi:` prefix and panic on an empty URN.

This surfaces through the `--file` mode added in #23664, where a policy pack's `validateStack` rule run over an exported state can report a stack-level violation.

The deployment path (`pulumi up`/`preview`) never hits this: `step_generator.go` already substitutes the root stack URN for a stack-level violation's empty URN, so consumers always receive a valid URN. The offline analyze path added in #23664 is a near-duplicate of that loop that skipped the substitution — that inconsistency is the root cause.

## What

Fix the root cause in the analyze path: stack-level violations are now attributed to the snapshot's root stack URN, mirroring the deployment path in `step_generator.go`. A diagnostic whose URN is empty or absent from the (non-deleted) snapshot resources falls back to the root stack, so `pulumi policy analyze` renders stack-level violations against the stack, consistent with `pulumi up`. The resolution logic is extracted into a shared `resolveStackPolicyViolationURN` helper used by both paths, so they can't diverge again — that divergence was this bug's root cause.

Keep a defensive guard in the renderer: the shared `policyResourceClause` helper (used by both the violation and remediation renderers) returns an empty clause for any URN that is not a valid Pulumi URN, so an invalid URN can never panic the display. As a side effect of routing both renderers through that helper, policy **remediation** resource types now also render as display names (e.g. `aws:s3:Bucket`), consistent with how policy violations already render them after #23705.

## Test

- `pkg/resource/deploy/analyze_snapshot_test.go`: stack-level violations are attributed to a valid root stack URN (from the snapshot's root stack resource, synthesized when absent); a resource-scoped URN is preserved; and violations targeting a deleted resource, a resourceless snapshot, or a malformed root stack URN all fall back to a valid URN (or the empty-URN boundary the renderer guard tolerates).
- `pkg/backend/display/diff_test.go`: `policyResourceClause` returns empty for empty/malformed URNs without panicking; `renderDiffPolicyViolationEvent` does not panic and omits the clause for a stack-level violation; and both the violation and remediation renderers render resource types as display names.
