### PR TITLE
build: ignore generated Go testdata fixture artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,12 @@ tests/testdata/codegen/*-pp/*/package.json
 tests/testdata/codegen/*-pp/*/go.sum
 tests/testdata/codegen/*-pp/*/tsconfig.json
 
+# The Go policy pack fixtures are committed as minimal go.mod files and get tidied/built in place
+# when tests (or an editor's Go modules integration) run over them. The resulting go.sum files and
+# compiled policy analyzer binaries are generated, not source, so don't track them.
+sdk/go/pulumi-language-go/testdata/policies/*/go.sum
+sdk/go/pulumi-language-go/testdata/policies/*/pulumi-analyzer-policy-*
+
 # We don't need to keep fuzzing failures around
 pkg/engine/lifecycletest/testdata/rapid/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,13 @@
     },
     "gopls": {
         // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
+        // The testdata trees contain many minimal/generated nested go.mod fixtures; excluding them keeps gopls from tidying them in place (which produces spurious go.mod/go.sum diffs) and speeds up loading. These dirs are also excluded from `make tidy` (see scripts/tidy.sh).
         "build.directoryFilters": [
             "-sdk/nodejs/bin",
             "-sdk/nodejs/tests",
-            "-sdk/python/env"
+            "-sdk/python/env",
+            "-sdk/go/pulumi-language-go/testdata",
+            "-tests/testdata"
         ],
         // Uses https://github.com/mvdan/gofumpt for formatting.
         "formatting.gofumpt": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,22 @@ Finally, please limit your pull requests to contain only one feature at a time. 
 
 Please see the [developer docs](https://pulumi-developer-docs.readthedocs.io/latest/docs/contributing/development.html) for instructions.
 
+### Editor setup: avoiding testdata go.mod churn
+
+Many Go test fixtures under `sdk/go/pulumi-language-go/testdata` and `tests/testdata` are committed as
+minimal `go.mod` files and are tidied or built in place when tests run. Editors that automatically sync
+Go modules — notably IntelliJ/GoLand's Go modules integration, and gopls — will run `go mod tidy` over
+these nested modules, expanding the `go.mod` files with the full transitive dependency set and generating
+`go.sum` files. The result is large spurious diffs that are easy to commit by accident.
+
+The generated `go.sum` files and policy analyzer binaries are git-ignored, and `make tidy` already skips
+these directories. To also avoid `go.mod` churn, exclude the `testdata` trees from your editor's Go module
+integration:
+
+- **VS Code**: handled automatically via `gopls.build.directoryFilters` in `.vscode/settings.json`.
+- **IntelliJ/GoLand**: mark `sdk/go/pulumi-language-go/testdata` and `tests/testdata` as *Excluded*
+  directories (right-click → Mark Directory as → Excluded).
+
 ## Submitting a Pull Request
 
 For contributors we use the [standard fork based workflow](https://gist.github.com/Chaser324/ce0505fbed06b947d962): Fork this repository, create a topic branch, and when ready, open a pull request from your fork.

--- a/changelog/pending/build-chore-20260629-132415.yaml
+++ b/changelog/pending/build-chore-20260629-132415.yaml
@@ -1,0 +1,6 @@
+component: build
+kind: chore
+body: Ignore generated go.sum files and policy analyzer binaries produced when Go testdata fixtures are tidied or built in place
+time: 2026-06-29T13:24:15-07:00
+custom:
+    PR: "23727"


### PR DESCRIPTION
## Summary

The Go policy-pack fixtures under `sdk/go/pulumi-language-go/testdata/policies` and the codegen fixtures under `tests/testdata` are committed as **minimal** `go.mod` files and are tidied/built *in place* when tests — or an editor's Go modules integration (IntelliJ/GoLand, gopls) — run over them. That regenerates the full transitive dependency set into `go.mod`, writes `go.sum` files, and leaves compiled `pulumi-analyzer-policy-*` binaries behind, producing large spurious diffs that are easy to commit by accident.

`make tidy` already excludes these directories (`scripts/tidy.sh`), and `.gitignore` already covers the program-codegen `*-pp` artifacts — but the policy-pack `go.sum`/binaries and the editor angle were never handled. This PR finishes those patterns:

- **`.gitignore`** — ignore the generated policy `go.sum` files and `pulumi-analyzer-policy-*` binaries. The committed `go.mod` fixtures and the tracked `testdata/sample/*` `go.sum` files are unaffected.
- **`.vscode/settings.json`** — exclude the `testdata` trees from `gopls` via `build.directoryFilters`, so gopls stops loading/tidying these nested modules in place.
- **`CONTRIBUTING.md`** — document the churn and the IntelliJ/GoLand "mark as Excluded" workaround (IntelliJ stores this in `.idea/`, which is git-ignored, so it can't be shipped in-repo).

Note: the `go.mod` files themselves are tracked source fixtures, so they can't be git-ignored — preventing the in-place tidy (the editor-exclusion guidance) is the actual cure for that part.

## Test plan
- [ ] N/A — no code change; this is gitignore / editor-config / docs only.

## Validation
- [x] Verified via `git check-ignore` that the new rules match the generated `policies/*/go.sum` and `pulumi-analyzer-policy-*` artifacts, and do **not** match the tracked `testdata/sample/*` `go.sum` files or the committed `go.mod` fixtures.
- [x] Changelog entry follows the `.changie.yaml` format (component / kind / body / time), matching existing entries.
- [ ] `make lint` / `make test_fast` / `make tidy` — not applicable (no Go or go.mod changes).

## Changelog
- [x] Changelog entry added (`build` / chore).

## Risk

Minimal. No runtime, CLI, SDK, or build-logic changes. The `.gitignore` rules are narrowly scoped to the policy fixture directories; the gopls `directoryFilters` only affect editor language features over `testdata` (generated fixtures); and `make tidy` already excludes the same paths, so CI behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
