### PR TITLE
Warn if login differs from env

### DIFF
--- a/changelog/pending/cli-improvement-20260628-203235.yaml
+++ b/changelog/pending/cli-improvement-20260628-203235.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: improvement
+body: '`pulumi login` will warn if the given login differs from PULUMI_BACKEND_URL'
+time: 2026-06-28T20:32:35.227007+01:00

--- a/pkg/cmd/pulumi/auth/login.go
+++ b/pkg/cmd/pulumi/auth/login.go
@@ -41,7 +41,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Command {
+func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager, store env.Env) *cobra.Command {
 	var cloudURL string
 	var defaultOrg string
 	var localMode bool
@@ -121,6 +121,10 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Comman
 				cloudURL = args[0]
 			}
 
+			// Track whether the user explicitly provided a URL, so we can warn below if it conflicts
+			// with PULUMI_BACKEND_URL.
+			userProvidedURL := cloudURL != "" || localMode
+
 			// For local mode, store state by default in the user's home directory.
 			if localMode {
 				if cloudURL != "" {
@@ -159,7 +163,7 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Comman
 			}
 			if cloudURL == "" {
 				var err error
-				cloudURL, err = pkgWorkspace.GetCurrentCloudURL(ws, env.Global(), project)
+				cloudURL, err = pkgWorkspace.GetCurrentCloudURL(ws, store, project)
 				if err != nil {
 					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
@@ -176,6 +180,14 @@ func NewLoginCmd(ws pkgWorkspace.Context, lm backend.LoginManager) *cobra.Comman
 				// Ensure we have the correct cloudurl type before logging in
 				if err := validateCloudBackendType(cloudURL); err != nil {
 					return err
+				}
+			}
+
+			if userProvidedURL {
+				if envURL := store.GetString(env.BackendURL); envURL != "" && envURL != cloudURL {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"Warning: The PULUMI_BACKEND_URL environment variable is set to '%s', "+
+							"which conflicts with the login URL '%s'.\n", envURL, cloudURL)
 				}
 			}
 

--- a/pkg/cmd/pulumi/auth/login_test.go
+++ b/pkg/cmd/pulumi/auth/login_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 
 	pkgBackend "github.com/pulumi/pulumi/pkg/v3/backend"
@@ -26,6 +27,7 @@ import (
 	pkgWorkspace "github.com/pulumi/pulumi/pkg/v3/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -229,7 +231,8 @@ func TestLoginURLResolution(t *testing.T) {
 				},
 			}
 
-			cmd := NewLoginCmd(tt.ws, mockLoginManager)
+			store := env.NewEnv(env.MapStore(tt.envVars))
+			cmd := NewLoginCmd(tt.ws, mockLoginManager, store)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetContext(t.Context())
@@ -446,4 +449,49 @@ func TestExtractOIDCDefaults(t *testing.T) {
 			assert.Equal(t, tt.wantUser, gotUser, "user mismatch")
 		})
 	}
+}
+
+// TestLoginEnvConflict tests that we warn the user if they login with a cloud URL that conflicts with the
+// PULUMI_BACKEND_URL environment variable.
+func TestLoginEnvConflict(t *testing.T) {
+	t.Parallel()
+
+	ws := &pkgWorkspace.MockContext{}
+	lm := &backend.MockLoginManager{
+		LoginF: func(
+			ctx context.Context,
+			ws pkgWorkspace.Context,
+			sink diag.Sink,
+			url string,
+			project *workspace.Project,
+			setCurrent bool,
+			insecure bool,
+			color colors.Colorization,
+		) (pkgBackend.Backend, error) {
+			return &pkgBackend.MockBackend{
+				URLF:  func() string { return url },
+				NameF: func() string { return "test-backend" },
+				CurrentUserF: func() (string, []string, *workspace.TokenInformation, error) {
+					return "test-user", nil, nil, nil
+				},
+			}, nil
+		},
+	}
+	store := env.NewEnv(env.MapStore{
+		"PULUMI_BACKEND_URL": "https://env-backend.example.com",
+	})
+	cmd := NewLoginCmd(ws, lm, store)
+
+	stderr := &strings.Builder{}
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(stderr)
+	cmd.SetContext(t.Context())
+	cmd.SetArgs([]string{"https://example.com"})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t,
+		stderr.String(),
+		"Warning: The PULUMI_BACKEND_URL environment variable is set to "+
+			"'https://env-backend.example.com', which conflicts with the login URL "+
+			"'https://example.com'.")
 }

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -496,7 +496,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 		{
 			Name: "Pulumi Cloud Commands",
 			Commands: []*cobra.Command{
-				auth.NewLoginCmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager),
+				auth.NewLoginCmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager, env.Global()),
 				auth.NewLogoutCmd(pkgWorkspace.Instance),
 				whoami.NewWhoAmICmd(pkgWorkspace.Instance, cmdBackend.DefaultLoginManager),
 				org.NewOrgCmd(),

