### PR TITLE
ci: balance macOS acceptance partitions by macOS-only timing data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
               "$CODEGEN_TESTS_FLAG" \
               --platform macos-latest \
               --version-set current \
+              --timing-glob 'macOS-*.json' \
               --partition-module pkg 1 \
               --partition-module sdk 1 \
               --partition-module tests 8 \

--- a/scripts/get-job-matrix.py
+++ b/scripts/get-job-matrix.py
@@ -11,6 +11,7 @@ Uses `gotestsum tool ci-matrix` to divide up Go packages into partitions to redu
 
 
 import argparse
+import glob
 import itertools
 import json
 import os
@@ -260,12 +261,29 @@ Matrix = TypedDict("Matrix", {
 })
 
 
-def run_gotestsum_ci_matrix_packages(go_packages: List[str], partition_module: PartitionModule, tags: List[str]) -> List[TestSuite]:
-    """Runs `gotestsum tool ci-matrix` to compute Go test partitions"""
+def resolve_timing_files(timing_glob: str) -> str:
+    """Resolve the --timing-files glob passed to gotestsum.
+
+    `timing_glob` may select a single platform's timing data (e.g. 'macOS-*.json'),
+    which keeps a platform's partitions balanced by its own runtimes rather than the
+    blended cross-platform pool. If the glob matches no files yet — e.g. the first run
+    after the prefixed timing data is introduced — fall back to all timing files so the
+    partitioning never regresses to an even split.
+    """
     script_dir = os.path.dirname(os.path.realpath(__file__))
     test_reports_dir = os.path.join(script_dir, "..", "test-results")
     os.makedirs(test_reports_dir, exist_ok=True)
 
