### PR TITLE
Add `--output $format` to `pulumi policy list` and `pulumi policy group list`

### DIFF
--- a/changelog/pending/cli-improvement-20260625-131427.yaml
+++ b/changelog/pending/cli-improvement-20260625-131427.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Add --output $format to `pulumi policy list` and `pulumi policy group list`
+time: 2026-06-25T13:14:27.099189+02:00

--- a/pkg/cmd/pulumi/policy/policy_group_list.go
+++ b/pkg/cmd/pulumi/policy/policy_group_list.go
@@ -27,12 +27,15 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+type policyGroupsRenderFunc func(w io.Writer, policyGroups []apitype.PolicyGroupSummary) error
 
 func newPolicyGroupCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -51,7 +54,10 @@ func newPolicyGroupCmd() *cobra.Command {
 }
 
 func newPolicyGroupListCmd() *cobra.Command {
-	var jsonOut bool
+	output := outputflag.OutputFlag[policyGroupsRenderFunc]{
+		RenderForTerminal: formatPolicyGroupsConsole,
+		RenderJSON:        formatPolicyGroupsJSON,
+	}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -105,10 +111,7 @@ func newPolicyGroupListCmd() *cobra.Command {
 				inContToken = outContToken
 			}
 
-			if jsonOut {
-				return formatPolicyGroupsJSON(cmd.OutOrStdout(), allPolicyGroups)
-			}
-			return formatPolicyGroupsConsole(cmd.OutOrStdout(), allPolicyGroups)
+			return output.Get()(cmd.OutOrStdout(), allPolicyGroups)
 		},
 	}
 
@@ -119,8 +122,7 @@ func newPolicyGroupListCmd() *cobra.Command {
 		Required: 0,
 	})
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/policy/policy_list.go
+++ b/pkg/cmd/pulumi/policy/policy_list.go
@@ -27,6 +27,7 @@ import (
 	cmdBackend "github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/backend"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
@@ -34,8 +35,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type policyPacksRenderFunc func(w io.Writer, policyPacks []apitype.PolicyPackWithVersions) error
+
 func newPolicyListCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobra.Command {
-	var jsonOut bool
+	output := outputflag.OutputFlag[policyPacksRenderFunc]{
+		RenderForTerminal: formatPolicyPacksConsole,
+		RenderJSON:        formatPolicyPacksJSON,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -89,10 +95,7 @@ func newPolicyListCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobr
 				inContToken = outContToken
 			}
 
-			if jsonOut {
-				return formatPolicyPacksJSON(cmd.OutOrStdout(), allPolicyPacks)
-			}
-			return formatPolicyPacksConsole(cmd.OutOrStdout(), allPolicyPacks)
+			return output.Get()(cmd.OutOrStdout(), allPolicyPacks)
 		},
 	}
 
@@ -103,8 +106,7 @@ func newPolicyListCmd(ws pkgWorkspace.Context, lm cmdBackend.LoginManager) *cobr
 		Required: 0,
 	})
 
-	cmd.PersistentFlags().BoolVarP(
-		&jsonOut, "json", "j", false, "Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.PersistentFlags(), &output)
 	return cmd
 }
 


### PR DESCRIPTION
Add the new standard `--output $format` flag, keeping `--json` as a hidden flag for backwards compatibility.

Ref https://github.com/pulumi/pulumi/issues/22959