--- a/pkg/resource/plugin/cloud_credentials.go
+++ b/pkg/resource/plugin/cloud_credentials.go
@@ -25,13 +25,13 @@ import (
 // plugins launched with this context, so trusted providers can reach the cloud on the user's
 // behalf. It returns nil for non-cloud logins and when logged out, so plugins only ever receive
 // credentials they can actually use.
-func pulumiCloudCredentialEnv(project *workspace.Project) map[string]string {
-	url := currentCloudURL(project)
+func pulumiCloudCredentialEnv(store env.Env, project *workspace.Project) map[string]string {
+	url := currentCloudURL(store, project)
 	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
 		return nil
 	}
 
-	token := env.AccessToken.Value()
+	token := store.GetString(env.AccessToken)
 	if token == "" {
 		if account, _, err := workspace.GetAccountWithAgentFallback(url); err == nil {
 			token = account.AccessToken
@@ -49,8 +49,8 @@ func pulumiCloudCredentialEnv(project *workspace.Project) map[string]string {
 
 // currentCloudURL mirrors the CLI's backend selection: PULUMI_BACKEND_URL wins, then the project's
 // backend, then the active stored login, falling back to shared agent credentials.
-func currentCloudURL(project *workspace.Project) string {
-	if url := env.BackendURL.Value(); url != "" {
+func currentCloudURL(store env.Env, project *workspace.Project) string {
+	if url := store.GetString(env.BackendURL); url != "" {
 		return url
 	}
 	if project != nil && project.Backend != nil && project.Backend.URL != "" {

--- a/pkg/resource/plugin/cloud_credentials_test.go
+++ b/pkg/resource/plugin/cloud_credentials_test.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"testing"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,14 +30,14 @@ func TestPulumiCloudCredentialEnv(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"PULUMI_API":          "https://api.example.com",
 			"PULUMI_ACCESS_TOKEN": "secret",
-		}, pulumiCloudCredentialEnv(nil))
+		}, pulumiCloudCredentialEnv(env.Global(), nil))
 	})
 
 	t.Run("diy backend gets nothing", func(t *testing.T) {
 		t.Setenv("PULUMI_BACKEND_URL", "file:///tmp/state")
 		t.Setenv("PULUMI_ACCESS_TOKEN", "secret")
 
-		assert.Nil(t, pulumiCloudCredentialEnv(nil))
+		assert.Nil(t, pulumiCloudCredentialEnv(env.Global(), nil))
 	})
 
 	t.Run("logged out gets nothing", func(t *testing.T) {
@@ -44,6 +45,6 @@ func TestPulumiCloudCredentialEnv(t *testing.T) {
 		t.Setenv("PULUMI_BACKEND_URL", "")
 		t.Setenv("PULUMI_ACCESS_TOKEN", "")
 
-		assert.Nil(t, pulumiCloudCredentialEnv(nil))
+		assert.Nil(t, pulumiCloudCredentialEnv(env.Global(), nil))
 	})
 }

--- a/pkg/resource/plugin/context.go
+++ b/pkg/resource/plugin/context.go
@@ -249,7 +249,7 @@ func NewContextWithRoot(ctx context.Context, d, statusD diag.Sink, host Host,
 		disableProviderPreview: disableProviderPreview,
 		config:                 config,
 		projectName:            projectName,
-		CloudCredentialEnv:     pulumiCloudCredentialEnv(project),
+		CloudCredentialEnv:     pulumiCloudCredentialEnv(env.Global(), project),
 	}
 
 	projectPlugins, err := projectPluginsFromProject(pctx, plugins, packages)


### PR DESCRIPTION
Prompted by https://pulumi.slack.com/archives/C011EMDQ8JE/p1782661229738589

If the user gives a specific backend to login in to for `pulumi login` and that differs from `PULUMI_BACKEND_URL` (which will get used for all later operations as the backend to use) then warn the user that the env var is set.

This is to help prevent users getting confused by running `pulumi login some.domain` but then the next operation seemingly ignoring that login because `PULUMI_BACKEND_URL` was still set to something else.