### PR TITLE
Update analyzer plugins to use property.Value

### DIFF
--- a/pkg/cmd/pulumi/policy/policy_analyze_test.go
+++ b/pkg/cmd/pulumi/policy/policy_analyze_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // makeAnalyzeSnapshot builds a minimal snapshot with a single resource.
@@ -287,9 +288,9 @@ func TestPolicyAnalyzeCmd_File_UndecryptableSecretsRedacted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "secret values redacted")
 
-	pw := analyzer.analyzeProperties["password"]
-	require.True(t, pw.IsSecret())
-	assert.Equal(t, "[secret]", pw.SecretValue().Element.StringValue())
+	pw := analyzer.analyzeProperties.Get("password")
+	require.True(t, pw.Secret())
+	assert.Equal(t, "[secret]", pw.AsString())
 }
 
 // The progress (non-diff) display reads the synthetic ref's Name()/Project(); the other
@@ -580,10 +581,9 @@ func TestPolicyAnalyzeCmd_AnalyzeStackCalled_PrintsAndUsesOutputs(t *testing.T) 
 	expected := "    test-pack@v [mandatory]  stack-policy  (pkg:index:MyResource: res)stack-level violation\n"
 	assert.Equal(t, expected, stdout)
 
-	got, ok := analyzer.analyzeStackProperties["origin"]
+	got, ok := analyzer.analyzeStackProperties.GetOk("origin")
 	require.True(t, ok)
-	assert.True(t, got.DeepEquals(resource.NewProperty("output")))
-	assert.False(t, got.DeepEquals(resource.NewProperty("input")))
+	assert.Equal(t, property.New("output"), got)
 }
 
 func decodeEngineEventsJSON(t *testing.T, out string) []apitype.EngineEvent {
@@ -613,12 +613,12 @@ type fakeAnalyzer struct {
 	remediate              bool
 	stackDiagnostic        *plugin.AnalyzeDiagnostic
 	analyzeStackCalled     bool
-	analyzeStackProperties resource.PropertyMap
-	analyzeProperties      resource.PropertyMap
+	analyzeStackProperties property.Map
+	analyzeProperties      property.Map
 }
 
 func (a *fakeAnalyzer) Analyze(_ context.Context, r plugin.AnalyzerResource) (plugin.AnalyzeResponse, error) {
-	a.analyzeProperties = r.Properties.Copy()
+	a.analyzeProperties = r.Properties
 	if a.mandatory {
 		return plugin.AnalyzeResponse{
 			Diagnostics: []plugin.AnalyzeDiagnostic{{
@@ -638,7 +638,7 @@ func (a *fakeAnalyzer) AnalyzeStack(
 ) (plugin.AnalyzeResponse, error) {
 	a.analyzeStackCalled = true
 	if len(resources) > 0 {
-		a.analyzeStackProperties = resources[0].Properties.Copy()
+		a.analyzeStackProperties = resources[0].Properties
 	}
 	if a.stackDiagnostic != nil {
 		return plugin.AnalyzeResponse{
@@ -656,7 +656,7 @@ func (a *fakeAnalyzer) Remediate(_ context.Context, _ plugin.AnalyzerResource) (
 				PolicyPackName:    "test-pack",
 				PolicyPackVersion: "1.0.0",
 				Description:       "fixes a property",
-				Properties:        resource.PropertyMap{"k": resource.NewProperty("fixed")},
+				Properties:        property.NewMap(map[string]property.Value{"k": property.New("fixed")}),
 			}},
 		}, nil
 	}

--- a/pkg/engine/lifecycletest/analyzer_test.go
+++ b/pkg/engine/lifecycletest/analyzer_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -385,21 +386,21 @@ func TestResourceRemediation(t *testing.T) {
 							PolicyPackName:    "analyzerA",
 							PolicyPackVersion: "1.0.0",
 							Description:       "a remediation that gets ignored because it runs first",
-							Properties: resource.PropertyMap{
-								"a":   resource.NewProperty("nope"),
-								"ggg": resource.NewProperty(true),
-							},
+							Properties: property.NewMap(map[string]property.Value{
+								"a":   property.New("nope"),
+								"ggg": property.New(true),
+							}),
 						},
 						{
 							PolicyName:        "real-deal",
 							PolicyPackName:    "analyzerA",
 							PolicyPackVersion: "1.0.0",
 							Description:       "a remediation that actually gets applied because it runs last",
-							Properties: resource.PropertyMap{
-								"a":   resource.NewProperty("foo"),
-								"fff": resource.NewProperty(true),
-								"z":   resource.NewProperty("bar"),
-							},
+							Properties: property.NewMap(map[string]property.Value{
+								"a":   property.New("foo"),
+								"fff": property.New(true),
+								"z":   property.New("bar"),
+							}),
 						},
 					}}, nil
 				},

--- a/pkg/resource/deploy/analyze_snapshot.go
+++ b/pkg/resource/deploy/analyze_snapshot.go
@@ -119,7 +119,7 @@ func stateToAnalyzerResource(
 		URN:        res.URN,
 		Type:       res.Type,
 		Name:       res.URN.Name(),
-		Properties: properties,
+		Properties: resource.FromResourcePropertyMap(properties),
 		Options: plugin.AnalyzerResourceOptions{
 			Protect:                 res.Protect,
 			IgnoreChanges:           res.IgnoreChanges,
@@ -136,7 +136,7 @@ func stateToAnalyzerResource(
 					URN:        provRes.URN,
 					Type:       provRes.Type,
 					Name:       provRes.URN.Name(),
-					Properties: provRes.Inputs,
+					Properties: resource.FromResourcePropertyMap(provRes.Inputs),
 				}
 			}
 		}
@@ -197,11 +197,10 @@ func AnalyzeSnapshot(
 						EnforcementLevel:  apitype.Advisory,
 						URN:               res.URN,
 					})
-				} else if tresult.Properties != nil {
+				} else {
 					// Report what would be remediated without applying it.
 					events.OnPolicyRemediation(res.URN, tresult,
-						resource.FromResourcePropertyMap(analyzerRes.Properties),
-						resource.FromResourcePropertyMap(tresult.Properties))
+						analyzerRes.Properties, tresult.Properties)
 				}
 				// A remediation might not set diagnostic or properties, we just ignore them.
 			}

