### PR TITLE
Fix policy violation message indentation in diff output

### DIFF
--- a/changelog/pending/cli-display-improvement-20260628-163542.yaml
+++ b/changelog/pending/cli-display-improvement-20260628-163542.yaml
@@ -1,0 +1,6 @@
+component: cli/display
+kind: improvement
+body: Fix policy violation message indentation in diff output
+time: 2026-06-28T16:35:42.231167+03:00
+custom:
+  PR: 23715

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -217,6 +217,11 @@ func renderDiffPolicyRemediationEvent(payload engine.PolicyRemediationEventPaylo
 func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 	prefix string, linePrefix string, opts Options,
 ) string {
+	const (
+		defaultPolicyPrefix = "    "
+		messageIndent       = "  "
+	)
+
 	// Colorize mandatory and warning violations differently.
 	c := colors.SpecWarning
 	if payload.EnforcementLevel == apitype.Mandatory {
@@ -233,23 +238,28 @@ func renderDiffPolicyViolationEvent(payload engine.PolicyViolationEventPayload,
 		c, payload.EnforcementLevel, severity, payload.PolicyName, colors.Reset,
 		payload.ResourceURN.Type().DisplayName(), resourceText(payload.ResourceURN, opts))
 
-	// If there is already a prefix string requested, use it, otherwise fall back to a default.
+	// If there is no prefix, use the default diff-view indentation and include the policy pack name.
 	if prefix == "" {
-		policyLine = fmt.Sprintf("    %s%s@v%s %s%s",
-			colors.SpecInfo, payload.PolicyPackName, payload.PolicyPackVersion, colors.Reset, policyLine)
-	} else {
-		policyLine = fmt.Sprintf("%s%s", prefix, policyLine)
+		prefix = defaultPolicyPrefix
+		policyLine = fmt.Sprintf("%s%s@v%s %s%s", colors.SpecInfo, payload.PolicyPackName,
+			payload.PolicyPackVersion, colors.Reset, policyLine,
+		)
 	}
 
-	// If there is a line prefix, separate the heading and lines with a newline.
-	if linePrefix != "" {
-		policyLine += "\n"
+	// If there is no explicit line prefix, indent message lines relative to the policy line.
+	if linePrefix == "" {
+		linePrefix = prefix + messageIndent
 	}
+
+	policyLine = prefix + policyLine
 
 	// The message may span multiple lines, so we massage it so it will be indented properly.
 	message := strings.TrimSuffix(payload.Message, "\n")
-	message = strings.ReplaceAll(message, "\n", "\n"+linePrefix)
-	policyLine = fmt.Sprintf("%s%s%s", policyLine, linePrefix, message)
+	if message != "" {
+		message = strings.ReplaceAll(message, "\n", "\n"+linePrefix)
+		policyLine = fmt.Sprintf("%s\n%s%s", policyLine, linePrefix, message)
+	}
+
 	return opts.Color.Colorize(policyLine + "\n")
 }
 

--- a/pkg/backend/display/diff_test.go
+++ b/pkg/backend/display/diff_test.go
@@ -438,3 +438,77 @@ func TestRenderDiffPolicyViolationEventUsesDisplayResourceTypeNameWithURNs(t *te
 		"(aws:s3:Bucket: urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket)",
 	)
 }
+
+func TestRenderDiffPolicyViolationEventIndentsMultilineMessageWithoutLinePrefix(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket")
+	payload := engine.PolicyViolationEventPayload{
+		ResourceURN:       urn,
+		Message:           "Policy description:\nmy-bucket: violation details",
+		PolicyName:        "s3-bucket-replication-enabled",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		EnforcementLevel:  apitype.Advisory,
+	}
+
+	output := renderDiffPolicyViolationEvent(payload, "", "", Options{
+		Color: colors.Never,
+	})
+
+	assert.Contains(t, output, "    foo-policy-pack@v0.0.6")
+	assert.Contains(t, output, "[advisory]  s3-bucket-replication-enabled")
+	assert.Contains(t, output, "(aws:s3:Bucket: my-bucket)")
+	assert.Contains(t, output, "\n      Policy description:\n      my-bucket: violation details\n")
+}
+
+func TestRenderDiffPolicyViolationEventPreservesExplicitLinePrefix(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket")
+	payload := engine.PolicyViolationEventPayload{
+		ResourceURN:       urn,
+		Message:           "Policy description:\nmy-bucket: violation details",
+		PolicyName:        "s3-bucket-replication-enabled",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		EnforcementLevel:  apitype.Advisory,
+	}
+
+	output := renderDiffPolicyViolationEvent(payload, "        - ", "          ", Options{
+		Color: colors.Never,
+	})
+
+	assert.Contains(t, output, "        - [advisory]  s3-bucket-replication-enabled")
+	assert.Contains(t, output, "(aws:s3:Bucket: my-bucket)")
+	assert.Contains(t, output, "\n          Policy description:\n          my-bucket: violation details\n")
+
+	// In grouped policy summaries, the policy pack name is rendered by the group header,
+	// so individual policy lines should not repeat it.
+	assert.NotContains(t, output, "foo-policy-pack@v0.0.6")
+}
+
+func TestRenderDiffPolicyViolationEventDoesNotAddBlankLineForEmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	urn := resource.URN("urn:pulumi:dev::project::aws:s3/bucket:Bucket::my-bucket")
+	payload := engine.PolicyViolationEventPayload{
+		ResourceURN:       urn,
+		Message:           "",
+		PolicyName:        "s3-bucket-replication-enabled",
+		PolicyPackName:    "foo-policy-pack",
+		PolicyPackVersion: "0.0.6",
+		EnforcementLevel:  apitype.Advisory,
+	}
+
+	output := renderDiffPolicyViolationEvent(payload, "", "", Options{
+		Color: colors.Never,
+	})
+
+	assert.Contains(t, output, "    foo-policy-pack@v0.0.6")
+	assert.Contains(t, output, "[advisory]  s3-bucket-replication-enabled")
+	assert.Contains(t, output, "(aws:s3:Bucket: my-bucket)")
+
+	assert.NotContains(t, output, "\n      \n")
+	assert.NotContains(t, output, "\n      Policy description")
+}


