### PR TITLE
Remove unused `@types/split` dev dependency

### DIFF
--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -42,7 +42,6 @@
                 "@types/node": "14.18.63",
                 "@types/normalize-package-data": "2.4.4",
                 "@types/sinon": "10.0.20",
-                "@types/split2": "2.1.6",
                 "@typescript-eslint/eslint-plugin": "4.33.0",
                 "@typescript-eslint/parser": "4.33.0",
                 "corepack": "0.34.5",
@@ -2471,16 +2470,6 @@
             "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/split2": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/@types/split2/-/split2-2.1.6.tgz",
-            "integrity": "sha512-ddaFSOMuy2Rp97l6q/LEteQygvTQJuEZ+SRhxFKR0uXGsdbFDqX/QF2xoGcOqLQ8XV91v01SnAv2vpgihNgW/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "4.33.0",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -42,7 +42,6 @@
         "@types/node": "14.18.63",
         "@types/normalize-package-data": "2.4.4",
         "@types/sinon": "10.0.20",
-        "@types/split2": "2.1.6",
         "@typescript-eslint/eslint-plugin": "4.33.0",
         "@typescript-eslint/parser": "4.33.0",
         "corepack": "0.34.5",


### PR DESCRIPTION
The `split2` package was removed in #7032 in 2021.