### PR TITLE
Fix deletedWith and replaceWith options in Python component resource providers

### DIFF
--- a/changelog/pending/20260626--sdk-python--fix-deletedwith-and-replacewith-in-python-component-resources.yaml
+++ b/changelog/pending/20260626--sdk-python--fix-deletedwith-and-replacewith-in-python-component-resources.yaml
@@ -1,0 +1,4 @@
+changes:
+- type: fix
+  scope: sdk/python
+  description: Fix `deletedWith` and `replaceWith` resource options being mishandled in Python component resource providers, causing "invalid DeletedWith URN" errors

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -279,13 +279,11 @@ class ProviderServicer(ResourceProviderServicer):
 
         deleted_with = None
         if request.deletedWith != "":
-            deleted_with = _create_provider_resource(request.deletedWith)
+            deleted_with = DependencyResource(request.deletedWith)
 
         replace_with: Optional[list[pulumi.Resource]] = None
         if request.replace_with:
-            replace_with = [
-                _create_provider_resource(urn) for urn in request.replace_with
-            ]
+            replace_with = [DependencyResource(urn) for urn in request.replace_with]
 
         replacement_trigger: Optional[Any] = None
         if request.HasField("replacement_trigger"):


### PR DESCRIPTION
## Summary

- `deletedWith` and `replaceWith` were passed through `_create_provider_resource()` in `_construct_options()`, which is designed for **provider references** (`urn::id`), not plain resource URNs.
- `_parse_resource_reference()` splits on the last `::`, stripping the resource name off the URN and treating it as a provider ID — producing a truncated URN the engine rejects.
- Fix: use `DependencyResource(urn)` for both fields, matching how `parent` and `depends_on` are already handled.

Fixes #23708

## Test plan

- [x] Manually verify a Pulumi YAML program with `deletedWith` set on a Python component resource no longer errors on `pulumi preview`
- [ ] Run Python SDK unit tests: `cd sdk/python && mise exec -- make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)