### PR TITLE
Remove the `tmp` runtime dependency from the Node.js SDK

### DIFF
--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -17,7 +17,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
-import * as tmp from "tmp";
 import { version as DEFAULT_VERSION } from "../version";
 import { download } from "./download";
 import { minimumVersion } from "./minimumVersion";
@@ -252,34 +251,20 @@ function withDefaults(opts?: PulumiCommandOptions): Required<PulumiCommandOption
     return { version, root, skipVersionCheck };
 }
 
-function writeTempFile(
+async function writeTempFile(
     contents: string,
     options?: { extension?: string },
 ): Promise<{ path: string; cleanup: () => void }> {
-    return new Promise<{ path: string; cleanup: () => void }>((resolve, reject) => {
-        tmp.file(
-            {
-                // Powershell requires a `.ps1` extension.
-                postfix: options?.extension,
-                // Powershell won't execute the script if the file descriptor is open.
-                discardDescriptor: true,
-            },
-            (tmpErr, tmpPath, _fd, cleanup) => {
-                if (tmpErr) {
-                    reject(tmpErr);
-                } else {
-                    fs.writeFile(tmpPath, contents, (writeErr) => {
-                        if (writeErr) {
-                            cleanup();
-                            reject(writeErr);
-                        } else {
-                            resolve({ path: tmpPath, cleanup });
-                        }
-                    });
-                }
-            },
-        );
-    });
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pulumi-"));
+    const cleanup = () => fs.rmSync(dir, { recursive: true, force: true });
+    try {
+        const filePath = path.join(dir, `tmp${options?.extension ?? ""}`);
+        await fs.promises.writeFile(filePath, contents);
+        return { path: filePath, cleanup };
+    } catch (err) {
+        cleanup();
+        throw err;
+    }
 }
 
 /**

--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@pulumi/pulumi",
-    "version": "3.248.0",
+    "version": "3.249.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@pulumi/pulumi",
-            "version": "3.248.0",
+            "version": "3.249.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
@@ -22,7 +22,6 @@
                 "@opentelemetry/sdk-trace-node": "^1.30",
                 "@types/google-protobuf": "^3.15.5",
                 "@types/semver": "^7.5.6",
-                "@types/tmp": "^0.2.6",
                 "execa": "^5.1.0",
                 "fdir": "^6.5.0",
                 "google-protobuf": "^3.21.4",
@@ -34,7 +33,6 @@
                 "require-from-string": "^2.0.1",
                 "semver": "^7.5.2",
                 "source-map-support": "^0.5.6",
-                "tmp": "^0.2.4",
                 "upath": "^1.1.0"
             },
             "devDependencies": {
@@ -2493,12 +2491,6 @@
             "dependencies": {
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/tmp": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
-            "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
-            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "4.33.0",
@@ -8882,15 +8874,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tmp": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.14"
             }
         },
         "node_modules/to-regex-range": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -22,7 +22,6 @@
         "@opentelemetry/sdk-trace-node": "^1.30",
         "@types/google-protobuf": "^3.15.5",
         "@types/semver": "^7.5.6",
-        "@types/tmp": "^0.2.6",
         "execa": "^5.1.0",
         "fdir": "^6.5.0",
         "google-protobuf": "^3.21.4",
@@ -34,7 +33,6 @@
         "require-from-string": "^2.0.1",
         "semver": "^7.5.2",
         "source-map-support": "^0.5.6",
-        "tmp": "^0.2.4",
         "upath": "^1.1.0"
     },
     "devDependencies": {

--- a/sdk/nodejs/tests/automation/cmd.spec.ts
+++ b/sdk/nodejs/tests/automation/cmd.spec.ts
@@ -16,7 +16,6 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as semver from "semver";
 import * as os from "os";
-import * as tmp from "tmp";
 import * as upath from "upath";
 import { PulumiCommand, parseAndValidatePulumiVersion } from "../../automation";
 
@@ -36,27 +35,27 @@ describe("automation/cmd", () => {
 
     describe("CLI installation", () => {
         it("installs the requested version", async () => {
-            const tmpDir = tmp.dirSync({ prefix: "automation-test-", unsafeCleanup: true });
+            const tmpDir = fs.mkdtempSync(upath.join(os.tmpdir(), "automation-test-"));
             try {
-                const cmd = await PulumiCommand.install({ root: tmpDir.name, version: new semver.SemVer("3.97.0") });
-                assert.doesNotThrow(() => fs.statSync(upath.join(tmpDir.name, "bin", "pulumi")));
+                const cmd = await PulumiCommand.install({ root: tmpDir, version: new semver.SemVer("3.97.0") });
+                assert.doesNotThrow(() => fs.statSync(upath.join(tmpDir, "bin", "pulumi")));
                 const { stdout } = await cmd.run(["version"], ".", {});
                 assert.strictEqual(stdout.trim(), "3.97.0");
             } finally {
-                tmpDir.removeCallback();
+                fs.rmSync(tmpDir, { recursive: true, force: true });
             }
         });
 
         it("does not re-install the version if it already exists", async () => {
-            const tmpDir = tmp.dirSync({ prefix: "automation-test-", unsafeCleanup: true });
+            const tmpDir = fs.mkdtempSync(upath.join(os.tmpdir(), "automation-test-"));
             try {
-                await PulumiCommand.install({ root: tmpDir.name, version: new semver.SemVer("3.97.0") });
-                const binary1 = fs.statSync(upath.join(tmpDir.name, "bin", "pulumi"));
-                await PulumiCommand.install({ root: tmpDir.name, version: new semver.SemVer("3.97.0") });
-                const binary2 = fs.statSync(upath.join(tmpDir.name, "bin", "pulumi"));
+                await PulumiCommand.install({ root: tmpDir, version: new semver.SemVer("3.97.0") });
+                const binary1 = fs.statSync(upath.join(tmpDir, "bin", "pulumi"));
+                await PulumiCommand.install({ root: tmpDir, version: new semver.SemVer("3.97.0") });
+                const binary2 = fs.statSync(upath.join(tmpDir, "bin", "pulumi"));
                 assert.strictEqual(binary1.ino, binary2.ino);
             } finally {
-                tmpDir.removeCallback();
+                fs.rmSync(tmpDir, { recursive: true, force: true });
             }
         });
 

--- a/sdk/nodejs/tests/automation/localWorkspace.command.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.command.spec.ts
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 import assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import * as semver from "semver";
-import * as tmp from "tmp";
 
 import { CommandResult, LocalWorkspace, PulumiCommand, Stack } from "../../automation";
 import { withTestBackend } from "./util";
@@ -29,13 +31,13 @@ describe("LocalWorkspace - PulumiCommand", () => {
     });
 
     it("sets pulumi version when using a custom CLI instance", async () => {
-        const tmpDir = tmp.dirSync({ prefix: "automation-test-", unsafeCleanup: true });
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "automation-test-"));
         try {
             const cmd = await PulumiCommand.get();
             const ws = await LocalWorkspace.create(withTestBackend({ pulumiCommand: cmd }));
             assert.strictEqual(versionRegex.test(ws.pulumiVersion), true);
         } finally {
-            tmpDir.removeCallback();
+            fs.rmSync(tmpDir, { recursive: true, force: true });
         }
     });
 

--- a/sdk/nodejs/tests/automation/util.ts
+++ b/sdk/nodejs/tests/automation/util.ts
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import { randomUUID } from "crypto";
-import * as tmp from "tmp";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 import { LocalWorkspaceOptions, ProjectRuntime, Stack } from "../../automation";
 
@@ -93,12 +95,9 @@ function withTemporaryFileBackend(
     description?: string,
     runtime?: string,
 ): LocalWorkspaceOptions {
-    const tmpDir = tmp.dirSync({
-        prefix: "nodejs-tests-automation-",
-        unsafeCleanup: true,
-    });
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nodejs-tests-automation-"));
 
-    const backend = { url: `file://${tmpDir.name}` };
+    const backend = { url: `file://${tmpDir}` };
 
     if (name === undefined) {
         name = "node_test";
@@ -109,7 +108,7 @@ function withTemporaryFileBackend(
 
     return withTestConfigPassphrase({
         ...opts,
-        pulumiHome: tmpDir.name,
+        pulumiHome: tmpDir,
         projectSettings: {
             // We are obliged to provide a name and runtime if we provide project
             // settings, so we do so, but we spread in the provided project settings

--- a/sdk/nodejs/tests/runtime/closure-integration-tests.ts
+++ b/sdk/nodejs/tests/runtime/closure-integration-tests.ts
@@ -15,9 +15,9 @@
 import { randomInt } from "crypto";
 import execa from "execa";
 import * as fs from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import * as process from "process";
-import * as tmp from "tmp";
 import { pack } from "./pack";
 
 // Write a package.json that installs the local pulumi package and ensures we
@@ -71,26 +71,26 @@ async function copyDir(src: string, dest: string) {
 }
 
 async function run(typescriptVersion: string, nodeTypesVersion: string) {
-    const tmpDir = tmp.dirSync({ prefix: "closure-test-", unsafeCleanup: true });
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "closure-test-"));
     const sdkRoot = path.join(__dirname, "..", "..", "..");
     const sdkRootBin = path.join(sdkRoot, "bin");
     // Add a random suffix to the package name to avoid any issues with npm caching the tgz.
     const packageName = `pulumi-${randomInt(10000, 99999)}.tgz`;
-    const pulumiPackagePath = path.join(tmpDir.name, packageName);
+    const pulumiPackagePath = path.join(tmpDir, packageName);
     await pack(sdkRootBin, pulumiPackagePath);
-    await writePackageJSON(tmpDir.name, pulumiPackagePath, typescriptVersion, nodeTypesVersion);
-    await copyDir(path.join(sdkRoot, "tests", "runtime", "testdata", "closure-tests"), tmpDir.name);
+    await writePackageJSON(tmpDir, pulumiPackagePath, typescriptVersion, nodeTypesVersion);
+    await copyDir(path.join(sdkRoot, "tests", "runtime", "testdata", "closure-tests"), tmpDir);
 
-    await execa("npm", ["install", "--install-links"], { cwd: tmpDir.name });
+    await execa("npm", ["install", "--install-links"], { cwd: tmpDir });
 
-    await execa("npx", ["--no-install", "tsc"], { cwd: tmpDir.name });
+    await execa("npx", ["--no-install", "tsc"], { cwd: tmpDir });
 
     await execa("npx", ["--no-install", "mocha", "--timeout", "30000", "test.js"], {
-        cwd: tmpDir.name,
+        cwd: tmpDir,
         stdio: "inherit",
     });
 
-    tmpDir.removeCallback();
+    await fs.rm(tmpDir, { recursive: true, force: true });
 }
 
 async function main() {

--- a/sdk/nodejs/tests/runtime/install-package-tests.ts
+++ b/sdk/nodejs/tests/runtime/install-package-tests.ts
@@ -22,9 +22,9 @@
 import { randomInt } from "crypto";
 import execa from "execa";
 import * as fs from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 import * as process from "process";
-import * as tmp from "tmp";
 import { pack } from "./pack";
 
 // Write a package.json that installs the local pulumi package and optional dependencies.
@@ -95,11 +95,11 @@ async function exec(command: string, args: string[], options: execa.Options): Pr
 async function main() {
     const sdkRoot = path.join(__dirname, "..", "..", "..");
     const sdkRootBin = path.join(sdkRoot, "bin");
-    const tmpPackageDir = tmp.dirSync({ prefix: "pulumi-package-", unsafeCleanup: true });
+    const tmpPackageDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulumi-package-"));
     try {
         // Add a random suffix to the package name to avoid any issues with yarn caching the tgz.
         const packageName = `pulumi-${randomInt(10000, 99999)}.tgz`;
-        const pulumiPackagePath = path.join(tmpPackageDir.name, packageName);
+        const pulumiPackagePath = path.join(tmpPackageDir, packageName);
         await pack(sdkRootBin, pulumiPackagePath);
 
         const packageManagers = [
@@ -161,30 +161,30 @@ async function main() {
 
         for (const pm of packageManagers) {
             for (const deps of dependencies) {
-                const tmpDir = tmp.dirSync({ prefix: "install-test-", unsafeCleanup: true });
+                const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "install-test-"));
                 try {
                     await runTest(tmpDir, pulumiPackagePath, pm.name, pm.version, deps);
                 } finally {
-                    tmpDir.removeCallback();
+                    await fs.rm(tmpDir, { recursive: true, force: true });
                 }
             }
         }
     } finally {
-        tmpPackageDir.removeCallback();
+        await fs.rm(tmpPackageDir, { recursive: true, force: true });
     }
 }
 
 async function runTest(
-    tmpDir: tmp.DirResult,
+    tmpDir: string,
     pulumiPackagePath: string,
     packageManager: string,
     packageManagerVersion: string,
     peerDeps: Record<string, string | undefined>,
 ) {
-    await writePackageJSON(tmpDir.name, pulumiPackagePath, peerDeps);
-    await writeTSConfig(tmpDir.name);
+    await writePackageJSON(tmpDir, pulumiPackagePath, peerDeps);
+    await writeTSConfig(tmpDir);
     const projectName = `install-test-${packageManager}-${packageManagerVersion}`.replace(/[^a-zA-Z0-9]/g, "-");
-    await writeProgram(tmpDir.name, projectName);
+    await writeProgram(tmpDir, projectName);
 
     const dependencies = Object.entries(peerDeps)
         .filter(([_, v]) => v !== undefined)
@@ -201,40 +201,40 @@ async function runTest(
     const corepack = path.join(bin.trim(), "corepack");
 
     // Install the package manager to test.
-    logs += await exec(corepack, ["enable"], { cwd: tmpDir.name });
-    logs += await exec(corepack, ["use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir.name });
+    logs += await exec(corepack, ["enable"], { cwd: tmpDir });
+    logs += await exec(corepack, ["use", `${packageManager}@${packageManagerVersion}`], { cwd: tmpDir });
 
     const env = {
         PULUMI_CONFIG_PASSPHRASE: "test",
-        PULUMI_HOME: tmpDir.name,
+        PULUMI_HOME: tmpDir,
     };
 
     // Up and down a test stack to ensure we're able to load & run typescript code.
     const stackName = `install-test-${randomInt(10000, 99999)}`;
     try {
         logs += await exec("pulumi", ["stack", "init", stackName], {
-            cwd: tmpDir.name,
+            cwd: tmpDir,
             env,
         });
         logs += await exec("pulumi", ["up", "--stack", stackName, "--skip-preview"], {
-            cwd: tmpDir.name,
+            cwd: tmpDir,
             env,
         });
 
         console.log(`✅ ${packageManager}@${packageManagerVersion}${dependenciesString}`);
     } catch (err) {
         console.log(
-            `❌ Failed to run test with ${packageManager}@${packageManagerVersion}${dependenciesString} in ${tmpDir.name}: ${err}`,
+            `❌ Failed to run test with ${packageManager}@${packageManagerVersion}${dependenciesString} in ${tmpDir}: ${err}`,
         );
         console.log(`Captured stdout: ${logs}`);
         throw err;
     } finally {
         await exec("pulumi", ["destroy", "--stack", stackName, "--yes"], {
-            cwd: tmpDir.name,
+            cwd: tmpDir,
             env,
         });
         await exec("pulumi", ["stack", "rm", stackName, "--yes"], {
-            cwd: tmpDir.name,
+            cwd: tmpDir,
             env,
         });
     }


### PR DESCRIPTION
We can replace this with node builtins. This dependency was mostly used in tests, with 1 non-test usage in the auto API install command.