### PR TITLE
add traces for `pulumi do`

### DIFF
--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -168,9 +168,7 @@ func NewDoCmd(
 			return nil, nil, fmt.Errorf("create plugin context: %w", err)
 		}
 
-		loadCtx, loadSpan := tracer.Start(ctx, "pulumi-do.load-provider")
-		p, err := pluginFromSource(loadCtx, pctx, wd, pkgargs[0])
-		loadSpan.End()
+		p, err := pluginFromSource(ctx, pctx, wd, pkgargs[0])
 		if err != nil {
 			// Close the plugin context we opened above since we're not returning it to the caller.
 			contract.IgnoreClose(pctx)
@@ -214,9 +212,7 @@ func NewDoCmd(
 			}
 		}
 
-		schemaCtx, schemaSpan := tracer.Start(ctx, "pulumi-do.get-schema")
-		getSchema, err := p.GetSchema(schemaCtx, schemaRequest)
-		schemaSpan.End()
+		getSchema, err := p.GetSchema(ctx, schemaRequest)
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("get schema: %w", err)
@@ -238,9 +234,7 @@ func NewDoCmd(
 			packageDescriptor.Parameterization.Value = spec.Parameterization.Parameter
 		}
 
-		_, bindSpan := tracer.Start(ctx, "pulumi-do.bind-schema")
-		boundpkg, err := packages.BindSpec(spec, schema.NewPluginLoader(pctx))
-		bindSpan.End()
+		boundpkg, err := packages.BindSpecWithContext(ctx, spec, schema.NewPluginLoader(pctx))
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("bind schema: %w", err)