--- a/pkg/resource/deploy/analyze_snapshot_test.go
+++ b/pkg/resource/deploy/analyze_snapshot_test.go
@@ -230,13 +230,13 @@ func TestAnalyzeSnapshot_RemediationReportedNotApplied(t *testing.T) {
 					PolicyName:     "fix-key",
 					PolicyPackName: "test-pack",
 					Description:    "sets key to good",
-					Properties:     resource.ToResourcePropertyMap(remediated),
+					Properties:     remediated,
 				}},
 			}, nil
 		},
 		// Analysis still sees the original properties (remediation was not applied).
 		AnalyzeF: func(r plugin.AnalyzerResource) (plugin.AnalyzeResponse, error) {
-			assert.Equal(t, original, resource.FromResourcePropertyMap(r.Properties),
+			assert.Equal(t, original, r.Properties,
 				"analysis should see original properties, not remediated ones")
 			return plugin.AnalyzeResponse{}, nil
 		},

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1359,7 +1359,7 @@ func (sg *stepGenerator) continueStepsFromImport(
 			URN:        new.URN,
 			Type:       new.Type,
 			Name:       new.URN.Name(),
-			Properties: inputs,
+			Properties: resource.FromResourcePropertyMap(inputs),
 			Options: plugin.AnalyzerResourceOptions{
 				Protect:                 new.Protect,
 				IgnoreChanges:           goal.IgnoreChanges,
@@ -1376,7 +1376,7 @@ func (sg *stepGenerator) continueStepsFromImport(
 				URN:        providerResource.URN,
 				Type:       providerResource.Type,
 				Name:       providerResource.URN.Name(),
-				Properties: providerResource.Inputs,
+				Properties: resource.FromResourcePropertyMap(providerResource.Inputs),
 			}
 		}
 
@@ -1401,14 +1401,13 @@ func (sg *stepGenerator) continueStepsFromImport(
 					EnforcementLevel:  apitype.Advisory,
 					URN:               new.URN,
 				})
-			} else if tresult.Properties != nil {
+			} else {
 				// Emit a nice message so users know what was remediated.
 				sg.deployment.events.OnPolicyRemediation(new.URN, tresult,
-					resource.FromResourcePropertyMap(inputs),
-					resource.FromResourcePropertyMap(tresult.Properties))
+					resource.FromResourcePropertyMap(inputs), tresult.Properties)
 				// Use the transformed inputs rather than the old ones from this point onwards.
-				inputs = tresult.Properties
-				new.Inputs = tresult.Properties
+				inputs = resource.ToResourcePropertyMap(tresult.Properties)
+				new.Inputs = resource.ToResourcePropertyMap(tresult.Properties)
 			}
 		}
 		summary := resourceanalyzer.NewRemediatePolicySummary(new.URN, response, info)
