### PR TITLE
Fix format policy violation resource types as display names

### DIFF
--- a/changelog/pending/backend-fix-20260626-151749.yaml
+++ b/changelog/pending/backend-fix-20260626-151749.yaml
@@ -1,4 +1,4 @@
-component: backend
+component: cli
 kind: fix
 body: Use display resource type names in policy violation output
 time: 2026-06-26T15:17:49.534339+03:00

--- a/changelog/pending/backend-fix-20260626-151749.yaml
+++ b/changelog/pending/backend-fix-20260626-151749.yaml
@@ -1,0 +1,4 @@
+component: backend
+kind: fix
+body: Use display resource type names in policy violation output
+time: 2026-06-26T15:17:49.534339+03:00

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -231,7 +231,7 @@ func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 	// Print the individual policy's name and target resource type/name.
 	policyLine := fmt.Sprintf("%s[%s]%s  %s%s  (%s: %s)",
 		c, payload.EnforcementLevel, severity, payload.PolicyName, colors.Reset,
-		payload.ResourceURN.Type(), resourceText(payload.ResourceURN, opts))
+		payload.ResourceURN.Type().DisplayName(), resourceText(payload.ResourceURN, opts))
 
 	// If there is already a prefix string requested, use it, otherwise fall back to a default.
 	if prefix == "" {

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -390,3 +390,51 @@ func TestCreateDiffDoesNotIndentBeneathHiddenParent(t *testing.T) {
 `
 	assert.Equal(t, strings.TrimSuffix(expected, "\n"), diff)
 }
+
+func TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket")
+
+	payload := engine.PolicyViolationEventPayload{
+		ResourceURN:       urn,
+		Message:           "S3 buckets should have cross-region replication.",
+		PolicyName:        "s3-bucket-replication-enabled",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		EnforcementLevel:  apitype.Advisory,
+	}
+
+	output := renderDiffPolicyViolationEvent(payload, "", "", Options{
+		Color: colors.Never,
+	})
+
+	assert.Contains(t, output, "(aws:s3:Bucket: my-bucket)")
+	assert.NotContains(t, output, "aws:s3/bucket:Bucket")
+}
+
+func TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket")
+
+	payload := engine.PolicyViolationEventPayload{
+		ResourceURN:       urn,
+		Message:           "S3 buckets should have cross-region replication.",
+		PolicyName:        "s3-bucket-replication-enabled",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		EnforcementLevel:  apitype.Advisory,
+	}
+
+	output := renderDiffPolicyViolationEvent(payload, "", "", Options{
+		Color:    colors.Never,
+		ShowURNs: true,
+	})
+
+	assert.Contains(
+		t,
+		output,
+		"(aws:s3:Bucket: urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket)",
+	)
+}


### PR DESCRIPTION
## Problem

Policy violation output renders resource types using raw provider tokens, for example `aws:s3/bucket:Bucket`.

This is inconsistent with the normal CLI resource tree, which renders the same resource as `aws:s3:Bucket`.

## Root cause

Policy violation rendering uses `payload.ResourceURN.Type()` directly.

The normal resource tree uses `urn.Type().DisplayName()` for the user-facing resource type column.

## Fix

Use `payload.ResourceURN.Type().DisplayName()` when rendering policy violation resource types.

`DisplayName()` is already used by the normal resource tree for the user-facing resource type column, so this makes policy violation output consistent with existing CLI rendering.

## Testing

- `cd pkg && go test -count=1 ./backend/display -run 'TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName'`
- `mise exec -- make format`
- `mise exec -- make lint`

<details>
<summary>Test output</summary>

```text
hostname_comp pkg % go test -v -count=1 ./backend/display -run 'TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName|TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName'
=== RUN   TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName
=== PAUSE TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName
=== RUN   TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs
=== PAUSE TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs
=== CONT  TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName
=== CONT  TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs
--- PASS: TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeName (0.00s)
--- PASS: TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs (0.00s)
PASS
ok  	github.com/pulumi/pulumi/pkg/v3/backend/display	0.444s
hostname_comp pkg

mise exec -- make format
Checking for golangci-lint ....... ✓
FORMAT:
golangci-lint fmt
Checking for go .................. ✓
=== sdk/nodejs (ensure) ===
Checking for npm ................. ✓
Checking for node ................ ✓
make[1]: Nothing to be done for `ensure'.
=== sdk/python (ensure) ===
Checking for uv .................. ✓
../../scripts/retry uv venv --allow-existing
COMMAND     =  uv venv --allow-existing
Using CPython 3.11.15 interpreter at: /Users/s.neboshirskiy/.local/share/mise/installs/python/3.11/bin/python3
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
::info Tests successful.. failures refer to test flakes that were successfully re-run.
../../scripts/retry uv sync --dev
COMMAND     =  uv sync --dev
Resolved 75 packages in 18ms
Audited 65 packages in 1ms
::info Tests successful.. failures refer to test flakes that were successfully re-run.
=== sdk/go (ensure) ===
Checking for go .................. ✓
make[1]: Nothing to be done for `ensure'.
=== sdk/pcl (ensure) ===
Checking for go .................. ✓
make[1]: Nothing to be done for `ensure'.
cd sdk/nodejs && npx biome format --write ../../pkg/codegen/schema/pulumi.json
Formatted 1 file in 6ms. No fixes applied.
hostname_comp pulumi % 
hostname_comp pulumi % 
hostname_comp pulumi % 
hostname_comp pulumi % mise exec -- make lint
LINT:
Checking for golangci-lint ....... ✓
[golangci-lint] Linting sdk...
0 issues.
[golangci-lint] Linting pkg...
0 issues.
[golangci-lint] Linting tests...
0 issues.
[golangci-lint] Linting sdk/go/pulumi-language-go...
0 issues.
[golangci-lint] Linting sdk/nodejs/cmd/pulumi-language-nodejs...
0 issues.
[golangci-lint] Linting sdk/python/cmd/pulumi-language-python...
0 issues.
[golangci-lint] Linting sdk/pcl...
0 issues.
# NOTE: github.com/santhosh-tekuri/jsonschema uses Go's regexp engine, but
# JSON schema says regexps should conform to ECMA 262.
go run github.com/santhosh-tekuri/jsonschema/cmd/jv@v0.7.0 pkg/codegen/schema/pulumi.json
schema pkg/codegen/schema/pulumi.json: ok
# We only want to run `make ensure` in sdk/nodejs to install biome.  We can't depend
# need here, and don't necessarily have installed in CI.
cd sdk/nodejs && make ensure
Checking for npm ................. ✓
Checking for node ................ ✓
make[1]: Nothing to be done for `ensure'.
cd sdk/nodejs && npx biome format ../../pkg/codegen/schema/pulumi.json
Checked 1 file in 6ms. No fixes applied.
## 3.249.0 (2026-06-26)

### Features

- [cli/policy] Add a `--file` flag to `pulumi policy analyze` to analyze a state file (as produced by `pulumi stack export`) without requiring a stack or backend login

### Bug Fixes

- [sdkgen/python] Cache package references per-deployment in generated SDKs [#22459](https://github.com/pulumi/pulumi/pull/22459)
- [backend] Use display resource type names in policy violation output

### Improvements

- [sdk/nodejs] Use npm as the package manager for the Node.js SDK
- [cli] Add `--output $format` flag to `pulumi stack {list,history,tag list}`
- [cli/plugin] Add `--output $format` to `pulumi plugin list`
- [cli/engine] Fix TestDebuggerAttach for dlv@1.27
- [cli] Add --output $format to `pulumi policy list` and `pulumi policy group list`
- [cli] Add --output $format to `pulumi project list`

### Miscellaneous

- [pkg/testing] Allow ProgramTest to use npm for Node.js tests
hostname_comp pulumi %
```

</details>

Fixes #14096