--- a/pkg/cmd/pulumi/do/do.go
+++ b/pkg/cmd/pulumi/do/do.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	codegenrpc "github.com/pulumi/pulumi/sdk/v3/proto/go/codegen"
+	"go.opentelemetry.io/otel"
 )
 
 func NewDoCmd(
@@ -152,6 +153,7 @@ func NewDoCmd(
 		}
 
 		ctx := cmd.Context()
+		tracer := otel.Tracer("pulumi-cli")
 
 		host, err := newHost(ctx, sink, sink)
 		if err != nil {
@@ -166,7 +168,9 @@ func NewDoCmd(
 			return nil, nil, fmt.Errorf("create plugin context: %w", err)
 		}
 
-		p, err := pluginFromSource(ctx, pctx, wd, pkgargs[0])
+		loadCtx, loadSpan := tracer.Start(ctx, "pulumi-do.load-provider")
+		p, err := pluginFromSource(loadCtx, pctx, wd, pkgargs[0])
+		loadSpan.End()
 		if err != nil {
 			// Close the plugin context we opened above since we're not returning it to the caller.
 			contract.IgnoreClose(pctx)
@@ -210,13 +214,17 @@ func NewDoCmd(
 			}
 		}
 
-		getSchema, err := p.GetSchema(ctx, schemaRequest)
+		schemaCtx, schemaSpan := tracer.Start(ctx, "pulumi-do.get-schema")
+		getSchema, err := p.GetSchema(schemaCtx, schemaRequest)
+		schemaSpan.End()
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("get schema: %w", err)
 		}
+		_, unmarshalSpan := tracer.Start(ctx, "pulumi-do.unmarshal-schema")
 		var spec schema.PackageSpec
 		err = json.Unmarshal(getSchema.Schema, &spec)
+		unmarshalSpan.End()
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("unmarshal schema: %w", err)
@@ -230,7 +238,9 @@ func NewDoCmd(
 			packageDescriptor.Parameterization.Value = spec.Parameterization.Parameter
 		}
 
+		_, bindSpan := tracer.Start(ctx, "pulumi-do.bind-schema")
 		boundpkg, err := packages.BindSpec(spec, schema.NewPluginLoader(pctx))
+		bindSpan.End()
 		if err != nil {
 			cleanup()
 			return nil, nil, fmt.Errorf("bind schema: %w", err)

--- a/pkg/cmd/pulumi/packages/packages.go
+++ b/pkg/cmd/pulumi/packages/packages.go
@@ -54,7 +54,14 @@ import (
 
 // BindSpec binds a PackageSpec into a Package, returning any error or error diagnostics encountered.
 func BindSpec(spec schema.PackageSpec, loader schema.Loader) (*schema.Package, error) {
-	pkg, diags, err := schema.BindSpec(spec, loader, schema.ValidationOptions{
+	return BindSpecWithContext(context.Background(), spec, loader)
+}
+
+// BindSpecWithContext is [BindSpec] with an explicit context that parents the spans emitted while binding.
+func BindSpecWithContext(
+	ctx context.Context, spec schema.PackageSpec, loader schema.Loader,
+) (*schema.Package, error) {
+	pkg, diags, err := schema.BindSpecWithContext(ctx, spec, loader, schema.ValidationOptions{
 		AllowDanglingReferences: true,
 	})
 	if err != nil {
@@ -472,6 +479,9 @@ func providerFromSource(
 	pctx *plugin.Context, packageSource string, reg registry.Registry,
 	e env.Env, concurrency int, installCtx packageinstallation.Context,
 ) (plugin.Provider, workspace.PackageSpec, error) {
+	ctx, span := otel.Tracer("pulumi-cli").Start(pctx.Request(), "provider.load")
+	defer span.End()
+
 	var version string
 	if parts := strings.SplitN(packageSource, "@", 2); len(parts) > 1 {
 		packageSource = parts[0]
@@ -479,7 +489,7 @@ func providerFromSource(
 	}
 	packageSpec := workspace.PackageSpec{Source: packageSource, Version: version}
 	{
-		proj, _, err := installCtx.LoadBaseProjectFrom(pctx.Request(), pctx.Pwd)
+		proj, _, err := installCtx.LoadBaseProjectFrom(ctx, pctx.Pwd)
 		if err != nil && !errors.Is(err, workspace.ErrProjectNotFound) {
 			return nil, workspace.PackageSpec{}, fmt.Errorf("error loading Pulumi Project: %w", err)
 		}
@@ -490,7 +500,7 @@ func providerFromSource(
 		}
 	}
 
-	f, spec, _, err := packageinstallation.InstallPlugin(pctx.Request(), packageSpec, nil, "", packageinstallation.Options{
+	f, spec, _, err := packageinstallation.InstallPlugin(ctx, packageSpec, nil, "", packageinstallation.Options{
 		Options: packageresolution.Options{
 			ResolveWithRegistry:                        !e.GetBool(env.DisableRegistryResolve),
 			ResolveVersionWithLocalWorkspace:           true,
@@ -501,7 +511,7 @@ func providerFromSource(
 	if err != nil {
 		return nil, workspace.PackageSpec{}, fmt.Errorf("unable to install %s: %w", packageSpec, err)
 	}
-	p, err := f(pctx.Request(), ".")
+	p, err := f(ctx, ".")
 	if err != nil {
 		return nil, workspace.PackageSpec{}, fmt.Errorf("unable to run %s: %w", packageSpec, err)
 	}

--- a/pkg/codegen/schema/bind.go
+++ b/pkg/codegen/schema/bind.go
@@ -158,15 +158,20 @@ func validateSpec(spec PackageSpec) (hcl.Diagnostics, error) {
 //     diagnostic. Until we have line/column information, we use JSON pointers to the offending entities. These pointers
 //     are passed around using `path` parameters. The `errorf` function is provided as a utility to easily create a
 //     diagnostic error that is appropriately tagged with a JSON pointer.
-func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
+func bindSpec(ctx context.Context, spec PackageSpec, languages map[string]Language, loader Loader,
 	validate bool,
 	options ValidationOptions,
 ) (*Package, hcl.Diagnostics, error) {
+	ctx, span := schemaTracer.Start(ctx, "schema.BindSpec")
+	defer span.End()
+
 	var diags hcl.Diagnostics
 
 	// Validate the package against the metaschema.
 	if validate {
+		_, vspan := schemaTracer.Start(ctx, "schema.validateSpec")
 		validationDiags, err := validateSpec(spec)
+		vspan.End()
 		diags = diags.Extend(validationDiags)
 		if err != nil {
 			return nil, diags, fmt.Errorf("validating spec: %w", err)
@@ -194,19 +199,25 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader,
 		return nil, diags, err
 	}
 
+	_, rspan := schemaTracer.Start(ctx, "schema.bindResources")
 	provider, resources, resourceDiags, err := types.finishResources(sortedKeys(spec.Resources), options)
+	rspan.End()
 	diags = diags.Extend(resourceDiags)
 	if err != nil {
 		return nil, diags, err
 	}
 
+	_, fspan := schemaTracer.Start(ctx, "schema.bindFunctions")
 	functions, functionDiags, err := types.finishFunctions(sortedKeys(spec.Functions), options)
+	fspan.End()
 	diags = diags.Extend(functionDiags)
 	if err != nil {
 		return nil, diags, err
 	}
 
+	_, tspan := schemaTracer.Start(ctx, "schema.bindTypes")
 	typeList, typeDiags, err := types.finishTypes(sortedKeys(spec.Types), options)
+	tspan.End()
 	diags = diags.Extend(typeDiags)
 	if err != nil {
 		return nil, diags, err
@@ -380,7 +391,15 @@ type ValidationOptions struct {
 // BindSpec converts a serializable PackageSpec into a Package. Any semantic errors encountered during binding are
 // contained in the returned diagnostics. The returned error is only non-nil if a fatal error was encountered.
 func BindSpec(spec PackageSpec, loader Loader, options ValidationOptions) (*Package, hcl.Diagnostics, error) {
-	return bindSpec(spec, nil, loader, true, options)
+	return BindSpecWithContext(context.Background(), spec, loader, options)
+}
+
+// BindSpecWithContext is [BindSpec] with an explicit context that parents the OpenTelemetry spans emitted while
+// binding the package.
+func BindSpecWithContext(
+	ctx context.Context, spec PackageSpec, loader Loader, options ValidationOptions,
+) (*Package, hcl.Diagnostics, error) {
+	return bindSpec(ctx, spec, nil, loader, true, options)
 }
 
 // ImportSpec converts a serializable PackageSpec into a Package. Unlike BindSpec, ImportSpec does not validate its
@@ -390,7 +409,7 @@ func BindSpec(spec PackageSpec, loader Loader, options ValidationOptions) (*Pack
 func ImportSpec(
 	spec PackageSpec, languages map[string]Language, loader Loader, options ValidationOptions,
 ) (*Package, error) {
-	pkg, diags, err := bindSpec(spec, languages, loader, false, options)
+	pkg, diags, err := bindSpec(context.Background(), spec, languages, loader, false, options)
 	if err != nil {
 		return nil, err
 	}
@@ -404,9 +423,19 @@ func ImportSpec(
 // PartialPackage loads and binds its members on-demand rather than at import time. This is useful when the entire
 // contents of a package are not needed (e.g. for referenced packages).
 func ImportPartialSpec(spec PartialPackageSpec, languages map[string]Language, loader Loader) (*PartialPackage, error) {
+	return ImportPartialSpecWithContext(context.Background(), spec, languages, loader)
+}
+
+func ImportPartialSpecWithContext(
+	ctx context.Context, spec PartialPackageSpec, languages map[string]Language, loader Loader,
+) (*PartialPackage, error) {
+	_, span := schemaTracer.Start(ctx, "schema.ImportPartialSpec")
+	defer span.End()
+
 	pkg := &PartialPackage{
 		spec:      &spec,
 		languages: languages,
+		ctx:       ctx,
 	}
 	types, diags, err := newBinder(spec.PackageInfoSpec, partialPackageSpecSource{&spec}, loader, pkg)
 	if err != nil {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -239,7 +239,7 @@ func (l *pluginLoader) LoadPackageReferenceV2(
 		spec.Version = pluginVersion.String()
 	}
 
-	p, err := ImportPartialSpec(spec, nil, l)
+	p, err := ImportPartialSpecWithContext(ctx, spec, nil, l)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/schema/loader_client.go
+++ b/pkg/codegen/schema/loader_client.go
@@ -112,7 +112,7 @@ func (l *LoaderClient) LoadPackageReferenceV2(
 		return nil, err
 	}
 
-	p, err := ImportPartialSpec(spec, nil, l)
+	p, err := ImportPartialSpecWithContext(ctx, spec, nil, l)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/schema/mock_pulumi_schema.go
+++ b/pkg/codegen/schema/mock_pulumi_schema.go
@@ -104,7 +104,7 @@ func newPulumiPackage() *Package {
 		},
 	}
 
-	pkg, diags, err := bindSpec(spec, nil, nullLoader{}, false, ValidationOptions{
+	pkg, diags, err := bindSpec(context.Background(), spec, nil, nullLoader{}, false, ValidationOptions{
 		AllowPulumiPackage:      true,
 		AllowDanglingReferences: true,
 	})

--- a/pkg/codegen/schema/package_reference.go
+++ b/pkg/codegen/schema/package_reference.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -25,7 +26,19 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/slice"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/segmentio/encoding/json"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
+
+var schemaTracer = otel.Tracer("github.com/pulumi/pulumi/pkg/v3/codegen/schema")
+
+func (p *PartialPackage) traceCtx() context.Context {
+	if p.ctx != nil {
+		return p.ctx
+	}
+	return context.Background()
+}
 
 // A PackageReference represents a references Pulumi Package. Applications that do not need access to the entire
 // definition of a Pulumi Package should use PackageReference rather than Package, as the former uses memory more
@@ -381,6 +394,8 @@ type PartialPackage struct {
 	languages map[string]Language
 	types     *types
 
+	ctx context.Context
+
 	config []*Property
 
 	def *Package
@@ -532,6 +547,9 @@ func (p *PartialPackage) Provider() (*Resource, error) {
 		return p.def.Provider, nil
 	}
 
+	_, span := schemaTracer.Start(p.traceCtx(), "schema.bindProvider")
+	defer span.End()
+
 	provider, diags, err := p.types.bindResourceDef("pulumi:providers:"+p.spec.Name, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -668,6 +686,9 @@ func (p *PartialPackage) Definition() (*Package, error) {
 	if p.def != nil {
 		return p.def, nil
 	}
+
+	_, span := schemaTracer.Start(p.traceCtx(), "schema.bindDefinition")
+	defer span.End()
 
 	config, err := p.bindConfig()
 	if err != nil {
@@ -901,6 +922,9 @@ func (p partialPackageResources) Get(token string) (*Resource, bool, error) {
 	if token != "pulumi:providers:"+p.spec.Name {
 		token = resolveSpecToken(p.spec.Resources, token, p.resourceAliases)
 	}
+	_, span := schemaTracer.Start(p.traceCtx(), "schema.bindResource",
+		trace.WithAttributes(attribute.String("schema.token", token)))
+	defer span.End()
 	res, diags, err := p.types.bindResourceDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})
@@ -966,6 +990,9 @@ func (p partialPackageFunctions) Get(token string) (*Function, bool, error) {
 	defer p.m.Unlock()
 
 	token = resolveSpecToken(p.spec.Functions, token, p.functionAliases)
+	_, span := schemaTracer.Start(p.traceCtx(), "schema.bindFunction",
+		trace.WithAttributes(attribute.String("schema.token", token)))
+	defer span.End()
 	fn, diags, err := p.types.bindFunctionDef(token, ValidationOptions{
 		AllowDanglingReferences: true,
 	})

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -616,6 +617,9 @@ func (p *provider) Parameterize(ctx context.Context, request ParameterizeRequest
 
 // GetSchema fetches the schema for this resource provider, if any.
 func (p *provider) GetSchema(ctx context.Context, req GetSchemaRequest) (GetSchemaResponse, error) {
+	_, span := otel.Tracer("pulumi-cli").Start(ctx, "provider.GetSchema")
+	defer span.End()
+
 	var subpackageVersion string
 	if req.SubpackageVersion != nil {
 		subpackageVersion = req.SubpackageVersion.String()

--- a/pkg/testing/pulumi-test-language/runner/runner.go
+++ b/pkg/testing/pulumi-test-language/runner/runner.go
@@ -417,7 +417,7 @@ func (l *providerLoader) LoadPackageReferenceV2(
 		}
 	}
 
-	p, err := schema.ImportPartialSpec(spec, nil, l)
+	p, err := schema.ImportPartialSpecWithContext(ctx, spec, nil, l)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go"
+	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -616,6 +617,9 @@ func (p *provider) Parameterize(ctx context.Context, request ParameterizeRequest
 
 // GetSchema fetches the schema for this resource provider, if any.
 func (p *provider) GetSchema(ctx context.Context, req GetSchemaRequest) (GetSchemaResponse, error) {
+	_, span := otel.Tracer("pulumi-cli").Start(ctx, "provider.GetSchema")
+	defer span.End()
+
 	var subpackageVersion string
 	if req.SubpackageVersion != nil {
 		subpackageVersion = req.SubpackageVersion.String()


### PR DESCRIPTION
There are a few slower processes happening in `pulumi do`, which currently don't show up in tracing data.  Add some traces to make that work visible when tracing, to help performance investigation.
