### PR TITLE
enable automatic logging unconditionally

### DIFF
--- a/.github/workflows/ci-run-test.yml
+++ b/.github/workflows/ci-run-test.yml
@@ -416,7 +416,6 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CI_ACCESS_SECRET }}
           DOTNET_VERSION: ${{ fromJson(inputs.version-set).dotnet }}
-          PULUMI_ENABLE_AUTOMATIC_LOGGING: true
       - name: Convert Node coverage data
         if: ${{ inputs.platform != 'windows-latest' }}
         run: |

--- a/changelog/pending/cli-feat-20260630-100351.yaml
+++ b/changelog/pending/cli-feat-20260630-100351.yaml
@@ -1,0 +1,4 @@
+component: cli
+kind: feat
+body: Enable automatic logging for every command by default
+time: 2026-06-30T10:03:51.384651612+02:00

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -313,13 +313,10 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			// or secrets manager, so logs will be gzip-compressed (not
 			// encrypted). Engine operations may upgrade to encrypted logging
 			// when a secrets manager becomes available.
-			if env.EnableAutomaticLogging.Value() {
-				var logErr error
-				autoLogger, logErr = backendlogging.StartLogging(
-					cmd.Context(), nil /* sm */)
-				if logErr != nil {
-					logging.V(3).Infof("automatic logging unavailable: %v", logErr)
-				}
+			var logErr error
+			autoLogger, logErr = backendlogging.StartLogging(cmd.Context(), nil /* sm */)
+			if logErr != nil {
+				logging.V(3).Infof("automatic logging unavailable: %v", logErr)
 			}
 
 			cmdutil.InitTracing("pulumi-cli", "pulumi", tracingFlag)

--- a/sdk/go/common/env/env.go
+++ b/sdk/go/common/env/env.go
@@ -259,9 +259,6 @@ var (
 var DisableJournaling = env.Bool("DISABLE_JOURNALING",
 	"Disable journaling of engine operations to the backend")
 
-var EnableAutomaticLogging = env.Bool("ENABLE_AUTOMATIC_LOGGING",
-	"Enable automatic encrypted logging of engine operations to disk")
-
 var LogRotationMaxAgeDays = env.Int("LOG_ROTATION_MAX_AGE_DAYS",
 	"Maximum age in days for automatic log files before rotation deletes them (default 7)")
 

--- a/tests/integration/plugin_logging/plugin_logging_test.go
+++ b/tests/integration/plugin_logging/plugin_logging_test.go
@@ -54,10 +54,6 @@ func TestPluginLoggingDecrypt(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer e.DeleteIfNotFailed()
 
-	e.Env = append(e.Env,
-		"PULUMI_ENABLE_AUTOMATIC_LOGGING=true",
-	)
-
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 
 	pulumiYAML := fmt.Sprintf(`name: test-plugin-logging


### PR DESCRIPTION
We want automatic logging to always be enabled by default. This way we always have the logs available when necessary.  We don't have the mechanism for making sharing these logs easier implemented yet, but we can enable the feature for everyone in the meantime, and people can share the logs they decrypt using `pulumi logs decrypt` already.
