### PR TITLE
Add CLI support for extension-parameterized packages

### DIFF
--- a/changelog/pending/cli-feat-package-extension-flag.yaml
+++ b/changelog/pending/cli-feat-package-extension-flag.yaml
@@ -1,0 +1,6 @@
+component: cli
+kind: feat
+body: Add an `--extension` flag to package commands for extension-parameterized packages, reinstalled from `Pulumi.yaml` on `pulumi install`
+time: 2026-06-16T00:00:00+00:00
+custom:
+  PR: ""

--- a/pkg/cmd/pulumi/convert/convert.go
+++ b/pkg/cmd/pulumi/convert/convert.go
@@ -607,10 +607,15 @@ func generateAndLinkSdksForPackages(
 			pkgWorkspace.Instance,
 			pctx,
 			pkg.Name,
-			&plugin.ParameterizeValue{Value: pkg.Parameterization.Value},
+			&plugin.ParameterizeValue{
+				Name:    pkg.Parameterization.Name,
+				Version: pkg.Parameterization.Version,
+				Value:   pkg.Parameterization.Value,
+			},
 			registry,
 			env.Global(),
-			0, /* unbounded concurrency */
+			0,     /* unbounded concurrency */
+			false, /* asExtension */
 		)
 		if err != nil {
 			return fmt.Errorf("creating package schema: %w", err)

--- a/pkg/cmd/pulumi/packagecmd/package_add.go
+++ b/pkg/cmd/pulumi/packagecmd/package_add.go
@@ -46,6 +46,8 @@ import (
 // Constructs the `pulumi package add` command.
 func newPackageAddCmd() *cobra.Command {
 	var language string
+	var parameterArgs []string
+	var asExtension bool
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a package to your Pulumi project, plugin, or current directory.",
@@ -93,6 +95,12 @@ that begin with dashes, you may need to use '--' to separate the provider name
 from the parameters, as in:
 
   pulumi package add <provider> -- --provider-parameter-flag value
+
+Use '--extension' to add the package as an extension of its base provider
+instead of a replacement. The extension's parameters are the flag's value,
+quoted as a single shell-style string:
+
+  pulumi package add <provider> --extension "key=value ..."
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agent := agentdetect.Detect(os.Getenv)
@@ -149,7 +157,8 @@ from the parameters, as in:
 			}
 
 			pluginSource := args[0]
-			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+
+			parameters := &plugin.ParameterizeArgs{Args: parameterArgs}
 
 			pkg, packageSpec, diags, err := packages.InstallPackage(
 				cmd.OutOrStdout(),
@@ -162,7 +171,8 @@ from the parameters, as in:
 				parameters,
 				target.reg,
 				env.Global(),
-				0, /* unbounded concurrency */
+				0,           /* unbounded concurrency */
+				asExtension, /* asExtension */
 			)
 			cmdDiag.PrintDiagnostics(pctx.Diag, diags)
 			if err != nil {
@@ -170,6 +180,23 @@ from the parameters, as in:
 					return fmt.Errorf("%w\nSearch: pulumi api '/api/registry/packages?search=<term>'", err)
 				}
 				return err
+			}
+
+			if asExtension {
+				if target.projectFilePath != nil {
+					target.proj.AddPackage(pkg.Name, workspace.PackageSpec{
+						Source:     pkg.ExtensionParameterization.BaseProvider.Name,
+						Version:    pkg.ExtensionParameterization.BaseProvider.Version.String(),
+						Extensions: parameterArgs,
+					})
+					fileName := filepath.Base(*target.projectFilePath)
+					if err := target.proj.Save(*target.projectFilePath); err != nil {
+						return fmt.Errorf("failed to update %s: %w", fileName, err)
+					}
+				}
+
+				fmt.Fprintf(cmd.ErrOrStderr(), "Extended package %s\n", schemaDisplayName(pkg))
+				return nil
 			}
 
 			// Build and add the package spec to the project
@@ -239,6 +266,7 @@ from the parameters, as in:
 
 	cmd.Flags().StringVar(&language, "language", "",
 		"Run outside a Pulumi project or plugin: [nodejs|python|go|dotnet|java]")
+	packages.AddExtensionFlag(cmd, &parameterArgs, &asExtension)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
+++ b/pkg/cmd/pulumi/packagecmd/package_extract_schema.go
@@ -37,6 +37,8 @@ import (
 )
 
 func newExtractSchemaCommand() *cobra.Command {
+	var parameterArgs []string
+	var asExtension bool
 	cmd := &cobra.Command{
 		Use:   "get-schema",
 		Short: "Get the schema.json from a package",
@@ -71,9 +73,9 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			defer contract.IgnoreClose(pctx)
 
-			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+			parameters := &plugin.ParameterizeArgs{Args: parameterArgs}
 			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
-				registry, env.Global(), 0 /* unbounded concurrency */)
+				registry, env.Global(), 0 /* unbounded concurrency */, asExtension)
 			if err != nil {
 				return err
 			}
@@ -112,6 +114,8 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 	// It's worth mentioning the `--`, as it means that Cobra will stop parsing flags.
 	// In other words, a provider parameter can be `--foo` as long as it's after `--`.
 	cmd.Use = "get-schema <schema-source> [flags] [--] [provider-parameter]..."
+
+	packages.AddExtensionFlag(cmd, &parameterArgs, &asExtension)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
+++ b/pkg/cmd/pulumi/packagecmd/package_gen_sdk.go
@@ -47,6 +47,8 @@ func newGenSdkCommand() *cobra.Command {
 	var out string
 	var version string
 	var local bool
+	var parameterArgs []string
+	var asExtension bool
 	cmd := &cobra.Command{
 		Use:   "gen-sdk",
 		Short: "Generate SDK(s) from a package or schema",
@@ -81,9 +83,9 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 			}
 			defer contract.IgnoreClose(pctx)
 
-			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+			parameters := &plugin.ParameterizeArgs{Args: parameterArgs}
 			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
-				registry, env.Global(), 0 /* unbounded concurrency */)
+				registry, env.Global(), 0 /* unbounded concurrency */, asExtension)
 			if err != nil {
 				return err
 			}
