### PR TITLE
convert pkg/util/nosleep package to slog

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -227,7 +227,7 @@ linters:
         text: 'use (cmd\.OutOrStdout|cmd\.ErrOrStderr|fmt\.Fprint\*)'
       - linters:
           - forbidigo
-        path-except: ^NO_MIGRATED_PACKAGES_YET$
+        path-except: ^pkg/util/nosleep/
         text: 'logging wrapper \(slog migration\)'
       - linters:
           - forbidigo

--- a/pkg/util/nosleep/darwin.go
+++ b/pkg/util/nosleep/darwin.go
@@ -17,11 +17,10 @@
 package nosleep
 
 import (
+	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 func keepRunning() DoneFunc {
@@ -31,12 +30,12 @@ func keepRunning() DoneFunc {
 	// we intentionally ignore the error here.  If we can't keep the system awake we still want to continue.
 	err := cmd.Start()
 	if err != nil {
-		logging.V(5).Infof("Failed to get wake lock: %v", err)
+		slog.Info("Failed to get wake lock", "err", err)
 		return func() {}
 	}
-	logging.V(5).Infof("Got wake lock (caffeinate with pid %d)", cmd.Process.Pid)
+	slog.Info("Got wake lock", "mechanism", "caffeinate", "pid", cmd.Process.Pid)
 	return func() {
 		_ = cmd.Process.Kill()
-		logging.V(5).Infof("Released wake lock (caffeinate with pid %d)", cmd.Process.Pid)
+		slog.Info("Released wake lock", "mechanism", "caffeinate", "pid", cmd.Process.Pid)
 	}
 }

--- a/pkg/util/nosleep/unix.go
+++ b/pkg/util/nosleep/unix.go
@@ -17,8 +17,9 @@
 package nosleep
 
 import (
+	"log/slog"
+
 	"github.com/godbus/dbus/v5"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 
 func keepRunning() DoneFunc {
@@ -44,13 +45,13 @@ func keepRunning() DoneFunc {
 		reasonForInhibit,
 		inhibitIdleFlag).Store(&cookie)
 	if err != nil {
-		logging.V(5).Infof("Failed to get wake lock: %v", err)
+		slog.Info("Failed to get wake lock", "err", err)
 		// We did not succeed in setting up the inhibit, so just return a no-op function
 		return func() {}
 	}
-	logging.V(5).Infof("Got wake lock (gnome session manager, with cookie %d)", cookie)
+	slog.Info("Got wake lock", "mechanism", "gnome session manager", "cookie", cookie)
 	return func() {
 		_ = obj.Call("org.gnome.SessionManager.Uninhibit", 0, cookie).Store()
-		logging.V(5).Infof("Released wake lock (gnome session manager, with cookie %d)", cookie)
+		slog.Info("Released wake lock", "mechanism", "gnome session manager", "cookie", cookie)
 	}
 }

--- a/pkg/util/nosleep/windows.go
+++ b/pkg/util/nosleep/windows.go
@@ -17,7 +17,8 @@
 package nosleep
 
 import (
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	"log/slog"
+
 	"golang.org/x/sys/windows"
 )
 
@@ -30,10 +31,10 @@ func keepRunning() DoneFunc {
 	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
 	setThreadExecStateProc := kernel32.NewProc("SetThreadExecutionState")
 	setThreadExecStateProc.Call(EsSystemRequired | EsContinuous)
-	logging.V(5).Infof("Got wake lock (SetThreadExecutionState)")
+	slog.Info("Got wake lock", "mechanism", "SetThreadExecutionState")
 	return func() {
 		// At the end of the long running process, we can allow the system to sleep again.
 		setThreadExecStateProc.Call(EsContinuous)
-		logging.V(5).Infof("Released wake lock (SetThreadExecutionState)")
+		slog.Info("Released wake lock", "mechanism", "SetThreadExecutionState")
 	}
 }


### PR DESCRIPTION
Following on to the previous PR introducing the right infrastructure for this, convert `pkg/util/nosleep` to use slog directly, so we get nice structured logs.

Based on https://github.com/pulumi/pulumi/pull/23732