### PR TITLE
Check that `UpgradeCurrentLogger` can't fail future logging calls

### DIFF
--- a/changelog/pending/backend-service-fix-20260626-135617.yaml
+++ b/changelog/pending/backend-service-fix-20260626-135617.yaml
@@ -1,0 +1,4 @@
+component: backend/service
+kind: fix
+body: Don't fail a operation due to a logging failure
+time: 2026-06-26T13:56:17.67228+02:00

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -2029,7 +2029,7 @@ func (b *cloudBackend) runEngineAction(
 		displayEvents, displayDone, op.Opts.Display, dryRun)
 
 	if err := pkgLogging.RenameCurrentLogger(string(stackRef.FullyQualifiedName()), update.UpdateID); err != nil {
-		return nil, nil, err
+		logging.V(3).Infof("encrypted log failed to rename: %v", err)
 	}
 
 	// The engineEvents channel receives all events from the engine, which we then forward onto other

--- a/pkg/logging/encrypted.go
+++ b/pkg/logging/encrypted.go
@@ -250,7 +250,7 @@ func (l *Logger) rename(stackName, updateID string) error {
 	defer l.mu.Unlock()
 
 	// Close before renaming — Windows cannot rename an open file.
-	if err := l.f.Close(); err != nil {
+	if err := l.f.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 		return fmt.Errorf("closing log file: %w", err)
 	}
 	if err := l.renameLocked(stackName, updateID); err != nil {

--- a/pkg/logging/encrypted_test.go
+++ b/pkg/logging/encrypted_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -121,6 +122,61 @@ func TestUpgradeToEncryptedDoesNotDeadlock(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, strings.Contains(string(plaintext), preUpgrade),
 		"decrypted log should contain data written before the upgrade")
+}
+
+// TestRenameToleratesClosedLogFile asserts that automatic update logging is
+// best-effort: a failure while renaming the log file must never surface to its
+// caller.
+//
+// The backend calls RenameCurrentLogger right after acquiring the update lock
+// (pkg/backend/httpstate/backend.go). If an earlier UpgradeCurrentLogger left the
+// log handle closed, the rename closes the already-closed handle and returns
+// "closing log file: file already closed". The backend treats that error as fatal
+// and aborts the update with the lock still held, so the following Destroy and
+// RemoveStack fail with "[409] Conflict: ... update is currently in progress".
+//
+// RenameCurrentLogger must therefore return nil even when the log file is already
+// closed.
+func TestRenameToleratesClosedLogFile(t *testing.T) {
+	if runtime.GOOS != "windows" && os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions, so the rename failure cannot be simulated")
+	}
+	t.Setenv("PULUMI_HOME", t.TempDir())
+
+	l, err := StartLogging(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = l.Close() })
+
+	// Make the rename inside the upgrade fail so it leaves the log file handle
+	// closed, exactly as a transient sharing violation does on Windows. The
+	// upgrade error is expected and (as in production) ignored. restore undoes the
+	// injection so the rename below is blocked only by the closed handle.
+	restore := failNextLogRename(t, l.FilePath())
+	_ = UpgradeCurrentLogger(t.Context(), "test-org/test-proj/test-stack", "", loggingSecretsManager{})
+	restore()
+
+	require.NoError(t, RenameCurrentLogger("test-org/test-proj/test-stack", "update-id"),
+		"a best-effort logging failure must never abort the update and leak its lock")
+}
+
+// failNextLogRename makes the next rename of the log file fail, leaving its
+// handle closed — the state a transient sharing violation produces on Windows.
+// The returned func undoes the injection.
+func failNextLogRename(t *testing.T, path string) (restore func()) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		// os.Open opens without FILE_SHARE_DELETE on Windows, so holding this
+		// handle makes any rename of the file fail — the real mechanism behind the
+		// CI flake (an AV/indexer transiently holding the just-closed log file).
+		f, err := os.Open(path)
+		require.NoError(t, err)
+		return func() { _ = f.Close() }
+	}
+	// Elsewhere, an open handle doesn't block renames, so make the directory
+	// read-only instead.
+	dir := filepath.Dir(path)
+	require.NoError(t, os.Chmod(dir, 0o500))
+	return func() { require.NoError(t, os.Chmod(dir, 0o700)) }
 }
 
 // TestRenameWhileWriting exercises renaming the live log file while concurrent


### PR DESCRIPTION
We assume our logging framework's calls are fallable, and we can safely ignore failures:

https://github.com/pulumi/pulumi/blob/9fd06c1f63cc96364edc6860452567154846a28c/pkg/cmd/pulumi/stack/secrets.go#L313-L315

This is true only when ignoring one failure doesn't cause another later down the line. This PR adds a test that replicates the failure we saw in https://github.com/pulumi/pulumi/actions/runs/27960130119/job/83622152193?pr=23657:

```
=== FAIL: go/auto TestInlineConcurrentUpdateError (3.47s)
    errors_test.go:115:
        	Error Trace:	D:/a/pulumi/pulumi/sdk/go/auto/errors_test.go:115
        	Error:      	Expected nil, but got: auto.autoError***stdout:"Updating (moolumi/testf35f7f5d42ff291c)\n\nView Live: https://app.pulumi.com/moolumi/inline_conflict_error/testf35f7f5d42ff291c/updates/1\n\n", stderr:"error: closing log file: close D:\\a\\pulumi\\pulumi\\home\\logs\\pulumi-20260626T085401-8176.log: file already closed\n", code:1, err:(*fmt.wrapError)(0x2243a6f6a840)***
        	Test:       	TestInlineConcurrentUpdateError
    errors_test.go:119:
        	Error Trace:	D:/a/pulumi/pulumi/sdk/go/auto/errors_test.go:119
        	Error:      	Received unexpected error:
        	            	failed to destroy stack: exit status 1
        	            	code: 1
        	            	stdout: Destroying (moolumi/testf35f7f5d42ff291c)

        	            	stderr: error: [409] Conflict: Another update is currently in progress.
        	            	To learn more about possible reasons and resolution, visit https://www.pulumi.com/docs/support/troubleshooting/common-issues/update-conflicts/

        	Test:       	TestInlineConcurrentUpdateError
        	Messages:   	destroy failed
    errors_test.go:98:
        	Error Trace:	D:/a/pulumi/pulumi/sdk/go/auto/errors_test.go:98
        	            				C:/hostedtoolcache/windows/go/1.26.4/x64/src/runtime/panic.go:694
        	            				C:/hostedtoolcache/windows/go/1.26.4/x64/src/testing/testing.go:1022
        	            				D:/a/pulumi/pulumi/sdk/go/auto/errors_test.go:119
        	Error:      	Expected nil, but got: auto.autoError***stdout:"", stderr:"error: [409] Conflict: Stack has an update in-progress.\n", code:1, err:(*fmt.wrapError)(0x2243a71985c0)***
        	Test:       	TestInlineConcurrentUpdateError
        	Messages:   	failed to remove stack. Resources have leaked.

```

[CI failure (windows)](https://github.com/pulumi/pulumi/actions/runs/28238658456/job/83660763712) & [CI failure (ubuntu)](https://github.com/pulumi/pulumi/actions/runs/28238658456/job/83660763719) show that the added test actually reproduces the failure.