@@ -147,6 +149,7 @@ If a folder either the plugin binary must match the folder name (e.g. 'aws' and 
 	cmd.Flags().StringVar(&overlays, "overlays", "", "A folder of extra overlay files to copy to the generated SDK")
 	cmd.Flags().StringVar(&version, "version", "", "The provider plugin version to generate the SDK for")
 	cmd.Flags().BoolVar(&local, "local", false, "Generate an SDK appropriate for local usage")
+	packages.AddExtensionFlag(cmd, &parameterArgs, &asExtension)
 	contract.AssertNoErrorf(cmd.Flags().MarkHidden("overlays"), `Could not mark "overlay" as hidden`)
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_info.go
+++ b/pkg/cmd/pulumi/packagecmd/package_info.go
@@ -47,6 +47,8 @@ func newPackageInfoCmd() *cobra.Command {
 	var module string
 	var resource string
 	var function string
+	var parameterArgs []string
+	var asExtension bool
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Show information about a package",
@@ -83,7 +85,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 				return errors.New("only one of --function or --resource can be specified")
 			}
 
-			parameters := &plugin.ParameterizeArgs{Args: args[1:]}
+			parameters := &plugin.ParameterizeArgs{Args: parameterArgs}
 			stdout := cmd.OutOrStdout()
 			color := cmdutil.GetGlobalColorization()
 
@@ -107,7 +109,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 			}
 
 			spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, args[0], parameters,
-				registry, env.Global(), 0 /* unbounded concurrency */)
+				registry, env.Global(), 0 /* unbounded concurrency */, asExtension)
 			if err != nil {
 				return err
 			}
@@ -134,6 +136,7 @@ The <provider> argument can be specified in the same way as in 'pulumi package a
 	cmd.Flags().StringVarP(&module, "module", "m", "", "Module name")
 	cmd.Flags().StringVarP(&resource, "resource", "r", "", "Resource name")
 	cmd.Flags().StringVarP(&function, "function", "f", "", "Function name")
+	packages.AddExtensionFlag(cmd, &parameterArgs, &asExtension)
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/packagecmd/package_publish.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish.go
@@ -67,7 +67,7 @@ type packagePublishCmd struct {
 
 	extractSchema func(
 		ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
-		registry registry.Registry, e env.Env, concurrency int,
+		registry registry.Registry, e env.Env, concurrency int, asExtension bool,
 	) (*schema.PackageSpec, *workspace.PackageSpec, error)
 }
 
@@ -181,7 +181,7 @@ func (cmd *packagePublishCmd) Run(
 	defer contract.IgnoreClose(pctx)
 
 	pkg, _, err := cmd.extractSchema(pkgWorkspace.Instance, pctx, packageSrc, packageParams, b.GetReadOnlyCloudRegistry(),
-		env.Global(), 0 /* unbounded concurrency */)
+		env.Global(), 0 /* unbounded concurrency */, false /* asExtension */)
 	if err != nil {
 		return fmt.Errorf("failed to get schema: %w", err)
 	}

