### PR TITLE
Fix TestDebuggerAttach for dlv@1.27

### DIFF
--- a/changelog/pending/cli-engine-improvement-20260625-102244.yaml
+++ b/changelog/pending/cli-engine-improvement-20260625-102244.yaml
@@ -1,0 +1,4 @@
+component: cli/engine
+kind: improvement
+body: Fix TestDebuggerAttach for dlv@1.27
+time: 2026-06-25T10:22:44.003933+02:00

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -1592,9 +1592,23 @@ outer:
 	resp, err = dap.ReadProtocolMessage(reader)
 	require.NoError(t, err)
 	assert.IsType(t, &dap.ContinueResponse{}, resp)
-	resp, err = dap.ReadProtocolMessage(reader)
-	require.NoError(t, err)
-	assert.IsType(t, &dap.TerminatedEvent{}, resp)
+	// On program exit the debugger sends both an "exited" and a "terminated" event. DAP doesn't
+	// guarantee their order, and delve changed it in 1.27 (exited now precedes terminated), so read
+	// until we see the terminated event.
+	sawTerminated := false
+	for i := 0; i < 2 && !sawTerminated; i++ {
+		resp, err = dap.ReadProtocolMessage(reader)
+		require.NoError(t, err)
+		switch resp.(type) {
+		case *dap.TerminatedEvent:
+			sawTerminated = true
+		case *dap.ExitedEvent:
+			// Ignore; its order relative to the terminated event is not guaranteed.
+		default:
+			t.Fatalf("unexpected DAP message waiting for terminated event: %T", resp)
+		}
+	}
+	require.True(t, sawTerminated, "expected a terminated event")
 
 	err = dap.WriteProtocolMessage(conn, &dap.DisconnectRequest{
 		Request: newDAPRequest(seq, "disconnect"),


### PR DESCRIPTION
delve 1.27.0 reordered the DAP exit events, sending exited before terminated. The test asserted a fixed order and failed.

Read the post-continue events in a loop and accept exited/terminated in either order.