### PR TITLE
add infrastructure for logging directly through slog

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -167,6 +167,10 @@ linters:
           msg: "use cmd.ErrOrStderr() instead of os.Stderr in pkg/cmd"
         - pattern: ^fmt\.Print(f|ln)?$
           msg: "use fmt.Fprint*(cmd.OutOrStdout(), ...) instead of fmt.Print* in pkg/cmd"
+        - pattern: ^logging\.V$
+          msg: "use log/slog directly instead of the logging wrapper (slog migration)"
+        - pattern: ^logging\.(Infof|Warningf|Errorf)$
+          msg: "use log/slog directly instead of the logging wrapper (slog migration)"
     revive:
       rules:
         - name: use-any
@@ -221,6 +225,10 @@ linters:
           - forbidigo
         path-except: ^pkg/cmd/
         text: 'use (cmd\.OutOrStdout|cmd\.ErrOrStderr|fmt\.Fprint\*)'
+      - linters:
+          - forbidigo
+        path-except: ^NO_MIGRATED_PACKAGES_YET$
+        text: 'logging wrapper \(slog migration\)'
       - linters:
           - forbidigo
         path: _test\.go$

--- a/sdk/go/common/util/logging/log.go
+++ b/sdk/go/common/util/logging/log.go
@@ -114,6 +114,17 @@ func sinkEnabled(level slog.Level) bool {
 
 const LevelTrace = slog.LevelDebug - 4
 
+func verbosityLevel(verbose int) slog.Level {
+	switch {
+	case verbose >= 11:
+		return LevelTrace
+	case verbose >= 10:
+		return slog.LevelDebug
+	default:
+		return slog.LevelInfo
+	}
+}
+
 // VerboseLogger logs messages only if verbosity matches the level it was built with.
 type VerboseLogger struct{ level int32 }
 
@@ -220,7 +231,7 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 
 	if LogToStderr {
 		primary = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
-			Level: LevelTrace,
+			Level: verbosityLevel(Verbose),
 		})
 	} else if Verbose > 0 {
 		f, err := os.Create(logFileName())
@@ -228,7 +239,7 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 			logFilePath = f.Name()
 			logFile = f
 			primary = slog.NewJSONHandler(f, &slog.HandlerOptions{
-				Level: LevelTrace,
+				Level: verbosityLevel(Verbose),
 			})
 		}
 	}


### PR DESCRIPTION
In subsequent PRs, I want to move our logging form `logging.V(<n>)` to direct calls to `slog.Debug/Info` instead.  To make sure that works, we need to filter the verbosity level directly in the log handler (currently our logging API takes care of that).

We also add a linter for it, so packages (that are going to be transformed one by one) that are already transformed will no longer use the old API.

The biggest change here is going to be the reduction in number of log levels.

We map the current log levels 1-9 to `slog.Info`, 10 to `slog.Debug` and 11 to `slog.Log(ctx. logging.LevelTrace, ...)`.There's no `slog.Trace` function, but I think it's useful to have the tracing level for our purpose for our current `V(11)`.

The actual transformation is going to be split up into multiple subsequent PRs, to make each one of those easy to review.