@@ -3266,7 +3265,7 @@ func (sg *stepGenerator) analyzeAll(
 		URN:        new.URN,
 		Type:       new.Type,
 		Name:       new.URN.Name(),
-		Properties: inputs,
+		Properties: resource.FromResourcePropertyMap(inputs),
 		Options: plugin.AnalyzerResourceOptions{
 			Protect:                 new.Protect,
 			IgnoreChanges:           goal.IgnoreChanges,
@@ -3283,7 +3282,7 @@ func (sg *stepGenerator) analyzeAll(
 			URN:        providerResource.URN,
 			Type:       providerResource.Type,
 			Name:       providerResource.URN.Name(),
-			Properties: providerResource.Inputs,
+			Properties: resource.FromResourcePropertyMap(providerResource.Inputs),
 		}
 	}
 
@@ -3321,7 +3320,7 @@ func (sg *stepGenerator) AnalyzeResources(ctx context.Context) error {
 					Name: v.URN.Name(),
 					// Unlike Analyze, AnalyzeStack is called on the final outputs of each resource,
 					// to verify the final stack is in a compliant state.
-					Properties: v.Outputs,
+					Properties: resource.FromResourcePropertyMap(v.Outputs),
 					Options: plugin.AnalyzerResourceOptions{
 						Protect:                 v.Protect,
 						IgnoreChanges:           v.IgnoreChanges,
@@ -3373,7 +3372,7 @@ func (sg *stepGenerator) AnalyzeResources(ctx context.Context) error {
 					URN:        providerResource.URN,
 					Type:       providerResource.Type,
 					Name:       providerResource.URN.Name(),
-					Properties: providerResource.Inputs,
+					Properties: resource.FromResourcePropertyMap(providerResource.Inputs),
 				}
 			}
 			resources = append(resources, res)

--- a/pkg/resource/plugin/analyzer.go
+++ b/pkg/resource/plugin/analyzer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
 
 // AnalyzerPolicyType indicates the type of a policy.
@@ -69,7 +70,7 @@ type AnalyzerResource struct {
 	URN        resource.URN
 	Type       tokens.Type
 	Name       string
-	Properties resource.PropertyMap
+	Properties property.Map
 	Options    AnalyzerResourceOptions
 	Provider   *AnalyzerProviderResource
 }
@@ -99,7 +100,7 @@ type AnalyzerProviderResource struct {
 	URN        resource.URN
 	Type       tokens.Type
 	Name       string
-	Properties resource.PropertyMap
+	Properties property.Map
 }
 
 // AnalyzeDiagnostic indicates that resource analysis failed; it contains the property and reason
@@ -131,7 +132,7 @@ type Remediation struct {
 	PolicyPackName    string
 	PolicyPackVersion string
 	URN               resource.URN
-	Properties        resource.PropertyMap
+	Properties        property.Map
 	Diagnostic        string
 }
 

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -302,8 +302,8 @@ func (a *analyzer) Analyze(ctx context.Context, r AnalyzerResource) (AnalyzeResp
 	urn, t, name, props := r.URN, r.Type, r.Name, r.Properties
 
 	label := fmt.Sprintf("%s.Analyze(%s)", a.label(), t)
-	logging.V(7).Infof("%s executing (#props=%d)", label, len(props))
-	mprops, err := MarshalProperties(props,
+	logging.V(7).Infof("%s executing (#props=%d)", label, props.Len())
+	mprops, err := MarshalProperties(resource.ToResourcePropertyMap(props),
 		MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 	if err != nil {
 		return AnalyzeResponse{}, err
@@ -346,20 +346,20 @@ func (a *analyzer) AnalyzeStack(ctx context.Context, resources []AnalyzerStackRe
 	logging.V(7).Infof("%s.AnalyzeStack(#resources=%d) executing", a.label(), len(resources))
 
 	protoResources := make([]*pulumirpc.AnalyzerResource, len(resources))
-	for idx, resource := range resources {
-		props, err := MarshalProperties(resource.Properties,
+	for idx, res := range resources {
+		props, err := MarshalProperties(resource.ToResourcePropertyMap(res.Properties),
 			MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 		if err != nil {
 			return AnalyzeResponse{}, fmt.Errorf("marshalling properties: %w", err)
 		}
 
-		provider, err := marshalProvider(resource.Provider)
+		provider, err := marshalProvider(res.Provider)
 		if err != nil {
 			return AnalyzeResponse{}, err
 		}
 
 		propertyDeps := make(map[string]*pulumirpc.AnalyzerPropertyDependencies)
-		for pk, pd := range resource.PropertyDependencies {
+		for pk, pd := range res.PropertyDependencies {
 			// Skip properties that have no dependencies.
 			if len(pd) == 0 {
 				continue
@@ -375,14 +375,14 @@ func (a *analyzer) AnalyzeStack(ctx context.Context, resources []AnalyzerStackRe
 		}
 
 		protoResources[idx] = &pulumirpc.AnalyzerResource{
-			Urn:                  string(resource.URN),
-			Type:                 string(resource.Type),
-			Name:                 resource.Name,
+			Urn:                  string(res.URN),
+			Type:                 string(res.Type),
+			Name:                 res.Name,
 			Properties:           props,
-			Options:              marshalResourceOptions(resource.Options),
+			Options:              marshalResourceOptions(res.Options),
 			Provider:             provider,
-			Parent:               string(resource.Parent),
-			Dependencies:         convertURNs(resource.Dependencies),
+			Parent:               string(res.Parent),
+			Dependencies:         convertURNs(res.Dependencies),
 			PropertyDependencies: propertyDeps,
 		}
 	}
@@ -422,8 +422,8 @@ func (a *analyzer) Remediate(ctx context.Context, r AnalyzerResource) (Remediate
 	urn, t, name, props := r.URN, r.Type, r.Name, r.Properties
 
 	label := fmt.Sprintf("%s.Remediate(%s)", a.label(), t)
-	logging.V(7).Infof("%s executing (#props=%d)", label, len(props))
-	mprops, err := MarshalProperties(props,
+	logging.V(7).Infof("%s executing (#props=%d)", label, props.Len())
+	mprops, err := MarshalProperties(resource.ToResourcePropertyMap(props),
 		MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: false})
 	if err != nil {
 		return RemediateResponse{}, err
@@ -475,7 +475,7 @@ func (a *analyzer) Remediate(ctx context.Context, r AnalyzerResource) (Remediate
 			Description:       r.GetDescription(),
 			PolicyPackName:    r.GetPolicyPackName(),
 			PolicyPackVersion: policyPackVersion,
-			Properties:        tprops,
+			Properties:        resource.FromResourcePropertyMap(tprops),
 			Diagnostic:        r.GetDiagnostic(),
 		}
 	}
@@ -768,7 +768,7 @@ func marshalProvider(provider *AnalyzerProviderResource) (*pulumirpc.AnalyzerPro
 		return nil, nil
 	}
 
-	props, err := MarshalProperties(provider.Properties,
+	props, err := MarshalProperties(resource.ToResourcePropertyMap(provider.Properties),
 		MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 	if err != nil {
 		return nil, fmt.Errorf("marshalling properties: %w", err)

--- a/pkg/resource/plugin/analyzer_server.go
+++ b/pkg/resource/plugin/analyzer_server.go
@@ -58,7 +58,7 @@ func (a *analyzerServer) Analyze(
 		URN:        resource.URN(req.GetUrn()),
 		Type:       tokens.Type(req.GetType()),
 		Name:       req.GetName(),
-		Properties: props,
+		Properties: resource.FromResourcePropertyMap(props),
 		Options:    convertResourceOptions(req.GetOptions()),
 		Provider:   provider,
 	})
@@ -106,7 +106,7 @@ func (a *analyzerServer) AnalyzeStack(
 					URN:        resource.URN(r.GetUrn()),
 					Type:       tokens.Type(r.GetType()),
 					Name:       r.GetName(),
-					Properties: props,
+					Properties: resource.FromResourcePropertyMap(props),
 					Options:    convertResourceOptions(r.GetOptions()),
 					Provider:   provider,
 				},
@@ -153,7 +153,7 @@ func (a *analyzerServer) Remediate(
 		URN:        resource.URN(req.GetUrn()),
 		Type:       tokens.Type(req.GetType()),
 		Name:       req.GetName(),
-		Properties: props,
+		Properties: resource.FromResourcePropertyMap(props),
 		Options:    convertResourceOptions(req.GetOptions()),
 		Provider:   provider,
 	})
@@ -162,11 +162,12 @@ func (a *analyzerServer) Remediate(
 	}
 
 	remediations, err := slice.MapError(res.Remediations, func(r Remediation) (*pulumirpc.Remediation, error) {
-		mprops, err := MarshalProperties(r.Properties, MarshalOptions{
-			KeepUnknowns:     true,
-			KeepSecrets:      true,
-			SkipInternalKeys: false,
-		})
+		mprops, err := MarshalProperties(
+			resource.ToResourcePropertyMap(r.Properties), MarshalOptions{
+				KeepUnknowns:     true,
+				KeepSecrets:      true,
+				SkipInternalKeys: false,
+			})
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +392,7 @@ func convertProvider(p *pulumirpc.AnalyzerProviderResource) (*AnalyzerProviderRe
 		URN:        resource.URN(p.Urn),
 		Type:       tokens.Type(p.Type),
 		Name:       p.Name,
-		Properties: props,
+		Properties: resource.FromResourcePropertyMap(props),
 	}, nil
 }
 


### PR DESCRIPTION
Updates `plugin.Analyzer` to use `property.Value` instead of `resource.PropertyValue` (and likewise for maps).

This only updates the version in pkg, the version in sdk is left as is.