### PR TITLE
Don't always same output values

### DIFF
--- a/changelog/pending/cli-fix-20260626-130005.yaml
+++ b/changelog/pending/cli-fix-20260626-130005.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: fix
+body: Don't ignore diffs in `Output` values
+time: 2026-06-26T13:00:05.884538+01:00

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -211,10 +211,8 @@ func (props PropertyMap) diff(other PropertyMap, opts diffOptions, path Property
 		}
 
 		if new, has := other[k]; has {
-			// If a new exists, use it; for output properties, however, ignore differences.
-			if new.IsOutput() {
-				sames[k] = old
-			} else if diff := old.diff(new, opts, append(path, string(k))); diff != nil {
+			// If a new exists, use it;
+			if diff := old.diff(new, opts, append(path, string(k))); diff != nil {
 				if !old.HasValue() {
 					adds[k] = new
 				} else if !new.HasValue() {
@@ -492,10 +490,8 @@ func (props PropertyMap) DiffIncludeUnknowns(other PropertyMap, ignoreKeys ...Ig
 		}
 
 		if new, has := other[k]; has {
-			// If a new exists, use it; for output properties, however, ignore differences.
-			if new.IsOutput() {
-				sames[k] = new
-			} else if diff := old.DiffIncludeUnknowns(new, ignoreKeys...); diff != nil {
+			// If a new exists, use it;
+			if diff := old.DiffIncludeUnknowns(new, ignoreKeys...); diff != nil {
 				if !old.HasValue() {
 					adds[k] = new
 				} else if !new.HasValue() {


### PR DESCRIPTION
Noticed this while working on https://github.com/pulumi/pulumi/pull/23668. I don't think this check makes sense, it means every output gets marked 'same' even if it totally changed.