### PR TITLE
do: allow `--otel-traces` to be passed after `--help`

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -189,6 +189,18 @@ func (loggingWriter) Write(bytes []byte) (int, error) {
 	return len(bytes), nil
 }
 
+func parseRootPersistentFlags(rootPersistent *pflag.FlagSet, args []string) {
+	pf := pflag.NewFlagSet("", pflag.ContinueOnError)
+	pf.ParseErrorsAllowlist.UnknownFlags = true
+	pf.AddFlagSet(rootPersistent)
+	// pflag aborts Parse with ErrHelp on an undeclared --help/-h, dropping every flag after it.
+	// Declaring help keeps parsing going so e.g. `--help --otel-traces ...` still sees --otel-traces.
+	if pf.Lookup("help") == nil {
+		pf.BoolP("help", "h", false, "")
+	}
+	_ = pf.Parse(args)
+}
+
 // NewPulumiCmd creates a new Pulumi Cmd instance.
 func NewPulumiCmd() (*cobra.Command, func()) {
 	var cwd string
@@ -281,9 +293,7 @@ func NewPulumiCmd() (*cobra.Command, func()) {
 			// when this PersistentPreRunE runs, so all the flag-dependent init below is
 			// skipped. Parse what we can ourselves before continuing.
 			if cmd.DisableFlagParsing {
-				pf := cmd.Root().PersistentFlags()
-				pf.ParseErrorsAllowlist.UnknownFlags = true
-				_ = pf.Parse(args)
+				parseRootPersistentFlags(cmd.Root().PersistentFlags(), args)
 			}
 
 			commandPath := strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), "pulumi"))

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -970,6 +971,60 @@ func TestDiffVersions(t *testing.T) {
 			minorDiff := diffMinorVersions(v1, v2)
 
 			require.Equal(t, c.minorDiff, minorDiff)
+		})
+	}
+}
+
+// TestParseRootPersistentFlags guards against a --help / -h token causing pflag to drop the root
+// flags that follow it (e.g. --otel-traces), which left tracing silently disabled for `pulumi do`.
+func TestParseRootPersistentFlags(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		args      []string
+		wantOtel  string
+		wantColor string
+	}{
+		{
+			name:     "otel flag, no help",
+			args:     []string{"random:index:RandomString", "create", "--otel-traces", "grpc://localhost:4317"},
+			wantOtel: "grpc://localhost:4317",
+		},
+		{
+			name:     "help before otel flag",
+			args:     []string{"random:index:RandomString", "create", "--help", "--otel-traces", "grpc://localhost:4317"},
+			wantOtel: "grpc://localhost:4317",
+		},
+		{
+			name:     "short help before otel flag",
+			args:     []string{"random:index:RandomString", "create", "-h", "--otel-traces", "grpc://localhost:4317"},
+			wantOtel: "grpc://localhost:4317",
+		},
+		{
+			name: "help between two root flags, with unknown provider flags",
+			args: []string{
+				"random:index:RandomString", "create", "--length", "8",
+				"--help", "--otel-traces", "file:///tmp/t.json", "--color", "never",
+			},
+			wantOtel:  "file:///tmp/t.json",
+			wantColor: "never",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			var otelTraces, color string
+			root := pflag.NewFlagSet("pulumi", pflag.ContinueOnError)
+			root.StringVar(&otelTraces, "otel-traces", "", "")
+			root.StringVar(&color, "color", "", "")
+
+			parseRootPersistentFlags(root, c.args)
+
+			assert.Equal(t, c.wantOtel, otelTraces)
+			assert.Equal(t, c.wantColor, color)
 		})
 	}
 }


### PR DESCRIPTION
I wanted to look at `pulumi do` performance with tracing, however didn't get any traces out of it.  Turns out we don't declare the `--help` flag, and thus parsing the flag unceremoniously aborts parsing the rest of the flags, as soon as `--help` is encountered.

Work around that, and make sure all the flags are passed, even if they come after `--help`.

(Mostly to save others and future me from confusion why we don't get any traces here)