--- a/pkg/cmd/pulumi/packagecmd/package_publish_test.go
+++ b/pkg/cmd/pulumi/packagecmd/package_publish_test.go
@@ -374,7 +374,7 @@ func TestPackagePublishCmd_Run(t *testing.T) {
 				extractSchema: func(
 					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
-					registry registry.Registry, _ env.Env, _ int,
+					registry registry.Registry, _ env.Env, _ int, _ bool,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
 					if tt.mockSchema == nil && tt.schemaExtractionErr == nil {
 						return nil, nil, errors.New("mock schema extraction failed")
@@ -471,7 +471,7 @@ func TestPackagePublishCmd_IOErrors(t *testing.T) {
 				extractSchema: func(
 					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
-					registry registry.Registry, _ env.Env, _ int,
+					registry registry.Registry, _ env.Env, _ int, _ bool,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
 					return tt.mockSchema, nil, nil
 				},
@@ -531,7 +531,7 @@ func TestPackagePublishCmd_BackendErrors(t *testing.T) {
 				extractSchema: func(
 					ws pkgWorkspace.Context,
 					pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters,
-					registry registry.Registry, _ env.Env, _ int,
+					registry registry.Registry, _ env.Env, _ int, _ bool,
 				) (*schema.PackageSpec, *workspace.PackageSpec, error) {
 					return validSchema, nil, nil
 				},
@@ -567,7 +567,7 @@ func TestPackagePublishCmd_Run_ReadProjectError(t *testing.T) {
 			packageSource string,
 			parameters plugin.ParameterizeParameters,
 			registry registry.Registry,
-			_ env.Env, _ int,
+			_ env.Env, _ int, _ bool,
 		) (*schema.PackageSpec, *workspace.PackageSpec, error) {
 			pkg := &schema.PackageSpec{
 				Name:    "test-package",

--- a/pkg/cmd/pulumi/packageresolution/package_resolution.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution.go
@@ -147,6 +147,14 @@ type (
 	}
 )
 
+// parameterizeArgs returns the arguments used to parameterize a package on install.
+func parameterizeArgs(spec workspace.PackageSpec) []string {
+	if len(spec.Parameters) > 0 {
+		return spec.Parameters
+	}
+	return spec.Extensions
+}
+
 func naivePackageDescriptor(
 	ctx context.Context, spec workspace.PackageSpec,
 ) (workspace.UnresolvedPackageDescriptor, error) {
@@ -163,7 +171,7 @@ func naivePackageDescriptor(
 		version, spec.PluginDownloadURL, spec.Checksums)
 	return workspace.UnresolvedPackageDescriptor{
 		PluginDescriptor:     pluginDesc,
-		ParameterizationArgs: spec.Parameters,
+		ParameterizationArgs: parameterizeArgs(spec),
 	}, err
 }
 
@@ -179,8 +187,9 @@ func naiveResolution(
 		}
 	}
 
-	// If there is no parameters in the spec, then we have fully resolved here.
-	if len(spec.Parameters) == 0 {
+	// With no parameterization args, there is nothing to parameterize, so the
+	// package resolves to its plugin descriptor alone.
+	if len(parameterizeArgs(spec)) == 0 {
 		return PackageResolution{
 			Spec: spec,
 			Pkg: workspace.PackageDescriptor{
@@ -205,10 +214,11 @@ func registryResolution(
 		Source:     path.Join(metadata.Source, metadata.Publisher, metadata.Name),
 		Version:    metadata.Version.String(),
 		Parameters: spec.Parameters,
+		Extensions: spec.Extensions,
 		Checksums:  spec.Checksums,
 	}
 
-	if len(spec.Parameters) > 0 && metadata.Parameterization != nil {
+	if len(parameterizeArgs(spec)) > 0 && metadata.Parameterization != nil {
 		return nil, fmt.Errorf(
 			"unable to resolve package: resolved plugin to %s, which is already parameterized",
 			spec.Source,
@@ -223,12 +233,12 @@ func registryResolution(
 		Checksums:         spec.Checksums,
 	}
 
-	if len(spec.Parameters) > 0 {
+	if len(parameterizeArgs(spec)) > 0 {
 		plugin := PluginResolution{
 			Spec: spec,
 			Pkg: workspace.UnresolvedPackageDescriptor{
 				PluginDescriptor:     pluginDescriptor,
-				ParameterizationArgs: spec.Parameters,
+				ParameterizationArgs: parameterizeArgs(spec),
 			},
 			InstalledInWorkspace: installed,
 		}
@@ -290,7 +300,7 @@ func Resolve(
 	if plugin.IsLocalPluginPath(ctx, spec.Source) {
 		return PathResolution{
 			Path:                 spec.Source,
-			ParameterizationArgs: spec.Parameters,
+			ParameterizationArgs: parameterizeArgs(spec),
 			Spec:                 spec,
 		}, nil
 	}

--- a/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
+++ b/pkg/cmd/pulumi/packageresolution/package_resolution_test.go
@@ -420,6 +420,54 @@ func TestResolvePackage(t *testing.T) {
 			},
 		},
 		{
+			name: "spec with extensions returns PluginResolution",
+			pluginSpec: workspace.PackageSpec{
+				Source:     "param-pkg",
+				Extensions: []string{"ext-arg1", "ext-arg2"},
+			},
+			workspace: pluginstorage.MockContext{},
+			registryResponse: func() (registry.Registry, error) {
+				meta := apitype.PackageMetadata{
+					Name:              "param-pkg",
+					Publisher:         "pulumi",
+					Source:            "pulumi",
+					Version:           semver.Version{Major: 1, Minor: 0, Patch: 0},
+					PluginDownloadURL: "https://example.com/param-pkg",
+				}
+				return registry.Mock{
+					GetPackageF: func(
+						ctx context.Context, source, publisher, name string, version *semver.Version,
+					) (apitype.PackageMetadata, error) {
+						if source == "pulumi" && publisher == "pulumi" && name == "param-pkg" {
+							return meta, nil
+						}
+						return apitype.PackageMetadata{}, registry.ErrNotFound
+					},
+					ListPackagesF: func(ctx context.Context, name *string) iter.Seq2[apitype.PackageMetadata, error] {
+						return func(yield func(apitype.PackageMetadata, error) bool) {
+							yield(meta, nil)
+						}
+					},
+				}, nil
+			},
+			expected: PluginResolution{
+				Spec: workspace.PackageSpec{
+					Source:     "pulumi/pulumi/param-pkg",
+					Version:    "1.0.0",
+					Extensions: []string{"ext-arg1", "ext-arg2"},
+				},
+				Pkg: workspace.UnresolvedPackageDescriptor{
+					PluginDescriptor: workspace.PluginDescriptor{
+						Name:              "param-pkg",
+						Kind:              apitype.ResourcePlugin,
+						Version:           &semver.Version{Major: 1, Minor: 0, Patch: 0},
+						PluginDownloadURL: "https://example.com/param-pkg",
+					},
+					ParameterizationArgs: []string{"ext-arg1", "ext-arg2"},
+				},
+			},
+		},
+		{
 			name: "spec with parameters + metadata with parameterization returns error",
 			pluginSpec: workspace.PackageSpec{
 				Source:     "already-param-pkg",

--- a/pkg/cmd/pulumi/packages/extension.go
+++ b/pkg/cmd/pulumi/packages/extension.go
@@ -1,0 +1,63 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packages
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/shlex"
+	"github.com/spf13/cobra"
+)
+
+// AddExtensionFlag registers the shared --extension flag on a package command. It is a
+// holds the extension's provider-defined parameters as one shell-quoted string.
+//
+// PreRunE resolves it: when the flag is set, its value is shlex-split into params and
+// isExtension is true; otherwise params defaults to the positional tokens after the
+// source and isExtension is false. Combining positional parameters with --extension is
+// rejected.
+func AddExtensionFlag(cmd *cobra.Command, params *[]string, isExtension *bool) {
+	var extension string
+	cmd.Flags().StringVar(&extension, "extension", "",
+		"Add an extension layered onto a base provider rather than a replacement. "+
+			"The value is the extension's provider-defined parameters as one shell-quoted "+
+			`string, e.g. --extension "key=value ..."`)
+
+	inner := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if inner != nil {
+			if err := inner(cmd, args); err != nil {
+				return err
+			}
+		}
+		if cmd.Flags().Changed("extension") {
+			*isExtension = true
+			if len(args) > 1 {
+				return errors.New("combining replacement parameters with --extension is not supported yet")
+			}
+			toks, err := shlex.Split(extension)
+			if err != nil {
+				return fmt.Errorf("parse --extension parameters: %w", err)
+			}
+			*params = toks
+			return nil
+		}
+		if len(args) > 0 {
+			*params = args[1:]
+		}
+		return nil
+	}
+}

--- a/pkg/cmd/pulumi/packages/extension_test.go
+++ b/pkg/cmd/pulumi/packages/extension_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packages
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddExtensionFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// args is the raw command line after the subcommand, parsed through a real
+		// flag set so --extension behaves exactly as in the CLI.
+		args          []string
+		wantParams    []string
+		wantExtension bool
+		wantErr       string
+	}{
+		{
+			name:       "replacement passes every token after the source",
+			args:       []string{"example.com/base", "p1", "p2"},
+			wantParams: []string{"p1", "p2"},
+		},
+		{
+			name:       "replacement with no parameters",
+			args:       []string{"example.com/base"},
+			wantParams: []string{},
+		},
+		{
+			name:       "replacement ignores a dash separator",
+			args:       []string{"example.com/base", "--", "p1"},
+			wantParams: []string{"p1"},
+		},
+		{
+			name:          "extension splits its value like a shell line",
+			args:          []string{"--extension", "spell=fireball mana=42", "example.com/base"},
+			wantParams:    []string{"spell=fireball", "mana=42"},
+			wantExtension: true,
+		},
+		{
+			name:          "extension honors shell quoting",
+			args:          []string{"--extension", `species="giant pacific octopus"`, "example.com/base"},
+			wantParams:    []string{"species=giant pacific octopus"},
+			wantExtension: true,
+		},
+		{
+			name:          "extension with no parameters",
+			args:          []string{"--extension", "", "example.com/base"},
+			wantParams:    []string{},
+			wantExtension: true,
+		},
+		{
+			name:    "combining replacement and extension is rejected",
+			args:    []string{"--extension", "spell=fireball", "example.com/base", "p1"},
+			wantErr: "combining replacement parameters with --extension is not supported yet",
+		},
+		{
+			name:    "unbalanced quotes are a parse error",
+			args:    []string{"--extension", `incantation="unterminated`, "example.com/base"},
+			wantErr: "parse --extension parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &cobra.Command{Use: "test"}
+			var params []string
+			var isExtension bool
+			AddExtensionFlag(cmd, &params, &isExtension)
+			require.NoError(t, cmd.Flags().Parse(tt.args))
+
+			err := cmd.PreRunE(cmd, cmd.Flags().Args())
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantParams, params)
+			assert.Equal(t, tt.wantExtension, isExtension)
+		})
+	}
+}

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -79,9 +79,10 @@ func BindSpecWithContext(
 // It returns the path to the installed package.
 func InstallPackage(stdout io.Writer, ws pkgWorkspace.Context, proj workspace.BaseProject, pctx *plugin.Context,
 	language, root, schemaSource string, parameters plugin.ParameterizeParameters,
-	registry registry.Registry, e env.Env, concurrency int,
+	registry registry.Registry, e env.Env, concurrency int, asExtension bool,
 ) (*schema.Package, *workspace.PackageSpec, hcl.Diagnostics, error) {
-	pkgSpec, specOverride, err := SchemaFromSchemaSource(ws, pctx, schemaSource, parameters, registry, e, concurrency)
+	pkgSpec, specOverride, err := SchemaFromSchemaSource(ws, pctx, schemaSource, parameters, registry, e, concurrency,
+		asExtension)
 	if err != nil {
 		var diagErr hcl.Diagnostics
 		if errors.As(err, &diagErr) {
@@ -383,9 +384,10 @@ func setSpecNamespace(spec *schema.PackageSpec, pluginSpec workspace.PluginDescr
 func SchemaFromSchemaSource(
 	ws pkgWorkspace.Context,
 	pctx *plugin.Context, packageSource string, parameters plugin.ParameterizeParameters, registry registry.Registry,
-	env env.Env, concurrency int,
+	env env.Env, concurrency int, asExtension bool,
 ) (*schema.PackageSpec, *workspace.PackageSpec, error) {
-	raw, packageSpec, err := schemaJSONBytes(ws, pctx, packageSource, parameters, registry, env, concurrency)
+	raw, packageSpec, parameterizationName, err := schemaJSONBytes(
+		ws, pctx, packageSource, parameters, registry, env, concurrency)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -396,6 +398,31 @@ func SchemaFromSchemaSource(
 	if packageSpec == nil {
 		// The schema came from a file, so there is no plugin to describe.
 		return &spec, nil, nil
+	}
+	if asExtension && spec.ExtensionParameterization == nil {
+		return nil, nil, fmt.Errorf(
+			"%s did not return an extension-parameterized schema; the source may not support "+
+				"extension parameterization",
+			packageSource)
+	}
+	if parameterizationName != "" {
+		switch {
+		case spec.Parameterization != nil && spec.ExtensionParameterization != nil:
+			return nil, nil, errors.New(
+				"provider returned schema with both parameterization and extensionParameterization blocks; " +
+					"the provider must emit exactly one")
+		case spec.Parameterization == nil && spec.ExtensionParameterization == nil:
+			return nil, nil, fmt.Errorf(
+				"provider returned schema without a parameterization block but parameterize identified the package as %q; "+
+					"the provider must emit a schema whose parameterization name matches its parameterize response",
+				parameterizationName)
+		}
+		if spec.Name != parameterizationName {
+			return nil, nil, fmt.Errorf(
+				"provider returned schema parameterized as %q but parameterize identified the package as %q; "+
+					"the provider must emit a schema whose parameterization name matches its parameterize response",
+				spec.Name, parameterizationName)
+		}
 	}
 	pluginSpec, err := workspace.NewPluginDescriptor(pctx.Request(), packageSource, apitype.ResourcePlugin, nil, "", nil)
 	if err != nil {
@@ -417,7 +444,7 @@ func PartialPackageFromSchemaSource(
 	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
 	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
 ) (*schema.PartialPackage, error) {
-	raw, _, err := schemaJSONBytes(ws, pctx, packageSource, parameters, reg, env, concurrency)
+	raw, _, _, err := schemaJSONBytes(ws, pctx, packageSource, parameters, reg, env, concurrency)
 	if err != nil {
 		return nil, err
 	}
@@ -434,42 +461,44 @@ func PartialPackageFromSchemaSource(
 func schemaJSONBytes(
 	ws pkgWorkspace.Context, pctx *plugin.Context, packageSource string,
 	parameters plugin.ParameterizeParameters, reg registry.Registry, env env.Env, concurrency int,
-) ([]byte, *workspace.PackageSpec, error) {
+) ([]byte, *workspace.PackageSpec, string, error) {
 	switch filepath.Ext(packageSource) {
 	case ".yaml", ".yml":
 		if !parameters.Empty() {
-			return nil, nil, errors.New("parameterization arguments are not supported for yaml files")
+			return nil, nil, "", errors.New("parameterization arguments are not supported for yaml files")
 		}
 		f, err := os.ReadFile(packageSource)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		var spec schema.PackageSpec
 		if err := yaml.Unmarshal(f, &spec); err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		raw, err := json.Marshal(spec)
-		return raw, nil, err
+		return raw, nil, "", err
 	case ".json":
 		if !parameters.Empty() {
-			return nil, nil, errors.New("parameterization arguments are not supported for json files")
+			return nil, nil, "", errors.New("parameterization arguments are not supported for json files")
 		}
 		raw, err := os.ReadFile(packageSource)
-		return raw, nil, err
+		return raw, nil, "", err
 	}
 
 	p, packageSpec, err := ProviderFromSource(ws, pctx, packageSource, reg, env, concurrency)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	defer contract.IgnoreClose(p)
 
 	var request plugin.GetSchemaRequest
+	var parameterizationName string
 	if !parameters.Empty() {
 		resp, err := p.Parameterize(pctx.Request(), plugin.ParameterizeRequest{Parameters: parameters})
 		if err != nil {
-			return nil, nil, fmt.Errorf("parameterize: %w", err)
+			return nil, nil, "", fmt.Errorf("parameterize: %w", err)
 		}
+		parameterizationName = resp.Name
 		request = plugin.GetSchemaRequest{SubpackageName: resp.Name, SubpackageVersion: &resp.Version}
 	}
 	tracer := otel.Tracer("pulumi-cli")
@@ -478,9 +507,9 @@ func schemaJSONBytes(
 	getSchema, err := p.GetSchema(pctx.Request(), request)
 	schemaSpan.End()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
-	return getSchema.Schema, &packageSpec, nil
+	return getSchema.Schema, &packageSpec, parameterizationName, nil
 }
 
 // ProviderFromSource takes a plugin name or path.

--- a/pkg/cmd/pulumi/schema/schema_check.go
+++ b/pkg/cmd/pulumi/schema/schema_check.go
@@ -48,6 +48,8 @@ type checkArgs struct {
 
 func newSchemaCheckCommand() *cobra.Command {
 	schemaCheckArgs := checkArgs{}
+	var parameterArgs []string
+	var asExtension bool
 
 	cmd := &cobra.Command{
 		Use:   "check",
@@ -84,7 +86,7 @@ or a JSON/YAML schema file. Pass "-" to read a JSON schema from stdin.`,
 			}
 			defer contract.IgnoreClose(pctx)
 
-			spec, err := schemaFromSourceOrStdin(cmd, pctx, reg, source, args[1:])
+			spec, err := schemaFromSourceOrStdin(cmd, pctx, reg, source, parameterArgs, asExtension)
 			if err != nil {
 				return err
 			}
@@ -117,6 +119,7 @@ or a JSON/YAML schema file. Pass "-" to read a JSON schema from stdin.`,
 
 	cmd.PersistentFlags().BoolVar(&schemaCheckArgs.allowDanglingReferences, "allow-dangling-references", false,
 		"Whether references to nonexistent types should be considered errors")
+	packages.AddExtensionFlag(cmd, &parameterArgs, &asExtension)
 
 	return cmd
 }
@@ -125,7 +128,7 @@ or a JSON/YAML schema file. Pass "-" to read a JSON schema from stdin.`,
 // the schema is read as JSON from stdin. Otherwise it delegates to SchemaFromSchemaSource
 // which supports files, plugin names, and plugin paths.
 func schemaFromSourceOrStdin(
-	cmd *cobra.Command, pctx *plugin.Context, reg registry.Registry, source string, extraArgs []string,
+	cmd *cobra.Command, pctx *plugin.Context, reg registry.Registry, source string, extraArgs []string, asExtension bool,
 ) (*schema.PackageSpec, error) {
 	if source == "-" {
 		return schemaFromStdin(cmd)
@@ -133,7 +136,7 @@ func schemaFromSourceOrStdin(
 
 	parameters := &plugin.ParameterizeArgs{Args: extraArgs}
 	spec, _, err := packages.SchemaFromSchemaSource(pkgWorkspace.Instance, pctx, source, parameters,
-		reg, env.Global(), 0 /* unbounded concurrency */)
+		reg, env.Global(), 0 /* unbounded concurrency */, asExtension)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/pulumi/state/state_move.go
+++ b/pkg/cmd/pulumi/state/state_move.go
@@ -471,6 +471,15 @@ func (cmd *stateMoveCmd) Run(
 		}
 	}
 
+	// Carry extension blobs across the move so any moved resource's ExtensionRef
+	// still resolves on the destination. Drop blobs the source no longer references.
+	destExts, missing := deploy.MapExtensions(destSnapshot.Resources, destSnapshot.Extensions, sourceSnapshot)
+	if len(missing) > 0 {
+		return fmt.Errorf("source snapshot is missing extension blob(s) %v referenced by moved resources", missing)
+	}
+	destSnapshot.Extensions = destExts
+	sourceSnapshot.Extensions, _ = deploy.MapExtensions(sourceSnapshot.Resources, sourceSnapshot.Extensions, nil)
+
 	err = destSnapshot.VerifyIntegrity()
 	if err != nil {
 		return fmt.Errorf(`failed to verify integrity of destination snapshot: %w

--- a/pkg/cmd/pulumi/state/state_move_test.go
+++ b/pkg/cmd/pulumi/state/state_move_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
@@ -1281,7 +1282,8 @@ func TestMoveProviderWithSameInputs(t *testing.T) {
 	}
 
 	sourceSnapshot, destSnapshot, stdout := runMoveWithDestResources(
-		t, sourceResources, destResources, []string{string(sourceResources[1].URN)})
+		t, sourceResources, destResources, []string{string(sourceResources[1].URN)},
+	)
 
 	//nolint:lll
 	expectedStdout := `Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:
@@ -1431,7 +1433,8 @@ func TestProviderParentsAreTreatedAsProviders(t *testing.T) {
 
 	sourceSnapshot, destSnapshot, stdout := runMoveWithOptions(
 		t, sourceResources, []string{string(sourceResources[2].URN)},
-		&MoveOptions{IncludeParents: true})
+		&MoveOptions{IncludeParents: true},
+	)
 
 	assert.Contains(t, stdout.String(),
 		"Planning to move the following resources from organization/test/sourceStack to organization/test/destStack:\n\n"+
@@ -1501,4 +1504,114 @@ func TestMoveBreaksCopiedProviderDependenciesToRemainingSourceResources(t *testi
 			"dependencies on resources in organization/test/sourceStack:\n\n"+
 			"  - urn:pulumi:sourceStack::test::pulumi:providers:a::default_1_0_0 has "+
 			"a dependency on urn:pulumi:sourceStack::test::a:b:c::remaining")
+}
+
+func TestStateMoveExtensionBlobs(t *testing.T) {
+	t.Parallel()
+
+	providerURN := resource.NewURN("sourceStack", "test", "", "pulumi:providers:extbase", "default_1_0_0")
+	provider := &pkgresource.State{
+		URN: providerURN, Type: "pulumi:providers:extbase::default_1_0_0", ID: "provider_id", Custom: true,
+	}
+	greeting := func(name, ref string) *pkgresource.State {
+		return &pkgresource.State{
+			URN:          resource.NewURN("sourceStack", "test", "", "extbase:index:Greeting", name),
+			Type:         "extbase:index:Greeting",
+			Provider:     string(providerURN) + "::provider_id",
+			ExtensionRef: pkgresource.ExtensionRef(ref),
+		}
+	}
+
+	cases := []struct {
+		name          string
+		stayBehindRef string
+		moveRef       string
+		exts          map[apitype.ExtensionRef]apitype.Extension
+		sourceHas     []string
+		sourceLacks   []string
+		destHas       []string
+		destLacks     []string
+	}{
+		{
+			name:          "shared_blob_stays_on_source_and_copies_to_dest",
+			stayBehindRef: "ext-blob-1",
+			moveRef:       "ext-blob-1",
+			exts: map[apitype.ExtensionRef]apitype.Extension{
+				"ext-blob-1": {Name: "myext", Version: "1.0.0", Value: []byte("Hello")},
+			},
+			sourceHas: []string{"ext-blob-1"},
+			destHas:   []string{"ext-blob-1"},
+		},
+		{
+			name:          "unreferenced_blob_is_pruned_from_source",
+			stayBehindRef: "ext-kept",
+			moveRef:       "ext-moved",
+			exts: map[apitype.ExtensionRef]apitype.Extension{
+				"ext-kept":  {Name: "keep", Version: "1.0.0", Value: []byte("Hi")},
+				"ext-moved": {Name: "move", Version: "1.0.0", Value: []byte("Bye")},
+			},
+			sourceHas:   []string{"ext-kept"},
+			sourceLacks: []string{"ext-moved"},
+			destHas:     []string{"ext-moved"},
+			destLacks:   []string{"ext-kept"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			sm := b64.NewBase64SecretsManager()
+			b, err := diy.New(ctx, diagtest.LogSink(t), "file://"+filepath.ToSlash(t.TempDir()), nil)
+			require.NoError(t, err)
+
+			importStack := func(
+				name string, resources []*pkgresource.State, exts map[apitype.ExtensionRef]apitype.Extension,
+			) backend.Stack {
+				snap := deploy.NewSnapshot(deploy.Manifest{}, sm, resources, nil, deploy.SnapshotMetadata{}, nil, exts)
+				udep, err := stack.SerializeUntypedDeployment(ctx, snap, nil)
+				require.NoError(t, err)
+				ref, err := b.ParseStackReference(name)
+				require.NoError(t, err)
+				s, err := b.CreateStack(ctx, ref, "", nil, nil)
+				require.NoError(t, err)
+				require.NoError(t, b.ImportDeployment(ctx, s, udep))
+				return s
+			}
+
+			moveMe := greeting("moveMe", c.moveRef)
+			source := importStack("organization/test/sourceStack",
+				[]*pkgresource.State{provider, greeting("stayBehind", c.stayBehindRef), moveMe}, c.exts)
+			dest := importStack("organization/test/destStack", nil, nil)
+
+			mp := &secrets.MockProvider{}
+			mp = mp.Add("b64", func(_ json.RawMessage) (secrets.Manager, error) { return sm, nil })
+
+			cmd := stateMoveCmd{Yes: true, Stdout: &bytes.Buffer{}, Colorizer: colors.Never}
+			require.NoError(t, cmd.Run(ctx, source, dest, []string{string(moveMe.URN)}, mp, mp))
+
+			sourceSnap, err := source.Snapshot(ctx, mp)
+			require.NoError(t, err)
+			destSnap, err := dest.Snapshot(ctx, mp)
+			require.NoError(t, err)
+
+			for _, ref := range c.sourceHas {
+				assert.Contains(t, sourceSnap.Extensions, apitype.ExtensionRef(ref),
+					"source must retain a referenced blob")
+			}
+			for _, ref := range c.sourceLacks {
+				assert.NotContains(t, sourceSnap.Extensions, apitype.ExtensionRef(ref),
+					"source must drop a blob no longer referenced after the move")
+			}
+			for _, ref := range c.destHas {
+				assert.Contains(t, destSnap.Extensions, apitype.ExtensionRef(ref),
+					"destination must receive the moved resource's blob")
+			}
+			for _, ref := range c.destLacks {
+				assert.NotContains(t, destSnap.Extensions, apitype.ExtensionRef(ref),
+					"destination must not receive an unrelated blob")
+			}
+		})
+	}
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -184,7 +184,7 @@ func (p PackageSpec) String() string {
 }
 
 type packageSpecMarshalled struct {
-	Source            string            `json:"source,omitzero" yaml:"source,omitempty"`
+	Source            string            `json:"source" yaml:"source"`
 	Version           string            `json:"version,omitzero" yaml:"version,omitempty"`
 	Parameters        []string          `json:"parameters,omitzero" yaml:"parameters,omitempty"`
 	Checksums         map[string][]byte `json:"checksums,omitzero" yaml:"checksums,omitempty"`

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -132,10 +132,13 @@ type PackageSpec struct {
 
 	// When marshaling, prefer to unmarshal without the <name>@<version> shorthand.
 	unmarshalledFromFull bool
+
+	// CLI args passed to the extension's Parameterize call. This must be implemented in the provider.
+	Extensions []string
 }
 
 func (p PackageSpec) String() string {
-	if len(p.Parameters) == 0 && len(p.Checksums) == 0 && len(p.PluginDownloadURL) == 0 {
+	if len(p.Parameters) == 0 && len(p.Checksums) == 0 && len(p.PluginDownloadURL) == 0 && len(p.Extensions) == 0 {
 		if len(p.Version) == 0 {
 			return p.Source
 		}
@@ -165,21 +168,33 @@ func (p PackageSpec) String() string {
 		b.WriteString(", PluginDownloadURL: ")
 		b.WriteString(p.PluginDownloadURL)
 	}
+
+	if len(p.Extensions) != 0 {
+		b.WriteString(", Extension: ")
+		for i, extension := range p.Extensions {
+			b.WriteString(extension)
+			if i != len(p.Extensions)-1 {
+				b.WriteRune(' ')
+			}
+		}
+	}
 	b.WriteString(" }")
 
 	return b.String()
 }
 
 type packageSpecMarshalled struct {
-	Source            string            `json:"source" yaml:"source"`
+	Source            string            `json:"source,omitzero" yaml:"source,omitempty"`
 	Version           string            `json:"version,omitzero" yaml:"version,omitempty"`
 	Parameters        []string          `json:"parameters,omitzero" yaml:"parameters,omitempty"`
 	Checksums         map[string][]byte `json:"checksums,omitzero" yaml:"checksums,omitempty"`
 	PluginDownloadURL string            `json:"pluginDownloadURL,omitzero" yaml:"pluginDownloadURL,omitempty"`
+	Extensions        []string          `json:"extensions,omitzero" yaml:"extensions,omitempty"`
 }
 
 func marshalPackageSpec[T any](ps PackageSpec, from func(any) (T, error)) (T, error) {
-	if len(ps.Parameters) == 0 && len(ps.Checksums) == 0 && ps.PluginDownloadURL == "" && !ps.unmarshalledFromFull {
+	if len(ps.Parameters) == 0 && len(ps.Checksums) == 0 && ps.PluginDownloadURL == "" &&
+		len(ps.Extensions) == 0 && !ps.unmarshalledFromFull {
 		name := ps.Source
 		if ps.Version != "" {
 			name += "@" + ps.Version
@@ -192,6 +207,7 @@ func marshalPackageSpec[T any](ps PackageSpec, from func(any) (T, error)) (T, er
 		Parameters:        ps.Parameters,
 		Checksums:         ps.Checksums,
 		PluginDownloadURL: ps.PluginDownloadURL,
+		Extensions:        ps.Extensions,
 	})
 }
 
@@ -221,6 +237,7 @@ func (ps *PackageSpec) unmarshal(from func(any) error) error {
 		Parameters:           full.Parameters,
 		Checksums:            full.Checksums,
 		PluginDownloadURL:    full.PluginDownloadURL,
+		Extensions:           full.Extensions,
 		unmarshalledFromFull: true,
 	}
 	return nil

--- a/sdk/go/common/workspace/project.json
+++ b/sdk/go/common/workspace/project.json
@@ -299,6 +299,13 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "extensions":{
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "description":"For an extension package, the parameters that extend the base provider"
                 }
             }
         },

--- a/sdk/go/common/workspace/project_test.go
+++ b/sdk/go/common/workspace/project_test.go
@@ -1481,6 +1481,51 @@ packages:
 	})
 }
 
+func TestPackageValueSerializationExtension(t *testing.T) {
+	t.Parallel()
+
+	proj := func() *Project {
+		return &Project{
+			Name:    "test-project",
+			Runtime: NewProjectRuntimeInfo("nodejs", nil),
+			Packages: map[string]PackageSpec{
+				"extension-string-base": {
+					Source:     "kubernetes",
+					Extensions: []string{"-c", "crds.yaml"},
+				},
+				"extension-inline-base": {
+					Source:     "kubernetes",
+					Version:    "4.29.0",
+					Parameters: []string{"some-param"},
+					Extensions: []string{"-c", "crds.yaml"},
+				},
+			},
+		}
+	}
+
+	test := func(
+		t *testing.T,
+		marshal func(any) ([]byte, error),
+		unmarshal func([]byte, any) error,
+	) {
+		bytes, err := marshal(proj())
+		require.NoError(t, err)
+
+		newProj := new(Project)
+		require.NoError(t, unmarshal(bytes, newProj))
+		assert.EqualExportedValues(t, proj(), newProj)
+	}
+
+	t.Run("JSON", func(t *testing.T) {
+		t.Parallel()
+		test(t, json.Marshal, json.Unmarshal)
+	})
+	t.Run("YAML", func(t *testing.T) {
+		t.Parallel()
+		test(t, yaml.Marshal, yaml.Unmarshal)
+	})
+}
+
 func TestWorkspaceSpecString(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Introduces an `--extension` flag for `pulumi package add` subcommand. This flag takes a single string parameter that base providers (such as Kubernetes) can parse for parameterization arguments.

Generating a package is of the following format"

`pulumi package add <source> --extension "<extension params as one shell-quoted string>"`

Example: `pulumi package add kubernetes --extension "-c crd.yaml -n gateway"`
 
  - Add a shared --extension flag to the package commands for adding a package as an extension of its base provider
  - Record extensions in Pulumi.yaml keyed by their base provider, and reinstall them during pulumi install
  - Pass the extension name and version through convert's by-value parameterization so generated SDKs resolve the right provider

Stacked on #23579.
