### PR TITLE
Add `--output $format` flag to `pulumi config env list`

### DIFF
--- a/changelog/pending/cli-improvement-20260626-config-env-ls.yaml
+++ b/changelog/pending/cli-improvement-20260626-config-env-ls.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: Add `--output $format` flag to `pulumi config env list`
+time: 2026-06-26T15:49:58.924705+02:00

--- a/pkg/cmd/pulumi/config/config_env.go
+++ b/pkg/cmd/pulumi/config/config_env.go
@@ -152,40 +152,14 @@ func (cmd *configEnvCmd) loadEnvPreamble(ctx context.Context,
 	return projectStack, project, &stack, nil
 }
 
-func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, jsonOut bool) error {
+func (cmd *configEnvCmd) listStackEnvironments(ctx context.Context, render stackEnvironmentsRenderFunc) error {
 	projectStack, _, _, err := cmd.loadEnvPreamble(ctx)
 	if err != nil {
 		return err
 	}
 	imports := projectStack.Environment.Imports()
 
-	if jsonOut {
-		if len(imports) == 0 {
-			ui.Fprintf(cmd.stdout, "[]\n")
-		} else {
-			err := ui.FprintJSON(cmd.stdout, imports)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		rows := []cmdutil.TableRow{}
-		for _, imp := range imports {
-			rows = append(rows, cmdutil.TableRow{Columns: []string{imp}})
-		}
-
-		if len(imports) > 0 {
-			ui.FprintTable(cmd.stdout, cmdutil.Table{
-				Headers: []string{"ENVIRONMENTS"},
-				Rows:    rows,
-			}, nil)
-		} else {
-			ui.Fprintf(cmd.stdout, "This stack configuration has no environments listed. "+
-				"Try adding one with `pulumi config env add <projectName>/<envName>`.\n")
-		}
-	}
-
-	return nil
+	return render(cmd.stdout, imports)
 }
 
 func (cmd *configEnvCmd) editStackEnvironment(

--- a/pkg/cmd/pulumi/config/config_env_list.go
+++ b/pkg/cmd/pulumi/config/config_env_list.go
@@ -16,15 +16,24 @@ package config
 
 import (
 	"context"
+	"io"
 
 	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/constrictor"
+	"github.com/pulumi/pulumi/pkg/v3/cmd/pulumi/ui"
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 )
 
-func newConfigEnvListCmd(parent *configEnvCmd) *cobra.Command {
-	var jsonOut bool
+type stackEnvironmentsRenderFunc func(w io.Writer, imports []string) error
 
-	impl := configEnvLsCmd{parent: parent, jsonOut: &jsonOut}
+func newConfigEnvListCmd(parent *configEnvCmd) *cobra.Command {
+	output := outputflag.OutputFlag[stackEnvironmentsRenderFunc]{
+		RenderForTerminal: formatStackEnvironmentsConsole,
+		RenderJSON:        formatStackEnvironmentsJSON,
+	}
+
+	impl := configEnvLsCmd{parent: parent, output: &output}
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -39,9 +48,7 @@ func newConfigEnvListCmd(parent *configEnvCmd) *cobra.Command {
 
 	constrictor.AttachArguments(cmd, constrictor.NoArgs)
 
-	cmd.Flags().BoolVarP(
-		&jsonOut, "json", "j", false,
-		"Emit output as JSON")
+	outputflag.VarWithJSONAlias(cmd, cmd.Flags(), &output)
 
 	return cmd
 }
@@ -49,9 +56,36 @@ func newConfigEnvListCmd(parent *configEnvCmd) *cobra.Command {
 type configEnvLsCmd struct {
 	parent *configEnvCmd
 
-	jsonOut *bool
+	output *outputflag.OutputFlag[stackEnvironmentsRenderFunc]
 }
 
 func (cmd *configEnvLsCmd) run(ctx context.Context, _ []string) error {
-	return cmd.parent.listStackEnvironments(ctx, *cmd.jsonOut)
+	return cmd.parent.listStackEnvironments(ctx, cmd.output.Get())
+}
+
+func formatStackEnvironmentsConsole(w io.Writer, imports []string) error {
+	if len(imports) == 0 {
+		ui.Fprintf(w, "This stack configuration has no environments listed. "+
+			"Try adding one with `pulumi config env add <projectName>/<envName>`.\n")
+		return nil
+	}
+
+	rows := []cmdutil.TableRow{}
+	for _, imp := range imports {
+		rows = append(rows, cmdutil.TableRow{Columns: []string{imp}})
+	}
+
+	ui.FprintTable(w, cmdutil.Table{
+		Headers: []string{"ENVIRONMENTS"},
+		Rows:    rows,
+	}, nil)
+	return nil
+}
+
+func formatStackEnvironmentsJSON(w io.Writer, imports []string) error {
+	if len(imports) == 0 {
+		ui.Fprintf(w, "[]\n")
+		return nil
+	}
+	return ui.FprintJSON(w, imports)
 }

--- a/pkg/cmd/pulumi/config/config_env_list_test.go
+++ b/pkg/cmd/pulumi/config/config_env_list_test.go
@@ -22,10 +22,17 @@ import (
 	"github.com/pulumi/esc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 )
 
-func ptr[T any](v T) *T {
-	return &v
+func lsOutput(t *testing.T, format string) *outputflag.OutputFlag[stackEnvironmentsRenderFunc] {
+	output := &outputflag.OutputFlag[stackEnvironmentsRenderFunc]{
+		RenderForTerminal: formatStackEnvironmentsConsole,
+		RenderJSON:        formatStackEnvironmentsJSON,
+	}
+	require.NoError(t, output.Set(format))
+	return output
 }
 
 func TestConfigEnvLsCmd(t *testing.T) {
@@ -48,7 +55,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -73,7 +80,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -104,7 +111,7 @@ runtime: yaml`
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -139,7 +146,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -175,7 +182,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(false)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)
@@ -211,7 +218,7 @@ thirdEnv
 		stdin := strings.NewReader("")
 		var stdout bytes.Buffer
 		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, jsonOut: ptr(true)}
+		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
 		ctx := t.Context()
 		err := ls.run(ctx, nil)
 		require.NoError(t, err)

--- a/pkg/cmd/pulumi/config/config_env_list_test.go
+++ b/pkg/cmd/pulumi/config/config_env_list_test.go
@@ -16,30 +16,32 @@ package config
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/pulumi/esc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/pulumi/pulumi/pkg/v3/util/outputflag"
 )
 
-func lsOutput(t *testing.T, format string) *outputflag.OutputFlag[stackEnvironmentsRenderFunc] {
-	output := &outputflag.OutputFlag[stackEnvironmentsRenderFunc]{
-		RenderForTerminal: formatStackEnvironmentsConsole,
-		RenderJSON:        formatStackEnvironmentsJSON,
-	}
-	require.NoError(t, output.Set(format))
-	return output
+const configEnvLsProjectYAML = `name: test
+runtime: yaml`
+
+func runConfigEnvLs(t *testing.T, stackYAML string, env *esc.Environment, args ...string) string {
+	var stdout bytes.Buffer
+	parent := newConfigEnvCmdForTest(
+		strings.NewReader(""), &stdout, configEnvLsProjectYAML, stackYAML, env, nil, nil)
+	cmd := newConfigEnvListCmd(parent)
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	require.NoError(t, cmd.ExecuteContext(t.Context()))
+	return cleanStdout(stdout.String())
 }
 
 func TestConfigEnvLsCmd(t *testing.T) {
 	t.Parallel()
-
-	projectYAML := `name: test
-runtime: yaml`
 
 	t.Run("no imports", func(t *testing.T) {
 		t.Parallel()
@@ -52,18 +54,10 @@ runtime: yaml`
 			},
 		}
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = "This stack configuration has no environments listed. " +
 			"Try adding one with `pulumi config env add <projectName>/<envName>`.\n"
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, "", env))
 	})
 
 	t.Run("no imports, json", func(t *testing.T) {
@@ -77,17 +71,9 @@ runtime: yaml`
 			},
 		}
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, "", env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = "[]\n"
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, "", env, "--output", "json"))
 	})
 
 	t.Run("with imports", func(t *testing.T) {
@@ -108,21 +94,13 @@ runtime: yaml`
     - thirdEnv
 `
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = `ENVIRONMENTS
 env
 otherEnv
 thirdEnv
 `
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, stackYAML, env))
 	})
 
 	t.Run("with imports, json", func(t *testing.T) {
@@ -143,14 +121,6 @@ thirdEnv
     - thirdEnv
 `
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = `[
   "env",
   "otherEnv",
@@ -158,7 +128,7 @@ thirdEnv
 ]
 `
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, stackYAML, env, "--output", "json"))
 	})
 
 	t.Run("with imports", func(t *testing.T) {
@@ -179,21 +149,13 @@ thirdEnv
     - thirdEnv
 `
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "default")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = `ENVIRONMENTS
 env
 otherEnv
 thirdEnv
 `
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, stackYAML, env))
 	})
 
 	t.Run("repeated imports", func(t *testing.T) {
@@ -215,14 +177,6 @@ thirdEnv
     - thirdEnv
 `
 
-		stdin := strings.NewReader("")
-		var stdout bytes.Buffer
-		parent := newConfigEnvCmdForTest(stdin, &stdout, projectYAML, stackYAML, env, nil, nil)
-		ls := &configEnvLsCmd{parent: parent, output: lsOutput(t, "json")}
-		ctx := t.Context()
-		err := ls.run(ctx, nil)
-		require.NoError(t, err)
-
 		const expectedOut = `[
   "env",
   "otherEnv",
@@ -231,6 +185,6 @@ thirdEnv
 ]
 `
 
-		assert.Equal(t, expectedOut, cleanStdout(stdout.String()))
+		assert.Equal(t, expectedOut, runConfigEnvLs(t, stackYAML, env, "--output", "json"))
 	})
 }


### PR DESCRIPTION
Add the new standard `--output $format` flag, keeping `--json` as a hidden flag for backwards compatibility.

Ref https://github.com/pulumi/pulumi/issues/22959