### PR DESCRIPTION
## Summary

Fix policy violation message indentation in diff output.

When policy violations are rendered in diff output, `renderDiffPolicyViolationEvent` may be called without an explicit `linePrefix`. In that case, multi-line policy violation messages were not indented relative to the policy violation line, making the output harder to read.

Before:

```text
    foo-policy-pack@v0.0.6 [advisory]  s3-bucket-replication-enabled  (aws:s3:Bucket: my-bucket)Policy description:
  my-bucket: violation details
```

After:

```text
    foo-policy-pack@v0.0.6 [advisory]  s3-bucket-replication-enabled  (aws:s3:Bucket: my-bucket)
      Policy description:
      my-bucket: violation details
```

This change derives the default message indentation from the policy line prefix when no explicit `linePrefix` is provided.

Callers that already provide an explicit `linePrefix`, such as the grouped policy summary, keep their existing formatting.

Related to #14098.

<details>
<summary>Testing</summary>

go test -count=1 ./backend/display -run 'TestRenderDiffPolicyViolationEvent'
ok  	github.com/pulumi/pulumi/pkg/v3/backend/display	0.641s
hostname@mac2011okko pkg % go test -count=1 ./backend/display
ok  	github.com/pulumi/pulumi/pkg/v3/backend/display	0.662s
pkg % mise exec -- make lint
make: *** No rule to make target `lint'.  Stop.

pkg % cd ..
pulumi % mise exec -- make lint
LINT:
Checking for golangci-lint ....... ✓
[golangci-lint] Linting sdk...
0 issues.
[golangci-lint] Linting pkg...

0 issues.
[golangci-lint] Linting tests...
0 issues.
[golangci-lint] Linting sdk/go/pulumi-language-go...
0 issues.
[golangci-lint] Linting sdk/nodejs/cmd/pulumi-language-nodejs...
0 issues.
[golangci-lint] Linting sdk/python/cmd/pulumi-language-python...
0 issues.
[golangci-lint] Linting sdk/pcl...
0 issues.
# NOTE: github.com/santhosh-tekuri/jsonschema uses Go's regexp engine, but
# JSON schema says regexps should conform to ECMA 262.
go run github.com/santhosh-tekuri/jsonschema/cmd/jv@v0.7.0 pkg/codegen/schema/pulumi.json
schema pkg/codegen/schema/pulumi.json: ok
# We only want to run `make ensure` in sdk/nodejs to install biome.  We can't depend
# need here, and don't necessarily have installed in CI.
cd sdk/nodejs && make ensure
Checking for npm ................. ✓
Checking for node ................ ✓
make[1]: Nothing to be done for `ensure'.
cd sdk/nodejs && npx biome format ../../pkg/codegen/schema/pulumi.json
Checked 1 file in 6ms. No fixes applied.
## 3.249.0 (2026-06-28)

### Features

- [cli/policy] Add a `--file` flag to `pulumi policy analyze` to analyze a state file (as produced by `pulumi stack export`) without requiring a stack or backend login

### Bug Fixes

- [sdkgen/python] Cache package references per-deployment in generated SDKs [#22459](https://github.com/pulumi/pulumi/pull/22459)
- [backend/diy] Fix `pulumi stack tag rm` not removing the last tag on self-managed (diy) backends [#23702](https://github.com/pulumi/pulumi/pull/23702)
- [backend/service] Don't fail a operation due to a logging failure
- [cli] Use display resource type names in policy violation output
- [sdk/python] Fix `deletedWith` and `replaceWith` resource options in Python component resource providers [#23710](https://github.com/pulumi/pulumi/pull/23710)

### Improvements

- [sdk/nodejs] Use npm as the package manager for the Node.js SDK
- [cli] Add `--output $format` flag to `pulumi stack {list,history,tag list}`
- [cli/plugin] Add `--output $format` to `pulumi plugin list`
- [cli/engine] Fix TestDebuggerAttach for dlv@1.27
- [cli] Add --output $format to `pulumi policy list` and `pulumi policy group list`
- [cli] Add --output $format to `pulumi project list`
- [cli] Add `--output $format` flag to `pulumi config env list`
- [cli/display] Indent policy violation messages in diff output

### Miscellaneous

- [pkg/testing] Allow ProgramTest to use npm for Node.js tests

</details>