+    if not glob.glob(os.path.join(test_reports_dir, timing_glob)):
+        if global_verbosity >= 1:
+            print(f"No timing files match {timing_glob!r}; falling back to *.json", file=sys.stderr)
+        timing_glob = "*.json"
+
+    return os.path.join(test_reports_dir, timing_glob)
+
+
+def run_gotestsum_ci_matrix_packages(go_packages: List[str], partition_module: PartitionModule, tags: List[str], timing_glob: str) -> List[TestSuite]:
+    """Runs `gotestsum tool ci-matrix` to compute Go test partitions"""
     if partition_module.partitions == 1:
         pkgs = " ".join(go_packages)
         return [{
@@ -280,7 +298,7 @@ def run_gotestsum_ci_matrix_packages(go_packages: List[str], partition_module: P
         "--partitions",
         f"{partition_module.partitions}",
         "--timing-files",
-        f"{test_reports_dir}/*.json",
+        resolve_timing_files(timing_glob),
         "--debug",
     ]
 
@@ -322,13 +340,9 @@ def run_gotestsum_ci_matrix_packages(go_packages: List[str], partition_module: P
 
 
 def run_gotestsum_ci_matrix_single_package(
-    partition_pkg: PartitionPackage, tests: List[str], tags: List[str]
+    partition_pkg: PartitionPackage, tests: List[str], tags: List[str], timing_glob: str
 ) -> List[TestSuite]:
     """Runs `gotestsum tool ci-matrix` to compute Go test partitions for a single package"""
-    script_dir = os.path.dirname(os.path.realpath(__file__))
-    test_reports_dir = os.path.join(script_dir, "..", "test-results")
-    os.makedirs(test_reports_dir, exist_ok=True)
-
     gotestsum_matrix_args = [
         "gotestsum",
         "tool",
@@ -336,7 +350,7 @@ def run_gotestsum_ci_matrix_single_package(
         "--partitions",
         f"{partition_pkg.partitions}",
         "--timing-files",
-        f"{test_reports_dir}/*.json",
+        resolve_timing_files(timing_glob),
         "--partition-tests-in-package",
         partition_pkg.package,
         "--debug",
@@ -402,6 +416,7 @@ def get_matrix(
     partition_packages: List[PartitionPackage],
     platforms: List[str],
     version_sets: List[VersionSet],
+    timing_glob: str = "*.json",
     fast: bool = False,
     codegen_tests: bool = False,
 ) -> Matrix:
@@ -447,12 +462,12 @@ def get_matrix(
             # Skip all Go packages for lowest-deps tests (only Makefile tests)
             go_packages = set()
 
-        test_suites += run_gotestsum_ci_matrix_packages(list(go_packages), item, tags)
+        test_suites += run_gotestsum_ci_matrix_packages(list(go_packages), item, tags, timing_glob)
 
     for item in partition_packages:
         pkg_tests = run_list_tests(item.package_dir, tags)
 
-        test_suites += run_gotestsum_ci_matrix_single_package(item, pkg_tests, tags)
+        test_suites += run_gotestsum_ci_matrix_single_package(item, pkg_tests, tags, timing_glob)
 
     return {
         "test-suite": test_suites,
@@ -525,6 +540,7 @@ def generate_matrix(args: argparse.Namespace):
         partition_modules=partition_modules,
         partition_packages=partition_packages,
         version_sets=version_sets,
+        timing_glob=args.timing_glob,
         codegen_tests=args.codegen_tests,
     )
 
@@ -578,6 +594,16 @@ def add_generate_matrix_args(parser: argparse.ArgumentParser):
         nargs="*",
         default=["all"],
         help="Go build tags",
+    )
+
+    parser.add_argument(
+        "--timing-glob",
+        action="store",
+        default="*.json",
+        help="Glob (relative to test-results/) selecting the timing files used to balance "
+        + "partitions. Defaults to all platforms' timing data. Pass e.g. 'macOS-*.json' to "
+        + "balance a single platform's partitions by its own runtimes. Falls back to '*.json' "
+        + "when the glob matches no files.",
     )
 
     parser.add_argument(

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -93,7 +93,12 @@ if shutil.which('gotestsum') is not None:
     junit_dir = root.joinpath('junit')
     if not junit_dir.is_dir():
         os.mkdir(str(junit_dir))
-    json_file = str(test_results_dir.joinpath(f'{test_run}.json'))
+    # Prefix the timing file with the OS so that the job matrix generator can
+    # partition a platform using only that platform's timing data. On GitHub
+    # Actions RUNNER_OS is one of Linux, Windows, macOS; fall back to the local
+    # platform otherwise. See scripts/get-job-matrix.py's --timing-glob.
+    os_label = os.environ.get('RUNNER_OS') or platform.system()
+    json_file = str(test_results_dir.joinpath(f'{os_label}-{test_run}.json'))
     junit_file = str(junit_dir.joinpath(f'{test_run}-junit.xml'))
     args = ['gotestsum', '--junitfile', junit_file, '--jsonfile', json_file, '--packages', pkgs, '--'] + \
         opts


### PR DESCRIPTION
## Problem

The macOS acceptance jobs and the Ubuntu integration jobs both split `tests/integration` into the **same** 8 partitions, computed once from a single shared pool of `gotestsum` timing data. That pool is Ubuntu-dominated (Ubuntu runs both `minimum` and `current`, far more often than macOS), so the partition boundaries are balanced for **Ubuntu** runtimes.

On macOS the same tests cost very differently — Go program tests run 6–13× slower (e.g. `TestNoLogError` 26s→339s, `TestResourceRefsGetResourceGo` 27s→342s) — so the Ubuntu-balanced split leaves one macOS partition far heavier than the rest. In a recent merge run the macOS `tests/integration` partitions ranged **15.2m → 34.1m**, and that 34m partition is the **critical path** of the whole merge queue run (build → that job → release).

## Change

Give the macOS matrix its own timing pool:

- **`go-test.py`** prefixes each timing file with the OS (`macOS-`/`Linux-`/`Windows-`, from `RUNNER_OS`) so timing data is identifiable by platform after artifacts merge into `test-results/`.
- **`get-job-matrix.py`** gains `--timing-glob`, selecting which timing files feed `ci-matrix`. Defaults to `*.json` (all platforms, unchanged). Falls back to `*.json` when the glob matches nothing, so the first run (before prefixed data exists) **cannot** regress to an even split.
- The **macOS acceptance matrix** passes `--timing-glob 'macOS-*.json'`.

## Expected impact & how it's measured

This balances the macOS partitions by macOS runtimes, lowering the heaviest macOS partition that gates the merge queue. The realized saving depends on how diluted the live timing cache is, and is **measured on the merge queue after this lands** — it accrues over the first few runs as `macOS-*.json` timing accumulates. By construction it cannot make the macOS split worse than today's blended split.

No changelog entry (CI-infra only, consistent with prior partitioning PRs such as #23512).